### PR TITLE
Closure dev

### DIFF
--- a/priv/repo/migrations/20161220223007_create_tag_closure.exs
+++ b/priv/repo/migrations/20161220223007_create_tag_closure.exs
@@ -1,0 +1,14 @@
+defmodule Vutuv.Repo.Migrations.CreateTagClosure do
+  use Ecto.Migration
+
+  def change do
+    create table(:tag_closures) do
+      add :parent_id, references(:tags)
+      add :child_id, references(:tags)
+      add :depth, :integer
+
+      timestamps()
+    end
+
+  end
+end

--- a/priv/repo/migrations/20170106120438_create_tag_closure.exs
+++ b/priv/repo/migrations/20170106120438_create_tag_closure.exs
@@ -9,6 +9,6 @@ defmodule Vutuv.Repo.Migrations.CreateTagClosure do
 
       timestamps()
     end
-
+    create unique_index(:tag_closures, [:parent_id, :child_id], unique: true)
   end
 end

--- a/web/controllers/admin/tag_closure_controller.ex
+++ b/web/controllers/admin/tag_closure_controller.ex
@@ -28,6 +28,8 @@ defmodule Vutuv.Admin.TagClosureController do
         conn
         |> put_flash(:info, gettext("Tag closure created successfully."))
         |> redirect(to: admin_tag_closure_path(conn, :index, conn.assigns[:tag]))
+      {:error, _, changeset, errors} ->
+        render(conn, "new.html", changeset: changeset, value: value)
       {:error, changeset} ->
         render(conn, "new.html", changeset: changeset)
     end

