### PR TITLE
Show age on the profile when the birthday is known

### DIFF
--- a/lib/vutuv/ads.ex
+++ b/lib/vutuv/ads.ex
@@ -209,33 +209,12 @@ defmodule Vutuv.Ads do
   end
 
   @doc "Today as a German calendar day (Europe/Berlin)."
-  def today, do: berlin_date(DateTime.utc_now())
+  defdelegate today, to: Vutuv.BerlinTime
 
   @doc """
-  The German calendar date of a UTC instant, without a timezone database:
-  CEST (UTC+2) between the last Sunday of March, 01:00 UTC, and the last
-  Sunday of October, 01:00 UTC; CET (UTC+1) otherwise. That EU rule has been
-  fixed since 1996, so hardcoding it beats pulling in tzdata for one offset.
+  The German calendar date of a UTC instant. The Berlin day rule lives in
+  `Vutuv.BerlinTime` now (the ad rotation and the profile age display share
+  it); kept here as a thin alias so existing callers keep working.
   """
-  def berlin_date(%DateTime{} = utc) do
-    offset_hours = if german_summer_time?(utc), do: 2, else: 1
-
-    utc
-    |> DateTime.add(offset_hours * 3600, :second)
-    |> DateTime.to_date()
-  end
-
-  defp german_summer_time?(utc) do
-    dst_start = last_sunday_at_one_utc(utc.year, 3)
-    dst_end = last_sunday_at_one_utc(utc.year, 10)
-
-    DateTime.compare(utc, dst_start) != :lt and DateTime.compare(utc, dst_end) == :lt
-  end
-
-  defp last_sunday_at_one_utc(year, month) do
-    last_of_month = Date.new!(year, month, Date.days_in_month(Date.new!(year, month, 1)))
-    # day_of_week: Monday = 1 ... Sunday = 7; rem/2 turns Sunday into 0.
-    last_sunday = Date.add(last_of_month, -rem(Date.day_of_week(last_of_month), 7))
-    DateTime.new!(last_sunday, ~T[01:00:00], "Etc/UTC")
-  end
+  defdelegate berlin_date(utc), to: Vutuv.BerlinTime, as: :date
 end

--- a/lib/vutuv/berlin_time.ex
+++ b/lib/vutuv/berlin_time.ex
@@ -1,0 +1,43 @@
+defmodule Vutuv.BerlinTime do
+  @moduledoc """
+  "What day is it in Germany?" without a timezone database.
+
+  vutuv carries no `tzdata` dependency, so the one offset it needs - Europe/
+  Berlin - is computed from the fixed EU daylight-saving rule: CEST (UTC+2)
+  between the last Sunday of March, 01:00 UTC, and the last Sunday of
+  October, 01:00 UTC; CET (UTC+1) otherwise. That rule has been stable since
+  1996, so hardcoding it beats pulling in a whole timezone database for a
+  single offset.
+
+  This is the single source for the German calendar day. The daily ad
+  rotation (`Vutuv.Ads`) books and serves ads by it; the profile age display
+  (`VutuvWeb.UserHelpers.age/1`) rolls a member's age over at German local
+  midnight rather than at UTC midnight.
+  """
+
+  @doc "Today as a German calendar day (Europe/Berlin)."
+  def today, do: date(DateTime.utc_now())
+
+  @doc "The German calendar date of a UTC instant."
+  def date(%DateTime{} = utc) do
+    offset_hours = if summer_time?(utc), do: 2, else: 1
+
+    utc
+    |> DateTime.add(offset_hours * 3600, :second)
+    |> DateTime.to_date()
+  end
+
+  defp summer_time?(utc) do
+    dst_start = last_sunday_at_one_utc(utc.year, 3)
+    dst_end = last_sunday_at_one_utc(utc.year, 10)
+
+    DateTime.compare(utc, dst_start) != :lt and DateTime.compare(utc, dst_end) == :lt
+  end
+
+  defp last_sunday_at_one_utc(year, month) do
+    last_of_month = Date.new!(year, month, Date.days_in_month(Date.new!(year, month, 1)))
+    # day_of_week: Monday = 1 ... Sunday = 7; rem/2 turns Sunday into 0.
+    last_sunday = Date.add(last_of_month, -rem(Date.day_of_week(last_of_month), 7))
+    DateTime.new!(last_sunday, ~T[01:00:00], "Etc/UTC")
+  end
+end

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -179,7 +179,8 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       counts.following > 0 && "- #{gettext("Following")}: #{counts.following}",
       counts.connections > 0 && "- #{gettext("Connections")}: #{counts.connections}",
       doc.gender && "- #{gettext("Gender")}: #{User.gender_gettext(doc.gender)}",
-      doc.birthdate && "- #{gettext("Birthday")}: #{doc.birthdate}"
+      doc.birthdate && "- #{gettext("Birthday")}: #{doc.birthdate}",
+      doc.age && "- #{gettext("Age")}: #{doc.age}"
     ]
     |> Enum.filter(& &1)
     |> Enum.join("\n")

--- a/lib/vutuv_web/agent_docs/profile_doc.ex
+++ b/lib/vutuv_web/agent_docs/profile_doc.ex
@@ -69,6 +69,7 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
       current_position: current_position(job),
       gender: public_gender(user),
       birthdate: user.birthdate,
+      age: UserHelpers.age(user),
       member_since: NaiveDateTime.to_date(user.inserted_at),
       avatar_url: avatar_url(user),
       counts: %{

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -212,7 +212,8 @@ defmodule VutuvWeb.AgentDocs.Text do
       counts.following > 0 && "#{gettext("Following")}: #{counts.following}",
       counts.connections > 0 && "#{gettext("Connections")}: #{counts.connections}",
       doc.gender && "#{gettext("Gender")}: #{User.gender_gettext(doc.gender)}",
-      doc.birthdate && "#{gettext("Birthday")}: #{doc.birthdate}"
+      doc.birthdate && "#{gettext("Birthday")}: #{doc.birthdate}",
+      doc.age && "#{gettext("Age")}: #{doc.age}"
     ]
     |> Enum.filter(& &1)
     |> Enum.join("\n")

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -611,7 +611,16 @@ the resulting ~200px rail width. --%>
         <div :if={@user.birthdate} class="flex items-center gap-2.5">
           <.detail_icon name="cake" class="h-4 w-4 shrink-0 text-slate-400 dark:text-slate-500" />
           <dt class="sr-only">{gettext("Birthday")}</dt>
