### PR TITLE
Add a dev-only secret_key_base so dev boots out of the box

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,6 +6,11 @@ config :vutuv, :serve_uploads_locally, true
 config :vutuv, VutuvWeb.Endpoint,
   http: [port: 4000],
   url: [host: "localhost", port: 4000],
+  # Dev-only signing secret so `mix phx.server` boots without extra setup.
+  # This is not a real secret: it only signs localhost dev sessions/cookies.
+  # Production reads its secret_key_base from the environment in runtime.exs,
+  # and the test env has its own in config/test.exs.
+  secret_key_base: "ijWzKCx7VABaOUeORdkVKPKRD3oDmIkgeynooZRJ64AvDyMpbY3dAPZmU2LlegOv",
   debug_errors: true,
   code_reloader: true,
   check_origin: false,


### PR DESCRIPTION
## Why

`secret_key_base` was configured only in `runtime.exs`'s `:prod` branch, so a fresh checkout running `mix phx.server` returned **500** on any session-backed page:

```
** (ArgumentError) cookie store expects conn.secret_key_base to be set
```

Local dev required an undocumented `SECRET_KEY_BASE` env var or a hand-written `config/dev.secret.exs`. (Surfaced while smoke-testing #768.)

## What changed

One line in `config/dev.exs`: a hardcoded dev-only `secret_key_base`, mirroring what `config/test.exs` already does. It is **not a real secret** — it only signs localhost dev sessions/cookies. Production still reads its secret from the environment in `runtime.exs`, and that path is unchanged.

## Verified

Booted `mix phx.server` on a clean tree: `/sessions/new` and `/` now return **200** and render normally (both 500'd before). Full suite still **210 passing** (the change is `:dev`-only and does not touch `:test`).

No version bump: this is a dev-only config change with no effect on the released artifact.