--- a/web/controllers/admin/tag_closure_controller.ex
+++ b/web/controllers/admin/tag_closure_controller.ex
@@ -1,0 +1,78 @@
+defmodule Vutuv.Admin.TagClosureController do
+  use Vutuv.Web, :controller
+  plug :logged_in?
+  plug Vutuv.Plug.AuthAdmin
+
+  alias Vutuv.TagClosure
+
+  def index(conn, _params) do
+    tag_closures = Repo.all(TagClosure)
+    render(conn, "index.html", tag_closures: tag_closures)
+  end
+
+  def new(conn, _params) do
+    changeset = TagClosure.changeset(%TagClosure{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"tag_closure" => tag_closure_params}) do
+    changeset = TagClosure.changeset(%TagClosure{}, tag_closure_params)
+
+    case Repo.insert(changeset) do
+      {:ok, _tag_closure} ->
+        conn
+        |> put_flash(:info, gettext("Tag closure created successfully."))
+        |> redirect(to: admin_tag_closure_path(conn, :index))
+      {:error, changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    tag_closure = Repo.get!(TagClosure, id)
+    render(conn, "show.html", tag_closure: tag_closure)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    tag_closure = Repo.get!(TagClosure, id)
+    changeset = TagClosure.changeset(tag_closure)
+    render(conn, "edit.html", tag_closure: tag_closure, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "tag_closure" => tag_closure_params}) do
+    tag_closure = Repo.get!(TagClosure, id)
+    changeset = TagClosure.changeset(tag_closure, tag_closure_params)
+
+    case Repo.update(changeset) do
+      {:ok, tag_closure} ->
+        conn
+        |> put_flash(:info, gettext("Tag closure updated successfully."))
+        |> redirect(to: admin_tag_closure_path(conn, :show, tag_closure))
+      {:error, changeset} ->
+        render(conn, "edit.html", tag_closure: tag_closure, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    tag_closure = Repo.get!(TagClosure, id)
+
+    # Here we use delete! (with a bang) because we expect
+    # it to always work (and if it does not, it will raise).
+    Repo.delete!(tag_closure)
+
+    conn
+    |> put_flash(:info, gettext("Tag closure deleted successfully."))
+    |> redirect(to: admin_tag_closure_path(conn, :index))
+  end
+
+  defp logged_in?(conn, _opts) do
+    if conn.assigns.current_user do
+      conn
+    else
+      conn
+      |> put_flash(:error, gettext("You must be logged in to access that page"))
+      |> redirect(to: page_path(conn, :index))
+      |> halt()
+    end
+  end
+end

--- a/web/models/tag.ex
+++ b/web/models/tag.ex
@@ -9,6 +9,12 @@ defmodule Vutuv.Tag do
     has_many :tag_localizations, Vutuv.TagLocalization, on_delete: :delete_all
     has_many :tag_synonyms, Vutuv.TagSynonym, on_delete: :delete_all
 
+    has_many :parent_closures, Vutuv.TagClosure, foreign_key: :child_id, on_delete: :delete_all
+    has_many :parents, through: [:parent_closures, :parent]
+
+    has_many :child_closures, Vutuv.TagClosure, foreign_key: :parent_id, on_delete: :delete_all
+    has_many :children, through: [:child_closures, :child]
+
     timestamps()
   end
 

--- a/web/models/tag_closure.ex
+++ b/web/models/tag_closure.ex
@@ -1,5 +1,7 @@
 defmodule Vutuv.TagClosure do
   use Vutuv.Web, :model
+  import Ecto.Query
+  alias Vutuv.Repo
 
   schema "tag_closures" do
     field :depth, :integer
@@ -15,7 +17,84 @@ defmodule Vutuv.TagClosure do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:depth])
-    |> validate_required([:depth])
+    |> cast(params, [:depth, :parent_id, :child_id])
+    |> validate_required([:depth, :parent_id, :child_id])
+    |> unique_constraint(:parent_id_child_id)
+  end
+
+  def add_closure(parent_id, child_id) do
+    create_initial_closure(parent_id)
+    create_initial_closure(child_id)
+    parent_closures = Repo.all(from c in __MODULE__, where: c.child_id == ^parent_id)
+    child_closures = Repo.all(from c in __MODULE__, where: c.depth > 0 and c.parent_id == ^child_id)
+    Ecto.Multi.new
+    |> create_parents(child_id, parent_closures)
+    |> create_children(parent_id, child_closures)
+    |> Repo.transaction
+  end
+
+  defp create_parents(multi, _, []), do: multi
+
+  defp create_parents(multi, id, [%{parent_id: id, depth: depth} | tail]), do: create_parents(multi, id, tail)
+
+  defp create_parents(multi, child_id, [%{parent_id: parent_id, depth: depth} | tail]) do
+    IO.puts "\ntag_closure_#{parent_id}_#{child_id}"
+    changeset = 
+      %__MODULE__{}
+      |>changeset(%{parent_id: parent_id, child_id: child_id, depth: depth+1})
+    Ecto.Multi.insert(multi, "tag_closure_#{parent_id}_#{child_id}", changeset)
+    |> create_parents(child_id, tail)
+  end
+
+  defp create_children(multi, _, []), do: multi
+
+  defp create_children(multi, id, [%{child_id: id, depth: depth} | tail]), do: create_parents(multi, id, tail)
+
+  defp create_children(multi, parent_id, [%{child_id: child_id, depth: depth} | tail]) do
+    IO.puts "\ntag_closure_#{parent_id}_#{child_id}"
+    changeset = 
+      %__MODULE__{}
+      |>changeset(%{parent_id: parent_id, child_id: child_id, depth: depth+1})
+    Ecto.Multi.insert(multi, "tag_closure_#{parent_id}_#{child_id}", changeset)
+    |> create_children(parent_id, tail)
+  end
+
+  defp create_initial_closure(id) do
+    %__MODULE__{}
+    |>changeset(%{parent_id: id, child_id: id, depth: 0})
+    |> Repo.insert
+  end
+
+  def delete_closure(id, id), do: :error
+
+  def delete_closure(parent_id, child_id) do
+    closure = Repo.one(from c in __MODULE__, where: c.child_id == ^child_id and c.parent_id == ^parent_id)
+    parent_closures = Repo.all(from c in __MODULE__, where: c.child_id == ^parent_id)
+    child_closures = Repo.all(from c in __MODULE__, where: c.depth > 0 and c.parent_id == ^child_id)
+    Ecto.Multi.new
+    |> Ecto.Multi.delete("tag_closure", closure)
+    |> delete_parents(child_id, parent_closures)
+    |> delete_children(parent_id, child_closures)
+    |> Repo.transaction
+  end
+
+  defp delete_parents(multi, _, []), do: multi
+
+  defp delete_parents(multi, id, [%{parent_id: id, depth: depth} | tail]), do: create_parents(multi, id, tail)
+
+  defp delete_parents(multi, child_id, [%{parent_id: parent_id, depth: depth} | tail]) do
+    query = from(c in __MODULE__, where: c.parent_id == ^parent_id and c.child_id == ^child_id and c.depth == ^(depth+1))
+    Ecto.Multi.delete_all(multi, "tag_closure_#{parent_id}_#{child_id}", query)
+    |> delete_parents(child_id, tail)
+  end
+
+  defp delete_children(multi, _, []), do: multi
+
+  defp delete_children(multi, id, [%{child_id: id, depth: depth} | tail]), do: create_parents(multi, id, tail)
+
+  defp delete_children(multi, parent_id, [%{child_id: child_id, depth: depth} | tail]) do
+    query = from(c in __MODULE__, where: c.parent_id == ^parent_id and c.child_id == ^child_id and c.depth == ^(depth+1))
+    Ecto.Multi.delete_all(multi, "tag_closure_#{parent_id}_#{child_id}", query)
+    |> delete_children(parent_id, tail)
   end
 end

