### PR TITLE
Keep Erlang crash dumps out of the release directory (#828)

### DIFF
--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -4,6 +4,8 @@
 # releases/<vsn>/env.sh and sourced by bin/vutuv before the VM starts,
 # for every subcommand (start, daemon, eval, rpc, remote).
 #
+# 1. Working directory (issue #826)
+#
 # Run the one-off console subcommands from a directory the release owner
 # can always read. Without this, `bin/vutuv eval ...` crashes at boot when
 # invoked from a working directory the app user cannot read, e.g.
@@ -22,9 +24,25 @@
 # and using absolute / Application.app_dir paths) are deliberately left
 # untouched, so this only hardens the manual console commands.
 #
-# See https://github.com/wintermeyer/vutuv/issues/826
+# 2. Crash dumps (issue #828)
+#
+# On a VM crash Erlang writes erl_crash.dump to the cwd. The serving node
+# runs with WorkingDirectory = the release dir (pruned on each deploy) and
+# the console commands cd into RELEASE_ROOT above, so a default dump would
+# land in the release tree. Send it to a stable location outside the
+# release dir instead, unless the operator already chose one in the
+# environment (e.g. ERL_CRASH_DUMP in shared/.env).
+#
+# See https://github.com/wintermeyer/vutuv/issues/826 and /issues/828
+
+: "${ERL_CRASH_DUMP:=${TMPDIR:-/tmp}/vutuv-erl_crash.dump}"
+export ERL_CRASH_DUMP
+
 case "$RELEASE_COMMAND" in
   eval | rpc | remote)
     cd "$RELEASE_ROOT" || exit 1
+    # A crash dump from a one-off console command is rarely useful, so skip
+    # writing one rather than leave a large file behind.
+    export ERL_CRASH_DUMP_SECONDS=0
     ;;
 esac


### PR DESCRIPTION
**TL;DR** Point `ERL_CRASH_DUMP` at a stable location outside the (deploy-pruned) release dir, and skip the dump entirely for the one-off console commands. Follow-up hardening to #826. Fixes #828.

## Why

The serving node runs under systemd with `WorkingDirectory` = the release dir, and the `eval`/`rpc`/`remote` console commands `cd` into `RELEASE_ROOT` (from the #826 fix). Erlang writes `erl_crash.dump` to the cwd on a VM crash, so a default dump lands in the release tree, which the deploy prunes ("keep last 5"). The crashing console of #826 left stray dumps under the production slot dir.

(The stray dumps themselves were already cleared on bremen2 by today's deploy pruning; this PR is the recurrence hardening.)

## Change

`rel/env.sh.eex` now:

```sh
: "${ERL_CRASH_DUMP:=${TMPDIR:-/tmp}/vutuv-erl_crash.dump}"
export ERL_CRASH_DUMP

case "$RELEASE_COMMAND" in
  eval | rpc | remote)
    cd "$RELEASE_ROOT" || exit 1
    export ERL_CRASH_DUMP_SECONDS=0
    ;;
esac
```

- **Serving node**: a genuine crash still produces a dump, but at `/tmp/vutuv-erl_crash.dump` (default) instead of the release dir.
- **Console commands** (`eval`/`rpc`/`remote`): `ERL_CRASH_DUMP_SECONDS=0` skips the dump (rarely useful for one-off commands).
- **Operator override**: if `ERL_CRASH_DUMP` is already set in the environment (e.g. `shared/.env`), it is respected.

## Verification (fresh `MIX_ENV=prod mix release`)

- `eval` reports `ERL_CRASH_DUMP_SECONDS=0` and the default dump path.
- A pre-set `ERL_CRASH_DUMP` wins (override respected).
- The #826 unreadable-cwd fix still works (`eval` from a `chmod 000` cwd runs).