### PR TITLE
Simplify forms

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -37,8 +37,6 @@ config :phoenix, :json_library, Jason
 config :arc,
   storage: Arc.Storage.Local
 
-config :slugger, separator_char: ?-
-
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -67,13 +67,7 @@ defmodule Vutuv.Accounts do
       "description" => "email when registering vutuv"
     }
 
-    profile_attrs = %{
-      "gender" => attrs["gender"],
-      "first_name" => attrs["first_name"],
-      "last_name" => attrs["last_name"]
-    }
-
-    attrs = Map.merge(attrs, %{"email_addresses" => [email_attrs], "profile" => profile_attrs})
+    attrs = Map.merge(attrs, %{"email_addresses" => [email_attrs]})
 
     %User{}
     |> User.create_changeset(attrs)

--- a/lib/vutuv/biographies/profile.ex
+++ b/lib/vutuv/biographies/profile.ex
@@ -16,9 +16,7 @@ defmodule Vutuv.Biographies.Profile do
           middlename: String.t(),
           nickname: String.t(),
           gender: String.t(),
-          birthday_day: integer,
-          birthday_month: integer,
-          birthday_year: integer,
+          birthday: Date.t(),
           active_slug: String.t(),
           avatar: String.t(),
           headline: String.t(),
@@ -37,9 +35,7 @@ defmodule Vutuv.Biographies.Profile do
     field :middlename, :string
     field :nickname, :string
     field :gender, :string
-    field :birthday_day, :integer
-    field :birthday_month, :integer
-    field :birthday_year, :integer
+    field :birthday, :date
     field :active_slug, :string
     field :avatar, Vutuv.Avatar.Type
     field :headline, :string
@@ -66,9 +62,7 @@ defmodule Vutuv.Biographies.Profile do
       :honorific_prefix,
       :honorific_suffix,
       :gender,
-      :birthday_day,
-      :birthday_month,
-      :birthday_year,
+      :birthday,
       :locale,
       :active_slug,
       :headline,

--- a/lib/vutuv/biographies/profile.ex
+++ b/lib/vutuv/biographies/profile.ex
@@ -11,10 +11,8 @@ defmodule Vutuv.Biographies.Profile do
           id: integer,
           user_id: integer,
           user: User.t() | %Ecto.Association.NotLoaded{},
-          first_name: String.t(),
-          last_name: String.t(),
-          middlename: String.t(),
-          nickname: String.t(),
+          full_name: String.t(),
+          preferred_name: String.t(),
           gender: String.t(),
           birthday: Date.t(),
           active_slug: String.t(),
@@ -30,10 +28,8 @@ defmodule Vutuv.Biographies.Profile do
         }
 
   schema "profiles" do
-    field :first_name, :string
-    field :last_name, :string
-    field :middlename, :string
-    field :nickname, :string
+    field :full_name, :string
+    field :preferred_name, :string
     field :gender, :string
     field :birthday, :date
     field :active_slug, :string
@@ -55,10 +51,8 @@ defmodule Vutuv.Biographies.Profile do
   def changeset(profile, attrs) do
     profile
     |> cast(attrs, [
-      :first_name,
-      :last_name,
-      :middlename,
-      :nickname,
+      :full_name,
+      :preferred_name,
       :honorific_prefix,
       :honorific_suffix,
       :gender,
@@ -69,29 +63,11 @@ defmodule Vutuv.Biographies.Profile do
       :noindex?
     ])
     |> cast_attachments(attrs, [:avatar])
-    |> validate_required([:gender])
-    |> validate_first_name_or_last_name(attrs)
-    |> validate_length(:first_name, max: 80)
-    |> validate_length(:last_name, max: 80)
-    |> validate_length(:middlename, max: 80)
-    |> validate_length(:nickname, max: 80)
+    |> validate_required([:full_name, :gender])
+    |> validate_length(:full_name, max: 80)
+    |> validate_length(:preferred_name, max: 80)
     |> validate_length(:honorific_prefix, max: 80)
     |> validate_length(:honorific_suffix, max: 80)
     |> validate_length(:headline, max: 255)
-  end
-
-  defp validate_first_name_or_last_name(changeset, %{}) do
-    first_name = get_field(changeset, :first_name)
-    last_name = get_field(changeset, :last_name)
-
-    if first_name || last_name do
-      changeset
-    else
-      message = "First name or last name must be present"
-
-      changeset
-      |> add_error(:first_name, message)
-      |> add_error(:last_name, message)
-    end
   end
 end

--- a/lib/vutuv/generals.ex
+++ b/lib/vutuv/generals.ex
@@ -34,7 +34,7 @@ defmodule Vutuv.Generals do
 
     {downcase_name, slug_value} =
       if is_binary(name) do
-        {String.downcase(name), Slugger.slugify_downcase(name)}
+        {String.downcase(name), Slugger.slugify_downcase(name, ?.)}
       else
         {nil, nil}
       end

--- a/lib/vutuv_web/templates/user/edit_form.html.eex
+++ b/lib/vutuv_web/templates/user/edit_form.html.eex
@@ -6,21 +6,13 @@
   <% end %>
 
   <%= inputs_for f, :profile, fn fp -> %>
-    <%= label fp, :first_name, gettext("First name") %>
-    <%= text_input fp, :first_name %>
-    <%= error_tag fp, :first_name %>
+    <%= label fp, :full_name, gettext("Full name") %>
+    <%= text_input fp, :full_name %>
+    <%= error_tag fp, :full_name %>
 
-    <%= label fp, :last_name, gettext("Last name") %>
-    <%= text_input fp, :last_name %>
-    <%= error_tag fp, :last_name %>
-
-    <%= label fp, :middlename, gettext("Middle name") %>
-    <%= text_input fp, :middlename  %>
-    <%= error_tag fp, :middlename %>
-
-    <%= label fp, :nickname, gettext("Nickname")  %>
-    <%= text_input fp, :nickname %>
-    <%= error_tag fp, :nickname %>
+    <%= label fp, :preferred_name, gettext("Preferred name")  %>
+    <%= text_input fp, :preferred_name %>
+    <%= error_tag fp, :preferred_name %>
 
     <%= label fp, :honorific_prefix, gettext("Honorific prefix") %>
     <%= text_input fp, :honorific_prefix %>

--- a/lib/vutuv_web/templates/user/edit_form.html.eex
+++ b/lib/vutuv_web/templates/user/edit_form.html.eex
@@ -31,20 +31,27 @@
     <%= error_tag fp, :honorific_suffix %>
 
     <%= label fp, :gender, gettext("Gender") %>
-    <%= select fp, :gender, ["Gender": "", "Female": "female", "Male": "male", "Other": "other"] %>
+    <%= select fp, :gender, [{gettext("Female"), "female"}, {gettext("Male"), "male"}, {gettext("Other"), "other"}] %>
     <%= error_tag fp, :gender %>
 
