### PR TITLE
Interactive avatar/cover crop on upload

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -8,6 +8,9 @@ import "./keyboard_shortcuts"
 // Passkey (WebAuthn/FIDO2) login + enrolment ceremony on /login and /settings
 // (self-contained, reveals itself only on supporting browsers; see webauthn.js).
 import "./webauthn"
+// Avatar/cover crop modal on the profile editor (self-contained progressive
+// enhancement of the two file inputs; see image_crop.js).
+import "./image_crop"
 
 // LiveSocket drives the incremental LiveView shell (live unread badges, the
 // notifications/messages pages, presence). The CSRF token is rendered into the

--- a/assets/js/image_crop.js
+++ b/assets/js/image_crop.js
@@ -1,0 +1,316 @@
+// Avatar / cover crop modal — a small, self-contained progressive enhancement
+// for the two file inputs on the profile editor (/:slug/edit).
+//
+// The server keeps the original upload and does the real crop + resize with
+// libvips (see Vutuv.Uploads / Vutuv.Uploads.Crop). The browser's only job is
+// to let the member pick *which part* of their photo to keep and hand the
+// server a crop rectangle as four fractions "x,y,w,h" of the EXIF-rotated
+// image, written into a hidden field next to the file input.
+//
+// Both sides work in the rotated coordinate space: we decode with
+// `createImageBitmap(file, {imageOrientation: "from-image"})`, which bakes in
+// the EXIF orientation, and the server crops after its own autorotate, so the
+// fractions line up no matter how the source was rotated.
+//
+// Wiring (set in lib/vutuv_web/templates/user/edit.html.heex):
+//   <input type="file" data-crop-target="user_avatar_crop" data-crop-aspect="1">
+//   <input type="hidden" id="user_avatar_crop" name="user[avatar_crop]">
+//   <img data-crop-preview="user_avatar_crop" hidden>
+//
+// If anything here is unsupported (old browser, decode failure, user cancels)
+// the plain file input still submits and the server falls back to its centered
+// crop — exactly the behaviour from before this file existed.
+
+const MAX_ZOOM = 4 // up to 4x past "cover" fit
+
+// Delegated so it works regardless of when the inputs appear in the DOM.
+function register() {
+  document.addEventListener("change", (event) => {
+    const input = event.target
+    if (input instanceof HTMLInputElement && input.matches('input[type="file"][data-crop-target]')) {
+      onFilePicked(input)
+    }
+  })
+}
+
+function onFilePicked(input) {
+  const file = input.files && input.files[0]
+  const hidden = document.getElementById(input.dataset.cropTarget)
+
+  // A fresh pick clears any crop from a previous selection up front; the modal
+  // sets it again on Save. A new upload must never inherit the old crop.
+  if (hidden) hidden.value = ""
+  clearPreview(input)
+
+  if (!file || !file.type.startsWith("image/") || typeof createImageBitmap !== "function") {
+    return // leave the plain upload in place
+  }
+
+  createImageBitmap(file, { imageOrientation: "from-image" })
+    .then((bitmap) => openCropper(input, hidden, bitmap))
+    .catch(() => {}) // decode failed: leave the plain upload in place
+}
+
+function openCropper(input, hidden, bitmap) {
+  const aspect = parseFloat(input.dataset.cropAspect) || 1
+  // Translatable copy comes from the template via data-* (gettext), with
+  // English fallbacks here — the same pattern as webauthn.js.
+  const labels = {
+    title: input.dataset.cropTitle || "Position your photo",
+    hint:
+      input.dataset.cropHint ||
+      "Drag to move, use the slider to zoom. The framed area is what others see.",
+    save: input.dataset.cropSave || "Use photo",
+    cancel: input.dataset.cropCancel || "Cancel",
+    zoom: input.dataset.cropZoom || "Zoom",
+  }
+
+  // ── State (all geometry in CSS pixels of the stage) ──
+  // scale: image px -> stage px. offset: top-left of the drawn image in the
+  // stage. coverScale fills the frame (object-cover); we never zoom out past
+  // it, so the frame is always fully covered and every crop fraction is in 0..1.
+  let stageW = 0
+  let stageH = 0
+  let coverScale = 1
+  let scale = 1
+  let offsetX = 0
+  let offsetY = 0
+
+  const ui = buildModal(aspect, labels)
+  document.body.appendChild(ui.overlay)
+
+  const ctx = ui.canvas.getContext("2d")
+  const dpr = window.devicePixelRatio || 1
+
+  layout()
+  window.addEventListener("resize", layout)
+
+  // Size the stage to fit both the dialog width and a viewport-height budget,
+  // then recompute the cover fit and redraw. The height budget keeps a tall
+  // (square) frame from pushing the Save button off a short screen — the
+  // dialog also scrolls as a last resort.
+  function layout() {
+    const maxH = Math.max(160, window.innerHeight * 0.55)
+    const parent = ui.stage.parentElement
+    const cs = getComputedStyle(parent)
+    stageW = parent.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight)
+    stageH = Math.round(stageW / aspect)
+    if (stageH > maxH) {
+      stageH = Math.round(maxH)
+      stageW = Math.round(stageH * aspect)
+    }
+    ui.stage.style.width = `${stageW}px`
+    ui.stage.style.height = `${stageH}px`
+    ui.canvas.width = Math.round(stageW * dpr)
+    ui.canvas.height = Math.round(stageH * dpr)
+    ui.canvas.style.width = `${stageW}px`
+    ui.canvas.style.height = `${stageH}px`
+
+    coverScale = Math.max(stageW / bitmap.width, stageH / bitmap.height)
+    const zoom = parseFloat(ui.zoom.value) || 1
+    scale = coverScale * zoom
+    // Keep the current focal point roughly centered after a resize.
+    offsetX = (stageW - bitmap.width * scale) / 2
+    offsetY = (stageH - bitmap.height * scale) / 2
+    clampOffsets()
+    draw()
+  }
+
+  function draw() {
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.clearRect(0, 0, stageW, stageH)
+    ctx.drawImage(bitmap, offsetX, offsetY, bitmap.width * scale, bitmap.height * scale)
+  }
+
+  // The image must always cover the frame: offsets are bounded so no gap shows.
+  function clampOffsets() {
+    const drawnW = bitmap.width * scale
+    const drawnH = bitmap.height * scale
+    offsetX = Math.min(0, Math.max(stageW - drawnW, offsetX))
+    offsetY = Math.min(0, Math.max(stageH - drawnH, offsetY))
+  }
+
+  // ── Zoom: keep the frame's center fixed while scaling ──
+  function applyZoom(nextZoom) {
+    nextZoom = Math.min(MAX_ZOOM, Math.max(1, nextZoom))
+    ui.zoom.value = String(nextZoom)
+    const newScale = coverScale * nextZoom
+    const cx = stageW / 2
+    const cy = stageH / 2
+    // Image point currently under the center stays under the center.
+    offsetX = cx - ((cx - offsetX) / scale) * newScale
+    offsetY = cy - ((cy - offsetY) / scale) * newScale
+    scale = newScale
+    clampOffsets()
+    draw()
+  }
+
+  ui.zoom.addEventListener("input", () => applyZoom(parseFloat(ui.zoom.value) || 1))
+
+  ui.stage.addEventListener(
+    "wheel",
+    (e) => {
+      e.preventDefault()
+      const step = e.deltaY < 0 ? 1.08 : 1 / 1.08
+      applyZoom((parseFloat(ui.zoom.value) || 1) * step)
+    },
+    { passive: false }
+  )
+
+  // ── Pan: pointer drag works for mouse and touch alike ──
+  let dragging = false
+  let lastX = 0
+  let lastY = 0
+
+  ui.stage.addEventListener("pointerdown", (e) => {
+    dragging = true
+    lastX = e.clientX
+    lastY = e.clientY
+    ui.stage.setPointerCapture(e.pointerId)
+  })
+
+  ui.stage.addEventListener("pointermove", (e) => {
+    if (!dragging) return
+    offsetX += e.clientX - lastX
+    offsetY += e.clientY - lastY
+    lastX = e.clientX
+    lastY = e.clientY
+    clampOffsets()
+    draw()
+  })
+
+  const endDrag = () => {
+    dragging = false
+  }
+  ui.stage.addEventListener("pointerup", endDrag)
+  ui.stage.addEventListener("pointercancel", endDrag)
+
+  // ── Finish ──
+  function cleanup() {
+    window.removeEventListener("resize", layout)
+    ui.overlay.remove()
+    bitmap.close && bitmap.close()
+  }
+
+  function cancel() {
+    // Drop the selection entirely so nothing uploads on cancel.
+    input.value = ""
+    if (hidden) hidden.value = ""
+    clearPreview(input)
+    cleanup()
+  }
+
+  function save() {
+    // The visible frame maps to this image-space rectangle; express it as
+    // fractions for Vutuv.Uploads.Crop.
+    const x = clamp01(-offsetX / scale / bitmap.width)
+    const y = clamp01(-offsetY / scale / bitmap.height)
+    const w = clamp01(stageW / scale / bitmap.width)
+    const h = clamp01(stageH / scale / bitmap.height)
+    if (hidden) hidden.value = `${round4(x)},${round4(y)},${round4(w)},${round4(h)}`
+    showPreview(input, ui, x, y, w, h, bitmap)
+    cleanup()
+  }
+
+  ui.save.addEventListener("click", save)
+  ui.cancel.addEventListener("click", cancel)
+  ui.overlay.addEventListener("click", (e) => {
+    if (e.target === ui.overlay) cancel()
+  })
+  document.addEventListener("keydown", function onKey(e) {
+    if (!document.body.contains(ui.overlay)) {
+      document.removeEventListener("keydown", onKey)
+    } else if (e.key === "Escape") {
+      cancel()
+    }
+  })
+}
+
+// Builds the modal DOM. Tailwind scans assets/js, so these utility classes are
+// part of the build (see app.css `@source "../js"`).
+function buildModal(aspect, labels) {
+  const overlay = el("div", "fixed inset-0 z-[60] flex items-center justify-center bg-black/70 p-4")
+  const dialog = el(
+    "div",
+    "max-h-[calc(100vh-2rem)] w-full max-w-md overflow-y-auto rounded-2xl bg-white p-4 shadow-xl dark:bg-slate-900"
+  )
+  const title = el("h2", "text-base font-semibold text-slate-900 dark:text-white", labels.title)
+  const hint = el("p", "mt-1 text-xs text-slate-600 dark:text-slate-400", labels.hint)
+
+  // The stage size is set in pixels by layout() (it fits a viewport-height
+  // budget, so it is not always full width); mx-auto keeps it centered.
+  const stage = el(
+    "div",
+    "relative mx-auto mt-3 touch-none select-none overflow-hidden rounded-lg bg-slate-100 ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"
+  )
+  const canvas = el("canvas", "block h-full w-full cursor-grab active:cursor-grabbing")
+  // A frame outline so the cropped area reads clearly (the whole stage IS the
+  // crop, so this is just a visual cue, not a separate region).
+  const frame = el("div", "pointer-events-none absolute inset-0 rounded-lg ring-2 ring-white/70")
+  stage.append(canvas, frame)
+
+  const zoom = el("input", "mt-3 block w-full accent-brand-600")
+  zoom.type = "range"
+  zoom.min = "1"
+  zoom.max = String(MAX_ZOOM)
+  zoom.step = "0.01"
+  zoom.value = "1"
+  zoom.setAttribute("aria-label", labels.zoom)
+
+  const actions = el("div", "mt-4 flex items-center justify-end gap-3")
+  const cancel = el(
+    "button",
+    "rounded-lg bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700",
+    labels.cancel
+  )
+  cancel.type = "button"
+  const save = el(
+    "button",
+    "rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700",
+    labels.save
+  )
+  save.type = "button"
+  actions.append(cancel, save)
+
+  dialog.append(title, hint, stage, zoom, actions)
+  overlay.appendChild(dialog)
+  return { overlay, dialog, stage, canvas, zoom, save, cancel }
+}
+
+// After Save, show the chosen crop as a small preview next to the input so the
+// member sees what they picked without reopening the modal.
+function showPreview(input, ui, x, y, w, h, bitmap) {
+  const img = document.querySelector(`[data-crop-preview="${input.dataset.cropTarget}"]`)
+  if (!img) return
+  const sx = x * bitmap.width
+  const sy = y * bitmap.height
+  const sw = w * bitmap.width
+  const sh = h * bitmap.height
+  const out = document.createElement("canvas")
+  const maxW = 240
+  out.width = Math.min(maxW, Math.round(sw))
+  out.height = Math.round(out.width * (sh / sw))
+  out.getContext("2d").drawImage(bitmap, sx, sy, sw, sh, 0, 0, out.width, out.height)
+  img.src = out.toDataURL("image/png")
+  img.hidden = false
+}
+
+function clearPreview(input) {
+  const img = document.querySelector(`[data-crop-preview="${input.dataset.cropTarget}"]`)
+  if (img) {
+    img.hidden = true
+    img.removeAttribute("src")
+  }
+}
+
+function el(tag, className, text) {
+  const node = document.createElement(tag)
+  if (className) node.className = className
+  if (text != null) node.textContent = text
+  return node
+}
+
+const clamp01 = (v) => Math.min(1, Math.max(0, v))
+const round4 = (v) => Math.round(v * 10000) / 10000
+
+register()

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -19,6 +19,7 @@ defmodule Vutuv.Accounts do
   alias Vutuv.Notifications.Bounces
   alias Vutuv.Notifications.Emailer
   alias Vutuv.Repo
