### PR TITLE
Add a unique index to connections, preventing duplicates

### DIFF
--- a/priv/repo/migrations/20161122111934_add_connection_unique_index.exs
+++ b/priv/repo/migrations/20161122111934_add_connection_unique_index.exs
@@ -1,0 +1,7 @@
+defmodule Vutuv.Repo.Migrations.AddConnectionUniqueIndex do
+  use Ecto.Migration
+
+  def change do
+  	create unique_index(:connections, [:follower_id, :followee_id], unique: true)
+  end
+end

--- a/web/controllers/work_experience_controller.ex
+++ b/web/controllers/work_experience_controller.ex
@@ -10,14 +10,7 @@ defmodule Vutuv.WorkExperienceController do
     user = 
       conn.assigns[:user]
       |> Repo.preload([work_experiences: (from u in Vutuv.WorkExperience, order_by: [desc: u.start_year, desc: u.start_month])])
-    work_experiences = 
-      user.work_experiences
-      |> Enum.sort(&(if(&1.start_year == &2.start_year) do
-        &1.start_month > &2.start_month
-      else
-        &1.start_year > &2.start_year
-      end))
-    render(conn, "index.html", user: user, work_experience: work_experiences)
+    render(conn, "index.html", user: user, work_experience: user.work_experiences)
   end
 
   def new(conn, _params) do

--- a/web/models/connection.ex
+++ b/web/models/connection.ex
@@ -25,6 +25,7 @@ defmodule Vutuv.Connection do
     |> cast(params, @required_fields++@optional_fields)
     |> validate_required(@required_fields)
     |> validate_not_following_self
+    |> unique_constraint(:follower_id_followee_id, message: ("You're already following this person."))
   end
 
   defp validate_not_following_self(%{changes: %{followee_id: same, follower_id: same}} = changeset) do

--- a/web/views/user_helpers.ex
+++ b/web/views/user_helpers.ex
@@ -24,7 +24,7 @@ defmodule Vutuv.UserHelpers do
   end
 
   def email(%User{id: id}) do
-    Repo.one(from e in Vutuv.Email, where: e.user_id == ^id and e.public? == true, limit: 1, select: e.value)
+    Repo.one(from e in Vutuv.Email, where: e.user_id == ^id, limit: 1, select: e.value)
   end
 
   def users_by_email(email) do


### PR DESCRIPTION
Currently a user can follow another user twice. This creates errors in application logic due to the use of `Repo.one`

The use of `Repo.one` is not incorrect, because there should not be duplicate entries in the database, and errors alert us to the presence of these duplicate entries. 

This merge will require a database migration of vutuv. Because the migration adds a unique index, the migration will fail if there are no duplicate entries in the database.

This pull request will close #349