-    <%= label fp, :birthday_day, gettext("Birthday day") %>
-    <%= select fp, :birthday_day, 1..31 %>
-    <%= error_tag fp, :birthday_day %>
-
-    <%= label fp, :birthday_month, gettext("Birthday month") %>
-    <%= select fp, :birthday_month, 1..12 %>
-    <%= error_tag fp, :birthday_month %>
-
-    <%= label fp, :birthday_year, gettext("Birthday year") %>
-    <%= select fp, :birthday_year, 1900..2200 %>
-    <%= error_tag fp, :birthday_year %>
+    <%= label fp, :birthday, gettext("Date of birth") %>
+    <%= date_select fp, :birthday, year: [options: 1900..2020, selected: 1980], month: [
+      options: [
+        {gettext("January"), "1"},
+        {gettext("February"), "2"},
+        {gettext("March"), "3"},
+        {gettext("April"), "4"},
+        {gettext("May"), "5"},
+        {gettext("June"), "6"},
+        {gettext("July"), "7"},
+        {gettext("August"), "8"},
+        {gettext("September"), "9"},
+        {gettext("October"), "10"},
+        {gettext("November"), "11"},
+        {gettext("December"), "12"},
+      ]
+    ] %>
+    <%= error_tag fp, :birthday %>
 
     <%= label fp, :locale, gettext("Locale") %>
     <%= text_input fp, :locale %>

--- a/lib/vutuv_web/templates/user/index.html.eex
+++ b/lib/vutuv_web/templates/user/index.html.eex
@@ -10,7 +10,7 @@
   <tbody>
     <%= for user <- @users do %>
       <tr>
-        <td><%= user.profile.first_name %></td>
+        <td><%= user.profile.full_name %></td>
 
         <td>
           <%= link gettext("Show"), to: Routes.user_path(@conn, :show, user) %>

--- a/lib/vutuv_web/templates/user/new_form.html.eex
+++ b/lib/vutuv_web/templates/user/new_form.html.eex
@@ -15,17 +15,19 @@
   <%= password_input f, :password %>
   <%= error_tag f, :password %>
 
-  <%= label f, :first_name, gettext("First name") %>
-  <%= text_input f, :first_name %>
-  <%= error_tag f, :first_name %>
+  <%= inputs_for f, :profile, fn fp -> %>
+    <%= label fp, :first_name, gettext("First name") %>
+    <%= text_input fp, :first_name %>
+    <%= error_tag fp, :first_name %>
 
-  <%= label f, :last_name, gettext("Last name") %>
-  <%= text_input f, :last_name %>
-  <%= error_tag f, :last_name %>
+    <%= label fp, :last_name, gettext("Last name") %>
+    <%= text_input fp, :last_name %>
+    <%= error_tag fp, :last_name %>
 
-  <%= label f, :gender, gettext("Gender") %>
-  <%= select f, :gender, [{gettext("Female"), "female"}, {gettext("Male"), "male"}, {gettext("Other"), "other"}] %>
-  <%= error_tag f, :gender %>
+    <%= label fp, :gender, gettext("Gender") %>
+    <%= select fp, :gender, [{gettext("Female"), "female"}, {gettext("Male"), "male"}, {gettext("Other"), "other"}] %>
+    <%= error_tag fp, :gender %>
+  <% end %>
 
   <div>
     <%= submit gettext("Sign up") %>

--- a/lib/vutuv_web/templates/user/new_form.html.eex
+++ b/lib/vutuv_web/templates/user/new_form.html.eex
@@ -16,13 +16,9 @@
   <%= error_tag f, :password %>
 
   <%= inputs_for f, :profile, fn fp -> %>
-    <%= label fp, :first_name, gettext("First name") %>
-    <%= text_input fp, :first_name %>
-    <%= error_tag fp, :first_name %>
-
-    <%= label fp, :last_name, gettext("Last name") %>
-    <%= text_input fp, :last_name %>
-    <%= error_tag fp, :last_name %>
+    <%= label fp, :full_name, gettext("Full name") %>
+    <%= text_input fp, :full_name %>
+    <%= error_tag fp, :full_name %>
 
     <%= label fp, :gender, gettext("Gender") %>
     <%= select fp, :gender, [{gettext("Female"), "female"}, {gettext("Male"), "male"}, {gettext("Other"), "other"}] %>

--- a/lib/vutuv_web/templates/user/show.html.eex
+++ b/lib/vutuv_web/templates/user/show.html.eex
@@ -4,23 +4,13 @@
   <h3><%= gettext "Profile" %></h3>
   <ul>
     <li>
-      <strong><%= gettext "First name:" %></strong>
-      <%= @profile.first_name %>
+      <strong><%= gettext "Full name:" %></strong>
+      <%= @profile.full_name %>
     </li>
 
     <li>
-      <strong><%= gettext "Last name:" %></strong>
-      <%= @profile.last_name %>
-    </li>
-
-    <li>
-      <strong><%= gettext "Middle name:" %></strong>
-      <%= @profile.middlename %>
-    </li>
-
-    <li>
-      <strong><%= gettext "Nickname:" %></strong>
-      <%= @profile.nickname %>
+      <strong><%= gettext "Preferred name:" %></strong>
+      <%= @profile.preferred_name %>
     </li>
 
     <li>

--- a/lib/vutuv_web/templates/user/show.html.eex
+++ b/lib/vutuv_web/templates/user/show.html.eex
@@ -39,18 +39,8 @@
     </li>
 
     <li>
-      <strong><%= gettext "Birthday day:" %></strong>
-      <%= @profile.birthday_day %>
-    </li>
-
-    <li>
-      <strong><%= gettext "Birthday month:" %></strong>
-      <%= @profile.birthday_month %>
-    </li>
-
-    <li>
-      <strong><%= gettext "Birthday year:" %></strong>
-      <%= @profile.birthday_year %>
+      <strong><%= gettext "Date of birth" %></strong>
+      <%= @profile.birthday %>
     </li>
 
     <li>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -12,17 +12,17 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:67
+#: lib/vutuv_web/templates/user/show.html.eex:47
 msgid "Active slug:"
 msgstr "Aktives slug"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/new_form.html.eex:33
+#: lib/vutuv_web/templates/user/new_form.html.eex:31
 msgid "Already signed up?"
 msgstr "Schon ...?"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:62
+#: lib/vutuv_web/templates/user/show.html.eex:42
 msgid "Avatar:"
 msgstr "Avatar:"
 
@@ -35,21 +35,6 @@ msgstr "Avatar:"
 #: lib/vutuv_web/templates/user/edit.html.eex:5
 msgid "Back"
 msgstr "Zurück"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:42
-msgid "Birthday day:"
-msgstr "Geburtstag"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:47
-msgid "Birthday month:"
-msgstr "Geburtsmonat"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:52
-msgid "Birthday year:"
-msgstr "Geburtsjahr"
 
 #, elixir-format
 #: lib/vutuv_web/templates/user/new.html.eex:8
@@ -87,37 +72,27 @@ msgid "Email"
 msgstr "E-Mail"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:7
