### PR TITLE
Remove Google+ from the base URI list.

### DIFF
--- a/lib/vutuv/profiles/social_media_account.ex
+++ b/lib/vutuv/profiles/social_media_account.ex
@@ -21,7 +21,6 @@ defmodule Vutuv.Profiles.SocialMediaAccount do
   base_urls = [
     {"Facebook", "http://facebook.com/"},
     {"Twitter", "http://twitter.com/"},
-    {"Google+", "https://plus.google.com/+"},
     {"Instagram", "http://instagram.com/"},
     {"Youtube", "http://youtube.com/channel/"},
     {"Snapchat", nil},


### PR DESCRIPTION
Removed Google+ from the list of base URIs for social media accounts. This is the closest resolution to [`issues/741`](https://github.com/wintermeyer/vutuv/issues/741#event-26239213898) that I am able to provide.

#### Linkage

Resolves [`issues/741`](https://github.com/wintermeyer/vutuv/issues/741#event-26239213898).