--- a/web/models/tag_closure.ex
+++ b/web/models/tag_closure.ex
@@ -1,0 +1,21 @@
+defmodule Vutuv.TagClosure do
+  use Vutuv.Web, :model
+
+  schema "tag_closures" do
+    field :depth, :integer
+
+    belongs_to :parent, Vutuv.Tag
+    belongs_to :child, Vutuv.Tag
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:depth])
+    |> validate_required([:depth])
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -97,7 +97,7 @@ defmodule Vutuv.Router do
         resources "/tag_urls", TagUrlController, as: :url
       end
       resources "/tag_synonyms", TagSynonymController, as: :synonym
-      resources "/tag_closures", TagClosureController
+      resources "/tag_closures", TagClosureController, as: :closure
     end
   end
 

--- a/web/templates/admin/tag/show.html.eex
+++ b/web/templates/admin/tag/show.html.eex
@@ -31,6 +31,7 @@
       <p>
         <%= @tag.slug %>
       </p>
+      <%= link gettext("View related tags"), to: admin_tag_closure_path(@conn, :index, @tag), class: "card__morelink" %>
     
   </section>
 

--- a/web/templates/admin/tag_closure/edit.html.eex
+++ b/web/templates/admin/tag_closure/edit.html.eex
@@ -9,14 +9,17 @@
 
 <div class="breadcrumbs">
 <%= Vutuv.UserHelpers.gen_breadcrumbs([
-      {gettext("Tag closures"), admin_tag_closure_path(@conn, :index)},
+      {gettext("Admin"), admin_admin_path(@conn, :index)},
+      {gettext("Tags"), admin_tag_path(@conn, :index)},
+      {@tag.slug, admin_tag_path(@conn, :show, @tag)},
+      {gettext("Tag closures"), admin_tag_closure_path(@conn, :index, @tag)},
       gettext("Edit")]) %>
 </div>
 
 <div class="card-list">
   <section class="card">
-    <%= render "form.html", backlink: admin_tag_closure_path(@conn, :index), changeset: @changeset,
-                            action: admin_tag_closure_path(@conn, :update, @tag_closure) %>
+    <%= render "form.html", conn: @conn, backlink: admin_tag_closure_path(@conn, :index, @tag), changeset: @changeset,
+                            action: admin_tag_closure_path(@conn, :update, @tag, @tag_closure) %>
   </section>
   <aside>
     <%= render Vutuv.SharedView, "_ad.html" %>

