### PR TITLE
Fix invisible login/registration input text (#761)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2,3 +2,24 @@
 @source "../../lib/vutuv_web";
 
 @import "./legacy.css";
+
+/*
+ * Issue #761: keep login / registration inputs readable.
+ *
+ * Tailwind v4's Preflight resets every form control to
+ * `color: inherit; background-color: transparent`. Inside `.imagebox__form`
+ * (which sets `color: #fff`) that made the typed text white on a transparent
+ * field over the photo background — invisible in Chrome and Firefox.
+ *
+ * Restore a solid, light field with dark text. Submit buttons keep their own
+ * styling, so they are excluded.
+ */
+.imagebox__input:not([type="submit"]) {
+  background-color: #ffffff;
+  color: #1a1a1a;
+}
+
+.imagebox__input:not([type="submit"])::placeholder {
+  color: #6b7280;
+  opacity: 1;
+}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "5.0.0",
+      version: "5.0.1",
       elixir: "~> 1.20-rc",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/login_input_visibility_test.exs
+++ b/test/vutuv_web/login_input_visibility_test.exs
@@ -1,0 +1,59 @@
+defmodule VutuvWeb.LoginInputVisibilityTest do
+  use ExUnit.Case, async: true
+
+  # Regression test for issue #761 ("Login email address is invisible").
+  #
+  # Tailwind v4's Preflight base reset gives every form control
+  # `color: inherit` and `background-color: transparent`. On the login,
+  # PIN and registration screens the inputs carry the `.imagebox__input`
+  # class inside `.imagebox__form`, which sets `color: #fff`. The inputs
+  # therefore inherited white text and a transparent field, rendering the
+  # typed value as white-on-photo — invisible in Chrome and Firefox.
+  #
+  # The fix is a CSS override that gives those inputs a solid field and a
+  # dark text colour. This test reads the source stylesheet and asserts the
+  # override is present and effective, so the regression cannot creep back
+  # in unnoticed.
+
+  @app_css Path.expand("../../assets/css/app.css", __DIR__)
+
+  defp imagebox_input_rule do
+    css = File.read!(@app_css)
+
+    # Grab the declaration block of the rule that targets `.imagebox__input`
+    # while excluding submit buttons (which legitimately stay blue/white).
+    [_, declarations] =
+      Regex.run(~r/\.imagebox__input[^{}]*:not\(\[type=["']?submit["']?\]\)[^{}]*\{([^}]*)\}/, css) ||
+        flunk("""
+        No `.imagebox__input:not([type=submit])` rule found in #{@app_css}.
+        The login/registration inputs need an explicit, visible fill so they
+        don't inherit Tailwind Preflight's transparent/white reset (issue #761).
+        """)
+
+    declarations
+  end
+
+  test "the source app.css exists" do
+    assert File.exists?(@app_css)
+  end
+
+  test "imagebox inputs are given a concrete, non-transparent background" do
+    declarations = imagebox_input_rule()
+
+    assert declarations =~ ~r/background-color\s*:/,
+           "the input rule must set a background-color"
+
+    refute declarations =~ ~r/background-color\s*:\s*(transparent|#0000\b|rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\))/i,
+           "the input background must not be transparent (it would show the photo through it)"
+  end
+
+  test "imagebox inputs are given a concrete, non-inherited text colour" do
+    declarations = imagebox_input_rule()
+
+    assert declarations =~ ~r/(^|;)\s*color\s*:/,
+           "the input rule must set an explicit text color"
+
+    refute declarations =~ ~r/(^|;)\s*color\s*:\s*inherit/i,
+           "the input text color must not inherit the white `.imagebox__form` color"
+  end
+end

--- a/test/vutuv_web/login_input_visibility_test.exs
+++ b/test/vutuv_web/login_input_visibility_test.exs
@@ -23,7 +23,10 @@ defmodule VutuvWeb.LoginInputVisibilityTest do
     # Grab the declaration block of the rule that targets `.imagebox__input`
     # while excluding submit buttons (which legitimately stay blue/white).
     [_, declarations] =
-      Regex.run(~r/\.imagebox__input[^{}]*:not\(\[type=["']?submit["']?\]\)[^{}]*\{([^}]*)\}/, css) ||
+      Regex.run(
+        ~r/\.imagebox__input[^{}]*:not\(\[type=["']?submit["']?\]\)[^{}]*\{([^}]*)\}/,
+        css
+      ) ||
         flunk("""
         No `.imagebox__input:not([type=submit])` rule found in #{@app_css}.
         The login/registration inputs need an explicit, visible fill so they
@@ -43,7 +46,8 @@ defmodule VutuvWeb.LoginInputVisibilityTest do
     assert declarations =~ ~r/background-color\s*:/,
            "the input rule must set a background-color"
 
-    refute declarations =~ ~r/background-color\s*:\s*(transparent|#0000\b|rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\))/i,
+    refute declarations =~
+             ~r/background-color\s*:\s*(transparent|#0000\b|rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\))/i,
            "the input background must not be transparent (it would show the photo through it)"
   end
 


### PR DESCRIPTION
Closes #761

## Problem

On `/sessions/new` (and the PIN-login and registration screens) the text you type into the input is **invisible**.

The inputs carry the `.imagebox__input` class inside `.imagebox__form`, which sets `color: #fff`. Tailwind v4's Preflight base reset gives every form control:

```css
button, input, select, optgroup, textarea {
  color: inherit;            /* -> inherits #fff from .imagebox__form */
  background-color: transparent;
}
```

So the input inherited **white text** on a **transparent field** over the photo background → white-on-photo, unreadable.

Diagnosis credit to @shaedrich, who pinpointed the Preflight reset.

## Verification (Chrome)

Computed styles of the email input on the live page, before vs. after the fix (typed value `alice@example.com`):

| property | before | after |
|---|---|---|
| `color` | `rgb(255,255,255)` (white) | `rgb(26,26,26)` (dark) |
| `background-color` | `rgba(0,0,0,0)` (transparent) | `rgb(255,255,255)` (white) |
| `caret-color` | white | dark |

Before the fix the field renders empty even with `alice@example.com` typed in; after the fix the text is clearly readable. Reproduced in Chrome (Blink), matching the Firefox report.

## Fix

An override in `assets/css/app.css` (after the imports, so it beats Preflight's `@layer base`) gives the inputs a solid light field with dark text. Submit buttons keep their styling and are excluded:

```css
.imagebox__input:not([type="submit"]) {
  background-color: #ffffff;
  color: #1a1a1a;
}
.imagebox__input:not([type="submit"])::placeholder {
  color: #6b7280;
  opacity: 1;
}
```

This also fixes the same invisible-text issue on the PIN-login, registration and index forms, which share the class.

## Tests

Added `test/vutuv_web/login_input_visibility_test.exs` — a regression guard that asserts the stylesheet gives `.imagebox__input` a concrete, non-transparent background and a non-inherited text colour. Full suite green (`mix test` → 175 passed).