### PR TITLE
Fix descending year-range warning in work-experience form

### DIFF
--- a/lib/vutuv_web/templates/work_experience/form_content.html.heex
+++ b/lib/vutuv_web/templates/work_experience/form_content.html.heex
@@ -25,7 +25,7 @@
 
   <div class={"editform__field#{if error_tag(f, :start_year), do: " editform__field--error"}"}>
     <%= label f, :start_year, gettext("Start year") %>
-    <%= select f, :start_year, @current_year..1920, prompt: gettext("Select a year") %>
+    <%= select f, :start_year, @current_year..1920//-1, prompt: gettext("Select a year") %>
     <%= error_tag f, :start_year %>
   </div>
 
@@ -40,7 +40,7 @@
 
   <div class={"editform__field#{if error_tag(f, :end_year), do: " editform__field--error"}"}>
     <%= label f, :end_year, gettext("End year") %>
-    <%= select f, :end_year, @current_year..1920, prompt: gettext("Select a year") %>
+    <%= select f, :end_year, @current_year..1920//-1, prompt: gettext("Select a year") %>
     <%= error_tag f, :end_year %>
   </div>
 


### PR DESCRIPTION
The work-experience start/end year selects use `@current_year..1920`, a descending range. Elixir 1.12+ warns because `a..b` only defaults to a step of `-1` as a deprecated fallback when `b < a`; the intended step must be explicit (`a..b//-1`).

The dropdowns rendered correctly, but the warning surfaced as a CI annotation on every run (and in local `mix test`). This spells the step out as `//-1` for both the start- and end-year selects in `lib/vutuv_web/templates/work_experience/form_content.html.heex`.

Cosmetic only, no behavior change. Found while reviewing the CI annotations on #765.