--- a/web/templates/admin/tag_closure/edit.html.eex
+++ b/web/templates/admin/tag_closure/edit.html.eex
@@ -1,0 +1,24 @@
+
+  <div class="profile-header">
+    <div class="profile-header__info">
+      <h1><%= gettext "Edit tag closure" %></h1>
+    </div>
+  </div>
+</header>
+<%= render Vutuv.LayoutView, "flash.html", assigns %>
+
+<div class="breadcrumbs">
+<%= Vutuv.UserHelpers.gen_breadcrumbs([
+      {gettext("Tag closures"), admin_tag_closure_path(@conn, :index)},
+      gettext("Edit")]) %>
+</div>
+
+<div class="card-list">
+  <section class="card">
+    <%= render "form.html", backlink: admin_tag_closure_path(@conn, :index), changeset: @changeset,
+                            action: admin_tag_closure_path(@conn, :update, @tag_closure) %>
+  </section>
+  <aside>
+    <%= render Vutuv.SharedView, "_ad.html" %>
+  </aside>
+</div>

--- a/web/templates/admin/tag_closure/form.html.eex
+++ b/web/templates/admin/tag_closure/form.html.eex
@@ -18,7 +18,7 @@
   <%= hidden_input f, :type, value: "child" %>
   <%= label f, :value, gettext("Child slug"), class: "control-label" %>
 <% end %>
-  <%= text_input f, :value, class: "form-control" %>
+  <%= text_input f, :value, class: "form-control", value: @value %>
   <%= error_tag f, :value %>
 </div>
 

--- a/web/templates/admin/tag_closure/form.html.eex
+++ b/web/templates/admin/tag_closure/form.html.eex
@@ -6,36 +6,20 @@
   <% end %>
 
 <div class="editform__field
-	<%= if( error_tag f, :parent_id ) do %>
+	<%= if( error_tag f, :value ) do %>
 	 editform__field--error"
 	 <% else %>
 	 "
 	 <% end %>">
-  <%= label f, :parent_id, class: "control-label" %>
-  <%= number_input f, :parent_id, class: "form-control" %>
-  <%= error_tag f, :parent_id %>
-</div>
-
-<div class="editform__field
-	<%= if( error_tag f, :child_id ) do %>
-	 editform__field--error"
-	 <% else %>
-	 "
-	 <% end %>">
-  <%= label f, :child_id, class: "control-label" %>
-  <%= number_input f, :child_id, class: "form-control" %>
-  <%= error_tag f, :child_id %>
-</div>
-
-<div class="editform__field
-	<%= if( error_tag f, :depth ) do %>
-	 editform__field--error"
-	 <% else %>
-	 "
-	 <% end %>">
-  <%= label f, :depth, class: "control-label" %>
-  <%= number_input f, :depth, class: "form-control" %>
-  <%= error_tag f, :depth %>
+<%= if @conn.params["parent"] == "true" do %>
+  <%= hidden_input f, :type, value: "parent" %>
+  <%= label f, :value, gettext("Parent slug"), class: "control-label" %>
+<%= else %>
+  <%= hidden_input f, :type, value: "child" %>
+  <%= label f, :value, gettext("Child slug"), class: "control-label" %>
+<% end %>
+  <%= text_input f, :value, class: "form-control" %>
+  <%= error_tag f, :value %>
 </div>
 
 <div class="editform__actions">

--- a/web/templates/admin/tag_closure/form.html.eex
+++ b/web/templates/admin/tag_closure/form.html.eex
@@ -1,0 +1,45 @@
+<%= form_for @changeset, @action, [class: "editform"], fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p class="editform__error"><%= gettext "Oops, something went wrong! Please check the errors below." %></p>
+    </div>
+  <% end %>
+
+<div class="editform__field
+	<%= if( error_tag f, :parent_id ) do %>
+	 editform__field--error"
+	 <% else %>
+	 "
+	 <% end %>">
+  <%= label f, :parent_id, class: "control-label" %>
+  <%= number_input f, :parent_id, class: "form-control" %>
+  <%= error_tag f, :parent_id %>
+</div>
+
+<div class="editform__field
+	<%= if( error_tag f, :child_id ) do %>
+	 editform__field--error"
+	 <% else %>
+	 "
+	 <% end %>">
+  <%= label f, :child_id, class: "control-label" %>
+  <%= number_input f, :child_id, class: "form-control" %>
+  <%= error_tag f, :child_id %>
+</div>
+
+<div class="editform__field
+	<%= if( error_tag f, :depth ) do %>
+	 editform__field--error"
+	 <% else %>
+	 "
+	 <% end %>">
+  <%= label f, :depth, class: "control-label" %>
+  <%= number_input f, :depth, class: "form-control" %>
+  <%= error_tag f, :depth %>
+</div>
+
+<div class="editform__actions">
+  <%= link gettext("Cancel"), to: @backlink, class: "button button--cancel" %>
+  <%= submit gettext("Submit"), class: "button" %>
+</div>
+<% end %>

