### PR TITLE
Allow manual production deploys via workflow_dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ name: Deploy
 on:
   push:
     branches: [main]
+  # Manual redeploy of main from the Actions tab, e.g. to re-run a deploy
+  # without pushing a no-op commit.
+  workflow_dispatch:
 
 # Never run two production deploys at once; let an in-flight one finish.
 concurrency:


### PR DESCRIPTION
The Deploy workflow only fired on pushes to main, so re-running a deploy
(e.g. after a server-side fix) required a no-op commit. A bare
workflow_dispatch trigger adds a manual 'Run workflow' button without
changing the automatic behavior; the deploy-production concurrency group
still serializes runs.
