### PR TITLE
Replace “Avater” with “Avatar”.

### DIFF
--- a/lib/vutuv_web/templates/user/form_content.html.heex
+++ b/lib/vutuv_web/templates/user/form_content.html.heex
@@ -6,7 +6,7 @@
   <% end %>
   <%= if @current_user do %>
     <div class={"editform__field#{if error_tag(f, :avatar), do: " editform__field--error"}"}>
-    <%= label f, :avatar, gettext("Avater") %>
+    <%= label f, :avatar, gettext("Avatar") %>
     <div class={"editform__inputwrap#{if error_tag(f, :avatar), do: " editform__field--error"}"}>
       <%= file_input f, :avatar %>
     </div>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -83,7 +83,7 @@ msgid "Are you sure?"
 msgstr "Sind Sie sicher?"
 
 #: web/templates/user/form.html.eex:9
-msgid "Avater"
+msgid "Avatar"
 msgstr "Avatar"
 
 #: web/templates/admin/slug/edit.html.eex:6

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -84,7 +84,7 @@ msgid "Are you sure?"
 msgstr ""
 
 #: web/templates/user/form.html.eex:9
-msgid "Avater"
+msgid "Avatar"
 msgstr ""
 
 #: web/templates/admin/slug/edit.html.eex:6

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -83,7 +83,7 @@ msgid "Are you sure?"
 msgstr ""
 
 #: web/templates/user/form.html.eex:9
-msgid "Avater"
+msgid "Avatar"
 msgstr ""
 
 #: web/templates/admin/slug/edit.html.eex:6


### PR DESCRIPTION
I have resolved [`issues/751`](https://github.com/wintermeyer/vutuv/issues/751#issue-2622076044), by replacing (the erroneous) “Avater” with (the correct) “Avatar”.