--- a/web/templates/admin/tag_closure/index.html.eex
+++ b/web/templates/admin/tag_closure/index.html.eex
@@ -1,7 +1,7 @@
 
   <div class="profile-header">
     <div class="profile-header__info">
-      <h1><%= gettext "All tag closures" %></h1>
+      <h1><%= gettext "Related Tags" %></h1>
     </div>
   </div>
 </header>
@@ -9,46 +9,71 @@
 
 <div class="breadcrumbs">
   <%= Vutuv.UserHelpers.gen_breadcrumbs([
-      gettext("Tag closures")]) %>
+      {gettext("Admin"), admin_admin_path(@conn, :index)},
+      {gettext("Tags"), admin_tag_path(@conn, :index)},
+      {@tag.slug, admin_tag_path(@conn, :show, @tag)},
+      gettext("Related Tags")]) %>
 </div>
 
 <div class="card-list">
   <section class="card">
+    <h1>Parents</h1>
     <table>
       <thead>
         <tr>
-          <th><%= gettext "Parent" %></th>
-          <th><%= gettext "Child" %></th>
+          <th><%= gettext "Slug" %></th>
           <th><%= gettext "Depth" %></th>
-    
+          <th></th>
           <th></th>
         </tr>
       </thead>
       <tbody>
-    <%= for {tag_closure, index} <- Enum.with_index(@tag_closures) do %>
+    <%= for tag_closure <- @tag.parent_closures do %>
         <tr>
-          <td><%= tag_closure.parent_id %></td>
-          <td><%= tag_closure.child_id %></td>
+          <td><%= tag_closure.parent.slug %></td>
           <td><%= tag_closure.depth %></td>
-    
+          <td><%= link gettext("View related"), to: admin_tag_closure_path(@conn, :index, tag_closure.parent) %></td>
           <td>
-            <%= link to: admin_tag_closure_path(@conn, :show, tag_closure), class: "button button--icon button--small" do %>
-            <i class="icon icon--search"></i>
-            <% end %>
-            <%= link to: admin_tag_closure_path(@conn, :edit, tag_closure), class: "button button--icon button--small" do %>
-            <i class="icon icon--edit"></i>
-            <% end %>
-            <%= button to: admin_tag_closure_path(@conn, :delete, tag_closure), method: :delete, class: "button button--icon button--small", form: [class: "button button--icon button--small"] do %>
-            <i class="icon icon--delete"></i>
-            <% end %>
+          <%= button to: admin_tag_closure_path(@conn, :delete, @tag, tag_closure), method: :delete, class: "button button--icon button--small", form: [class: "button button--icon button--small"] do %>
+          <i class="icon icon--delete"></i>
+          <% end %>
           </td>
         </tr>
     <% end %>
       </tbody>
     </table>
-
     <p>
-      <%= link gettext("New tag closure"), to: admin_tag_closure_path(@conn, :new), class: "card__morelink" %>
+      <%= link gettext("Add a parent"), to: admin_tag_closure_path(@conn, :new, @tag, parent: true), class: "card__morelink" %>
+    </p>
+  </section>
+  <section class="card">
+    <h1>Children</h1>
+    <table>
+      <thead>
+        <tr>
+          <th><%= gettext "Slug" %></th>
+          <th><%= gettext "Depth" %></th>
+          <th></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+    <%= for tag_closure <- @tag.child_closures do %>
+        <tr>
+          <td><%= tag_closure.child.slug %></td>
+          <td><%= tag_closure.depth %></td>
+          <td><%= link gettext("View related"), to: admin_tag_closure_path(@conn, :index, tag_closure.child) %></td>
+          <td>
+          <%= button to: admin_tag_closure_path(@conn, :delete, @tag, tag_closure), method: :delete, class: "button button--icon button--small", form: [class: "button button--icon button--small"] do %>
+          <i class="icon icon--delete"></i>
+          <% end %>
+          </td>
+        </tr>
+    <% end %>
+      </tbody>
+    </table>
+    <p>
+      <%= link gettext("Add a Child"), to: admin_tag_closure_path(@conn, :new, @tag, parent: false), class: "card__morelink" %>
     </p>
   </section>
   <aside>

