### PR TITLE
Report a re-used login PIN as "already used", not "expired" (#839)

### DIFF
--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -4,6 +4,18 @@ vutuv is **passwordless**. The baseline login is a two-step email-PIN flow
 (`/login` mails a 6-digit PIN, the second step verifies it; no password is ever
 stored).
 
+The PIN lives in `login_pins` (one row per `(user, type)`, shared by the
+`login`, `email` change and `delete` flows). It stays valid for 30 minutes from
+when it is minted (`minted_at`) and it is **one-time**: a successful check stamps
+`consumed_at`, so it can never be replayed. A classic (non-LiveView) PIN form can
+be posted twice — a double-tap, a back-navigation, a retried request — so
+`Vutuv.Accounts.check_pin/3` tells an **already-used** PIN (`consumed_at` set →
+`{:already_used, _}`, a calm "already used" notice because the first submit
+already logged the member in) apart from a genuinely **expired** one
+(`minted_at` past the window, or cleared → `{:expired, _}`). Collapsing the two
+once told members who had just logged in that their fresh PIN had expired
+(issue #839).
+
 Returning members can also enrol one or more **passkeys** (WebAuthn / FIDO2 —
 Touch ID, Windows Hello, a security key) from the Account hub and sign in with
 one as an **alternative first factor**, skipping the email round-trip entirely

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -425,13 +425,23 @@ defmodule Vutuv.Accounts do
       type: type,
       payload: payload,
       minted_at: NaiveDateTime.utc_now(:second),
+      consumed_at: nil,
       pin_hash: hash_pin(pin, salt),
       pin_salt: salt,
       pin_login_attempts: 0
     })
     |> Repo.insert!(
       on_conflict:
-        {:replace, [:payload, :minted_at, :pin_hash, :pin_salt, :pin_login_attempts, :updated_at]},
+        {:replace,
+         [
+           :payload,
+           :minted_at,
+           :consumed_at,
+           :pin_hash,
+           :pin_salt,
+           :pin_login_attempts,
+           :updated_at
+         ]},
       conflict_target: [:user_id, :type]
     )
 
@@ -479,10 +489,32 @@ defmodule Vutuv.Accounts do
     |> Repo.update!()
   end
 
+  # A one-time PIN is spent the moment it verifies. We stamp *when* rather than
+  # only nulling `minted_at` (which also marks a timeout or a lockout), so a
+  # re-submission can be reported as "already used" instead of the misleading
+  # "PIN expired" a member saw right after a successful login (issue #839).
+  defp mark_consumed(login_pin) do
+    login_pin
+    |> LoginPin.changeset(%{consumed_at: NaiveDateTime.utc_now(:second)})
+    |> Repo.update!()
+  end
+
+  defp consumed?(%{consumed_at: nil}), do: false
+  defp consumed?(%{consumed_at: _}), do: true
+
   defp pin_expired?(%{minted_at: nil}), do: true
 
   defp pin_expired?(%{minted_at: date_time}) do
     NaiveDateTime.diff(NaiveDateTime.utc_now(), date_time, :second) > @pin_expire_time
+  end
+
+  # Prod runs at Logger level :error, so these surface only in dev/staging — but
+  # they record *why* a PIN was turned away (never the PIN or the address) so a
+  # future report like issue #839 is diagnosable without guessing.
+  defp log_pin_rejected(%LoginPin{} = login_pin, reason) do
+    Logger.info(
+      "login_pin rejected: reason=#{reason} type=#{login_pin.type} user_id=#{login_pin.user_id}"
+    )
   end
 
   # A registration mints the account and its first "login" PIN in the same
@@ -734,12 +766,22 @@ defmodule Vutuv.Accounts do
 
   defp verify_pin(%LoginPin{} = login_pin, pin) do
     cond do
+      # Checked before expiry and before re-validating: a PIN that was already
+      # used successfully must never be replayed, and a duplicate submission of
+      # it (a double-tap or back-navigation of the classic PIN form) reads as
+      # "already used", not "expired" — the member had in fact just logged in
+      # (issue #839).
+      consumed?(login_pin) ->
+        log_pin_rejected(login_pin, "already_used")
+        {:already_used, Gettext.gettext(VutuvWeb.Gettext, "This PIN has already been used.")}
+
       pin_expired?(login_pin) ->
         expire_pin(login_pin)
+        log_pin_rejected(login_pin, "expired")
         {:expired, Gettext.gettext(VutuvWeb.Gettext, "PIN expired")}
 
       valid_pin?(login_pin, pin) ->