+  alias Vutuv.Uploads.Crop
 
   # ── Registration ──
 
@@ -781,26 +782,46 @@ defmodule Vutuv.Accounts do
   # rolled-back update (a name too long, a constraint, ...) never orphans them
   # (issue #776). User.changeset already validated the uploads in memory; here
   # we store them against the just-committed user (final id + handle, which the
-  # served filename embeds) and set both the filename and the content
-  # fingerprint columns in a second write.
+  # served filename embeds) and set the filename, content fingerprint and crop
+  # columns in a second write.
   defp store_pending_images(user, attrs) do
     user
-    |> store_pending_image(:avatar, image_upload(attrs, :avatar), &Vutuv.Avatar.store/1)
-    |> store_pending_image(:cover_photo, image_upload(attrs, :cover_photo), &Vutuv.Cover.store/1)
+    |> store_pending_image(
+      :avatar,
+      :avatar_crop,
+      image_upload(attrs, :avatar),
+      crop_param(attrs, "avatar_crop"),
+      &Vutuv.Avatar.store/2
+    )
+    |> store_pending_image(
+      :cover_photo,
+      :cover_crop,
+      image_upload(attrs, :cover_photo),
+      crop_param(attrs, "cover_crop"),
+      &Vutuv.Cover.store/2
+    )
   end
 