-msgid "First name:"
-msgstr "Vorname"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:37
+#: lib/vutuv_web/templates/user/show.html.eex:27
 msgid "Gender:"
 msgstr "Geschlecht"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:72
+#: lib/vutuv_web/templates/user/show.html.eex:52
 msgid "Headline:"
 msgstr "Headline:"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:27
+#: lib/vutuv_web/templates/user/show.html.eex:17
 msgid "Honorific prefix:"
 msgstr "Ehrentitel"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:32
+#: lib/vutuv_web/templates/user/show.html.eex:22
 msgid "Honorific suffix:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:12
-msgid "Last name:"
-msgstr "Nachname:"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:57
+#: lib/vutuv_web/templates/user/show.html.eex:37
 msgid "Locale:"
 msgstr ""
 
@@ -128,7 +103,7 @@ msgid "Login"
 msgstr "Einloggen"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/new_form.html.eex:34
+#: lib/vutuv_web/templates/user/new_form.html.eex:32
 msgid "Login here"
 msgstr "Einloggen hier"
 
@@ -149,12 +124,7 @@ msgid "New user"
 msgstr "Neue User"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:22
-msgid "Nickname:"
-msgstr "Spitzname"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:77
+#: lib/vutuv_web/templates/user/show.html.eex:57
 msgid "Noindex?:"
 msgstr ""
 
@@ -218,22 +188,10 @@ msgid "Verified:"
 msgstr "Verifiziert:"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:9
-#: lib/vutuv_web/templates/user/new_form.html.eex:18
-msgid "First name"
-msgstr "Vorname"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:33
-#: lib/vutuv_web/templates/user/new_form.html.eex:26
+#: lib/vutuv_web/templates/user/edit_form.html.eex:25
+#: lib/vutuv_web/templates/user/new_form.html.eex:23
 msgid "Gender"
 msgstr "Geschlecht"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:13
-#: lib/vutuv_web/templates/user/new_form.html.eex:22
-msgid "Last name"
-msgstr "Nachname:"
 
 #, elixir-format
 #: lib/vutuv_web/templates/password_reset/edit.html.eex:10
@@ -244,7 +202,7 @@ msgstr "Passwort"
 
 #, elixir-format
 #: lib/vutuv_web/templates/user/new_form.html.eex:8
-#: lib/vutuv_web/templates/user/new_form.html.eex:31
+#: lib/vutuv_web/templates/user/new_form.html.eex:29
 msgid "Sign up"
 msgstr "Anmelden"
 
@@ -276,7 +234,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/vutuv_web/templates/email_address/form.html.eex:29
-#: lib/vutuv_web/templates/user/edit_form.html.eex:71
+#: lib/vutuv_web/templates/user/edit_form.html.eex:70
 msgid "Save"
 msgstr ""
 
@@ -297,67 +255,37 @@ msgid "is public"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:57
+#: lib/vutuv_web/templates/user/edit_form.html.eex:56
 msgid "Active slug"
 msgstr "Aktives slug"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:37
-msgid "Birthday day"
-msgstr "Geburtstag"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:41
-msgid "Birthday month"
-msgstr "Geburtsmonat"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:45
-msgid "Birthday year"
-msgstr "Geburtsjahr"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:61
+#: lib/vutuv_web/templates/user/edit_form.html.eex:60
 msgid "Headline"
 msgstr "Headline:"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:25
+#: lib/vutuv_web/templates/user/edit_form.html.eex:17
 msgid "Honorific prefix"
 msgstr "Ehrentitel"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:29
+#: lib/vutuv_web/templates/user/edit_form.html.eex:21
 msgid "Honorific suffix"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:17
-msgid "Middle name"
-msgstr "Zweiter Vorname"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:17
-msgid "Middle name:"
-msgstr "Zweiter Vorname"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:21
-msgid "Nickname"
-msgstr "Spitzname"
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:65
+#: lib/vutuv_web/templates/user/edit_form.html.eex:64
 msgid "No index?"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:53
+#: lib/vutuv_web/templates/user/edit_form.html.eex:52
 msgid "Avatar"
 msgstr "Avatar:"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:49
+#: lib/vutuv_web/templates/user/edit_form.html.eex:48
 msgid "Locale"
 msgstr ""
 
@@ -367,12 +295,12 @@ msgid "is public:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:92
+#: lib/vutuv_web/templates/user/show.html.eex:72
 msgid "Edit email address"
 msgstr "Ändern E-Mail"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:83
+#: lib/vutuv_web/templates/user/show.html.eex:63
 msgid "Edit profile"
 msgstr "Ändern Profil"
 
@@ -382,7 +310,7 @@ msgid "Edit user"
 msgstr "Ändern"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:87
+#: lib/vutuv_web/templates/user/show.html.eex:67
 msgid "Email addresses"
 msgstr "Neue E-Mail Adresse"
 
@@ -392,7 +320,7 @@ msgid "Listing users"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:96
+#: lib/vutuv_web/templates/user/show.html.eex:76
 msgid "New email address"
 msgstr "Neue E-Mail Adresse"
 
@@ -406,22 +334,112 @@ msgstr "Meine Profil"
 msgid "Show user"
 msgstr "Anzeigen"
 
-#, elixir-format, fuzzy
-#: lib/vutuv_web/templates/user/new_form.html.eex:27
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:26
+#: lib/vutuv_web/templates/user/new_form.html.eex:24
 msgid "Female"
 msgstr "Frau"
 
-#, elixir-format, fuzzy
-#: lib/vutuv_web/templates/user/new_form.html.eex:27
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:26
+#: lib/vutuv_web/templates/user/new_form.html.eex:24
 msgid "Male"
 msgstr "Mann"
 
-#, elixir-format, fuzzy
-#: lib/vutuv_web/templates/user/new_form.html.eex:27
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:26
+#: lib/vutuv_web/templates/user/new_form.html.eex:24
 msgid "Other"
 msgstr "Sonstiges"
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/vutuv_web/templates/user/new.html.eex:3
 msgid "The fast, secure and less annoying social network."
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:35
+msgid "April"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:39
+msgid "August"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:29
+#: lib/vutuv_web/templates/user/show.html.eex:32
+msgid "Date of birth"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:43
+msgid "December"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:33
+msgid "February"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:9
+#: lib/vutuv_web/templates/user/new_form.html.eex:19
+msgid "Full name"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/show.html.eex:7
+msgid "Full name:"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:32
+msgid "January"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:38
+msgid "July"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:37
+msgid "June"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:34
+msgid "March"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:36
+msgid "May"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:42
+msgid "November"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:41
+msgid "October"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:13
+msgid "Preferred name"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/show.html.eex:12
+msgid "Preferred name:"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:40
+msgid "September"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,17 +11,17 @@ msgid ""
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:67
+#: lib/vutuv_web/templates/user/show.html.eex:47
 msgid "Active slug:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/new_form.html.eex:33
+#: lib/vutuv_web/templates/user/new_form.html.eex:31
 msgid "Already signed up?"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:62
