### PR TITLE
Blue/green zero-downtime deploys with a /health readiness gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ Deployment is automatic. Two GitHub Actions workflows drive it:
 - **CI** (`.github/workflows/ci.yml`) runs `mix precommit` (compile with `--warnings-as-errors`, unused-deps, format, `credo --strict`, tests) on every pull request and on pushes to `main`.
 - **Deploy** (`.github/workflows/deploy.yml`) runs on every push to `main`. So **merging or pushing anything to `main` ships it to production**; there is no separate deploy command.
 
-The Deploy job runs on the self-hosted `vutuv3` runner (on bremen2) and executes `scripts/deploy.sh`, which builds a `prod` release, runs migrations against `vutuv3_prod`, atomically flips the `current` symlink, and restarts the `vutuv3` systemd service. A `deploy-production` concurrency group ensures two production deploys never overlap. nginx is not touched by the script.
+The Deploy job runs on the self-hosted `vutuv3` runner (on bremen2) and executes `scripts/deploy.sh`, a **blue/green zero-downtime deploy**: it builds a `prod` release, runs migrations against `vutuv3_prod`, starts the release on the idle slot (`vutuv3@blue` on port 4003 / `vutuv3@green` on port 4005), waits until `GET /health` answers 200 with a live database connection, switches the nginx upstream (`/etc/nginx/snippets/vutuv3-upstream.conf`) with a graceful reload, drains for 30 s and stops the old slot. A failed build or boot leaves the old slot serving, untouched. A `deploy-production` concurrency group ensures two production deploys never overlap.
+
+Because the old code briefly serves against the already-migrated database, **migrations must be backward-compatible**; a deploy that cannot be (such as the one-time UUID v7 re-key prepared on the `version-6` branch, see `DEPLOY_TODO.md` there) is a planned-downtime deploy and must be run deliberately. The systemd slot template lives in `scripts/systemd/vutuv3@.service`.
 
 ## Maintenance / ops tasks
 

--- a/lib/vutuv_web/controllers/health_controller.ex
+++ b/lib/vutuv_web/controllers/health_controller.ex
@@ -1,0 +1,17 @@
+defmodule VutuvWeb.HealthController do
+  use VutuvWeb, :controller
+
+  # Readiness probe for the blue/green deploy (scripts/deploy.sh): the new
+  # release only receives traffic after this returns 200. The SELECT 1 makes
+  # "up" mean "serving requests AND connected to the database", not merely
+  # "the HTTP listener is bound". A failed query crashes the request and the
+  # probe sees a 500.
+  def index(conn, _params) do
+    %{rows: [[1]]} = Vutuv.Repo.query!("SELECT 1")
+
+    conn
+    |> put_resp_header("cache-control", "no-store")
+    |> put_resp_content_type("text/plain")
+    |> send_resp(200, "ok")
+  end
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -41,6 +41,10 @@ defmodule VutuvWeb.Router do
   # by the browser pipeline's `accepts ["html"]`.
   scope "/", VutuvWeb do
     get("/robots.txt", PageController, :robots)
+    # Deploy readiness probe (see VutuvWeb.HealthController). No pipeline:
+    # it is hit by curl on localhost and must not depend on sessions or
+    # content negotiation.
+    get("/health", HealthController, :index)
   end
 
   scope "/", VutuvWeb do

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,23 +1,73 @@
 #!/usr/bin/env bash
 #
