### PR TITLE
Stamp an FQDN Message-ID on every outbound email

### DIFF
--- a/lib/vutuv/notifications/emailer.ex
+++ b/lib/vutuv/notifications/emailer.ex
@@ -27,6 +27,7 @@ defmodule Vutuv.Notifications.Emailer do
   alias VutuvWeb.Plug.Locale
 
   @from_address {"vutuv", "info@vutuv.de"}
+  @from_domain @from_address |> elem(1) |> String.split("@") |> List.last()
 
   # Always-safe headers for every message.
   #
@@ -54,6 +55,7 @@ defmodule Vutuv.Notifications.Emailer do
     |> from(@from_address)
     |> robot_headers()
     |> envelope_sender()
+    |> message_id()
   end
 
   @doc """
@@ -73,6 +75,7 @@ defmodule Vutuv.Notifications.Emailer do
       email
       |> robot_headers()
       |> envelope_sender()
+      |> message_id()
       |> Vutuv.Mailer.deliver()
     end
   end
@@ -92,6 +95,18 @@ defmodule Vutuv.Notifications.Emailer do
   defp envelope_sender(email), do: header(email, "Sender", bounce_address())
 
   defp bounce_address, do: Application.fetch_env!(:vutuv, :bounce_address)
+
+  # A globally-unique RFC 5322 Message-ID whose right-hand side is the From
+  # domain (vutuv.de). Without one set here, the Swoosh SMTP adapter lets
+  # gen_smtp fall back to "<token@<hostname>>", the machine's bare short
+  # hostname (e.g. "@bremen2"): a non-FQDN id that costs a point on spam
+  # scoring. Idempotent: mail built through base_email keeps that id when it
+  # reaches the deliver/1 chokepoint; only a message that arrived without one
+  # (a builder that skipped the base) gets stamped there.
+  defp message_id(%Swoosh.Email{headers: %{"Message-ID" => _}} = email), do: email
+
+  defp message_id(email),
+    do: header(email, "Message-ID", "<#{Vutuv.UUIDv7.generate()}@#{@from_domain}>")
 
   @doc """
   Adds the bulk-only headers (`Precedence: bulk`, `List-Unsubscribe`). These are

--- a/test/vutuv/notifications/emailer_test.exs
+++ b/test/vutuv/notifications/emailer_test.exs
@@ -32,6 +32,22 @@ defmodule Vutuv.Notifications.EmailerTest do
       assert email.headers["Precedence"] == "bulk"
       assert email.headers["List-Unsubscribe"] =~ "mailto:"
     end
+
+    test "base_email stamps a Message-ID with an FQDN, not the bare local hostname" do
+      message_id = Emailer.base_email().headers["Message-ID"]
+
+      # <token@vutuv.de> — the right-hand side must be the From domain. Without
+      # a Message-ID set here, the Swoosh SMTP adapter lets gen_smtp fall back
+      # to the machine's short hostname (e.g. "@bremen2"), which costs a point
+      # on spam scoring.
+      assert message_id =~ ~r/^<[^@\s>]+@vutuv\.de>$/,
+             "expected <token@vutuv.de>, got: #{inspect(message_id)}"
+    end
+
+    test "base_email gives every message its own unique Message-ID" do
+      refute Emailer.base_email().headers["Message-ID"] ==
+               Emailer.base_email().headers["Message-ID"]
+    end
   end
 
   describe "deliver/1 chokepoint" do
@@ -67,6 +83,36 @@ defmodule Vutuv.Notifications.EmailerTest do
       Emailer.deliver(raw)
 
       assert_email_sent(fn email -> assert_robot_headers(email) end)
+    end
+
+    test "stamps an FQDN Message-ID even when a builder forgot the base" do
+      raw =
+        Swoosh.Email.new()
+        |> Swoosh.Email.from({"vutuv", "info@vutuv.de"})
+        |> Swoosh.Email.to("nobody@example.com")
+        |> Swoosh.Email.subject("Naked email")
+        |> Swoosh.Email.text_body("hi")
+
+      assert raw.headers["Message-ID"] == nil
+
+      Emailer.deliver(raw)
+
+      assert_email_sent(fn sent -> assert sent.headers["Message-ID"] =~ ~r/@vutuv\.de>$/ end)
+    end
+
+    test "preserves the Message-ID the base already stamped (idempotent)" do
+      email =
+        Emailer.base_email()
+        |> Swoosh.Email.to("nobody@example.com")
+        |> Swoosh.Email.subject("Has an id")
+        |> Swoosh.Email.text_body("hi")
+
+      original = email.headers["Message-ID"]
+      assert original =~ ~r/@vutuv\.de>$/
+
+      Emailer.deliver(email)
+
+      assert_email_sent(fn sent -> assert sent.headers["Message-ID"] == original end)
     end
   end
 


### PR DESCRIPTION
## What

Every outbound vutuv email now carries an explicit RFC 5322 `Message-ID`
of the form `<uuidv7@vutuv.de>`.

## Why

Production mail was going out with `Message-ID: <token@bremen2>` (the host's
bare short hostname) because the app never set the header, so the Swoosh SMTP
adapter let gen_smtp generate one from the local hostname. A non-FQDN
Message-ID is a small but real spam-score penalty (mail-tester / SpamAssassin)
and was the last blemish on vutuv's otherwise clean sender-auth posture.

This came out of verifying #760: a live test confirmed SPF, DKIM and DMARC
already pass under `p=reject`, leaving only this cosmetic gap. Part of #760.

## How

- `base_email/0` stamps `<UUIDv7@vutuv.de>`; the domain is derived from the
  `From` address, so it tracks any future change.
- The `deliver/1` chokepoint re-applies it for any builder that skipped the
  base, mirroring the existing robot-header / bounce-envelope guarantees.
- Idempotent: a message keeps the id `base_email` gave it; only a base-less
  message gets stamped at delivery.
- Safe by construction: gen_smtp only generates a `Message-ID` when none is
  present (`mimemail.erl`), so a pre-set header is sent verbatim.

## Tests

Test-first. Added to `emailer_test.exs`:

- `base_email` stamps `<token@vutuv.de>`, never the bare hostname
- each email gets a unique id
- `deliver/1` stamps an FQDN id when a builder forgot the base
- `deliver/1` preserves an already-set id (idempotent)

`mix test test/vutuv/notifications/ test/vutuv/activity_email_test.exs test/vutuv/chat/unread_notifier_test.exs` → 50 passed; `mix format --check-formatted` clean.

https://claude.ai/code/session_01GUc4GbNHw5Gg1KY8X7jzDU