+#: lib/vutuv_web/templates/user/show.html.eex:42
 msgid "Avatar:"
 msgstr ""
 
@@ -33,21 +33,6 @@ msgstr ""
 #: lib/vutuv_web/templates/password_reset/new.html.eex:19
 #: lib/vutuv_web/templates/user/edit.html.eex:5
 msgid "Back"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:42
-msgid "Birthday day:"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:47
-msgid "Birthday month:"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:52
-msgid "Birthday year:"
 msgstr ""
 
 #, elixir-format
@@ -86,37 +71,27 @@ msgid "Email"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:7
-msgid "First name:"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:37
+#: lib/vutuv_web/templates/user/show.html.eex:27
 msgid "Gender:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:72
+#: lib/vutuv_web/templates/user/show.html.eex:52
 msgid "Headline:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:27
+#: lib/vutuv_web/templates/user/show.html.eex:17
 msgid "Honorific prefix:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:32
+#: lib/vutuv_web/templates/user/show.html.eex:22
 msgid "Honorific suffix:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:12
-msgid "Last name:"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:57
+#: lib/vutuv_web/templates/user/show.html.eex:37
 msgid "Locale:"
 msgstr ""
 
@@ -127,7 +102,7 @@ msgid "Login"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/new_form.html.eex:34
+#: lib/vutuv_web/templates/user/new_form.html.eex:32
 msgid "Login here"
 msgstr ""
 
@@ -148,12 +123,7 @@ msgid "New user"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:22
-msgid "Nickname:"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:77
+#: lib/vutuv_web/templates/user/show.html.eex:57
 msgid "Noindex?:"
 msgstr ""
 
@@ -217,21 +187,9 @@ msgid "Verified:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:9
-#: lib/vutuv_web/templates/user/new_form.html.eex:18
-msgid "First name"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:33
-#: lib/vutuv_web/templates/user/new_form.html.eex:26
+#: lib/vutuv_web/templates/user/edit_form.html.eex:25
+#: lib/vutuv_web/templates/user/new_form.html.eex:23
 msgid "Gender"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:13
-#: lib/vutuv_web/templates/user/new_form.html.eex:22
-msgid "Last name"
 msgstr ""
 
 #, elixir-format
@@ -243,7 +201,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/vutuv_web/templates/user/new_form.html.eex:8
-#: lib/vutuv_web/templates/user/new_form.html.eex:31
+#: lib/vutuv_web/templates/user/new_form.html.eex:29
 msgid "Sign up"
 msgstr ""
 
@@ -275,7 +233,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/vutuv_web/templates/email_address/form.html.eex:29
-#: lib/vutuv_web/templates/user/edit_form.html.eex:71
+#: lib/vutuv_web/templates/user/edit_form.html.eex:70
 msgid "Save"
 msgstr ""
 
@@ -296,67 +254,37 @@ msgid "is public"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:57
+#: lib/vutuv_web/templates/user/edit_form.html.eex:56
 msgid "Active slug"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:37
-msgid "Birthday day"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:41
-msgid "Birthday month"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:45
-msgid "Birthday year"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:61
+#: lib/vutuv_web/templates/user/edit_form.html.eex:60
 msgid "Headline"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:25
+#: lib/vutuv_web/templates/user/edit_form.html.eex:17
 msgid "Honorific prefix"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:29
+#: lib/vutuv_web/templates/user/edit_form.html.eex:21
 msgid "Honorific suffix"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:17
-msgid "Middle name"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:17
-msgid "Middle name:"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:21
-msgid "Nickname"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:65
+#: lib/vutuv_web/templates/user/edit_form.html.eex:64
 msgid "No index?"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:53
+#: lib/vutuv_web/templates/user/edit_form.html.eex:52
 msgid "Avatar"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:49
+#: lib/vutuv_web/templates/user/edit_form.html.eex:48
 msgid "Locale"
 msgstr ""
 
@@ -366,12 +294,12 @@ msgid "is public:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:92
+#: lib/vutuv_web/templates/user/show.html.eex:72
 msgid "Edit email address"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:83
+#: lib/vutuv_web/templates/user/show.html.eex:63
 msgid "Edit profile"
 msgstr ""
 
@@ -381,7 +309,7 @@ msgid "Edit user"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:87
+#: lib/vutuv_web/templates/user/show.html.eex:67
 msgid "Email addresses"
 msgstr ""
 
@@ -391,7 +319,7 @@ msgid "Listing users"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:96
+#: lib/vutuv_web/templates/user/show.html.eex:76
 msgid "New email address"
 msgstr ""
 
@@ -406,21 +334,111 @@ msgid "Show user"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/new_form.html.eex:27
+#: lib/vutuv_web/templates/user/edit_form.html.eex:26
+#: lib/vutuv_web/templates/user/new_form.html.eex:24
 msgid "Female"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/new_form.html.eex:27
+#: lib/vutuv_web/templates/user/edit_form.html.eex:26
+#: lib/vutuv_web/templates/user/new_form.html.eex:24
 msgid "Male"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/new_form.html.eex:27
+#: lib/vutuv_web/templates/user/edit_form.html.eex:26
+#: lib/vutuv_web/templates/user/new_form.html.eex:24
 msgid "Other"
 msgstr ""
 
 #, elixir-format
 #: lib/vutuv_web/templates/user/new.html.eex:3
 msgid "The fast, secure and less annoying social network."
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:35
+msgid "April"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:39
+msgid "August"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:29
+#: lib/vutuv_web/templates/user/show.html.eex:32
+msgid "Date of birth"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:43
+msgid "December"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:33
+msgid "February"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:9
+#: lib/vutuv_web/templates/user/new_form.html.eex:19
+msgid "Full name"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/show.html.eex:7
+msgid "Full name:"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:32
+msgid "January"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:38
+msgid "July"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:37
+msgid "June"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:34
+msgid "March"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:36
+msgid "May"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:42
+msgid "November"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:41
+msgid "October"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:13
+msgid "Preferred name"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/show.html.eex:12
+msgid "Preferred name:"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:40
+msgid "September"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -12,17 +12,17 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:67
+#: lib/vutuv_web/templates/user/show.html.eex:47
 msgid "Active slug:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/new_form.html.eex:33
+#: lib/vutuv_web/templates/user/new_form.html.eex:31
 msgid "Already signed up?"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:62
+#: lib/vutuv_web/templates/user/show.html.eex:42
 msgid "Avatar:"
 msgstr ""
 
@@ -34,21 +34,6 @@ msgstr ""
 #: lib/vutuv_web/templates/password_reset/new.html.eex:19
 #: lib/vutuv_web/templates/user/edit.html.eex:5
 msgid "Back"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:42
-msgid "Birthday day:"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:47
-msgid "Birthday month:"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:52
-msgid "Birthday year:"
 msgstr ""
 
 #, elixir-format
@@ -87,37 +72,27 @@ msgid "Email"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:7
-msgid "First name:"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:37
+#: lib/vutuv_web/templates/user/show.html.eex:27
 msgid "Gender:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:72