-        expire_pin(login_pin)
+        mark_consumed(login_pin)
         pin_response(login_pin)
 
       true ->

--- a/lib/vutuv/accounts/login_pin.ex
+++ b/lib/vutuv/accounts/login_pin.ex
@@ -7,6 +7,10 @@ defmodule Vutuv.Accounts.LoginPin do
     field(:payload, :string)
     field(:type, :string)
     field(:minted_at, :naive_datetime)
+    # Set once the PIN has been successfully used. A re-submission of an
+    # already-consumed PIN is then reported as "already used", not "expired"
+    # (issue #839): `minted_at` alone could not tell the two apart.
+    field(:consumed_at, :naive_datetime)
     # `pin_hash` stores the peppered, salted HMAC of the PIN (hex), never plaintext.
     field(:pin_hash, :string)
     field(:pin_salt, :binary)
@@ -22,6 +26,7 @@ defmodule Vutuv.Accounts.LoginPin do
       :payload,
       :type,
       :minted_at,
+      :consumed_at,
       :pin_hash,
       :pin_salt,
       :pin_login_attempts

--- a/lib/vutuv_web/controllers/email_controller.ex
+++ b/lib/vutuv_web/controllers/email_controller.ex
@@ -138,6 +138,11 @@ defmodule VutuvWeb.EmailController do
         |> put_flash(:error, reason)
         |> render("confirm.html", user: conn.assigns[:user])
 
+      {:already_used, message} ->
+        conn
+        |> put_flash(:info, message)
+        |> redirect(to: ~p"/settings/emails")
+
       {:expired, message} ->
         conn
         |> put_flash(:error, message)

--- a/lib/vutuv_web/controllers/session_controller.ex
+++ b/lib/vutuv_web/controllers/session_controller.ex
@@ -310,6 +310,19 @@ defmodule VutuvWeb.SessionController do
             |> redirect(to: ~p"/")
         end
 
+      # already used — the classic PIN form was submitted twice (a double-tap or
+      # back-navigation): the first submit already logged them in, so this is
+      # not a failure. Reassure with an :info flash instead of the old scary
+      # "PIN expired" error, and drop the spent cookie (issue #839).
+      {:already_used, _message} ->
+        conn
+        |> Accounts.delete_pin_cookie()
+        |> put_flash(
+          :info,
+          gettext("This PIN was already used. If that was you, you are already signed in.")
+        )
+        |> redirect(to: ~p"/login")
+
       # expired, drop cookie
       {:expired, message} ->
         conn

--- a/lib/vutuv_web/controllers/user_controller.ex
+++ b/lib/vutuv_web/controllers/user_controller.ex
@@ -268,6 +268,11 @@ defmodule VutuvWeb.UserController do
         |> put_flash(:error, reason)
         |> render("delete_confirmation.html", body_class: "stretch")
 
+      {:already_used, message} ->
+        conn
+        |> put_flash(:info, message)
+        |> redirect(to: ~p"/#{user}")
+
       {:expired, message} ->
         conn
         |> put_flash(:error, message)

--- a/lib/vutuv_web/gettext_extraction_anchors.ex
+++ b/lib/vutuv_web/gettext_extraction_anchors.ex
@@ -13,7 +13,8 @@ defmodule VutuvWeb.GettextExtractionAnchors do
   msgid, add the same literal here.
 
     * `Male` / `Female` / `Diverse` — `Vutuv.Accounts.User.gender_gettext/1`
