### PR TITLE
Normalize legacy usernames and redirect their old profile URLs

### DIFF
--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -780,6 +780,92 @@ defmodule Vutuv.Accounts do
     end
   end
 
+  @doc """
+  One-off backfill that brings every legacy handle into line with the
+  Twitter-style rule (`User.username_changeset/2`: `^[a-z0-9_]+$`, max 15
+  chars) - chiefly the dotted and over-length imports from the old vutuv.
+
+  For each member whose current `username` fails the charset rule, it
+  regenerates a valid handle from the member's name (so `Oliver Gassner` ->
+  `oliver_gassner`) and preserves the retired handle in `users.legacy_username`,
+  so the old handle is never lost and the old profile URL 301s to the new one
+  (`VutuvWeb.Plug.UserResolveSlug`). Returns the number of members renamed.
+
+  **Uniqueness is guaranteed in code, not left to the DB constraint.** Every
+  handle already in use (the untouched valid accounts) plus every handle minted
+  during this run are held in one set; the plain name-handle is used only when
+  it is free, otherwise a 6-char stem plus a random number is re-rolled until it
+  lands on a free handle. So two members with the same name (or whose names
+  normalize the same) can never collide on the same new handle - the run never
+  trips the `users.username` unique index and so never aborts mid-migration.
+
+  Idempotent: a regenerated handle is itself charset-valid, so a second run
+  finds nothing left to rename. Referenced by the `NormalizeLegacyUsernames`
+  data migration; this is a system correction, not a member action, so it
+  deliberately bypasses the username-change quota ledger. (A member whose name
+  is a single letter regenerates to a 1-2 char handle: charset-valid and
+  resolvable, just shy of the 3-char editor minimum, exactly as registration
+  would mint it today.)
+  """
+  def normalize_legacy_usernames do
+    reserved = MapSet.new(ReservedSlugs.list())
+
+    # Handles we must not collide with: every already-valid handle. The invalid
+    # ones are being replaced, and a freshly minted handle (no dots, <=15 chars)
+    # can never equal one of them anyway, so they do not constrain us.
+    taken =
+      from(u in User, where: fragment("? ~ '^[a-z0-9_]+$'", u.username), select: u.username)
+      |> Repo.all()
+      |> MapSet.new()
+
+    invalid =
+      from(u in User,
+        where: fragment("? !~ '^[a-z0-9_]+$'", u.username),
+        select: %{id: u.id, old: u.username, first: u.first_name, last: u.last_name}
+      )
+      |> Repo.all()
+
+    {_taken, renamed} =
+      Enum.reduce(invalid, {taken, 0}, fn row, {taken, renamed} ->
+        new_username = unique_legacy_handle("#{row.first} #{row.last}", taken, reserved)
+
+        {1, _} =
+          Repo.update_all(from(u in User, where: u.id == ^row.id),
+            set: [username: new_username, legacy_username: row.old]
+          )
+
+        {MapSet.put(taken, new_username), renamed + 1}
+      end)
+
+    renamed
+  end
+
+  # A handle guaranteed free against `taken` and never a reserved word: the
+  # name's plain handle when that is free, otherwise a stem plus a random number
+  # re-rolled until it lands on a free handle.
+  defp unique_legacy_handle(name, taken, reserved) do
+    base = Vutuv.SlugHelpers.handleize(name)
+
+    if base != "" and not MapSet.member?(taken, base) and not MapSet.member?(reserved, base) do
+      base
+    else
+      stem = base |> String.slice(0, 6) |> String.trim("_")
+
+      Stream.repeatedly(fn -> random_handle(stem) end)
+      |> Enum.find(fn handle ->
+        not MapSet.member?(taken, handle) and not MapSet.member?(reserved, handle)
+      end)
+    end
+  end
+
+  # `stem_<random>`, trimmed so an empty stem yields just the number, and within
+  # the 15-char limit (stem <= 6, "_", up to 8 random digits). Crypto-strong so
+  # the draws do not depend on a process seed.
+  defp random_handle(stem) do
+    number = :crypto.strong_rand_bytes(4) |> :binary.decode_unsigned() |> rem(100_000_000)
+    String.trim_leading("#{stem}_#{number}", "_")
+  end
+
   # The plain profile fields a member may edit about themselves. The API's
   # PATCH /me writes through this list; the username (quota'd,
   # Twitter-validated), email addresses (PIN-verified identities) and

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -40,6 +40,13 @@ defmodule Vutuv.Accounts.User do
     field(:avatar_crop, :string)
     field(:cover_crop, :string)
     field(:username, :string)
