### PR TITLE
User email generation

### DIFF
--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -91,7 +91,7 @@ defmodule Vutuv.Accounts do
   end
 
   @doc """
-  Deletes a User.
+  Deletes a user.
   """
   @spec delete_user(User.t()) :: {:ok, User.t()} | changeset_error
   def delete_user(%User{} = user) do
@@ -108,6 +108,9 @@ defmodule Vutuv.Accounts do
 
   @doc """
   Confirms a user's email.
+
+  This function sets the user's confirmed_at value, and the email_address's
+  verified value, to true.
   """
   @spec confirm_user_email(User.t()) :: {:ok, User.t()} | changeset_error
   def confirm_user_email(%User{confirmed_at: nil} = user) do
@@ -149,7 +152,7 @@ defmodule Vutuv.Accounts do
   end
 
   @doc """
-  Returns the list of email_addresses.
+  Returns the list of a user's email_addresses.
   """
   @spec list_email_addresses(User.t()) :: [EmailAddress.t()]
   def list_email_addresses(user) do
@@ -163,15 +166,11 @@ defmodule Vutuv.Accounts do
   def get_email_address(id), do: Repo.get(EmailAddress, id)
 
   @doc """
-  Creates a email_address.
+  Creates an email_address.
   """
   @spec create_email_address(User.t(), map) :: {:ok, EmailAddress.t()} | changeset_error
-  def create_email_address(%User{id: user_id} = user, attrs \\ %{}) do
-    email_count =
-      EmailAddress
-      |> where([e], e.user_id == ^user_id)
-      |> Repo.aggregate(:count, :id)
-
+  def create_email_address(%User{} = user, attrs \\ %{}) do
+    email_count = length(user.email_addresses)
     attrs = Map.put(attrs, "position", email_count + 1)
 
     user
@@ -181,7 +180,7 @@ defmodule Vutuv.Accounts do
   end
 
   @doc """
-  Updates a email_address.
+  Updates an email_address.
   """
   @spec update_email_address(EmailAddress.t(), map) :: {:ok, EmailAddress.t()} | changeset_error
   def update_email_address(%EmailAddress{} = email_address, attrs) do
@@ -191,7 +190,7 @@ defmodule Vutuv.Accounts do
   end
 
   @doc """
-  Deletes a EmailAddress.
+  Deletes an email_address.
   """
   @spec delete_email_address(EmailAddress.t()) :: {:ok, EmailAddress.t()} | changeset_error
   def delete_email_address(%EmailAddress{} = email_address) do

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -2,12 +2,12 @@ defmodule Vutuv.Accounts do
   @moduledoc """
   The Accounts context.
   """
+
   import Ecto
   import Ecto.Query, warn: false
 
-  alias Vutuv.{Accounts.User, Repo, Sessions, Sessions.Session, Accounts.EmailAddress}
-
-  @dialyzer {:nowarn_function, get_gravatar: 2}
+  alias Vutuv.{Repo, Sessions, Sessions.Session}
+  alias Vutuv.Accounts.{EmailAddress, User}
 
   @type changeset_error :: {:error, Ecto.Changeset.t()}
 
@@ -16,11 +16,11 @@ defmodule Vutuv.Accounts do
   """
   @spec list_users() :: [User.t()]
   def list_users() do
-    Repo.all(
-      from u in User,
-        join: e in assoc(u, :email_addresses),
-        preload: [email_addresses: e]
-    )
+    User
+    |> join(:left, [u], _ in assoc(u, :email_addresses))
+    |> join(:left, [u], _ in assoc(u, :profile))
+    |> preload([_, e, p], email_addresses: e, profile: p)
+    |> Repo.all()
   end
 
   @doc """
@@ -28,12 +28,12 @@ defmodule Vutuv.Accounts do
   """
   @spec get_user(integer) :: User.t() | nil
   def get_user(id) do
-    Repo.one(
-      from u in User,
-        where: u.id == ^id,
-        join: e in assoc(u, :email_addresses),
-        preload: [email_addresses: e]
-    )
+    User
+    |> where([u], u.id == ^id)
+    |> join(:left, [u], _ in assoc(u, :email_addresses))
+    |> join(:left, [u], _ in assoc(u, :profile))
+    |> preload([_, e, p], email_addresses: e, profile: p)
+    |> Repo.one()
   end
 
   @doc """
@@ -48,12 +48,10 @@ defmodule Vutuv.Accounts do
   end
 
   def get_by(%{"email" => email}) do
-    Repo.one(
-      from u in User,
-        join: e in assoc(u, :email_addresses),
-        where: e.value == ^email,
-        preload: [email_addresses: e]
-    )
+    case Repo.get_by(EmailAddress, %{value: email}) do
+      %EmailAddress{user_id: user_id} -> get_user(user_id)
+      _ -> nil
+    end
   end
 
   def get_by(%{"user_id" => user_id}), do: Repo.get(User, user_id)
@@ -63,40 +61,23 @@ defmodule Vutuv.Accounts do
   """
   @spec create_user(map) :: {:ok, User.t()} | changeset_error
   def create_user(attrs) do
-    user = User.create_changeset(%User{}, attrs)
-
-    email =
-      EmailAddress.changeset(%EmailAddress{}, %{
-        value: attrs["email"],
-        position: 1,
-        description: "email when registering vutuv"
-      })
-
-    profile_attrs = %{
-      first_name: attrs["first_name"],
-      last_name: attrs["last_name"],
-      gender: attrs["gender"]
+    email_attrs = %{
+      "value" => attrs["email"],
+      "position" => 1,
+      "description" => "email when registering vutuv"
     }
 
-    user_with_email = Ecto.Changeset.put_assoc(user, :email_addresses, [email])
+    profile_attrs = %{
+      "gender" => attrs["gender"],
+      "first_name" => attrs["first_name"],
+      "last_name" => attrs["last_name"]
+    }
 
-    case Repo.insert(user_with_email) do
-      {:ok, new_user} ->
-        img = get_gravatar(attrs["email"], new_user.id)
-        profile_attrs_update = Map.put(profile_attrs, :avatar, img)
-        user_with_profile = Ecto.build_assoc(new_user, :profile, profile_attrs_update)
+    attrs = Map.merge(attrs, %{"email_addresses" => [email_attrs], "profile" => profile_attrs})
 
-        case Repo.insert(user_with_profile) do
-          {:ok, _} ->
-            {:ok, new_user}
-
-          {:error, changeset} ->
-            {:error, changeset}
-        end
-
-      {:error, changeset} ->
-        {:error, changeset}
-    end
+    %User{}
+    |> User.create_changeset(attrs)
+    |> Repo.insert()
   end
 
   @doc """
