### PR TITLE
Rename profile "Tags & endorsements" section to just "Tags"

### DIFF
--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -27,7 +27,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       blank_to_nil(doc.work_info),
       profile_facts(doc),
       section(
-        gettext("Tags & endorsements"),
+        gettext("Tags"),
         Enum.map(doc.tags, &entry_line("tags", &1))
       ),
       section(

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -27,7 +27,7 @@ defmodule VutuvWeb.AgentDocs.Text do
       blank_to_nil(doc.work_info),
       profile_facts(doc),
       section(
-        gettext("Tags & endorsements"),
+        gettext("Tags"),
         Enum.map(doc.tags, &entry_line("tags", &1))
       ),
       section(

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -356,13 +356,13 @@ the resulting ~200px rail width. --%>
       </.card_footer_link>
     </.card>
 
-    <%!-- Tags & endorsements --%>
+    <%!-- Tags --%>
     <.card :if={Enum.count(@user_tags) > 0 or @as_owner?}>
       <%!-- The dashed add tile is onboarding scaffolding: it shows only while the
       card is empty. Once there are entries the card is a clean showcase and
       "Verwalten" (manage_footer) leads to the page where tags are added/removed
       (tags have no edit form). --%>
-      <.section_header title={gettext("Tags & endorsements")} />
+      <.section_header title={gettext("Tags")} />
 
       <.empty_add :if={@as_owner? and Enum.count(@user_tags) == 0} href={~p"/#{@user}/tags/new"}>
         {gettext("Add a tag")}

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -52,7 +52,7 @@ msgstr "Eine Adresse wurde geändert."
 #: lib/vutuv_web/templates/address/index.html.heex:6
 #: lib/vutuv_web/templates/address/new.html.heex:4
 #: lib/vutuv_web/templates/address/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:637
+#: lib/vutuv_web/templates/user/show.html.heex:683
 #, elixir-autogen
 msgid "Addresses"
 msgstr "Adressen"
@@ -86,7 +86,7 @@ msgstr "Geburtstag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:182
 #: lib/vutuv_web/agent_docs/text.ex:215
-#: lib/vutuv_web/templates/user/show.html.heex:586
+#: lib/vutuv_web/templates/user/show.html.heex:607
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
@@ -119,7 +119,7 @@ msgstr "Wählen Sie einen Typ aus"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/templates/user/show.html.heex:547
+#: lib/vutuv_web/templates/user/show.html.heex:550
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -155,7 +155,7 @@ msgid "Disable"
 msgstr "Inaktivieren"
 
 #: lib/vutuv_web/templates/settings/index.html.heex:165
-#: lib/vutuv_web/templates/user/show.html.heex:271
+#: lib/vutuv_web/templates/user/show.html.heex:274
 #, elixir-autogen
 msgid "Download"
 msgstr "Download"
@@ -172,7 +172,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:5
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:5
 #: lib/vutuv_web/templates/url/edit.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:591
+#: lib/vutuv_web/templates/user/show.html.heex:612
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:5
 #, elixir-autogen
 msgid "Edit"
@@ -258,7 +258,7 @@ msgstr "Nachname eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/templates/user/show.html.heex:396
+#: lib/vutuv_web/templates/user/show.html.heex:399
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:6
 #: lib/vutuv_web/templates/work_experience/new.html.heex:4
@@ -282,7 +282,7 @@ msgstr "Vorname"
 #: lib/vutuv_web/agent_docs/text.ex:211
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:507
+#: lib/vutuv_web/templates/user/show.html.heex:510
 #, elixir-autogen
 msgid "Followers"
 msgstr "Follower"
@@ -293,7 +293,7 @@ msgstr "Follower"
 #: lib/vutuv_web/components/ui.ex:475
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:525
+#: lib/vutuv_web/templates/user/show.html.heex:528
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
@@ -301,7 +301,7 @@ msgstr "Folge ich"
 #: lib/vutuv_web/agent_docs/markdown.ex:181
 #: lib/vutuv_web/agent_docs/text.ex:214
 #: lib/vutuv_web/templates/user/edit.html.heex:63
-#: lib/vutuv_web/templates/user/show.html.heex:582
+#: lib/vutuv_web/templates/user/show.html.heex:602
 #, elixir-autogen
 msgid "Gender"
 msgstr "Geschlecht"
@@ -368,7 +368,7 @@ msgstr "Link wurde geändert."
 #: lib/vutuv_web/templates/url/index.html.heex:6
 #: lib/vutuv_web/templates/url/new.html.heex:4
 #: lib/vutuv_web/templates/url/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:460
+#: lib/vutuv_web/templates/user/show.html.heex:463
 #, elixir-autogen
 msgid "Links"
 msgstr "Links"
@@ -432,7 +432,7 @@ msgstr "Name"
 msgid "New"
 msgstr "Neu"
 
-#: lib/vutuv/notifications/emailer.ex:179
+#: lib/vutuv/notifications/emailer.ex:194
 #, elixir-autogen
 msgid "New message from @%{slug} on vutuv"
 msgstr "Neue Nachricht von @%{slug} auf vutuv"
@@ -490,7 +490,7 @@ msgstr "Telefonnummer"
 #: lib/vutuv_web/templates/phone_number/index.html.heex:6
 #: lib/vutuv_web/templates/phone_number/new.html.heex:4
 #: lib/vutuv_web/templates/phone_number/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:618
+#: lib/vutuv_web/templates/user/show.html.heex:652
 #, elixir-autogen
 msgid "Phone Numbers"
 msgstr "Telefonnummern"
@@ -556,7 +556,7 @@ msgstr "Provider"
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:46
+#: lib/vutuv_web/templates/user/show.html.heex:43
 #, elixir-autogen
 msgid "Public"
 msgstr "Öffentlich"
@@ -607,7 +607,7 @@ msgstr "Slug"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:40
 #: lib/vutuv_web/agent_docs/text.ex:40
-#: lib/vutuv_web/templates/user/show.html.heex:599
+#: lib/vutuv_web/templates/user/show.html.heex:620
 #, elixir-autogen
 msgid "Social Media"
 msgstr "Social Media"
@@ -691,12 +691,12 @@ msgstr "User"
 msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr "Der User %{name} wurde angelegt. Eine E-Mail mit einem PIN wurde verschickt."
 
-#: lib/vutuv_web/controllers/user_controller.ex:386
+#: lib/vutuv_web/controllers/user_controller.ex:390
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr "User wurde gelöscht."
 
-#: lib/vutuv_web/controllers/user_controller.ex:330
+#: lib/vutuv_web/controllers/user_controller.ex:334
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr "Profil aktualisiert."
@@ -757,15 +757,15 @@ msgstr "Benutzer"
 msgid "Value"
 msgstr "Wert"
 
-#: lib/vutuv_web/templates/user/show.html.heex:277
-#: lib/vutuv_web/templates/user/show.html.heex:671
+#: lib/vutuv_web/templates/user/show.html.heex:280
+#: lib/vutuv_web/templates/user/show.html.heex:721
 #, elixir-autogen
 msgid "vCard"
 msgstr "vCard"
 
 #: lib/vutuv_web/components/ui.ex:1228
-#: lib/vutuv_web/templates/user/show.html.heex:519
-#: lib/vutuv_web/templates/user/show.html.heex:538
+#: lib/vutuv_web/templates/user/show.html.heex:522
+#: lib/vutuv_web/templates/user/show.html.heex:541
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
@@ -948,7 +948,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:576
+#: lib/vutuv_web/templates/user/show.html.heex:591
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -964,22 +964,22 @@ msgstr "Verifizieren"
 msgid "Choose a gender"
 msgstr "Geschlecht auswählen"
 
-#: lib/vutuv/notifications/emailer.ex:123
+#: lib/vutuv/notifications/emailer.ex:138
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr "PIN zum Löschen eines vutuv Accounts"
 
-#: lib/vutuv/notifications/emailer.ex:117
+#: lib/vutuv/notifications/emailer.ex:132
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr "Weitere E-Mail Adresse für einen vutuv Account verifizieren"
 
-#: lib/vutuv/notifications/emailer.ex:105
+#: lib/vutuv/notifications/emailer.ex:120
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr "vutuv Account einrichten"
 
-#: lib/vutuv/notifications/emailer.ex:111
+#: lib/vutuv/notifications/emailer.ex:126
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr "vutuv Login-PIN"
@@ -1382,6 +1382,8 @@ msgstr ""
 msgid "Tag urls"
 msgstr ""
 
+#: lib/vutuv_web/agent_docs/markdown.ex:30
+#: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/live/search_live.ex:146
 #: lib/vutuv_web/live/search_live.ex:292
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:5
@@ -1390,6 +1392,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:4
+#: lib/vutuv_web/templates/user/show.html.heex:365
 #: lib/vutuv_web/templates/user_tag/form_content.html.heex:5
 #: lib/vutuv_web/templates/user_tag/index.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
@@ -1399,7 +1402,7 @@ msgstr "Tags"
 
 #: lib/vutuv_web/controllers/email_controller.ex:118
 #: lib/vutuv_web/controllers/session_controller.ex:271
-#: lib/vutuv_web/controllers/user_controller.ex:401
+#: lib/vutuv_web/controllers/user_controller.ex:405
 #, elixir-autogen
 msgid "Too many incorrect attempts."
 msgstr "Zu viele fehlerhafter Versuche."
@@ -1540,7 +1543,7 @@ msgstr ""
 msgid "tag name"
 msgstr "Tag Name"
 
-#: lib/vutuv/notifications/emailer.ex:153
+#: lib/vutuv/notifications/emailer.ex:168
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr "verifizierter Account"
@@ -1634,13 +1637,13 @@ msgstr "Mein Konto löschen"
 msgid "Disable slugs"
 msgstr "Slugs deaktivieren"
 
-#: lib/vutuv_web/controllers/user_controller.ex:316
-#: lib/vutuv_web/templates/user/show.html.heex:132
+#: lib/vutuv_web/controllers/user_controller.ex:320
+#: lib/vutuv_web/templates/user/show.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:378
+#: lib/vutuv_web/templates/user/show.html.heex:381
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Empfehlen"
@@ -1672,7 +1675,7 @@ msgstr "Ausloggen"
 msgid "Member"
 msgstr "Mitglied"
 
-#: lib/vutuv_web/templates/user/show.html.heex:149
+#: lib/vutuv_web/templates/user/show.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
@@ -1766,8 +1769,8 @@ msgstr "Diese E-Mail-Adresse konnte nicht hinzugefügt werden."
 #: lib/vutuv_web/controllers/session_controller.ex:48
 #: lib/vutuv_web/controllers/session_controller.ex:115
 #: lib/vutuv_web/controllers/session_controller.ex:131
-#: lib/vutuv_web/controllers/user_controller.ex:356
-#: lib/vutuv_web/controllers/user_controller.ex:371
+#: lib/vutuv_web/controllers/user_controller.ex:360
+#: lib/vutuv_web/controllers/user_controller.ex:375
 #, elixir-autogen, elixir-format
 msgid "Too many attempts. Please try again later."
 msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
@@ -1777,7 +1780,7 @@ msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
 msgid "Unverified users"
 msgstr "Nicht verifizierte User"
 
-#: lib/vutuv_web/templates/user/show.html.heex:162
+#: lib/vutuv_web/templates/user/show.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr "Verifiziertes Profil"
@@ -1797,7 +1800,7 @@ msgstr "Wir haben einen PIN an Ihre E-Mail-Adresse geschickt. Geben Sie ihn unte
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr "Wir haben einen PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie ihn unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:688
+#: lib/vutuv_web/templates/user/show.html.heex:739
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
@@ -1813,14 +1816,14 @@ msgstr "Nachricht schreiben…"
 msgid "Your login session expired. Please try again."
 msgstr "Ihre Anmeldung ist abgelaufen. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/templates/user/show.html.heex:192
+#: lib/vutuv_web/templates/user/show.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] "Follower"
 msgstr[1] "Follower"
 
-#: lib/vutuv_web/templates/user/show.html.heex:196
+#: lib/vutuv_web/templates/user/show.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr "folgt"
@@ -1893,41 +1896,41 @@ msgid_plural "%{count} years"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/templates/user/show.html.heex:440
+#: lib/vutuv_web/templates/user/show.html.heex:443
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr "Dauer in dieser Position"
 
-#: lib/vutuv_web/templates/user/show.html.heex:103
+#: lib/vutuv_web/templates/user/show.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Add a cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:110
+#: lib/vutuv_web/templates/user/show.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
 #: lib/vutuv_web/views/ad_html.ex:73
-#: lib/vutuv_web/views/user_html.ex:104
+#: lib/vutuv_web/views/user_html.ex:242
 #: lib/vutuv_web/views/work_experience_html.ex:16
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
 #: lib/vutuv_web/views/ad_html.ex:77
-#: lib/vutuv_web/views/user_html.ex:108
+#: lib/vutuv_web/views/user_html.ex:246
 #: lib/vutuv_web/views/work_experience_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
 
-#: lib/vutuv_web/templates/user/show.html.heex:110
+#: lib/vutuv_web/templates/user/show.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Change cover"
 msgstr "Titelbild ändern"
 
-#: lib/vutuv_web/templates/user/show.html.heex:103
+#: lib/vutuv_web/templates/user/show.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Change cover photo"
 msgstr "Titelbild ändern"
@@ -1937,86 +1940,86 @@ msgstr "Titelbild ändern"
 msgid "Cover photo"
 msgstr "Titelbild"
 
-#: lib/vutuv_web/templates/user/show.html.heex:96
+#: lib/vutuv_web/templates/user/show.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
 #: lib/vutuv_web/views/ad_html.ex:81
-#: lib/vutuv_web/views/user_html.ex:112
+#: lib/vutuv_web/views/user_html.ex:250
 #: lib/vutuv_web/views/work_experience_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
 #: lib/vutuv_web/views/ad_html.ex:71
-#: lib/vutuv_web/views/user_html.ex:102
+#: lib/vutuv_web/views/user_html.ex:240
 #: lib/vutuv_web/views/work_experience_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
 #: lib/vutuv_web/views/ad_html.ex:70
-#: lib/vutuv_web/views/user_html.ex:101
+#: lib/vutuv_web/views/user_html.ex:239
 #: lib/vutuv_web/views/work_experience_html.ex:13
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
 #: lib/vutuv_web/views/ad_html.ex:76
-#: lib/vutuv_web/views/user_html.ex:107
+#: lib/vutuv_web/views/user_html.ex:245
 #: lib/vutuv_web/views/work_experience_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
 #: lib/vutuv_web/views/ad_html.ex:75
-#: lib/vutuv_web/views/user_html.ex:106
+#: lib/vutuv_web/views/user_html.ex:244
 #: lib/vutuv_web/views/work_experience_html.ex:18
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
 #: lib/vutuv_web/views/ad_html.ex:72
-#: lib/vutuv_web/views/user_html.ex:103
+#: lib/vutuv_web/views/user_html.ex:241
 #: lib/vutuv_web/views/work_experience_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
 #: lib/vutuv_web/views/ad_html.ex:74
-#: lib/vutuv_web/views/user_html.ex:105
+#: lib/vutuv_web/views/user_html.ex:243
 #: lib/vutuv_web/views/work_experience_html.ex:17
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
 
-#: lib/vutuv_web/views/user_html.ex:71
+#: lib/vutuv_web/views/user_html.ex:73
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr "Mitglied seit %{month} %{year}"
 
-#: lib/vutuv_web/views/user_html.ex:76
+#: lib/vutuv_web/views/user_html.ex:78
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
 #: lib/vutuv_web/views/ad_html.ex:80
-#: lib/vutuv_web/views/user_html.ex:111
+#: lib/vutuv_web/views/user_html.ex:249
 #: lib/vutuv_web/views/work_experience_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
 #: lib/vutuv_web/views/ad_html.ex:79
-#: lib/vutuv_web/views/user_html.ex:110
+#: lib/vutuv_web/views/user_html.ex:248
 #: lib/vutuv_web/views/work_experience_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
 #: lib/vutuv_web/views/ad_html.ex:78
-#: lib/vutuv_web/views/user_html.ex:109
+#: lib/vutuv_web/views/user_html.ex:247
 #: lib/vutuv_web/views/work_experience_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "September"
@@ -2189,7 +2192,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/post_live/saved.ex:251
 #: lib/vutuv_web/live/search_live.ex:147
 #: lib/vutuv_web/live/search_live.ex:306
-#: lib/vutuv_web/templates/user/show.html.heex:328
+#: lib/vutuv_web/templates/user/show.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr "Beiträge"
@@ -2343,7 +2346,7 @@ msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
 msgid "Posts by %{name}"
 msgstr "Beiträge von %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:352
+#: lib/vutuv_web/templates/user/show.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr "Alle %{count} Beiträge ansehen"
@@ -2674,49 +2677,49 @@ msgid "Use a different email address"
 msgstr "Andere E-Mail-Adresse verwenden"
 
 #: lib/vutuv_web/templates/url/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:462
+#: lib/vutuv_web/templates/user/show.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:620
+#: lib/vutuv_web/templates/user/show.html.heex:654
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:601
+#: lib/vutuv_web/templates/user/show.html.heex:622
 #, elixir-autogen, elixir-format
 msgid "Add a social media account"
 msgstr "Social-Media-Konto hinzufügen"
 
 #: lib/vutuv_web/templates/address/index.html.heex:13
-#: lib/vutuv_web/templates/user/show.html.heex:639
+#: lib/vutuv_web/templates/user/show.html.heex:685
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:549
+#: lib/vutuv_web/templates/user/show.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:578
+#: lib/vutuv_web/templates/user/show.html.heex:593
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
 
-#: lib/vutuv_web/controllers/user_controller.ex:267
-#: lib/vutuv_web/templates/user/show.html.heex:399
+#: lib/vutuv_web/controllers/user_controller.ex:271
+#: lib/vutuv_web/templates/user/show.html.heex:402
 #: lib/vutuv_web/templates/work_experience/index.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
-#: lib/vutuv_web/controllers/user_controller.ex:271
-#: lib/vutuv_web/templates/user/show.html.heex:333
+#: lib/vutuv_web/controllers/user_controller.ex:275
+#: lib/vutuv_web/templates/user/show.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
@@ -2730,7 +2733,7 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:333
+#: lib/vutuv_web/templates/user/show.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr "Beitrag schreiben"
@@ -2775,7 +2778,7 @@ msgid "Connect with %{name} to read it."
 msgstr "Vernetzen Sie sich mit %{name}, um ihn zu lesen."
 
 #: lib/vutuv_web/components/ui.ex:529
-#: lib/vutuv_web/templates/user/show.html.heex:45
+#: lib/vutuv_web/templates/user/show.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Vernetzt"
@@ -2829,7 +2832,7 @@ msgstr "Zum Profil, um sich zu vernetzen"
 msgid "Ignore"
 msgstr "Ignorieren"
 
-#: lib/vutuv_web/templates/user/show.html.heex:667
+#: lib/vutuv_web/templates/user/show.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2839,7 +2842,7 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Noch keine Vernetzungen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:662
+#: lib/vutuv_web/templates/user/show.html.heex:714
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Andere Formate"
@@ -2864,7 +2867,7 @@ msgstr "Diese Vernetzung entfernen?"
 msgid "Sent requests"
 msgstr "Gesendete Anfragen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:668
+#: lib/vutuv_web/templates/user/show.html.heex:718
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Nur Text"
@@ -2914,7 +2917,7 @@ msgstr "Ihre Anfrage ist noch ausstehend."
 msgid "accepted your connection request."
 msgstr "hat Ihre Vernetzungsanfrage angenommen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:205
+#: lib/vutuv_web/templates/user/show.html.heex:208
 #: lib/vutuv_web/views/admin/moderation_html.ex:55
 #, elixir-autogen, elixir-format
 msgid "connection"
@@ -2959,7 +2962,7 @@ msgid "Endorsement"
 msgstr "Empfehlung"
 
 #: lib/vutuv_web/live/notification_live/index.ex:208
-#: lib/vutuv_web/templates/user/show.html.heex:44
+#: lib/vutuv_web/templates/user/show.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgstr "Follower"
@@ -3188,7 +3191,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Nur Sie können diesen Beitrag sehen, solange eine Meldung dazu bearbeitet wird."
 
-#: lib/vutuv_web/templates/user/show.html.heex:84
+#: lib/vutuv_web/templates/user/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Only you can see your profile right now - it is hidden while a report is handled."
 msgstr "Nur Sie können Ihr Profil gerade sehen, es ist verborgen, solange eine Meldung bearbeitet wird."
@@ -3253,7 +3256,7 @@ msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
 #: lib/vutuv_web/components/post_components.ex:362
-#: lib/vutuv_web/templates/user/show.html.heex:231
+#: lib/vutuv_web/templates/user/show.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr "Melden"
@@ -3545,42 +3548,42 @@ msgstr "vutuv ist ein freundliches, familienfreundliches Netzwerk. Alles, was Si
 msgid "yes"
 msgstr "ja"
 
-#: lib/vutuv/notifications/emailer.ex:408
+#: lib/vutuv/notifications/emailer.ex:423
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr "Eine Verwarnung für Ihr vutuv-Konto"
 
-#: lib/vutuv/notifications/emailer.ex:468
+#: lib/vutuv/notifications/emailer.ex:483
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr "Moderation: %{count} Fälle warten"
 
-#: lib/vutuv/notifications/emailer.ex:446
+#: lib/vutuv/notifications/emailer.ex:461
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr "Moderation: Ein Profil wurde gemeldet"
 
-#: lib/vutuv/notifications/emailer.ex:401
+#: lib/vutuv/notifications/emailer.ex:416
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr "Der von Ihnen gemeldete Inhalt wurde überarbeitet"
 
-#: lib/vutuv/notifications/emailer.ex:394
+#: lib/vutuv/notifications/emailer.ex:409
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr "Ihr Inhalt auf vutuv wird geprüft"
 
-#: lib/vutuv/notifications/emailer.ex:387
+#: lib/vutuv/notifications/emailer.ex:402
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr "Ihr Inhalt auf vutuv wurde gemeldet und ist verborgen"
 
-#: lib/vutuv/notifications/emailer.ex:422
+#: lib/vutuv/notifications/emailer.ex:437
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr "Ihr vutuv-Konto wurde deaktiviert"
 
-#: lib/vutuv/notifications/emailer.ex:415
+#: lib/vutuv/notifications/emailer.ex:430
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr "Ihr vutuv-Konto ist gesperrt"
@@ -4558,13 +4561,13 @@ msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr "Sie können nach Namen (Vor- und Nachname), E-Mail Adressen, Tags oder nach Wörtern in öffentlichen Beiträgen suchen."
 
 #: lib/vutuv_web/templates/block/index.html.heex:28
-#: lib/vutuv_web/templates/user/show.html.heex:249
+#: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr "Blockieren"
 
 #: lib/vutuv_web/live/message_live/index.ex:528
-#: lib/vutuv_web/templates/user/show.html.heex:242
+#: lib/vutuv_web/templates/user/show.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr "@%{slug} blockieren? Dadurch werden alle Follows und die Vernetzung zwischen Ihnen entfernt, Ihre Unterhaltung wird geschlossen und jede Interaktion in beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das Entfernte nicht wieder her."
@@ -4582,13 +4585,13 @@ msgid "Blocked members cannot follow you, connect with you, message you, or repl
 msgstr "Blockierte Mitglieder können Ihnen nicht folgen, sich nicht mit Ihnen vernetzen, Ihnen keine Nachrichten schreiben und nicht auf Ihre Beiträge antworten - und Sie können auch nicht mit ihnen interagieren. Beim Blockieren wurden alle Follows und die Vernetzung zwischen Ihnen entfernt; eine Aufhebung stellt sie nicht wieder her."
 
 #: lib/vutuv_web/templates/block/index.html.heex:63
-#: lib/vutuv_web/templates/user/show.html.heex:259
+#: lib/vutuv_web/templates/user/show.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr "Blockierung aufheben"
 
 #: lib/vutuv_web/templates/block/index.html.heex:61
-#: lib/vutuv_web/templates/user/show.html.heex:256
+#: lib/vutuv_web/templates/user/show.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "Unblock @%{slug}?"
 msgstr "Blockierung von @%{slug} aufheben?"
@@ -4626,7 +4629,7 @@ msgstr "Mitglieder finden"
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:525
+#: lib/vutuv_web/templates/user/show.html.heex:528
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4728,8 +4731,8 @@ msgstr "müller"
 msgid "searches first names only (last: for last names)"
 msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
-#: lib/vutuv_web/controllers/user_controller.ex:265
-#: lib/vutuv_web/templates/user/show.html.heex:365
+#: lib/vutuv_web/controllers/user_controller.ex:269
+#: lib/vutuv_web/templates/user/show.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Tag hinzufügen"
@@ -4743,13 +4746,6 @@ msgstr "Dieses Tag hinzufügen"
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, or posts"
 msgstr "Nach Personen, Tags oder Beiträgen suchen"
-
-#: lib/vutuv_web/agent_docs/markdown.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/templates/user/show.html.heex:362
-#, elixir-autogen, elixir-format
-msgid "Tags & endorsements"
-msgstr "Tags & Empfehlungen"
 
 #: lib/vutuv_web/templates/tag/single_card.html.heex:8
 #, elixir-autogen, elixir-format
@@ -5422,17 +5418,17 @@ msgstr "Beitrag schreiben"
 msgid "Your profile"
 msgstr "Ihr Profil"
 
-#: lib/vutuv_web/templates/user/show.html.heex:295
+#: lib/vutuv_web/templates/user/show.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr "Profil vervollständigen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:301
+#: lib/vutuv_web/templates/user/show.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/controllers/user_controller.ex:260
+#: lib/vutuv_web/controllers/user_controller.ex:264
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -5464,7 +5460,7 @@ msgstr "Fußzeilen-Navigation"
 msgid "View post"
 msgstr "Beitrag ansehen"
 
-#: lib/vutuv/notifications/emailer.ex:141
+#: lib/vutuv/notifications/emailer.ex:156
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
@@ -5659,17 +5655,17 @@ msgstr "z. B. Dr. oder Prof."
 msgid "e.g. Jr. or PhD"
 msgstr "z. B. jun. oder B.Sc."
 
-#: lib/vutuv/notifications/emailer.ex:221
+#: lib/vutuv/notifications/emailer.ex:236
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr "@%{slug} hat Sie auf vutuv empfohlen"
 
-#: lib/vutuv/notifications/emailer.ex:207
+#: lib/vutuv/notifications/emailer.ex:222
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 
-#: lib/vutuv/notifications/emailer.ex:236
+#: lib/vutuv/notifications/emailer.ex:251
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to connect on vutuv"
 msgstr "@%{slug} möchte sich auf vutuv mit Ihnen vernetzen"
@@ -5932,7 +5928,7 @@ msgstr[1] "vor %{count} Minuten"
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
 
-#: lib/vutuv/notifications/emailer.ex:322
+#: lib/vutuv/notifications/emailer.ex:337
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
@@ -5957,7 +5953,7 @@ msgstr "Von allen Geräten außer diesem abmelden?"
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
 
-#: lib/vutuv/notifications/emailer.ex:297
+#: lib/vutuv/notifications/emailer.ex:312
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
@@ -5972,7 +5968,7 @@ msgstr "Angemeldete Geräte"
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
 
-#: lib/vutuv/notifications/emailer.ex:325
+#: lib/vutuv/notifications/emailer.ex:340
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
@@ -5982,7 +5978,7 @@ msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
 msgid "This device"
 msgstr "Dieses Gerät"
 
-#: lib/vutuv/notifications/emailer.ex:319
+#: lib/vutuv/notifications/emailer.ex:334
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen haben."
@@ -6121,7 +6117,7 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/controllers/user_controller.ex:264
+#: lib/vutuv_web/controllers/user_controller.ex:268
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
@@ -6131,7 +6127,7 @@ msgstr "Kurzbeschreibung hinzufügen"
 msgid "Tagline"
 msgstr "Kurzbeschreibung"
 
-#: lib/vutuv_web/templates/user/show.html.heex:71
+#: lib/vutuv_web/templates/user/show.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Preview: how logged-out visitors and search engines see your profile."
 msgstr "Vorschau: So sehen abgemeldete Besucher und Suchmaschinen Ihr Profil."
@@ -6141,17 +6137,17 @@ msgstr "Vorschau: So sehen abgemeldete Besucher und Suchmaschinen Ihr Profil."
 msgid "View as"
 msgstr "Ansehen als"
 
-#: lib/vutuv_web/templates/user/show.html.heex:43
+#: lib/vutuv_web/templates/user/show.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "You"
 msgstr "Sie"
 
-#: lib/vutuv_web/templates/user/show.html.heex:67
+#: lib/vutuv_web/templates/user/show.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "Preview: how a member who follows you sees your profile. The controls here are inactive."
 msgstr "Vorschau: So sieht ein Mitglied, das Ihnen folgt, Ihr Profil. Die Schaltflächen sind hier inaktiv."
 
-#: lib/vutuv_web/templates/user/show.html.heex:69
+#: lib/vutuv_web/templates/user/show.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "Preview: how a member you are connected with sees your profile. The controls here are inactive."
 msgstr "Vorschau: So sieht ein mit Ihnen vernetztes Mitglied Ihr Profil. Die Schaltflächen sind hier inaktiv."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -53,7 +53,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/index.html.heex:6
 #: lib/vutuv_web/templates/address/new.html.heex:4
 #: lib/vutuv_web/templates/address/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:637
+#: lib/vutuv_web/templates/user/show.html.heex:683
 #, elixir-autogen
 msgid "Addresses"
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:182
 #: lib/vutuv_web/agent_docs/text.ex:215
-#: lib/vutuv_web/templates/user/show.html.heex:586
+#: lib/vutuv_web/templates/user/show.html.heex:607
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -120,7 +120,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/templates/user/show.html.heex:547
+#: lib/vutuv_web/templates/user/show.html.heex:550
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -156,7 +156,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/index.html.heex:165
-#: lib/vutuv_web/templates/user/show.html.heex:271
+#: lib/vutuv_web/templates/user/show.html.heex:274
 #, elixir-autogen
 msgid "Download"
 msgstr ""
@@ -173,7 +173,7 @@ msgstr ""
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:5
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:5
 #: lib/vutuv_web/templates/url/edit.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:591
+#: lib/vutuv_web/templates/user/show.html.heex:612
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:5
 #, elixir-autogen
 msgid "Edit"
@@ -259,7 +259,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/templates/user/show.html.heex:396
+#: lib/vutuv_web/templates/user/show.html.heex:399
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:6
 #: lib/vutuv_web/templates/work_experience/new.html.heex:4
@@ -283,7 +283,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:211
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:507
+#: lib/vutuv_web/templates/user/show.html.heex:510
 #, elixir-autogen
 msgid "Followers"
 msgstr ""
@@ -294,7 +294,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:475
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:525
+#: lib/vutuv_web/templates/user/show.html.heex:528
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -302,7 +302,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:181
 #: lib/vutuv_web/agent_docs/text.ex:214
 #: lib/vutuv_web/templates/user/edit.html.heex:63
-#: lib/vutuv_web/templates/user/show.html.heex:582
+#: lib/vutuv_web/templates/user/show.html.heex:602
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -369,7 +369,7 @@ msgstr ""
 #: lib/vutuv_web/templates/url/index.html.heex:6
 #: lib/vutuv_web/templates/url/new.html.heex:4
 #: lib/vutuv_web/templates/url/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:460
+#: lib/vutuv_web/templates/user/show.html.heex:463
 #, elixir-autogen
 msgid "Links"
 msgstr ""
@@ -433,7 +433,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:179
+#: lib/vutuv/notifications/emailer.ex:194
 #, elixir-autogen
 msgid "New message from @%{slug} on vutuv"
 msgstr ""
@@ -491,7 +491,7 @@ msgstr ""
 #: lib/vutuv_web/templates/phone_number/index.html.heex:6
 #: lib/vutuv_web/templates/phone_number/new.html.heex:4
 #: lib/vutuv_web/templates/phone_number/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:618
+#: lib/vutuv_web/templates/user/show.html.heex:652
 #, elixir-autogen
 msgid "Phone Numbers"
 msgstr ""
@@ -557,7 +557,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:46
+#: lib/vutuv_web/templates/user/show.html.heex:43
 #, elixir-autogen
 msgid "Public"
 msgstr ""
@@ -608,7 +608,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:40
 #: lib/vutuv_web/agent_docs/text.ex:40
-#: lib/vutuv_web/templates/user/show.html.heex:599
+#: lib/vutuv_web/templates/user/show.html.heex:620
 #, elixir-autogen
 msgid "Social Media"
 msgstr ""
@@ -692,12 +692,12 @@ msgstr ""
 msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:386
+#: lib/vutuv_web/controllers/user_controller.ex:390
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:330
+#: lib/vutuv_web/controllers/user_controller.ex:334
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr ""
@@ -758,15 +758,15 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:277
-#: lib/vutuv_web/templates/user/show.html.heex:671
+#: lib/vutuv_web/templates/user/show.html.heex:280
+#: lib/vutuv_web/templates/user/show.html.heex:721
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1228
-#: lib/vutuv_web/templates/user/show.html.heex:519
-#: lib/vutuv_web/templates/user/show.html.heex:538
+#: lib/vutuv_web/templates/user/show.html.heex:522
+#: lib/vutuv_web/templates/user/show.html.heex:541
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -949,7 +949,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:576
+#: lib/vutuv_web/templates/user/show.html.heex:591
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -965,22 +965,22 @@ msgstr ""
 msgid "Choose a gender"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:123
+#: lib/vutuv/notifications/emailer.ex:138
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:117
+#: lib/vutuv/notifications/emailer.ex:132
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:105
+#: lib/vutuv/notifications/emailer.ex:120
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:111
+#: lib/vutuv/notifications/emailer.ex:126
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr ""
@@ -1383,6 +1383,8 @@ msgstr ""
 msgid "Tag urls"
 msgstr ""
 
+#: lib/vutuv_web/agent_docs/markdown.ex:30
+#: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/live/search_live.ex:146
 #: lib/vutuv_web/live/search_live.ex:292
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:5
@@ -1391,6 +1393,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:4
+#: lib/vutuv_web/templates/user/show.html.heex:365
 #: lib/vutuv_web/templates/user_tag/form_content.html.heex:5
 #: lib/vutuv_web/templates/user_tag/index.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
@@ -1400,7 +1403,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:118
 #: lib/vutuv_web/controllers/session_controller.ex:271
-#: lib/vutuv_web/controllers/user_controller.ex:401
+#: lib/vutuv_web/controllers/user_controller.ex:405
 #, elixir-autogen
 msgid "Too many incorrect attempts."
 msgstr ""
@@ -1541,7 +1544,7 @@ msgstr ""
 msgid "tag name"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:153
+#: lib/vutuv/notifications/emailer.ex:168
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr ""
@@ -1635,13 +1638,13 @@ msgstr ""
 msgid "Disable slugs"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:316
-#: lib/vutuv_web/templates/user/show.html.heex:132
+#: lib/vutuv_web/controllers/user_controller.ex:320
+#: lib/vutuv_web/templates/user/show.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:378
+#: lib/vutuv_web/templates/user/show.html.heex:381
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
@@ -1673,7 +1676,7 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:149
+#: lib/vutuv_web/templates/user/show.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -1767,8 +1770,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/session_controller.ex:48
 #: lib/vutuv_web/controllers/session_controller.ex:115
 #: lib/vutuv_web/controllers/session_controller.ex:131
-#: lib/vutuv_web/controllers/user_controller.ex:356
-#: lib/vutuv_web/controllers/user_controller.ex:371
+#: lib/vutuv_web/controllers/user_controller.ex:360
+#: lib/vutuv_web/controllers/user_controller.ex:375
 #, elixir-autogen, elixir-format
 msgid "Too many attempts. Please try again later."
 msgstr ""
@@ -1778,7 +1781,7 @@ msgstr ""
 msgid "Unverified users"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:162
+#: lib/vutuv_web/templates/user/show.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Verified profile"
 msgstr ""
@@ -1798,7 +1801,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:688
+#: lib/vutuv_web/templates/user/show.html.heex:739
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1814,14 +1817,14 @@ msgstr ""
 msgid "Your login session expired. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:192
+#: lib/vutuv_web/templates/user/show.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:196
+#: lib/vutuv_web/templates/user/show.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr ""
@@ -1894,41 +1897,41 @@ msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:440
+#: lib/vutuv_web/templates/user/show.html.heex:443
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:103
+#: lib/vutuv_web/templates/user/show.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Add a cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:110
+#: lib/vutuv_web/templates/user/show.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Add cover photo"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:73
-#: lib/vutuv_web/views/user_html.ex:104
+#: lib/vutuv_web/views/user_html.ex:242
 #: lib/vutuv_web/views/work_experience_html.ex:16
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:77
-#: lib/vutuv_web/views/user_html.ex:108
+#: lib/vutuv_web/views/user_html.ex:246
 #: lib/vutuv_web/views/work_experience_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:110
+#: lib/vutuv_web/templates/user/show.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Change cover"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:103
+#: lib/vutuv_web/templates/user/show.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Change cover photo"
 msgstr ""
@@ -1938,86 +1941,86 @@ msgstr ""
 msgid "Cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:96
+#: lib/vutuv_web/templates/user/show.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Cover photo of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:81
-#: lib/vutuv_web/views/user_html.ex:112
+#: lib/vutuv_web/views/user_html.ex:250
 #: lib/vutuv_web/views/work_experience_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:71
-#: lib/vutuv_web/views/user_html.ex:102
+#: lib/vutuv_web/views/user_html.ex:240
 #: lib/vutuv_web/views/work_experience_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:70
-#: lib/vutuv_web/views/user_html.ex:101
+#: lib/vutuv_web/views/user_html.ex:239
 #: lib/vutuv_web/views/work_experience_html.ex:13
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:76
-#: lib/vutuv_web/views/user_html.ex:107
+#: lib/vutuv_web/views/user_html.ex:245
 #: lib/vutuv_web/views/work_experience_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:75
-#: lib/vutuv_web/views/user_html.ex:106
+#: lib/vutuv_web/views/user_html.ex:244
 #: lib/vutuv_web/views/work_experience_html.ex:18
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:72
-#: lib/vutuv_web/views/user_html.ex:103
+#: lib/vutuv_web/views/user_html.ex:241
 #: lib/vutuv_web/views/work_experience_html.ex:15
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:74
-#: lib/vutuv_web/views/user_html.ex:105
+#: lib/vutuv_web/views/user_html.ex:243
 #: lib/vutuv_web/views/work_experience_html.ex:17
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:71
+#: lib/vutuv_web/views/user_html.ex:73
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:76
+#: lib/vutuv_web/views/user_html.ex:78
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:80
-#: lib/vutuv_web/views/user_html.ex:111
+#: lib/vutuv_web/views/user_html.ex:249
 #: lib/vutuv_web/views/work_experience_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:79
-#: lib/vutuv_web/views/user_html.ex:110
+#: lib/vutuv_web/views/user_html.ex:248
 #: lib/vutuv_web/views/work_experience_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:78
-#: lib/vutuv_web/views/user_html.ex:109
+#: lib/vutuv_web/views/user_html.ex:247
 #: lib/vutuv_web/views/work_experience_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "September"
@@ -2190,7 +2193,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:251
 #: lib/vutuv_web/live/search_live.ex:147
 #: lib/vutuv_web/live/search_live.ex:306
-#: lib/vutuv_web/templates/user/show.html.heex:328
+#: lib/vutuv_web/templates/user/show.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr ""
@@ -2344,7 +2347,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:352
+#: lib/vutuv_web/templates/user/show.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2675,49 +2678,49 @@ msgid "Use a different email address"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:462
+#: lib/vutuv_web/templates/user/show.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:620
+#: lib/vutuv_web/templates/user/show.html.heex:654
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:601
+#: lib/vutuv_web/templates/user/show.html.heex:622
 #, elixir-autogen, elixir-format
 msgid "Add a social media account"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/index.html.heex:13
-#: lib/vutuv_web/templates/user/show.html.heex:639
+#: lib/vutuv_web/templates/user/show.html.heex:685
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:549
+#: lib/vutuv_web/templates/user/show.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:578
+#: lib/vutuv_web/templates/user/show.html.heex:593
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:267
-#: lib/vutuv_web/templates/user/show.html.heex:399
+#: lib/vutuv_web/controllers/user_controller.ex:271
+#: lib/vutuv_web/templates/user/show.html.heex:402
 #: lib/vutuv_web/templates/work_experience/index.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:271
-#: lib/vutuv_web/templates/user/show.html.heex:333
+#: lib/vutuv_web/controllers/user_controller.ex:275
+#: lib/vutuv_web/templates/user/show.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
@@ -2731,7 +2734,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:333
+#: lib/vutuv_web/templates/user/show.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
@@ -2776,7 +2779,7 @@ msgid "Connect with %{name} to read it."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:529
-#: lib/vutuv_web/templates/user/show.html.heex:45
+#: lib/vutuv_web/templates/user/show.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr ""
@@ -2830,7 +2833,7 @@ msgstr ""
 msgid "Ignore"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:667
+#: lib/vutuv_web/templates/user/show.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2840,7 +2843,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:662
+#: lib/vutuv_web/templates/user/show.html.heex:714
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2865,7 +2868,7 @@ msgstr ""
 msgid "Sent requests"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:668
+#: lib/vutuv_web/templates/user/show.html.heex:718
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2915,7 +2918,7 @@ msgstr ""
 msgid "accepted your connection request."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:205
+#: lib/vutuv_web/templates/user/show.html.heex:208
 #: lib/vutuv_web/views/admin/moderation_html.ex:55
 #, elixir-autogen, elixir-format
 msgid "connection"
@@ -2960,7 +2963,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:208
-#: lib/vutuv_web/templates/user/show.html.heex:44
+#: lib/vutuv_web/templates/user/show.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgstr ""
@@ -3189,7 +3192,7 @@ msgstr ""
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:84
+#: lib/vutuv_web/templates/user/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Only you can see your profile right now - it is hidden while a report is handled."
 msgstr ""
@@ -3254,7 +3257,7 @@ msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:362
-#: lib/vutuv_web/templates/user/show.html.heex:231
+#: lib/vutuv_web/templates/user/show.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr ""
@@ -3546,42 +3549,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:408
+#: lib/vutuv/notifications/emailer.ex:423
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:468
+#: lib/vutuv/notifications/emailer.ex:483
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:446
+#: lib/vutuv/notifications/emailer.ex:461
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:401
+#: lib/vutuv/notifications/emailer.ex:416
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:394
+#: lib/vutuv/notifications/emailer.ex:409
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:387
+#: lib/vutuv/notifications/emailer.ex:402
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:422
+#: lib/vutuv/notifications/emailer.ex:437
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:415
+#: lib/vutuv/notifications/emailer.ex:430
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -4559,13 +4562,13 @@ msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:28
-#: lib/vutuv_web/templates/user/show.html.heex:249
+#: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:528
-#: lib/vutuv_web/templates/user/show.html.heex:242
+#: lib/vutuv_web/templates/user/show.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
@@ -4583,13 +4586,13 @@ msgid "Blocked members cannot follow you, connect with you, message you, or repl
 msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:63
-#: lib/vutuv_web/templates/user/show.html.heex:259
+#: lib/vutuv_web/templates/user/show.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:61
-#: lib/vutuv_web/templates/user/show.html.heex:256
+#: lib/vutuv_web/templates/user/show.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "Unblock @%{slug}?"
 msgstr ""
@@ -4627,7 +4630,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:525
+#: lib/vutuv_web/templates/user/show.html.heex:528
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4729,8 +4732,8 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:265
-#: lib/vutuv_web/templates/user/show.html.heex:365
+#: lib/vutuv_web/controllers/user_controller.ex:269
+#: lib/vutuv_web/templates/user/show.html.heex:368
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -4743,13 +4746,6 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, or posts"
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/markdown.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/templates/user/show.html.heex:362
-#, elixir-autogen, elixir-format
-msgid "Tags & endorsements"
 msgstr ""
 
 #: lib/vutuv_web/templates/tag/single_card.html.heex:8
@@ -5418,17 +5414,17 @@ msgstr ""
 msgid "Your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:295
+#: lib/vutuv_web/templates/user/show.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:301
+#: lib/vutuv_web/templates/user/show.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:260
+#: lib/vutuv_web/controllers/user_controller.ex:264
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5460,7 +5456,7 @@ msgstr ""
 msgid "View post"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:141
+#: lib/vutuv/notifications/emailer.ex:156
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr ""
@@ -5653,17 +5649,17 @@ msgstr ""
 msgid "e.g. Jr. or PhD"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:221
+#: lib/vutuv/notifications/emailer.ex:236
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:207
+#: lib/vutuv/notifications/emailer.ex:222
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:236
+#: lib/vutuv/notifications/emailer.ex:251
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to connect on vutuv"
 msgstr ""
@@ -5926,7 +5922,7 @@ msgstr[1] ""
 msgid "All other devices have been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:322
+#: lib/vutuv/notifications/emailer.ex:337
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr ""
@@ -5951,7 +5947,7 @@ msgstr ""
 msgid "Log this device out of your account?"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:297
+#: lib/vutuv/notifications/emailer.ex:312
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr ""
@@ -5966,7 +5962,7 @@ msgstr ""
 msgid "That device has been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:325
+#: lib/vutuv/notifications/emailer.ex:340
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr ""
@@ -5976,7 +5972,7 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:319
+#: lib/vutuv/notifications/emailer.ex:334
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -6106,7 +6102,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:264
+#: lib/vutuv_web/controllers/user_controller.ex:268
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6116,7 +6112,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:71
+#: lib/vutuv_web/templates/user/show.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Preview: how logged-out visitors and search engines see your profile."
 msgstr ""
@@ -6126,17 +6122,17 @@ msgstr ""
 msgid "View as"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:43
+#: lib/vutuv_web/templates/user/show.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "You"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:67
+#: lib/vutuv_web/templates/user/show.html.heex:70
 #, elixir-autogen, elixir-format
 msgid "Preview: how a member who follows you sees your profile. The controls here are inactive."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:69
+#: lib/vutuv_web/templates/user/show.html.heex:72
 #, elixir-autogen, elixir-format
 msgid "Preview: how a member you are connected with sees your profile. The controls here are inactive."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -52,7 +52,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/index.html.heex:6
 #: lib/vutuv_web/templates/address/new.html.heex:4
 #: lib/vutuv_web/templates/address/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:637
+#: lib/vutuv_web/templates/user/show.html.heex:683
 #, elixir-autogen
 msgid "Addresses"
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:182
 #: lib/vutuv_web/agent_docs/text.ex:215
-#: lib/vutuv_web/templates/user/show.html.heex:586
+#: lib/vutuv_web/templates/user/show.html.heex:607
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -119,7 +119,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/templates/user/show.html.heex:547
+#: lib/vutuv_web/templates/user/show.html.heex:550
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -155,7 +155,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/index.html.heex:165
-#: lib/vutuv_web/templates/user/show.html.heex:271
+#: lib/vutuv_web/templates/user/show.html.heex:274
 #, elixir-autogen
 msgid "Download"
 msgstr ""
@@ -172,7 +172,7 @@ msgstr ""
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:5
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:5
 #: lib/vutuv_web/templates/url/edit.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:591
+#: lib/vutuv_web/templates/user/show.html.heex:612
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:5
 #, elixir-autogen
 msgid "Edit"
@@ -258,7 +258,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/templates/user/show.html.heex:396
+#: lib/vutuv_web/templates/user/show.html.heex:399
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:6
 #: lib/vutuv_web/templates/work_experience/new.html.heex:4
@@ -282,7 +282,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:211
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:507
+#: lib/vutuv_web/templates/user/show.html.heex:510
 #, elixir-autogen
 msgid "Followers"
 msgstr ""
@@ -293,7 +293,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:475
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:525
+#: lib/vutuv_web/templates/user/show.html.heex:528
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:181
 #: lib/vutuv_web/agent_docs/text.ex:214
 #: lib/vutuv_web/templates/user/edit.html.heex:63
-#: lib/vutuv_web/templates/user/show.html.heex:582
+#: lib/vutuv_web/templates/user/show.html.heex:602
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -368,7 +368,7 @@ msgstr ""
 #: lib/vutuv_web/templates/url/index.html.heex:6
 #: lib/vutuv_web/templates/url/new.html.heex:4
 #: lib/vutuv_web/templates/url/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:460
+#: lib/vutuv_web/templates/user/show.html.heex:463
 #, elixir-autogen
 msgid "Links"
 msgstr ""
@@ -432,7 +432,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:179
+#: lib/vutuv/notifications/emailer.ex:194
 #, elixir-autogen
 msgid "New message from @%{slug} on vutuv"
 msgstr ""
@@ -490,7 +490,7 @@ msgstr ""
 #: lib/vutuv_web/templates/phone_number/index.html.heex:6
 #: lib/vutuv_web/templates/phone_number/new.html.heex:4
 #: lib/vutuv_web/templates/phone_number/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:618
+#: lib/vutuv_web/templates/user/show.html.heex:652
 #, elixir-autogen
 msgid "Phone Numbers"
 msgstr ""
@@ -556,7 +556,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:46
+#: lib/vutuv_web/templates/user/show.html.heex:43
 #, elixir-autogen
 msgid "Public"
 msgstr ""
@@ -607,7 +607,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:40
 #: lib/vutuv_web/agent_docs/text.ex:40
-#: lib/vutuv_web/templates/user/show.html.heex:599
+#: lib/vutuv_web/templates/user/show.html.heex:620
 #, elixir-autogen
 msgid "Social Media"
 msgstr ""
@@ -691,12 +691,12 @@ msgstr ""
 msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:386
+#: lib/vutuv_web/controllers/user_controller.ex:390
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:330
+#: lib/vutuv_web/controllers/user_controller.ex:334
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr ""
@@ -757,15 +757,15 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:277
-#: lib/vutuv_web/templates/user/show.html.heex:671
+#: lib/vutuv_web/templates/user/show.html.heex:280
+#: lib/vutuv_web/templates/user/show.html.heex:721
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1228
-#: lib/vutuv_web/templates/user/show.html.heex:519
-#: lib/vutuv_web/templates/user/show.html.heex:538
+#: lib/vutuv_web/templates/user/show.html.heex:522
+#: lib/vutuv_web/templates/user/show.html.heex:541
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -948,7 +948,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:576
+#: lib/vutuv_web/templates/user/show.html.heex:591
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -964,22 +964,22 @@ msgstr ""
 msgid "Choose a gender"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:123
+#: lib/vutuv/notifications/emailer.ex:138
 #, elixir-autogen
 msgid "Confirm your account deletion"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:117
+#: lib/vutuv/notifications/emailer.ex:132
 #, elixir-autogen
 msgid "Confirm your email"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:105
+#: lib/vutuv/notifications/emailer.ex:120
 #, elixir-autogen
 msgid "Confirm your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:111
+#: lib/vutuv/notifications/emailer.ex:126
 #, elixir-autogen
 msgid "Login to vutuv"
 msgstr ""
@@ -1382,6 +1382,8 @@ msgstr ""
 msgid "Tag urls"
 msgstr ""
 
+#: lib/vutuv_web/agent_docs/markdown.ex:30
+#: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/live/search_live.ex:146
 #: lib/vutuv_web/live/search_live.ex:292
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:5
@@ -1390,6 +1392,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:4
+#: lib/vutuv_web/templates/user/show.html.heex:365
 #: lib/vutuv_web/templates/user_tag/form_content.html.heex:5
 #: lib/vutuv_web/templates/user_tag/index.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
@@ -1399,7 +1402,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:118
 #: lib/vutuv_web/controllers/session_controller.ex:271
-#: lib/vutuv_web/controllers/user_controller.ex:401
+#: lib/vutuv_web/controllers/user_controller.ex:405
 #, elixir-autogen
 msgid "Too many incorrect attempts."
 msgstr ""
@@ -1540,7 +1543,7 @@ msgstr ""
 msgid "tag name"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:153
+#: lib/vutuv/notifications/emailer.ex:168
 #, elixir-autogen
 msgid "vutuv Account verified"
 msgstr ""
@@ -1634,13 +1637,13 @@ msgstr ""
 msgid "Disable slugs"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:316
-#: lib/vutuv_web/templates/user/show.html.heex:132
+#: lib/vutuv_web/controllers/user_controller.ex:320
+#: lib/vutuv_web/templates/user/show.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:378
+#: lib/vutuv_web/templates/user/show.html.heex:381
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Endorse"
 msgstr ""
@@ -1672,7 +1675,7 @@ msgstr ""
 msgid "Member"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:149
+#: lib/vutuv_web/templates/user/show.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -1766,8 +1769,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/session_controller.ex:48
 #: lib/vutuv_web/controllers/session_controller.ex:115
 #: lib/vutuv_web/controllers/session_controller.ex:131
-#: lib/vutuv_web/controllers/user_controller.ex:356
-#: lib/vutuv_web/controllers/user_controller.ex:371
+#: lib/vutuv_web/controllers/user_controller.ex:360
+#: lib/vutuv_web/controllers/user_controller.ex:375
 #, elixir-autogen, elixir-format
 msgid "Too many attempts. Please try again later."
 msgstr ""
@@ -1777,7 +1780,7 @@ msgstr ""
 msgid "Unverified users"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:162
+#: lib/vutuv_web/templates/user/show.html.heex:165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verified profile"
 msgstr ""
@@ -1797,7 +1800,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:688
+#: lib/vutuv_web/templates/user/show.html.heex:739
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1813,14 +1816,14 @@ msgstr ""
 msgid "Your login session expired. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:192
+#: lib/vutuv_web/templates/user/show.html.heex:195
 #, elixir-autogen, elixir-format, fuzzy
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:196
+#: lib/vutuv_web/templates/user/show.html.heex:199
 #, elixir-autogen, elixir-format, fuzzy
 msgid "following"
 msgstr ""
@@ -1893,41 +1896,41 @@ msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:440
+#: lib/vutuv_web/templates/user/show.html.heex:443
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:103
+#: lib/vutuv_web/templates/user/show.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Add a cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:110
+#: lib/vutuv_web/templates/user/show.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Add cover photo"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:73
-#: lib/vutuv_web/views/user_html.ex:104
+#: lib/vutuv_web/views/user_html.ex:242
 #: lib/vutuv_web/views/work_experience_html.ex:16
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:77
-#: lib/vutuv_web/views/user_html.ex:108
+#: lib/vutuv_web/views/user_html.ex:246
 #: lib/vutuv_web/views/work_experience_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:110
+#: lib/vutuv_web/templates/user/show.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Change cover"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:103
+#: lib/vutuv_web/templates/user/show.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Change cover photo"
 msgstr ""
@@ -1937,86 +1940,86 @@ msgstr ""
 msgid "Cover photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:96
+#: lib/vutuv_web/templates/user/show.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Cover photo of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:81
-#: lib/vutuv_web/views/user_html.ex:112
+#: lib/vutuv_web/views/user_html.ex:250
 #: lib/vutuv_web/views/work_experience_html.ex:24
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:71
-#: lib/vutuv_web/views/user_html.ex:102
+#: lib/vutuv_web/views/user_html.ex:240
 #: lib/vutuv_web/views/work_experience_html.ex:14
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:70
-#: lib/vutuv_web/views/user_html.ex:101
+#: lib/vutuv_web/views/user_html.ex:239
 #: lib/vutuv_web/views/work_experience_html.ex:13
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:76
-#: lib/vutuv_web/views/user_html.ex:107
+#: lib/vutuv_web/views/user_html.ex:245
 #: lib/vutuv_web/views/work_experience_html.ex:19
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:75
-#: lib/vutuv_web/views/user_html.ex:106
+#: lib/vutuv_web/views/user_html.ex:244
 #: lib/vutuv_web/views/work_experience_html.ex:18
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:72
-#: lib/vutuv_web/views/user_html.ex:103
+#: lib/vutuv_web/views/user_html.ex:241
 #: lib/vutuv_web/views/work_experience_html.ex:15
 #, elixir-autogen, elixir-format, fuzzy
 msgid "March"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:74
-#: lib/vutuv_web/views/user_html.ex:105
+#: lib/vutuv_web/views/user_html.ex:243
 #: lib/vutuv_web/views/work_experience_html.ex:17
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:71
+#: lib/vutuv_web/views/user_html.ex:73
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:76
+#: lib/vutuv_web/views/user_html.ex:78
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:80
-#: lib/vutuv_web/views/user_html.ex:111
+#: lib/vutuv_web/views/user_html.ex:249
 #: lib/vutuv_web/views/work_experience_html.ex:23
 #, elixir-autogen, elixir-format, fuzzy
 msgid "November"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:79
-#: lib/vutuv_web/views/user_html.ex:110
+#: lib/vutuv_web/views/user_html.ex:248
 #: lib/vutuv_web/views/work_experience_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
 #: lib/vutuv_web/views/ad_html.ex:78
-#: lib/vutuv_web/views/user_html.ex:109
+#: lib/vutuv_web/views/user_html.ex:247
 #: lib/vutuv_web/views/work_experience_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "September"
@@ -2189,7 +2192,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:251
 #: lib/vutuv_web/live/search_live.ex:147
 #: lib/vutuv_web/live/search_live.ex:306
-#: lib/vutuv_web/templates/user/show.html.heex:328
+#: lib/vutuv_web/templates/user/show.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr ""
@@ -2343,7 +2346,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:352
+#: lib/vutuv_web/templates/user/show.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2674,49 +2677,49 @@ msgid "Use a different email address"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:462
+#: lib/vutuv_web/templates/user/show.html.heex:465
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:620
+#: lib/vutuv_web/templates/user/show.html.heex:654
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:601
+#: lib/vutuv_web/templates/user/show.html.heex:622
 #, elixir-autogen, elixir-format
 msgid "Add a social media account"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/index.html.heex:13
-#: lib/vutuv_web/templates/user/show.html.heex:639
+#: lib/vutuv_web/templates/user/show.html.heex:685
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:549
+#: lib/vutuv_web/templates/user/show.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:578
+#: lib/vutuv_web/templates/user/show.html.heex:593
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:267
-#: lib/vutuv_web/templates/user/show.html.heex:399
+#: lib/vutuv_web/controllers/user_controller.ex:271
+#: lib/vutuv_web/templates/user/show.html.heex:402
 #: lib/vutuv_web/templates/work_experience/index.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:271
-#: lib/vutuv_web/templates/user/show.html.heex:333
+#: lib/vutuv_web/controllers/user_controller.ex:275
+#: lib/vutuv_web/templates/user/show.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
@@ -2730,7 +2733,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:333
+#: lib/vutuv_web/templates/user/show.html.heex:336
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
@@ -2775,7 +2778,7 @@ msgid "Connect with %{name} to read it."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:529
-#: lib/vutuv_web/templates/user/show.html.heex:45
+#: lib/vutuv_web/templates/user/show.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr ""
@@ -2829,7 +2832,7 @@ msgstr ""
 msgid "Ignore"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:667
+#: lib/vutuv_web/templates/user/show.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2839,7 +2842,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:662
+#: lib/vutuv_web/templates/user/show.html.heex:714
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2864,7 +2867,7 @@ msgstr ""
 msgid "Sent requests"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:668
+#: lib/vutuv_web/templates/user/show.html.heex:718
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2914,7 +2917,7 @@ msgstr ""
 msgid "accepted your connection request."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:205
+#: lib/vutuv_web/templates/user/show.html.heex:208
 #: lib/vutuv_web/views/admin/moderation_html.ex:55
 #, elixir-autogen, elixir-format
 msgid "connection"
@@ -2959,7 +2962,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:208
-#: lib/vutuv_web/templates/user/show.html.heex:44
+#: lib/vutuv_web/templates/user/show.html.heex:41
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follower"
 msgstr ""
@@ -3188,7 +3191,7 @@ msgstr ""
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:84
+#: lib/vutuv_web/templates/user/show.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Only you can see your profile right now - it is hidden while a report is handled."
 msgstr ""
@@ -3253,7 +3256,7 @@ msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:362
-#: lib/vutuv_web/templates/user/show.html.heex:231
+#: lib/vutuv_web/templates/user/show.html.heex:234
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report"
 msgstr ""
@@ -3545,42 +3548,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:408
+#: lib/vutuv/notifications/emailer.ex:423
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:468
+#: lib/vutuv/notifications/emailer.ex:483
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:446
+#: lib/vutuv/notifications/emailer.ex:461
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:401
+#: lib/vutuv/notifications/emailer.ex:416
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:394
+#: lib/vutuv/notifications/emailer.ex:409
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:387
+#: lib/vutuv/notifications/emailer.ex:402
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:422
+#: lib/vutuv/notifications/emailer.ex:437
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:415
+#: lib/vutuv/notifications/emailer.ex:430
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -4558,13 +4561,13 @@ msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:28
-#: lib/vutuv_web/templates/user/show.html.heex:249
+#: lib/vutuv_web/templates/user/show.html.heex:252
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:528
-#: lib/vutuv_web/templates/user/show.html.heex:242
+#: lib/vutuv_web/templates/user/show.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
@@ -4582,13 +4585,13 @@ msgid "Blocked members cannot follow you, connect with you, message you, or repl
 msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:63
-#: lib/vutuv_web/templates/user/show.html.heex:259
+#: lib/vutuv_web/templates/user/show.html.heex:262
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:61
-#: lib/vutuv_web/templates/user/show.html.heex:256
+#: lib/vutuv_web/templates/user/show.html.heex:259
 #, elixir-autogen, elixir-format
 msgid "Unblock @%{slug}?"
 msgstr ""
@@ -4626,7 +4629,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:525
+#: lib/vutuv_web/templates/user/show.html.heex:528
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follows"
 msgstr ""
@@ -4728,8 +4731,8 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:265
-#: lib/vutuv_web/templates/user/show.html.heex:365
+#: lib/vutuv_web/controllers/user_controller.ex:269
+#: lib/vutuv_web/templates/user/show.html.heex:368
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a tag"
 msgstr ""
@@ -4742,13 +4745,6 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:186
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Search for people, tags, or posts"
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/markdown.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/templates/user/show.html.heex:362
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Tags & endorsements"
 msgstr ""
 
 #: lib/vutuv_web/templates/tag/single_card.html.heex:8
@@ -5417,17 +5413,17 @@ msgstr ""
 msgid "Your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:295
+#: lib/vutuv_web/templates/user/show.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:301
+#: lib/vutuv_web/templates/user/show.html.heex:304
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:260
+#: lib/vutuv_web/controllers/user_controller.ex:264
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a profile photo"
 msgstr ""
@@ -5459,7 +5455,7 @@ msgstr ""
 msgid "View post"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:141
+#: lib/vutuv/notifications/emailer.ex:156
 #, elixir-autogen, elixir-format
 msgid "Someone tried to register with your email address"
 msgstr ""
@@ -5652,17 +5648,17 @@ msgstr ""
 msgid "e.g. Jr. or PhD"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:221
+#: lib/vutuv/notifications/emailer.ex:236
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:207
+#: lib/vutuv/notifications/emailer.ex:222
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:236
+#: lib/vutuv/notifications/emailer.ex:251
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to connect on vutuv"
 msgstr ""
@@ -5925,7 +5921,7 @@ msgstr[1] ""
 msgid "All other devices have been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:322
+#: lib/vutuv/notifications/emailer.ex:337
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr ""
@@ -5950,7 +5946,7 @@ msgstr ""
 msgid "Log this device out of your account?"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:297
+#: lib/vutuv/notifications/emailer.ex:312
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr ""
@@ -5965,7 +5961,7 @@ msgstr ""
 msgid "That device has been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:325
+#: lib/vutuv/notifications/emailer.ex:340
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr ""
@@ -5975,7 +5971,7 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:319
+#: lib/vutuv/notifications/emailer.ex:334
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -6105,7 +6101,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:264
+#: lib/vutuv_web/controllers/user_controller.ex:268
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6115,7 +6111,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:71
+#: lib/vutuv_web/templates/user/show.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Preview: how logged-out visitors and search engines see your profile."
 msgstr ""
@@ -6125,17 +6121,17 @@ msgstr ""
 msgid "View as"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:43
+#: lib/vutuv_web/templates/user/show.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "You"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:67
+#: lib/vutuv_web/templates/user/show.html.heex:70
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Preview: how a member who follows you sees your profile. The controls here are inactive."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:69
+#: lib/vutuv_web/templates/user/show.html.heex:72
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Preview: how a member you are connected with sees your profile. The controls here are inactive."
 msgstr ""

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -364,7 +364,7 @@ defmodule VutuvWeb.AgentDocsDriftTest do
   test "?lang=de translates the labels, English stays the default" do
     de_txt = get(build_conn(), "/drift_tester.txt?lang=de").resp_body
     assert de_txt =~ "Mitglied seit:"
-    assert de_txt =~ "TAGS & EMPFEHLUNGEN"
+    assert de_txt =~ "TAGS"
 
     de_md = get(build_conn(), "/drift_tester.md?lang=de").resp_body
     assert de_md =~ "## Lebenslauf"

--- a/test/vutuv_web/tag_wording_test.exs
+++ b/test/vutuv_web/tag_wording_test.exs
@@ -17,7 +17,8 @@ defmodule VutuvWeb.TagWordingTest do
 
       html = conn |> get(~p"/#{user}") |> html_response(200)
 
-      assert html =~ "Tags &amp; endorsements"
+      assert html =~ ~r{<h2[^>]*>\s*Tags\s*</h2>}
+      refute html =~ "endorsements"
       refute html =~ ~r/skill/i
     end
 
@@ -31,7 +32,8 @@ defmodule VutuvWeb.TagWordingTest do
         |> get(~p"/#{user}")
         |> html_response(200)
 
-      assert html =~ "Tags &amp; Empfehlungen"
+      assert html =~ ~r{<h2[^>]*>\s*Tags\s*</h2>}
+      refute html =~ "Empfehlungen"
       refute html =~ "Fähigkeit"
     end
 


### PR DESCRIPTION
## What

The profile tag card header read **"TAGS & EMPFEHLUNGEN"** in German (and "Tags & endorsements" in English). This renames it to just **"Tags"** in every language.

| Before | After |
|---|---|
| `TAGS & EMPFEHLUNGEN` | `TAGS` |

## Why

"Tags" alone is cleaner. The section is fundamentally about tags, and each chip already shows its endorsement count as a small badge, so naming endorsements in the header was redundant.

## How

- Point all three render sites at the already-existing, already-translated `"Tags"` gettext msgid instead of the standalone `"Tags & endorsements"` string:
  - `lib/vutuv_web/templates/user/show.html.heex` — the HTML profile card header
  - `lib/vutuv_web/agent_docs/markdown.ex` + `text.ex` — the `.md`/`.txt` agent-format siblings, kept in sync per the agent-docs rule (drift test stays green)
- `mix gettext.extract --merge` then drops the now-unused msgid from `default.pot` and both locale `.po` files. German resolves to "Tags" automatically; English falls back to the same. No other translations changed — the bulk of the `.po` diff is regenerated source-location comments.

## Tests

Updated test-first, then made the change:
- `test/vutuv_web/tag_wording_test.exs` — asserts the section `<h2>` reads exactly "Tags" and that "endorsements"/"Empfehlungen" no longer appear
- `test/vutuv_web/agent_docs/agent_docs_drift_test.exs` — German doc heading assertion updated to "TAGS"

All 64 tests across the wording, drift, and agent-format suites pass locally.