### PR TITLE
Send emails multiple users

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -91,8 +91,16 @@ main {
   box-shadow: 0 0 1.0rem #404040;
   padding: 1.5rem 3.0rem;
 }
+.user-grid {
+  display: grid;
+  grid-gap: 1.5rem;
+}
 .card {
-  background-color: #e8e8e8;
+  width: 100%;
+  background-color: #f8f8f8;
+  padding: 1.5rem;
+  box-shadow: 0 0 0.5rem #888888;
+  margin: 1.5rem auto;
 }
 .profile-header {
   display: flex;
@@ -128,6 +136,9 @@ footer {
   background-color: #495057;
   color: #e6e6e6;
   text-align: center;
+}
+footer form {
+  margin: 0;
 }
 footer ul {
   max-width: 112.0rem;
@@ -172,5 +183,8 @@ button.link {
   }
   footer {
     text-align: left;
+  }
+  .user-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
 }

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -61,4 +61,14 @@ defmodule Vutuv.Accounts do
     |> UserCredential.update_password_changeset(attrs)
     |> Repo.update()
   end
+
+  @doc """
+  Sets the `is_admin` value.
+  """
+  @spec set_admin(UserCredential.t(), map) :: {:ok, UserCredential.t()} | changeset_error
+  def set_admin(%UserCredential{} = user_credential, attrs) do
+    user_credential
+    |> UserCredential.admin_changeset(attrs)
+    |> Repo.update()
+  end
 end

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -71,4 +71,13 @@ defmodule Vutuv.Accounts do
     |> UserCredential.admin_changeset(attrs)
     |> Repo.update()
   end
+
+  @doc """
+  Returns a boolean value stating if the the user has admin rights.
+  """
+  @spec user_is_admin?(integer) :: boolean
+  def user_is_admin?(id) do
+    with user_credential <- get_user_credential(%{"user_id" => id}),
+         do: user_credential.is_admin
+  end
 end

--- a/lib/vutuv/accounts/user_credential.ex
+++ b/lib/vutuv/accounts/user_credential.ex
@@ -13,6 +13,7 @@ defmodule Vutuv.Accounts.UserCredential do
           password_hash: String.t(),
           otp_secret: String.t(),
           confirmed: boolean,
+          is_admin: boolean,
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -22,6 +23,7 @@ defmodule Vutuv.Accounts.UserCredential do
     field :password_hash, :string
     field :otp_secret, :string
     field :confirmed, :boolean, default: false
+    field :is_admin, :boolean, default: false
 
     belongs_to :user, User
 
@@ -63,4 +65,8 @@ defmodule Vutuv.Accounts.UserCredential do
   end
 
   defp put_pass_hash(changeset), do: changeset
+
+  def admin_changeset(user_credential, attrs) do
+    cast(user_credential, attrs, [:is_admin])
+  end
 end

--- a/lib/vutuv/devices.ex
+++ b/lib/vutuv/devices.ex
@@ -38,7 +38,7 @@ defmodule Vutuv.Devices do
   Returns a list of a user's email_addresses.
   """
   @spec list_email_addresses(User.t()) :: [EmailAddress.t()]
-  def list_email_addresses(user) do
+  def list_email_addresses(%User{} = user) do
     Repo.all(assoc(user, :email_addresses))
   end
 

--- a/lib/vutuv/devices.ex
+++ b/lib/vutuv/devices.ex
@@ -12,6 +12,14 @@ defmodule Vutuv.Devices do
   @type changeset_error :: {:error, Ecto.Changeset.t()}
 
   @doc """
+  Returns a list of primary email_addresses.
+  """
+  @spec list_primary_email_addresses() :: [EmailAddress.t()]
+  def list_primary_email_addresses() do
+    EmailAddress |> where([e], e.position == 1) |> Repo.all()
+  end
+
+  @doc """
   Returns a list of unverified email addresses.
 
   This is used by the EmailManager, which is responsible for handling

--- a/lib/vutuv/notifications.ex
+++ b/lib/vutuv/notifications.ex
@@ -1,0 +1,70 @@
+defmodule Vutuv.Notifications do
+  @moduledoc """
+  The Notifications context.
+  """
+
+  import Ecto
+  import Ecto.Query, warn: false
+
+  @type changeset_error :: {:error, Ecto.Changeset.t()}
+
+  alias Vutuv.Notifications.EmailNotification
+  alias Vutuv.{UserProfiles.User, Repo}
+
+  @doc """
+  Returns the list of email_notifications.
+  """
+  @spec list_email_notifications(User.t()) :: [EmailNotification.t()]
+  def list_email_notifications(%User{} = user) do
+    Repo.all(assoc(user, :email_notifications))
+  end
+
+  @doc """
+  Gets a single email_notification.
+
+  Raises `Ecto.NoResultsError` if the Email notification does not exist.
+  """
+  @spec get_email_notification!(User.t(), integer) :: EmailNotification.t() | no_return
+  def get_email_notification!(%User{} = user, id) do
+    Repo.get_by!(EmailNotification, id: id, owner_id: user.id)
+  end
+
+  @doc """
+  Creates a email_notification.
+  """
+  @spec create_email_notification(User.t(), map) :: {:ok, EmailNotification.t()} | changeset_error
+  def create_email_notification(%User{} = user, attrs \\ %{}) do
+    user
+    |> build_assoc(:email_notifications)
+    |> EmailNotification.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a email_notification.
+  """
+  @spec update_email_notification(EmailNotification.t(), map) ::
+          {:ok, EmailNotification.t()} | changeset_error
+  def update_email_notification(%EmailNotification{} = email_notification, attrs) do
+    email_notification
+    |> EmailNotification.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a EmailNotification.
+  """
+  @spec delete_email_notification(EmailNotification.t()) ::
+          {:ok, EmailNotification.t()} | changeset_error
+  def delete_email_notification(%EmailNotification{} = email_notification) do
+    Repo.delete(email_notification)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking email_notification changes.
+  """
+  @spec change_email_notification(EmailNotification.t()) :: Ecto.Changeset.t()
+  def change_email_notification(%EmailNotification{} = email_notification) do
+    EmailNotification.changeset(email_notification, %{})
+  end
+end

--- a/lib/vutuv/notifications/email_notification.ex
+++ b/lib/vutuv/notifications/email_notification.ex
@@ -1,0 +1,35 @@
+defmodule Vutuv.Notifications.EmailNotification do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Vutuv.UserProfiles.User
+
+  @type t :: %__MODULE__{
+          id: integer,
+          body: String.t(),
+          delivered: boolean,
+          subject: String.t(),
+          owner_id: integer,
+          owner: User.t() | %Ecto.Association.NotLoaded{},
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "email_notifications" do
+    field :body, :string
+    field :delivered, :boolean, default: false
+    field :subject, :string
+
+    belongs_to :owner, User
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(email_notification, attrs) do
+    email_notification
+    |> cast(attrs, [:subject, :body, :delivered])
+    |> validate_required([:subject, :body, :delivered])
+  end
+end

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -107,7 +107,7 @@ defmodule Vutuv.Tags do
   def list_user_tags(%User{} = user) do
     assoc(user, :user_tags)
     |> Repo.all()
-    |> Repo.preload(:tag)
+    |> Repo.preload([:tag, :user_tag_endorsements])
   end
 
   @doc """

--- a/lib/vutuv/user_profiles/user.ex
+++ b/lib/vutuv/user_profiles/user.ex
@@ -10,6 +10,7 @@ defmodule Vutuv.UserProfiles.User do
   alias Vutuv.{
     Accounts.UserCredential,
     Biographies.WorkExperience,
+    Notifications.EmailNotification,
     Publications.Post,
     Sessions.Session,
     SocialNetworks.SocialMediaAccount,
@@ -33,6 +34,7 @@ defmodule Vutuv.UserProfiles.User do
           noindex: boolean,
           addresses: [Address.t()] | %Ecto.Association.NotLoaded{},
           email_addresses: [EmailAddress.t()] | %Ecto.Association.NotLoaded{},
+          email_notifications: [EmailNotification.t()] | %Ecto.Association.NotLoaded{},
           followees: [UserConnection.t()] | %Ecto.Association.NotLoaded{},
           followers: [UserConnection.t()] | %Ecto.Association.NotLoaded{},
           phone_numbers: [PhoneNumber.t()] | %Ecto.Association.NotLoaded{},
@@ -64,6 +66,11 @@ defmodule Vutuv.UserProfiles.User do
 
     has_many :addresses, Address, on_delete: :delete_all
     has_many :email_addresses, EmailAddress, on_delete: :delete_all
+
+    has_many :email_notifications, EmailNotification,
+      foreign_key: :owner_id,
+      on_delete: :delete_all
+
     has_many :phone_numbers, PhoneNumber, on_delete: :delete_all
     has_many :posts, Post, on_delete: :delete_all
     has_many :sessions, Session, on_delete: :delete_all

--- a/lib/vutuv_web/controllers/authorize.ex
+++ b/lib/vutuv_web/controllers/authorize.ex
@@ -52,7 +52,10 @@ defmodule VutuvWeb.Authorize do
     |> halt()
   end
 
-  defp need_login(conn) do
+  @doc """
+  Redirects user when user is not authenticated - current_user is nil.
+  """
+  def need_login(conn) do
     conn
     |> put_session(:request_path, current_path(conn))
     |> put_flash(:error, gettext("You need to log in to view this page"))

--- a/lib/vutuv_web/controllers/email_address_controller.ex
+++ b/lib/vutuv_web/controllers/email_address_controller.ex
@@ -10,18 +10,18 @@ defmodule VutuvWeb.EmailAddressController do
 
   def action(conn, _), do: auth_action_slug(conn, __MODULE__)
 
-  def index(conn, _params, user) do
-    email_addresses = Devices.list_email_addresses(user)
+  def index(conn, _params, current_user) do
+    email_addresses = Devices.list_email_addresses(current_user)
     render(conn, "index.html", email_addresses: email_addresses)
   end
 
-  def new(conn, _params, _user) do
+  def new(conn, _params, _current_user) do
     changeset = Devices.change_email_address(%EmailAddress{})
     render(conn, "new.html", changeset: changeset)
   end
 
-  def create(conn, %{"email_address" => email_address_params}, user) do
-    case Devices.create_email_address(user, email_address_params) do
+  def create(conn, %{"email_address" => email_address_params}, current_user) do
+    case Devices.create_email_address(current_user, email_address_params) do
       {:ok, email_address} ->
         verify_email(conn, %{"email" => email_address.value}, "verify this email address", true)
 
@@ -56,37 +56,37 @@ defmodule VutuvWeb.EmailAddressController do
     |> redirect(to: Routes.verification_path(conn, :new, email: email))
   end
 
-  def show(conn, %{"id" => id}, user) do
-    email_address = Devices.get_email_address!(user, id)
+  def show(conn, %{"id" => id}, current_user) do
+    email_address = Devices.get_email_address!(current_user, id)
     render(conn, "show.html", email_address: email_address)
   end
 
-  def edit(conn, %{"id" => id}, user) do
-    email_address = Devices.get_email_address!(user, id)
+  def edit(conn, %{"id" => id}, current_user) do
+    email_address = Devices.get_email_address!(current_user, id)
     changeset = Devices.change_email_address(email_address)
     render(conn, "edit.html", email_address: email_address, changeset: changeset)
   end
 
-  def update(conn, %{"id" => id, "email_address" => email_address_params}, user) do
-    email_address = Devices.get_email_address!(user, id)
+  def update(conn, %{"id" => id, "email_address" => email_address_params}, current_user) do
+    email_address = Devices.get_email_address!(current_user, id)
 
     case Devices.update_email_address(email_address, email_address_params) do
       {:ok, email_address} ->
         conn
         |> put_flash(:info, gettext("Email address updated successfully."))
-        |> redirect(to: Routes.user_email_address_path(conn, :show, user, email_address))
+        |> redirect(to: Routes.user_email_address_path(conn, :show, current_user, email_address))
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "edit.html", email_address: email_address, changeset: changeset)
     end
   end
 
-  def delete(conn, %{"id" => id}, user) do
-    email_address = Devices.get_email_address!(user, id)
+  def delete(conn, %{"id" => id}, current_user) do
+    email_address = Devices.get_email_address!(current_user, id)
     {:ok, _email_address} = Devices.delete_email_address(email_address)
 
     conn
     |> put_flash(:info, gettext("Email address deleted successfully."))
-    |> redirect(to: Routes.user_email_address_path(conn, :index, user))
+    |> redirect(to: Routes.user_email_address_path(conn, :index, current_user))
   end
 end

--- a/lib/vutuv_web/controllers/email_notification_controller.ex
+++ b/lib/vutuv_web/controllers/email_notification_controller.ex
@@ -1,0 +1,81 @@
+defmodule VutuvWeb.EmailNotificationController do
+  use VutuvWeb, :controller
+
+  import VutuvWeb.Authorize
+
+  alias Vutuv.{Accounts, Notifications}
+  alias Vutuv.Notifications.EmailNotification
+
+  @dialyzer {:nowarn_function, new: 3}
+
+  def action(%Plug.Conn{assigns: %{current_user: %{id: id} = current_user}} = conn, _) do
+    if Accounts.user_is_admin?(id) do
+      auth_action_slug(conn, __MODULE__)
+    else
+      unauthorized(conn, current_user)
+    end
+  end
+
+  # change this to need_login?
+  def action(conn, _), do: auth_action_slug(conn, __MODULE__)
+
+  def index(conn, _params, current_user) do
+    email_notifications = Notifications.list_email_notifications(current_user)
+    render(conn, "index.html", email_notifications: email_notifications)
+  end
+
+  def new(conn, _params, _current_user) do
+    changeset = Notifications.change_email_notification(%EmailNotification{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"email_notification" => email_notification_params}, current_user) do
+    case Notifications.create_email_notification(current_user, email_notification_params) do
+      {:ok, email_notification} ->
+        conn
+        |> put_flash(:info, gettext("Email notification created successfully."))
+        |> redirect(
+          to: Routes.user_email_notification_path(conn, :show, current_user, email_notification)
+        )
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}, current_user) do
+    email_notification = Notifications.get_email_notification!(current_user, id)
+    render(conn, "show.html", email_notification: email_notification)
+  end
+
+  def edit(conn, %{"id" => id}, current_user) do
+    email_notification = Notifications.get_email_notification!(current_user, id)
+    changeset = Notifications.change_email_notification(email_notification)
+    render(conn, "edit.html", email_notification: email_notification, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "email_notification" => email_notification_params}, current_user) do
+    email_notification = Notifications.get_email_notification!(current_user, id)
+
+    case Notifications.update_email_notification(email_notification, email_notification_params) do
+      {:ok, email_notification} ->
+        conn
+        |> put_flash(:info, gettext("Email notification updated successfully."))
+        |> redirect(
+          to: Routes.user_email_notification_path(conn, :show, current_user, email_notification)
+        )
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "edit.html", email_notification: email_notification, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}, current_user) do
+    email_notification = Notifications.get_email_notification!(current_user, id)
+    {:ok, _email_notification} = Notifications.delete_email_notification(email_notification)
+
+    conn
+    |> put_flash(:info, gettext("Email notification deleted successfully."))
+    |> redirect(to: Routes.user_email_notification_path(conn, :index, current_user))
+  end
+end