+    # The member's original legacy handle (the dotted / over-length import),
+    # preserved before Accounts.normalize_legacy_usernames/0 rewrote :username
+    # to a valid one - kept so the old handle is never lost. It also drives the
+    # old-URL redirect: VutuvWeb.Plug.UserResolveSlug resolves an unknown slug
+    # through here. nil for accounts that were already valid. Set once by the
+    # backfill, never cast from params.
+    field(:legacy_username, :string)
     field(:admin?, :boolean)
     field(:headline, :string)
     field(:noindex?, :boolean, default: false)

--- a/lib/vutuv/slug_helpers.ex
+++ b/lib/vutuv/slug_helpers.ex
@@ -33,7 +33,14 @@ defmodule Vutuv.SlugHelpers do
     end
   end
 
-  defp handleize(text) do
+  @doc """
+  Normalizes free text into a handle body (no uniqueness check): downcased,
+  transliterated, non-`[a-z0-9_]` runs collapsed to `_`, capped at
+  #{@handle_max_length} chars. The pure core of `gen_handle_unique/4`, exposed
+  so callers that manage their own uniqueness (the legacy-username backfill)
+  can reuse the exact same normalization.
+  """
+  def handleize(text) do
     text
     |> String.downcase()
     |> transliterate()

--- a/lib/vutuv_web/plugs/user_resolve_slugs.ex
+++ b/lib/vutuv_web/plugs/user_resolve_slugs.ex
@@ -1,11 +1,21 @@
 defmodule VutuvWeb.Plug.UserResolveSlug do
   @moduledoc """
   Resolves the `:slug` / `:user_slug` path segment to the member whose
-  `username` it is. There is exactly one live handle per member - old
-  handles are neither reserved nor redirected, so an unknown handle is a
-  plain 404.
+  `username` it is. There is exactly one live handle per member.
+
+  A live handle always wins. Only when the slug resolves to no member do we
+  fall back to `users.legacy_username` - the original handle a member was
+  renamed away from (the dotted / over-length imports) - and 301 to that
+  member's current handle, so an old profile URL keeps working. The
+  reconstructed location swaps just the handle segment and carries the query
+  string; the agent-format extension (`.md`, `.json`, ...) is re-appended by
+  `VutuvWeb.Plug.AgentFormat`. Anything else is a plain 404 - retired handles
+  are not otherwise reserved or redirected.
   """
 
+  import Ecto.Query, only: [from: 2]
+
+  alias Vutuv.Accounts.User
   alias Vutuv.Repo
 
   def init(opts) do
@@ -17,14 +27,45 @@ defmodule VutuvWeb.Plug.UserResolveSlug do
   def call(conn, _opts), do: invalid_slug(conn)
 
   defp resolve(conn, slug) do
-    case Repo.get_by(Vutuv.Accounts.User, username: slug) do
+    case Repo.get_by(User, username: slug) do
       nil ->
-        invalid_slug(conn)
+        case redirect_target(slug) do
+          nil -> invalid_slug(conn)
+          current -> redirect_to_current(conn, slug, current)
+        end
 
       user ->
         conn
         |> Plug.Conn.assign(:user_id, user.id)
         |> Plug.Conn.assign(:user, user)
