### PR TITLE
Keep part of an overflowing block in a post preview, don't drop it

### DIFF
--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -20,6 +20,10 @@ defmodule VutuvWeb.Markdown do
   @url_display_max 40
   @trailing_punct ~w(. , ; : ! ?)
   @preview_limit 1000
+  # When a whole block would overflow the preview, keep a word-cut of it (so a
+  # one-line intro above a long block doesn't leave a one-line preview) — but
+  # only if at least this many characters of budget remain, else just stop.
+  @preview_min_block 200
   @inline_image ~r/!\[([^\]]*)\]\(([^)\s]+)\)/
 
   # A `@handle` mention or a `#hashtag`. The leading `@`/`#` must not sit
@@ -396,11 +400,25 @@ defmodule VutuvWeb.Markdown do
 
   defp accumulate_blocks([block | rest], kept, length, limit) do
     new_length = length + 2 + String.length(block)
+    remaining = limit - length - 2
 
-    if new_length > limit do
-      join_blocks(kept)
-    else
-      accumulate_blocks(rest, [block | kept], new_length, limit)
+    cond do
+      new_length <= limit ->
+        accumulate_blocks(rest, [block | kept], new_length, limit)
+
+      # Near-full already: stop. There is plenty above for the CSS clamp.
+      remaining < @preview_min_block ->
+        join_blocks(kept)
+
+      # The next whole block overflows but there is room. Don't drop it — that is
+      # what left a one-line intro stranded above a long list. A fence is atomic
+      # (cutting it breaks rendering everything after), so include it whole and
+      # let the CSS line-clamp trim it; any other block is word-cut to the budget.
+      fence_block?(block) ->
+        join_blocks([block | kept])
+
+      true ->
+        join_blocks([word_cut(block, remaining) | kept])
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.8.0",
+      version: "7.8.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/markdown_test.exs
+++ b/test/vutuv_web/markdown_test.exs
@@ -34,6 +34,47 @@ defmodule VutuvWeb.MarkdownTest do
     assert render("line one\nline two") =~ "<br"
   end
 
+  describe "render_preview/3 truncation" do
+    defp preview(text, opts \\ []) do
+      {html, truncated?} = Markdown.render_preview(text, [], opts)
+      {Phoenix.HTML.safe_to_string(html), truncated?}
+    end
+
+    test "short content is rendered whole and not marked truncated" do
+      {html, truncated?} = preview("Just a short post.")
+
+      assert html =~ "Just a short post."
+      refute truncated?
+    end
+
+    test "a one-line intro above a long block keeps part of that block (not just the intro)" do
+      intro = "Testing this self-improvement rule for my setup:"
+      long = "- " <> String.duplicate("word ", 400)
+
+      {html, truncated?} = preview(intro <> "\n\n" <> long)
+
+      assert truncated?
+      assert html =~ "Testing this self-improvement rule"
+      # The long block is word-cut into the preview instead of being dropped, so
+      # its text and list markup appear — it used to collapse to just the intro.
+      assert html =~ "<li>"
+      assert html =~ "word word"
+    end
+
+    test "an overflowing fenced code block is kept whole rather than cut mid-fence" do
+      intro = "Here is the code:"
+      fence = "```\n" <> String.duplicate("x = 1\n", 300) <> "```"
+
+      {html, truncated?} = preview(intro <> "\n\n" <> fence)
+
+      assert truncated?
+      assert html =~ "Here is the code"
+      # Cutting a fence breaks rendering, so it is included whole (the CSS clamp
+      # trims it visually) — the preview is never stranded on the intro line.
+      assert html =~ "x = 1"
+    end
+  end
+
   test "raw HTML shows as literal text and never executes" do
     html = render(~s|<script>alert("x")</script> **safe**|)
     refute html =~ "<script"


### PR DESCRIPTION
## What

A post preview built its excerpt by accumulating whole Markdown blocks up to a character budget, then **dropping the next block entirely** once it would overflow. A short intro line above a long block collapsed the preview to just that one line — e.g. "Testing this setup:" with the long list below gone — even with plenty of budget left.

## Change

`VutuvWeb.Markdown.accumulate_blocks/4` now **word-cuts** an overflowing block into the preview (reusing the existing `word_cut/2`) instead of dropping it, unless little budget remains (`< @preview_min_block`, 200 chars). A fenced code block is atomic — cutting it mid-fence breaks rendering of everything after — so it is included whole and the CSS line-clamp trims it visually.

Adds three `render_preview/3` tests: short content (no truncation), intro-above-long-block (keeps part of the block), and an overflowing fence (kept whole).

## Notes

- `mix precommit` green (2119 tests, credo clean, formatted).
- Patch bump to 7.8.1 (refinement to existing behavior, no new feature).

https://claude.ai/code/session_01HzYkhUkHv53atDoRqq3ySP