--- a/lib/vutuv_web/controllers/followee_controller.ex
+++ b/lib/vutuv_web/controllers/followee_controller.ex
@@ -54,7 +54,7 @@ defmodule VutuvWeb.FolloweeController do
   end
 
   defp current_user_check(%{id: user_id}, %{"follower_id" => follower_id}) do
-    user_id == follower_id
+    to_string(user_id) == follower_id
   end
 
   defp current_user_check(%{id: user_id}, %{follower_id: follower_id}) do

--- a/lib/vutuv_web/email.ex
+++ b/lib/vutuv_web/email.ex
@@ -17,7 +17,19 @@ defmodule VutuvWeb.Email do
   """
 
   import Bamboo.Email
+
   alias VutuvWeb.Mailer
+
+  @doc """
+  A notification email.
+  """
+  def notification(address, subject, body) do
+    address
+    |> base_email()
+    |> subject(subject)
+    |> text_body(body)
+    |> Mailer.deliver_later()
+  end
 
   @doc """
   An email with a verification link in it.

--- a/lib/vutuv_web/email_notifications.ex
+++ b/lib/vutuv_web/email_notifications.ex
@@ -1,0 +1,18 @@
+defmodule VutuvWeb.EmailNotifications do
+  @moduledoc """
+  Module for handling email notifications to multiple users.
+  """
+
+  alias Vutuv.{Devices, Notifications}
+  alias Vutuv.Notifications.EmailNotification
+  alias VutuvWeb.Email
+
+  @doc """
+  Sends emails to all users and updates the email_notification delivered value.
+  """
+  def send_emails(%EmailNotification{body: body, subject: subject} = email_notification) do
+    addresses = Enum.map(Devices.list_primary_email_addresses(), & &1.value)
+    Email.notification(addresses, subject, body)
+    Notifications.update_email_notification(email_notification, %{delivered: true})
+  end
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -23,6 +23,7 @@ defmodule VutuvWeb.Router do
     resources "/users", UserController, except: [:new], param: "slug" do
       resources "/addresses", AddressController
       resources "/email_addresses", EmailAddressController