-# Build and deploy the vutuv production release on the server. Intended to be
-# run by the self-hosted GitHub Actions runner (user `vutuv3` on bremen2) from
-# a fresh checkout of the repo. Builds a release, runs migrations against
-# vutuv3_prod, flips the `current` symlink atomically, and restarts the
-# service. Does NOT touch nginx — the one-time domain cutover is manual.
+# Blue/green zero-downtime deploy of the vutuv production release. Run by the
+# self-hosted GitHub Actions runner (user `vutuv3` on bremen2) from a fresh
+# checkout of the repo.
+#
+# Flow: build a release, run migrations, start it on the idle slot, wait until
+# its /health probe answers, switch the nginx upstream, drain, stop the old
+# slot. Users never hit a dead port; a failed build or boot leaves the old
+# slot serving untouched.
+#
+# Because the old code keeps serving against the already-migrated database
+# until the switch, MIGRATIONS MUST BE BACKWARD-COMPATIBLE. A deploy that
+# cannot satisfy that (e.g. the one-time UUID v7 re-key prepared on the
+# version-6 branch, see DEPLOY_TODO.md there) is a planned-downtime deploy
+# and must be run deliberately, not pushed casually to main.
+#
+# Server-side layout (set up once, as root):
+#   /var/www/vutuv3/
+#     releases/<ts>/        unpacked mix releases
+#     slots/blue|green      symlink, pins each slot to its release
+#     current               convenience pointer to the live release
+#     shared/.env           secrets (chmod 600)
+#     shared/.env.blue      PORT=4003
+#     shared/.env.green     PORT=4005
+#     shared/active-slot    blue|green (absent = pre-blue/green legacy mode)
+#   systemd: vutuv3@.service templated on the slot (scripts/systemd/)
+#   nginx:   /etc/nginx/snippets/vutuv3-upstream.conf, rewritten on switch
+#   sudoers: /etc/sudoers.d/vutuv3 scopes exactly the commands used below
 #
 set -euo pipefail
 
 # The OTP application is :vutuv, so the release and its launcher are named
-# `vutuv` (bin/vutuv, _build/prod/rel/vutuv). The OS user, service unit and
-# install path use `vutuv3` to sit alongside the old `legacy-vutuv` instance
-# and the stale /var/www/vutuv static dir without colliding.
+# `vutuv` (bin/vutuv, _build/prod/rel/vutuv). The OS user, service units and
+# install path use `vutuv3`.
 RELEASE=vutuv
-SERVICE=vutuv3
+APP=vutuv3
 APP_ROOT=/var/www/vutuv3
 RELEASES_DIR="$APP_ROOT/releases"
+SLOTS_DIR="$APP_ROOT/slots"
 SHARED_ENV="$APP_ROOT/shared/.env"
+STATE_FILE="$APP_ROOT/shared/active-slot"
+LOCK_FILE="$APP_ROOT/shared/.deploy.lock"
+UPSTREAM_FILE=/etc/nginx/snippets/vutuv3-upstream.conf
 KEEP_RELEASES=5
+BLUE_PORT=4003
+GREEN_PORT=4005
+DRAIN_SECONDS=30
+HEALTH_RETRIES=30
+HEALTH_INTERVAL=2
+
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+
+# Belt and braces next to the workflow-level concurrency group: never let two
+# deploys interleave on the server.
+exec 9>"$LOCK_FILE"
+flock -n 9 || { log "ERROR: another deploy holds $LOCK_FILE"; exit 1; }
+
+# Determine the slots. `legacy` means the pre-blue/green single service
+# (vutuv3.service on $BLUE_PORT) is still serving; the first blue/green
+# deploy replaces it via the green slot and stops it like any old slot.
+ACTIVE_SLOT=$(cat "$STATE_FILE" 2>/dev/null || echo legacy)
+case "$ACTIVE_SLOT" in
+  blue)  NEW_SLOT=green NEW_PORT=$GREEN_PORT OLD_UNIT="$APP@blue" ;;
+  green) NEW_SLOT=blue  NEW_PORT=$BLUE_PORT  OLD_UNIT="$APP@green" ;;
+  legacy) NEW_SLOT=green NEW_PORT=$GREEN_PORT OLD_UNIT="$APP" ;;
+  *) log "ERROR: unknown active slot '$ACTIVE_SLOT' in $STATE_FILE"; exit 1 ;;
+esac
+NEW_UNIT="$APP@$NEW_SLOT"
+log "Deploying: $ACTIVE_SLOT -> $NEW_SLOT (port $NEW_PORT)"
 
 export MIX_ENV=prod
 