--- a/web/templates/admin/tag_closure/index.html.eex
+++ b/web/templates/admin/tag_closure/index.html.eex
@@ -1,0 +1,57 @@
+
+  <div class="profile-header">
+    <div class="profile-header__info">
+      <h1><%= gettext "All tag closures" %></h1>
+    </div>
+  </div>
+</header>
+<%= render Vutuv.LayoutView, "flash.html", assigns %>
+
+<div class="breadcrumbs">
+  <%= Vutuv.UserHelpers.gen_breadcrumbs([
+      gettext("Tag closures")]) %>
+</div>
+
+<div class="card-list">
+  <section class="card">
+    <table>
+      <thead>
+        <tr>
+          <th><%= gettext "Parent" %></th>
+          <th><%= gettext "Child" %></th>
+          <th><%= gettext "Depth" %></th>
+    
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+    <%= for {tag_closure, index} <- Enum.with_index(@tag_closures) do %>
+        <tr>
+          <td><%= tag_closure.parent_id %></td>
+          <td><%= tag_closure.child_id %></td>
+          <td><%= tag_closure.depth %></td>
+    
+          <td>
+            <%= link to: admin_tag_closure_path(@conn, :show, tag_closure), class: "button button--icon button--small" do %>
+            <i class="icon icon--search"></i>
+            <% end %>
+            <%= link to: admin_tag_closure_path(@conn, :edit, tag_closure), class: "button button--icon button--small" do %>
+            <i class="icon icon--edit"></i>
+            <% end %>
+            <%= button to: admin_tag_closure_path(@conn, :delete, tag_closure), method: :delete, class: "button button--icon button--small", form: [class: "button button--icon button--small"] do %>
+            <i class="icon icon--delete"></i>
+            <% end %>
+          </td>
+        </tr>
+    <% end %>
+      </tbody>
+    </table>
+
+    <p>
+      <%= link gettext("New tag closure"), to: admin_tag_closure_path(@conn, :new), class: "card__morelink" %>
+    </p>
+  </section>
+  <aside>
+    <%= render Vutuv.SharedView, "_ad.html" %>
+  </aside>
+</div>

--- a/web/templates/admin/tag_closure/new.html.eex
+++ b/web/templates/admin/tag_closure/new.html.eex
@@ -9,14 +9,17 @@
 
 <div class="breadcrumbs">
   <%= Vutuv.UserHelpers.gen_breadcrumbs([
-        {gettext("Tag closures"), admin_tag_closure_path(@conn, :index)},
-        gettext("New")]) %>
+      {gettext("Admin"), admin_admin_path(@conn, :index)},
+      {gettext("Tags"), admin_tag_path(@conn, :index)},
+      {@tag.slug, admin_tag_path(@conn, :show, @tag)},
+      {gettext("Tag closures"), admin_tag_closure_path(@conn, :index, @tag)},
+      gettext("New")]) %>
 </div>
 
 <div class="card-list">
   <section class="card">
-    <%= render "form.html", backlink: admin_tag_closure_path(@conn, :index), changeset: @changeset,
-                            action: admin_tag_closure_path(@conn, :create) %>
+    <%= render "form.html", conn: @conn, backlink: admin_tag_closure_path(@conn, :index, @tag), changeset: @changeset,
+                            action: admin_tag_closure_path(@conn, :create, @tag) %>
   </section>
   <aside>
     <%= render Vutuv.SharedView, "_ad.html" %>