+      resources "/email_notifications", EmailNotificationController
       resources "/followers", FollowerController, only: [:index]
       resources "/followees", FolloweeController, only: [:index, :create, :delete]
       resources "/posts", PostController

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -28,7 +28,7 @@ defmodule VutuvWeb.Router do
       resources "/followees", FolloweeController, only: [:index, :create, :delete]
       resources "/posts", PostController
       resources "/social_media_accounts", SocialMediaAccountController
-      resources "/tags", UserTagController, only: [:new, :create, :delete], as: :tag
+      resources "/tags", UserTagController, only: [:index, :new, :create, :delete], as: :tag
 
       resources "/user_tag_endorsements", UserTagEndorsementController,
         only: [:create, :delete],

--- a/lib/vutuv_web/templates/address/index.html.eex
+++ b/lib/vutuv_web/templates/address/index.html.eex
@@ -40,5 +40,5 @@
 <% end %>
 
 <%= if assigns[:current_user] && @current_user.id == @user.id do %>
-<span><%= link gettext("New address"), to: Routes.user_address_path(@conn, :new, @current_user) %></span>
+  <span><%= link gettext("New address"), to: Routes.user_address_path(@conn, :new, @current_user) %></span>
 <% end %>

--- a/lib/vutuv_web/templates/email_notification/edit.html.eex
+++ b/lib/vutuv_web/templates/email_notification/edit.html.eex
@@ -1,0 +1,5 @@
+<h1><%= gettext "Edit email notification" %></h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.user_email_notification_path(@conn, :update, @current_user, @email_notification)) %>
+
+<span><%= link gettext("Back"), to: Routes.user_email_notification_path(@conn, :index, @current_user) %></span>

--- a/lib/vutuv_web/templates/email_notification/form.html.eex
+++ b/lib/vutuv_web/templates/email_notification/form.html.eex
@@ -5,17 +5,17 @@
     </div>
   <% end %>
 
-  <%= label f, :subject %>
+  <%= label f, :subject, gettext("Subject") %>
   <%= text_input f, :subject %>
   <%= error_tag f, :subject %>
 
-  <%= label f, :body %>
+  <%= label f, :body, gettext("Body") %>
   <%= text_input f, :body %>
   <%= error_tag f, :body %>
 
