### PR TITLE
Include docker support for development environments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+_build
+node_modules
+deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM elixir:1.3.2
+MAINTAINER Gregor Tätzner <gregor@freenet.de>
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install hex
+RUN mix local.hex --force
+
+# Install rebar
+RUN mix local.rebar --force
+
+# Install the Phoenix framework itself
+RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phoenix_new.ez
+
+# Install NodeJS 6.x and the NPM
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get install -y -q nodejs mariadb-client
+
+# Set /app as workdir
+WORKDIR /app
+
+# include dep files
+COPY package.json ./
+COPY brunch-config.js ./
+COPY mix.* ./
+# install deps
+RUN npm install && \
+    mix deps.get && \
+    mix deps.compile
+
+# include the project
+COPY bin ./bin
+COPY config ./config
+COPY lib ./lib
+COPY priv ./priv
+COPY rel ./rel
+COPY test ./test
+COPY web ./web
+
+CMD ["bin/run.sh"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ Go to the `/config` directory and create two files named
 use Mix.Config
 ```
 
+## Quickstart with Docker
+
+You can also bootstrap your development environment with docker, without installing any dependencies on your host system. You need:
+- [Docker Engine >= 1.10](https://docs.docker.com/engine/)
+- [Docker Compose >= 1.6](https://docs.docker.com/engine/)
+
+Now you should be able to build and start vutuv with this command:
+```bash
+$ docker-compose up -d
+```
+
+Docker Compose already configures a mariadb database for you, installs all required dependencies and migrates the database schema. You can access the application as usual on http://localhost:4000
+
+### Run tests with docker
+
+To execute the tests, first connect to the running app container and run them inside the container:
+```bash
+$ docker exec -it vutuv_app_1 bash
+$ MIX_ENV=test mix test
+```
+
 ## Configure your SMTP setup
 
 The system uses the [Bamboo](https://github.com/thoughtbot/bamboo) email
@@ -44,7 +65,7 @@ library by [thoughtbot](https://thoughtbot.com/) to send emails via SMTP.
 ### Development
 
 In the development environment emails are not sent to an actual SMTP
-server but displayed in the browser via [Bamboo.EmailPreviewPlug](https://hexdocs.pm/bamboo/Bamboo.EmailPreviewPlug.html). To see which emails have been send you have to visit https://www.vutuv.de/sent_emails
+server but displayed in the browser via [Bamboo.EmailPreviewPlug](https://hexdocs.pm/bamboo/Bamboo.EmailPreviewPlug.html). To see which emails have been send you have to visit http://localhost:4000/sent_emails
 
 ### Production
 
@@ -59,7 +80,7 @@ config :vutuv, Vutuv.Mailer,
 ```
 For more information on the these settings, consult the [bamboo docs](https://github.com/thoughtbot/bamboo).
 
-## Start the application
+## Start the application without Docker
 
 You should now be able to run the application by following the steps below.
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+mix ecto.create
+mix ecto.migrate
+
+mix phoenix.server

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -39,10 +39,10 @@ config :phoenix, :stacktrace_depth, 20
 # Configure your database
 config :vutuv, Vutuv.Repo,
   adapter: Ecto.Adapters.MySQL,
-  username: "root",
-  password: "",
-  database: "vutuv_dev",
-  hostname: "localhost",
+  username: System.get_env("DB_USER"),
+  password: System.get_env("DB_PASSWORD"),
+  database: System.get_env("DB_DATABASE"),
+  hostname: System.get_env("DB_HOST"),
   pool_size: 10
 
 # Bamboo Email

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,10 +14,10 @@ config :logger, level: :warn
 # Configure your database
 config :vutuv, Vutuv.Repo,
   adapter: Ecto.Adapters.MySQL,
-  username: "root",
-  password: "",
-  database: "vutuv_test",
-  hostname: "localhost",
+  username: System.get_env("DB_USER"),
+  password: System.get_env("DB_PASSWORD"),
+  database: System.get_env("DB_DATABASE"),
+  hostname: System.get_env("DB_HOST"),
   pool: Ecto.Adapters.SQL.Sandbox
 
 config :vutuv, Vutuv.Mailer,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '2'
+services:
+    app:
+        build: .
+        image: vutuv
+        environment:
+        - MIX_ENV=dev
+        - DB_PORT=3306
+        - DB_HOST=mysql
+        - DB_USER=dev
+        - DB_PASSWORD=dev
+        - DB_DATABASE=dev
+        volumes: # bind source files to the container
+        - ./config:/app/config
+        - ./web:/app/web
+        - ./lib:/app/lib
+        - ./test:/app/test
+        ports:
+        - "4000:4000"
+        links:
+        - db:mysql
+
+    db:
+        image: mariadb:10
+        environment:
+        - MYSQL_ROOT_PASSWORD=root
+        - MYSQL_DATABASE=dev
+        - MYSQL_USER=dev
+        - MYSQL_PASSWORD=dev
+        ports:
+        - "3306:3306"


### PR DESCRIPTION
Hi,
I was missing a quick start setup for vutuv, so I included docker support. Now you can build and run vutuv with just one command (tested on linux). This could lower the barrier for new developers, also you keep your system clean.

Hope you like it.