### PR TITLE
Mark all outbound email as auto-generated via one DRY chokepoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Visit http://localhost:4000.
 
 Emails are displayed in the browser via Swoosh's mailbox preview at http://localhost:4000/sent_emails.
 
+Every vutuv email is machine-generated, so all of it carries the `Auto-Submitted: auto-generated` (RFC 3834) and `X-Auto-Response-Suppress: All` headers to keep out-of-office and other auto-responders silent. Mail is built from `Vutuv.Notifications.Emailer.base_email/0` and sent through the single `Emailer.deliver/1` chokepoint, the only place allowed to call `Vutuv.Mailer.deliver/1`.
+
 ### Admin access
 
 Flag your account as admin:
@@ -54,7 +56,7 @@ Admin panel: http://localhost:4000/admin
 - **Forms**: `<.form>` component with `<.inputs_for>` for nested forms
 - **Assets**: esbuild + Tailwind CSS v4
 - **HTTP server**: Bandit
-- **Email**: Swoosh with compile-time EEx text templates
+- **Email**: Swoosh with compile-time EEx text templates; all mail built from `Emailer.base_email/0` and sent through one `Emailer.deliver/1` chokepoint that stamps the auto-generated robot headers
 - **Images**: avatars and URL screenshots are stored on local disk and resized with [`image`](https://hex.pm/packages/image) (libvips); see `Vutuv.Avatar` / `Vutuv.Screenshot`
 - **URL screenshots**: rendered by local headless Chromium, wrapped in a browser window frame (`Vutuv.BrowserFrame`) and stored as WebP; see `Vutuv.PageScreenshot`. Needs a `chromium`/`chrome` binary on the host (set `CHROMIUM_PATH` if it is not on `$PATH`)
 

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -157,7 +157,7 @@ defmodule Vutuv.Accounts do
   # the user is shown "check your email", so a dropped mail must at least be
   # logged (the magic link is already persisted, so we do not roll back).
   defp deliver_login_email(mail, address) do
-    case Vutuv.Mailer.deliver(mail) do
+    case Emailer.deliver(mail) do
       {:ok, _} = ok ->
         ok
 

--- a/lib/vutuv/notifications/cronjob.ex
+++ b/lib/vutuv/notifications/cronjob.ex
@@ -30,7 +30,7 @@ defmodule Vutuv.Notifications.Cronjob do
 
       unless Enum.empty?(todays_users) do
         Emailer.birthday_reminder(user, todays_users, future_users)
-        |> Vutuv.Mailer.deliver()
+        |> Emailer.deliver()
       end
     end
   end

--- a/lib/vutuv/notifications/emailer.ex
+++ b/lib/vutuv/notifications/emailer.ex
@@ -1,5 +1,22 @@
 defmodule Vutuv.Notifications.Emailer do
-  @moduledoc false
+  @moduledoc """
+  Builds and delivers every outbound vutuv email.
+
+  All mail vutuv sends is machine-generated (login PINs, registration, email
+  confirmation, account deletion, payment info, invoices, birthday reminders),
+  so two things are guaranteed here in exactly one place:
+
+    * `base_email/0` sets the `From` and the auto-generated robot headers that
+      tell a recipient's mail system not to auto-reply (no out-of-office /
+      vacation responder bouncing back to `info@vutuv.de`).
+    * `deliver/1` is the single delivery chokepoint. It re-applies the robot
+      headers (belt and suspenders, in case a future builder forgets the base)
+      and hands the message to `Vutuv.Mailer`.
+
+  No code outside this module may call `Vutuv.Mailer.deliver/1` or Swoosh
+  directly. Every builder function returns a `%Swoosh.Email{}`; `deliver/1`
+  sends it.
+  """
 
   import Swoosh.Email
   require Ecto.Query
@@ -7,6 +24,51 @@ defmodule Vutuv.Notifications.Emailer do
   alias VutuvWeb.Plug.Locale
 
   @from_address {"vutuv", "info@vutuv.de"}
+
+  # Always-safe headers for every message.
+  #
+  #   * Auto-Submitted: auto-generated — RFC 3834. A conforming responder
+  #     (including vacation/OOO) must not reply to a message carrying it.
+  #   * X-Auto-Response-Suppress: All — Microsoft Exchange / Outlook. Suppresses
+  #     out-of-office, auto-replies, and delivery/read receipts.
+  @robot_headers [
+    {"Auto-Submitted", "auto-generated"},
+    {"X-Auto-Response-Suppress", "All"}
+  ]
+
+  # Opt-in headers for bulk mail only (see bulk_headers/1).
+  @bulk_headers [
+    {"Precedence", "bulk"},
+    {"List-Unsubscribe", "<mailto:info@vutuv.de?subject=unsubscribe>"}
+  ]
+
+  @doc """
+  Base builder every email starts from. Sets the `From` and the auto-generated
+  robot headers, so those live in exactly one place.
+  """
+  def base_email do
+    new()
+    |> from(@from_address)
+    |> robot_headers()
+  end
+
+  @doc """
+  The single delivery chokepoint for all outbound mail. Re-applies the robot
+  headers and then hands the message to `Vutuv.Mailer`.
+  """
+  def deliver(%Swoosh.Email{} = email) do
+    email
+    |> robot_headers()
+    |> Vutuv.Mailer.deliver()
+  end
+
+  @doc """
+  Adds the bulk-only headers (`Precedence: bulk`, `List-Unsubscribe`). These are
+  **not** safe for one-to-one transactional mail because `Precedence: bulk` can
+  hurt inbox placement, so they are opt-in and applied only to bulk mail such as
+  the birthday reminder.
+  """
+  def bulk_headers(%Swoosh.Email{} = email), do: put_headers(email, @bulk_headers)
 
   def login_email({link, pin}, email, %Vutuv.Accounts.User{validated?: false} = user) do
     gen_email(
@@ -84,10 +146,9 @@ defmodule Vutuv.Notifications.Emailer do
     template = "payment_information_email_#{get_locale(user.locale)}"
     accounting_email = accounting_email()
 
-    new()
+    base_email()
     |> to({VutuvWeb.UserHelpers.name_for_email_to_field(user), email})
     |> bcc(accounting_email)
-    |> from(@from_address)
     |> subject(
       Gettext.gettext(VutuvWeb.Gettext, "Order") <>
         " \"#{recuiter_package.name}\" " <> Gettext.gettext(VutuvWeb.Gettext, "subscription")
@@ -111,9 +172,8 @@ defmodule Vutuv.Notifications.Emailer do
           recruiter_subscription.recruiter_package_id
         )
 
-      new()
+      base_email()
       |> to(accounting_email)
-      |> from(@from_address)
       |> subject("Rechnung: #{recuiter_package.name} für #{user.first_name} #{user.last_name}")
       |> text_body(
         VutuvWeb.EmailText.render("trigger_recruiter_subscription_invoice.text", %{
@@ -122,7 +182,6 @@ defmodule Vutuv.Notifications.Emailer do
           user: user
         })
       )
-      |> Vutuv.Mailer.deliver()
     end
   end
 
@@ -130,12 +189,10 @@ defmodule Vutuv.Notifications.Emailer do
     email = primary_email(user)
     template = "verification_confirmation_#{get_locale(user.locale)}"
 
-    new()
+    base_email()
     |> to({VutuvWeb.UserHelpers.name_for_email_to_field(user), email})
-    |> from(@from_address)
     |> subject(Gettext.gettext(VutuvWeb.Gettext, "vutuv Account verified"))
     |> text_body(VutuvWeb.EmailText.render("#{template}.text", %{user: user}))
-    |> Vutuv.Mailer.deliver()
   end
 
   def birthday_reminder(user, birthday_childs, future_birthday_childs) do
@@ -169,9 +226,9 @@ defmodule Vutuv.Notifications.Emailer do
 
     Gettext.put_locale(VutuvWeb.Gettext, user.locale)
 
-    new()
+    base_email()
     |> to({VutuvWeb.UserHelpers.name_for_email_to_field(user), email})
-    |> from(@from_address)
+    |> bulk_headers()
     |> subject("#{Gettext.gettext(VutuvWeb.Gettext, "Birthday")}: #{truncated_subject}")
     |> text_body(
       VutuvWeb.EmailText.render("#{template}.text", %{
@@ -189,9 +246,8 @@ defmodule Vutuv.Notifications.Emailer do
   defp gen_email(link, pin, email, user, template, email_subject) do
     url = Application.get_env(:vutuv, VutuvWeb.Endpoint)[:public_url]
 
-    new()
+    base_email()
     |> to({VutuvWeb.UserHelpers.name_for_email_to_field(user), email})
-    |> from(@from_address)
     |> subject(email_subject)
     |> text_body(
       VutuvWeb.EmailText.render("#{template}.text", %{
@@ -201,6 +257,12 @@ defmodule Vutuv.Notifications.Emailer do
         user: user
       })
     )
+  end
+
+  defp robot_headers(email), do: put_headers(email, @robot_headers)
+
+  defp put_headers(email, headers) do
+    Enum.reduce(headers, email, fn {name, value}, acc -> header(acc, name, value) end)
   end
 
   defp primary_email(user) do

--- a/lib/vutuv_web/controllers/admin/user_controller.ex
+++ b/lib/vutuv_web/controllers/admin/user_controller.ex
@@ -12,7 +12,9 @@ defmodule VutuvWeb.Admin.UserController do
 
     case Repo.update(changeset) do
       {:ok, user} ->
-        Emailer.verification_notice(user)
+        user
+        |> Emailer.verification_notice()
+        |> Emailer.deliver()
 
         conn
         |> put_flash(:info, gettext("User verified successfully."))

--- a/lib/vutuv_web/controllers/email_controller.ex
+++ b/lib/vutuv_web/controllers/email_controller.ex
@@ -28,7 +28,7 @@ defmodule VutuvWeb.EmailController do
 
     Vutuv.Accounts.gen_magic_link(conn.assigns[:user], "email", email)
     |> Emailer.email_creation_email(email, conn.assigns[:user])
-    |> Vutuv.Mailer.deliver()
+    |> Emailer.deliver()
 
     redirect(conn, to: ~p"/")
   end

--- a/lib/vutuv_web/controllers/recruiter_subscription_controller.ex
+++ b/lib/vutuv_web/controllers/recruiter_subscription_controller.ex
@@ -40,7 +40,7 @@ defmodule VutuvWeb.RecruiterSubscriptionController do
           conn.assigns[:user],
           VutuvWeb.UserHelpers.email(conn.assigns[:user])
         )
-        |> Vutuv.Mailer.deliver()
+        |> Emailer.deliver()
 
         # Send an email to accounting
         accounting_email = Application.fetch_env!(:vutuv, VutuvWeb.Endpoint)[:accounting_email]
@@ -51,6 +51,7 @@ defmodule VutuvWeb.RecruiterSubscriptionController do
             conn.assigns[:user],
             accounting_email
           )
+          |> Emailer.deliver()
         end
 
         conn

--- a/lib/vutuv_web/controllers/user_controller.ex
+++ b/lib/vutuv_web/controllers/user_controller.ex
@@ -320,7 +320,7 @@ defmodule VutuvWeb.UserController do
       email(conn.assigns[:current_user]),
       conn.assigns[:current_user]
     )
-    |> Vutuv.Mailer.deliver()
+    |> Emailer.deliver()
 
     conn
     |> put_flash(

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "5.0.1",
+      version: "5.1.0",
       elixir: "~> 1.20-rc",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/notifications/emailer_test.exs
+++ b/test/vutuv/notifications/emailer_test.exs
@@ -1,0 +1,165 @@
+defmodule Vutuv.Notifications.EmailerTest do
+  @moduledoc """
+  Every outbound vutuv email is machine-generated, so every message must carry
+  the auto-generated robot headers (issue #763). These tests assert the headers
+  are present on at least one message of every type and that the single
+  `deliver/1` chokepoint re-applies them.
+  """
+  use Vutuv.DataCase, async: false
+  import Swoosh.TestAssertions
+
+  alias Vutuv.Notifications.Emailer
+
+  @magic {"https://vutuv.de/magic", "123456"}
+
+  defp assert_robot_headers(email) do
+    assert email.headers["Auto-Submitted"] == "auto-generated"
+    assert email.headers["X-Auto-Response-Suppress"] == "All"
+    email
+  end
+
+  describe "base_email/0 and headers" do
+    test "base_email carries the From and the robot headers" do
+      email = Emailer.base_email()
+
+      assert email.from == {"vutuv", "info@vutuv.de"}
+      assert_robot_headers(email)
+    end
+
+    test "bulk_headers/1 adds the opt-in bulk headers" do
+      email = Emailer.base_email() |> Emailer.bulk_headers()
+
+      assert email.headers["Precedence"] == "bulk"
+      assert email.headers["List-Unsubscribe"] =~ "mailto:"
+    end
+  end
+
+  describe "deliver/1 chokepoint" do
+    test "re-applies the robot headers even when a builder forgot the base" do
+      raw =
+        Swoosh.Email.new()
+        |> Swoosh.Email.from({"vutuv", "info@vutuv.de"})
+        |> Swoosh.Email.to("nobody@example.com")
+        |> Swoosh.Email.subject("Naked email")
+        |> Swoosh.Email.text_body("hi")
+
+      assert raw.headers["Auto-Submitted"] == nil
+
+      Emailer.deliver(raw)
+
+      assert_email_sent(fn email -> assert_robot_headers(email) end)
+    end
+  end
+
+  describe "transactional builders carry the robot headers" do
+    test "registration email (unvalidated user)" do
+      user = insert(:user, validated?: false, locale: "en")
+
+      @magic
+      |> Emailer.login_email("reg@example.com", user)
+      |> assert_robot_headers()
+    end
+
+    test "login email (validated user)" do
+      user = insert(:user, validated?: true, locale: "en")
+
+      @magic
+      |> Emailer.login_email("login@example.com", user)
+      |> assert_robot_headers()
+    end
+
+    test "fbs registration email (unvalidated user)" do
+      user = insert(:user, validated?: false, locale: "en")
+
+      @magic
+      |> Emailer.fbs_login_email("fbsreg@example.com", user)
+      |> assert_robot_headers()
+    end
+
+    test "fbs login email (validated user)" do
+      user = insert(:user, validated?: true, locale: "en")
+
+      @magic
+      |> Emailer.fbs_login_email("fbslogin@example.com", user)
+      |> assert_robot_headers()
+    end
+
+    test "email creation email" do
+      user = insert(:user, locale: "en")
+
+      @magic
+      |> Emailer.email_creation_email("newaddress@example.com", user)
+      |> assert_robot_headers()
+    end
+
+    test "user deletion email" do
+      user = insert(:user, locale: "en")
+
+      @magic
+      |> Emailer.user_deletion_email("delete@example.com", user)
+      |> assert_robot_headers()
+    end
+
+    test "verification notice" do
+      user = insert(:user, locale: "en")
+      insert(:email, user: user, value: "verify@example.com")
+
+      user
+      |> Emailer.verification_notice()
+      |> assert_robot_headers()
+    end
+
+    test "payment information email" do
+      user = insert(:user, locale: "en")
+      package = insert(:recruiter_package)
+      subscription = insert(:recruiter_subscription, user: user, recruiter_package: package)
+
+      subscription
+      |> Emailer.payment_information_email(user, "pay@example.com")
+      |> assert_robot_headers()
+    end
+
+    test "invoice email" do
+      with_accounting_email("accounting@vutuv.de", fn ->
+        user = insert(:user, locale: "en")
+        package = insert(:recruiter_package)
+        subscription = insert(:recruiter_subscription, user: user, recruiter_package: package)
+
+        subscription
+        |> Emailer.issue_invoice(user, "accounting@vutuv.de")
+        |> assert_robot_headers()
+      end)
+    end
+  end
+
+  describe "bulk builders carry both robot and bulk headers" do
+    test "birthday reminder" do
+      user = insert(:user, locale: "en")
+      insert(:email, user: user, value: "birthday@example.com")
+      child = insert(:user, birthdate: ~D[1990-01-01])
+
+      email = Emailer.birthday_reminder(user, [child], [])
+
+      assert_robot_headers(email)
+      assert email.headers["Precedence"] == "bulk"
+    end
+  end
+
+  # Temporarily set the accounting email in the endpoint config so the
+  # invoice builder produces a message, then restore the previous config.
+  defp with_accounting_email(value, fun) do
+    config = Application.fetch_env!(:vutuv, VutuvWeb.Endpoint)
+
+    Application.put_env(
+      :vutuv,
+      VutuvWeb.Endpoint,
+      Keyword.put(config, :accounting_email, value)
+    )
+
+    try do
+      fun.()
+    after
+      Application.put_env(:vutuv, VutuvWeb.Endpoint, config)
+    end
+  end
+end

--- a/test/vutuv/notifications/mailer_chokepoint_test.exs
+++ b/test/vutuv/notifications/mailer_chokepoint_test.exs
@@ -1,0 +1,41 @@
+defmodule Vutuv.Notifications.MailerChokepointTest do
+  @moduledoc """
+  Regression guard for issue #763: all outbound mail must flow through the one
+  `Vutuv.Notifications.Emailer.deliver/1` chokepoint, which is the only place
+  that may call `Vutuv.Mailer.deliver/1` or build a Swoosh email. This keeps the
+  auto-generated robot headers (and the `From`) impossible to forget.
+  """
+  use ExUnit.Case, async: true
+
+  @emailer_path "lib/vutuv/notifications/emailer.ex"
+  @mailer_path "lib/vutuv/mailer.ex"
+
+  test "only the Emailer module calls Vutuv.Mailer.deliver/1" do
+    offenders =
+      lib_files()
+      |> Enum.reject(&(&1 == @emailer_path))
+      |> Enum.filter(&(File.read!(&1) =~ "Vutuv.Mailer.deliver("))
+
+    assert offenders == [],
+           "Vutuv.Mailer.deliver/1 must only be called from #{@emailer_path}. " <>
+             "Send mail through Vutuv.Notifications.Emailer.deliver/1 instead. " <>
+             "Offending files: #{Enum.join(offenders, ", ")}"
+  end
+
+  test "only the Emailer module builds Swoosh emails" do
+    offenders =
+      lib_files()
+      |> Enum.reject(&(&1 in [@emailer_path, @mailer_path]))
+      |> Enum.filter(fn path ->
+        contents = File.read!(path)
+        contents =~ "import Swoosh.Email" or contents =~ "Swoosh.Email.new("
+      end)
+
+    assert offenders == [],
+           "Swoosh emails must only be built in #{@emailer_path}. " <>
+             "Use Vutuv.Notifications.Emailer.base_email/0 instead. " <>
+             "Offending files: #{Enum.join(offenders, ", ")}"
+  end
+
+  defp lib_files, do: Path.wildcard("lib/**/*.ex")
+end


### PR DESCRIPTION
Closes #763.

## Problem

Every email vutuv sends is machine-generated, yet none carried the headers that tell a recipient's mail system not to auto-reply. A user's out-of-office / vacation responder would fire back at `info@vutuv.de` (noise at best, a bounce/loop risk at worst). Mail building and delivery were also spread across several modules and 7+ direct `Vutuv.Mailer.deliver/1` call sites, with some builders returning a `%Swoosh.Email{}` and others delivering internally, so there was no single place to guarantee the headers.

## Solution

All mail now flows through `Vutuv.Notifications.Emailer`:

- **`base_email/0`** returns `new() |> from(@from_address) |> robot_headers()`. The `From` and the auto-generated headers live in exactly one place; every builder starts from it.
- **`deliver/1`** is the single delivery chokepoint. It re-applies the robot headers (belt and suspenders, in case a future builder forgets the base) and then calls `Vutuv.Mailer.deliver/1`. No code outside the module calls `Vutuv.Mailer.deliver/1` or Swoosh directly.
- Every builder now **returns** a `%Swoosh.Email{}`; the build-vs-deliver inconsistency in `issue_invoice/3` and `verification_notice/1` is removed.

### Headers

Set on **every** message:
- `Auto-Submitted: auto-generated` (RFC 3834)
- `X-Auto-Response-Suppress: All` (Exchange / Outlook)

Bulk-only, opt-in via `bulk_headers/1` and applied only to the birthday reminder (since `Precedence: bulk` can hurt inbox placement for transactional mail):
- `Precedence: bulk`
- `List-Unsubscribe`

### Refactored call sites

`accounts.ex`, `user_controller.ex` (account deletion), `email_controller.ex`, `recruiter_subscription_controller.ex`, `admin/user_controller.ex` (verification notice), and `notifications/cronjob.ex` all now go through `Emailer.deliver/1`.

## Tests

- `emailer_test.exs` asserts the robot headers on a message of **every** type, that `bulk_headers/1` adds the bulk headers, and that `deliver/1` re-stamps a header-less email.
- `mailer_chokepoint_test.exs` is the regression guard: it fails if `Vutuv.Mailer.deliver/1` or Swoosh email building appears anywhere outside the Emailer module.

`mix precommit` is green (compile with `--warnings-as-errors`, `credo --strict`, format, 190 tests). Minor version bumped to `5.1.0`.