@@ -128,13 +109,17 @@ defmodule Vutuv.Accounts do
   @doc """
   Confirms a user's email.
   """
-  @spec confirm_user(User.t()) :: {:ok, User.t()} | changeset_error
-  def confirm_user(%User{} = user) do
+  @spec confirm_user_email(User.t()) :: {:ok, User.t()} | changeset_error
+  def confirm_user_email(%User{confirmed_at: nil} = user) do
     user |> User.confirm_changeset() |> Repo.update()
+    confirm_email(user)
+  end
 
-    email_address = hd(user.email_addresses)
+  def confirm_user_email(user), do: confirm_email(user)
 
-    email_address
+  defp confirm_email(%User{current_email: email, email_addresses: email_addresses}) do
+    email_addresses
+    |> Enum.find(&(&1.value == email))
     |> EmailAddress.verify_changeset()
     |> Repo.update()
   end
@@ -159,82 +144,35 @@ defmodule Vutuv.Accounts do
     Sessions.delete_user_sessions(user)
 
     user
-    |> User.create_changeset(attrs)
-    |> User.password_updated_changeset()
+    |> User.update_password_changeset(attrs)
     |> Repo.update()
   end
 
   @doc """
   Returns the list of email_addresses.
-
-  ## Examples
-
-      iex> list_email_addresses()
-      [%EmailAddress{}, ...]
-
   """
-  @spec list_email_addresses() :: [EmailAddress.t()]
-  def list_email_addresses do
-    Repo.all(EmailAddress)
+  @spec list_email_addresses(User.t()) :: [EmailAddress.t()]
+  def list_email_addresses(user) do
+    Repo.all(assoc(user, :email_addresses))
   end
 
   @doc """
   Gets a single email_address.
-
-  ## Examples
-
-      iex> get_email_address(123)
-      %EmailAddress{}
-
-      iex> get_email_address(456)
-      nil
-
   """
   @spec get_email_address(integer) :: EmailAddress.t() | nil
   def get_email_address(id), do: Repo.get(EmailAddress, id)
 
-  @spec list_email_address_user(integer) :: [String.t()] | nil
-  def list_email_address_user(user_id) do
-    query =
-      from e in EmailAddress,
-        select: e.value,
-        where: e.user_id == ^user_id
-
-    Repo.all(query)
-  end
-
   @doc """
   Creates a email_address.
-
-  ## Examples
-
-      iex> create_email_address(%{field: value})
-      {:ok, %EmailAddress{}}
-
-      iex> create_email_address(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
   """
-  @spec create_email_address(map) :: {:ok, EmailAddress.t()} | changeset_error
-  def create_email_address(attrs \\ %{}) do
-    user_id = check_user_id(attrs["user_id"])
+  @spec create_email_address(User.t(), map) :: {:ok, EmailAddress.t()} | changeset_error
+  def create_email_address(%User{id: user_id} = user, attrs \\ %{}) do
+    email_count =
+      EmailAddress
+      |> where([e], e.user_id == ^user_id)
+      |> Repo.aggregate(:count, :id)
 
-    last_email =
-      Repo.one(
-        from e in EmailAddress,
-          order_by: [desc: e.position],
-          where: e.user_id == ^user_id,
-          limit: 1
-      )
-
-    user = get_user(user_id) |> Repo.preload(:email_addresses)
-
-    attrs =
-      if last_email == nil do
-        %{attrs | "position" => 1}
-      else
-        %{attrs | "position" => Integer.to_string(last_email.position + 1)}
-      end
+    attrs = Map.put(attrs, "position", email_count + 1)
 
     user
     |> build_assoc(:email_addresses)
@@ -244,15 +182,6 @@ defmodule Vutuv.Accounts do
 
   @doc """
   Updates a email_address.
-
-  ## Examples
-
-      iex> update_email_address(email_address, %{field: new_value})
-      {:ok, %EmailAddress{}}
-
-      iex> update_email_address(email_address, %{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
   """
   @spec update_email_address(EmailAddress.t(), map) :: {:ok, EmailAddress.t()} | changeset_error
   def update_email_address(%EmailAddress{} = email_address, attrs) do
@@ -263,15 +192,6 @@ defmodule Vutuv.Accounts do
 
   @doc """
   Deletes a EmailAddress.
-
-  ## Examples
-
-      iex> delete_email_address(email_address)
-      {:ok, %EmailAddress{}}
-
-      iex> delete_email_address(email_address)
-      {:error, %Ecto.Changeset{}}
-
   """
   @spec delete_email_address(EmailAddress.t()) :: {:ok, EmailAddress.t()} | changeset_error
   def delete_email_address(%EmailAddress{} = email_address) do