+    end
+  end
+
+  # The current handle of the member who used to answer to this retired one, or
+  # nil. One indexed lookup on the (rare) miss path.
+  defp redirect_target(slug) do
+    Repo.one(from(u in User, where: u.legacy_username == ^slug, select: u.username))
+  end
+
+  defp redirect_to_current(conn, old_slug, current_slug) do
+    conn
+    |> Plug.Conn.put_status(:moved_permanently)
+    |> Phoenix.Controller.redirect(to: current_path(conn, old_slug, current_slug))
+    |> Plug.Conn.halt()
+  end
+
+  # Swap only the handle segment of the (extension-stripped) request path and
+  # keep the query string. AgentFormat's `keep_extension/1` re-adds any
+  # `.md`/`.json`/... it cut, so the redirect lands on the same format.
+  defp current_path(conn, old_slug, current_slug) do
+    path =
+      Enum.map_join(conn.path_info, "/", fn segment ->
+        if segment == old_slug, do: current_slug, else: segment
+      end)
+
+    case conn.query_string do
+      "" -> "/" <> path
+      query -> "/" <> path <> "?" <> query
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.8.0",
+      version: "7.9.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260624081029_add_legacy_username_to_users.exs
+++ b/priv/repo/migrations/20260624081029_add_legacy_username_to_users.exs
@@ -1,0 +1,23 @@
+defmodule Vutuv.Repo.Migrations.AddLegacyUsernameToUsers do
+  use Ecto.Migration
+
+  def change do
+    # Belt-and-suspenders: the member's original legacy handle (the dotted /
+    # over-length import) is preserved on their own row before the
+    # NormalizeLegacyUsernames backfill rewrites `username` to a valid one, so
+    # the old handle is never lost. It doubles as the redirect source -
+    # VutuvWeb.Plug.UserResolveSlug resolves an unknown slug through this column
+    # and 301s to the member's current `username`. Null for accounts that were
+    # already valid and never renamed.
+    #
+    # Additive nullable column -> backward compatible in one deploy. Unique so
+    # an old handle maps to exactly one member (they were unique as usernames);
+    # Postgres keeps the many NULLs distinct, so the already-valid members do
+    # not collide on it.
+    alter table(:users) do
+      add(:legacy_username, :string)
+    end
+
+    create(unique_index(:users, [:legacy_username]))
+  end
+end

--- a/priv/repo/migrations/20260624081456_normalize_legacy_usernames.exs
+++ b/priv/repo/migrations/20260624081456_normalize_legacy_usernames.exs
@@ -1,0 +1,34 @@
+defmodule Vutuv.Repo.Migrations.NormalizeLegacyUsernames do
+  use Ecto.Migration
+
+  alias Vutuv.Accounts
+
+  # Brings every legacy handle into line with the Twitter-style username rule
+  # (^[a-z0-9_]+$, max 15 chars): the dotted / over-length imports from the old
+  # vutuv get a valid handle regenerated from the member's name, and the old
+  # handle is preserved in users.legacy_username so it is never lost and the old
+  # profile URL 301s to the new one. The work lives in
+  # Vutuv.Accounts.normalize_legacy_usernames/0.
+  #
+  # Data-only (no DDL), so it runs in the implicit transaction: the rename is
+  # all-or-nothing, which is what the blue/green deploy wants. A fresh / test
+  # database has no members, so it is a no-op there - the real work only
+  # happens against the production data.
+  def up do
+    renamed = Accounts.normalize_legacy_usernames()
+    IO.puts("normalized #{renamed} legacy username(s)")
+  end
+
+  # Restores each renamed member's original handle from the legacy_username we
+  # stashed, then clears the column - the one case where the rename *is*
+  # reversible, because the old handle was preserved. (A member who has since
+  # changed their handle again keeps that newer one; this only rolls back
+  # rows still sitting on the minted handle.)
+  def down do
+    execute("""
+    UPDATE users
+       SET username = legacy_username, legacy_username = NULL
+     WHERE legacy_username IS NOT NULL
+    """)
+  end
+end