-  defp store_pending_image(user, _field, nil, _store), do: user
+  defp store_pending_image(user, _field, _crop_field, nil, _crop, _store), do: user
 
-  defp store_pending_image(user, field, %Plug.Upload{} = upload, store) do
-    # The store returns the content fingerprint alongside the filename; both are
-    # persisted, putting the row on the fingerprinted scheme (its URL carries the
-    # fingerprint in the filename, so no `updated_at`-based `?v=` is needed — an
-    # identical re-upload yields the same fingerprint and the same cacheable URL).
-    # A failure of either step (a rare disk/db error after a decode the changeset
-    # already proved) keeps the prior image rather than committing columns that
-    # point at a file that was never written.
-    with {:ok, file_name, fingerprint} <- store.({upload, user}),
-         attrs = %{field => file_name, fingerprint_field(field) => fingerprint},
+  defp store_pending_image(user, field, crop_field, %Plug.Upload{} = upload, crop, store) do
+    # The store returns the content fingerprint alongside the filename; the
+    # filename, fingerprint and crop are persisted together, putting the row on
+    # the fingerprinted scheme (its URL carries the fingerprint in the filename,
+    # so no `updated_at`-based `?v=` is needed). The crop is folded into the
+    # fingerprint, so re-cropping the same original still yields a fresh, cache-
+    # safe URL. The crop column is always reset to the freshly-submitted value:
+    # a new upload must not inherit the previous image's crop, and it is persisted
+    # so a later re-derive (`Vutuv.Uploads.Regenerator`) re-applies it (see
+    # `Vutuv.Uploads.Crop`). A failure of either step (a rare disk/db error after
+    # a decode the changeset already proved) keeps the prior image rather than
+    # committing columns that point at a file that was never written.
+    with {:ok, file_name, fingerprint} <- store.({upload, user}, crop),
+         attrs = %{
+           field => file_name,
+           fingerprint_field(field) => fingerprint,
+           crop_field => crop
+         },
          {:ok, saved} <- user |> Ecto.Changeset.change(attrs) |> Repo.update() do
       saved
     else
@@ -812,6 +833,14 @@ defmodule Vutuv.Accounts do
 
   defp fingerprint_field(:avatar), do: :avatar_fingerprint
   defp fingerprint_field(:cover_photo), do: :cover_fingerprint
+
+  # The user-chosen crop rectangle for an image, normalised to its canonical
+  # `"x,y,w,h"` form (or nil for no/invalid crop). Only the web form sends it
+  # (string keys); internal callers (e.g. the gravatar import) pass atom-keyed
+  # attrs with no crop, which Map.get reads as nil — i.e. centered.
+  defp crop_param(attrs, key) when is_binary(key) do
+    attrs |> Map.get(key) |> Crop.normalize()
+  end
 
   defp image_upload(attrs, field) do
     case attrs do

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -27,8 +27,18 @@ defmodule Vutuv.Accounts.User do
     # (Vutuv.Uploads). nil = not yet migrated to the fingerprinted scheme: the URL
     # builder then emits the legacy `?v=` URL, so a nil here serves exactly as
     # before. Set programmatically on store/regenerate, never cast from params.
+    # The crop string (below) is folded into this hash, so re-cropping the same
+    # original yields a fresh fingerprint and therefore a fresh, cache-safe URL.
     field(:avatar_fingerprint, :string)
     field(:cover_fingerprint, :string)
+    # The user-chosen crop rectangle for each image, "x,y,w,h" fractions (0..1)
+    # of the EXIF-rotated original; nil = no crop (centered, the pre-crop-UI
+    # behavior). Set programmatically alongside the file post-commit
+    # (Accounts.store_pending_image/6), never cast from params — like :avatar /
+    # :cover_photo themselves. Persisted so Vutuv.Uploads.Regenerator can
+    # re-apply the crop when it re-derives served versions from the original.
+    field(:avatar_crop, :string)
+    field(:cover_crop, :string)
     field(:active_slug, :string)
     field(:admin?, :boolean)
     field(:headline, :string)

--- a/lib/vutuv/uploaders/avatar.ex
+++ b/lib/vutuv/uploaders/avatar.ex
@@ -37,6 +37,7 @@ defmodule Vutuv.Avatar do
 
   alias Vix.Vips.Operation
   alias Vutuv.Uploads
+  alias Vutuv.Uploads.Crop
   alias Vutuv.Uploads.Originals
   alias Vutuv.Uploads.Spec
 
@@ -52,20 +53,23 @@ defmodule Vutuv.Avatar do
     # Everything version-shaped a past pipeline may have left: old-extension
     # versions, publicly stored originals, files named for a previous user
     # name, and the Waffle-era `_large` (512px) the current code never serves.
-    stale_glob: "*_*.*"
+    stale_glob: "*_*.*",
+    crop_field: :avatar_crop
   }
 
   @default_avatar ~s"data:image/svg+xml,%3Csvg%20width%3D%27200%27%20height%3D%27200%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20xmlns%3Axlink%3D%27http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%27%3E%3Cdefs%3E%3Ccircle%20id%3D%27a%27%20cx%3D%27100%27%20cy%3D%27100%27%20r%3D%27100%27%2F%3E%3C%2Fdefs%3E%3Cg%20fill%3D%27none%27%20fill-rule%3D%27evenodd%27%3E%3Cmask%20id%3D%27b%27%20fill%3D%27%23fff%27%3E%3Cuse%20xlink%3Ahref%3D%27%23a%27%2F%3E%3C%2Fmask%3E%3Cuse%20fill%3D%27%23EEE%27%20xlink%3Ahref%3D%27%23a%27%2F%3E%3Cpath%20d%3D%27M88.96%20154c-6.357-12.418-12.81-26.952-19.355-43.597C63.06%2093.76%2056.858%2075.626%2051%2056h29.437c1.247%204.844%202.714%2010.093%204.4%2015.743%201.682%205.653%203.428%2011.365%205.24%2017.143%201.808%205.772%203.615%2011.394%205.425%2016.86%201.81%205.466%203.59%2010.434%205.336%2014.904%201.618-4.47%203.365-9.438%205.234-14.905%201.87-5.465%203.71-11.087%205.518-16.86%201.807-5.777%203.554-11.49%205.237-17.142%201.682-5.65%203.15-10.9%204.395-15.743h28.71c-5.857%2019.626-12.055%2037.76-18.594%2054.403C124.8%20127.048%20118.352%20141.583%20112%20154H88.96z%27%20fill%3D%27%231A1918%27%20opacity%3D%27.1%27%20mask%3D%27url(%23b)%27%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E"
 
   @doc """
-  Stores every avatar version for `{upload, user}` and returns
-  `{:ok, original_file_name, fingerprint}` (kept in the `:avatar` /
-  `:avatar_fingerprint` columns), or `{:error, :invalid_file}` when the
+  Stores every avatar version for `{upload, user}`, cropping the served
+  versions to `crop` (a `"x,y,w,h"` string or `nil` for the centered default;
+  see `Vutuv.Uploads.Crop`) and returns `{:ok, original_file_name, fingerprint}`
+  (kept in the `:avatar` / `:avatar_fingerprint` columns; the crop is folded
+  into the fingerprint), or `{:error, :invalid_file}` when the
   extension is not whitelisted **or the file cannot be decoded as an image**
   (corrupt/truncated uploads used to crash the request with a `MatchError`).
   """