@@ -280,66 +200,9 @@ defmodule Vutuv.Accounts do
 
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking email_address changes.
-
-  ## Examples
-
-      iex> change_email_address(email_address)
-      %Ecto.Changeset{source: %EmailAddress{}}
-
   """
-  @spec change_user(EmailAddress.t()) :: Ecto.Changeset.t()
+  @spec change_email_address(EmailAddress.t()) :: Ecto.Changeset.t()
   def change_email_address(%EmailAddress{} = email_address) do
     EmailAddress.changeset(email_address, %{})
-  end
-
-  defp get_gravatar(primary_email, userid) do
-    hash =
-      primary_email
-      |> String.trim()
-      |> String.downcase()
-      |> :erlang.md5()
-      |> Base.encode16(case: :lower)
-
-    Application.ensure_all_started(:inets)
-    Application.ensure_all_started(:ssl)
-
-    img = 'https://www.gravatar.com/avatar/#{hash}?s=150&d=404'
-
-    if {:ok, {status, header, body}} = :httpc.request(:get, {img, []}, [], []) do
-      case status do
-        {_, 200, 'OK'} ->
-          create_upload(header, body, userid)
-
-        _ ->
-          nil
-      end
-    end
-  end
-
-  defp create_upload(header, body, userid) do
-    content_type = find_content_type(header) |> to_string
-    filextension = String.replace(content_type, "image/", "")
-    filename = "original.#{filextension}"
-    path = "#{Application.get_env(:vutuv, :storage_dir)}" <> "#{userid}/"
-    File.write(path <> filename, body)
-
-    %{
-      file_name: filename,
-      updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
-    }
-  end
-
-  defp find_content_type(header) do
-    Enum.reduce(header, fn {k, v}, acc ->
-      if k == 'Content-Type' or k == 'content-type', do: v, else: acc
-    end)
-  end
-
-  defp check_user_id(userid) do
-    if is_binary(userid) do
-      userid |> String.to_integer()
-    else
-      userid
-    end
   end
 end

--- a/lib/vutuv/accounts/email_address.ex
+++ b/lib/vutuv/accounts/email_address.ex
@@ -31,7 +31,7 @@ defmodule Vutuv.Accounts.EmailAddress do
   @doc false
   def changeset(email_address, attrs) do
     email_address
-    |> cast(attrs, [:user_id, :value, :description, :is_public, :position, :verified])
+    |> cast(attrs, [:user_id, :value, :description, :is_public, :position])
     |> validate_required([:value])
     |> validate_format(:value, ~r/^[A-Za-z0-9\._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/)
     |> validate_length(:value, max: 255)

--- a/lib/vutuv/accounts/email_address.ex
+++ b/lib/vutuv/accounts/email_address.ex
@@ -18,12 +18,12 @@ defmodule Vutuv.Accounts.EmailAddress do
         }
 
   schema "email_addresses" do
-    belongs_to :user, User
     field :value, :string
     field :description, :string
     field :is_public, :boolean, default: true
     field :position, :integer
     field :verified, :boolean, default: false
+    belongs_to :user, User
 
     timestamps()
   end

--- a/lib/vutuv/biographies.ex
+++ b/lib/vutuv/biographies.ex
@@ -13,12 +13,6 @@ defmodule Vutuv.Biographies do
 
   @doc """
   Returns the list of profiles.
-
-  ## Examples
-
-      iex> list_profiles()
-      [%Profile{}, ...]
-
   """
   @spec list_profiles() :: [Profile.t()]
   def list_profiles do
@@ -27,15 +21,6 @@ defmodule Vutuv.Biographies do
 
   @doc """
   Gets a single profile.
-
-  ## Examples
-
-      iex> get_profile(123)
-      %Profile{}
-
-      iex> get_profile(456)
-      nil
-
   """
   @spec get_profile(integer) :: Profile.t() | nil
   def get_profile(id), do: Repo.get(Profile, id)
@@ -51,15 +36,6 @@ defmodule Vutuv.Biographies do
 
   @doc """
   Creates a profile.