-  <%= label f, :delivered %>
-  <%= checkbox f, :delivered %>
-  <%= error_tag f, :delivered %>
+  <%= label f, :send_now, gettext("Send now") %>
+  <%= checkbox f, :send_now %>
+  <%= error_tag f, :send_now %>
 
   <div>
     <%= submit gettext("Save") %>

--- a/lib/vutuv_web/templates/email_notification/form.html.eex
+++ b/lib/vutuv_web/templates/email_notification/form.html.eex
@@ -10,7 +10,7 @@
   <%= error_tag f, :subject %>
 
   <%= label f, :body, gettext("Body") %>
-  <%= text_input f, :body %>
+  <%= textarea f, :body %>
   <%= error_tag f, :body %>
 
   <%= label f, :send_now, gettext("Send now") %>

--- a/lib/vutuv_web/templates/email_notification/form.html.eex
+++ b/lib/vutuv_web/templates/email_notification/form.html.eex
@@ -1,0 +1,23 @@
+<%= form_for @changeset, @action, [], fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p><%= gettext "Something went wrong. Please check the errors below." %></p>
+    </div>
+  <% end %>
+
+  <%= label f, :subject %>
+  <%= text_input f, :subject %>
+  <%= error_tag f, :subject %>
+
+  <%= label f, :body %>
+  <%= text_input f, :body %>
+  <%= error_tag f, :body %>
+
+  <%= label f, :delivered %>
+  <%= checkbox f, :delivered %>
+  <%= error_tag f, :delivered %>
+
+  <div>
+    <%= submit gettext("Save") %>
+  </div>
+<% end %>

--- a/lib/vutuv_web/templates/email_notification/index.html.eex
+++ b/lib/vutuv_web/templates/email_notification/index.html.eex
@@ -1,0 +1,34 @@
+<h1><%= gettext "Email notifications" %></h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Subject</th>
+      <th>Body</th>
+      <th>Delivered</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for email_notification <- @email_notifications do %>
+    <tr>
+      <td><%= email_notification.subject %></td>
+      <td><%= email_notification.body %></td>
+      <td><%= email_notification.delivered %></td>
+
+      <td>
+        <%= link gettext("Show"), to: Routes.user_email_notification_path(@conn, :show, @current_user, email_notification) %>
+        <%= link gettext("Edit"), to: Routes.user_email_notification_path(@conn, :edit, @current_user, email_notification) %>
+        <li>
+          <%= form_for @conn, Routes.user_email_notification_path(@conn, :delete, @current_user, email_notification), [method: "delete"], fn _f -> %>
+          <%= submit gettext("Delete"), class: "link" %>
+        <% end %>
+        </li>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<span><%= link gettext("New Email notification"), to: Routes.user_email_notification_path(@conn, :new, @current_user) %></span>

--- a/lib/vutuv_web/templates/email_notification/new.html.eex
+++ b/lib/vutuv_web/templates/email_notification/new.html.eex
@@ -1,0 +1,5 @@
+<h1><%= gettext "New email notification" %></h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.user_email_notification_path(@conn, :create, @current_user)) %>
+
+<span><%= link gettext("Back"), to: Routes.user_email_notification_path(@conn, :index, @current_user) %></span>

--- a/lib/vutuv_web/templates/email_notification/show.html.eex
+++ b/lib/vutuv_web/templates/email_notification/show.html.eex
@@ -1,0 +1,25 @@
+<h1><%= gettext "Email notification" %></h1>
+
+<ul>
+
+  <li>
+    <strong>Subject:</strong>
+    <%= @email_notification.subject %>
+  </li>
+
+  <li>
+    <strong>Body:</strong>
+    <%= @email_notification.body %>
+  </li>
+
+  <li>
+    <strong>Delivered:</strong>
+    <%= @email_notification.delivered %>
+  </li>
+
+</ul>
+
+<%= if assigns[:current_user] do %>
+<span><%= link gettext("Edit"), to: Routes.user_email_notification_path(@conn, :edit, @current_user, @email_notification) %></span>
+<span><%= link gettext("Back"), to: Routes.user_email_notification_path(@conn, :index, @current_user) %></span>
+<% end %>

--- a/lib/vutuv_web/templates/followee/_card.html.eex
+++ b/lib/vutuv_web/templates/followee/_card.html.eex
@@ -8,4 +8,4 @@
   <% end %>
 
   <span><%= link gettext("All following"), to: Routes.user_followee_path(@conn, :index, @user) %></span><br>
-<section class="card">
+</section>

--- a/lib/vutuv_web/templates/post/_card.html.eex
+++ b/lib/vutuv_web/templates/post/_card.html.eex
@@ -23,4 +23,8 @@
       </tbody>
     </table>
   <% end %>
+
+  <%= if assigns[:current_user] && @current_user.id == @user.id do %>
+    <span><%= link gettext("New post"), to: Routes.user_post_path(@conn, :new, @current_user) %></span>
+  <% end %>
 </section>

--- a/lib/vutuv_web/templates/post/form.html.eex
+++ b/lib/vutuv_web/templates/post/form.html.eex
@@ -23,6 +23,10 @@
   ] %>
   <%= error_tag f, :visibility_level %>
 
+  <%= inputs_for f, :post_tags, fn fp -> %>
+    <%= text_input fp, :name %>
+  <% end %>
+
   <div>
     <%= submit gettext("Save") %>
   </div>

--- a/lib/vutuv_web/templates/user/_profile_header.html.eex
+++ b/lib/vutuv_web/templates/user/_profile_header.html.eex
@@ -10,7 +10,7 @@
     <h4><%= ngettext "1 follower", "%{count} followers", Vutuv.UserConnections.follower_count(@user) %></h4>
 
     <%= if assigns[:current_user] && @current_user.id != @user.id do %>
-      <%= if user_connection = Vutuv.UserConnections.get_user_connection(@current_user, @user) do %>
+      <%= if user_connection = Vutuv.UserConnections.get_user_connection(@user, @current_user) do %>
         <%= form_for @conn, Routes.user_followee_path(@conn, :delete, @user, user_connection.id), [method: "delete"], fn _f -> %>
           <%= submit gettext("Unfollow"), class: "link" %>
         <% end %>

--- a/lib/vutuv_web/templates/user/_users_table.html.eex
+++ b/lib/vutuv_web/templates/user/_users_table.html.eex
@@ -21,9 +21,6 @@
           <% else %>
             <%= link gettext("View profile"), to: Routes.user_path(@conn, :show, user) %>
           <% end %>
-          <%= if assigns[:current_user] && @current_user.id == user.id do %>
-            <%= link gettext("Edit"), to: Routes.user_path(@conn, :edit, user) %>
-          <% end %>
         </td>
       </tr>
     <% end %>