-  def store({%Plug.Upload{}, _scope} = upload_and_scope) do
-    Uploads.store(upload_and_scope, @config)
+  def store({%Plug.Upload{}, _scope} = upload_and_scope, crop \\ nil) do
+    Uploads.store(upload_and_scope, @config, crop)
   end
 
   @doc """
@@ -151,23 +155,43 @@ defmodule Vutuv.Avatar do
   def og_jpeg(%{avatar: nil}), do: :error
   def og_jpeg(user), do: derive_jpeg(user, @og_size, @og_size, :center)
 
-  # JPEG from the best available source: decode + EXIF-autorotate,
-  # crop-resize, save **stripped** (`keep: []`). The original's metadata
-  # (camera, GPS) must never leak into a served or exported derivative —
-  # the same rule the AVIF pipeline enforces in Vutuv.Uploads.Spec.
+  # JPEG from the best available source: decode + EXIF-autorotate, apply the
+  # user's crop, crop-resize, save **stripped** (`keep: []`). The original's
+  # metadata (camera, GPS) must never leak into a served or exported
+  # derivative — the same rule the AVIF pipeline enforces in Vutuv.Uploads.Spec.
+  #
+  # The crop is applied only when deriving from the **original**; a served
+  # version fallback (legacy uploads with no kept original) is already cropped,
+  # so re-applying the fractions would double-crop it.
   defp derive_jpeg(user, width, height, gravity) do
-    with path when not is_nil(path) <- source_path(user),
-         {:ok, rotated} <- Spec.open_rotated(path),
-         {:ok, small} <- Image.thumbnail(rotated, "#{width}x#{height}", crop: gravity),
-         {:ok, data} <- Operation.jpegsave_buffer(small, keep: [], Q: 80) do
-      {:ok, data}
-    else
-      _ -> :error
+    case source(user) do
+      nil ->
+        :error
+
+      {origin, path} ->
+        crop = if origin == :original, do: Crop.parse(Map.get(user, :avatar_crop))
+
+        with {:ok, rotated} <- Spec.open_rotated(path),
+             {:ok, cropped} <- Crop.apply_to(rotated, crop),
+             {:ok, small} <- Image.thumbnail(cropped, "#{width}x#{height}", crop: gravity),
+             {:ok, data} <- Operation.jpegsave_buffer(small, keep: [], Q: 80) do
+          {:ok, data}
+        else
+          _ -> :error
+        end
     end
   end
 
-  defp source_path(user) do
-    Originals.path("#{@config.prefix}/#{user.id}") ||
-      Uploads.version_path({user.avatar, user}, :medium, @config)
+  defp source(user) do
+    case Originals.path("#{@config.prefix}/#{user.id}") do
+      nil ->
+        case Uploads.version_path({user.avatar, user}, :medium, @config) do
+          nil -> nil
+          path -> {:served, path}
+        end
+
+      path ->
+        {:original, path}
+    end
   end
 end

--- a/lib/vutuv/uploaders/cover.ex
+++ b/lib/vutuv/uploaders/cover.ex
@@ -34,17 +34,20 @@ defmodule Vutuv.Cover do
     # See Vutuv.Avatar's @config: the user column holding this image's content
     # fingerprint, baked into `<slug>-<version>-<fp>.avif` when set.
     fingerprint_field: :cover_fingerprint,
-    stale_glob: "*_{wide,original}.*"
+    stale_glob: "*_{wide,original}.*",
+    crop_field: :cover_crop
   }
 
   @doc """
-  Stores every cover version for `{upload, user}` and returns
-  `{:ok, original_file_name, fingerprint}` (kept in the `:cover_photo` /
-  `:cover_fingerprint` columns), or `{:error, :invalid_file}` when the extension
-  is not whitelisted or the file cannot be decoded as an image.
+  Stores every cover version for `{upload, user}`, cropping the served banner
+  to `crop` (a `"x,y,w,h"` string or `nil` for the full-width default; see
+  `Vutuv.Uploads.Crop`) and returns `{:ok, original_file_name, fingerprint}`
+  (kept in the `:cover_photo` / `:cover_fingerprint` columns; the crop is folded
+  into the fingerprint), or `{:error, :invalid_file}` when the
+  extension is not whitelisted or the file cannot be decoded as an image.
   """
-  def store({%Plug.Upload{}, _scope} = upload_and_scope) do
-    Uploads.store(upload_and_scope, @config)
+  def store({%Plug.Upload{}, _scope} = upload_and_scope, crop \\ nil) do
+    Uploads.store(upload_and_scope, @config, crop)
   end
 
   @doc """

--- a/lib/vutuv/uploads.ex
+++ b/lib/vutuv/uploads.ex
@@ -13,6 +13,7 @@ defmodule Vutuv.Uploads do
   """
 
   alias Vutuv.Repo
+  alias Vutuv.Uploads.Crop
   alias Vutuv.Uploads.Originals
   alias Vutuv.Uploads.Spec
 
@@ -24,20 +25,24 @@ defmodule Vutuv.Uploads do
   @hash_length 12
 
   @typedoc """
-  Per-uploader layout passed to the shared `store/2`, `url/3` and
+  Per-uploader layout passed to the shared `store/3`, `url/3` and
   `regenerate/3` pipeline (`Vutuv.Avatar` and `Vutuv.Cover` differ only in
-  these four knobs):
+  these knobs):
 
     * `:spec_key` — the `Vutuv.Uploads.Spec.versions/1` key (`:avatar | :cover`)
     * `:prefix` — the served-tree storage prefix (`"avatars"` / `"covers"`)
     * `:default_version` — the version `url/3` serves when none is given
     * `:stale_glob` — the `regenerate/3` sweep glob (relative to the dir)
