### PR TITLE
Add Facebook Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ erl_crash.dump
 # variables.
 /config/prod.secret.exs
 /config/dev.secret.exs
+/config/test.secret.exs
 
 # avatars in local storage
 #

--- a/config/config.exs
+++ b/config/config.exs
@@ -19,6 +19,16 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+config :vutuv, Vutuv.Mailer,
+  adapter: Bamboo.SMTPAdapter,
+  server: "127.0.0.1",
+  port: 25,
+  username: "",
+  password: "asdf",
+  tls: :if_available, # can be `:always` or `:never`
+  ssl: false, # can be `true`
+  retries: 1
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"
@@ -31,14 +41,6 @@ config :phoenix, :generators,
   migration: true,
   binary_id: false
 
-config :vutuv, Vutuv.Mailer,
-  adapter: Bamboo.SMTPAdapter,
-  server: "127.0.0.1",
-  port: 25,
-  username: "",
-  password: "asdf",
-  tls: :if_available, # can be `:always` or `:never`
-  ssl: false, # can be `true`
-  retries: 1
+
 
 config :vutuv, ecto_repos: [Vutuv.Repo]

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,3 +17,6 @@ config :vutuv, Vutuv.Repo,
   database: "vutuv_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+config :vutuv, Vutuv.Mailer,
+  adapter: Bamboo.TestAdapter

--- a/web/controllers/session_controller.ex
+++ b/web/controllers/session_controller.ex
@@ -1,5 +1,6 @@
 defmodule Vutuv.SessionController do
   use Vutuv.Web, :controller
+  import Vutuv.UserHelpers
 
   @api_url ~s(https://graph.facebook.com/v2.3/)
 
@@ -37,5 +38,87 @@ defmodule Vutuv.SessionController do
     conn
     |> Vutuv.Auth.logout()
     |> redirect(to: page_path(conn, :index))
+  end
+
+  def facebook_login(conn, _params) do
+    env = Application.fetch_env!(:vutuv, Vutuv.Endpoint)
+    url = "#{env[:url][:host]}/sessions/facebook/auth"
+    client_id = env[:facebook_client_id]
+    conn
+    |>redirect(external: "https://www.facebook.com/dialog/oauth?client_id=#{client_id}&redirect_uri=#{url}")
+  end
+
+  def facebook_auth(conn, %{"code"=> code}) do
+    HTTPoison.start
+
+    code
+    |> get_token
+    |> get_facebook_id
+    |> get_fields
+    |> Vutuv.Auth.login_by_facebook
+    |> handle_facebook_login_attempt(conn)
+  end
+
+  defp handle_facebook_login_attempt({:ok, user}, conn) do
+    Vutuv.Auth.login(conn, user)
+    |> put_flash(:info, gettext("Welcome back"))
+    |> redirect(to: user_path(conn, :show, user))
+  end
+
+  defp handle_facebook_login_attempt({:error, :not_found, fields}, conn) do
+    fields = Map.drop(fields,["id", "email"])
+    conn
+    |> Vutuv.Registration.register_user(fields, [{:oauth_providers, %Vutuv.OAuthProvider{provider: "facebook", provider_id: fields["id"]}}])
+    |> case do
+      {:ok, user} ->
+        conn
+        |> Vutuv.Auth.login(user)
+        |> put_flash(:info, "User #{full_name(user)} created successfully.")
+        |> redirect(to: user_path(conn, :show, user))
+      {:error, _changeset} ->
+        conn
+        |> put_flash(:error, "There was an error when trying to log you in via facebook.")
+        |> render("new.html")
+    end
+  end
+
+  defp get_token(code) do
+    env = Application.fetch_env!(:vutuv, Vutuv.Endpoint)
+    host = env[:url][:host]
+    client_id = env[:facebook_client_id]
+    client_secret = env[:facebook_client_secret]
+
+    api_call("oauth/access_token", [{"client_id","#{client_id}"}, {"redirect_uri", "#{host}/sessions/facebook/auth"},
+                                    {"client_secret","#{client_secret}"}, {"code", "#{code}"}])
+    |> HTTPoison.get!
+    |> decode_body
+  end
+
+  defp get_facebook_id(%{"access_token" => token}) do
+    api_call("me", [{"access_token", token}])
+    |> HTTPoison.get!
+    |> decode_body
+    |> Map.put("access_token", token) #Add the access token to the reply
+  end
+
+  defp get_fields(%{"id"=> id, "access_token" => token}) do
+    api_call(id, [{"fields", "email,first_name,last_name"}, {"access_token", token}])
+    |> HTTPoison.get!
+    |> decode_body
+  end
+
+  defp decode_body(%HTTPoison.Response{body: body}), do: Poison.decode! body #Turns the reply body into a map that elixir can work with
+
+  defp api_call(path, opts) do #Constructs an API request string from a path and options
+    "#{@api_url}#{path}?#{
+      for({k, v} <- opts) do
+        "#{k}=#{v}"
+      end
+      |> Enum.join("&")}"
+  end
+
+  def facebook_return(conn, _params) do
+    conn
+    |>redirect(to: session_path(conn, :new))
   end
 end

--- a/web/plugs/auth.ex
+++ b/web/plugs/auth.ex
@@ -38,6 +38,13 @@ defmodule Vutuv.Auth do
     {:ok, conn}
   end
 
+  def login_by_facebook(params) do
+    fb_id = params["id"]
+    user = Vutuv.Repo.one(from u in Vutuv.User, join: o in assoc(u, :oauth_providers), where: o.provider_id == ^fb_id and o.provider == "facebook")
+
+    if user == nil, do: {:error, :not_found, params}, else: {:ok, user}
+  end
+
   def logout(conn) do
     conn
     |> configure_session(drop: true)

--- a/web/router.ex
+++ b/web/router.ex
@@ -49,12 +49,14 @@ defmodule Vutuv.Router do
       resources "/social_media_accounts", SocialMediaAccountController
       resources "/work_experiences", WorkExperienceController
       resources "/addresses", AddressController
-      resources "/oauth_providers", OAuthProviderController
       resources "/search_terms", SearchTermController, only: [:show,:index]
     end
 
 
     resources "/sessions", SessionController, only: [:new, :create, :delete]
+    get "/sessions/facebook", SessionController, :facebook_login
+    get "/sessions/facebook/auth", SessionController, :facebook_auth
+    post "/sessions/facebook/auth", SessionController, :facebook_return
     get "/magic/login/:magiclink", SessionController, :show
     get "/magic/delete/:magiclink", UserController, :magic_delete
     get "/magic/email/:magiclink", EmailController, :magic_create

--- a/web/templates/session/new.html.eex
+++ b/web/templates/session/new.html.eex
@@ -5,3 +5,4 @@
   <%= submit "Log in", class: "pure-button pure-button-primary" %>
 <% end %>
 
+<%= link gettext("Login Via Facebook"), to: session_path(@conn, :facebook_login) %>


### PR DESCRIPTION
These changes, along with locally prepared secret configs, allow for any user to log into vutuv with their facebook account. It does not require magic links and thus is more convenient for the user. Possible improvements to this system include importing a wider variety of information from facebook, and a graphical login via facebook button, as opposed to a text link.