--- a/web/templates/admin/tag_closure/new.html.eex
+++ b/web/templates/admin/tag_closure/new.html.eex
@@ -1,0 +1,24 @@
+
+  <div class="profile-header">
+    <div class="profile-header__info">
+      <h1><%= gettext "New tag closure" %></h1>
+    </div>
+  </div>
+</header>
+<%= render Vutuv.LayoutView, "flash.html", assigns %>
+
+<div class="breadcrumbs">
+  <%= Vutuv.UserHelpers.gen_breadcrumbs([
+        {gettext("Tag closures"), admin_tag_closure_path(@conn, :index)},
+        gettext("New")]) %>
+</div>
+
+<div class="card-list">
+  <section class="card">
+    <%= render "form.html", backlink: admin_tag_closure_path(@conn, :index), changeset: @changeset,
+                            action: admin_tag_closure_path(@conn, :create) %>
+  </section>
+  <aside>
+    <%= render Vutuv.SharedView, "_ad.html" %>
+  </aside>
+</div>

--- a/web/templates/admin/tag_closure/new.html.eex
+++ b/web/templates/admin/tag_closure/new.html.eex
@@ -19,7 +19,7 @@
 <div class="card-list">
   <section class="card">
     <%= render "form.html", conn: @conn, backlink: admin_tag_closure_path(@conn, :index, @tag), changeset: @changeset,
-                            action: admin_tag_closure_path(@conn, :create, @tag) %>
+                            action: admin_tag_closure_path(@conn, :create, @tag), value: @conn.assigns[:value] %>
   </section>
   <aside>
     <%= render Vutuv.SharedView, "_ad.html" %>

--- a/web/templates/admin/tag_closure/show.html.eex
+++ b/web/templates/admin/tag_closure/show.html.eex
@@ -9,17 +9,20 @@
 
 <div class="breadcrumbs">
 <%= Vutuv.UserHelpers.gen_breadcrumbs([
-      {gettext("Tag closures"), admin_tag_closure_path(@conn, :index)},
+      {gettext("Admin"), admin_admin_path(@conn, :index)},
+      {gettext("Tags"), admin_tag_path(@conn, :index)},
+      {@tag.slug, admin_tag_path(@conn, :show, @tag)},
+      {gettext("Tag closures"), admin_tag_closure_path(@conn, :index, @tag)},
       gettext("Show")]) %>
 </div>
 
 <div class="card-list">
   <section class="card">
     <div class="card__edit button__list">
-      <%= link to: admin_tag_closure_path(@conn, :edit, @tag_closure), class: "button button-link button--icon button--small" do %>
+      <%= link to: admin_tag_closure_path(@conn, :edit, @tag, @tag_closure), class: "button button-link button--icon button--small" do %>
         <i class="icon icon--edit"></i>
       <% end %>
-      <%= button to: admin_tag_closure_path(@conn, :delete, @tag_closure), method: :delete, class: "button button-link button--icon button--small", form: [class: "button button--icon button--small"] do %>
+      <%= button to: admin_tag_closure_path(@conn, :delete, @tag, @tag_closure), method: :delete, class: "button button-link button--icon button--small", form: [class: "button button--icon button--small"] do %>
         <i class="icon icon--delete"></i>
       <% end %>
     </div>

