### PR TITLE
CI: bump actions/cache v4 -> v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           elixir-version: "1.20.0-otp-28"
 
       - name: Cache deps and _build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps


### PR DESCRIPTION
## What

Bump `actions/cache` from `v4` to `v5` in `.github/workflows/ci.yml`.

## Why

Every CI run printed a deprecation annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are
> being forced to run on Node.js 24: actions/cache@v4

`actions/cache@v5` is the GA release that targets the Node 24 runtime
natively, which clears the warning. It requires Actions Runner >= 2.327.1;
this job runs on GitHub-hosted `ubuntu-latest`, which is well past that, so
no runner change is needed. Cache key, paths and restore-keys are unchanged,
so existing caches still resolve.

Pre-existing CI infra noise surfaced while verifying #798; unrelated to that
change.

https://claude.ai/code/session_01GUc4GbNHw5Gg1KY8X7jzDU
