### PR TITLE
Show profile links as bare domains and tighten label spacing

### DIFF
--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -485,12 +485,13 @@ the resulting ~200px rail width. --%>
             />
           </a>
           <div class="mt-2 min-w-0 text-sm">
-            <p :if={url.description} class="truncate font-medium text-slate-800 dark:text-slate-100">{url.description}</p>
+            <p :if={url.description} class="mb-0.5 truncate font-medium text-slate-800 dark:text-slate-100">{url.description}</p>
             <a
               href={VutuvWeb.UrlHTML.linkable_url(url.value)}
+              title={url.value}
               class="block truncate font-medium text-brand-600 hover:text-brand-700"
             >
-              {url.value}
+              {VutuvWeb.UrlHTML.display_url(url.value)}
             </a>
           </div>
         </div>

--- a/lib/vutuv_web/views/url_html.ex
+++ b/lib/vutuv_web/views/url_html.ex
@@ -15,5 +15,28 @@ defmodule VutuvWeb.UrlHTML do
     end
   end
 
+  # The compact, human-friendly label for a profile link: just the host,
+  # without the `http(s)://` scheme and without the path. When the original
+  # URL carried a path, query or fragment a trailing ellipsis is appended so a
+  # long link reads as `example.com…` and signals there is more behind it. The
+  # full URL stays the clickable target via `linkable_url/1`; this is only the
+  # visible text.
+  def display_url(string) do
+    uri = URI.parse(linkable_url(string))
+
+    case uri.host do
+      host when is_binary(host) and host != "" ->
+        if uri.path in [nil, "", "/"] and uri.query in [nil, ""] and
+             uri.fragment in [nil, ""] do
+          host
+        else
+          host <> "…"
+        end
+
+      _ ->
+        to_string(string)
+    end
+  end
+
   embed_templates("../templates/url/*")
 end

--- a/test/vutuv_web/views/url_html_test.exs
+++ b/test/vutuv_web/views/url_html_test.exs
@@ -24,4 +24,27 @@ defmodule VutuvWeb.UrlHTMLTest do
     assert UrlHTML.linkable_url("data:text/html,<script>alert(1)</script>") == "#"
     assert UrlHTML.linkable_url("vbscript:msgbox(1)") == "#"
   end
+
+  describe "display_url/1 — the compact visible label" do
+    test "shows just the host, without the http(s):// scheme" do
+      assert UrlHTML.display_url("https://example.org") == "example.org"
+      assert UrlHTML.display_url("http://example.org") == "example.org"
+      assert UrlHTML.display_url("example.org") == "example.org"
+    end
+
+    test "treats a bare / path as no path (no ellipsis)" do
+      assert UrlHTML.display_url("https://example.org/") == "example.org"
+    end
+
+    test "appends an ellipsis when the URL carries a path, query or fragment" do
+      assert UrlHTML.display_url("https://example.org/some/long/path") == "example.org…"
+      assert UrlHTML.display_url("https://example.org?q=1") == "example.org…"
+      assert UrlHTML.display_url("https://example.org/#section") == "example.org…"
+      assert UrlHTML.display_url("example.org/path") == "example.org…"
+    end
+
+    test "keeps subdomains" do
+      assert UrlHTML.display_url("https://blog.example.org") == "blog.example.org"
+    end
+  end
 end


### PR DESCRIPTION
## What

On the profile page (`/:slug`), the **Links** cards now show each link as just its **domain name** instead of the full stored URL, and the gap between a link's description and its URL is tightened.

Before / after (the visible label):

```
Private Homepage                 Private Homepage
https://wintermeyer.de      ->   wintermeyer.de
```

## Why

- The `https://` / `http://` scheme is noise when a human scans the card; the domain is the part that identifies the link.
- The description-to-URL gap was visibly too wide.

## How

- New `VutuvWeb.UrlHTML.display_url/1` returns just the host (no scheme, no path). If the original URL carried a path, query or fragment it appends an ellipsis, so a deep link reads `example.com…` as a truncation hint.
- The full URL is unchanged as the click target (`linkable_url/1`, the XSS-safe href chokepoint) and now also rides a `title` tooltip, so the complete address stays discoverable on hover.
- The wide gap came from the global `<p>` element default (`margin-bottom: 15px` in `components.css`). The description `<p>` now overrides it with `mb-0.5` (~2px).

## Scope / safety

- Pure display change. The `href` is untouched.
- The agent-format siblings (`.md` / `.txt` / `.json` / `.xml`) keep the **full** URL as machine-readable data, so `agent_docs_drift_test.exs` still passes (the host is a substring of both the label and the full URL).
- Scoped to the profile show page only; the `/links` management list and section pages are unchanged.

## Tests

- New `display_url/1` unit tests in `test/vutuv_web/views/url_html_test.exs` (scheme stripping, bare-`/` no-ellipsis, path/query/fragment ellipsis, subdomain preservation).
- Verified the rendered page + generated CSS against the running dev server: link text is the bare domain, full URL in the `title`, and the `.mb-0.5` rule is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)