+#: lib/vutuv_web/templates/user/show.html.eex:52
 msgid "Headline:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:27
+#: lib/vutuv_web/templates/user/show.html.eex:17
 msgid "Honorific prefix:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:32
+#: lib/vutuv_web/templates/user/show.html.eex:22
 msgid "Honorific suffix:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:12
-msgid "Last name:"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:57
+#: lib/vutuv_web/templates/user/show.html.eex:37
 msgid "Locale:"
 msgstr ""
 
@@ -128,7 +103,7 @@ msgid "Login"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/new_form.html.eex:34
+#: lib/vutuv_web/templates/user/new_form.html.eex:32
 msgid "Login here"
 msgstr ""
 
@@ -149,12 +124,7 @@ msgid "New user"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:22
-msgid "Nickname:"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:77
+#: lib/vutuv_web/templates/user/show.html.eex:57
 msgid "Noindex?:"
 msgstr ""
 
@@ -218,21 +188,9 @@ msgid "Verified:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:9
-#: lib/vutuv_web/templates/user/new_form.html.eex:18
-msgid "First name"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:33
-#: lib/vutuv_web/templates/user/new_form.html.eex:26
+#: lib/vutuv_web/templates/user/edit_form.html.eex:25
+#: lib/vutuv_web/templates/user/new_form.html.eex:23
 msgid "Gender"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:13
-#: lib/vutuv_web/templates/user/new_form.html.eex:22
-msgid "Last name"
 msgstr ""
 
 #, elixir-format
@@ -244,7 +202,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/vutuv_web/templates/user/new_form.html.eex:8
-#: lib/vutuv_web/templates/user/new_form.html.eex:31
+#: lib/vutuv_web/templates/user/new_form.html.eex:29
 msgid "Sign up"
 msgstr ""
 
@@ -276,7 +234,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/vutuv_web/templates/email_address/form.html.eex:29
-#: lib/vutuv_web/templates/user/edit_form.html.eex:71
+#: lib/vutuv_web/templates/user/edit_form.html.eex:70
 msgid "Save"
 msgstr ""
 
@@ -297,67 +255,37 @@ msgid "is public"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:57
+#: lib/vutuv_web/templates/user/edit_form.html.eex:56
 msgid "Active slug"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:37
-msgid "Birthday day"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:41
-msgid "Birthday month"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:45
-msgid "Birthday year"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:61
+#: lib/vutuv_web/templates/user/edit_form.html.eex:60
 msgid "Headline"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:25
+#: lib/vutuv_web/templates/user/edit_form.html.eex:17
 msgid "Honorific prefix"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:29
+#: lib/vutuv_web/templates/user/edit_form.html.eex:21
 msgid "Honorific suffix"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:17
-msgid "Middle name"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:17
-msgid "Middle name:"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:21
-msgid "Nickname"
-msgstr ""
-
-#, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:65
+#: lib/vutuv_web/templates/user/edit_form.html.eex:64
 msgid "No index?"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:53
+#: lib/vutuv_web/templates/user/edit_form.html.eex:52
 msgid "Avatar"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/edit_form.html.eex:49
+#: lib/vutuv_web/templates/user/edit_form.html.eex:48
 msgid "Locale"
 msgstr ""
 
@@ -367,12 +295,12 @@ msgid "is public:"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:92
+#: lib/vutuv_web/templates/user/show.html.eex:72
 msgid "Edit email address"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:83
+#: lib/vutuv_web/templates/user/show.html.eex:63
 msgid "Edit profile"
 msgstr ""
 
@@ -382,7 +310,7 @@ msgid "Edit user"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:87
+#: lib/vutuv_web/templates/user/show.html.eex:67
 msgid "Email addresses"
 msgstr ""
 
@@ -392,7 +320,7 @@ msgid "Listing users"
 msgstr ""
 
 #, elixir-format
-#: lib/vutuv_web/templates/user/show.html.eex:96
+#: lib/vutuv_web/templates/user/show.html.eex:76
 msgid "New email address"
 msgstr ""
 
@@ -406,22 +334,112 @@ msgstr ""
 msgid "Show user"
 msgstr ""
 
-#, elixir-format, fuzzy
-#: lib/vutuv_web/templates/user/new_form.html.eex:27
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:26
+#: lib/vutuv_web/templates/user/new_form.html.eex:24
 msgid "Female"
 msgstr ""
 
-#, elixir-format, fuzzy
-#: lib/vutuv_web/templates/user/new_form.html.eex:27
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:26
+#: lib/vutuv_web/templates/user/new_form.html.eex:24
 msgid "Male"
 msgstr ""
 
-#, elixir-format, fuzzy
-#: lib/vutuv_web/templates/user/new_form.html.eex:27
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:26
+#: lib/vutuv_web/templates/user/new_form.html.eex:24
 msgid "Other"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/vutuv_web/templates/user/new.html.eex:3
 msgid "The fast, secure and less annoying social network."
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:35
+msgid "April"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:39
+msgid "August"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:29
+#: lib/vutuv_web/templates/user/show.html.eex:32
+msgid "Date of birth"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:43
+msgid "December"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:33
+msgid "February"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:9
+#: lib/vutuv_web/templates/user/new_form.html.eex:19
+msgid "Full name"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/show.html.eex:7
+msgid "Full name:"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:32
+msgid "January"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:38
+msgid "July"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:37
+msgid "June"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:34
+msgid "March"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:36
+msgid "May"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:42
+msgid "November"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:41
+msgid "October"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:13
+msgid "Preferred name"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/show.html.eex:12
+msgid "Preferred name:"
+msgstr ""
+
+#, elixir-format
+#: lib/vutuv_web/templates/user/edit_form.html.eex:40
+msgid "September"
 msgstr ""

--- a/priv/repo/migrations/20190327171932_create_profiles.exs
+++ b/priv/repo/migrations/20190327171932_create_profiles.exs
@@ -11,9 +11,7 @@ defmodule Vutuv.Repo.Migrations.CreateProfiles do
       add :honorific_prefix, :string
       add :honorific_suffix, :string
       add :gender, :string
-      add :birthday_day, :integer
-      add :birthday_month, :integer
-      add :birthday_year, :integer
+      add :birthday, :date
       add :locale, :string
       add :avatar, :string
       add :active_slug, :string

--- a/priv/repo/migrations/20190327171932_create_profiles.exs
+++ b/priv/repo/migrations/20190327171932_create_profiles.exs
@@ -4,10 +4,8 @@ defmodule Vutuv.Repo.Migrations.CreateProfiles do
   def change do
     create table(:profiles) do
       add :user_id, references(:users, on_delete: :delete_all)