-    * `Incorrect PIN` / `PIN expired` — the PIN check messages in `Vutuv.Accounts`
+    * `Incorrect PIN` / `PIN expired` / `This PIN has already been used.` — the
+      PIN check messages in `Vutuv.Accounts`
     * `Connected` — the connection relationship word guarded by
       `VutuvWeb.ConnectionVocabularyTest` (issue #797), asserted via the runtime
       API so the test file itself does not inject a msgid.
@@ -29,6 +30,7 @@ defmodule VutuvWeb.GettextExtractionAnchors do
       gettext("Diverse"),
       gettext("Incorrect PIN"),
       gettext("PIN expired"),
+      gettext("This PIN has already been used."),
       gettext("Connected")
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.43.1",
+      version: "7.43.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -110,7 +110,7 @@ msgstr "Geburtstag"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: lib/vutuv_web/controllers/email_controller.ex:238
+#: lib/vutuv_web/controllers/email_controller.ex:243
 #, elixir-autogen
 msgid "Cannot delete final email."
 msgstr "Eine E-Mail-Adresse muss immer vorhanden sein. Diese kann nicht gelöscht werden."
@@ -214,12 +214,12 @@ msgstr "E-Mail-Adresse"
 msgid "Email created successfully."
 msgstr "E-Mail-Adresse wurde gespeichert."
 
-#: lib/vutuv_web/controllers/email_controller.ex:234
+#: lib/vutuv_web/controllers/email_controller.ex:239
 #, elixir-autogen
 msgid "Email deleted successfully."
 msgstr "E-Mail-Adresse wurde gelöscht."
 
-#: lib/vutuv_web/controllers/email_controller.ex:218
+#: lib/vutuv_web/controllers/email_controller.ex:223
 #, elixir-autogen
 msgid "Email updated successfully."
 msgstr "E-Mail-Adresse wurde geändert."
@@ -791,7 +791,7 @@ msgstr "Nichts zu finden, Käpt'n!"
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr "Wir behalten uns das Recht vor, Accounts ohne Warnung zu löschen oder den Dienst einzustellen."
 
-#: lib/vutuv_web/controllers/session_controller.ex:412
+#: lib/vutuv_web/controllers/session_controller.ex:425
 #, elixir-autogen
 msgid "Welcome back!"
 msgstr "Willkommen zurück!"
@@ -947,12 +947,12 @@ msgstr "Wählen Sie einen Monat"
 msgid "Select a year"
 msgstr "Wählen Sie ein Jahr"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:28
+#: lib/vutuv_web/gettext_extraction_anchors.ex:29
 #, elixir-autogen
 msgid "Female"
 msgstr "Frau"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:27
+#: lib/vutuv_web/gettext_extraction_anchors.ex:28
 #, elixir-autogen
 msgid "Male"
 msgstr "Mann"
@@ -1392,9 +1392,9 @@ msgstr "Tag-URLs"
 msgid "Tags"
 msgstr "Tags"
 
-#: lib/vutuv_web/controllers/email_controller.ex:148
-#: lib/vutuv_web/controllers/session_controller.ex:371
-#: lib/vutuv_web/controllers/user_controller.ex:278
+#: lib/vutuv_web/controllers/email_controller.ex:153
+#: lib/vutuv_web/controllers/session_controller.ex:384
+#: lib/vutuv_web/controllers/user_controller.ex:283
 #, elixir-autogen
 msgid "Too many incorrect attempts."
 msgstr "Zu viele fehlerhafter Versuche."
@@ -2166,14 +2166,14 @@ msgstr "Personen, die mir nicht folgen"
 msgid "Post"
 msgstr "Posten"
 
-#: lib/vutuv_web/controllers/post_controller.ex:203
+#: lib/vutuv_web/controllers/post_controller.ex:205
 #, elixir-autogen, elixir-format
 msgid "Post deleted successfully."
 msgstr "Beitrag erfolgreich gelöscht."
 
 #: lib/vutuv_web/agent_docs/post_doc.ex:74
-#: lib/vutuv_web/controllers/post_controller.ex:51
-#: lib/vutuv_web/controllers/post_controller.ex:59
+#: lib/vutuv_web/controllers/post_controller.ex:54
+#: lib/vutuv_web/controllers/post_controller.ex:62
 #: lib/vutuv_web/controllers/user_controller.ex:72
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
 #: lib/vutuv_web/live/post_live/saved.ex:305
@@ -2340,7 +2340,7 @@ msgstr "Beiträge von %{name}"
 msgid "View all %{count} posts"
 msgstr "Alle %{count} Beiträge ansehen"
 
-#: lib/vutuv_web/controllers/post_controller.ex:129
+#: lib/vutuv_web/controllers/post_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "All posts"
 msgstr "Alle Beiträge"
@@ -2438,7 +2438,7 @@ msgstr "Gefällt mir entfernen"
 msgid "Unfollow"
 msgstr "Entfolgen"
 
-#: lib/vutuv_web/controllers/session_controller.ex:392
+#: lib/vutuv_web/controllers/session_controller.ex:405
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
@@ -2642,12 +2642,12 @@ msgstr "„Genervt von LinkedIn, Facebook und X? Ging mir genauso."
 msgid "Allow search engines to index your profile"
 msgstr "Suchmaschinen dürfen dieses Profil indizieren"
 
-#: lib/vutuv_web/controllers/session_controller.ex:409
+#: lib/vutuv_web/controllers/session_controller.ex:422
 #, elixir-autogen, elixir-format
 msgid "Welcome back, %{name}!"
 msgstr "Willkommen zurück, %{name}!"
 
-#: lib/vutuv_web/controllers/session_controller.ex:420
+#: lib/vutuv_web/controllers/session_controller.ex:433
 #, elixir-autogen, elixir-format
 msgid "You have %{count} new message."
 msgid_plural "You have %{count} new messages."
@@ -2866,7 +2866,7 @@ msgid_plural "Followers"
 msgstr[0] "Follower"
 msgstr[1] "Follower"
 
-#: lib/vutuv_web/controllers/session_controller.ex:388
+#: lib/vutuv_web/controllers/session_controller.ex:401
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Willkommen bei vutuv, %{name}!"
@@ -3335,13 +3335,13 @@ msgid "The report is justified. The content stays hidden and the owner gets a st
 msgstr "Die Meldung ist berechtigt. Der Inhalt bleibt verborgen und der Besitzer erhält einen Verwarnungspunkt (verwarnen, sperren, deaktivieren)."
 
 #: lib/vutuv_web/controllers/session_controller.ex:269
-#: lib/vutuv_web/controllers/session_controller.ex:360
+#: lib/vutuv_web/controllers/session_controller.ex:373
 #, elixir-autogen, elixir-format
 msgid "This account has been deactivated."
 msgstr "Dieses Konto wurde deaktiviert."
 
 #: lib/vutuv_web/controllers/session_controller.ex:260
-#: lib/vutuv_web/controllers/session_controller.ex:351
+#: lib/vutuv_web/controllers/session_controller.ex:364
 #, elixir-autogen, elixir-format
 msgid "This account is suspended until %{date}."
 msgstr "Dieses Konto ist bis zum %{date} gesperrt."
@@ -5384,7 +5384,7 @@ msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr "Ihre Tags (z.B. JavaScript, Kochen, Origami, Katze)"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:29
+#: lib/vutuv_web/gettext_extraction_anchors.ex:30
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "divers"
@@ -7135,7 +7135,7 @@ msgstr[1] "minus %{count} Gruppen"
 msgid "open the dev email inbox"
 msgstr "Dev-Postfach öffnen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:32
+#: lib/vutuv_web/gettext_extraction_anchors.ex:34
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr "Vernetzt"
@@ -7925,7 +7925,7 @@ msgstr "Identität verifiziert. Das Mitglied wurde per E-Mail benachrichtigt."
 msgid "Identity-verified"
 msgstr "Identität verifiziert"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:30
+#: lib/vutuv_web/gettext_extraction_anchors.ex:31
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
 msgstr "Falscher PIN"
@@ -7961,7 +7961,7 @@ msgstr "Nicht bestätigt"
 msgid "Open the member browser"
 msgstr "Mitgliederübersicht öffnen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:31
+#: lib/vutuv_web/gettext_extraction_anchors.ex:32
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
 msgstr "PIN abgelaufen"
@@ -8273,7 +8273,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/controllers/session_controller.ex:405
+#: lib/vutuv_web/controllers/session_controller.ex:418
 #, elixir-autogen, elixir-format
 msgid "A photo and a short tagline make your profile complete."
 msgstr "Ein Foto und eine Kurzbeschreibung machen Ihr Profil komplett."
@@ -8683,3 +8683,13 @@ msgstr "Wenn aktiviert, ist Ihr Profil von Mastodon & Co. aus auffindbar und Ihr
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:33
+#, elixir-autogen, elixir-format
+msgid "This PIN has already been used."
+msgstr "Dieser PIN wurde bereits verwendet."
+
+#: lib/vutuv_web/controllers/session_controller.ex:322
+#, elixir-autogen, elixir-format
+msgid "This PIN was already used. If that was you, you are already signed in."
+msgstr "Dieser PIN wurde bereits verwendet. Falls Sie das waren, sind Sie bereits angemeldet."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -111,7 +111,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: lib/vutuv_web/controllers/email_controller.ex:238
+#: lib/vutuv_web/controllers/email_controller.ex:243
 #, elixir-autogen
 msgid "Cannot delete final email."
 msgstr ""
@@ -215,12 +215,12 @@ msgstr ""
 msgid "Email created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/email_controller.ex:234
+#: lib/vutuv_web/controllers/email_controller.ex:239
 #, elixir-autogen
 msgid "Email deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/email_controller.ex:218
+#: lib/vutuv_web/controllers/email_controller.ex:223
 #, elixir-autogen
 msgid "Email updated successfully."
 msgstr ""
@@ -792,7 +792,7 @@ msgstr ""
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:412
+#: lib/vutuv_web/controllers/session_controller.ex:425
 #, elixir-autogen
 msgid "Welcome back!"
 msgstr ""
@@ -946,12 +946,12 @@ msgstr ""
 msgid "Select a year"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:28
+#: lib/vutuv_web/gettext_extraction_anchors.ex:29
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:27
+#: lib/vutuv_web/gettext_extraction_anchors.ex:28
 #, elixir-autogen
 msgid "Male"
 msgstr ""
@@ -1387,9 +1387,9 @@ msgstr ""
 msgid "Tags"
 msgstr ""
 
-#: lib/vutuv_web/controllers/email_controller.ex:148
-#: lib/vutuv_web/controllers/session_controller.ex:371
-#: lib/vutuv_web/controllers/user_controller.ex:278
+#: lib/vutuv_web/controllers/email_controller.ex:153
+#: lib/vutuv_web/controllers/session_controller.ex:384
+#: lib/vutuv_web/controllers/user_controller.ex:283
 #, elixir-autogen
 msgid "Too many incorrect attempts."
 msgstr ""
@@ -2161,14 +2161,14 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:203
+#: lib/vutuv_web/controllers/post_controller.ex:205
 #, elixir-autogen, elixir-format
 msgid "Post deleted successfully."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/post_doc.ex:74
-#: lib/vutuv_web/controllers/post_controller.ex:51
-#: lib/vutuv_web/controllers/post_controller.ex:59
+#: lib/vutuv_web/controllers/post_controller.ex:54
+#: lib/vutuv_web/controllers/post_controller.ex:62
 #: lib/vutuv_web/controllers/user_controller.ex:72
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
 #: lib/vutuv_web/live/post_live/saved.ex:305
@@ -2335,7 +2335,7 @@ msgstr ""
 msgid "View all %{count} posts"
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:129
+#: lib/vutuv_web/controllers/post_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "All posts"
 msgstr ""
@@ -2433,7 +2433,7 @@ msgstr ""
 msgid "Unfollow"
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:392
+#: lib/vutuv_web/controllers/session_controller.ex:405
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv!"
 msgstr ""
@@ -2637,12 +2637,12 @@ msgstr ""
 msgid "Allow search engines to index your profile"
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:409
+#: lib/vutuv_web/controllers/session_controller.ex:422
 #, elixir-autogen, elixir-format
 msgid "Welcome back, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:420
+#: lib/vutuv_web/controllers/session_controller.ex:433
 #, elixir-autogen, elixir-format
 msgid "You have %{count} new message."
 msgid_plural "You have %{count} new messages."
@@ -2861,7 +2861,7 @@ msgid_plural "Followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:388
+#: lib/vutuv_web/controllers/session_controller.ex:401
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
@@ -3330,13 +3330,13 @@ msgid "The report is justified. The content stays hidden and the owner gets a st
 msgstr ""
 
 #: lib/vutuv_web/controllers/session_controller.ex:269
-#: lib/vutuv_web/controllers/session_controller.ex:360
+#: lib/vutuv_web/controllers/session_controller.ex:373
 #, elixir-autogen, elixir-format
 msgid "This account has been deactivated."
 msgstr ""
 
 #: lib/vutuv_web/controllers/session_controller.ex:260
-#: lib/vutuv_web/controllers/session_controller.ex:351
+#: lib/vutuv_web/controllers/session_controller.ex:364
 #, elixir-autogen, elixir-format
 msgid "This account is suspended until %{date}."
 msgstr ""
@@ -5374,7 +5374,7 @@ msgstr ""
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:29
+#: lib/vutuv_web/gettext_extraction_anchors.ex:30
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
@@ -7112,7 +7112,7 @@ msgstr[1] ""
 msgid "open the dev email inbox"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:32
+#: lib/vutuv_web/gettext_extraction_anchors.ex:34
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr ""
@@ -7894,7 +7894,7 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:30
+#: lib/vutuv_web/gettext_extraction_anchors.ex:31
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
 msgstr ""
@@ -7930,7 +7930,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:31
+#: lib/vutuv_web/gettext_extraction_anchors.ex:32
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
 msgstr ""
@@ -8234,7 +8234,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:405
+#: lib/vutuv_web/controllers/session_controller.ex:418
 #, elixir-autogen, elixir-format
 msgid "A photo and a short tagline make your profile complete."
 msgstr ""
@@ -8641,4 +8641,14 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:33
+#, elixir-autogen, elixir-format
+msgid "This PIN has already been used."
+msgstr ""
+
+#: lib/vutuv_web/controllers/session_controller.ex:322
+#, elixir-autogen, elixir-format
+msgid "This PIN was already used. If that was you, you are already signed in."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: lib/vutuv_web/controllers/email_controller.ex:238
+#: lib/vutuv_web/controllers/email_controller.ex:243
 #, elixir-autogen
 msgid "Cannot delete final email."
 msgstr ""
@@ -214,12 +214,12 @@ msgstr ""
 msgid "Email created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/email_controller.ex:234
+#: lib/vutuv_web/controllers/email_controller.ex:239
 #, elixir-autogen
 msgid "Email deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/email_controller.ex:218
+#: lib/vutuv_web/controllers/email_controller.ex:223
 #, elixir-autogen
 msgid "Email updated successfully."
 msgstr ""
@@ -791,7 +791,7 @@ msgstr ""
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:412
+#: lib/vutuv_web/controllers/session_controller.ex:425
 #, elixir-autogen
 msgid "Welcome back!"
 msgstr ""
@@ -945,12 +945,12 @@ msgstr ""
 msgid "Select a year"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:28
+#: lib/vutuv_web/gettext_extraction_anchors.ex:29
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:27
+#: lib/vutuv_web/gettext_extraction_anchors.ex:28
 #, elixir-autogen
 msgid "Male"
 msgstr ""
@@ -1386,9 +1386,9 @@ msgstr ""
 msgid "Tags"
 msgstr ""
 
-#: lib/vutuv_web/controllers/email_controller.ex:148
-#: lib/vutuv_web/controllers/session_controller.ex:371
-#: lib/vutuv_web/controllers/user_controller.ex:278
+#: lib/vutuv_web/controllers/email_controller.ex:153
+#: lib/vutuv_web/controllers/session_controller.ex:384
+#: lib/vutuv_web/controllers/user_controller.ex:283
 #, elixir-autogen
 msgid "Too many incorrect attempts."
 msgstr ""
@@ -2160,14 +2160,14 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:203
+#: lib/vutuv_web/controllers/post_controller.ex:205
 #, elixir-autogen, elixir-format
 msgid "Post deleted successfully."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/post_doc.ex:74
-#: lib/vutuv_web/controllers/post_controller.ex:51
-#: lib/vutuv_web/controllers/post_controller.ex:59
+#: lib/vutuv_web/controllers/post_controller.ex:54
+#: lib/vutuv_web/controllers/post_controller.ex:62
 #: lib/vutuv_web/controllers/user_controller.ex:72
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
 #: lib/vutuv_web/live/post_live/saved.ex:305
@@ -2334,7 +2334,7 @@ msgstr ""
 msgid "View all %{count} posts"
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:129
+#: lib/vutuv_web/controllers/post_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "All posts"
 msgstr ""
@@ -2432,7 +2432,7 @@ msgstr ""
 msgid "Unfollow"
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:392
+#: lib/vutuv_web/controllers/session_controller.ex:405
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv!"
 msgstr ""
@@ -2636,12 +2636,12 @@ msgstr ""
 msgid "Allow search engines to index your profile"
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:409
+#: lib/vutuv_web/controllers/session_controller.ex:422
 #, elixir-autogen, elixir-format
 msgid "Welcome back, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:420
+#: lib/vutuv_web/controllers/session_controller.ex:433
 #, elixir-autogen, elixir-format
 msgid "You have %{count} new message."
 msgid_plural "You have %{count} new messages."
@@ -2860,7 +2860,7 @@ msgid_plural "Followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:388
+#: lib/vutuv_web/controllers/session_controller.ex:401
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
@@ -3329,13 +3329,13 @@ msgid "The report is justified. The content stays hidden and the owner gets a st
 msgstr ""
 
 #: lib/vutuv_web/controllers/session_controller.ex:269
-#: lib/vutuv_web/controllers/session_controller.ex:360
+#: lib/vutuv_web/controllers/session_controller.ex:373
 #, elixir-autogen, elixir-format
 msgid "This account has been deactivated."
 msgstr ""
 
 #: lib/vutuv_web/controllers/session_controller.ex:260
-#: lib/vutuv_web/controllers/session_controller.ex:351
+#: lib/vutuv_web/controllers/session_controller.ex:364
 #, elixir-autogen, elixir-format
 msgid "This account is suspended until %{date}."
 msgstr ""
@@ -5373,7 +5373,7 @@ msgstr ""
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:29
+#: lib/vutuv_web/gettext_extraction_anchors.ex:30
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
@@ -7111,7 +7111,7 @@ msgstr[1] ""
 msgid "open the dev email inbox"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:32
+#: lib/vutuv_web/gettext_extraction_anchors.ex:34
 #, elixir-autogen, elixir-format
 msgid "Connected"
 msgstr ""
@@ -7893,7 +7893,7 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:30
+#: lib/vutuv_web/gettext_extraction_anchors.ex:31
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
 msgstr ""
@@ -7929,7 +7929,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:31
+#: lib/vutuv_web/gettext_extraction_anchors.ex:32
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
 msgstr ""
@@ -8233,7 +8233,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:405
+#: lib/vutuv_web/controllers/session_controller.ex:418
 #, elixir-autogen, elixir-format
 msgid "A photo and a short tagline make your profile complete."
 msgstr ""
@@ -8640,4 +8640,14 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:33
+#, elixir-autogen, elixir-format
+msgid "This PIN has already been used."
+msgstr ""
+
+#: lib/vutuv_web/controllers/session_controller.ex:322
+#, elixir-autogen, elixir-format
+msgid "This PIN was already used. If that was you, you are already signed in."
 msgstr ""

--- a/priv/repo/migrations/20260704113415_add_consumed_at_to_login_pins.exs
+++ b/priv/repo/migrations/20260704113415_add_consumed_at_to_login_pins.exs
@@ -1,0 +1,17 @@
+defmodule Vutuv.Repo.Migrations.AddConsumedAtToLoginPins do
+  use Ecto.Migration
+
+  # Records when a one-time PIN was successfully used, so a re-submission of an
+  # already-consumed PIN (a double-submit / back-navigation of the classic PIN
+  # form) can be told apart from a genuinely timed-out one. Before this, both
+  # collapsed to `minted_at = nil` and were reported to the member as "PIN
+  # expired" — even right after a successful login (issue #839).
+  #
+  # Plain nullable column addition: N-1 compatible, safe in a single deploy. The
+  # currently deployed release simply ignores it.
+  def change do
+    alter table(:login_pins) do
+      add(:consumed_at, :naive_datetime)
+    end
+  end
+end

--- a/test/vutuv/accounts_test.exs
+++ b/test/vutuv/accounts_test.exs
@@ -260,8 +260,34 @@ defmodule Vutuv.AccountsTest do
       assert {:ok, %User{id: id}} = Accounts.check_pin(user, pin, "delete")
       assert id == user.id
 
-      # A consumed PIN is expired and cannot be replayed.
-      assert {:expired, _} = Accounts.check_pin(user, pin, "delete")
+      # A consumed PIN cannot be replayed, and it is reported as "already used"
+      # rather than "expired": a double-submit of the classic PIN form right
+      # after a successful login must not tell the member their fresh PIN timed
+      # out (issue #839).
+      assert {:already_used, _} = Accounts.check_pin(user, pin, "delete")
+    end
+
+    test "a re-submitted consumed login PIN reads as already used, not expired (issue #839)" do
+      user = insert(:user)
+      insert(:email, user: user, value: "dup@example.com")
+      pin = Accounts.gen_pin_for(user, "login")
+
+      # First submit logs in and consumes the PIN; the classic (non-LiveView)
+      # PIN form can be posted twice (double-tap, back navigation, a retried
+      # request), and that duplicate must not surface as "PIN expired".
+      assert {:ok, %User{}} = Accounts.check_pin("dup@example.com", pin, "login")
+      assert {:already_used, _} = Accounts.check_pin("dup@example.com", pin, "login")
+    end
+
+    test "re-minting a PIN clears the consumed marker" do
+      user = insert(:user)
+      pin = Accounts.gen_pin_for(user, "delete")
+      assert {:ok, %User{}} = Accounts.check_pin(user, pin, "delete")
+      assert {:already_used, _} = Accounts.check_pin(user, pin, "delete")
+
+      # A freshly requested PIN starts a clean life — never seen as already used.
+      pin = Accounts.gen_pin_for(user, "delete")
+      assert {:ok, %User{}} = Accounts.check_pin(user, pin, "delete")
     end
 
     test "returns the carried value for the email-change flow" do

--- a/test/vutuv_web/controllers/csrf_pin_flows_test.exs
+++ b/test/vutuv_web/controllers/csrf_pin_flows_test.exs
@@ -49,6 +49,27 @@ defmodule VutuvWeb.CsrfPinFlowsTest do
       assert redirected_to(conn) == ~p"/feed"
     end
 
+    test "a double-submitted PIN reassures instead of reporting it expired (issue #839)" do
+      user = insert(:user, email_confirmed?: true)
+      insert(:email, value: "double@example.com", user: user)
+
+      conn = post(build_conn(), ~p"/login", session: %{"email" => "double@example.com"})
+      pin = sent_pin()
+
+      # First submit logs in and consumes the one-time PIN.
+      first = submit_with_csrf(conn, ~p"/login", %{"session" => %{"pin" => pin}})
+      assert get_session(first, :user_id) == user.id
+
+      # A second submit of the SAME PIN — a double-tap or back-navigation still
+      # carrying the pin cookie — must NOT tell the member their fresh PIN
+      # expired. It reassures them with an :info notice instead (the pre-#839
+      # bug flashed the "PIN expired" error even though they had just logged in).
+      second = submit_with_csrf(conn, ~p"/login", %{"session" => %{"pin" => pin}})
+      assert redirected_to(second) == ~p"/login"
+      refute Phoenix.Flash.get(second.assigns.flash, :error)
+      assert Phoenix.Flash.get(second.assigns.flash, :info) =~ "already"
+    end
+
     test "greets a returning member by name and counts their unread conversations" do
       user = insert(:user, email_confirmed?: true)
       insert(:email, value: "greet@example.com", user: user)


### PR DESCRIPTION
## What & why

Fixes #839. A member reported that a login PIN they entered right after receiving it was rejected as "out of date". They had actually **logged in successfully** — what they saw was a *duplicate submission* of the now-consumed one-time PIN being mislabeled "PIN expired".

### Root cause (confirmed from production, read-only)

| Evidence | Finding |
|---|---|
| PIN minted (`login_pins.inserted_at`) | 10:30:51 UTC |
| PIN email delivered (`mail.log`) | 10:30:52 UTC, `250 Ok`, **1.4s** — no greylisting → mail latency refuted |
| Server clock (`timedatectl`) | NTP synchronized, no steps → clock skew refuted |
| **Session created** (`user_sessions`) | **10:31:30 UTC** — login succeeded |
| `login_pins` now | `minted_at = NULL`, `pin_login_attempts = 0` |

`expire_pin/1` nulled `minted_at` to mean **three different things** (consumed-by-success / timed-out / locked-out), and `pin_expired?/1` reported all three as "expired". So a double-tap or back-navigation of the classic (non-LiveView) PIN form re-submitted the consumed PIN and got the scary "PIN abgelaufen" — even though the first submit had logged the member in.

## The change

- **`login_pins.consumed_at`** (new nullable `:naive_datetime`) is stamped on a successful verify. Additive column, **N-1 deploy-safe** (the current release ignores it).
- **`Vutuv.Accounts.check_pin/3`** now distinguishes outcomes: `{:already_used, _}` (consumed) vs `{:expired, _}` (genuine timeout) vs `:lockout` vs `{:error, _}`. A consumed PIN is checked **first**, so one-time semantics are preserved (no replay / re-login).
- **All three PIN controllers** (login, email-change, account-deletion) handle `{:already_used, _}` with a calm `:info` notice instead of an error. Login copy: *"This PIN was already used. If that was you, you are already signed in."* (DE: *"Dieser PIN wurde bereits verwendet. Falls Sie das waren, sind Sie bereits angemeldet."*).
- A dev/staging `Logger.info` names the rejection reason (`already_used` / `expired`), closing the diagnostic gap that slowed this investigation. **Note:** prod runs at Logger level `:error` (`config/prod.exs`), so this stays quiet in production; raising that level would make future PIN-rejection reasons visible.

## Testing

- `mix precommit` green (compile `--warnings-as-errors`, `credo --strict`, format, **2684 tests**).
- New/updated tests: a consumed PIN → `{:already_used}` not `{:expired}`; re-minting clears the marker; and a **CSRF-enforced double-submit** of the login form (`csrf_pin_flows_test.exs`) reassures instead of erroring.

## Deploy notes

- Single additive nullable column → one ordinary deploy, no downtime, no backfill.
- Touches auth/session/forms, so per project policy a **real-browser smoke test of the login flow is worth doing before deploy** (happy path + a deliberate double-submit). Happy to drive it.
- Version bumped to **v7.43.2** (patch). If it races the current `main` version, reconcile the bump at merge.

https://claude.ai/code/session_01KFCnnGPqBCayjM8qdq238C