-          <dd class="my-0 font-medium text-slate-800 dark:text-slate-100">{format_birthdate(@user)}</dd>
+          <dd class="my-0 font-medium text-slate-800 dark:text-slate-100">
+            {format_birthdate(@user)}
+            <%= if years = age(@user) do %>
+              <span class="font-normal text-slate-600 dark:text-slate-400">({ngettext(
+                "%{count} year old",
+                "%{count} years old",
+                years
+              )})</span>
+            <% end %>
+          </dd>
         </div>
       </dl>
       <.card_footer_link :if={@as_owner? && has_general_info} href={~p"/#{@user}/edit"}>

--- a/lib/vutuv_web/views/user_helpers.ex
+++ b/lib/vutuv_web/views/user_helpers.ex
@@ -409,6 +409,34 @@ defmodule VutuvWeb.UserHelpers do
 
   defp format_usa(_), do: ""
 
+  @doc """
+  The member's age in whole years on the current German calendar day
+  (`Vutuv.BerlinTime.today/0`), or `nil` when there is no birthdate or it
+  lies in the future. Berlin time, so a German member's age rolls over at
+  local midnight rather than at UTC midnight.
+  """
+  def age(%User{birthdate: birthdate}), do: age(birthdate)
+  def age(%Date{} = birthdate), do: age(birthdate, Vutuv.BerlinTime.today())
+  def age(_), do: nil
+
+  @doc """
+  The whole-year age of `birthdate` as of the `reference` day (both `Date`s),
+  or `nil` when `reference` precedes `birthdate`. A February 29 birthday
+  rolls over on March 1 in non-leap years (the `{month, day}` tuple compare).
+  """
+  def age(%Date{} = birthdate, %Date{} = reference) do
+    years = reference.year - birthdate.year
+
+    years =
+      if {reference.month, reference.day} < {birthdate.month, birthdate.day} do
+        years - 1
+      else
+        years
+      end
+
+    if years >= 0, do: years, else: nil
+  end
+
   def gen_breadcrumbs(args) do
     Enum.reduce(tl(args), gen_breadcrumb(hd(args)), fn f, acc ->
       "#{acc} / #{gen_breadcrumb(f)}"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -27,7 +27,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:687
+#: lib/vutuv_web/templates/user/show.html.heex:698
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -88,7 +88,7 @@ msgstr "Geburtstag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:182
 #: lib/vutuv_web/agent_docs/text.ex:215
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:613
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
@@ -123,7 +123,7 @@ msgstr "Wählen Sie einen Typ aus"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/templates/user/show.html.heex:554
+#: lib/vutuv_web/templates/user/show.html.heex:556
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -176,7 +176,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:5
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:5
 #: lib/vutuv_web/templates/url/edit.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:616
+#: lib/vutuv_web/templates/user/show.html.heex:627
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:5
 #, elixir-autogen
 msgid "Edit"
@@ -262,7 +262,7 @@ msgstr "Nachname eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/templates/user/show.html.heex:402
+#: lib/vutuv_web/templates/user/show.html.heex:404
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:6
 #: lib/vutuv_web/templates/work_experience/new.html.heex:4
@@ -296,7 +296,7 @@ msgstr "Follower"
 #: lib/vutuv_web/components/ui.ex:475
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:532
+#: lib/vutuv_web/templates/user/show.html.heex:534
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
@@ -304,7 +304,7 @@ msgstr "Folge ich"
 #: lib/vutuv_web/agent_docs/markdown.ex:181
 #: lib/vutuv_web/agent_docs/text.ex:214
 #: lib/vutuv_web/templates/user/edit.html.heex:105
-#: lib/vutuv_web/templates/user/show.html.heex:606
+#: lib/vutuv_web/templates/user/show.html.heex:608
 #, elixir-autogen
 msgid "Gender"
 msgstr "Geschlecht"
@@ -482,7 +482,7 @@ msgid "Organization"
 msgstr "Organisation"
 
 #: lib/vutuv_web/templates/phone_number/form_content.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:656
+#: lib/vutuv_web/templates/user/show.html.heex:667
 #, elixir-autogen
 msgid "Phone Number"
 msgid_plural "Phone Numbers"
@@ -611,7 +611,7 @@ msgstr "Slug"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:40
 #: lib/vutuv_web/agent_docs/text.ex:40
-#: lib/vutuv_web/templates/user/show.html.heex:624
+#: lib/vutuv_web/templates/user/show.html.heex:635
 #, elixir-autogen
 msgid "Social Media"
 msgstr "Social Media"
@@ -695,12 +695,12 @@ msgstr "User"
 msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr "Der User %{name} wurde angelegt. Eine E-Mail mit einem PIN wurde verschickt."
 
-#: lib/vutuv_web/controllers/user_controller.ex:394
+#: lib/vutuv_web/controllers/user_controller.ex:415
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr "User wurde gelöscht."
 
-#: lib/vutuv_web/controllers/user_controller.ex:338
+#: lib/vutuv_web/controllers/user_controller.ex:359
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr "Profil aktualisiert."
@@ -762,14 +762,14 @@ msgid "Value"
 msgstr "Wert"
 
 #: lib/vutuv_web/templates/user/show.html.heex:280
-#: lib/vutuv_web/templates/user/show.html.heex:753
+#: lib/vutuv_web/templates/user/show.html.heex:764
 #, elixir-autogen
 msgid "vCard"
 msgstr "vCard"
 
 #: lib/vutuv_web/components/ui.ex:1228
-#: lib/vutuv_web/templates/user/show.html.heex:526
-#: lib/vutuv_web/templates/user/show.html.heex:545
+#: lib/vutuv_web/templates/user/show.html.heex:528
+#: lib/vutuv_web/templates/user/show.html.heex:547
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
@@ -952,7 +952,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:595
+#: lib/vutuv_web/templates/user/show.html.heex:597
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1396,7 +1396,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:368
+#: lib/vutuv_web/templates/user/show.html.heex:370
 #: lib/vutuv_web/templates/user_tag/form_content.html.heex:5
 #: lib/vutuv_web/templates/user_tag/index.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
@@ -1406,7 +1406,7 @@ msgstr "Tags"
 
 #: lib/vutuv_web/controllers/email_controller.ex:118
 #: lib/vutuv_web/controllers/session_controller.ex:271
-#: lib/vutuv_web/controllers/user_controller.ex:409
+#: lib/vutuv_web/controllers/user_controller.ex:430
 #, elixir-autogen
 msgid "Too many incorrect attempts."
 msgstr "Zu viele fehlerhafter Versuche."
@@ -1641,13 +1641,13 @@ msgstr "Mein Konto löschen"
 msgid "Disable slugs"
 msgstr "Slugs deaktivieren"
 
-#: lib/vutuv_web/controllers/user_controller.ex:324
+#: lib/vutuv_web/controllers/user_controller.ex:345
 #: lib/vutuv_web/templates/user/show.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:384
+#: lib/vutuv_web/templates/user/show.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Empfehlen"
@@ -1773,8 +1773,8 @@ msgstr "Diese E-Mail-Adresse konnte nicht hinzugefügt werden."
 #: lib/vutuv_web/controllers/session_controller.ex:48
 #: lib/vutuv_web/controllers/session_controller.ex:115
 #: lib/vutuv_web/controllers/session_controller.ex:131
-#: lib/vutuv_web/controllers/user_controller.ex:364
-#: lib/vutuv_web/controllers/user_controller.ex:379
+#: lib/vutuv_web/controllers/user_controller.ex:385
+#: lib/vutuv_web/controllers/user_controller.ex:400
 #, elixir-autogen, elixir-format
 msgid "Too many attempts. Please try again later."
 msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
@@ -1804,7 +1804,7 @@ msgstr "Wir haben einen PIN an Ihre E-Mail-Adresse geschickt. Geben Sie ihn unte
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr "Wir haben einen PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie ihn unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:771
+#: lib/vutuv_web/templates/user/show.html.heex:782
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
@@ -1900,7 +1900,7 @@ msgid_plural "%{count} years"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/templates/user/show.html.heex:446
+#: lib/vutuv_web/templates/user/show.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr "Dauer in dieser Position"
@@ -2349,7 +2349,7 @@ msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
 msgid "Posts by %{name}"
 msgstr "Beiträge von %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:358
+#: lib/vutuv_web/templates/user/show.html.heex:360
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr "Alle %{count} Beiträge ansehen"
@@ -2680,49 +2680,49 @@ msgid "Use a different email address"
 msgstr "Andere E-Mail-Adresse verwenden"
 
 #: lib/vutuv_web/templates/url/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:468
+#: lib/vutuv_web/templates/user/show.html.heex:470
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:658
+#: lib/vutuv_web/templates/user/show.html.heex:669
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:626
+#: lib/vutuv_web/templates/user/show.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Add a social media account"
 msgstr "Social-Media-Konto hinzufügen"
 
 #: lib/vutuv_web/templates/address/index.html.heex:13
-#: lib/vutuv_web/templates/user/show.html.heex:689
+#: lib/vutuv_web/templates/user/show.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:556
+#: lib/vutuv_web/templates/user/show.html.heex:558
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:597
+#: lib/vutuv_web/templates/user/show.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
 
-#: lib/vutuv_web/controllers/user_controller.ex:275
-#: lib/vutuv_web/templates/user/show.html.heex:405
+#: lib/vutuv_web/controllers/user_controller.ex:283
+#: lib/vutuv_web/templates/user/show.html.heex:407
 #: lib/vutuv_web/templates/work_experience/index.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
-#: lib/vutuv_web/controllers/user_controller.ex:279
-#: lib/vutuv_web/templates/user/show.html.heex:339
+#: lib/vutuv_web/controllers/user_controller.ex:287
+#: lib/vutuv_web/templates/user/show.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
@@ -2736,7 +2736,7 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:339
+#: lib/vutuv_web/templates/user/show.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr "Beitrag schreiben"
@@ -2835,7 +2835,7 @@ msgstr "Zum Profil, um sich zu vernetzen"
 msgid "Ignore"
 msgstr "Ignorieren"
 
-#: lib/vutuv_web/templates/user/show.html.heex:749
+#: lib/vutuv_web/templates/user/show.html.heex:760
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2845,7 +2845,7 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Noch keine Vernetzungen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:746
+#: lib/vutuv_web/templates/user/show.html.heex:757
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Andere Formate"
@@ -2870,7 +2870,7 @@ msgstr "Diese Vernetzung entfernen?"
 msgid "Sent requests"
 msgstr "Gesendete Anfragen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:750
+#: lib/vutuv_web/templates/user/show.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Nur Text"
@@ -2966,7 +2966,7 @@ msgstr "Empfehlung"
 
 #: lib/vutuv_web/live/notification_live/index.ex:208
 #: lib/vutuv_web/templates/user/show.html.heex:41
-#: lib/vutuv_web/templates/user/show.html.heex:514
+#: lib/vutuv_web/templates/user/show.html.heex:516
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3911,13 +3911,13 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:202
+#: lib/vutuv_web/agent_docs/markdown.ex:203
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:289
-#: lib/vutuv_web/agent_docs/text.ex:271
+#: lib/vutuv_web/agent_docs/markdown.ex:290
+#: lib/vutuv_web/agent_docs/text.ex:272
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -3947,20 +3947,20 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:278
-#: lib/vutuv_web/agent_docs/text.ex:262
+#: lib/vutuv_web/agent_docs/markdown.ex:279
+#: lib/vutuv_web/agent_docs/text.ex:263
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:275
-#: lib/vutuv_web/agent_docs/text.ex:259
+#: lib/vutuv_web/agent_docs/markdown.ex:276
+#: lib/vutuv_web/agent_docs/text.ex:260
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/text.ex:265
+#: lib/vutuv_web/agent_docs/markdown.ex:283
+#: lib/vutuv_web/agent_docs/text.ex:266
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
@@ -4015,18 +4015,18 @@ msgstr "Die vutuv-Mitglieder mit den meisten Followern"
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:262
-#: lib/vutuv_web/agent_docs/text.ex:248
+#: lib/vutuv_web/agent_docs/markdown.ex:263
+#: lib/vutuv_web/agent_docs/text.ex:249
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:219
+#: lib/vutuv_web/agent_docs/markdown.ex:220
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:220
+#: lib/vutuv_web/agent_docs/markdown.ex:221
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4635,7 +4635,7 @@ msgstr "Mitglieder finden"
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:532
+#: lib/vutuv_web/templates/user/show.html.heex:534
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4737,8 +4737,8 @@ msgstr "müller"
 msgid "searches first names only (last: for last names)"
 msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
-#: lib/vutuv_web/controllers/user_controller.ex:273
-#: lib/vutuv_web/templates/user/show.html.heex:371
+#: lib/vutuv_web/controllers/user_controller.ex:281
+#: lib/vutuv_web/templates/user/show.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Tag hinzufügen"
@@ -5424,17 +5424,17 @@ msgstr "Beitrag schreiben"
 msgid "Your profile"
 msgstr "Ihr Profil"
 
-#: lib/vutuv_web/templates/user/show.html.heex:298
+#: lib/vutuv_web/templates/user/show.html.heex:300
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr "Profil vervollständigen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:304
+#: lib/vutuv_web/templates/user/show.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/controllers/user_controller.ex:268
+#: lib/vutuv_web/controllers/user_controller.ex:276
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -6123,7 +6123,7 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/controllers/user_controller.ex:272
+#: lib/vutuv_web/controllers/user_controller.ex:280
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
@@ -6158,14 +6158,14 @@ msgstr "Vorschau: So sieht ein Mitglied, das Ihnen folgt, Ihr Profil. Die Schalt
 msgid "Preview: how a member you are connected with sees your profile. The controls here are inactive."
 msgstr "Vorschau: So sieht ein mit Ihnen vernetztes Mitglied Ihr Profil. Die Schaltflächen sind hier inaktiv."
 
-#: lib/vutuv_web/templates/user/show.html.heex:466
+#: lib/vutuv_web/templates/user/show.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] "Link"
 msgstr[1] "Links"
 
-#: lib/vutuv_web/templates/user/show.html.heex:334
+#: lib/vutuv_web/templates/user/show.html.heex:336
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6179,7 +6179,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:718
+#: lib/vutuv_web/templates/user/show.html.heex:729
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6200,7 +6200,7 @@ msgstr "Vorschau des neuen Avatars"
 msgid "New cover photo preview"
 msgstr "Vorschau des neuen Titelbilds"
 
-#: lib/vutuv_web/templates/user/show.html.heex:715
+#: lib/vutuv_web/templates/user/show.html.heex:726
 #, elixir-autogen, elixir-format
 msgid "Open in Google Maps"
 msgstr "In Google Maps öffnen"
@@ -6226,3 +6226,16 @@ msgstr "Foto verwenden"
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr "Zoom"
+
+#: lib/vutuv_web/templates/user/show.html.heex:617
+#, elixir-autogen, elixir-format
+msgid "%{count} year old"
+msgid_plural "%{count} years old"
+msgstr[0] "%{count} Jahr"
+msgstr[1] "%{count} Jahre"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:183
+#: lib/vutuv_web/agent_docs/text.ex:216
+#, elixir-autogen, elixir-format
+msgid "Age"
+msgstr "Alter"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -28,7 +28,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:687
+#: lib/vutuv_web/templates/user/show.html.heex:698
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:182
 #: lib/vutuv_web/agent_docs/text.ex:215
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:613
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -124,7 +124,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/templates/user/show.html.heex:554
+#: lib/vutuv_web/templates/user/show.html.heex:556
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -177,7 +177,7 @@ msgstr ""
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:5
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:5
 #: lib/vutuv_web/templates/url/edit.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:616
+#: lib/vutuv_web/templates/user/show.html.heex:627
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:5
 #, elixir-autogen
 msgid "Edit"
@@ -263,7 +263,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/templates/user/show.html.heex:402
+#: lib/vutuv_web/templates/user/show.html.heex:404
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:6
 #: lib/vutuv_web/templates/work_experience/new.html.heex:4
@@ -297,7 +297,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:475
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:532
+#: lib/vutuv_web/templates/user/show.html.heex:534
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -305,7 +305,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:181
 #: lib/vutuv_web/agent_docs/text.ex:214
 #: lib/vutuv_web/templates/user/edit.html.heex:105
-#: lib/vutuv_web/templates/user/show.html.heex:606
+#: lib/vutuv_web/templates/user/show.html.heex:608
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -483,7 +483,7 @@ msgid "Organization"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/form_content.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:656
+#: lib/vutuv_web/templates/user/show.html.heex:667
 #, elixir-autogen
 msgid "Phone Number"
 msgid_plural "Phone Numbers"
@@ -612,7 +612,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:40
 #: lib/vutuv_web/agent_docs/text.ex:40
-#: lib/vutuv_web/templates/user/show.html.heex:624
+#: lib/vutuv_web/templates/user/show.html.heex:635
 #, elixir-autogen
 msgid "Social Media"
 msgstr ""
@@ -696,12 +696,12 @@ msgstr ""
 msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:394
+#: lib/vutuv_web/controllers/user_controller.ex:415
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:338
+#: lib/vutuv_web/controllers/user_controller.ex:359
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr ""
@@ -763,14 +763,14 @@ msgid "Value"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/show.html.heex:280
-#: lib/vutuv_web/templates/user/show.html.heex:753
+#: lib/vutuv_web/templates/user/show.html.heex:764
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1228
-#: lib/vutuv_web/templates/user/show.html.heex:526
-#: lib/vutuv_web/templates/user/show.html.heex:545
+#: lib/vutuv_web/templates/user/show.html.heex:528
+#: lib/vutuv_web/templates/user/show.html.heex:547
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -953,7 +953,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:595
+#: lib/vutuv_web/templates/user/show.html.heex:597
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1397,7 +1397,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:368
+#: lib/vutuv_web/templates/user/show.html.heex:370
 #: lib/vutuv_web/templates/user_tag/form_content.html.heex:5
 #: lib/vutuv_web/templates/user_tag/index.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
@@ -1407,7 +1407,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:118
 #: lib/vutuv_web/controllers/session_controller.ex:271
-#: lib/vutuv_web/controllers/user_controller.ex:409
+#: lib/vutuv_web/controllers/user_controller.ex:430
 #, elixir-autogen
 msgid "Too many incorrect attempts."
 msgstr ""
@@ -1642,13 +1642,13 @@ msgstr ""
 msgid "Disable slugs"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:324
+#: lib/vutuv_web/controllers/user_controller.ex:345
 #: lib/vutuv_web/templates/user/show.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:384
+#: lib/vutuv_web/templates/user/show.html.heex:386
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
@@ -1774,8 +1774,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/session_controller.ex:48
 #: lib/vutuv_web/controllers/session_controller.ex:115
 #: lib/vutuv_web/controllers/session_controller.ex:131
-#: lib/vutuv_web/controllers/user_controller.ex:364
-#: lib/vutuv_web/controllers/user_controller.ex:379
+#: lib/vutuv_web/controllers/user_controller.ex:385
+#: lib/vutuv_web/controllers/user_controller.ex:400
 #, elixir-autogen, elixir-format
 msgid "Too many attempts. Please try again later."
 msgstr ""
@@ -1805,7 +1805,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:771
+#: lib/vutuv_web/templates/user/show.html.heex:782
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:446
+#: lib/vutuv_web/templates/user/show.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr ""
@@ -2350,7 +2350,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:358
+#: lib/vutuv_web/templates/user/show.html.heex:360
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2681,49 +2681,49 @@ msgid "Use a different email address"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:468
+#: lib/vutuv_web/templates/user/show.html.heex:470
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:658
+#: lib/vutuv_web/templates/user/show.html.heex:669
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:626
+#: lib/vutuv_web/templates/user/show.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Add a social media account"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/index.html.heex:13
-#: lib/vutuv_web/templates/user/show.html.heex:689
+#: lib/vutuv_web/templates/user/show.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:556
+#: lib/vutuv_web/templates/user/show.html.heex:558
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:597
+#: lib/vutuv_web/templates/user/show.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:275
-#: lib/vutuv_web/templates/user/show.html.heex:405
+#: lib/vutuv_web/controllers/user_controller.ex:283
+#: lib/vutuv_web/templates/user/show.html.heex:407
 #: lib/vutuv_web/templates/work_experience/index.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:279
-#: lib/vutuv_web/templates/user/show.html.heex:339
+#: lib/vutuv_web/controllers/user_controller.ex:287
+#: lib/vutuv_web/templates/user/show.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
@@ -2737,7 +2737,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:339
+#: lib/vutuv_web/templates/user/show.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
@@ -2836,7 +2836,7 @@ msgstr ""
 msgid "Ignore"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:749
+#: lib/vutuv_web/templates/user/show.html.heex:760
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2846,7 +2846,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:746
+#: lib/vutuv_web/templates/user/show.html.heex:757
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Sent requests"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:750
+#: lib/vutuv_web/templates/user/show.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2967,7 +2967,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:208
 #: lib/vutuv_web/templates/user/show.html.heex:41
-#: lib/vutuv_web/templates/user/show.html.heex:514
+#: lib/vutuv_web/templates/user/show.html.heex:516
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3912,13 +3912,13 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:202
+#: lib/vutuv_web/agent_docs/markdown.ex:203
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:289
-#: lib/vutuv_web/agent_docs/text.ex:271
+#: lib/vutuv_web/agent_docs/markdown.ex:290
+#: lib/vutuv_web/agent_docs/text.ex:272
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3948,20 +3948,20 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:278
-#: lib/vutuv_web/agent_docs/text.ex:262
+#: lib/vutuv_web/agent_docs/markdown.ex:279
+#: lib/vutuv_web/agent_docs/text.ex:263
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:275
-#: lib/vutuv_web/agent_docs/text.ex:259
+#: lib/vutuv_web/agent_docs/markdown.ex:276
+#: lib/vutuv_web/agent_docs/text.ex:260
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/text.ex:265
+#: lib/vutuv_web/agent_docs/markdown.ex:283
+#: lib/vutuv_web/agent_docs/text.ex:266
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
@@ -4016,18 +4016,18 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:262
-#: lib/vutuv_web/agent_docs/text.ex:248
+#: lib/vutuv_web/agent_docs/markdown.ex:263
+#: lib/vutuv_web/agent_docs/text.ex:249
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:219
+#: lib/vutuv_web/agent_docs/markdown.ex:220
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:220
+#: lib/vutuv_web/agent_docs/markdown.ex:221
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4636,7 +4636,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:532
+#: lib/vutuv_web/templates/user/show.html.heex:534
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4738,8 +4738,8 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:273
-#: lib/vutuv_web/templates/user/show.html.heex:371
+#: lib/vutuv_web/controllers/user_controller.ex:281
+#: lib/vutuv_web/templates/user/show.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5420,17 +5420,17 @@ msgstr ""
 msgid "Your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:298
+#: lib/vutuv_web/templates/user/show.html.heex:300
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:304
+#: lib/vutuv_web/templates/user/show.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:268
+#: lib/vutuv_web/controllers/user_controller.ex:276
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -6108,7 +6108,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:272
+#: lib/vutuv_web/controllers/user_controller.ex:280
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6143,14 +6143,14 @@ msgstr ""
 msgid "Preview: how a member you are connected with sees your profile. The controls here are inactive."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:466
+#: lib/vutuv_web/templates/user/show.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:334
+#: lib/vutuv_web/templates/user/show.html.heex:336
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6164,7 +6164,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:718
+#: lib/vutuv_web/templates/user/show.html.heex:729
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6185,7 +6185,7 @@ msgstr ""
 msgid "New cover photo preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:715
+#: lib/vutuv_web/templates/user/show.html.heex:726
 #, elixir-autogen, elixir-format
 msgid "Open in Google Maps"
 msgstr ""
@@ -6210,4 +6210,17 @@ msgstr ""
 #: lib/vutuv_web/templates/user/edit.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Zoom"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:617
+#, elixir-autogen, elixir-format
+msgid "%{count} year old"
+msgid_plural "%{count} years old"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:183
+#: lib/vutuv_web/agent_docs/text.ex:216
+#, elixir-autogen, elixir-format
+msgid "Age"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -27,7 +27,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:687
+#: lib/vutuv_web/templates/user/show.html.heex:698
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:182
 #: lib/vutuv_web/agent_docs/text.ex:215
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:613
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -123,7 +123,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:38
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/templates/user/show.html.heex:554
+#: lib/vutuv_web/templates/user/show.html.heex:556
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -176,7 +176,7 @@ msgstr ""
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:5
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:5
 #: lib/vutuv_web/templates/url/edit.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:616
+#: lib/vutuv_web/templates/user/show.html.heex:627
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:5
 #, elixir-autogen
 msgid "Edit"
@@ -262,7 +262,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:34
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/templates/user/show.html.heex:402
+#: lib/vutuv_web/templates/user/show.html.heex:404
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:6
 #: lib/vutuv_web/templates/work_experience/new.html.heex:4
@@ -296,7 +296,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:475
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:532
+#: lib/vutuv_web/templates/user/show.html.heex:534
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:181
 #: lib/vutuv_web/agent_docs/text.ex:214
 #: lib/vutuv_web/templates/user/edit.html.heex:105
-#: lib/vutuv_web/templates/user/show.html.heex:606
+#: lib/vutuv_web/templates/user/show.html.heex:608
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -482,7 +482,7 @@ msgid "Organization"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/form_content.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:656
+#: lib/vutuv_web/templates/user/show.html.heex:667
 #, elixir-autogen
 msgid "Phone Number"
 msgid_plural "Phone Numbers"
@@ -611,7 +611,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:40
 #: lib/vutuv_web/agent_docs/text.ex:40
-#: lib/vutuv_web/templates/user/show.html.heex:624
+#: lib/vutuv_web/templates/user/show.html.heex:635
 #, elixir-autogen
 msgid "Social Media"
 msgstr ""
@@ -695,12 +695,12 @@ msgstr ""
 msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:394
+#: lib/vutuv_web/controllers/user_controller.ex:415
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:338
+#: lib/vutuv_web/controllers/user_controller.ex:359
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr ""
@@ -762,14 +762,14 @@ msgid "Value"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/show.html.heex:280
-#: lib/vutuv_web/templates/user/show.html.heex:753
+#: lib/vutuv_web/templates/user/show.html.heex:764
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1228
-#: lib/vutuv_web/templates/user/show.html.heex:526
-#: lib/vutuv_web/templates/user/show.html.heex:545
+#: lib/vutuv_web/templates/user/show.html.heex:528
+#: lib/vutuv_web/templates/user/show.html.heex:547
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -952,7 +952,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:595
+#: lib/vutuv_web/templates/user/show.html.heex:597
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1396,7 +1396,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:5
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:368
+#: lib/vutuv_web/templates/user/show.html.heex:370
 #: lib/vutuv_web/templates/user_tag/form_content.html.heex:5
 #: lib/vutuv_web/templates/user_tag/index.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
@@ -1406,7 +1406,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:118
 #: lib/vutuv_web/controllers/session_controller.ex:271
-#: lib/vutuv_web/controllers/user_controller.ex:409
+#: lib/vutuv_web/controllers/user_controller.ex:430
 #, elixir-autogen
 msgid "Too many incorrect attempts."
 msgstr ""
@@ -1641,13 +1641,13 @@ msgstr ""
 msgid "Disable slugs"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:324
+#: lib/vutuv_web/controllers/user_controller.ex:345
 #: lib/vutuv_web/templates/user/show.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:384
+#: lib/vutuv_web/templates/user/show.html.heex:386
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Endorse"
 msgstr ""
@@ -1773,8 +1773,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/session_controller.ex:48
 #: lib/vutuv_web/controllers/session_controller.ex:115
 #: lib/vutuv_web/controllers/session_controller.ex:131
-#: lib/vutuv_web/controllers/user_controller.ex:364
-#: lib/vutuv_web/controllers/user_controller.ex:379
+#: lib/vutuv_web/controllers/user_controller.ex:385
+#: lib/vutuv_web/controllers/user_controller.ex:400
 #, elixir-autogen, elixir-format
 msgid "Too many attempts. Please try again later."
 msgstr ""
@@ -1804,7 +1804,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:771
+#: lib/vutuv_web/templates/user/show.html.heex:782
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1900,7 +1900,7 @@ msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:446
+#: lib/vutuv_web/templates/user/show.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr ""
@@ -2349,7 +2349,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:358
+#: lib/vutuv_web/templates/user/show.html.heex:360
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2680,49 +2680,49 @@ msgid "Use a different email address"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:468
+#: lib/vutuv_web/templates/user/show.html.heex:470
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:658
+#: lib/vutuv_web/templates/user/show.html.heex:669
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:626
+#: lib/vutuv_web/templates/user/show.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Add a social media account"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/index.html.heex:13
-#: lib/vutuv_web/templates/user/show.html.heex:689
+#: lib/vutuv_web/templates/user/show.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/index.html.heex:14
-#: lib/vutuv_web/templates/user/show.html.heex:556
+#: lib/vutuv_web/templates/user/show.html.heex:558
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:597
+#: lib/vutuv_web/templates/user/show.html.heex:599
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:275
-#: lib/vutuv_web/templates/user/show.html.heex:405
+#: lib/vutuv_web/controllers/user_controller.ex:283
+#: lib/vutuv_web/templates/user/show.html.heex:407
 #: lib/vutuv_web/templates/work_experience/index.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:279
-#: lib/vutuv_web/templates/user/show.html.heex:339
+#: lib/vutuv_web/controllers/user_controller.ex:287
+#: lib/vutuv_web/templates/user/show.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
@@ -2736,7 +2736,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:339
+#: lib/vutuv_web/templates/user/show.html.heex:341
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Ignore"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:749
+#: lib/vutuv_web/templates/user/show.html.heex:760
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2845,7 +2845,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:746
+#: lib/vutuv_web/templates/user/show.html.heex:757
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Sent requests"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:750
+#: lib/vutuv_web/templates/user/show.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2966,7 +2966,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:208
 #: lib/vutuv_web/templates/user/show.html.heex:41
-#: lib/vutuv_web/templates/user/show.html.heex:514
+#: lib/vutuv_web/templates/user/show.html.heex:516
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follower"
 msgid_plural "Followers"
@@ -3911,13 +3911,13 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:202
+#: lib/vutuv_web/agent_docs/markdown.ex:203
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:289
-#: lib/vutuv_web/agent_docs/text.ex:271
+#: lib/vutuv_web/agent_docs/markdown.ex:290
+#: lib/vutuv_web/agent_docs/text.ex:272
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3947,20 +3947,20 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:278
-#: lib/vutuv_web/agent_docs/text.ex:262
+#: lib/vutuv_web/agent_docs/markdown.ex:279
+#: lib/vutuv_web/agent_docs/text.ex:263
 #, elixir-autogen, elixir-format, fuzzy
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:275
-#: lib/vutuv_web/agent_docs/text.ex:259
+#: lib/vutuv_web/agent_docs/markdown.ex:276
+#: lib/vutuv_web/agent_docs/text.ex:260
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/text.ex:265
+#: lib/vutuv_web/agent_docs/markdown.ex:283
+#: lib/vutuv_web/agent_docs/text.ex:266
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
@@ -4015,18 +4015,18 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:262
-#: lib/vutuv_web/agent_docs/text.ex:248
+#: lib/vutuv_web/agent_docs/markdown.ex:263
+#: lib/vutuv_web/agent_docs/text.ex:249
 #, elixir-autogen, elixir-format, fuzzy
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:219
+#: lib/vutuv_web/agent_docs/markdown.ex:220
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:220
+#: lib/vutuv_web/agent_docs/markdown.ex:221
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4635,7 +4635,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:532
+#: lib/vutuv_web/templates/user/show.html.heex:534
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follows"
 msgstr ""
@@ -4737,8 +4737,8 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:273
-#: lib/vutuv_web/templates/user/show.html.heex:371
+#: lib/vutuv_web/controllers/user_controller.ex:281
+#: lib/vutuv_web/templates/user/show.html.heex:373
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a tag"
 msgstr ""
@@ -5419,17 +5419,17 @@ msgstr ""
 msgid "Your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:298
+#: lib/vutuv_web/templates/user/show.html.heex:300
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:304
+#: lib/vutuv_web/templates/user/show.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:268
+#: lib/vutuv_web/controllers/user_controller.ex:276
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a profile photo"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:272
+#: lib/vutuv_web/controllers/user_controller.ex:280
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6142,14 +6142,14 @@ msgstr ""
 msgid "Preview: how a member you are connected with sees your profile. The controls here are inactive."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:466
+#: lib/vutuv_web/templates/user/show.html.heex:468
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:334
+#: lib/vutuv_web/templates/user/show.html.heex:336
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6163,7 +6163,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:718
+#: lib/vutuv_web/templates/user/show.html.heex:729
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6184,7 +6184,7 @@ msgstr ""
 msgid "New cover photo preview"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:715
+#: lib/vutuv_web/templates/user/show.html.heex:726
 #, elixir-autogen, elixir-format
 msgid "Open in Google Maps"
 msgstr ""
@@ -6209,4 +6209,17 @@ msgstr ""
 #: lib/vutuv_web/templates/user/edit.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Zoom"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:617
+#, elixir-autogen, elixir-format
+msgid "%{count} year old"
+msgid_plural "%{count} years old"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:183
+#: lib/vutuv_web/agent_docs/text.ex:216
+#, elixir-autogen, elixir-format
+msgid "Age"
 msgstr ""

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -66,7 +66,7 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     end
   end
 
-  test "profile: every public fact appears in HTML, Markdown, text and JSON" do
+  test "profile: every public fact appears in HTML, Markdown, text and JSON", %{user: user} do
     rendered = formats_for("/drift_tester")
 
     facts = [
@@ -97,6 +97,15 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert Jason.decode!(rendered.json)["counts"]["followers"] == 1
     assert rendered.md =~ "Followers: 1"
     assert rendered.txt =~ "Followers: 1"
+
+    # The age, derived from the birthday in Berlin time, is an extra field in
+    # every machine format and reads naturally in the HTML.
+    age = VutuvWeb.UserHelpers.age(user)
+    assert rendered.html =~ "#{age} years old"
+    assert rendered.md =~ "Age: #{age}"
+    assert rendered.txt =~ "Age: #{age}"
+    assert Jason.decode!(rendered.json)["age"] == age
+    assert rendered.xml =~ "<age>#{age}</age>"
   end
 
   test "profile vCard carries the same contact facts", %{user: _user} do

--- a/test/vutuv_web/controllers/user_controller_test.exs
+++ b/test/vutuv_web/controllers/user_controller_test.exs
@@ -157,10 +157,11 @@ defmodule VutuvWeb.UserControllerTest do
     assert html =~ ~s(id="profile-social-media")
     assert html =~ "octocat"
 
-    # General info (gender, birthday in the en format)
+    # General info (gender, birthday in the en format, and the derived age)
     assert html =~ ~s(id="profile-about")
     assert html =~ "Female"
     assert html =~ "04/15/1990"
+    assert html =~ "#{VutuvWeb.UserHelpers.age(user)} years old"
 
     # Follower / following previews
     assert html =~ ~s(id="profile-followers")

--- a/test/vutuv_web/views/user_helpers_test.exs
+++ b/test/vutuv_web/views/user_helpers_test.exs
@@ -5,6 +5,7 @@ defmodule VutuvWeb.UserHelpersTest do
   """
   use Vutuv.DataCase, async: true
 
+  alias Vutuv.Accounts.User
   alias Vutuv.Repo
   alias VutuvWeb.UserHelpers
 
@@ -122,6 +123,47 @@ defmodule VutuvWeb.UserHelpersTest do
 
     test "empty list -> empty map" do
       assert UserHelpers.work_information_map([], 60) == %{}
+    end
+  end
+
+  describe "age/2 (whole years on a reference day)" do
+    test "counts a birthday that has already passed this year" do
+      assert UserHelpers.age(~D[1990-04-15], ~D[2026-06-18]) == 36
+    end
+
+    test "the birthday itself already counts (inclusive)" do
+      assert UserHelpers.age(~D[1990-06-18], ~D[2026-06-18]) == 36
+    end
+
+    test "a birthday still ahead this year has not been reached yet" do
+      assert UserHelpers.age(~D[1990-12-25], ~D[2026-06-18]) == 35
+    end
+
+    test "the day before the birthday is still the lower age" do
+      assert UserHelpers.age(~D[1990-06-19], ~D[2026-06-18]) == 35
+    end
+
+    test "a February 29 birthday rolls over on March 1 in non-leap years" do
+      # Feb 28 in a non-leap year: the leapling has not turned older yet.
+      assert UserHelpers.age(~D[2000-02-29], ~D[2026-02-28]) == 25
+      assert UserHelpers.age(~D[2000-02-29], ~D[2026-03-01]) == 26
+      # On a real Feb 29 the birthday lands exactly.
+      assert UserHelpers.age(~D[2000-02-29], ~D[2024-02-29]) == 24
+    end
+
+    test "a birthdate in the future has no meaningful age" do
+      assert UserHelpers.age(~D[2030-01-01], ~D[2026-06-18]) == nil
+    end
+  end
+
+  describe "age/1 (current Berlin day)" do
+    test "nil for a member without a birthdate" do
+      assert UserHelpers.age(%User{birthdate: nil}) == nil
+    end
+
+    test "returns the whole-year age for a member with a birthdate" do
+      birthdate = Date.add(Vutuv.BerlinTime.today(), -366 * 30)
+      assert UserHelpers.age(%User{birthdate: birthdate}) in [29, 30]
     end
   end
 


### PR DESCRIPTION
## What

When a member has set their birthdate, the profile now displays their **age** next to the birthday, and the age is also exposed as an extra field in the machine-readable agent formats.

- **HTML profile** (General Info card): e.g. `15.05.1990 (36 years old)` / German `(36 Jahre)`, the age shown muted inline next to the birthday.
- **Markdown / text**: a new labeled line `Age: 36` (`gettext("Age")` → de "Alter").
- **JSON / XML**: a new `age` field, carried for free from the shared `ProfileDoc` map (`"age": 36` / `<age>36</age>`).
- **vCard**: intentionally untouched (it never carried the birthday, so adding age there would be inconsistent).

## How

- The age uses **Berlin time** so a German member's age rolls over at German local midnight, not UTC midnight. The fixed-EU-DST "what day in Germany" logic (no `tzdata` dep) is extracted out of `Vutuv.Ads` into a shared **`Vutuv.BerlinTime`** module; `Vutuv.Ads.today/0` and `berlin_date/1` remain as thin `defdelegate`s, so the ad system and its tests are unchanged.
- The calculation is `VutuvWeb.UserHelpers.age/2` — a pure `(birthdate, reference) -> integer | nil` function (deterministic to test); `age/1` reads `BerlinTime.today/0` for the live value.
- Edge cases: a **Feb 29** birthday rolls over on **Mar 1** in non-leap years (a `{month, day}` tuple compare); a **future** birthdate yields `nil` (never shown).

## Tests

Written first, per the project's test-first rule:

- `user_helpers_test.exs`: `age/2` boundary cases (passed / upcoming / today / day-before birthday, Feb 29, future date) and `age/1` (nil-birthdate, live value).
- `user_controller_test.exs` (HTML) and `agent_docs_drift_test.exs` (md/txt/json/xml) assert the age in every format, computing the expected value via the helper so the assertions don't rot over time.

Full suite green: **1790 passed**.

## Notes

- The gettext catalog diff looks large but the only **content** changes are the two new strings (`Age`, `%{count} year old`); the rest is `#:` source-reference renumbering caused by inserting lines into `show.html.heex`.