-      add :first_name, :string
-      add :last_name, :string
-      add :middlename, :string
-      add :nickname, :string
+      add :full_name, :string
+      add :preferred_name, :string
       add :honorific_prefix, :string
       add :honorific_suffix, :string
       add :gender, :string

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -11,8 +11,7 @@ users = [
     "password" => "password",
     "profile" => %{
       "gender" => "female",
-      "first_name" => "Jane",
-      "last_name" => "Doe"
+      "full_name" => "Jane Doe"
     }
   },
   %{
@@ -20,8 +19,7 @@ users = [
     "password" => "password",
     "profile" => %{
       "gender" => "male",
-      "first_name" => "John",
-      "last_name" => "Smith"
+      "full_name" => "John Smith"
     }
   }
 ]
@@ -31,7 +29,9 @@ for user <- users do
   Vutuv.Accounts.confirm_user(user)
   Vutuv.Accounts.confirm_email_address(email_address)
 
+  name = String.replace(user.profile.full_name, " ", ".")
+
   Vutuv.Accounts.create_email_address(user, %{
-    "value" => "#{user.profile.first_name}_123@example.com"
+    "value" => "#{name}_123@example.com"
   })
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,16 +9,20 @@ users = [
   %{
     "email" => "jane.doe@example.com",
     "password" => "password",
-    "gender" => "female",
-    "first_name" => "Jane",
-    "last_name" => "Doe"
+    "profile" => %{
+      "gender" => "female",
+      "first_name" => "Jane",
+      "last_name" => "Doe"
+    }
   },
   %{
     "email" => "john.smith@example.org",
     "password" => "password",
-    "gender" => "male",
-    "first_name" => "John",
-    "last_name" => "Smith"
+    "profile" => %{
+      "gender" => "male",
+      "first_name" => "John",
+      "last_name" => "Smith"
+    }
   }
 ]
 

--- a/test/support/auth_test_helpers.ex
+++ b/test/support/auth_test_helpers.ex
@@ -10,9 +10,11 @@ defmodule VutuvWeb.AuthTestHelpers do
     user_params = %{
       "email" => email,
       "password" => "reallyHard2gue$$",
-      "gender" => Enum.random(["female", "male"]),
-      "first_name" => Faker.Name.first_name(),
-      "last_name" => Faker.Name.last_name()
+      "profile" => %{
+        "gender" => Enum.random(["female", "male"]),
+        "first_name" => Faker.Name.first_name(),
+        "last_name" => Faker.Name.last_name()
+      }
     }
 
     {:ok, user} = Accounts.create_user(user_params)

