### PR TITLE
Add vCard PHOTO regression tests (#749)

### DIFF
--- a/test/vutuv_web/controllers/api/v_card_controller_test.exs
+++ b/test/vutuv_web/controllers/api/v_card_controller_test.exs
@@ -1,5 +1,7 @@
 defmodule VutuvWeb.Api.VCardControllerTest do
-  use VutuvWeb.ConnCase, async: true
+  # Not async: the "with an avatar" regression test sets the global
+  # `:uploads_dir_prefix` application env (same constraint as Vutuv.AvatarTest).
+  use VutuvWeb.ConnCase, async: false
 
   setup do
     user = insert(:user, active_slug: "vcard-tester", validated?: true)
@@ -15,5 +17,44 @@ defmodule VutuvWeb.Api.VCardControllerTest do
     assert content_type =~ "text/vcard"
     assert conn.resp_body =~ "BEGIN:VCARD"
     assert conn.resp_body =~ "END:VCARD"
+  end
+
+  # Regression test for issue #749: a user who never uploaded a profile picture
+  # must not get the default placeholder embedded in their vCard. The default
+  # avatar is an inline SVG data URI, which is intentionally never emitted as a
+  # PHOTO line (the vCard PHOTO field only carries the uploaded JPEG/PNG).
+  test "omits the PHOTO line when the user has no profile picture" do
+    conn = get(build_conn(), "/api/1.0/users/vcard-tester/vcard")
+
+    assert conn.status == 200
+    refute conn.resp_body =~ "PHOTO"
+    refute conn.resp_body =~ "svg"
+  end
+
+  test "includes a base64 PHOTO line when the user has an avatar", %{user: user} do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_vcard_test_#{System.unique_integer([:positive])}")
+    prev = Application.get_env(:vutuv, :uploads_dir_prefix)
+    Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
+
+    on_exit(fn ->
+      File.rm_rf(tmp)
+
+      if prev,
+        do: Application.put_env(:vutuv, :uploads_dir_prefix, prev),
+        else: Application.delete_env(:vutuv, :uploads_dir_prefix)
+    end)
+
+    # Record the uploaded avatar and place the thumb where Vutuv.Avatar expects
+    # it: <prefix>/avatars/<id>/<First Last>_thumb.jpg
+    user = user |> Ecto.Changeset.change(avatar: "selfie.jpg") |> Repo.update!()
+    dir = Path.join(tmp, "avatars/#{user.id}")
+    File.mkdir_p!(dir)
+    {:ok, img} = Image.new(20, 20, color: [1, 2, 3])
+    {:ok, _} = Image.write(img, Path.join(dir, "#{user}_thumb.jpg"))
+
+    conn = get(build_conn(), "/api/1.0/users/vcard-tester/vcard")
+
+    assert conn.status == 200
+    assert conn.resp_body =~ "PHOTO;ENCODING=b;TYPE=JPEG:"
   end
 end


### PR DESCRIPTION
## What

Adds two regression tests for issue #749 ("Don't download default image in vCard when no profile picture has been uploaded").

## Why

#749 reported that a user without an uploaded profile picture might get the default placeholder image embedded in their downloaded vCard.

After investigation, the current code **already handles this correctly**: the default avatar is an inline SVG data URI, and `VCardJSON.vcard_photo/1` only emits a `PHOTO` line for the JPEG/PNG data URIs produced by a real upload. The SVG default falls through to the catch-all and no `PHOTO` line is written.

No application code needed changing, but the behaviour was not covered by a test. These tests lock it in:

- **omits the PHOTO line when the user has no profile picture** — asserts the vCard body contains neither `PHOTO` nor `svg`.
- **includes a base64 PHOTO line when the user has an avatar** — places a real thumbnail on disk where `Vutuv.Avatar` expects it and asserts a `PHOTO;ENCODING=b;TYPE=JPEG:` line is emitted, proving the omission is specific to the missing-photo case.

The file becomes `async: false` because the avatar case sets the global `:uploads_dir_prefix` env (same constraint as `Vutuv.AvatarTest`).

I verified the first test is a true guard via a mutation check: temporarily making `vcard_photo/1` emit the default SVG as a `PHOTO` line caused the test to fail as expected.

Closes #749