--- a/web/templates/admin/tag_closure/show.html.eex
+++ b/web/templates/admin/tag_closure/show.html.eex
@@ -1,0 +1,52 @@
+
+  <div class="profile-header">
+    <div class="profile-header__info">
+      <h1><%= gettext "Show tag closure" %></h1>
+    </div>
+  </div>
+</header>
+<%= render Vutuv.LayoutView, "flash.html", assigns %>
+
+<div class="breadcrumbs">
+<%= Vutuv.UserHelpers.gen_breadcrumbs([
+      {gettext("Tag closures"), admin_tag_closure_path(@conn, :index)},
+      gettext("Show")]) %>
+</div>
+
+<div class="card-list">
+  <section class="card">
+    <div class="card__edit button__list">
+      <%= link to: admin_tag_closure_path(@conn, :edit, @tag_closure), class: "button button-link button--icon button--small" do %>
+        <i class="icon icon--edit"></i>
+      <% end %>
+      <%= button to: admin_tag_closure_path(@conn, :delete, @tag_closure), method: :delete, class: "button button-link button--icon button--small", form: [class: "button button--icon button--small"] do %>
+        <i class="icon icon--delete"></i>
+      <% end %>
+    </div>
+    
+      <h1>
+        <strong><%= gettext "Parent" %>:</strong>
+      </h1>
+      <p>
+        <%= @tag_closure.parent_id %>
+      </p>
+    
+      <h1>
+        <strong><%= gettext "Child" %>:</strong>
+      </h1>
+      <p>
+        <%= @tag_closure.child_id %>
+      </p>
+    
+      <h1>
+        <strong><%= gettext "Depth" %>:</strong>
+      </h1>
+      <p>
+        <%= @tag_closure.depth %>
+      </p>
+    
+  </section>
+  <aside>
+    <%= render Vutuv.SharedView, "_ad.html" %>
+  </aside>
+</div>

--- a/web/views/admin/tag_closure_view.ex
+++ b/web/views/admin/tag_closure_view.ex
@@ -1,0 +1,3 @@
+defmodule Vutuv.Admin.TagClosureView do
+  use Vutuv.Web, :view
+end


### PR DESCRIPTION
Adds a closure table system to tags, allowing linking of two tags as parent and child. This system will allow for rapid comparison of tags by recommendation systems to determine how similar two tagged datasets are.

Currently tag_closures exist completely within the admin framework. The closure interface is accessible via the `View related tags` link on a tag's show page.

![image](https://cloud.githubusercontent.com/assets/11078691/21875079/d7135dc2-d83e-11e6-8a26-7795020acf5f.png)

This link leads to the following page

![image](https://cloud.githubusercontent.com/assets/11078691/21875117/1b895ef2-d83f-11e6-8632-f80490853562.png)

The options being `Add a parent` and `Add a child`. They do exactly as they say, and both link to a similar form. 

![image](https://cloud.githubusercontent.com/assets/11078691/21875144/7263f084-d83f-11e6-9844-12dae31f81f0.png)


The value field accepts a tag's `slug`, a lowercase string that serves as the identifier for the tag. In this case I'm going to add a child `bmw` to the tag `car`, as BMW is a type of car.

![image](https://cloud.githubusercontent.com/assets/11078691/21875190/cc35180e-d83f-11e6-9e7e-f4e4c62e2d58.png)

The result is as shown. Now lets add a BMW model as a child of `bmw`.

![image](https://cloud.githubusercontent.com/assets/11078691/21875214/f0ab7124-d83f-11e6-96f5-1f83d36cd797.png)

And after doing this, lets look at related tags to `car`.

![image](https://cloud.githubusercontent.com/assets/11078691/21875217/044ffcd6-d840-11e6-97f0-af89ebfa4c05.png)

Closure tables function by "closing" each link between a possible parent and child. Since `bmw` is a child of `car`, its children are also children of `car`. The distance between the tag in question and it's children are called the depth. `bmw` is an immediate child of `car`, so it's depth is one. Not shown in the list are self-referential closures that help behind the scenes, which have each tag as it's own child and parent, with a depth of 0.
To illustrate this, the database query `select * from tag_closures where parent_id = child_id;` returns
```
+-----+-----------+----------+-------+
| id  | parent_id | child_id | depth |
+-----+-----------+----------+-------+
| 153 |         7 |        7 |     0 |
| 154 |         8 |        8 |     0 |
| 157 |         9 |        9 |     0 |
| 161 |        10 |       10 |     0 |
| 165 |        12 |       12 |     0 |
| 169 |        13 |       13 |     0 |
| 174 |        11 |       11 |     0 |
| 239 |        15 |       15 |     0 |
+-----+-----------+----------+-------+
```

A few validations are appropriate here, the first is a unique index `parent_id_child_id`, as there should never be two identical closures that have different depths. Another validation is closures cannot exist at the same time as their reverse, as that would imply a circular tree. For example, if a closure `parent_id = 1, child_id = 2` exists, the reverse `parent_id=2, child_id=1` cannot be added.