--- a/lib/vutuv_web/templates/user/show.html.eex
+++ b/lib/vutuv_web/templates/user/show.html.eex
@@ -1,8 +1,8 @@
 <div class="user-grid">
   <%= render VutuvWeb.UserTagView, "_card.html", conn: @conn, current_user: @current_user, user_tags: @user.user_tags %>
+  <%= render VutuvWeb.EmailAddressView, "_card.html", conn: @conn, current_user: @current_user, user: @user %>
   <%= render VutuvWeb.FolloweeView, "_card.html", conn: @conn, current_user: @current_user, followees: Enum.map(@user.followees, & &1.followee), user: @user %>
   <%= render VutuvWeb.FollowerView, "_card.html", conn: @conn, current_user: @current_user, followers: Enum.map(@user.followers, & &1.follower), user: @user %>
-  <%= render VutuvWeb.EmailAddressView, "_card.html", conn: @conn, current_user: @current_user, user: @user %>
   <%= render VutuvWeb.SocialMediaAccountView, "_card.html", conn: @conn, current_user: @current_user, user: @user %>
   <%= render VutuvWeb.PostView, "_card.html", conn: @conn, current_user: @current_user, user: @user, posts: @posts %>
 

--- a/lib/vutuv_web/templates/user/show.html.eex
+++ b/lib/vutuv_web/templates/user/show.html.eex
@@ -1,8 +1,10 @@
-<%= render VutuvWeb.UserTagView, "_card.html", conn: @conn, current_user: @current_user, user_tags: @user.user_tags %>
-<%= render VutuvWeb.FolloweeView, "_card.html", conn: @conn, current_user: @current_user, followees: Enum.map(@user.followees, & &1.followee), user: @user %>
-<%= render VutuvWeb.FollowerView, "_card.html", conn: @conn, current_user: @current_user, followers: Enum.map(@user.followers, & &1.follower), user: @user %>
-<%= render VutuvWeb.EmailAddressView, "_card.html", conn: @conn, current_user: @current_user, user: @user %>
-<%= render VutuvWeb.SocialMediaAccountView, "_card.html", conn: @conn, current_user: @current_user, user: @user %>
-<%= render VutuvWeb.PostView, "_card.html", conn: @conn, current_user: @current_user, user: @user, posts: @posts %>
+<div class="user-grid">
+  <%= render VutuvWeb.UserTagView, "_card.html", conn: @conn, current_user: @current_user, user_tags: @user.user_tags %>
+  <%= render VutuvWeb.FolloweeView, "_card.html", conn: @conn, current_user: @current_user, followees: Enum.map(@user.followees, & &1.followee), user: @user %>
+  <%= render VutuvWeb.FollowerView, "_card.html", conn: @conn, current_user: @current_user, followers: Enum.map(@user.followers, & &1.follower), user: @user %>
+  <%= render VutuvWeb.EmailAddressView, "_card.html", conn: @conn, current_user: @current_user, user: @user %>
+  <%= render VutuvWeb.SocialMediaAccountView, "_card.html", conn: @conn, current_user: @current_user, user: @user %>
+  <%= render VutuvWeb.PostView, "_card.html", conn: @conn, current_user: @current_user, user: @user, posts: @posts %>
 
-<span><%= link gettext("Download vcard"), to: Routes.api_user_vcard_path(@conn, :vcard, @user) %></span><br>
+  <span><%= link gettext("Download vcard"), to: Routes.api_user_vcard_path(@conn, :vcard, @user) %></span><br>
+</div>

--- a/lib/vutuv_web/templates/user/show.html.eex
+++ b/lib/vutuv_web/templates/user/show.html.eex
@@ -1,5 +1,5 @@
 <div class="user-grid">
-  <%= render VutuvWeb.UserTagView, "_card.html", conn: @conn, current_user: @current_user, user_tags: @user.user_tags %>
+  <%= render VutuvWeb.UserTagView, "_card.html", conn: @conn, current_user: @current_user, user_tags: ViewUtils.sort_user_tags(@user.user_tags, 10), user: @user %>
   <%= render VutuvWeb.EmailAddressView, "_card.html", conn: @conn, current_user: @current_user, user: @user %>
   <%= render VutuvWeb.FolloweeView, "_card.html", conn: @conn, current_user: @current_user, followees: Enum.map(@user.followees, & &1.followee), user: @user %>
   <%= render VutuvWeb.FollowerView, "_card.html", conn: @conn, current_user: @current_user, followers: Enum.map(@user.followers, & &1.follower), user: @user %>

--- a/lib/vutuv_web/templates/user_tag/_card.html.eex
+++ b/lib/vutuv_web/templates/user_tag/_card.html.eex
@@ -1,5 +1,5 @@
 <section class="card">
-  <h2><%= gettext "Tags" %></h2>
+  <h2><%= gettext "User tags" %></h2>
 
   <ul class="tags">
     <%= for user_tag <- @user_tags do %>
@@ -11,4 +11,6 @@
       </li>
     <% end %>
   </ul>
+
+  <span><%= link gettext("All user tags"), to: Routes.user_tag_path(@conn, :index, @user) %></span>
 </section>

--- a/lib/vutuv_web/templates/user_tag/index.html.eex
+++ b/lib/vutuv_web/templates/user_tag/index.html.eex
@@ -1,0 +1,38 @@
+<h1><%= @user.full_name %> <%= gettext "user_tags" %></h1>
+
+<%= if @user_tags == [] do %>
+<h3><%= @user.full_name %> <%= gettext "has no user tags yet" %></h3>
+<% else %>
+<table>
+  <thead>
+    <tr>
+      <th><%= gettext "Name" %></th>
+      <th><%= gettext "Number of endorsements" %></th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for user_tag <- @user_tags do %>
+    <tr>
+      <td><%= user_tag.tag.name %></td>
+      <td><%= Enum.count(user_tag.user_tag_endorsements) %></td>
+
+      <td>
+        <%= if assigns[:current_user] && @current_user.id == @user.id do %>
+          <li>
+            <%= form_for @conn, Routes.user_tag_path(@conn, :delete, @current_user, user_tag), [method: "delete"], fn _f -> %>
+            <%= submit gettext("Delete"), class: "link" %>
+          <% end %>
+          </li>
+        <% end %>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+<% end %>
+
+<%= if assigns[:current_user] && @current_user.id == @user.id do %>
+  <span><%= link gettext("New user tag"), to: Routes.user_tag_path(@conn, :new, @current_user) %></span>
+<% end %>

