### PR TITLE
Redirect already-logged-in users away from /sessions/new

### DIFF
--- a/lib/vutuv_web/controllers/session_controller.ex
+++ b/lib/vutuv_web/controllers/session_controller.ex
@@ -4,6 +4,10 @@ defmodule VutuvWeb.SessionController do
   alias Vutuv.Accounts
   alias VutuvWeb.RateLimit
 
+  # The login page is logged-out-only, like registration. An already-logged-in
+  # visitor is redirected to their profile. :delete (logout) stays unguarded.
+  plug(VutuvWeb.Plug.RequireUserLoggedOut when action in [:new, :create])
+
   def new(conn, _) do
     render(conn, "new.html", body_class: "stretch")
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "5.2.1",
+      version: "5.2.2",
       elixir: "~> 1.20-rc",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/session_controller_test.exs
+++ b/test/vutuv_web/controllers/session_controller_test.exs
@@ -1,0 +1,37 @@
+defmodule VutuvWeb.SessionControllerTest do
+  use VutuvWeb.ConnCase, async: false
+  import Swoosh.TestAssertions
+
+  # The login page is a logged-out-only entry point, like registration
+  # (UserController :new/:create) and the landing page (PageController :index).
+  # A visitor who is already logged in should be bounced to their profile rather
+  # than shown the login form. :delete (logout) is intentionally not guarded.
+
+  describe "GET /sessions/new" do
+    test "shows the login form to a logged-out visitor", %{conn: conn} do
+      conn = get(conn, ~p"/sessions/new")
+
+      assert html_response(conn, 200) =~ "session[email]"
+    end
+
+    test "redirects an already-logged-in user to their profile", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      conn = get(conn, ~p"/sessions/new")
+
+      assert redirected_to(conn) == ~p"/users/#{user}"
+    end
+  end
+
+  describe "POST /sessions" do
+    test "does not start a login for an already-logged-in user", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      conn = post(conn, ~p"/sessions", session: %{"email" => "someone-else@example.com"})
+
+      assert redirected_to(conn) == ~p"/users/#{user}"
+      # The guard halts before login_by_email/2, so no PIN email goes out.
+      assert_no_email_sent()
+    end
+  end
+end


### PR DESCRIPTION
## Why

`/sessions/new` (the PIN login page) worked for users who were already logged in — showing them a login form they can't meaningfully use. It was the only **logged-out-only** entry point missing a guard: registration (`UserController :new/:create`) and the landing page (`PageController :index`) already redirect a logged-in visitor to their profile via `VutuvWeb.Plug.RequireUserLoggedOut`. This makes login consistent. (Confirmed with the maintainer: account-switching from the login page is intentionally not supported.)

## What changed

- One plug on `SessionController`, mirroring registration:
  ```elixir
  plug(VutuvWeb.Plug.RequireUserLoggedOut when action in [:new, :create])
  ```
  `:delete` (logout) stays unguarded. The PIN login is unaffected: step 1 (`login_by_email`) clears `:user_id`, so the PIN POST is no longer "logged in" and passes the guard.
- Version bumped `5.2.1 → 5.2.2`.

## Tests

New `test/vutuv_web/controllers/session_controller_test.exs`:
- logged-out users still see the login form;
- logged-in users are redirected from `:new` **and** `:create` (with `assert_no_email_sent`, proving login never starts).

Full suite: **210 passing**.

## Verified in a running app

Drove the real browser end to end: logged-out `/sessions/new` shows the form; after a real PIN login, `/sessions/new` redirects to `/users/<slug>`; after logout the form returns and a normal PIN login still works ("Willkommen zurück!"). The login email also rendered with the corrected subject **"vutuv Login-PIN"**.