@@ -39,6 +89,10 @@ dest="$RELEASES_DIR/$ts"
 mkdir -p "$dest"
 cp -a "_build/prod/rel/$RELEASE/." "$dest/"
 
+# If a previous deploy died between starting the slot and switching traffic,
+# the idle slot may still run stale code — clear it before repointing.
+sudo systemctl stop "$NEW_UNIT" 2>/dev/null || true
+
 # Load runtime secrets (DB creds, SECRET_KEY_BASE, ...) so the migrate step
 # can connect. The file is chmod 600 and never leaves the server.
 set -a
@@ -46,17 +100,62 @@ set -a
 source "$SHARED_ENV"
 set +a
 
-# Run migrations against the cloned production database (vutuv3_prod).
+# Run migrations. The old slot keeps serving against the migrated schema
+# until the switch — see the backward-compatibility note in the header.
 "$dest/bin/$RELEASE" eval "Vutuv.Release.migrate()"
 
-# Atomically activate the new release.
+# Pin the idle slot to the new release and boot it.
+ln -sfn "$dest" "$SLOTS_DIR/$NEW_SLOT"
+sudo systemctl start "$NEW_UNIT"
+
+# Gate: no traffic until the new instance serves /health (HTTP 200 with a
+# live database connection) on its own port.
+for i in $(seq 1 "$HEALTH_RETRIES"); do
+  if curl -fsS -o /dev/null --max-time 5 "http://127.0.0.1:$NEW_PORT/health"; then
+    log "Health check passed (attempt $i)"
+    break
+  fi
+  if [ "$i" -eq "$HEALTH_RETRIES" ]; then
+    log "ERROR: $NEW_SLOT never became healthy; $ACTIVE_SLOT still serves traffic"
+    sudo systemctl stop "$NEW_UNIT" 2>/dev/null || true
+    exit 1
+  fi
+  sleep "$HEALTH_INTERVAL"
+done
+
+# Switch traffic: rewrite the nginx upstream and reload. Reload is graceful —
+# running requests and websockets finish on the old workers.
+printf 'upstream vutuv3 {\n    server 127.0.0.1:%s;\n}\n' "$NEW_PORT" \
+  | sudo tee "$UPSTREAM_FILE" > /dev/null
+sudo nginx -t
+sudo nginx -s reload
+log "Traffic switched to $NEW_SLOT"
+
+# Record the new state; keep `current` as a convenience pointer for manual
+# `bin/vutuv eval` sessions and backup scripts.
+echo "$NEW_SLOT" > "$STATE_FILE"
 ln -sfn "$dest" "$APP_ROOT/current"
+sudo systemctl enable "$NEW_UNIT" 2>/dev/null || true
+if [ "$ACTIVE_SLOT" = legacy ]; then
+  sudo systemctl disable "$APP" 2>/dev/null || true
+else
+  sudo systemctl disable "$OLD_UNIT" 2>/dev/null || true
+fi
 
-# Restart via scoped sudoers (see /etc/sudoers.d/vutuv3).
-sudo systemctl restart "$SERVICE"
+# Drain, then stop the old instance. The drain lets in-flight requests and
+# LiveView websockets finish; it stays short because the app's periodic
+# sweepers (e.g. unread-message emails) must not run twice for long.
+log "Draining $ACTIVE_SLOT for ${DRAIN_SECONDS}s..."
+sleep "$DRAIN_SECONDS"
+sudo systemctl stop "$OLD_UNIT" 2>/dev/null || true
+log "Stopped $ACTIVE_SLOT"
 