--- a/lib/vutuv_web/view_utils.ex
+++ b/lib/vutuv_web/view_utils.ex
@@ -41,4 +41,10 @@ defmodule VutuvWeb.ViewUtils do
       month - 1
     )
   end
+
+  def sort_user_tags(user_tags, limit) do
+    user_tags
+    |> Enum.sort(&(Enum.count(&1.user_tag_endorsements) <= Enum.count(&2.user_tag_endorsements)))
+    |> Enum.take(limit)
+  end
 end

--- a/lib/vutuv_web/views/email_notification_view.ex
+++ b/lib/vutuv_web/views/email_notification_view.ex
@@ -1,0 +1,3 @@
+defmodule VutuvWeb.EmailNotificationView do
+  use VutuvWeb, :view
+end

--- a/priv/repo/migrations/20190327171932_create_user_credentials.exs
+++ b/priv/repo/migrations/20190327171932_create_user_credentials.exs
@@ -7,6 +7,7 @@ defmodule Vutuv.Repo.Migrations.CreateUserCredentials do
       add :password_hash, :string
       add :otp_secret, :string
       add :confirmed, :boolean, default: false, null: false
+      add :is_admin, :boolean, default: false, null: false
 
       timestamps()
     end

--- a/priv/repo/migrations/20191022002529_create_email_notifications.exs
+++ b/priv/repo/migrations/20191022002529_create_email_notifications.exs
@@ -1,0 +1,16 @@
+defmodule Vutuv.Repo.Migrations.CreateEmailNotifications do
+  use Ecto.Migration
+
+  def change do
+    create table(:email_notifications) do
+      add :subject, :string
+      add :body, :string
+      add :delivered, :boolean, default: false, null: false
+      add :owner_id, references(:users, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create index(:email_notifications, [:owner_id])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -75,7 +75,7 @@ for user <- created_users do
 
   Enum.each(
     other_user_ids,
-    &UserConnections.create_user_connection(%{"followee_id" => user.id, "follower_id" => &1.id})
+    &Vutuv.UserConnections.create_user_connection(%{"followee_id" => user.id, "follower_id" => &1})
   )
 end
 
@@ -242,7 +242,7 @@ for user <- other_users_attrs do
 
   Enum.each(
     followee_ids,
-    &UserConnections.create_user_connection(%{"followee_id" => &1.id, "follower_id" => user.id})
+    &Vutuv.UserConnections.create_user_connection(%{"followee_id" => &1, "follower_id" => user.id})
   )
 
   for user_tag <- user_tags do

--- a/priv/templates/phx.gen.html/controller_test.exs
+++ b/priv/templates/phx.gen.html/controller_test.exs
@@ -36,7 +36,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     end
   end
 
-  describe "write work_experience" do
+  describe "write <%= schema.plural %>" do
     test "redirects to show when data is valid", %{conn: conn} do
       conn = post(conn, Routes.<%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @create_attrs)
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -54,6 +54,15 @@ defmodule Vutuv.Factory do
     }
   end
 
