### PR TITLE
Remove Google+ from social media providers

### DIFF
--- a/lib/vutuv/profiles/social_media_account.ex
+++ b/lib/vutuv/profiles/social_media_account.ex
@@ -16,12 +16,11 @@ defmodule Vutuv.Profiles.SocialMediaAccount do
   @required_fields ~w(provider value)a
   @optional_fields ~w()a
 
-  @accepted_providers ~w(Facebook Twitter Google+ Instagram Youtube Snapchat LinkedIn XING GitHub)
+  @accepted_providers ~w(Facebook Twitter Instagram Youtube Snapchat LinkedIn XING GitHub)
 
   base_urls = [
     {"Facebook", "http://facebook.com/"},
     {"Twitter", "http://twitter.com/"},
-    {"Google+", "https://plus.google.com/+"},
     {"Instagram", "http://instagram.com/"},
     {"Youtube", "http://youtube.com/channel/"},
     {"Snapchat", nil},
@@ -33,7 +32,6 @@ defmodule Vutuv.Profiles.SocialMediaAccount do
   display_rules = [
     {"Facebook", ""},
     {"Twitter", "@"},
-    {"Google+", "+"},
     {"Instagram", "@"},
     {"Youtube", ""},
     {"Snapchat", ""},

--- a/lib/vutuv_web/templates/social_media_account/form_content.html.heex
+++ b/lib/vutuv_web/templates/social_media_account/form_content.html.heex
@@ -7,7 +7,7 @@
 
   <div class={"editform__field#{if error_tag(f, :provider), do: " editform__field--error"}"}>
     <%= label f, :provider %>
-    <%= select f, :provider, ["Facebook", "Twitter", "Google+", "Instagram", "Youtube", "Snapchat", "LinkedIn", "XING", "GitHub"], prompt: "Select a Social Media Provider", autofocus: true, class: "form-control" %>
+    <%= select f, :provider, ["Facebook", "Twitter", "Instagram", "Youtube", "Snapchat", "LinkedIn", "XING", "GitHub"], prompt: "Select a Social Media Provider", autofocus: true, class: "form-control" %>
     <%= error_tag f, :provider %>
   </div>
 

--- a/test/vutuv/profiles/social_media_account_test.exs
+++ b/test/vutuv/profiles/social_media_account_test.exs
@@ -1,0 +1,30 @@
+defmodule Vutuv.Profiles.SocialMediaAccountTest do
+  use Vutuv.DataCase
+
+  alias Vutuv.Profiles.SocialMediaAccount
+
+  describe "changeset/2 provider validation" do
+    test "accepts a supported provider" do
+      changeset = SocialMediaAccount.changeset(%SocialMediaAccount{}, %{provider: "Facebook", value: "vutuv"})
+      assert changeset.valid?
+    end
+
+    test "rejects Google+ as a provider" do
+      changeset = SocialMediaAccount.changeset(%SocialMediaAccount{}, %{provider: "Google+", value: "vutuv"})
+      refute changeset.valid?
+      assert changeset.errors[:provider]
+    end
+  end
+
+  describe "social_media_link/1" do
+    test "builds a link for a supported provider" do
+      account = %SocialMediaAccount{provider: "Facebook", value: "vutuv"}
+      assert {:safe, _} = SocialMediaAccount.social_media_link(account)
+    end
+
+    test "returns an empty string for Google+" do
+      account = %SocialMediaAccount{provider: "Google+", value: "vutuv"}
+      assert SocialMediaAccount.social_media_link(account) == ""
+    end
+  end
+end

--- a/test/vutuv/profiles/social_media_account_test.exs
+++ b/test/vutuv/profiles/social_media_account_test.exs
@@ -5,12 +5,19 @@ defmodule Vutuv.Profiles.SocialMediaAccountTest do
 
   describe "changeset/2 provider validation" do
     test "accepts a supported provider" do
-      changeset = SocialMediaAccount.changeset(%SocialMediaAccount{}, %{provider: "Facebook", value: "vutuv"})
+      changeset =
+        SocialMediaAccount.changeset(%SocialMediaAccount{}, %{
+          provider: "Facebook",
+          value: "vutuv"
+        })
+
       assert changeset.valid?
     end
 
     test "rejects Google+ as a provider" do
-      changeset = SocialMediaAccount.changeset(%SocialMediaAccount{}, %{provider: "Google+", value: "vutuv"})
+      changeset =
+        SocialMediaAccount.changeset(%SocialMediaAccount{}, %{provider: "Google+", value: "vutuv"})
+
       refute changeset.valid?
       assert changeset.errors[:provider]
     end


### PR DESCRIPTION
Google+ shut down in April 2019, so offering it as a social media provider links to a dead service.

This supersedes #754, which removed only the base URL entry. That left Google+ still selectable in the form and still accepted by the changeset, while `social_media_link/1` fell through to the empty-string catch-all, producing a non-functional (empty) link rather than removing the provider.

This PR drops **all four** references that defined the provider:

- `@accepted_providers` (changeset validation)
- `base_urls` (link generation)
- `display_rules` (display prefix)
- the provider `<select>` in `social_media_account/form_content.html.heex`

### Tests

Adds `test/vutuv/profiles/social_media_account_test.exs` covering that Google+ is now rejected by the changeset and that a supported provider still builds a link. Full suite: 166 passing.

### Notes / follow-ups

- Any existing Google+ rows in the database are now orphaned (they fail re-validation on edit and render an empty link). A data migration to drop or relabel them would be a clean follow-up if production data contains any.
- This **removes** Google+ but does not add the Fediverse replacement requested in #741 — that can be a separate change.

Supersedes #754. Resolves the remaining inconsistency from #741.