-# Keep only the most recent releases.
-cd "$RELEASES_DIR"
-ls -1dt */ 2>/dev/null | tail -n "+$((KEEP_RELEASES + 1))" | xargs -r rm -rf
+# Keep only the most recent releases, but never one a slot still points at.
+pinned=$(readlink -f "$SLOTS_DIR/blue" 2>/dev/null; readlink -f "$SLOTS_DIR/green" 2>/dev/null; true)
+find "$RELEASES_DIR" -mindepth 1 -maxdepth 1 -type d | sort | head -n "-$KEEP_RELEASES" \
+  | while read -r old; do
+      case "$pinned" in *"$(readlink -f "$old")"*) continue ;; esac
+      rm -rf "$old"
+    done
 
-echo "Deployed $SERVICE release $ts"
+log "Deployed $APP release $ts on slot $NEW_SLOT (port $NEW_PORT)"

--- a/scripts/systemd/vutuv3@.service
+++ b/scripts/systemd/vutuv3@.service
@@ -1,0 +1,30 @@
+# Blue/green slot template for the vutuv production app (vutuv.de).
+# Install as /etc/systemd/system/vutuv3@.service; instances vutuv3@blue
+# (port 4003) and vutuv3@green (port 4005). The port comes from
+# shared/.env.%i, which overrides the PORT in shared/.env. Each slot is
+# pinned to its own release via the slots/%i symlink, so a deploy never
+# changes the code under a running instance.
+[Unit]
+Description=vutuv production app (%i slot) at vutuv.de
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=exec
+User=vutuv3
+Group=vutuv3
+WorkingDirectory=/var/www/vutuv3/slots/%i
+EnvironmentFile=/var/www/vutuv3/shared/.env
+EnvironmentFile=/var/www/vutuv3/shared/.env.%i
+ExecStart=/var/www/vutuv3/slots/%i/bin/vutuv start
+# No ExecStop: RELEASE_DISTRIBUTION=none has no node for `bin/vutuv stop`
+# RPC. systemd sends SIGTERM to the BEAM, which shuts down gracefully.
+KillSignal=SIGTERM
+TimeoutStopSec=15
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+SyslogIdentifier=vutuv3-%i
+
+[Install]
+WantedBy=multi-user.target

--- a/test/vutuv_web/controllers/health_controller_test.exs
+++ b/test/vutuv_web/controllers/health_controller_test.exs
@@ -1,0 +1,20 @@
+defmodule VutuvWeb.HealthControllerTest do
+  use VutuvWeb.ConnCase, async: true
+
+  describe "GET /health" do
+    test "returns 200 ok as plain text once the app can reach the database" do
+      conn = get(build_conn(), "/health")
+
+      assert conn.status == 200
+      assert conn.resp_body == "ok"
+      assert [content_type] = get_resp_header(conn, "content-type")
+      assert content_type =~ "text/plain"
+    end
+
+    test "is not cached by proxies or browsers" do
+      conn = get(build_conn(), "/health")
+
+      assert ["no-store"] = get_resp_header(conn, "cache-control")
+    end
+  end
+end


### PR DESCRIPTION
Replaces the restart-based deploy (which dropped all connections and risked extended downtime on a failed boot) with the blue/green pattern already proven by wincon on bremen2.

## How it works
- builds the release, runs migrations, starts the new code on the idle slot (`vutuv3@blue` :4003 / `vutuv3@green` :4005), each slot pinned to its own release dir
- waits for `GET /health` (new endpoint, `SELECT 1` against the DB, test-covered) before any traffic moves
- switches `/etc/nginx/snippets/vutuv3-upstream.conf` and reloads nginx gracefully, drains 30 s, stops the old slot
- failed build/boot: old instance keeps serving, deploy aborts

## Notes
- Migrations must stay backward-compatible (old code serves briefly against the migrated schema). The version-6 UUID re-key is exempt: planned-downtime deploy.
- Server prep on bremen2 (unit template, `.env.blue/.env.green`, nginx snippet, sudoers) is done before merge; the first deploy after merge performs the switchover from the single `vutuv3.service` with zero downtime.
- `mix precommit` green locally (216 tests).