+    * `:crop_field` — the scope field holding the persisted crop string that
+      `regenerate/3` re-applies (`:avatar_crop` / `:cover_crop`); absent for
+      uploaders without a user-chosen crop
   """
   @type uploader_config :: %{
-          spec_key: atom(),
-          prefix: String.t(),
-          default_version: atom(),
-          stale_glob: String.t()
+          required(:spec_key) => atom(),
+          required(:prefix) => String.t(),
+          required(:default_version) => atom(),
+          required(:stale_glob) => String.t(),
+          optional(:crop_field) => atom()
         }
 
   @doc """
@@ -78,17 +83,23 @@ defmodule Vutuv.Uploads do
   (privately). Clearing prior versions keeps exactly one image set per dir, so a
   re-upload never accumulates stale fingerprinted/legacy files.
   """
-  def store({%Plug.Upload{} = upload, scope}, config) do
+  def store({%Plug.Upload{} = upload, scope}, config, crop \\ nil) do
     if valid_extension?(upload.filename) do
       ext = Path.extname(upload.filename)
       storage_dir = storage_dir(scope, config)
       dir = disk_dir(storage_dir)
       File.mkdir_p!(dir)
-      fingerprint = content_hash(upload.path)
+      # The crop is folded into the fingerprint so re-cropping the *same*
+      # original yields a different filename (and a cache-safe URL); see
+      # content_hash/2. The crop only shapes the derived (served) versions —
+      # the original is kept verbatim and uncropped, so a future re-derive (or
+      # re-crop) starts from the full upload.
+      fingerprint = content_hash(upload.path, crop)
 
       with {:ok, rotated} <- Spec.open_rotated(upload.path),
+           {:ok, cropped} <- Crop.apply_to(rotated, Crop.parse(crop)),
            :ok <- clear_public_versions(dir),
-           :ok <- write_derived_versions(rotated, dir, scope, fingerprint, config),
+           :ok <- write_derived_versions(cropped, dir, scope, fingerprint, config),
            :ok <- Originals.store(storage_dir, upload.path, ext) do
         {:ok, upload.filename, fingerprint}
       else
@@ -99,14 +110,17 @@ defmodule Vutuv.Uploads do
     end
   end
 
-  # The first 12 hex of the SHA-256 of the uploaded bytes — the content
-  # fingerprint baked into the served filename. Hashing the **original** (not a
-  # derived version) makes it deterministic, so a regeneration of the same image
-  # produces the same name (idempotent migration) and an identical re-upload
-  # reuses the same URL.
-  defp content_hash(path) do
+  # The first 12 hex of the SHA-256 of the uploaded bytes **plus the crop
+  # string** — the content fingerprint baked into the served filename. Hashing
+  # the **original** (not a derived version) makes it deterministic, so a
+  # regeneration of the same image and crop produces the same name (idempotent
+  # migration) and an identical re-upload reuses the same URL. Folding the crop
+  # in means re-cropping the same original yields a fresh fingerprint, so the
+  # immutable (`?v=`-less) URL changes and no stale crop is served from cache.
+  # A nil crop appends "", leaving the no-crop hash byte-identical to before.
+  defp content_hash(path, crop) do
     :sha256
-    |> :crypto.hash(File.read!(path))
+    |> :crypto.hash(File.read!(path) <> (crop || ""))
     |> Base.encode16(case: :lower)
     |> binary_part(0, @hash_length)
   end
@@ -279,10 +293,18 @@ defmodule Vutuv.Uploads do
 
       original ->
         File.mkdir_p!(dir)
-        fingerprint = content_hash(original)
+        # Re-apply the user's persisted crop so a re-derive from the kept
+        # original never silently un-crops the served versions. The crop is
+        # folded into the fingerprint (as it was at store time), so the
+        # recomputed fingerprint matches the persisted column and the migration
+        # stays idempotent. A nil crop_field (uploaders without a crop) is a
+        # no-op centered derive, byte-identical to the pre-crop behaviour.
+        crop = crop_for(user, config)
+        fingerprint = content_hash(original, crop)
 
         with {:ok, rotated} <- Spec.open_rotated(original),
-             :ok <- write_derived_versions(rotated, dir, user, fingerprint, config),
+             {:ok, cropped} <- Crop.apply_to(rotated, Crop.parse(crop)),
+             :ok <- write_derived_versions(cropped, dir, user, fingerprint, config),
              {:ok, _user} <- persist_fingerprint(user, fingerprint, config) do
           :ok
         end
@@ -300,6 +322,13 @@ defmodule Vutuv.Uploads do
       fingerprint_converged?(user, dir, fingerprint, config) -> :unchanged
       Originals.locate(storage_dir, [Path.join(dir, "*_original.*")]) -> :ok
       true -> {:skipped, :missing_original}
+    end
+  end
+
+  defp crop_for(scope, config) do
+    case Map.get(config, :crop_field) do
+      nil -> nil
+      field -> Map.get(scope, field)
     end
   end
 

--- a/lib/vutuv/uploads/crop.ex
+++ b/lib/vutuv/uploads/crop.ex
@@ -1,0 +1,106 @@
+defmodule Vutuv.Uploads.Crop do
+  @moduledoc """
+  The user-chosen crop rectangle applied to an upload before it is resized
+  into served versions.
+
+  A crop is four fractions of the **EXIF-rotated** original — `{x, y, w, h}`
+  in `0..1`, `x`/`y` the top-left corner, `w`/`h` the size — produced by the
+  in-browser crop modal (`assets/js/image_crop.js`) and persisted per image
+  (`users.avatar_crop` / `users.cover_crop`) so `Vutuv.Uploads.Regenerator`
+  can re-apply it when it re-derives the served versions from the kept
+  original (without persistence, the next format/quality regen would silently
+  un-crop everyone).
+
+  On the wire and in the DB a crop is the compact string `"x,y,w,h"`; `nil` or
+  an unparseable value means "no crop" — the centered behavior from before the
+  crop UI — and is never an error: a bad crop param must not fail an upload.
+
+  Both sides agree on the **rotated** coordinate space. The browser reads
+  pixels with `createImageBitmap(file, {imageOrientation: "from-image"})` and
+  the server crops *after* `Vutuv.Uploads.Spec.open_rotated/1` autorotates, so
+  the fractions line up regardless of the source's EXIF orientation.
+  """
+
+  @typedoc "A crop rectangle as `{x, y, w, h}` fractions in `0..1`."
+  @type t :: {float(), float(), float(), float()}
+
+  @doc """
+  Parses a stored/submitted `"x,y,w,h"` string into `{x, y, w, h}` fractions,
+  clamped to a valid in-bounds rectangle, or `nil` when the value is absent,
+  malformed or degenerate (zero width/height, or a full-frame crop that would
+  be a no-op).
+  """
+  @spec parse(String.t() | nil) :: t() | nil
+  def parse(nil), do: nil
+
+  def parse(value) when is_binary(value) do
+    with [x, y, w, h] <- String.split(value, ","),
+         {:ok, x} <- fraction(x),
+         {:ok, y} <- fraction(y),
+         {:ok, w} <- fraction(w),
+         {:ok, h} <- fraction(h),
+         {x, y, w, h} <- clamp_box(x, y, w, h),
+         true <- meaningful?(x, y, w, h) do
+      {x, y, w, h}
+    else
+      _ -> nil
+    end
+  end
+
+  def parse(_), do: nil
+
+  @doc """
+  Validates and re-serialises a submitted crop string to its canonical
+  `"x,y,w,h"` form, or `nil` when there is no meaningful crop. This is the
+  value persisted in the DB column.
+  """
+  @spec normalize(String.t() | nil) :: String.t() | nil
+  def normalize(value) do
+    case parse(value) do
+      nil -> nil
+      {x, y, w, h} -> Enum.map_join([x, y, w, h], ",", &dump_fraction/1)
+    end
+  end
+
+  @doc """
+  Crops the (already EXIF-rotated) `image` to `crop`, or returns it unchanged
+  when `crop` is `nil`. Resolves the fractions to clamped integer pixels so
+  independent per-edge rounding can never push the box past the image bounds.
+  """
+  @spec apply_to(Vix.Vips.Image.t(), t() | nil) ::
+          {:ok, Vix.Vips.Image.t()} | {:error, term()}
+  def apply_to(image, nil), do: {:ok, image}
+
+  def apply_to(image, {x, y, w, h}) do
+    iw = Image.width(image)
+    ih = Image.height(image)
+
+    left = clamp(round(x * iw), 0, iw - 1)
+    top = clamp(round(y * ih), 0, ih - 1)
+    width = clamp(round(w * iw), 1, iw - left)
+    height = clamp(round(h * ih), 1, ih - top)
+
+    Image.crop(image, left, top, width, height)
+  end
+
+  defp fraction(str) do
+    case Float.parse(String.trim(str)) do
+      {f, ""} when f >= 0.0 and f <= 1.0 -> {:ok, f}
+      _ -> :error
+    end
+  end
+
+  # Trim the box so x+w and y+h never exceed 1.0 (the corner already sits in
+  # 0..1, so the size is what can overrun).
+  defp clamp_box(x, y, w, h), do: {x, y, min(w, 1.0 - x), min(h, 1.0 - y)}
+
+  # A crop covering (almost) the whole frame is a no-op: treat it as none so we
+  # neither pay the crop op nor persist a meaningless rectangle.
+  defp meaningful?(x, y, w, h) do
+    w > 0.0 and h > 0.0 and not (x <= 0.0 and y <= 0.0 and w >= 0.999 and h >= 0.999)
+  end
+
+  defp dump_fraction(f), do: :erlang.float_to_binary(f * 1.0, decimals: 4)
+
+  defp clamp(v, lo, hi), do: v |> max(lo) |> min(hi)
+end

--- a/lib/vutuv_web/templates/user/edit.html.heex
+++ b/lib/vutuv_web/templates/user/edit.html.heex
@@ -31,7 +31,28 @@ before. --%>
               {gettext("Current avatar")}
             </span>
           </div>
-          <%= file_input f, :avatar, class: "mt-3 block w-full text-sm text-slate-600 file:mr-3 file:rounded-lg file:border-0 file:bg-brand-50 file:px-3 file:py-2 file:text-sm file:font-semibold file:text-brand-700 hover:file:bg-brand-100 dark:text-slate-300 dark:file:bg-brand-900/40 dark:file:text-brand-100" %>
+          <%= file_input f, :avatar,
+            accept: "image/*",
+            class: "mt-3 block w-full text-sm text-slate-600 file:mr-3 file:rounded-lg file:border-0 file:bg-brand-50 file:px-3 file:py-2 file:text-sm file:font-semibold file:text-brand-700 hover:file:bg-brand-100 dark:text-slate-300 dark:file:bg-brand-900/40 dark:file:text-brand-100",
+            data: [
+              crop_target: "user_avatar_crop",
+              crop_aspect: "1",
+              crop_title: gettext("Position your photo"),
+              crop_hint: gettext("Drag to move, use the slider to zoom. The framed area is what others see."),
+              crop_save: gettext("Use photo"),
+              crop_cancel: gettext("Cancel"),
+              crop_zoom: gettext("Zoom")
+            ] %>
+          <%= hidden_input f, :avatar_crop, id: "user_avatar_crop" %>
+          <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
+            {gettext("After choosing a file you can reposition and zoom it.")}
+          </p>
+          <img
+            data-crop-preview="user_avatar_crop"
+            hidden
+            alt={gettext("New avatar preview")}
+            class="mt-3 h-20 w-20 rounded-lg object-cover ring-1 ring-slate-200 dark:ring-slate-800"
+          />
           <%= error_tag f, :avatar %>
         </div>
         <%!-- Cover photo: preview the current cover (the same object-cover crop
@@ -50,7 +71,28 @@ before. --%>
               {gettext("Current cover photo")}
             </figcaption>
           </figure>
-          <%= file_input f, :cover_photo, class: "mt-3 block w-full text-sm text-slate-600 file:mr-3 file:rounded-lg file:border-0 file:bg-brand-50 file:px-3 file:py-2 file:text-sm file:font-semibold file:text-brand-700 hover:file:bg-brand-100 dark:text-slate-300 dark:file:bg-brand-900/40 dark:file:text-brand-100" %>
+          <%= file_input f, :cover_photo,
+            accept: "image/*",
+            class: "mt-3 block w-full text-sm text-slate-600 file:mr-3 file:rounded-lg file:border-0 file:bg-brand-50 file:px-3 file:py-2 file:text-sm file:font-semibold file:text-brand-700 hover:file:bg-brand-100 dark:text-slate-300 dark:file:bg-brand-900/40 dark:file:text-brand-100",
+            data: [
+              crop_target: "user_cover_crop",
+              crop_aspect: "4",
+              crop_title: gettext("Position your cover photo"),
+              crop_hint: gettext("Drag to move, use the slider to zoom. The framed area is what others see."),
+              crop_save: gettext("Use photo"),
+              crop_cancel: gettext("Cancel"),
+              crop_zoom: gettext("Zoom")
+            ] %>
+          <%= hidden_input f, :cover_crop, id: "user_cover_crop" %>
+          <p class="mt-1 text-xs text-slate-600 dark:text-slate-400">
+            {gettext("After choosing a file you can reposition and zoom it.")}
+          </p>
+          <img
+            data-crop-preview="user_cover_crop"
+            hidden
+            alt={gettext("New cover photo preview")}
+            class="mt-3 h-16 w-full rounded-lg object-cover ring-1 ring-slate-200 dark:ring-slate-800"
+          />
           <%= error_tag f, :cover_photo %>
         </div>
       </div>

--- a/priv/repo/migrations/20260618161456_add_image_crops_to_users.exs
+++ b/priv/repo/migrations/20260618161456_add_image_crops_to_users.exs
@@ -1,0 +1,19 @@
+defmodule Vutuv.Repo.Migrations.AddImageCropsToUsers do
+  use Ecto.Migration
+
+  # The user-chosen crop rectangle for the avatar and the cover photo, stored
+  # as a compact "x,y,w,h" string of fractions (0..1) of the EXIF-rotated
+  # original. nil = no crop chosen (the pipeline's old centered behavior). We
+  # persist it so Vutuv.Uploads.Regenerator can re-apply the crop when it
+  # re-derives served versions from the kept original after a Spec change —
+  # without it, the next format/quality regen would silently un-crop everyone.
+  #
+  # Two nullable columns, additive only: backward-compatible for the N-1
+  # blue/green deploy (the currently deployed release simply ignores them).
+  def change do
+    alter table(:users) do
+      add(:avatar_crop, :string)
+      add(:cover_crop, :string)
+    end
+  end
+end

--- a/test/vutuv/accounts_avatar_test.exs
+++ b/test/vutuv/accounts_avatar_test.exs
@@ -36,6 +36,20 @@ defmodule Vutuv.AccountsAvatarTest do
   end
 
   defp avatar_dir(user), do: Uploads.disk_dir("avatars/#{user.id}")
+  defp cover_dir(user), do: Uploads.disk_dir("covers/#{user.id}")
+
+  defp dims(path) do
+    {:ok, img} = Image.open(path)
+    {Image.width(img), Image.height(img)}
+  end
+
+  # The single served cover version on disk. Its name embeds the handle and the
+  # content fingerprint (`<slug>-wide-<fp>.avif`, see Vutuv.Uploads), so match it
+  # by shape rather than hardcoding the fingerprint.
+  defp served_wide(user) do
+    [path] = Path.wildcard(Path.join(cover_dir(user), "*-wide-*.avif"))
+    path
+  end
 
   test "a rolled-back update writes no avatar files and leaves the column unchanged" do
     user = insert_activated_user(first_name: "Ada")
@@ -79,6 +93,94 @@ defmodule Vutuv.AccountsAvatarTest do
 
     refute File.exists?(avatar_dir(user))
     assert Repo.get!(User, user.id).avatar == nil
+  end
+
+  test "a chosen avatar crop is normalised and persisted alongside the file" do
+    user = insert_activated_user(first_name: "Ada")
+
+    assert {:ok, updated} =
+             Accounts.update_user(user, %{
+               "avatar" => jpeg_upload(),
+               "avatar_crop" => "0.25,0,0.5,1"
+             })
+
+    assert updated.avatar_crop == "0.2500,0.0000,0.5000,1.0000"
+    assert Repo.get!(User, user.id).avatar_crop == "0.2500,0.0000,0.5000,1.0000"
+  end
+
+  test "a malformed crop param never fails the upload; it stores as no crop" do
+    user = insert_activated_user(first_name: "Ada")
+
+    assert {:ok, updated} =
+             Accounts.update_user(user, %{"avatar" => jpeg_upload(), "avatar_crop" => "garbage"})
+
+    assert updated.avatar == "selfie.jpg"
+    assert updated.avatar_crop == nil
+  end
+
+  test "re-cropping the same image moves the fingerprint; an identical re-upload keeps it" do
+    user = insert_activated_user(first_name: "Ada")
+    # Reuse one upload (the file on disk survives store), so the original bytes
+    # are byte-identical across the three saves and the crop is the only variable.
+    upload = jpeg_upload()
+
+    assert {:ok, a} =
+             Accounts.update_user(user, %{"avatar" => upload, "avatar_crop" => "0,0,0.5,0.5"})
+
+    # Same original bytes, a different crop: the crop is folded into the content
+    # fingerprint, so the immutable (no `?v=`) served URL changes and no stale
+    # crop is served from a browser/CDN cache.
+    assert {:ok, b} =
+             Accounts.update_user(Repo.get!(User, user.id), %{
+               "avatar" => upload,
+               "avatar_crop" => "0.5,0.5,0.5,0.5"
+             })
+
+    assert a.avatar_fingerprint =~ ~r/\A[0-9a-f]{12}\z/
+    refute a.avatar_fingerprint == b.avatar_fingerprint
+
+    # Same original bytes AND the same crop: the fingerprint is stable, so the
+    # URL stays cacheable across an identical re-upload.
+    assert {:ok, c} =
+             Accounts.update_user(Repo.get!(User, user.id), %{
+               "avatar" => upload,
+               "avatar_crop" => "0.5,0.5,0.5,0.5"
+             })
+
+    assert c.avatar_fingerprint == b.avatar_fingerprint
+  end
+
+  test "the cover crop reaches the pipeline: the derived banner has the cropped dimensions" do
+    user = insert_activated_user(first_name: "Ada")
+
+    # A 600x400 source; a wide band at y=30%..55% is a 600x100 region. The
+    # cover's width_down(1600) never upscales a 600px-wide source, so the
+    # derived wide version keeps the cropped 600x100 instead of the full 600x400.
+    assert {:ok, updated} =
+             Accounts.update_user(user, %{
+               "cover_photo" => jpeg_upload("banner.jpg"),
+               "cover_crop" => "0,0.3,1,0.25"
+             })
+
+    assert updated.cover_crop == "0.0000,0.3000,1.0000,0.2500"
+    assert dims(served_wide(user)) == {600, 100}
+  end
+
+  test "regenerate re-applies the persisted cover crop from the kept original" do
+    user = insert_activated_user(first_name: "Ada")
+
+    assert {:ok, _} =
+             Accounts.update_user(user, %{
+               "cover_photo" => jpeg_upload("banner.jpg"),
+               "cover_crop" => "0,0.3,1,0.25"
+             })
+
+    # Wipe the served version, then re-derive from the kept original. Without
+    # the persisted crop the regen would un-crop back to 600x400.
+    File.rm!(served_wide(user))
+    assert :ok = Vutuv.Cover.regenerate(Repo.get!(User, user.id), force: true)
+
+    assert dims(served_wide(user)) == {600, 100}
   end
 
   test "a rolled-back update writes no cover-photo files either" do

--- a/test/vutuv/uploads/crop_test.exs
+++ b/test/vutuv/uploads/crop_test.exs
@@ -1,0 +1,98 @@
+defmodule Vutuv.Uploads.CropTest do
+  @moduledoc """
+  The user-chosen crop rectangle: parsing the `"x,y,w,h"` wire/DB string into
+  clamped fractions, and applying it to a (rotated) image before the resize
+  pipeline. A malformed or absent crop is always "no crop", never an error —
+  a bad param must not fail an upload.
+  """
+  use ExUnit.Case, async: true
+
+  alias Vutuv.Uploads.Crop
+
+  describe "parse/1" do
+    test "parses a well-formed crop string into fractions" do
+      assert Crop.parse("0.1,0.2,0.5,0.4") == {0.1, 0.2, 0.5, 0.4}
+    end
+
+    test "treats nil, empty and malformed input as no crop" do
+      assert Crop.parse(nil) == nil
+      assert Crop.parse("") == nil
+      assert Crop.parse("not a crop") == nil
+      assert Crop.parse("0.1,0.2,0.5") == nil
+      assert Crop.parse("0.1,0.2,0.5,0.4,0.9") == nil
+      assert Crop.parse("a,b,c,d") == nil
+      assert Crop.parse(%{}) == nil
+    end
+
+    test "rejects out-of-range fractions" do
+      assert Crop.parse("-0.1,0,0.5,0.5") == nil
+      assert Crop.parse("0,0,1.5,0.5") == nil
+    end
+
+    test "trims a size that would overrun the right/bottom edge" do
+      # x=0.8, w=0.5 would reach 1.3; the width is clamped to 0.2.
+      assert {x, y, w, h} = Crop.parse("0.8,0,0.5,1")
+      assert_in_delta x, 0.8, 1.0e-9
+      assert_in_delta y, 0.0, 1.0e-9
+      assert_in_delta w, 0.2, 1.0e-9
+      assert_in_delta h, 1.0, 1.0e-9
+    end
+
+    test "a full-frame crop is treated as no crop (it would be a no-op)" do
+      assert Crop.parse("0,0,1,1") == nil
+    end
+
+    test "a zero-area crop is no crop" do
+      assert Crop.parse("0.2,0.2,0,0.5") == nil
+      assert Crop.parse("0.2,0.2,0.5,0") == nil
+    end
+  end
+
+  describe "normalize/1" do
+    test "re-serialises a valid crop to a canonical string" do
+      assert Crop.normalize("0.1,0.2,0.5,0.4") == "0.1000,0.2000,0.5000,0.4000"
+    end
+
+    test "is nil for an invalid or no-op crop" do
+      assert Crop.normalize(nil) == nil
+      assert Crop.normalize("garbage") == nil
+      assert Crop.normalize("0,0,1,1") == nil
+    end
+
+    test "round-trips through parse" do
+      assert "0.2500,0.2500,0.5000,0.5000" = normalized = Crop.normalize("0.25,0.25,0.5,0.5")
+      assert Crop.parse(normalized) == {0.25, 0.25, 0.5, 0.5}
+    end
+  end
+
+  describe "apply_to/2" do
+    test "returns the image unchanged when there is no crop" do
+      {:ok, img} = Image.new(100, 80, color: [10, 20, 30])
+      assert {:ok, same} = Crop.apply_to(img, nil)
+      assert {Image.width(same), Image.height(same)} == {100, 80}
+    end
+
+    test "crops to the fractional rectangle's pixel dimensions" do
+      {:ok, img} = Image.new(100, 100, color: [10, 20, 30])
+      assert {:ok, cropped} = Crop.apply_to(img, {0.25, 0.25, 0.5, 0.5})
+      assert {Image.width(cropped), Image.height(cropped)} == {50, 50}
+    end
+
+    test "extracts the correct region (position, not just size)" do
+      # Black 100x100 canvas with a white 20x20 square at the top-left (10,10).
+      {:ok, base} = Image.new(100, 100, color: [0, 0, 0])
+      {:ok, mark} = Image.new(20, 20, color: [255, 255, 255])
+      {:ok, img} = Image.compose(base, mark, x: 10, y: 10)
+
+      # Cropping the top-left quadrant keeps the white square... (compose adds
+      # an alpha channel, so read the red channel off whatever bands come back).
+      {:ok, top_left} = Crop.apply_to(img, {0.0, 0.0, 0.4, 0.4})
+      assert [r | _] = Image.get_pixel!(top_left, 10, 10)
+      assert r > 200
+
+      # ...cropping the bottom-right quadrant is all black.
+      {:ok, bottom_right} = Crop.apply_to(img, {0.6, 0.6, 0.4, 0.4})
+      assert bottom_right |> Image.get_pixel!(10, 10) |> Enum.take(3) == [0, 0, 0]
+    end
+  end
+end


### PR DESCRIPTION
## TL;DR

Members can now choose **which part** of their avatar/cover photo to keep. A small client-side crop modal (drag to reposition, slider/wheel to zoom — touch and mouse) records a crop rectangle; the server keeps the original and crops it with libvips. Progressive enhancement: no JS = the previous centered crop, so nothing regresses.

## Why

The profile editor uploaded photos as-is and the server cropped them with **no user control** — avatars were hard center-cropped to a square (routinely cutting off heads) and covers were auto-fit. There was no way to say "use *this* part."

## How it works

- **Client** (`assets/js/image_crop.js`): on file pick, a modal opens with a fixed frame (1:1 avatar, 4:1 cover banner). Drag to pan, slider/wheel to zoom. On *Use photo* it writes a crop rectangle as four fractions `"x,y,w,h"` of the EXIF-rotated image into a hidden field and shows a preview. Self-contained vanilla JS, attached by event delegation, matching `webauthn.js` / `keyboard_shortcuts.js`.
- **Coordinates, not a bitmap:** the browser sends the rectangle; the server keeps the original upload and does the real crop + resize with libvips. Avoids double JPEG compression, keeps the server as the source of truth, and reuses the existing kept-original / regenerate pipeline.
- **Orientation** is consistent on both sides: the browser decodes via `createImageBitmap({imageOrientation: "from-image"})` and the server crops *after* its own autorotate, both in oriented space, so portrait phone photos crop correctly.
- **Persistence:** the crop is stored in new `users.avatar_crop` / `cover_crop` columns and re-read by `Vutuv.Uploads.regenerate/3` (via `config.crop_field`). Without this, the next format/quality re-derive from the kept original would silently **un-crop everyone**.
- **Cover** banner frame is 4:1 client-side only; the cover `Spec` is unchanged — the crop just happens before the existing `width_down` resize.

## Key files

- `lib/vutuv/uploads/crop.ex` — new: parse / normalize / `apply_to` the crop rect (defensive; a bad param is "no crop", never an error).
- `lib/vutuv/uploads.ex`, `uploaders/avatar.ex`, `uploaders/cover.ex` — thread the crop through `store/3` + `regenerate/3`.
- `lib/vutuv/accounts.ex` — parse + persist the crop post-commit alongside the filename.
- `lib/vutuv_web/templates/user/edit.html.heex` — hidden fields, `data-*` wiring (gettext copy), preview.
- `assets/js/image_crop.js` + `app.js` import.
- Migration: two nullable string columns (additive, **N-1-safe** for blue/green deploy).

## Testing

- `mix precommit` green: compile (warnings-as-errors), format, `credo --strict`, **1727 tests** — including new `Vutuv.Uploads.Crop` unit tests and `Accounts` integration tests proving the crop reaches the pipeline (cover dims) and survives a regenerate.
- **Real-browser end to end** (the harness skips CSRF and doesn't run this JS): drove the modal, zoomed + panned to a corner, submitted through the real CSRF/multipart stack — the stored 96×96 avatar came back uniformly the chosen quadrant's colour. Cover modal verified with its 4:1 frame. Also fixed a modal-fit issue caught here (a tall square frame could push *Use photo* off a short viewport; it now fits a height budget and scrolls as a fallback).

## Note for the reviewer

The cover banner crop defaults to **4:1** — trivial to change if a different banner shape is preferred. Branch name is the worktree default (`worktree-image_resizes`). The branch is 5 commits behind `main` at open time; no rebase was done to avoid surprise changes.