-
-  ## Examples
-
-      iex> create_profile(%{field: value})
-      {:ok, %Profile{}}
-
-      iex> create_profile(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
   """
   @spec create_profile(map) :: {:ok, Profile.t()} | changeset_error
   def create_profile(attrs \\ %{}) do
@@ -70,15 +46,6 @@ defmodule Vutuv.Biographies do
 
   @doc """
   Updates a profile.
-
-  ## Examples
-
-      iex> update_profile(profile, %{field: new_value})
-      {:ok, %Profile{}}
-
-      iex> update_profile(profile, %{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
   """
   @spec update_profile(Profile.t(), map) :: {:ok, Profile.t()} | changeset_error
   def update_profile(%Profile{} = profile, attrs) do
@@ -89,15 +56,6 @@ defmodule Vutuv.Biographies do
 
   @doc """
   Deletes a Profile.
-
-  ## Examples
-
-      iex> delete_profile(profile)
-      {:ok, %Profile{}}
-
-      iex> delete_profile(profile)
-      {:error, %Ecto.Changeset{}}
-
   """
   @spec delete_profile(Profile.t()) :: {:ok, Profile.t()} | changeset_error
   def delete_profile(%Profile{} = profile) do
@@ -106,12 +64,6 @@ defmodule Vutuv.Biographies do
 
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking profile changes.
-
-  ## Examples
-
-      iex> change_profile(profile)
-      %Ecto.Changeset{source: %Profile{}}
-
   """
   @spec change_profile(Profile.t()) :: Ecto.Changeset.t()
   def change_profile(%Profile{} = profile) do

--- a/lib/vutuv_web/auth/confirm.ex
+++ b/lib/vutuv_web/auth/confirm.ex
@@ -1,0 +1,22 @@
+defmodule VutuvWeb.Auth.Confirm do
+  use Phauxth.Confirm.Base
+
+  alias Vutuv.{Accounts, Accounts.User}
+  alias VutuvWeb.Auth.Token
+
+  @impl true
+  def authenticate(%{"key" => token}, _user_context, opts) do
+    token
+    |> Token.verify(opts ++ [max_age: 1200])
+    |> get_user()
+  end
+
+  defp get_user({:ok, %{"email" => email} = data}) do
+    case Accounts.get_by(data) do
+      nil -> {:error, "no user found"}
+      user -> {:ok, %User{user | current_email: email}}
+    end
+  end
+
+  defp get_user({:error, message}), do: {:error, message}
+end

--- a/lib/vutuv_web/controllers/confirm_controller.ex
+++ b/lib/vutuv_web/controllers/confirm_controller.ex
@@ -1,22 +1,14 @@
 defmodule VutuvWeb.ConfirmController do
   use VutuvWeb, :controller
 
-  alias Phauxth.Confirm
   alias Vutuv.Accounts
-  alias VutuvWeb.Email
+  alias VutuvWeb.{Auth.Confirm, Email}
 
   def index(conn, params) do
     case Confirm.verify(params) do
-      {:ok, user} ->
-        Accounts.confirm_user(user)
-
-        email_addresses = Accounts.list_email_address_user(user.id)
-
-        for email_address <- email_addresses do
-          # if email_address.position == "1" or email_address.position == 1 do
-          Email.confirm_success(email_address)
-          # end
-        end
+      {:ok, %{current_email: email} = user} ->
+        Accounts.confirm_user_email(user)
+        Email.confirm_success(email)
 
         conn
         |> put_flash(:info, "Your account has been confirmed")

--- a/lib/vutuv_web/controllers/email_address_controller.ex
+++ b/lib/vutuv_web/controllers/email_address_controller.ex
@@ -1,11 +1,12 @@
 defmodule VutuvWeb.EmailAddressController do
   use VutuvWeb, :controller
 
-  alias Vutuv.Accounts
-  alias Vutuv.Accounts.EmailAddress
+  alias Vutuv.{Accounts, Accounts.EmailAddress}
 
   def index(conn, _params) do
-    email_addresses = Accounts.list_email_addresses()
+    user = conn.assigns.current_user
+
+    email_addresses = Accounts.list_email_addresses(user)
     render(conn, "index.html", email_addresses: email_addresses)
   end
 
@@ -15,7 +16,9 @@ defmodule VutuvWeb.EmailAddressController do
   end
 
   def create(conn, %{"email_address" => email_address_params}) do
-    case Accounts.create_email_address(email_address_params) do
+    user = conn.assigns.current_user
+
+    case Accounts.create_email_address(user, email_address_params) do
       {:ok, email_address} ->
         conn
         |> put_flash(:info, "Email address created successfully.")

--- a/lib/vutuv_web/controllers/email_address_controller.ex
+++ b/lib/vutuv_web/controllers/email_address_controller.ex
@@ -3,6 +3,8 @@ defmodule VutuvWeb.EmailAddressController do
 
   alias Vutuv.{Accounts, Accounts.EmailAddress}
 
+  @dialyzer {:nowarn_function, new: 2}
+
   def index(conn, _params) do
     user = conn.assigns.current_user
 

--- a/lib/vutuv_web/controllers/password_reset_controller.ex
+++ b/lib/vutuv_web/controllers/password_reset_controller.ex
@@ -42,12 +42,8 @@ defmodule VutuvWeb.PasswordResetController do
     end
   end
 
-  defp update_password({:ok, user}, conn, _params) do
-    email_addresses = user |> Accounts.list_email_addresses() |> Enum.map(& &1.value)
-
-    for email_address <- email_addresses do
-      Email.reset_success(email_address)
-    end
+  defp update_password({:ok, _user}, conn, %{"email" => email_address}) do
+    Email.reset_success(email_address)
 
     conn
     |> delete_session(:phauxth_session_id)

--- a/lib/vutuv_web/controllers/password_reset_controller.ex
+++ b/lib/vutuv_web/controllers/password_reset_controller.ex
@@ -43,7 +43,7 @@ defmodule VutuvWeb.PasswordResetController do
   end
 
   defp update_password({:ok, user}, conn, _params) do
-    email_addresses = Accounts.list_email_address_user(user.id)
+    email_addresses = user |> Accounts.list_email_addresses() |> Enum.map(& &1.value)
 
     for email_address <- email_addresses do
       Email.reset_success(email_address)

--- a/lib/vutuv_web/controllers/user_controller.ex
+++ b/lib/vutuv_web/controllers/user_controller.ex
@@ -9,7 +9,6 @@ defmodule VutuvWeb.UserController do
 
   @dialyzer {:nowarn_function, new: 2}
 
-  # the following plugs are defined in the controllers/authorize.ex file
   plug :user_check when action in [:index, :show]
   plug :id_check when action in [:edit, :update, :delete]
 
@@ -48,7 +47,7 @@ defmodule VutuvWeb.UserController do
   def show(%Plug.Conn{assigns: %{current_user: user}} = conn, %{"id" => id}) do
     user = if id == to_string(user.id), do: user, else: Accounts.get_user(id)
 
-    email_addresses = Accounts.list_email_address_user(id)
+    email_addresses = user |> Accounts.list_email_addresses() |> Enum.map(& &1.value)
     profile = Biographies.get_profile_user(id)
 
     render(conn, "show.html",

--- a/priv/repo/migrations/20190315081437_create_posts.exs
+++ b/priv/repo/migrations/20190315081437_create_posts.exs
@@ -3,16 +3,16 @@ defmodule Vutuv.Repo.Migrations.CreatePosts do
 
   def change do
     create table(:posts) do
+      add :user_id, references(:users, on_delete: :delete_all)
       add :body, :string
       add :title, :string
       add :page_info_cache, :string
       add :visibility_level, :string, default: "private"
       add :published_at, :utc_datetime
-      add :user_id, references(:users, on_delete: :delete_all)
 
       timestamps()
     end
 
-    create index(:posts, [:user_id])
+    create index(:posts, [:user_id, :title])
   end
 end

--- a/priv/repo/migrations/20190327171932_create_profiles.exs
+++ b/priv/repo/migrations/20190327171932_create_profiles.exs
@@ -22,5 +22,7 @@ defmodule Vutuv.Repo.Migrations.CreateProfiles do
 
       timestamps()
     end
+
+    create index(:profiles, [:user_id])
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -6,11 +6,23 @@
 #
 
 users = [
-  %{"email" => "jane.doe@example.com", "password" => "password"},
-  %{"email" => "john.smith@example.org", "password" => "password"}
+  %{
+    "email" => "jane.doe@example.com",
+    "password" => "password",
+    "gender" => "female",
+    "first_name" => "jane",
+    "last_name" => "doe"
+  },
+  %{
+    "email" => "john.smith@example.org",
+    "password" => "password",
+    "gender" => "male",
+    "first_name" => "john",
+    "last_name" => "smith"
+  }
 ]
 
 for user <- users do
   {:ok, user} = Vutuv.Accounts.create_user(user)
-  Vutuv.Accounts.confirm_user(user)
+  Vutuv.Accounts.confirm_user_email(user)
 end

--- a/test/support/auth_test_helpers.ex
+++ b/test/support/auth_test_helpers.ex
@@ -7,7 +7,14 @@ defmodule VutuvWeb.AuthTestHelpers do
   alias VutuvWeb.Auth.Token
 
   def add_user(email) do
-    user_params = %{"email" => email, "password" => "reallyHard2gue$$"}
+    user_params = %{
+      "email" => email,
+      "password" => "reallyHard2gue$$",
+      "gender" => Enum.random(["female", "male"]),
+      "first_name" => Faker.Name.first_name(),
+      "last_name" => Faker.Name.last_name()
+    }
+
     {:ok, user} = Accounts.create_user(user_params)
     user
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -6,6 +6,7 @@ defmodule Vutuv.Factory do
   def user_factory do
     %Vutuv.Accounts.User{
       email_addresses: build_list(1, :email_address),
+      profile: build(:profile),
       password_hash: Argon2.hash_pwd_salt("hard2gue$$"),
       confirmed_at: DateTime.truncate(DateTime.utc_now(), :second)
     }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -18,7 +18,7 @@ defmodule Vutuv.Factory do
       is_public: true,
       description: Faker.Company.bs(),
       position: 1,
-      verified: true
+      verified: false
     }
   end
 

--- a/test/vutuv/accounts/accounts_test.exs
+++ b/test/vutuv/accounts/accounts_test.exs
@@ -1,71 +1,86 @@
 defmodule Vutuv.AccountsTest do
   use Vutuv.DataCase
 
-  import VutuvWeb.AuthTestHelpers
+  alias Vutuv.{Accounts, Accounts.EmailAddress, Accounts.User}
+  alias Vutuv.Biographies.Profile
 
-  alias Vutuv.Accounts
-  alias Vutuv.Accounts.{EmailAddress, User}
+  @create_user_attrs %{
+    "email" => "fred@example.com",
+    "password" => "reallyHard2gue$$",
+    "gender" => "male",
+    "first_name" => "fred",
+    "last_name" => "frederickson"
+  }
+  @invalid_user_attrs %{"email" => "", "password" => ""}
+  @create_email_attrs %{
+    "is_public" => true,
+    "description" => "backup email",
+    "value" => "abcdef@vutuv.com",
+    "verified" => "true"
+  }
+  @update_email_attrs %{
+    "is_public" => false
+  }
+  @invalid_email_attrs %{
+    "value" => nil
+  }
 
-  @create_attrs %{"email" => "fred@example.com", "password" => "reallyHard2gue$$"}
-  @update_attrs %{"email" => "frederick@example.com", "password" => "reallyHard2gue$$"}
-  @invalid_attrs %{"email" => "", "password" => ""}
-
-  def fixture(:user, attrs \\ @create_attrs) do
+  def create_user(attrs \\ @create_user_attrs) do
     {:ok, user} = Accounts.create_user(attrs)
     user
   end
 
+  def create_email_address(user, attrs \\ @create_email_attrs) do
+    {:ok, email_address} = Accounts.create_email_address(user, attrs)
+    email_address
+  end
+
   describe "read user data" do
     test "list_users/1 returns all users" do
-      user = fixture(:user)
+      user = create_user()
       assert Accounts.list_users() == [user]
     end
 
-    test "get returns the user with given id" do
-      user = fixture(:user)
+    test "get_user returns the user with given id" do
+      user = create_user()
       assert Accounts.get_user(user.id) == user
     end
 
+    test "get_user returns email_addresses and profile" do
+      user = create_user()
+      user = Accounts.get_user(user.id)
+      assert [%EmailAddress{value: "fred@example.com", position: 1}] = user.email_addresses
+
+      assert %Profile{gender: "male", first_name: "fred", last_name: "frederickson"} =
+               user.profile
+    end
+
     test "change_user/1 returns a user changeset" do
-      user = fixture(:user)
+      user = create_user()
       assert %Ecto.Changeset{} = Accounts.change_user(user)
     end
   end
 
   describe "write user data" do
     test "create_user/1 with valid data creates a user" do
-      assert {:ok, %User{} = user} = Accounts.create_user(@create_attrs)
+      assert {:ok, %User{} = user} = Accounts.create_user(@create_user_attrs)
       email_address = hd(user.email_addresses)
       assert email_address.value == "fred@example.com"
     end
 
     test "create_user/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Accounts.create_user(@invalid_attrs)
-    end
-
-    test "update_user/2 with valid data updates the user" do
-      user = fixture(:user)
-      assert {:ok, user} = Accounts.update_user(user, @update_attrs)
-      assert %User{} = user
-      email_address = hd(user.email_addresses)
-      assert email_address.value == "fred@example.com"
-    end
-
-    test "update_user/2 with invalid data returns error changeset" do
-      user = fixture(:user)
-      assert {:error, %Ecto.Changeset{}} = Accounts.update_user(user, @invalid_attrs)
-      assert user == Accounts.get_user(user.id)
+      assert {:error, %Ecto.Changeset{}} = Accounts.create_user(@invalid_user_attrs)
     end
 
     test "update password changes the stored hash" do
-      %{password_hash: stored_hash} = user = fixture(:user)
+      %{password_hash: stored_hash} = user = create_user()
       attrs = %{password: "CN8W6kpb"}
       {:ok, %{password_hash: hash}} = Accounts.update_password(user, attrs)
       assert hash != stored_hash
     end
 
     test "update_password with weak password fails" do
-      user = fixture(:user)
+      user = create_user()
       attrs = %{password: "pass"}
       assert {:error, %Ecto.Changeset{}} = Accounts.update_password(user, attrs)
     end
@@ -73,43 +88,67 @@ defmodule Vutuv.AccountsTest do
 
   describe "delete user data" do
     test "delete_user/1 deletes the user" do
-      user = fixture(:user)
+      user = create_user()
       assert {:ok, %User{}} = Accounts.delete_user(user)
       refute Accounts.get_user(user.id)
     end
   end
 
-  describe "email_addresses" do
-    @valid_email_attrs %{
-      "is_public" => "true",
-      "description" => "some description",
-      "position" => "",
-      "value" => "abcdef@vutuv.com",
-      "user_id" => "1",
-      "verified" => "true"
-    }
-    @update_email_attrs %{
-      is_public: false,
-      description: "abcde@gmail.com",
-      position: 43,
-      user_id: 43,
-      value: "abcde@vutuv.com",
-      verified: false
-    }
-    @invalid_email_attrs %{
-      is_public: nil,
-      description: nil,
-      position: nil,
-      user_id: nil,
-      value: nil,
-      verified: nil
-    }
+  describe "read email_address data" do
+    test "list_email_addresses/1 returns all email addresses" do
+      user = create_user()
+      email_address = create_email_address(user)
+      assert email_address in Accounts.list_email_addresses(user)
+    end
 
-    setup do
-      user = add_user("abcde@vutuv.com")
-      %{@valid_email_attrs | "user_id" => user.id}
-      {:ok, email_address} = Accounts.create_email_address(@valid_email_attrs)
-      {:ok, %{email_address: email_address}}
+    test "get_email_address returns the email_address with given id" do
+      user = create_user()
+      email_address = create_email_address(user)
+      assert Accounts.get_email_address(email_address.id) == email_address
+    end
+
+    test "change_email_address/1 returns a email_address changeset" do
+      user = create_user()
+      email_address = create_email_address(user)
+      assert %Ecto.Changeset{} = Accounts.change_email_address(email_address)
+    end
+  end
+
+  describe "write email_address data" do
+    test "create_email_address/1 with valid data creates a email_address" do
+      user = create_user()
+
+      assert {:ok, %EmailAddress{} = email_address} =
+               Accounts.create_email_address(user, @create_email_attrs)
+
+      assert email_address.value == "abcdef@vutuv.com"
+      assert email_address.position == 2
+    end
+
+    test "create_email_address/1 with invalid data returns error changeset" do
+      user = create_user()
+
+      assert {:error, %Ecto.Changeset{}} =
+               Accounts.create_email_address(user, @invalid_email_attrs)
+    end
+
+    test "update email_address with valid data updates the email_address" do
+      user = create_user()
+      email_address = create_email_address(user)
+      assert email_address.is_public == true
+
+      assert {:ok, %EmailAddress{} = email_address} =
+               Accounts.update_email_address(email_address, @update_email_attrs)
+
+      assert email_address.is_public == false
+    end
+
+    test "update email_address with invalid data returns error changeset" do
+      user = create_user()
+      email_address = create_email_address(user)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Accounts.update_email_address(email_address, @invalid_email_attrs)
     end
   end
 end

--- a/test/vutuv/accounts/accounts_test.exs
+++ b/test/vutuv/accounts/accounts_test.exs
@@ -1,8 +1,10 @@
 defmodule Vutuv.AccountsTest do
   use Vutuv.DataCase
 
+  import Vutuv.Factory
+
   alias Vutuv.{Accounts, Accounts.EmailAddress, Accounts.User}
-  alias Vutuv.Biographies.Profile
+  alias Vutuv.{Biographies, Biographies.Profile}
 
   @create_user_attrs %{
     "email" => "fred@example.com",
@@ -11,43 +13,26 @@ defmodule Vutuv.AccountsTest do
     "first_name" => "fred",
     "last_name" => "frederickson"
   }
-  @invalid_user_attrs %{"email" => "", "password" => ""}
   @create_email_attrs %{
     "is_public" => true,
     "description" => "backup email",
-    "value" => "abcdef@vutuv.com",
-    "verified" => "true"
+    "value" => "abcdef@vutuv.com"
   }
-  @update_email_attrs %{
-    "is_public" => false
-  }
-  @invalid_email_attrs %{
-    "value" => nil
-  }
-
-  def create_user(attrs \\ @create_user_attrs) do
-    {:ok, user} = Accounts.create_user(attrs)
-    user
-  end
-
-  def create_email_address(user, attrs \\ @create_email_attrs) do
-    {:ok, email_address} = Accounts.create_email_address(user, attrs)
-    email_address
-  end
 
   describe "read user data" do
-    test "list_users/1 returns all users" do
-      user = create_user()
+    setup [:create_user]
+
+    test "list_users/1 returns all users", %{user: user} do
       assert Accounts.list_users() == [user]
+      insert(:user)
+      assert length(Accounts.list_users()) == 2
     end
 
-    test "get_user returns the user with given id" do
-      user = create_user()
+    test "get_user returns the user with given id", %{user: user} do
       assert Accounts.get_user(user.id) == user
     end
 
-    test "get_user returns email_addresses and profile" do
-      user = create_user()
+    test "get_user returns email_addresses and profile", %{user: user} do
       user = Accounts.get_user(user.id)
       assert [%EmailAddress{value: "fred@example.com", position: 1}] = user.email_addresses
 
@@ -55,8 +40,7 @@ defmodule Vutuv.AccountsTest do
                user.profile
     end
 
-    test "change_user/1 returns a user changeset" do
-      user = create_user()
+    test "change_user/1 returns a user changeset", %{user: user} do
       assert %Ecto.Changeset{} = Accounts.change_user(user)
     end
   end
@@ -64,60 +48,94 @@ defmodule Vutuv.AccountsTest do
   describe "write user data" do
     test "create_user/1 with valid data creates a user" do
       assert {:ok, %User{} = user} = Accounts.create_user(@create_user_attrs)
-      email_address = hd(user.email_addresses)
-      assert email_address.value == "fred@example.com"
+      assert [%EmailAddress{value: value, position: 1}] = user.email_addresses
+      assert value == "fred@example.com"
     end
 
     test "create_user/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Accounts.create_user(@invalid_user_attrs)
+      invalid_attrs = Map.merge(@create_user_attrs, %{"email" => ""})
+      assert {:error, %Ecto.Changeset{} = changeset} = Accounts.create_user(invalid_attrs)
+      assert %{email_addresses: [%{value: ["can't be blank"]}]} = errors_on(changeset)
+      invalid_attrs = Map.merge(@create_user_attrs, %{"password" => nil})
+      assert {:error, %Ecto.Changeset{} = changeset} = Accounts.create_user(invalid_attrs)
+      assert %{password: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "invalid email returns email_addresses error" do
+      attrs = Map.merge(@create_user_attrs, %{"email" => "invalid_email"})
+      assert {:error, changeset} = Accounts.create_user(attrs)
+      assert %{email_addresses: [%{value: ["has invalid format"]}]} = errors_on(changeset)
+    end
+
+    test "no first name or last name returns profile error" do
+      attrs = Map.merge(@create_user_attrs, %{"first_name" => "", "last_name" => ""})
+      assert {:error, changeset} = Accounts.create_user(attrs)
+
+      assert %{
+               profile: %{
+                 first_name: ["First name or last name must be present"],
+                 last_name: ["First name or last name must be present"]
+               }
+             } = errors_on(changeset)
     end
 
     test "update password changes the stored hash" do
-      %{password_hash: stored_hash} = user = create_user()
+      %{password_hash: stored_hash} = user = insert(:user)
       attrs = %{password: "CN8W6kpb"}
       {:ok, %{password_hash: hash}} = Accounts.update_password(user, attrs)
       assert hash != stored_hash
     end
 
     test "update_password with weak password fails" do
-      user = create_user()
+      user = insert(:user)
       attrs = %{password: "pass"}
       assert {:error, %Ecto.Changeset{}} = Accounts.update_password(user, attrs)
     end
   end
 
   describe "delete user data" do
-    test "delete_user/1 deletes the user" do
-      user = create_user()
+    setup [:create_user]
+
+    test "delete_user/1 deletes the user and associated tables", %{user: user} do
+      [email_address] = user.email_addresses
+      profile = user.profile
       assert {:ok, %User{}} = Accounts.delete_user(user)
       refute Accounts.get_user(user.id)
+      refute Accounts.get_email_address(email_address.id)
+      refute Biographies.get_profile(profile.id)
     end
   end
 
   describe "read email_address data" do
-    test "list_email_addresses/1 returns all email addresses" do
-      user = create_user()
-      email_address = create_email_address(user)
+    setup [:create_user, :create_email_address]
+
+    test "list_email_addresses/1 returns all a user's email addresses", %{
+      email_address: email_address,
+      user: user
+    } do
+      assert length(Accounts.list_email_addresses(user)) == 2
       assert email_address in Accounts.list_email_addresses(user)
+      insert(:email_address, %{user: user})
+      assert length(Accounts.list_email_addresses(user)) == 3
     end
 
-    test "get_email_address returns the email_address with given id" do
-      user = create_user()
-      email_address = create_email_address(user)
+    test "get_email_address returns the email_address with given id", %{
+      email_address: email_address
+    } do
       assert Accounts.get_email_address(email_address.id) == email_address
     end
 
-    test "change_email_address/1 returns a email_address changeset" do
-      user = create_user()
-      email_address = create_email_address(user)
+    test "change_email_address/1 returns a email_address changeset", %{
+      email_address: email_address
+    } do
       assert %Ecto.Changeset{} = Accounts.change_email_address(email_address)
     end
   end
 
   describe "write email_address data" do
-    test "create_email_address/1 with valid data creates a email_address" do
-      user = create_user()
+    setup [:create_user]
 
+    test "create_email_address/1 with valid data creates a email_address", %{user: user} do
       assert {:ok, %EmailAddress{} = email_address} =
                Accounts.create_email_address(user, @create_email_attrs)
 
@@ -125,30 +143,61 @@ defmodule Vutuv.AccountsTest do
       assert email_address.position == 2
     end
 
-    test "create_email_address/1 with invalid data returns error changeset" do
-      user = create_user()
-
-      assert {:error, %Ecto.Changeset{}} =
-               Accounts.create_email_address(user, @invalid_email_attrs)
+    test "position of new email_address is last", %{user: user} do
+      [email_address] = user.email_addresses
+      assert email_address.position == 1
+      email_attrs = Map.merge(@create_email_attrs, %{"value" => "xyz@vutuv.com"})
+      {:ok, email_address} = Accounts.create_email_address(user, email_attrs)
+      assert email_address.position == 2
+      email_attrs = Map.merge(@create_email_attrs, %{"value" => "zyx@vutuv.com"})
+      user = Accounts.get_user(user.id)
+      {:ok, email_address} = Accounts.create_email_address(user, email_attrs)
+      assert email_address.position == 3
     end
 
-    test "update email_address with valid data updates the email_address" do
-      user = create_user()
-      email_address = create_email_address(user)
+    test "create_email_address/1 with invalid data returns error changeset", %{user: user} do
+      assert {:error, %Ecto.Changeset{}} = Accounts.create_email_address(user, %{"value" => nil})
+    end
+
+    test "cannot set verified to true at creation time", %{user: user} do
+      attrs = Map.merge(@create_email_attrs, %{"verified" => true})
+      assert {:ok, %EmailAddress{verified: false}} = Accounts.create_email_address(user, attrs)
+    end
+
+    test "update email_address with valid data updates the email_address", %{user: user} do
+      email_address = insert(:email_address, %{user: user})
       assert email_address.is_public == true
 
       assert {:ok, %EmailAddress{} = email_address} =
-               Accounts.update_email_address(email_address, @update_email_attrs)
+               Accounts.update_email_address(email_address, %{"is_public" => false})
 
       assert email_address.is_public == false
     end
 
-    test "update email_address with invalid data returns error changeset" do
-      user = create_user()
-      email_address = create_email_address(user)
+    test "update email_address with invalid data returns error changeset", %{user: user} do
+      email_address = insert(:email_address, %{user: user})
 
       assert {:error, %Ecto.Changeset{}} =
-               Accounts.update_email_address(email_address, @invalid_email_attrs)
+               Accounts.update_email_address(email_address, %{"value" => nil})
     end
+  end
+
+  describe "delete email_address data" do
+    setup [:create_user, :create_email_address]
+
+    test "delete_email_address/1 deletes the email_address", %{email_address: email_address} do
+      assert {:ok, %EmailAddress{}} = Accounts.delete_email_address(email_address)
+      refute Accounts.get_email_address(email_address.id)
+    end
+  end
+
+  defp create_user(_) do
+    {:ok, user} = Accounts.create_user(@create_user_attrs)
+    {:ok, %{user: user}}
+  end
+
+  defp create_email_address(%{user: user}) do
+    {:ok, email_address} = Accounts.create_email_address(user, @create_email_attrs)
+    {:ok, %{email_address: email_address}}
   end
 end

--- a/test/vutuv/sessions/sessions_test.exs
+++ b/test/vutuv/sessions/sessions_test.exs
@@ -4,7 +4,14 @@ defmodule Vutuv.SessionsTest do
   alias Vutuv.{Accounts, Sessions, Sessions.Session}
 
   setup do
-    attrs = %{"email" => "fred@example.com", "password" => "reallyHard2gue$$"}
+    attrs = %{
+      "email" => "fred@example.com",
+      "password" => "reallyHard2gue$$",
+      "gender" => "male",
+      "first_name" => "fred",
+      "last_name" => "frederickson"
+    }
+
     {:ok, user} = Accounts.create_user(attrs)
     {:ok, user: user}
   end

--- a/test/vutuv_web/controllers/user_controller_test.exs
+++ b/test/vutuv_web/controllers/user_controller_test.exs
@@ -4,8 +4,13 @@ defmodule VutuvWeb.UserControllerTest do
   import VutuvWeb.AuthTestHelpers
   alias Vutuv.Accounts
 
-  @create_attrs %{email: "bill@example.com", password: "hard2guess"}
-  @update_attrs %{email: "william@example.com"}
+  @create_attrs %{
+    "email" => "bill@example.com",
+    "password" => "reallyHard2gue$$",
+    "gender" => "male",
+    "first_name" => "bill",
+    "last_name" => "shakespeare"
+  }
   @invalid_attrs %{email: nil}
 
   setup %{conn: conn} = config do
@@ -70,28 +75,6 @@ defmodule VutuvWeb.UserControllerTest do
     test "does not create user and renders errors when data is invalid", %{conn: conn} do
       conn = post(conn, Routes.user_path(conn, :create), user: @invalid_attrs)
       assert html_response(conn, 200) =~ "Sign up"
-    end
-  end
-
-  @tag :skip
-  describe "updates user" do
-    @tag login: "reg@example.com"
-    test "updates chosen user when data is valid", %{conn: conn, user: user} do
-      conn = put(conn, Routes.user_path(conn, :update, user), user: @update_attrs)
-      assert redirected_to(conn) == Routes.user_path(conn, :show, user)
-      updated_user = Accounts.get_user(user.id)
-      assert updated_user.email == "william@example.com"
-      conn = get(conn, Routes.user_path(conn, :show, user))
-      assert html_response(conn, 200) =~ "william@example.com"
-    end
-
-    @tag login: "reg@example.com"
-    test "does not update chosen user and renders errors when data is invalid", %{
-      conn: conn,
-      user: user
-    } do
-      conn = put(conn, Routes.user_path(conn, :update, user), user: @invalid_attrs)
-      assert html_response(conn, 200) =~ "Edit User"
     end
   end
 


### PR DESCRIPTION
This PR updates how the user and email addresses are created and queried, and it also updates the user / email_address tests.

## Users

The user changeset makes sure that the required email_address and profile values are present before allowing the user to be created.

All user queries preload the email_addresses and profile.

## Email addresses

When creating an email_address, the User struct is now needed (as the first argument).

The `list_email_addresses` function returns all the email_addresses for a specific user (there should be no need to have a function that lists all the email_addresses in the database).

The changeset has been updated so that `verified` cannot be set at email_address creation time.

## User / email_address confirmation

There are now two steps in the confirmation process - user confirmation, which happens when the first email_address is confirmed, and email_address confirmation (setting verified to true).

## Additional notes

The `get_gravatar` function has been temporarily removed. It is going to be replaced with an async version, as outlined in #611.