--- a/test/support/auth_test_helpers.ex
+++ b/test/support/auth_test_helpers.ex
@@ -12,8 +12,7 @@ defmodule VutuvWeb.AuthTestHelpers do
       "password" => "reallyHard2gue$$",
       "profile" => %{
         "gender" => Enum.random(["female", "male"]),
-        "first_name" => Faker.Name.first_name(),
-        "last_name" => Faker.Name.last_name()
+        "full_name" => "#{Faker.Name.first_name()} #{Faker.Name.last_name()}"
       }
     }
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -24,10 +24,8 @@ defmodule Vutuv.Factory do
 
   def profile_factory do
     %Vutuv.Biographies.Profile{
-      first_name: Faker.Name.first_name(),
-      last_name: Faker.Name.last_name(),
-      middlename: Faker.Name.first_name(),
-      nickname: Faker.Name.first_name(),
+      full_name: "#{Faker.Name.first_name()} #{Faker.Name.last_name()}",
+      preferred_name: Faker.Name.first_name(),
       gender: sequence(:gender, ["female", "male"]),
       birthday: Faker.Date.date_of_birth(18..59),
       active_slug: Faker.Internet.slug(),
@@ -35,7 +33,7 @@ defmodule Vutuv.Factory do
       # add valid avatar entry
       # avatar: "",
       headline: Faker.Company.bs(),
-      honorific_prefix: sequence(:honorific_prefix, ["dr", "mr", "ms"]),
+      honorific_prefix: sequence(:honorific_prefix, ["Dr", "Mr", "Ms"]),
       honorific_suffix: sequence(:honorific_suffix, ["", "PhD"]),
       locale: sequence(:locale, ["en", "de"]),
       noindex?: true

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -23,17 +23,13 @@ defmodule Vutuv.Factory do
   end
 
   def profile_factory do
-    %Date{year: year, month: month, day: day} = Faker.Date.date_of_birth(18..59)
-
     %Vutuv.Biographies.Profile{
       first_name: Faker.Name.first_name(),
       last_name: Faker.Name.last_name(),
       middlename: Faker.Name.first_name(),
       nickname: Faker.Name.first_name(),
       gender: sequence(:gender, ["female", "male"]),
-      birthday_day: day,
-      birthday_month: month,
-      birthday_year: year,
+      birthday: Faker.Date.date_of_birth(18..59),
       active_slug: Faker.Internet.slug(),
       # FIXME: riverrun - 2019-04-08
       # add valid avatar entry

--- a/test/vutuv/accounts/accounts_test.exs
+++ b/test/vutuv/accounts/accounts_test.exs
@@ -11,8 +11,7 @@ defmodule Vutuv.AccountsTest do
     "password" => "reallyHard2gue$$",
     "profile" => %{
       "gender" => "male",
-      "first_name" => "fred",
-      "last_name" => "frederickson"
+      "full_name" => "fred frederickson"
     }
   }
   @create_email_attrs %{
@@ -37,9 +36,7 @@ defmodule Vutuv.AccountsTest do
     test "get_user returns email_addresses and profile", %{user: user} do
       user = Accounts.get_user(user.id)
       assert [%EmailAddress{value: "fred@example.com", position: 1}] = user.email_addresses
-
-      assert %Profile{gender: "male", first_name: "fred", last_name: "frederickson"} =
-               user.profile
+      assert %Profile{gender: "male", full_name: "fred frederickson"} = user.profile
     end
 
     test "change_user/1 returns a user changeset", %{user: user} do
@@ -69,18 +66,12 @@ defmodule Vutuv.AccountsTest do
       assert %{email_addresses: [%{value: ["has invalid format"]}]} = errors_on(changeset)
     end
 
-    test "no first name or last name returns profile error" do
-      attrs =
-        Map.merge(@create_user_attrs, %{"profile" => %{"first_name" => "", "last_name" => ""}})
-
+    test "no full name returns profile error" do
+      attrs = Map.merge(@create_user_attrs, %{"profile" => %{"full_name" => ""}})
       assert {:error, changeset} = Accounts.create_user(attrs)
 
-      assert %{
-               profile: %{
-                 first_name: ["First name or last name must be present"],
-                 last_name: ["First name or last name must be present"]
-               }
-             } = errors_on(changeset)
+      assert %{profile: %{full_name: ["can't be blank"], gender: ["can't be blank"]}} =
+               errors_on(changeset)
     end
 
     test "update password changes the stored hash" do

--- a/test/vutuv/accounts/accounts_test.exs
+++ b/test/vutuv/accounts/accounts_test.exs
@@ -9,9 +9,11 @@ defmodule Vutuv.AccountsTest do
   @create_user_attrs %{
     "email" => "fred@example.com",
     "password" => "reallyHard2gue$$",
-    "gender" => "male",
-    "first_name" => "fred",
-    "last_name" => "frederickson"
+    "profile" => %{
+      "gender" => "male",
+      "first_name" => "fred",
+      "last_name" => "frederickson"
+    }
   }
   @create_email_attrs %{
     "is_public" => true,
@@ -68,7 +70,9 @@ defmodule Vutuv.AccountsTest do
     end
 
     test "no first name or last name returns profile error" do
-      attrs = Map.merge(@create_user_attrs, %{"first_name" => "", "last_name" => ""})
+      attrs =
+        Map.merge(@create_user_attrs, %{"profile" => %{"first_name" => "", "last_name" => ""}})
+
       assert {:error, changeset} = Accounts.create_user(attrs)
 
       assert %{

--- a/test/vutuv/biographies/biographies_test.exs
+++ b/test/vutuv/biographies/biographies_test.exs
@@ -9,9 +9,7 @@ defmodule Vutuv.BiographiesTest do
   @valid_attrs %{
     active_slug: "some active_slug",
     avatar: %Plug.Upload{path: "test/fixtures/elixir_logo.png", filename: "elixir_logo.png"},
-    birthday_day: 42,
-    birthday_month: 42,
-    birthday_year: 42,
+    birthday: Date.utc_today(),
     first_name: "some first_name",
     gender: "some gender",
     headline: "some headline",
@@ -26,9 +24,7 @@ defmodule Vutuv.BiographiesTest do
   @update_attrs %{
     active_slug: "some updated active_slug",
     avatar: %Plug.Upload{path: "test/fixtures/cool_photo.png", filename: "cool_photo.png"},
-    birthday_day: 43,
-    birthday_month: 43,
-    birthday_year: 43,
+    birthday: Date.utc_today(),
     first_name: "some updated first_name",
     gender: "some updated gender",
     headline: "some updated headline",
@@ -43,9 +39,6 @@ defmodule Vutuv.BiographiesTest do
   @invalid_attrs %{
     active_slug: nil,
     avatar: nil,
-    birthday_day: nil,
-    birthday_month: nil,
-    birthday_year: nil,
     first_name: nil,
     gender: nil,
     headline: nil,
@@ -92,9 +85,6 @@ defmodule Vutuv.BiographiesTest do
                updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
              }
 
-      assert(profile.birthday_day == 42)
-      assert profile.birthday_month == 42
-      assert profile.birthday_year == 42
       assert profile.first_name == "some first_name"
       assert profile.gender == "some gender"
       assert profile.headline == "some headline"
@@ -121,9 +111,6 @@ defmodule Vutuv.BiographiesTest do
                updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
              }
 
-      assert profile.birthday_day == 43
-      assert profile.birthday_month == 43
-      assert profile.birthday_year == 43
       assert profile.first_name == "some updated first_name"
       assert profile.gender == "some updated gender"
       assert profile.headline == "some updated headline"

--- a/test/vutuv/biographies/biographies_test.exs
+++ b/test/vutuv/biographies/biographies_test.exs
@@ -7,51 +7,24 @@ defmodule Vutuv.BiographiesTest do
   alias Vutuv.Biographies.{Profile, PhoneNumber}
 
   @valid_attrs %{
-    active_slug: "some active_slug",
     avatar: %Plug.Upload{path: "test/fixtures/elixir_logo.png", filename: "elixir_logo.png"},
-    birthday: Date.utc_today(),
-    first_name: "some first_name",
-    gender: "some gender",
-    headline: "some headline",
-    honorific_prefix: "some honorific_prefix",
-    honorific_suffix: "some honorific_suffix",
-    last_name: "some last_name",
-    locale: "some locale",
-    middlename: "some middlename",
-    nickname: "some nickname",
-    noindex?: true
+    full_name: "#{Faker.Name.first_name()} #{Faker.Name.last_name()}",
+    gender: Enum.random(["female", "male", "other"]),
+    preferred_name: Faker.Name.first_name(),
+    birthday: ~D[1980-01-15],
+    headline: Faker.Company.bs(),
+    honorific_prefix: "Dr",
+    honorific_suffix: "PhD"
   }
   @update_attrs %{
-    active_slug: "some updated active_slug",
-    avatar: %Plug.Upload{path: "test/fixtures/cool_photo.png", filename: "cool_photo.png"},
-    birthday: Date.utc_today(),
-    first_name: "some updated first_name",
-    gender: "some updated gender",
-    headline: "some updated headline",
-    honorific_prefix: "some updated honorific_prefix",
-    honorific_suffix: "some updated honorific_suffix",
-    last_name: "some updated last_name",
-    locale: "some updated locale",
-    middlename: "some updated middlename",
-    nickname: "some updated nickname",
-    noindex?: false
+    headline: Faker.Company.bs(),
+    preferred_name: Faker.Name.first_name()
   }
   @invalid_attrs %{
-    active_slug: nil,
-    avatar: nil,
-    first_name: nil,
-    gender: nil,
-    headline: nil,
-    honorific_prefix: nil,
-    honorific_suffix: nil,
-    last_name: nil,
-    locale: nil,
-    middlename: nil,
-    nickname: nil,
-    noindex?: nil
+    preferred_name: String.duplicate("GardenGnome", 8)
   }
-  @valid_phone_attrs %{type: "some type", value: "+9123450292"}
-  @update_phone_attrs %{type: "some updated type", value: "02122229999"}
+  @valid_phone_attrs %{type: "mobile", value: "+9123450292"}
+  @update_phone_attrs %{type: "work", value: "02122229999"}
   @invalid_phone_attrs %{type: nil, value: "abcde"}
 
   describe "profiles" do
@@ -78,23 +51,17 @@ defmodule Vutuv.BiographiesTest do
 
     test "create_profile/1 with valid data creates a profile" do
       assert {:ok, profile} = Biographies.create_profile(@valid_attrs)
-      assert profile.active_slug == "some active_slug"
 
       assert profile.avatar == %{
                file_name: "elixir_logo.png",
                updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
              }
 
-      assert profile.first_name == "some first_name"
-      assert profile.gender == "some gender"
-      assert profile.headline == "some headline"
-      assert profile.honorific_prefix == "some honorific_prefix"
-      assert profile.honorific_suffix == "some honorific_suffix"
-      assert profile.last_name == "some last_name"
-      assert profile.locale == "some locale"
-      assert profile.middlename == "some middlename"
-      assert profile.nickname == "some nickname"
-      assert profile.noindex? == true
+      assert profile.full_name
+      assert profile.gender in ["female", "male", "other"]
+      assert profile.preferred_name
+      assert profile.honorific_prefix == "Dr"
+      assert profile.honorific_suffix == "PhD"
     end
 
     test "create_profile/1 with invalid data returns error changeset" do
@@ -103,24 +70,12 @@ defmodule Vutuv.BiographiesTest do
 
     test "update_profile/2 with valid data updates the profile" do
       profile = profile_fixture()
-      assert {:ok, %Profile{} = profile} = Biographies.update_profile(profile, @update_attrs)
-      assert profile.active_slug == "some updated active_slug"
 
-      assert profile.avatar == %{
-               file_name: "cool_photo.png",
-               updated_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
-             }
+      assert {:ok, %Profile{headline: headline, preferred_name: preferred_name}} =
+               Biographies.update_profile(profile, @update_attrs)
 
-      assert profile.first_name == "some updated first_name"
-      assert profile.gender == "some updated gender"
-      assert profile.headline == "some updated headline"
-      assert profile.honorific_prefix == "some updated honorific_prefix"
-      assert profile.honorific_suffix == "some updated honorific_suffix"
-      assert profile.last_name == "some updated last_name"
-      assert profile.locale == "some updated locale"
-      assert profile.middlename == "some updated middlename"
-      assert profile.nickname == "some updated nickname"
-      assert profile.noindex? == false
+      assert headline != profile.headline
+      assert preferred_name != profile.preferred_name
     end
 
     test "update_profile/2 with invalid data returns error changeset" do
@@ -159,7 +114,7 @@ defmodule Vutuv.BiographiesTest do
                Biographies.create_phone_number(profile, @valid_phone_attrs)
 
       assert phone_number.value == "+9123450292"
-      assert phone_number.type == "some type"
+      assert phone_number.type == "mobile"
     end
 
     test "create_phone_number/1 with invalid data returns error changeset", %{profile: profile} do
@@ -173,7 +128,7 @@ defmodule Vutuv.BiographiesTest do
       assert {:ok, %PhoneNumber{} = phone_number} =
                Biographies.update_phone_number(phone_number, @update_phone_attrs)
 
-      assert phone_number.type == "some updated type"
+      assert phone_number.type == "work"
       assert phone_number.value == "02122229999"
     end
 

--- a/test/vutuv/generals/generals_test.exs
+++ b/test/vutuv/generals/generals_test.exs
@@ -8,12 +8,12 @@ defmodule Vutuv.GeneralsTest do
 
     @valid_attrs %{
       "description" => "some description",
-      "name" => "Some Name",
+      "name" => "Some name",
       "url" => "http://some-url.com"
     }
     @update_attrs %{
       "description" => "some updated description",
-      "name" => "Some Updated Name",
+      "name" => "Some updated name",
       "url" => "http://some-updated-url.com"
     }
     @invalid_attrs %{"description" => nil, "name" => nil, "url" => nil}
@@ -40,7 +40,7 @@ defmodule Vutuv.GeneralsTest do
     test "create_tag/1 with valid data creates a tag" do
       assert {:ok, %Tag{} = tag} = Generals.create_tag(@valid_attrs)
       assert tag.description == "some description"
-      assert tag.name == "Some Name"
+      assert tag.name == "Some name"
       assert tag.url == "http://some-url.com"
     end
 
@@ -52,7 +52,7 @@ defmodule Vutuv.GeneralsTest do
       tag = tag_fixture()
       assert {:ok, %Tag{} = tag} = Generals.update_tag(tag, @update_attrs)
       assert tag.description == "some updated description"
-      assert tag.name == "Some Updated Name"
+      assert tag.name == "Some updated name"
       assert tag.url == "http://some-updated-url.com"
     end
 

--- a/test/vutuv/sessions/sessions_test.exs
+++ b/test/vutuv/sessions/sessions_test.exs
@@ -7,9 +7,11 @@ defmodule Vutuv.SessionsTest do
     attrs = %{
       "email" => "fred@example.com",
       "password" => "reallyHard2gue$$",
-      "gender" => "male",
-      "first_name" => "fred",
-      "last_name" => "frederickson"
+      "profile" => %{
+        "gender" => "male",
+        "first_name" => "fred",
+        "last_name" => "frederickson"
+      }
     }
 
     {:ok, user} = Accounts.create_user(attrs)

--- a/test/vutuv/sessions/sessions_test.exs
+++ b/test/vutuv/sessions/sessions_test.exs
@@ -9,8 +9,7 @@ defmodule Vutuv.SessionsTest do
       "password" => "reallyHard2gue$$",
       "profile" => %{
         "gender" => "male",
-        "first_name" => "fred",
-        "last_name" => "frederickson"
+        "full_name" => "fred frederickson"
       }
     }
 

--- a/test/vutuv_web/controllers/user_controller_test.exs
+++ b/test/vutuv_web/controllers/user_controller_test.exs
@@ -9,8 +9,7 @@ defmodule VutuvWeb.UserControllerTest do
     "password" => "reallyHard2gue$$",
     "profile" => %{
       "gender" => "male",
-      "first_name" => "bill",
-      "last_name" => "shakespeare"
+      "full_name" => "bill shakespeare"
     }
   }
   @invalid_attrs %{email: nil}
@@ -69,13 +68,13 @@ defmodule VutuvWeb.UserControllerTest do
     setup [:add_user_session]
 
     test "successful when data is valid", %{conn: conn, user: user} do
-      attrs = %{"profile" => %{"last_name" => "Luxury yacht"}}
+      attrs = %{"profile" => %{"full_name" => "Raymond Luxury Yacht"}}
       conn = put(conn, Routes.user_path(conn, :update, user), user: attrs)
       assert redirected_to(conn) == Routes.user_path(conn, :show, user)
       updated_user = Accounts.get_user(user.id)
-      assert updated_user.profile.last_name == "Luxury yacht"
+      assert updated_user.profile.full_name == "Raymond Luxury Yacht"
       conn = get(conn, Routes.user_path(conn, :show, user))
-      assert html_response(conn, 200) =~ "Luxury yacht"
+      assert html_response(conn, 200) =~ "Raymond Luxury Yacht"
     end
 
     test "fails when data is invalid", %{conn: conn, user: user} do

--- a/test/vutuv_web/controllers/user_controller_test.exs
+++ b/test/vutuv_web/controllers/user_controller_test.exs
@@ -7,9 +7,11 @@ defmodule VutuvWeb.UserControllerTest do
   @create_attrs %{
     "email" => "bill@example.com",
     "password" => "reallyHard2gue$$",
-    "gender" => "male",
-    "first_name" => "bill",
-    "last_name" => "shakespeare"
+    "profile" => %{
+      "gender" => "male",
+      "first_name" => "bill",
+      "last_name" => "shakespeare"
+    }
   }
   @invalid_attrs %{email: nil}
 

--- a/test/vutuv_web/views/page_view_test.exs
+++ b/test/vutuv_web/views/page_view_test.exs
@@ -1,3 +1,0 @@
-defmodule VutuvWeb.PageViewTest do
-  use VutuvWeb.ConnCase, async: true
-end


### PR DESCRIPTION
This PR mainly reduces the number of inputs in the forms to make them more user-friendly.

The birthday entries have been put into one date_of_birth field, the names have been combined into a full_name field and nickname has been replaced with preferred_name (see #633 for more information about the name changes).