+  def email_notification_factory do
+    %Vutuv.Notifications.EmailNotification{
+      owner: build(:user),
+      subject: Faker.Company.name(),
+      body: Faker.Lorem.Shakespeare.romeo_and_juliet(),
+      delivered: false
+    }
+  end
+
   def post_factory do
     %Vutuv.Publications.Post{
       user: build(:user),

--- a/test/vutuv/accounts_test.exs
+++ b/test/vutuv/accounts_test.exs
@@ -9,7 +9,7 @@ defmodule Vutuv.AccountsTest do
     test "changes the stored hash" do
       %{user_credential: %{password_hash: stored_hash} = user_credential} = insert(:user)
       attrs = %{password: "CN8W6kpb"}
-      {:ok, %{password_hash: hash}} = Accounts.update_password(user_credential, attrs)
+      assert {:ok, %{password_hash: hash}} = Accounts.update_password(user_credential, attrs)
       assert hash != stored_hash
     end
 
@@ -17,6 +17,23 @@ defmodule Vutuv.AccountsTest do
       %{user_credential: user_credential} = insert(:user)
       attrs = %{password: "password"}
       assert {:error, %Ecto.Changeset{}} = Accounts.update_password(user_credential, attrs)
+    end
+  end
+
+  describe "set admin rights" do
+    test "is_admin is false by default" do
+      %{user_credential: user_credential} = insert(:user)
+      assert user_credential.is_admin == false
+    end
+
+    test "can set is_admin" do
+      %{user_credential: user_credential} = insert(:user)
+      assert user_credential.is_admin == false
+
+      assert {:ok, %{is_admin: true} = user_credential} =
+               Accounts.set_admin(user_credential, %{is_admin: true})
+
+      assert {:ok, %{is_admin: false}} = Accounts.set_admin(user_credential, %{is_admin: false})
     end
   end
 end

--- a/test/vutuv/devices_test.exs
+++ b/test/vutuv/devices_test.exs
@@ -18,6 +18,14 @@ defmodule Vutuv.DevicesTest do
   describe "read email_address data" do
     setup [:create_user, :create_email_address]
 
+    test "list_primary_email_addresses/1 returns all primary email_addresses" do
+      assert length(Repo.all(EmailAddress)) == 2
+      addresses = Devices.list_primary_email_addresses()
+      assert length(addresses) == 1
+      primary_addresses = Enum.filter(addresses, &(&1.position == 1))
+      assert primary_addresses == addresses
+    end
+
     test "list_email_addresses/1 returns all a user's email addresses", %{
       email_address: email_address,
       user: user

--- a/test/vutuv/notifications_test.exs
+++ b/test/vutuv/notifications_test.exs
@@ -1,0 +1,101 @@
+defmodule Vutuv.NotificationsTest do
+  use Vutuv.DataCase
+
+  import Vutuv.Factory
+
+  alias Vutuv.Notifications
+  alias Vutuv.Notifications.EmailNotification
+
+  @create_email_notification_attrs %{
+    "subject" => "Important announcement",
+    "body" => "We would like to announce ...",
+    "delivered" => false
+  }
+
+  describe "read email_notifications data" do
+    setup [:create_user]
+
+    test "list_email_notifications/1 returns all email_notifications", %{user: user} do
+      email_notification = insert(:email_notification, %{owner: user})
+      _email_notification = insert(:email_notification)
+      assert [email_notification_1] = Notifications.list_email_notifications(user)
+      assert email_notification.id == email_notification_1.id
+      assert email_notification_1.owner_id == user.id
+    end
+
+    test "get_email_notification!/2 returns the email_notification with given id", %{user: user} do
+      email_notification = insert(:email_notification, %{owner: user})
+      _email_notification = insert(:email_notification)
+
+      assert email_notification =
+               Notifications.get_email_notification!(user, email_notification.id)
+
+      assert email_notification.owner_id == user.id
+    end
+  end
+
+  describe "write email_notifications data" do
+    setup [:create_user]
+
+    test "create_email_notification/1 with valid data creates a email_notification", %{user: user} do
+      assert {:ok, %EmailNotification{} = email_notification} =
+               Notifications.create_email_notification(user, @create_email_notification_attrs)
+
+      assert email_notification.subject =~ "Important announcement"
+      assert email_notification.body =~ "We would like to announce ..."
+      assert email_notification.delivered == false
+      assert email_notification.owner_id == user.id
+    end
+
+    test "create_email_notification/1 with invalid data returns error changeset", %{user: user} do
+      invalid_attrs = %{body: ""}
+
+      assert {:error, %Ecto.Changeset{}} =
+               Notifications.create_email_notification(user, invalid_attrs)
+    end
+
+    test "update_email_notification/2 with valid data updates the email_notification" do
+      email_notification = insert(:email_notification)
+      update_attrs = %{"body" => "Nothing to announce", "delivered" => true}
+
+      assert {:ok, %EmailNotification{} = email_notification} =
+               Notifications.update_email_notification(email_notification, update_attrs)
+
+      assert email_notification.body =~ "Nothing to announce"
+      assert email_notification.delivered == true
+    end
+
+    test "update_email_notification/2 with invalid data returns error changeset", %{user: user} do
+      email_notification = insert(:email_notification, %{owner: user})
+      invalid_attrs = %{body: ""}
+
+      assert {:error, %Ecto.Changeset{}} =
+               Notifications.update_email_notification(email_notification, invalid_attrs)
+
+      assert email_notification_1 =
+               Notifications.get_email_notification!(user, email_notification.id)
+
+      assert email_notification.id == email_notification_1.id
+    end
+  end
+
+  describe "delete email_notifications data" do
+    setup [:create_user]
+
+    test "delete_email_notification/1 deletes the email_notification", %{user: user} do
+      email_notification = insert(:email_notification, %{owner: user})
+
+      assert {:ok, %EmailNotification{}} =
+               Notifications.delete_email_notification(email_notification)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Notifications.get_email_notification!(user, email_notification.id)
+      end
+    end
+  end
+
+  defp create_user(_) do
+    user = insert(:user)
+    {:ok, %{user: user}}
+  end
+end

--- a/test/vutuv_web/controllers/email_notification_controller_test.exs
+++ b/test/vutuv_web/controllers/email_notification_controller_test.exs
@@ -1,0 +1,163 @@
+defmodule VutuvWeb.EmailNotificationControllerTest do
+  use VutuvWeb.ConnCase
+
+  alias Vutuv.{Accounts, Notifications}
+
+  @create_attrs %{
+    "subject" => "Welcome to Vutuv",
+    "body" => "This is a blablabla ...",
+    "delivered" => false
+  }
+  @invalid_attrs %{"body" => ""}
+
+  setup %{conn: conn} do
+    conn = conn |> bypass_through(VutuvWeb.Router, [:browser]) |> get("/")
+    user = add_user("igor@example.com")
+    user_credential = Accounts.get_user_credential!(%{"user_id" => user.id})
+    {:ok, _user_credential} = Accounts.set_admin(user_credential, %{is_admin: true})
+    conn = conn |> add_session(user) |> send_resp(:ok, "/")
+    {:ok, %{conn: conn, user: user}}
+  end
+
+  describe "read email_notifications" do
+    test "lists all email_notifications", %{conn: conn, user: user} do
+      _email_notification = insert(:email_notification, %{owner: user})
+      conn = get(conn, Routes.user_email_notification_path(conn, :index, user))
+      assert html_response(conn, 200) =~ "Email notifications"
+    end
+
+    test "shows a single email_notifications", %{conn: conn, user: user} do
+      email_notification = insert(:email_notification, %{owner: user})
+      conn = get(conn, Routes.user_email_notification_path(conn, :show, user, email_notification))
+      assert html_response(conn, 200) =~ "Email notification"
+    end
+
+    test "redirects unauthenticated user", %{user: user} do
+      conn = build_conn()
+      conn = get(conn, Routes.user_email_notification_path(conn, :index, user))
+      assert redirected_to(conn) == Routes.session_path(conn, :new)
+      assert get_flash(conn, :error) =~ "need to log in"
+    end
+
+    test "redirects unauthorized user", %{conn: conn, user: user} do
+      other = add_user("raymond@example.com")
+      conn = get(conn, Routes.user_email_notification_path(conn, :index, other))
+      assert redirected_to(conn) == Routes.user_path(conn, :show, user)
+      assert get_flash(conn, :error) =~ "not authorized"
+    end
+
+    test "redirects non-admin user", %{conn: conn, user: user} do
+      user_credential = Accounts.get_user_credential!(%{"user_id" => user.id})
+      {:ok, _user_credential} = Accounts.set_admin(user_credential, %{is_admin: false})
+      conn = get(conn, Routes.user_email_notification_path(conn, :index, user))
+      assert redirected_to(conn) == Routes.user_path(conn, :show, user)
+      assert get_flash(conn, :error) =~ "not authorized"
+    end
+  end
+
+  describe "renders forms" do
+    test "new email_notification form", %{conn: conn, user: user} do
+      conn = get(conn, Routes.user_email_notification_path(conn, :new, user))
+      assert html_response(conn, 200) =~ "New email notification"
+    end
+
+    test "renders form for editing chosen email_notification", %{conn: conn, user: user} do
+      email_notification = insert(:email_notification, %{owner: user})
+      conn = get(conn, Routes.user_email_notification_path(conn, :edit, user, email_notification))
+      assert html_response(conn, 200) =~ "Edit email notification"
+    end
+
+    test "redirects unauthenticated user", %{user: user} do
+      conn = build_conn()
+      conn = get(conn, Routes.user_email_notification_path(conn, :new, user))
+      assert redirected_to(conn) == Routes.session_path(conn, :new)
+      assert get_flash(conn, :error) =~ "need to log in"
+    end
+
+    test "redirects non-admin user", %{conn: conn, user: user} do
+      user_credential = Accounts.get_user_credential!(%{"user_id" => user.id})
+      {:ok, _user_credential} = Accounts.set_admin(user_credential, %{is_admin: false})
+      conn = get(conn, Routes.user_email_notification_path(conn, :new, user))
+      assert redirected_to(conn) == Routes.user_path(conn, :show, user)
+      assert get_flash(conn, :error) =~ "not authorized"
+    end
+  end
+
+  describe "write email_notification" do
+    test "redirects to show when data is valid", %{conn: conn, user: user} do
+      conn =
+        post(conn, Routes.user_email_notification_path(conn, :create, user),
+          email_notification: @create_attrs
+        )
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == Routes.user_email_notification_path(conn, :show, user, id)
+
+      conn = get(conn, Routes.user_email_notification_path(conn, :show, user, id))
+      assert html_response(conn, 200) =~ "Email notification"
+      assert get_flash(conn, :info) =~ "created successfully"
+    end
+
+    test "create renders errors when data is invalid", %{conn: conn, user: user} do
+      conn =
+        post(conn, Routes.user_email_notification_path(conn, :create, user),
+          email_notification: @invalid_attrs
+        )
+
+      assert html_response(conn, 200) =~ "New email notification"
+    end
+
+    test "update email_notification with valid data", %{conn: conn, user: user} do
+      email_notification = insert(:email_notification, %{owner: user})
+      update_attrs = %{"body" => "Here are some updates to our service"}
+
+      conn =
+        put(conn, Routes.user_email_notification_path(conn, :update, user, email_notification),
+          email_notification: update_attrs
+        )
+
+      assert redirected_to(conn) ==
+               Routes.user_email_notification_path(conn, :show, user, email_notification)
+
+      conn = get(conn, Routes.user_email_notification_path(conn, :show, user, email_notification))
+      assert html_response(conn, 200) =~ "Here are some updates"
+    end
+
+    test "update renders errors when data is invalid", %{conn: conn, user: user} do
+      email_notification = insert(:email_notification, %{owner: user})
+
+      conn =
+        put(conn, Routes.user_email_notification_path(conn, :update, user, email_notification),
+          email_notification: @invalid_attrs
+        )
+
+      assert html_response(conn, 200) =~ "Edit email notification"
+    end
+  end
+
+  describe "delete email_notification" do
+    test "deletes chosen email_notification", %{conn: conn, user: user} do
+      email_notification = insert(:email_notification, %{owner: user})
+
+      conn =
+        delete(conn, Routes.user_email_notification_path(conn, :delete, user, email_notification))
+
+      assert redirected_to(conn) == Routes.user_email_notification_path(conn, :index, user)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.user_email_notification_path(conn, :show, user, email_notification))
+      end
+    end
+
+    test "cannot delete another user's email_notification", %{conn: conn, user: user} do
+      other = add_user("raymond@example.com")
+      email_notification = insert(:email_notification, %{owner: other})
+
+      assert_error_sent 404, fn ->
+        delete(conn, Routes.user_email_notification_path(conn, :delete, user, email_notification))
+      end
+
+      assert Notifications.get_email_notification!(other, email_notification.id)
+    end
+  end
+end

--- a/test/vutuv_web/controllers/email_notification_controller_test.exs
+++ b/test/vutuv_web/controllers/email_notification_controller_test.exs
@@ -95,7 +95,20 @@ defmodule VutuvWeb.EmailNotificationControllerTest do
 
       conn = get(conn, Routes.user_email_notification_path(conn, :show, user, id))
       assert html_response(conn, 200) =~ "Email notification"
-      assert get_flash(conn, :info) =~ "created successfully"
+      assert get_flash(conn, :info) =~ "notification created successfully"
+    end
+
+    test "email is sent when send_now is set to true", %{conn: conn, user: user} do
+      create_attrs = Map.merge(@create_attrs, %{"send_now" => true})
+
+      conn =
+        post(conn, Routes.user_email_notification_path(conn, :create, user),
+          email_notification: create_attrs
+        )
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == Routes.user_email_notification_path(conn, :show, user, id)
+      assert get_flash(conn, :info) =~ "notification created and sent successfully"
     end
 
     test "create renders errors when data is invalid", %{conn: conn, user: user} do

--- a/test/vutuv_web/controllers/email_notification_controller_test.exs
+++ b/test/vutuv_web/controllers/email_notification_controller_test.exs
@@ -6,7 +6,7 @@ defmodule VutuvWeb.EmailNotificationControllerTest do
   @create_attrs %{
     "subject" => "Welcome to Vutuv",
     "body" => "This is a blablabla ...",
-    "delivered" => false
+    "send_now" => false
   }
   @invalid_attrs %{"body" => ""}
 

--- a/test/vutuv_web/controllers/followee_controller_test.exs
+++ b/test/vutuv_web/controllers/followee_controller_test.exs
@@ -28,7 +28,7 @@ defmodule VutuvWeb.FolloweeControllerTest do
 
     test "creates a followee if follower is current_user", %{conn: conn, user: user} do
       other = insert(:user)
-      create_attrs = %{"followee_id" => other.id, "follower_id" => user.id}
+      create_attrs = %{"followee_id" => other.id, "follower_id" => to_string(user.id)}
       conn = post(conn, Routes.user_followee_path(conn, :create, other), followee: create_attrs)
       assert redirected_to(conn) == Routes.user_path(conn, :show, other)
       assert get_flash(conn, :info) =~ "Following user"

--- a/test/vutuv_web/controllers/user_controller_test.exs
+++ b/test/vutuv_web/controllers/user_controller_test.exs
@@ -44,7 +44,7 @@ defmodule VutuvWeb.UserControllerTest do
       user = add_user("reg@example.com")
       conn = get(conn, Routes.user_path(conn, :show, user))
       response = html_response(conn, 200)
-      assert response =~ ~r/Followers(.|\n)*Email addresses/
+      assert response =~ ~r/Email addresses(.|\n)*Followers/
       refute response =~ "Edit email"
     end
 

--- a/test/vutuv_web/controllers/user_tag_controller_test.exs
+++ b/test/vutuv_web/controllers/user_tag_controller_test.exs
@@ -9,6 +9,14 @@ defmodule VutuvWeb.UserTagControllerTest do
     {:ok, %{conn: conn, user: user}}
   end
 
+  describe "read user_tags" do
+    test "list a user's user_tags", %{conn: conn, user: user} do
+      user_tag = insert(:user_tag, %{user: user})
+      conn = get(conn, Routes.user_tag_path(conn, :index, user))
+      assert html_response(conn, 200) =~ user_tag.tag.name
+    end
+  end
+
   describe "renders forms" do
     setup [:add_session_to_conn]
 


### PR DESCRIPTION
This PR starts work on #662. It currently allows an administrator (a user with `is_admin` set to true) to create, edit and send emails to all users. It does not yet include the capability to send emails at specific times.

It also adds an `index` route for user_tags and limits the number of user_tags displayed in the user_tag card to 10 - similar to v1.1.

This PR also includes various updates to the html / css.