--- a/test/vutuv/accounts/legacy_username_normalization_test.exs
+++ b/test/vutuv/accounts/legacy_username_normalization_test.exs
@@ -1,0 +1,90 @@
+defmodule Vutuv.Accounts.LegacyUsernameNormalizationTest do
+  @moduledoc """
+  `Accounts.normalize_legacy_usernames/0` - the one-off backfill that renames
+  every charset-invalid legacy handle (the dotted / over-length imports) to a
+  valid handle regenerated from the member's name, preserving the old handle in
+  `users.legacy_username` so it is never lost and the profile URL keeps
+  redirecting.
+  """
+  use Vutuv.DataCase
+
+  alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
+
+  defp valid_handle?(handle) do
+    Regex.match?(~r/\A[a-z0-9_]+\z/, handle) and String.length(handle) <= 15
+  end
+
+  test "regenerates a valid handle from the member's name and preserves the old one" do
+    user = insert(:user, username: "oliver.gassner", first_name: "Oliver", last_name: "Gassner")
+
+    assert Accounts.normalize_legacy_usernames() == 1
+
+    reloaded = Repo.get!(User, user.id)
+    assert reloaded.username == "oliver_gassner"
+    assert reloaded.legacy_username == "oliver.gassner"
+  end
+
+  test "leaves an already-valid handle untouched and stores no legacy handle" do
+    user = insert(:user, username: "valid_handle", first_name: "Val", last_name: "Id")
+
+    assert Accounts.normalize_legacy_usernames() == 0
+
+    reloaded = Repo.get!(User, user.id)
+    assert reloaded.username == "valid_handle"
+    assert reloaded.legacy_username == nil
+  end
+
+  test "suffixes a collision when two members regenerate to the same handle" do
+    a = insert(:user, username: "a.b.one", first_name: "Same", last_name: "Name")
+    b = insert(:user, username: "a.b.two", first_name: "Same", last_name: "Name")
+
+    assert Accounts.normalize_legacy_usernames() == 2
+
+    handle_a = Repo.get!(User, a.id).username
+    handle_b = Repo.get!(User, b.id).username
+
+    assert handle_a != handle_b
+    assert valid_handle?(handle_a) and valid_handle?(handle_b)
+  end
+
+  test "mints a unique handle for every member even when many share one name" do
+    for i <- 1..8 do
+      insert(:user, username: "jane.roe.#{i}", first_name: "Jane", last_name: "Roe")
+    end
+
+    assert Accounts.normalize_legacy_usernames() == 8
+
+    handles =
+      User
+      |> Repo.all()
+      |> Enum.reject(&is_nil(&1.legacy_username))
+      |> Enum.map(& &1.username)
+
+    assert length(handles) == 8
+    assert length(Enum.uniq(handles)) == 8, "expected 8 distinct handles, got #{inspect(handles)}"
+    assert Enum.all?(handles, &valid_handle?/1)
+  end
+
+  test "does not collide a regenerated handle with an existing valid handle" do
+    # An already-valid member holds exactly the handle the legacy member's name
+    # would normalize to; the legacy one must be pushed onto a unique variant.
+    insert(:user, username: "jane_roe", first_name: "Jane", last_name: "Roe")
+    legacy = insert(:user, username: "jane.roe", first_name: "Jane", last_name: "Roe")
+
+    assert Accounts.normalize_legacy_usernames() == 1
+
+    assert Repo.get!(User, legacy.id).username != "jane_roe"
+    assert valid_handle?(Repo.get!(User, legacy.id).username)
+  end
+
+  test "is idempotent - a second run renames nothing and changes no handle" do
+    user = insert(:user, username: "x.y.z", first_name: "Ex", last_name: "Why")
+
+    assert Accounts.normalize_legacy_usernames() == 1
+    after_first = Repo.get!(User, user.id).username
+
+    assert Accounts.normalize_legacy_usernames() == 0
+    assert Repo.get!(User, user.id).username == after_first
+  end
+end

