### PR TITLE
Revise the markup (and punctuation) of `bug_report.md`, to incentivise compliance.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,17 +1,28 @@
 ---
 name: Bug report
-about: Report a problem so we can fix it
+about: Report a problem, so that we can fix it
 title: ''
 labels: bug
 assignees: ''
 ---
 
-Please provide the following information to help us fix a bug or create a new feature faster.
-Remove parts which are irrelevant for this issue (like this sentences). If you report a bug 
-please add the exact time (including seconds and time zone) plus a screenshot to the issue.
+<!--
+
+Please provide the following information, to help us fix a bug, or create a new feature faster.
+
+Remove parts that are irrelevant for this issue (like these sentences).
+
+If you report a bug, please add the exact time (including seconds and time zone), plus a screenshot, to the issue.
+
+-->
 
 ### Expected behavior
 
+
+
 ### Actual behavior
 
+
+
 ### Steps to reproduce the behavior
+


### PR DESCRIPTION
- Corrected grammar in instructions ("these" replaces "this").

- Delineated clauses.

- Rendered advice/instructions invisible, so that removal is not required.

- Added space for values beneath headings, to incentivise correct CommonMark spacing (1 × `\n`).