### PR TITLE
Show the profile-completion checklist only during onboarding windows

### DIFF
--- a/lib/vutuv/sessions.ex
+++ b/lib/vutuv/sessions.ex
@@ -132,6 +132,58 @@ defmodule Vutuv.Sessions do
     end
   end
 
+  # ── The profile-completion onboarding window ──
+
+  # How long after a fresh sign-in a member keeps seeing the profile-completion
+  # checklist. Kept equal to the "new account" window in VutuvWeb.UserController
+  # so a returning member gets the same brief nudge a brand-new one does, never a
+  # permanent one.
+  @onboarding_window_seconds 24 * 60 * 60
+
+  # No session activity for over a year is the gap after which a returning member
+  # is treated as freshly re-onboarding.
+  @dormant_seconds 365 * 24 * 60 * 60
+
+  @doc """
+  Whether `user` is in a brief "fresh return" window worth re-surfacing the
+  profile-completion checklist for (see `VutuvWeb.UserController`).
+
+  True when the account has a session that started within the last
+  #{div(@onboarding_window_seconds, 3600)}h **and** every session that started
+  before that was last seen over a year ago (or there is none). That is exactly
+  two members and no one else:
+
+    * one returning after more than a year away (their old sessions are stale), and
+    * a legacy account signing in for the first time since per-session tracking
+      shipped — its lazily-upgraded session is its only one, with nothing behind it.
+
+  A member who has merely stayed signed in is **not** fresh: their session
+  started over #{div(@onboarding_window_seconds, 3600)}h ago. The older sessions
+  are gated on `last_seen_at`, not `inserted_at`, on purpose: a long-lived
+  session kept alive all year has a recent `last_seen_at`, so it reads as "active
+  within the year", not as a year-old login.
+  """
+  def fresh_return?(%Accounts.User{} = user) do
+    recent_cutoff =
+      NaiveDateTime.add(NaiveDateTime.utc_now(), -@onboarding_window_seconds, :second)
+
+    year_cutoff = DateTime.add(DateTime.utc_now(:second), -@dormant_seconds, :second)
+
+    {recent, older} =
+      Repo.all(
+        from(s in UserSession,
+          where: s.user_id == ^user.id,
+          select: %{inserted_at: s.inserted_at, last_seen_at: s.last_seen_at}
+        )
+      )
+      |> Enum.split_with(&(NaiveDateTime.compare(&1.inserted_at, recent_cutoff) == :gt))
+
+    recent != [] and
+      Enum.all?(older, fn s ->
+        is_nil(s.last_seen_at) or DateTime.compare(s.last_seen_at, year_cutoff) == :lt
+      end)
+  end
+
   # ── Revocation ──
 
   @doc """

--- a/lib/vutuv_web/controllers/user_controller.ex
+++ b/lib/vutuv_web/controllers/user_controller.ex
@@ -84,11 +84,18 @@ defmodule VutuvWeb.UserController do
 
     posts_total = Vutuv.Posts.count_author_posts(user, posts_viewer)
 
+    as_owner? = owner? and is_nil(preview_as)
+    steps = completion_steps(user, posts_total)
+    # The checklist is a brief nudge, not permanent furniture: only the owner,
+    # only while a step is undone, and only inside the onboarding window. The
+    # window query is the last term so it runs only when the cheap checks pass.
+    show_completion? = as_owner? and Enum.any?(steps, &(not &1.done)) and onboarding_window?(user)
+
     conn
     |> assign(:can_preview?, owner?)
     |> assign(:preview_as, preview_as)
     |> assign(:preview?, not is_nil(preview_as))
-    |> assign(:as_owner?, owner? and is_nil(preview_as))
+    |> assign(:as_owner?, as_owner?)
     |> assign(:view_viewer, view_viewer)
     |> assign(:view_viewer_id, view_viewer && view_viewer.id)
     |> assign(:header_follow_id, header_follow_id(preview_as, current_user, user))
@@ -107,7 +114,8 @@ defmodule VutuvWeb.UserController do
     |> assign(:user, user)
     |> assign(:header_job, header_job)
     |> assign(:work_info, work_information_string_for_job(header_job, 60))
-    |> assign(:completion_steps, completion_steps(user, posts_total))
+    |> assign(:completion_steps, steps)
+    |> assign(:show_completion?, show_completion?)
     |> assign(:recommended_users, recommended_users)
     |> assign(:followers, followers)
     |> assign(:followees, followees)
@@ -283,6 +291,19 @@ defmodule VutuvWeb.UserController do
   defp present?(nil), do: false
   defp present?(value) when is_binary(value), do: String.trim(value) != ""
   defp present?(_), do: true
+
+  # When to surface the onboarding checklist at all: the first 24h of a new
+  # account, plus the 24h after a long-dormant member (or a legacy account that
+  # predates per-session tracking) signs back in. `or` short-circuits, so the
+  # session query in fresh_return?/1 runs only for accounts past the cheap
+  # account-age check.
+  defp onboarding_window?(user) do
+    account_fresh?(user) or Vutuv.Sessions.fresh_return?(user)
+  end
+
+  defp account_fresh?(user) do
+    NaiveDateTime.diff(NaiveDateTime.utc_now(), user.inserted_at, :second) < 24 * 60 * 60
+  end
 
   defp recommended_users(user) do
     case first_tag(user) do

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -285,11 +285,13 @@ the resulting ~200px rail width. --%>
     </section>
 
     <%!-- New-member onboarding checklist: the few highest-impact steps so a fresh
-    profile becomes findable and recognizable fast. Owner-only, shown while
-    anything is still undone and gone once every step is done; each todo links
-    straight to where it is done. Replaces the old 10-minute welcome note. --%>
+    profile becomes findable and recognizable fast. Owner-only, shown only inside
+    the onboarding window (a new account's first 24h, or the 24h after a dormant
+    member signs back in) while anything is still undone, and gone once every step
+    is done; @show_completion? carries that gate (see UserController). Each todo
+    links straight to where it is done. Replaces the old 10-minute welcome note. --%>
     <section
-      :if={@as_owner? and Enum.any?(@completion_steps, &(not &1.done))}
+      :if={@show_completion?}
       class="rounded-2xl bg-brand-50 p-6 ring-1 ring-brand-100 dark:bg-brand-900/30 dark:ring-brand-900/50"
     >
       <% done_count = Enum.count(@completion_steps, & &1.done) %>

--- a/test/vutuv/sessions_test.exs
+++ b/test/vutuv/sessions_test.exs
@@ -13,10 +13,33 @@ defmodule Vutuv.SessionsTest do
   @chrome_mac "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
   @safari_iphone "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
 
+  @day 24 * 60 * 60
+  @year 365 * @day
+
   defp conn_with(ua, ip \\ {203, 0, 113, 7}) do
     Plug.Test.conn(:get, "/")
     |> Map.put(:remote_ip, ip)
     |> Plug.Conn.put_req_header("user-agent", ua)
+  end
+
+  # ExMachina and timestamps() always stamp "now", so aging a session past the
+  # windows fresh_return?/1 reads needs a raw column rewrite. inserted_at is
+  # naive (timestamps()), last_seen_at is utc.
+  defp age_session(session, started_ago_s, last_seen_ago_s) do
+    inserted_at =
+      NaiveDateTime.utc_now()
+      |> NaiveDateTime.add(-started_ago_s, :second)
+      |> NaiveDateTime.truncate(:second)
+
+    last_seen_at = DateTime.add(DateTime.utc_now(:second), -last_seen_ago_s, :second)
+
+    {1, _} =
+      Repo.update_all(
+        from(s in UserSession, where: s.id == ^session.id),
+        set: [inserted_at: inserted_at, last_seen_at: last_seen_at]
+      )
+
+    :ok
   end
 
   describe "start_session/3 and active_session/1" do
@@ -205,6 +228,73 @@ defmodule Vutuv.SessionsTest do
       Sessions.start_session(user, conn_with(@chrome_mac))
 
       refute_received {:email, _}
+    end
+  end
+
+  describe "fresh_return?/1 (the profile-completion onboarding window)" do
+    test "a member who just signed in for the first time is in the window" do
+      user = insert(:user)
+      Sessions.start_session(user, conn_with(@chrome_mac), alert: false)
+
+      assert Sessions.fresh_return?(user)
+    end
+
+    test "a member with no session at all is not in the window" do
+      assert Sessions.fresh_return?(insert(:user)) == false
+    end
+
+    test "a member continuously signed in for over a day is not in the window" do
+      user = insert(:user)
+      {_t, session} = Sessions.start_session(user, conn_with(@chrome_mac), alert: false)
+      # Signed in two days ago and still active right now: established, not fresh.
+      age_session(session, 2 * @day, 0)
+
+      refute Sessions.fresh_return?(user)
+    end
+
+    test "a member returning after more than a year is in the window again" do
+      user = insert(:user)
+      {_t, old} = Sessions.start_session(user, conn_with(@chrome_mac), alert: false)
+      # The old session went quiet over a year ago...
+      age_session(old, 2 * @year, @year + @day)
+      # ...then a fresh sign-in just now.
+      Sessions.start_session(user, conn_with(@safari_iphone), alert: false)
+
+      assert Sessions.fresh_return?(user)
+    end
+
+    test "a member last active within the year is not in the window" do
+      user = insert(:user)
+      {_t, recent} = Sessions.start_session(user, conn_with(@chrome_mac), alert: false)
+      # Prior session from a month ago, well inside the year...
+      age_session(recent, 40 * @day, 30 * @day)
+      # ...and a fresh sign-in now. Recently active, so not re-onboarding.
+      Sessions.start_session(user, conn_with(@safari_iphone), alert: false)
+
+      refute Sessions.fresh_return?(user)
+    end
+
+    test "a returner signing in on two devices at once still counts" do
+      user = insert(:user)
+      {_t, old} = Sessions.start_session(user, conn_with(@chrome_mac), alert: false)
+      age_session(old, 2 * @year, @year + @day)
+      # Phone and laptop both signed in during the return burst, both fresh.
+      Sessions.start_session(user, conn_with(@safari_iphone), alert: false)
+      Sessions.start_session(user, conn_with(@chrome_mac), alert: false)
+
+      assert Sessions.fresh_return?(user)
+    end
+
+    test "a long-lived session kept alive all year is read as active, not dormant" do
+      user = insert(:user)
+      {_t, kept_alive} = Sessions.start_session(user, conn_with(@chrome_mac), alert: false)
+      # Started two years ago but last seen just now (never logged out): this
+      # member has been around the whole time, so a fresh sign-in is not a
+      # "return" — last_seen_at, not inserted_at, decides.
+      age_session(kept_alive, 2 * @year, 0)
+      Sessions.start_session(user, conn_with(@safari_iphone), alert: false)
+
+      refute Sessions.fresh_return?(user)
     end
   end
 end

--- a/test/vutuv_web/controllers/profile_edit_affordances_test.exs
+++ b/test/vutuv_web/controllers/profile_edit_affordances_test.exs
@@ -149,6 +149,50 @@ defmodule VutuvWeb.ProfileEditAffordancesTest do
 
       refute html =~ "Complete your profile"
     end
+
+    test "a long-dormant or legacy owner signing back in sees it again", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      # Age only the account out of the 24h "new account" window. The session
+      # the login just minted is the member's one and only, and it is fresh —
+      # the dormant-return / legacy-first-sign-in window, so it shows again.
+      backdate_account(user)
+
+      html = conn |> get(~p"/#{user}") |> html_response(200)
+
+      assert html =~ "Complete your profile"
+    end
+
+    test "an established owner past the onboarding window no longer sees it", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      # Old account, signed in two days ago, still active now: neither the
+      # new-account nor the dormant-return window applies.
+      backdate_account(user)
+      backdate_sessions(user)
+
+      html = conn |> get(~p"/#{user}") |> html_response(200)
+
+      refute html =~ "Complete your profile"
+    end
+  end
+
+  # Push the account's creation out of the 24h "new account" window.
+  defp backdate_account(user), do: backdate(Vutuv.Accounts.User, user.id, :id)
+
+  # Age every one of the member's sessions so the most recent sign-in is more
+  # than a day old (last_seen_at stays recent — the GET bumps it — so the member
+  # reads as established-and-active, not as a year-dormant returner).
+  defp backdate_sessions(user), do: backdate(Vutuv.Sessions.UserSession, user.id, :user_id)
+
+  defp backdate(schema, id, key) do
+    two_days_ago =
+      NaiveDateTime.utc_now()
+      |> NaiveDateTime.add(-2 * 24 * 60 * 60, :second)
+      |> NaiveDateTime.truncate(:second)
+
+    Repo.update_all(
+      from(r in schema, where: field(r, ^key) == ^id),
+      set: [inserted_at: two_days_ago]
+    )
   end
 
   describe "edit forms carry the delete action" do


### PR DESCRIPTION
## TL;DR
The owner's profile-completion checklist (`Profil vervollständigen`) no longer shows on every visit forever. It appears only inside a brief, high-intent **onboarding window**: a brand-new account's first 24h, or the first 24h after a long-dormant or legacy member signs back in. Outside those windows it stays hidden, even with steps undone.

## Why
The checklist (`lib/vutuv_web/templates/user/show.html.heex`) was gated only on "owner ∧ a step is undone", so an established member who never finished setting up saw it on every page view indefinitely. It is meant as an onboarding nudge, not permanent furniture.

## Behavior

| Member | Before | After |
| --- | --- | --- |
| New account, first 24h | shows | shows |
| New account, day 3, steps undone | shows | **hidden** |
| Returning after >1 year | shows | shows for 24h, then hidden |
| Legacy account (predates per-session tracking) signing back in | shows | shows for 24h, then hidden |
| Established, continuously active | shows | **hidden** |
| Visitor (not owner) | hidden | hidden |

## How it's gated
`VutuvWeb.UserController` computes `@show_completion?` = owner ∧ any step undone ∧ (`account_fresh?` ∨ `Vutuv.Sessions.fresh_return?/1`):

- `account_fresh?` — `users.inserted_at` is under 24h old.
- `fresh_return?/1` — the account has a session that **started** within the last 24h **and** every session that started before that was **last seen** over a year ago (or there is none). One rule covers both returning cases: a >1-year returner (old sessions are stale) and a legacy account's first sign-in since per-session tracking shipped (its lazily-upgraded session is its only one, with nothing behind it).

Design notes:
- The literal "logged in but has no `user_sessions` row" idea can't be the gate: `ConfigureSession` mints the row synchronously before the page renders, so it is never observable. The session-history rule captures the same members without it.
- Older sessions are judged on `last_seen_at`, not `inserted_at`, so a long-lived session kept alive all year reads as *active*, not as a year-old login.
- No "shipped before <date>" constant; the rule self-corrects as login history accumulates.
- `or` short-circuits and the session query is the last term, so it runs only for an owner with an undone step who is already past the 24h account window.

## Tests
- `test/vutuv/sessions_test.exs` — 7 unit tests for `fresh_return?/1`: first sign-in, no sessions, continuously-active, >1-year return, within-the-year, two-device return burst, and the kept-alive-session case.
- `test/vutuv_web/controllers/profile_edit_affordances_test.exs` — a long-dormant/legacy owner sees it again; an established owner past the window does not. The 3 existing checklist tests still pass (fixture users are created "now").
- `mix precommit` green: compile `--warnings-as-errors`, `format --check-formatted`, `credo --strict`, **1780 tests passed**.

## Not done
Display logic, fully covered by unit + controller tests, so not browser-smoke-tested. Happy to drive it in a real browser (fresh account shows it, aged account doesn't) if wanted.