### PR TITLE
Add unique slug

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -58,9 +58,11 @@ body {
   background-color: #4a6a90;
   color: #e6e6e6;
   display: grid;
-  grid-gap: 0;
-  grid-template-rows: auto 1fr auto;
   grid-template-columns: 1fr;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas: "header"
+                        "main"
+                        "footer";
 }
 header,
 main {
@@ -68,7 +70,15 @@ main {
   padding: 0 1.5rem;
 }
 header {
+  grid-area: header;
   text-align: center;
+}
+main {
+  grid-area: main;
+  position: relative;
+}
+.v-bg {
+  display: none;
 }
 .inset h1 {
   font-size: 10.8rem;
@@ -84,6 +94,7 @@ header {
   padding: 1.5rem 3.0rem;
 }
 footer {
+  grid-area: footer;
   background-color: #495057;
   color: #e6e6e6;
   text-align: center;
@@ -116,8 +127,10 @@ button.link {
 }
 @media screen and (min-width: 40.0rem) and (orientation: landscape) {
   body {
-    grid-template-rows: 1fr auto;
     grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: 1fr auto;
+    grid-template-areas: "header main"
+                          "footer footer";
   }
   header,
   main {
@@ -129,7 +142,17 @@ button.link {
     text-align: right;
   }
   footer {
-    grid-column: span 2;
     text-align: left;
+  }
+  .v-bg {
+    grid-column: 2;
+    grid-row: 1;
+    display: block;
+    opacity: 0.2;
+    z-index: -1;
+  }
+  .v-bg svg {
+    margin-left: -35rem;
+    height: 80rem;
   }
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -61,8 +61,8 @@ body {
   grid-template-columns: 1fr;
   grid-template-rows: auto 1fr auto;
   grid-template-areas: "header"
-                        "main"
-                        "footer";
+                       "main"
+                       "footer";
 }
 header,
 main {
@@ -109,16 +109,21 @@ footer ul li {
   text-decoration: none;
   padding: 0 1.5rem;
 }
-footer a {
+footer form {
+  margin: 0;
+}
+footer a,
+footer button.link {
   color: #e6e6e6;
 }
-footer a:focus, a:hover {
+footer a:focus, a:hover,
+footer button.link:focus, button.link:hover {
   color: #b8b8b8;
 }
 button.link {
   background: none;
-  color: #0069d9;
   border: none;
+  color: #0069d9;
   padding: 0 !important;
   font: inherit;
   letter-spacing: 0;
@@ -130,7 +135,7 @@ button.link {
     grid-template-columns: repeat(2, 1fr);
     grid-template-rows: 1fr auto;
     grid-template-areas: "header main"
-                          "footer footer";
+                         "footer footer";
   }
   header,
   main {

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -65,9 +65,8 @@ defmodule Vutuv.Accounts.User do
 
   defp password_hash_changeset(user, attrs) do
     user
-    |> cast(attrs, [:slug, :password])
-    |> validate_required([:slug, :password])
-    |> unique_constraint(:slug)
+    |> cast(attrs, [:password])
+    |> validate_required([:password])
     |> validate_password(:password)
     |> put_pass_hash()
   end

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -46,7 +46,7 @@ defmodule Vutuv.Accounts.User do
     user
     |> password_hash_changeset(attrs)
     |> cast_assoc(:email_addresses, required: true)
-    |> cast_assoc(:profile, required: true)
+    |> cast_assoc(:profile, required: true, with: &Profile.create_changeset/2)
   end
 
   def update_changeset(%__MODULE__{} = user, attrs) do

--- a/lib/vutuv/biographies.ex
+++ b/lib/vutuv/biographies.ex
@@ -2,6 +2,7 @@ defmodule Vutuv.Biographies do
   @moduledoc """
   The Biographies context.
   """
+
   import Ecto
   import Ecto.Query, warn: false
 
@@ -25,15 +26,6 @@ defmodule Vutuv.Biographies do
   """
   @spec get_profile(integer) :: Profile.t() | nil
   def get_profile(id), do: Repo.get(Profile, id)
-
-  @spec get_profile_user(integer) :: Profile.t() | nil
-  def get_profile_user(user_id) do
-    query =
-      from p in Profile,
-        where: p.user_id == ^user_id
-
-    Repo.one(query)
-  end
 
   @doc """
   Gets a single profile with phone numbers and tags.

--- a/lib/vutuv/biographies/locale.ex
+++ b/lib/vutuv/biographies/locale.ex
@@ -5,9 +5,12 @@ defmodule Vutuv.Biographies.Locale do
 
   defstruct locale: "en", quality: 1.0
 
+  @default_locale "en"
+
   @doc """
   Returns a map of supported locales.
   """
+  @spec supported() :: map
   def supported do
     %{
       "en" => "en",
@@ -24,16 +27,20 @@ defmodule Vutuv.Biographies.Locale do
   @doc """
   Returns a supported locale.
   """
+  @spec supported(String.t()) :: String.t() | nil
   def supported(locale) do
-    if locale in Map.values(supported()), do: locale, else: Map.get(supported(), locale)
+    if locale in Map.values(supported()) do
+      locale
+    else
+      Map.get(supported(), String.downcase(locale))
+    end
   end
 
   @doc """
-  Parses an accept-language header entry and creates structs.
+  Parses an accept-language header entry and finds a supported locale.
   """
-  def parse_al([]), do: supported() |> Map.values() |> hd
-
-  def parse_al([pattern]) do
+  @spec parse_al(String.t()) :: String.t()
+  def parse_al(pattern) do
     pattern
     |> String.split(",")
     |> Enum.map(&create_struct(String.split(&1, ";")))
@@ -49,7 +56,7 @@ defmodule Vutuv.Biographies.Locale do
     %__MODULE__{locale: supported(locale), quality: String.to_float(quality)}
   end
 
-  defp find_default([]), do: supported() |> Map.values() |> hd
+  defp find_default([]), do: @default_locale
 
   defp find_default([%__MODULE__{locale: locale} | rest]) do
     if locale in Map.values(supported()) do

--- a/lib/vutuv/biographies/locale.ex
+++ b/lib/vutuv/biographies/locale.ex
@@ -1,0 +1,50 @@
+defmodule Vutuv.Biographies.Locale do
+  @moduledoc """
+  Module to help find a user's preferred locale.
+  """
+
+  defstruct locale: "en", quality: 1.0
+
+  @supported ["en", "en_US", "en_AU", "en_CA", "en_GB", "de", "de_DE", "de_CH"]
+  @supported_map %{
+    "en" => "en",
+    "en-us" => "en_US",
+    "en-au" => "en_AU",
+    "en-ca" => "en_CA",
+    "en-gb" => "en_GB",
+    "de" => "de",
+    "de-de" => "de_DE",
+    "de-ch" => "de_CH"
+  }
+
+  @doc """
+  Parses an accept-language header entry and creates structs.
+  """
+  def parse_al([]), do: hd(@supported)
+
+  def parse_al([pattern]) do
+    pattern
+    |> String.split(",")
+    |> Enum.map(&create_struct(String.split(&1, ";")))
+    |> Enum.sort(&(&1.quality >= &2.quality))
+    |> find_default()
+  end
+
+  defp create_struct([locale]) do
+    %__MODULE__{locale: @supported_map[locale]}
+  end
+
+  defp create_struct([locale, "q=" <> quality]) do
+    %__MODULE__{locale: @supported_map[locale], quality: String.to_float(quality)}
+  end
+
+  defp find_default([]), do: hd(@supported)
+
+  defp find_default([%__MODULE__{locale: locale} | rest]) do
+    if locale in @supported do
+      locale
+    else
+      find_default(rest)
+    end
+  end
+end

--- a/lib/vutuv/biographies/locale.ex
+++ b/lib/vutuv/biographies/locale.ex
@@ -5,22 +5,33 @@ defmodule Vutuv.Biographies.Locale do
 
   defstruct locale: "en", quality: 1.0
 
-  @supported ["en", "en_US", "en_AU", "en_CA", "en_GB", "de", "de_DE", "de_CH"]
-  @supported_map %{
-    "en" => "en",
-    "en-us" => "en_US",
-    "en-au" => "en_AU",
-    "en-ca" => "en_CA",
-    "en-gb" => "en_GB",
-    "de" => "de",
-    "de-de" => "de_DE",
-    "de-ch" => "de_CH"
-  }
+  @doc """
+  Returns a map of supported locales.
+  """
+  def supported do
+    %{
+      "en" => "en",
+      "en-us" => "en_US",
+      "en-au" => "en_AU",
+      "en-ca" => "en_CA",
+      "en-gb" => "en_GB",
+      "de" => "de",
+      "de-de" => "de_DE",
+      "de-ch" => "de_CH"
+    }
+  end
+
+  @doc """
+  Returns a supported locale.
+  """
+  def supported(locale) do
+    if locale in Map.values(supported()), do: locale, else: Map.get(supported(), locale)
+  end
 
   @doc """
   Parses an accept-language header entry and creates structs.
   """
-  def parse_al([]), do: hd(@supported)
+  def parse_al([]), do: supported() |> Map.values() |> hd
 
   def parse_al([pattern]) do
     pattern
@@ -31,17 +42,17 @@ defmodule Vutuv.Biographies.Locale do
   end
 
   defp create_struct([locale]) do
-    %__MODULE__{locale: @supported_map[locale]}
+    %__MODULE__{locale: supported(locale)}
   end
 
   defp create_struct([locale, "q=" <> quality]) do
-    %__MODULE__{locale: @supported_map[locale], quality: String.to_float(quality)}
+    %__MODULE__{locale: supported(locale), quality: String.to_float(quality)}
   end
 
-  defp find_default([]), do: hd(@supported)
+  defp find_default([]), do: supported() |> Map.values() |> hd
 
   defp find_default([%__MODULE__{locale: locale} | rest]) do
-    if locale in @supported do
+    if locale in Map.values(supported()) do
       locale
     else
       find_default(rest)

--- a/lib/vutuv/biographies/phone_number.ex
+++ b/lib/vutuv/biographies/phone_number.ex
@@ -24,7 +24,7 @@ defmodule Vutuv.Biographies.PhoneNumber do
   end
 
   @doc false
-  def changeset(phone_number, attrs) do
+  def changeset(%__MODULE__{} = phone_number, attrs) do
     phone_number
     |> cast(attrs, [:value, :type])
     |> update_change(:value, &String.trim/1)

--- a/lib/vutuv/biographies/profile.ex
+++ b/lib/vutuv/biographies/profile.ex
@@ -4,7 +4,7 @@ defmodule Vutuv.Biographies.Profile do
   import Ecto.Changeset
 
   alias Vutuv.Accounts.User
-  alias Vutuv.Biographies.PhoneNumber
+  alias Vutuv.Biographies.{Locale, PhoneNumber}
   alias Vutuv.Generals.Tag
 
   @type t :: %__MODULE__{
@@ -47,7 +47,7 @@ defmodule Vutuv.Biographies.Profile do
   end
 
   @doc false
-  def changeset(profile, attrs) do
+  def changeset(%__MODULE__{} = profile, attrs) do
     profile
     |> cast(attrs, [
       :full_name,
@@ -67,6 +67,17 @@ defmodule Vutuv.Biographies.Profile do
     |> validate_length(:honorific_prefix, max: 80)
     |> validate_length(:honorific_suffix, max: 80)
     |> validate_length(:headline, max: 255)
-    |> validate_length(:locale, min: 2, max: 5)
+    |> validate_length(:locale, min: 2, max: 6)
+    |> put_supported_locale()
   end
+
+  defp put_supported_locale(%Ecto.Changeset{valid?: true, changes: %{locale: locale}} = changeset) do
+    if new_locale = Locale.supported(locale) do
+      change(changeset, %{locale: new_locale})
+    else
+      add_error(changeset, :locale, "Unsupported locale")
+    end
+  end
+
+  defp put_supported_locale(changeset), do: changeset
 end

--- a/lib/vutuv/biographies/profile.ex
+++ b/lib/vutuv/biographies/profile.ex
@@ -67,5 +67,6 @@ defmodule Vutuv.Biographies.Profile do
     |> validate_length(:honorific_prefix, max: 80)
     |> validate_length(:honorific_suffix, max: 80)
     |> validate_length(:headline, max: 255)
+    |> validate_length(:locale, min: 2, max: 5)
   end
 end

--- a/lib/vutuv/biographies/profile.ex
+++ b/lib/vutuv/biographies/profile.ex
@@ -1,6 +1,7 @@
 defmodule Vutuv.Biographies.Profile do
   use Ecto.Schema
   use Arc.Ecto.Schema
+
   import Ecto.Changeset
 
   alias Vutuv.Accounts.User
@@ -20,6 +21,7 @@ defmodule Vutuv.Biographies.Profile do
           honorific_prefix: String.t(),
           honorific_suffix: String.t(),
           locale: String.t(),
+          accept_language: String.t(),
           noindex?: boolean,
           phone_numbers: [PhoneNumber.t()] | %Ecto.Association.NotLoaded{},
           inserted_at: DateTime.t(),
@@ -36,6 +38,7 @@ defmodule Vutuv.Biographies.Profile do
     field :honorific_prefix, :string
     field :honorific_suffix, :string
     field :locale, :string
+    field :accept_language, :string
     field :noindex?, :boolean, default: false
 
     belongs_to :user, User
@@ -67,17 +70,28 @@ defmodule Vutuv.Biographies.Profile do
     |> validate_length(:honorific_prefix, max: 80)
     |> validate_length(:honorific_suffix, max: 80)
     |> validate_length(:headline, max: 255)
-    |> validate_length(:locale, min: 2, max: 6)
-    |> put_supported_locale()
+    |> add_locale_data()
   end
 
-  defp put_supported_locale(%Ecto.Changeset{valid?: true, changes: %{locale: locale}} = changeset) do
-    if new_locale = Locale.supported(locale) do
-      change(changeset, %{locale: new_locale})
-    else
-      add_error(changeset, :locale, "Unsupported locale")
+  @doc false
+  def create_changeset(%__MODULE__{} = profile, attrs) do
+    {attrs, al} =
+      case Map.get(attrs, "accept_language") do
+        nil -> {attrs, nil}
+        al -> {Map.put(attrs, "locale", Locale.parse_al(al)), al}
+      end
+
+    profile
+    |> changeset(attrs)
+    |> change(%{accept_language: al})
+  end
+
+  defp add_locale_data(%Ecto.Changeset{valid?: true, changes: %{locale: locale}} = changeset) do
+    case Locale.supported(locale) do
+      nil -> add_error(changeset, :locale, "Unsupported locale")
+      new_locale -> change(changeset, %{locale: new_locale})
     end
   end
 
-  defp put_supported_locale(changeset), do: changeset
+  defp add_locale_data(changeset), do: changeset
 end

--- a/lib/vutuv/biographies/profile_tag.ex
+++ b/lib/vutuv/biographies/profile_tag.ex
@@ -22,7 +22,7 @@ defmodule Vutuv.Biographies.ProfileTag do
   end
 
   @doc false
-  def changeset(profile_tag, attrs) do
+  def changeset(%__MODULE__{} = profile_tag, attrs) do
     profile_tag
     |> cast(attrs, [:profile_id, :tag_id])
     |> validate_required([:profile_id, :tag_id])

--- a/lib/vutuv/generals/tag.ex
+++ b/lib/vutuv/generals/tag.ex
@@ -28,7 +28,7 @@ defmodule Vutuv.Generals.Tag do
   end
 
   @doc false
-  def changeset(tag, attrs) do
+  def changeset(%__MODULE__{} = tag, attrs) do
     tag
     |> cast(attrs, [:name, :downcase_name, :slug, :description, :url])
     |> validate_required([:name])

--- a/lib/vutuv/sessions/session.ex
+++ b/lib/vutuv/sessions/session.ex
@@ -24,7 +24,7 @@ defmodule Vutuv.Sessions.Session do
   end
 
   @doc false
-  def changeset(session, attrs) do
+  def changeset(%__MODULE__{} = session, attrs) do
     session
     |> set_expires_at(attrs)
     |> cast(attrs, [:user_id])

--- a/lib/vutuv/socials/post.ex
+++ b/lib/vutuv/socials/post.ex
@@ -31,14 +31,14 @@ defmodule Vutuv.Socials.Post do
   end
 
   @doc false
-  def changeset(post, attrs) do
+  def changeset(%__MODULE__{} = post, attrs) do
     post
     |> cast(attrs, [:body, :title, :page_info_cache, :visibility_level])
     |> validate_required([:body, :title])
   end
 
   @doc false
-  def create_changeset(post, attrs) do
+  def create_changeset(%__MODULE__{} = post, attrs) do
     post |> set_published_at(attrs) |> changeset(attrs)
   end
 

--- a/lib/vutuv_web/controllers/user_controller.ex
+++ b/lib/vutuv_web/controllers/user_controller.ex
@@ -4,7 +4,7 @@ defmodule VutuvWeb.UserController do
   import VutuvWeb.Authorize
 
   alias Phauxth.Log
-  alias Vutuv.{Accounts, Accounts.User, Biographies.Locale}
+  alias Vutuv.{Accounts, Accounts.User}
   alias VutuvWeb.{Auth.Otp, Email}
 
   @dialyzer {:nowarn_function, new: 2}
@@ -26,8 +26,8 @@ defmodule VutuvWeb.UserController do
   end
 
   def create(conn, %{"user" => user_params}) do
-    locale = conn |> get_req_header("accept-language") |> Locale.parse_al()
-    user_params = add_locale_to_params(user_params, locale)
+    user_params =
+      conn |> get_req_header("accept-language") |> add_accept_language_to_params(user_params)
 
     case Accounts.create_user(user_params) do
       {:ok, user} ->
@@ -76,9 +76,10 @@ defmodule VutuvWeb.UserController do
     |> redirect(to: Routes.session_path(conn, :new))
   end
 
-  defp add_locale_to_params(%{"profile" => _} = user_params, locale) do
-    put_in(user_params, ["profile", "locale"], locale)
+  defp add_accept_language_to_params(accept_language, %{"profile" => _} = user_params) do
+    al = if accept_language == [], do: "", else: hd(accept_language)
+    put_in(user_params, ["profile", "accept_language"], al)
   end
 
-  defp add_locale_to_params(user_params, _), do: user_params
+  defp add_accept_language_to_params(_, user_params), do: user_params
 end

--- a/lib/vutuv_web/endpoint.ex
+++ b/lib/vutuv_web/endpoint.ex
@@ -16,6 +16,7 @@ defmodule VutuvWeb.Endpoint do
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do
+    socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
     plug Phoenix.LiveReloader
     plug Phoenix.CodeReloader
   end

--- a/lib/vutuv_web/templates/layout/app.html.eex
+++ b/lib/vutuv_web/templates/layout/app.html.eex
@@ -8,6 +8,17 @@
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
   </head>
   <body>
+    <div class="v-bg">
+      <svg viewBox="0 0 100 100">
+        <defs>
+          <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0" style="stop-color:#ffffff;stop-opacity:0" />
+            <stop offset="1" style="stop-color:#ffffff" />
+          </linearGradient>
+        </defs>
+        <path d="M10 35 l20 50 h20 l20 -50 h-20 l-10 30 l-10 -30 z" fill="url(#grad1)" />
+      </svg>
+    </div>
     <header>
       <div class="inset">
         <h1>vutuv</h1>

--- a/priv/repo/migrations/20190327171932_create_profiles.exs
+++ b/priv/repo/migrations/20190327171932_create_profiles.exs
@@ -11,6 +11,7 @@ defmodule Vutuv.Repo.Migrations.CreateProfiles do
       add :gender, :string
       add :birthday, :date
       add :locale, :string
+      add :accept_language, :string
       add :avatar, :string
       add :headline, :string
       add :noindex?, :boolean, default: false, null: false

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,10 +4,12 @@ defmodule Vutuv.Factory do
   use ExMachina.Ecto, repo: Vutuv.Repo
 
   def user_factory do
+    %{full_name: full_name} = profile = build(:profile)
+
     %Vutuv.Accounts.User{
       email_addresses: build_list(1, :email_address),
-      profile: build(:profile),
-      slug: Faker.Internet.slug(),
+      profile: profile,
+      slug: Slugger.slugify(full_name, ?.),
       password_hash: Argon2.hash_pwd_salt("hard2gue$$"),
       confirmed: true
     }

--- a/test/vutuv/accounts/accounts_test.exs
+++ b/test/vutuv/accounts/accounts_test.exs
@@ -6,10 +6,12 @@ defmodule Vutuv.AccountsTest do
   alias Vutuv.{Accounts, Accounts.EmailAddress, Accounts.EmailManager, Accounts.User, Repo}
   alias Vutuv.{Biographies, Biographies.Profile}
 
+  @accept_language "en-ca,en;q=0.8,en-us;q=0.6,de-de;q=0.4,de;q=0.2"
   @create_user_attrs %{
     "email" => "fred@example.com",
     "password" => "reallyHard2gue$$",
     "profile" => %{
+      "accept_language" => @accept_language,
       "gender" => "male",
       "full_name" => "fred frederickson"
     }
@@ -47,6 +49,9 @@ defmodule Vutuv.AccountsTest do
   describe "write user data" do
     test "create_user/1 with valid data creates a user" do
       assert {:ok, %User{} = user} = Accounts.create_user(@create_user_attrs)
+      assert user.profile.accept_language == @accept_language
+      assert user.profile.gender == "male"
+      assert user.profile.locale == "en_CA"
       assert [%EmailAddress{value: value, position: 1}] = user.email_addresses
       assert value == "fred@example.com"
     end

--- a/test/vutuv/biographies/locale_test.exs
+++ b/test/vutuv/biographies/locale_test.exs
@@ -1,0 +1,24 @@
+defmodule Vutuv.BiographiesLocaleTest do
+  use ExUnit.Case
+
+  alias Vutuv.Biographies.Locale
+
+  test "locale with top quality is selected" do
+    al = ["en-ca,en;q=0.8,en-us;q=0.6,de-de;q=0.4,de;q=0.2"]
+    assert Locale.parse_al(al) == "en_CA"
+    al = ["en;q=0.8,en-us;q=0.6,de-de;q=0.4,de;q=0.2"]
+    assert Locale.parse_al(al) == "en"
+    al = ["en;q=0.6,en-us;q=0.4,de-de;q=0.2,de;q=0.8"]
+    assert Locale.parse_al(al) == "de"
+  end
+
+  test "unsupported locale is not selected" do
+    al = ["zh,en;q=0.6,en-us;q=0.4,de-de;q=0.2,de;q=0.8"]
+    assert Locale.parse_al(al) == "de"
+  end
+
+  test "invalid input returns default locale" do
+    al = ["garbage"]
+    assert Locale.parse_al(al) == Locale.parse_al([])
+  end
+end

--- a/test/vutuv/biographies/locale_test.exs
+++ b/test/vutuv/biographies/locale_test.exs
@@ -1,24 +1,24 @@
-defmodule Vutuv.BiographiesLocaleTest do
+defmodule Vutuv.Biographies.LocaleTest do
   use ExUnit.Case
 
   alias Vutuv.Biographies.Locale
 
   test "locale with top quality is selected" do
-    al = ["en-ca,en;q=0.8,en-us;q=0.6,de-de;q=0.4,de;q=0.2"]
+    al = "en-ca,en;q=0.8,en-us;q=0.6,de-de;q=0.4,de;q=0.2"
     assert Locale.parse_al(al) == "en_CA"
-    al = ["en;q=0.8,en-us;q=0.6,de-de;q=0.4,de;q=0.2"]
+    al = "en;q=0.8,en-us;q=0.6,de-de;q=0.4,de;q=0.2"
     assert Locale.parse_al(al) == "en"
-    al = ["en;q=0.6,en-us;q=0.4,de-de;q=0.2,de;q=0.8"]
+    al = "en;q=0.6,en-us;q=0.4,de-de;q=0.2,de;q=0.8"
     assert Locale.parse_al(al) == "de"
   end
 
   test "unsupported locale is not selected" do
-    al = ["zh,en;q=0.6,en-us;q=0.4,de-de;q=0.2,de;q=0.8"]
+    al = "zh,en;q=0.6,en-us;q=0.4,de-de;q=0.2,de;q=0.8"
     assert Locale.parse_al(al) == "de"
   end
 
   test "invalid input returns default locale" do
-    al = ["garbage"]
-    assert Locale.parse_al(al) == Locale.parse_al([])
+    al = "garbage"
+    assert Locale.parse_al(al) == Locale.parse_al("")
   end
 end

--- a/test/vutuv_web/controllers/user_controller_test.exs
+++ b/test/vutuv_web/controllers/user_controller_test.exs
@@ -79,6 +79,16 @@ defmodule VutuvWeb.UserControllerTest do
       assert html_response(conn, 200) =~ "Raymond Luxury Yacht"
     end
 
+    test "updates locale data when locale is supported", %{conn: conn, user: user} do
+      attrs = %{"profile" => %{"locale" => "de_CH"}}
+      conn = put(conn, Routes.user_path(conn, :update, user), user: attrs)
+      assert redirected_to(conn) == Routes.user_path(conn, :show, user)
+      updated_user = Accounts.get_user(user.id)
+      assert updated_user.profile.locale == "de_CH"
+      conn = get(conn, Routes.user_path(conn, :show, user))
+      assert html_response(conn, 200) =~ "de_CH"
+    end
+
     test "fails when data is invalid", %{conn: conn, user: user} do
       attrs = %{"profile" => %{"honorific_prefix" => String.duplicate("Dr", 42)}}
       conn = put(conn, Routes.user_path(conn, :update, user), user: attrs)


### PR DESCRIPTION
Note: this includes and supersedes #649.

Fixes #646, adding the user locale and accept-language header to the user profile data.

Also makes sure that unique slugs are generated when creating users.