--- a/test/vutuv_web/plugs/user_resolve_slug_redirect_test.exs
+++ b/test/vutuv_web/plugs/user_resolve_slug_redirect_test.exs
@@ -1,0 +1,55 @@
+defmodule VutuvWeb.Plug.UserResolveSlugRedirectTest do
+  @moduledoc """
+  A retired legacy handle (the dotted / over-length imports, preserved in
+  `users.legacy_username`) 301s to the member's current handle - across the
+  profile, its sub-pages and the agent-format siblings - while a live handle
+  always wins over a stale legacy handle.
+  """
+  use VutuvWeb.ConnCase
+
+  setup do
+    user =
+      insert_activated_user(
+        username: "oliver_gassner",
+        legacy_username: "oliver.gassner",
+        first_name: "Oliver",
+        last_name: "Gassner"
+      )
+
+    %{user: user}
+  end
+
+  test "301s an old dotted profile URL to the current handle", %{conn: conn} do
+    conn = get(conn, "/oliver.gassner")
+    assert redirected_to(conn, 301) == "/oliver_gassner"
+  end
+
+  test "keeps the agent-format extension on the redirect", %{conn: conn} do
+    conn = get(conn, "/oliver.gassner.md")
+    assert redirected_to(conn, 301) == "/oliver_gassner.md"
+  end
+
+  test "redirects a profile sub-page too", %{conn: conn} do
+    conn = get(conn, "/oliver.gassner/emails")
+    assert redirected_to(conn, 301) == "/oliver_gassner/emails"
+  end
+
+  test "carries the query string", %{conn: conn} do
+    conn = get(conn, "/oliver.gassner?lang=de")
+    assert redirected_to(conn, 301) == "/oliver_gassner?lang=de"
+  end
+
+  test "a live handle always wins over a stale legacy handle", %{conn: conn} do
+    live = insert_activated_user(username: "live_handle", first_name: "Live", last_name: "One")
+    insert_activated_user(username: "someone_else", legacy_username: "live_handle")
+
+    conn = get(conn, "/live_handle")
+
+    assert html_response(conn, 200) =~ live.first_name
+  end
+
+  test "an unknown handle still 404s, never a redirect", %{conn: conn} do
+    conn = get(conn, "/nope.nope")
+    assert conn.status == 404
+  end
+end


### PR DESCRIPTION
## What

Brings every legacy handle into line with the current Twitter-style username rule (`^[a-z0-9_]+$`, max 15 chars). The old vutuv import left ~60k of ~60.5k members with handles that contain a dot or exceed 15 chars, which breaks @mention linking and the agent-format URLs (a handle ending in e.g. `.md` is swallowed by `AgentFormat` before it can resolve).

## How

- **`users.legacy_username`** (new column) preserves each member's original handle, so it is never lost.
- **Backfill migration** regenerates a valid handle from the member's name (`Oliver Gassner` → `oliver_gassner`); already-valid handles are left untouched.
- **`UserResolveSlug`** 301s an unknown slug through `legacy_username` to the member's current handle, covering the profile, its sub-pages and the `.md`/`.json`/`.xml`/`.vcf` siblings. A live handle always wins over a stale legacy one.
- **Uniqueness guaranteed in code** (in-memory set + random re-roll on conflict), so two same-name members can never collide and abort the 60k-row migration.
- Reversible: the migration's `down` restores `username` from `legacy_username`.

## Verification

Test-run against a fresh restore of the **production** database: 60,149 handles renamed in <4s, **zero duplicate usernames**, zero still-invalid, old→new redirects confirmed end to end (HTML, `.md`, `.json`). `mix precommit` green (2131 tests).

## Deploy note

Two migrations (add column, then backfill). Merging runs both in one deploy; the backfill renames while the previous release still serves, so there is a brief window where old dotted URLs 404 on the old release before the new release (with the redirect) takes over. Acceptable for a one-time correction.