### PR TITLE
Jobs 9/9: /api/2.0 jobs + organizations endpoints and job.published webhook (#936)

### DIFF
--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -30,8 +30,14 @@ identities), follow/unfollow (a mutual follow makes the pair vernetzt — no
 separate connection lifecycle) + `GET …/relationship`, posts (compose with
 deny-based audiences, replies, like/bookmark/repost switches, the
 cursor-paginated `/feed` with signed opaque cursors), direct messages (request
-model included; a declined request stays indistinguishable from silence) and the
-notification feed.
+model included; a declined request stays indistinguishable from silence), the
+notification feed, and **jobs + organizations** (issue #936, `jobs:read` /
+`jobs:write`): the viewer-scoped board `GET /jobs` (same filters as the website),
+`GET /jobs/:id`, the poster's own lifecycle `POST /jobs` (create or publish),
+`PATCH /jobs/:id`, `POST /jobs/:id/closure`, `DELETE /jobs/:id` (all through the
+same `Vutuv.Jobs` changesets, quota gate and 90-day lifecycle as the `/jobs`
+forms — an API posting is indistinguishable), plus read-only `GET /organizations`
+and `GET /organizations/:slug`. Applications and people search stay out of scope.
 
 Per-token rate limit (5,000/h, `X-RateLimit-*` headers), RFC 9457 problem+json
 errors (422 with per-field messages), additive-only within `/api/2.0` (breaking
@@ -49,13 +55,19 @@ that fails every app token on its next request), members approve scopes on the
 envelopes (HMAC-SHA256 in `X-Vutuv-Signature`, ids/usernames only, never
 content) for members who granted the matching scope; DB-backed queue with
 exponential backoff drained by `Vutuv.Webhooks.Deliverer`, auto-disable after
-sustained failure, test ping from the app page.
+sustained failure, test ping from the app page. The one exception to the
+content-free envelope is `job.published` (issue #936, needs the poster's
+`jobs:read` grant, emitted from `Vutuv.Jobs.publish/4`): because a published
+posting is public, its payload carries the posting's public structured fields
+(title, location, salary, tags) so an integrator can mirror an opening without a
+follow-up fetch.
 
 Developer docs in English with curl examples at `/developers` (Markdown files in
 `priv/dev_docs/`, also served raw under `.md`): overview with a
 development/bug-reporting section, authentication, a task-recipe cookbook ("how
 do I post / send a DM?"), the data model (entities + visibility rules), the
-endpoint reference and webhooks — linked from the footer of every page.
+endpoint reference, the Jobs API chapter (postings, organizations, lifecycle,
+`job.published`) and webhooks — linked from the footer of every page.
 
 API profile responses carry the member's `noindex?`/`noai?` consent flags
 in-band (the public `.json`/`.md` siblings signal the same via

--- a/docs/architecture/jobs.md
+++ b/docs/architecture/jobs.md
@@ -264,3 +264,19 @@ The detail page carries `JobPosting` JSON-LD (only when `indexable?`), with
 `applicantLocationRequirements` for remote, `baseSalary`, `skills` from the tags
 (required first) and `hiringOrganization`. The `.md/.txt/.json/.xml` siblings
 come from `VutuvWeb.AgentDocs.JobPostingDoc` (drift-tested against the HTML).
+
+## `/api/2.0` (issue #936)
+
+The whole lifecycle is a second door on the same room: `VutuvWeb.ApiV2.JobController`
+(`jobs:read`/`jobs:write`) reuses the exact `Vutuv.Jobs` context — `board_page/3`
++ `board_filters/2` for `GET /jobs`, `create_draft/3`/`publish/4`/`update_posting/4`/
+`close/2`/`delete_job_posting/1` for the writes — so an API posting is
+indistinguishable from a form one (same quotas, gate, validations, 90-day
+lifecycle). Responses reuse `JobPostingDoc` (`api_show/1` = the public show doc
+plus the owner-only `id`/`status`/`street_address`/`coordinates`/close fields,
+never drifting from the shared shape). `VutuvWeb.ApiV2.OrganizationController`
+serves the organization directory + page read-only from `OrganizationDoc`. A
+successful **first** publish (draft → published, never an edit) emits the
+`job.published` webhook from `Vutuv.Jobs.publish/4` — the one topic whose payload
+carries the posting's public structured fields (see the API subsystem doc). Full
+developer reference: `priv/dev_docs/jobs.md` (`/developers/jobs`).

--- a/lib/vutuv/api_auth/scopes.ex
+++ b/lib/vutuv/api_auth/scopes.ex
@@ -18,6 +18,7 @@ defmodule Vutuv.ApiAuth.Scopes do
     social:read social:write
     posts:read posts:write
     messages:read messages:write
+    jobs:read jobs:write
   )
 
   def all, do: @scopes
@@ -62,4 +63,10 @@ defmodule Vutuv.ApiAuth.Scopes do
 
   def description("messages:write"),
     do: gettext("Send messages as you")
+
+  def description("jobs:read"),
+    do: gettext("Read job postings and organization pages visible to you")
+
+  def description("jobs:write"),
+    do: gettext("Post, edit and close job openings as you")
 end

--- a/lib/vutuv/jobs.ex
+++ b/lib/vutuv/jobs.ex
@@ -341,7 +341,61 @@ defmodule Vutuv.Jobs do
       |> after_save(user, attrs)
       |> broadcast_updated()
       |> board_ping()
+      |> emit_published(user, posting.status)
     end
+  end
+
+  # Fire the `job.published` webhook only on the transition *into* published (a
+  # fresh draft going live), never on an edit that re-publishes an already-live
+  # posting — integrators subscribe to hear about new openings, not every save.
+  defp emit_published({:ok, %JobPosting{} = posting} = result, %User{} = user, previous_status)
+       when previous_status != :published do
+    Vutuv.Webhooks.emit(user.id, "job.published", published_webhook_data(posting))
+    result
+  end
+
+  defp emit_published(result, _user, _previous_status), do: result
+
+  # The public structured fields of a published posting (the same the board
+  # shows), so a subscriber can mirror the opening with real filter data. Thin
+  # by the webhook contract's spirit: only what already sits on the public page.
+  defp published_webhook_data(%JobPosting{} = posting) do
+    %{
+      "id" => posting.id,
+      "url" => VutuvWeb.Endpoint.url() <> "/jobs/" <> posting.slug,
+      "title" => posting.title,
+      "employer" => webhook_employer(posting),
+      "employment_type" => Atom.to_string(posting.employment_type),
+      "workplace_type" => Atom.to_string(posting.workplace_type),
+      "zip_code" => posting.zip_code,
+      "city" => posting.city,
+      "country" => posting.country,
+      "remote_countries" => posting.remote_countries,
+      "salary" => webhook_salary(posting),
+      "tags" => posting |> all_tags() |> Enum.map(& &1.name)
+    }
+  end
+
+  defp webhook_employer(%JobPosting{organization: %Organizations.Organization{name: name}}),
+    do: name
+
+  defp webhook_employer(%JobPosting{hiring_org_name: name}) when is_binary(name), do: name
+
+  defp webhook_employer(%JobPosting{user: %User{} = user}),
+    do: VutuvWeb.UserHelpers.full_name(user)
+
+  defp webhook_employer(_), do: nil
+
+  defp webhook_salary(%JobPosting{employment_type: :volunteer}), do: nil
+  defp webhook_salary(%JobPosting{salary_min: nil}), do: nil
+
+  defp webhook_salary(%JobPosting{} = posting) do
+    %{
+      "min" => posting.salary_min,
+      "max" => posting.salary_max,
+      "currency" => posting.salary_currency,
+      "period" => posting.salary_period
+    }
   end
 
   @doc "Closes a live posting with a reason (`:filled`/`:withdrawn`)."

--- a/lib/vutuv/sitemap.ex
+++ b/lib/vutuv/sitemap.ex
@@ -23,7 +23,7 @@ defmodule Vutuv.Sitemap do
   # Keep `@dev_doc_pages` in sync with VutuvWeb.DevDocController's registry — a
   # drift test (sitemap_dev_docs_test.exs) fails the build if a dev-doc page is
   # added there without appearing in the sitemap.
-  @dev_doc_pages ~w(authentication cookbook data-model reference webhooks)
+  @dev_doc_pages ~w(authentication cookbook data-model reference jobs webhooks)
 
   @static_paths [
                   "/",

--- a/lib/vutuv/webhooks.ex
+++ b/lib/vutuv/webhooks.ex
@@ -43,7 +43,13 @@ defmodule Vutuv.Webhooks do
     "endorsement.created" => "social:read",
     "post.liked" => "posts:read",
     "post.replied" => "posts:read",
-    "message.created" => "messages:read"
+    "message.created" => "messages:read",
+    # The poster's own event, so it rides on their `jobs:read` grant. Unlike
+    # every other topic this payload carries the posting's public structured
+    # fields (title, location, salary, tags), never anything private — a
+    # published posting is public, and integrators mirror new openings without
+    # a follow-up fetch. Emitted from `Vutuv.Jobs.publish/4`.
+    "job.published" => "jobs:read"
   }
 
   @max_attempts 8

--- a/lib/vutuv_web/agent_docs/job_posting_doc.ex
+++ b/lib/vutuv_web/agent_docs/job_posting_doc.ex
@@ -42,6 +42,35 @@ defmodule VutuvWeb.AgentDocs.JobPostingDoc do
   end
 
   @doc """
+  The authenticated `/api/2.0/jobs/:id` detail doc: the public show doc plus the
+  fields an owner's tooling needs — the id, the effective lifecycle status and
+  its dates, the raw visibility, the street address and resolved coordinates.
+  Reuses `build_show/1` so the shared fields never drift from the public page.
+  """
+  def api_show(%JobPosting{} = posting) do
+    build_show(posting)
+    |> Map.merge(%{
+      id: posting.id,
+      status: Atom.to_string(Jobs.effective_status(posting)),
+      visibility: Atom.to_string(posting.visibility),
+      street_address: posting.street_address,
+      coordinates: coordinates(posting),
+      closed_at: AgentDocs.iso_date(posting.closed_at),
+      close_reason: posting.close_reason && Atom.to_string(posting.close_reason)
+    })
+  end
+
+  @doc "A board listing entry for the API — `summary/1` plus the posting id."
+  def api_summary(%JobPosting{} = posting) do
+    Map.put(summary(posting), :id, posting.id)
+  end
+
+  defp coordinates(%JobPosting{lat: lat, lon: lon}) when is_float(lat) and is_float(lon),
+    do: %{lat: lat, lon: lon}
+
+  defp coordinates(_), do: nil
+
+  @doc """
   The compact card entry of a posting for a **listing** doc — the board
   (`/jobs`) and the organization / tag "Offene Stellen" sections. Carries the
   same structured location, salary and tag fields as the detail doc so agents

--- a/lib/vutuv_web/controllers/api_v2/job_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/job_controller.ex
@@ -1,0 +1,301 @@
+defmodule VutuvWeb.ApiV2.JobController do
+  @moduledoc """
+  Job postings over the API (issue #936) — the second door to the same room as
+  the `/jobs` forms. Every write runs through the exact `Vutuv.Jobs` changesets
+  and policies (the 90-day lifecycle, the anti-abuse gate, organization
+  attribution only with a role, the salary/AGG/location validations), so an API
+  posting is indistinguishable from a form posting and fires the same
+  `job.published` webhook.
+
+  Reads (`jobs:read`): `GET /jobs` (the viewer-scoped board, cursor-paginated,
+  the same filters as `/jobs`), `GET /jobs/:id` (one posting — the owner sees any
+  state, a stranger only a live published one). Writes (`jobs:write`, own
+  postings only): `POST /jobs` (create a draft, or `publish: true` to go live in
+  one call), `PATCH /jobs/:id` (edit, or publish a draft), `POST /jobs/:id/closure`
+  (close with `filled`/`withdrawn`), `DELETE /jobs/:id` (discard a draft).
+  """
+
+  use VutuvWeb, :controller
+
+  alias Vutuv.Jobs
+  alias Vutuv.Jobs.JobPosting
+  alias Vutuv.Organizations
+  alias Vutuv.UUIDv7
+  alias VutuvWeb.AgentDocs.JobPostingDoc
+  alias VutuvWeb.ApiV2
+  alias VutuvWeb.ApiV2.Problem
+
+  # ── Reads ──
+
+  def index(conn, params) do
+    viewer = conn.assigns.current_user
+
+    ApiV2.with_cursor(conn, params, fn cursor ->
+      filters = Jobs.board_filters(normalize_filters(params), viewer)
+      page = Jobs.board_page(viewer, filters, cursor: cursor, limit: ApiV2.page_limit(params))
+
+      doc = %{
+        type: "jobs",
+        jobs: Enum.map(page.entries, &JobPostingDoc.api_summary/1),
+        more: page.more?,
+        next_cursor: ApiV2.encode_cursor(page.more? && page.cursor)
+      }
+
+      ApiV2.send_json(conn, doc)
+    end)
+  end
+
+  def show(conn, %{"id" => id}) do
+    case fetch_readable_job(id, conn.assigns.current_user) do
+      {:ok, posting} -> ApiV2.send_json(conn, JobPostingDoc.api_show(posting))
+      :error -> Problem.not_found(conn)
+    end
+  end
+
+  # ── Writes ──
+
+  def create(conn, params) do
+    user = conn.assigns.current_user
+
+    case resolve_organization(Map.get(params, "organization"), user) do
+      {:ok, organization} -> do_create(conn, user, params, organization)
+      {:error, reason} -> organization_error(conn, reason)
+    end
+  end
+
+  defp do_create(conn, user, params, organization) do
+    if truthy(params["publish"]) do
+      create_and_publish(conn, user, params, organization)
+    else
+      case Jobs.create_draft(user, params, organization: organization) do
+        {:ok, posting} -> ApiV2.send_json(conn, JobPostingDoc.api_show(posting), 201)
+        {:error, %Ecto.Changeset{} = changeset} -> Problem.validation_failed(conn, changeset)
+      end
+    end
+  end
+
+  # POST /jobs with publish:true is atomic — a failed publish deletes the draft
+  # so there is never an orphan; the client gets a published posting or a clean
+  # error and nothing created.
+  defp create_and_publish(conn, user, params, organization) do
+    case Jobs.create_draft(user, params, organization: organization) do
+      {:error, %Ecto.Changeset{} = changeset} ->
+        Problem.validation_failed(conn, changeset)
+
+      {:ok, draft} ->
+        case Jobs.publish(draft, user, params, organization: organization) do
+          {:ok, posting} ->
+            ApiV2.send_json(conn, JobPostingDoc.api_show(posting), 201)
+
+          {:error, reason} ->
+            Jobs.delete_job_posting(draft)
+            publish_error(conn, reason)
+        end
+    end
+  end
+
+  def update(conn, %{"id" => id} = params) do
+    user = conn.assigns.current_user
+
+    case fetch_own_job(id, user) do
+      {:ok, posting} -> do_update(conn, posting, user, params)
+      :error -> Problem.not_found(conn)
+    end
+  end
+
+  defp do_update(conn, posting, user, params) do
+    cond do
+      Jobs.effective_status(posting) in [:expired, :closed] ->
+        Problem.send_problem(conn, 409, "Not editable",
+          detail: "An expired or closed posting cannot be edited or reopened — repost instead.",
+          extra: %{reason: :not_editable}
+        )
+
+      posting.status == :draft and truthy(params["publish"]) ->
+        publish_draft(conn, posting, user, params)
+
+      true ->
+        edit_posting(conn, posting, user, params)
+    end
+  end
+
+  defp publish_draft(conn, posting, user, params) do
+    with {:ok, organization} <- organization_for_update(params, posting, user),
+         {:ok, published} <- Jobs.publish(posting, user, params, organization: organization) do
+      ApiV2.send_json(conn, JobPostingDoc.api_show(published))
+    else
+      {:error, {:organization, reason}} -> organization_error(conn, reason)
+      {:error, reason} -> publish_error(conn, reason)
+    end
+  end
+
+  defp edit_posting(conn, posting, user, params) do
+    with {:ok, organization} <- organization_for_update(params, posting, user),
+         {:ok, updated} <- Jobs.update_posting(posting, user, params, organization: organization) do
+      ApiV2.send_json(conn, JobPostingDoc.api_show(updated))
+    else
+      {:error, {:organization, reason}} -> organization_error(conn, reason)
+      {:error, %Ecto.Changeset{} = changeset} -> Problem.validation_failed(conn, changeset)
+    end
+  end
+
+  def close(conn, %{"id" => id} = params) do
+    user = conn.assigns.current_user
+
+    with {:ok, posting} <- fetch_own_job(id, user),
+         {:ok, reason} <- parse_close_reason(params["reason"]),
+         true <- Jobs.effective_status(posting) in [:published, :expired] do
+      {:ok, closed} = Jobs.close(posting, reason)
+      ApiV2.send_json(conn, JobPostingDoc.api_show(closed))
+    else
+      :error ->
+        Problem.not_found(conn)
+
+      {:error, :bad_reason} ->
+        Problem.send_problem(conn, 422, "Validation failed",
+          detail: "reason must be \"filled\" or \"withdrawn\".",
+          extra: %{errors: %{reason: ["is invalid"]}}
+        )
+
+      false ->
+        Problem.send_problem(conn, 409, "Not closeable",
+          detail: "Only a live posting can be closed.",
+          extra: %{reason: :not_closeable}
+        )
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+
+    case fetch_own_job(id, user) do
+      {:ok, %JobPosting{status: :draft} = posting} ->
+        {:ok, _deleted} = Jobs.delete_job_posting(posting)
+        send_resp(conn, 204, "")
+
+      {:ok, _published} ->
+        Problem.send_problem(conn, 409, "Cannot discard",
+          detail: "Only a draft can be discarded; close a published posting instead.",
+          extra: %{reason: :not_draft}
+        )
+
+      :error ->
+        Problem.not_found(conn)
+    end
+  end
+
+  # ── Internals ──
+
+  # A posting the viewer may read: the owner sees any state (their tooling needs
+  # the final state of an expired/closed posting); everyone else only a currently
+  # live, published one, mirroring the public detail page's visibility gate.
+  defp fetch_readable_job(id, viewer) do
+    fetch_job(id, fn posting ->
+      Jobs.owner?(posting, viewer) or
+        (Jobs.visible_to?(posting, viewer) and Jobs.effective_status(posting) == :published)
+    end)
+  end
+
+  defp fetch_own_job(id, user), do: fetch_job(id, &Jobs.owner?(&1, user))
+
+  defp fetch_job(id, allow?) do
+    with uuid when is_binary(uuid) <- UUIDv7.cast_or_nil(id),
+         %JobPosting{} = posting <- Jobs.get_job_posting(uuid),
+         true <- allow?.(posting) do
+      {:ok, Jobs.preload_for_show(posting)}
+    else
+      _missing_or_hidden -> :error
+    end
+  end
+
+  # `organization` in the body attributes the posting to a verified organization
+  # page — only a role holder may, otherwise a clean "attribution denied". A
+  # missing key on an update keeps the current attribution.
+  defp resolve_organization(nil, _user), do: {:ok, nil}
+  defp resolve_organization("", _user), do: {:ok, nil}
+
+  defp resolve_organization(slug, user) when is_binary(slug) do
+    case Organizations.get_organization_by_slug(slug) do
+      nil ->
+        {:error, :unknown_organization}
+
+      org ->
+        if Organizations.can_manage?(org, user),
+          do: {:ok, org},
+          else: {:error, :attribution_denied}
+    end
+  end
+
+  defp resolve_organization(_other, _user), do: {:ok, nil}
+
+  defp organization_for_update(params, posting, user) do
+    if Map.has_key?(params, "organization") do
+      case resolve_organization(params["organization"], user) do
+        {:ok, org} -> {:ok, org}
+        {:error, reason} -> {:error, {:organization, reason}}
+      end
+    else
+      {:ok, posting.organization}
+    end
+  end
+
+  defp organization_error(conn, :attribution_denied) do
+    Problem.send_problem(conn, 403, "Attribution denied",
+      detail: "You need a role at that organization to post on its behalf.",
+      extra: %{reason: :attribution_denied}
+    )
+  end
+
+  defp organization_error(conn, :unknown_organization) do
+    Problem.send_problem(conn, 422, "Unknown organization",
+      detail: "No verified organization has that slug.",
+      extra: %{reason: :unknown_organization}
+    )
+  end
+
+  defp publish_error(conn, %Ecto.Changeset{} = changeset),
+    do: Problem.validation_failed(conn, changeset)
+
+  defp publish_error(conn, :email_unconfirmed) do
+    Problem.send_problem(conn, 403, "Email unconfirmed",
+      detail: "Confirm your email address before publishing.",
+      extra: %{reason: :email_unconfirmed}
+    )
+  end
+
+  defp publish_error(conn, :account_too_new) do
+    Problem.send_problem(conn, 403, "Account too new",
+      detail: "Your account is not old enough to publish a job posting yet.",
+      extra: %{reason: :account_too_new}
+    )
+  end
+
+  defp publish_error(conn, reason) when reason in [:member_quota, :organization_quota] do
+    Problem.send_problem(conn, 409, "Quota exceeded",
+      detail: "You have reached the maximum number of concurrently published postings.",
+      extra: %{reason: reason}
+    )
+  end
+
+  defp parse_close_reason(reason) when reason in ["filled", "withdrawn"],
+    do: {:ok, String.to_existing_atom(reason)}
+
+  defp parse_close_reason(_other), do: {:error, :bad_reason}
+
+  # The board's filter parser reads `workplace`/`employment`; accept the API's
+  # documented `workplace_type`/`employment_type` names as aliases.
+  defp normalize_filters(params) do
+    params
+    |> alias_param("workplace_type", "workplace")
+    |> alias_param("employment_type", "employment")
+  end
+
+  defp alias_param(params, from, to) do
+    case params[from] do
+      nil -> params
+      value -> Map.put_new(params, to, value)
+    end
+  end
+
+  defp truthy(value), do: value in [true, "true", "1", "on", 1]
+end

--- a/lib/vutuv_web/controllers/api_v2/organization_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/organization_controller.ex
@@ -1,0 +1,73 @@
+defmodule VutuvWeb.ApiV2.OrganizationController do
+  @moduledoc """
+  Verified organization pages over the API (issue #936, `jobs:read`) — read-only,
+  the same doc the public `.json` pages serve (`VutuvWeb.AgentDocs.OrganizationDoc`),
+  so HR tooling can resolve the employer behind a posting.
+
+  `GET /organizations` lists verified organizations (paginated, `?q=` search);
+  `GET /organizations/:slug` returns one page with its aliases, verified domains,
+  postal address, linked people and open positions.
+  """
+
+  use VutuvWeb, :controller
+
+  alias Vutuv.Jobs
+  alias Vutuv.Organizations
+  alias VutuvWeb.AgentDocs.OrganizationDoc
+  alias VutuvWeb.ApiV2
+  alias VutuvWeb.ApiV2.Problem
+
+  def index(conn, params) do
+    page = Organizations.directory_page(page: parse_page(params["page"]), search: params["q"])
+
+    doc =
+      page.entries
+      |> OrganizationDoc.build_index(page.total)
+      |> Map.merge(%{page: page.page, total_pages: page.total_pages})
+
+    ApiV2.send_json(conn, doc)
+  end
+
+  # Resolve by slug or by a claimed root handle (issue #941): the public page is
+  # reachable both ways (`/organizations/:slug` and `/:handle`), and the listing's
+  # `url` points at the canonical path — a handle for a handle-holding
+  # organization — so a consumer that parses the last URL segment must resolve
+  # against either.
+  def show(conn, %{"slug" => slug}) do
+    viewer = conn.assigns.current_user
+
+    with {:error, :not_found} <- Organizations.fetch_visible_organization(slug, viewer),
+         {:error, :not_found} <-
+           Organizations.fetch_visible_organization_by_username(slug, viewer) do
+      Problem.not_found(conn)
+    else
+      {:ok, organization} -> ApiV2.send_json(conn, organization_doc(organization))
+    end
+  end
+
+  defp organization_doc(organization) do
+    domains = Organizations.verified_domains(organization)
+    aliases = Organizations.list_aliases(organization)
+    people = Organizations.organization_people_page(organization, limit: 200)
+    total = Organizations.organization_people_count(organization)
+    open_positions = Jobs.list_organization_postings(organization, limit: 200).entries
+
+    OrganizationDoc.build_show(
+      organization,
+      domains,
+      aliases,
+      people.entries,
+      total,
+      open_positions
+    )
+  end
+
+  defp parse_page(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {n, _} when n >= 1 -> n
+      _invalid -> 1
+    end
+  end
+
+  defp parse_page(_value), do: 1
+end

--- a/lib/vutuv_web/controllers/dev_doc_controller.ex
+++ b/lib/vutuv_web/controllers/dev_doc_controller.ex
@@ -19,6 +19,7 @@ defmodule VutuvWeb.DevDocController do
     {"cookbook", "Cookbook", "Cookbook"},
     {"data-model", "The data model", "Data model"},
     {"reference", "API reference", "Reference"},
+    {"jobs", "Jobs API", "Jobs"},
     {"webhooks", "Webhooks", "Webhooks"}
   ]
 

--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -266,7 +266,8 @@ defmodule VutuvWeb.PageController do
   raw Markdown at `/developers.md`, `/developers/authentication.md`,
   `/developers/cookbook.md` (task recipes: posting, direct messages, ...),
   `/developers/data-model.md` (entities and visibility rules),
-  `/developers/reference.md` and `/developers/webhooks.md`.
+  `/developers/reference.md`, `/developers/jobs.md` (job postings and
+  organizations) and `/developers/webhooks.md`.
 
   vutuv is open source: https://github.com/wintermeyer/vutuv — bug reports
   and feature requests via GitHub issues.

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -716,6 +716,22 @@ defmodule VutuvWeb.Router do
       assigns: %{api_scope: "social:write"}
     )
 
+    # Jobs (issue #936): the viewer-scoped board and one posting (jobs:read),
+    # then the poster's own lifecycle — create/edit/publish, close, discard a
+    # draft (jobs:write). Every write runs the same Vutuv.Jobs changesets and
+    # policies as the /jobs forms, so an API posting is indistinguishable.
+    get("/jobs", JobController, :index, assigns: %{api_scope: "jobs:read"})
+    get("/jobs/:id", JobController, :show, assigns: %{api_scope: "jobs:read"})
+    post("/jobs", JobController, :create, assigns: %{api_scope: "jobs:write"})
+    patch("/jobs/:id", JobController, :update, assigns: %{api_scope: "jobs:write"})
+    post("/jobs/:id/closure", JobController, :close, assigns: %{api_scope: "jobs:write"})
+    delete("/jobs/:id", JobController, :delete, assigns: %{api_scope: "jobs:write"})
+
+    # Verified organization pages, read-only (the employer behind a posting).
+    get("/organizations", OrganizationController, :index, assigns: %{api_scope: "jobs:read"})
+
+    get("/organizations/:slug", OrganizationController, :show, assigns: %{api_scope: "jobs:read"})
+
     # JSON 404 for unknown API paths — without this they would fall through
     # to the HTML profile routes. Also the CORS preflight's match. The one
     # route that legitimately needs no scope.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.99.0",
+      version: "7.100.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/dev_docs/authentication.md
+++ b/priv/dev_docs/authentication.md
@@ -54,6 +54,8 @@ A token only ever does what its scopes allow. A `*:write` scope implies its
 | `posts:write`    | Write, edit and delete your posts |
 | `messages:read`  | Read your messages |
 | `messages:write` | Send messages as you |
+| `jobs:read`      | Read job postings and organization pages visible to you |
+| `jobs:write`     | Post, edit and close job openings as you |
 
 Request only the scopes you will use — members see the list when they
 create the token, and a narrow token is an easy yes.

--- a/priv/dev_docs/jobs.md
+++ b/priv/dev_docs/jobs.md
@@ -1,0 +1,291 @@
+# Jobs API
+
+Post, manage and read job openings and the organizations behind them, so an
+HR tool never has to drive the browser. Two scopes:
+
+* `jobs:read` — read the board, one posting, and organization pages (the same
+  a signed-in member sees on the website).
+* `jobs:write` — create, edit, publish, close and discard **your own** postings.
+  Implies `jobs:read`.
+
+Base URL `https://vutuv.de/api/2.0`, bearer token, `application/problem+json`
+errors — see [the reference](/developers/reference) and
+[authentication](/developers/authentication). In the examples `$API` is
+`https://vutuv.de/api/2.0` and `auth()` adds your token:
+
+```bash
+export VUTUV_TOKEN="vutuv_pat_..."
+export API="https://vutuv.de/api/2.0"
+auth() { curl -sS -H "Authorization: Bearer $VUTUV_TOKEN" "$@"; }
+```
+
+## The lifecycle
+
+A posting is not a rented slot you keep bumping — it lives at most 90 days,
+then it is honestly done:
+
+```text
+draft ──publish──▶ published ──90 days pass──▶ expired ──30 days──▶ owner-only
+                     │
+                     └──closure (filled | withdrawn)──▶ closed
+```
+
+* **Publishing** stamps `expires_on` to 90 days out. There is **no renewal
+  endpoint** — a role that is still open gets a fresh posting (a new URL, an
+  honest `posted_on`), so nothing on the board is ever older than 90 days.
+* An **expired or closed** posting cannot be edited or reopened; `PATCH` and
+  the publish flow refuse it (`409`, `reason: not_editable`). Repost instead:
+  read the old posting, `POST` its fields as a new draft.
+* The API posts through the exact same `Vutuv.Jobs` changesets and policies as
+  the website — quotas, the account-age gate, organization attribution only
+  with a role, the salary and anti-discrimination checks, the rate limiter. An
+  API posting is indistinguishable from a form one.
+
+`status` in a response is the **effective** status: a published posting past
+its `expires_on` reads as `expired` even before the nightly sweeper flips it.
+
+## Read the board
+
+### GET /jobs
+
+Scope `jobs:read`. The viewer-scoped public board, newest first,
+cursor-paginated. Same filters as the website's `/jobs`:
+
+| Query param | Meaning |
+|-------------|---------|
+| `q` | full-text over title + description |
+| `tag` | a tag slug the posting carries |
+| `near` + `radius` | a city or postal code, and one of `10`/`25`/`50`/`100` km |
+| `country` | an ISO 3166-1 alpha-2 code (`DE`), remote postings match on applicant country |
+| `salary_min` | a yearly figure, or `mine` for your own stored expectation |
+| `workplace_type` | `onsite` / `hybrid` / `remote` |
+| `employment_type` | `full_time`, `part_time`, `contract`, … |
+| `my_tags` | `1` to keep only postings matching a tag on your profile |
+
+```bash
+auth "$API/jobs?near=Köln&radius=50&salary_min=60000&limit=25"
+auth "$API/jobs?cursor=NEXT_CURSOR_FROM_LAST_PAGE"
+```
+
+```json
+{
+  "type": "jobs",
+  "jobs": [
+    {"id": "0190…", "title": "Backend Engineer (m/w/d)",
+     "url": "https://vutuv.de/jobs/backend-engineer-…",
+     "employer": {"name": "ACME GmbH", "verified": true, "url": "…"},
+     "employment_type": "Full-time", "workplace_type": "On-site",
+     "location": {"zip_code": "50667", "city": "Köln", "country": "DE",
+                  "country_name": "Germany"},
+     "remote_countries": [],
+     "salary": {"min": 60000, "max": 80000, "currency": "EUR", "period": "year"},
+     "tags": [{"name": "Elixir", "slug": "elixir", "url": "…"}]}
+  ],
+  "more": true,
+  "next_cursor": "SFMyNTY…"
+}
+```
+
+The board lists only live, published, publicly visible postings you are allowed
+to see; blocks and members-only visibility are applied server-side.
+
+### GET /jobs/:id
+
+Scope `jobs:read`. One posting by its `id`, with the full structured location,
+salary, tags and its lifecycle `status` + dates. As the **owner** you read a
+posting in any state (your tooling needs the final state of an expired or closed
+one); everyone else reads only a currently live, published posting (`404`
+otherwise).
+
+```bash
+auth $API/jobs/0190abcd-…
+```
+
+```json
+{
+  "type": "job_posting",
+  "id": "0190…",
+  "status": "published",
+  "visibility": "everyone",
+  "title": "Backend Engineer (m/w/d)",
+  "description": "We are hiring …",
+  "employer": {"name": "ACME GmbH", "verified": true, "url": "…"},
+  "employment_type": "Full-time",
+  "workplace_type": "On-site",
+  "location": {"zip_code": "50667", "city": "Köln", "country": "DE",
+               "country_name": "Germany"},
+  "street_address": "Domkloster 4",
+  "coordinates": {"lat": 50.9413, "lon": 6.9583},
+  "remote_countries": [],
+  "salary": {"min": 60000, "max": 80000, "currency": "EUR", "period": "year"},
+  "language": "de",
+  "posted_on": "2026-07-14",
+  "expires_on": "2026-10-12",
+  "closed_at": null,
+  "close_reason": null,
+  "required_tags": [{"name": "Elixir", "slug": "elixir", "url": "…"}],
+  "nice_to_have_tags": [],
+  "apply": {"kind": "url", "target": "https://acme.example/careers/42"}
+}
+```
+
+## Write your postings
+
+### POST /jobs
+
+Scope `jobs:write`. Create a draft, or publish in one call with
+`"publish": true`. Fields (all optional on a draft except `title`):
+
+`title`, `hiring_org_name` (free-text employer for a personal posting),
+`description` (Markdown), `employment_type`, `workplace_type`,
+`street_address`, `zip_code`, `city`, `country`, `remote_countries` (a list of
+ISO codes, for a remote posting), `salary_min`, `salary_max`,
+`salary_currency` (default `EUR`), `salary_period` (default `year`),
+`apply_kind` (`url`/`email`/`message`), `apply_url`, `apply_email`,
+`language`, `visibility` (`everyone`/`members`), `seo?`, `geo?`,
+`required_tags` and `nice_to_have_tags` (a comma-separated string or a list),
+`image_ids`, and `organization` (a verified organization's slug — allowed only
+if you hold a role there).
+
+```bash
+# A draft (only a title is required)
+auth -X POST $API/jobs -H "Content-Type: application/json" \
+  -d '{"title": "Backend Engineer (m/w/d)"}'
+
+# Create and publish in one call
+auth -X POST $API/jobs -H "Content-Type: application/json" -d '{
+  "title": "Backend Engineer (m/w/d)",
+  "workplace_type": "onsite", "zip_code": "50667", "city": "Köln", "country": "DE",
+  "employment_type": "full_time",
+  "salary_min": 60000, "salary_max": 80000, "salary_currency": "EUR", "salary_period": "year",
+  "apply_kind": "url", "apply_url": "https://acme.example/careers/42",
+  "required_tags": "Elixir, Phoenix",
+  "publish": true
+}'
+```
+
+Answers `201` with the posting document. **Publishing enforces completeness**:
+an onsite/hybrid draft needs `zip_code` + `city` + `country`, a remote draft
+needs `remote_countries`, and every non-volunteer posting needs a full salary
+range — otherwise a `422` with per-field errors. A `POST` with `publish: true`
+is atomic: it either returns a published posting or a clean error and creates
+nothing.
+
+### PATCH /jobs/:id
+
+Scope `jobs:write`, own postings only. Edit any field. On a **draft**, pass
+`"publish": true` to go live (the same completeness checks apply; a failed
+publish keeps your draft so you can fix and retry). A key you omit is left
+unchanged — including `organization`, whose current attribution is kept unless
+you send the key.
+
+```bash
+# Fill in the missing fields and publish the draft
+auth -X PATCH $API/jobs/0190… -H "Content-Type: application/json" -d '{
+  "zip_code": "50667", "city": "Köln", "country": "DE",
+  "salary_min": 60000, "salary_max": 80000,
+  "apply_kind": "url", "apply_url": "https://acme.example/careers/42",
+  "publish": true
+}'
+```
+
+Editing an expired or closed posting answers `409` (`reason: not_editable`).
+
+### POST /jobs/:id/closure
+
+Scope `jobs:write`. End a live posting early with a reason:
+
+```bash
+auth -X POST $API/jobs/0190…/closure -H "Content-Type: application/json" \
+  -d '{"reason": "filled"}'
+```
+
+`reason` is `filled` or `withdrawn`. Answers `200` with the posting (`status:
+"closed"`). Only a live posting can be closed (`409` otherwise).
+
+### DELETE /jobs/:id
+
+Scope `jobs:write`. Discard a **draft** (`204`). A published posting cannot be
+discarded — close it instead (`409`, `reason: not_draft`) — so the lifecycle
+stays honest.
+
+## Organizations
+
+### GET /organizations
+
+Scope `jobs:read`. Verified organization pages, alphabetical, `?page=N` and a
+`?q=` search over name / city / alias.
+
+```bash
+auth "$API/organizations?q=acme&page=1"
+```
+
+### GET /organizations/:slug
+
+Scope `jobs:read`. One organization page with its aliases, verified domains,
+postal address, linked people and open positions — the employer behind a
+posting. The path segment may be the organization's slug **or** its claimed root
+handle (whatever the last segment of its `url` in the listing is).
+
+```bash
+auth $API/organizations/acme-gmbh
+```
+
+```json
+{
+  "type": "organization",
+  "name": "ACME GmbH", "slug": "acme-gmbh", "kind": "Company",
+  "website_url": "https://acme.example",
+  "verified_domains": ["acme.example"], "primary_domain": "acme.example",
+  "aliases": [{"name": "ACME Cologne", "kind": "trade_name"}],
+  "city": "Köln", "country": "DE", "country_name": "Germany",
+  "address_line": "Domkloster 4, 50667 Köln, Germany",
+  "people_total": 12, "people": [{"name": "…", "title": "…", "url": "…"}],
+  "open_positions": [{"id": "0190…", "title": "…", "url": "…", "salary": {"…": "…"}}]
+}
+```
+
+## The `job.published` webhook
+
+Instead of polling the board, subscribe to `job.published` (needs the poster's
+`jobs:read` grant) and hear about a member's new openings as they go live.
+Unlike every other topic this payload carries the posting's **public structured
+fields** — the same the board shows — so you can mirror an opening without a
+follow-up fetch. It never carries anything that is not already on the public
+posting. See [Webhooks](/developers/webhooks) for the delivery and signature
+contract.
+
+```json
+{
+  "event": "job.published",
+  "occurred_at": "2026-07-14T09:00:00Z",
+  "member": "wintermeyer",
+  "data": {
+    "id": "0190…",
+    "url": "https://vutuv.de/jobs/backend-engineer-…",
+    "title": "Backend Engineer (m/w/d)",
+    "employer": "ACME GmbH",
+    "employment_type": "full_time", "workplace_type": "onsite",
+    "zip_code": "50667", "city": "Köln", "country": "DE", "remote_countries": [],
+    "salary": {"min": 60000, "max": 80000, "currency": "EUR", "period": "year"},
+    "tags": ["Elixir", "Phoenix"]
+  }
+}
+```
+
+## Errors you will meet
+
+| Status | `reason` | When |
+|--------|----------|------|
+| `403` | `attribution_denied` | you named an `organization` you have no role at |
+| `403` | `account_too_new` / `email_unconfirmed` | your account cannot publish yet |
+| `404` | — | the posting does not exist or is not visible to you |
+| `409` | `member_quota` / `organization_quota` | too many postings live at once |
+| `409` | `not_editable` | editing an expired or closed posting |
+| `409` | `not_closeable` | closing something that is not live |
+| `409` | `not_draft` | deleting a published posting (close it instead) |
+| `422` | — | incomplete location, missing salary range, unknown organization, or a bad `reason` |
+
+Applications and people search over the API are out of scope; an "easy apply"
+routes the candidate to the employer's own channel, and vutuv stores no
+applications table.

--- a/priv/dev_docs/reference.md
+++ b/priv/dev_docs/reference.md
@@ -350,6 +350,16 @@ messages answers `403`; too many new requests answer `429`.
 Scope: `messages:write`. Answer an incoming request; `/read` clears your
 unread marker (`204`).
 
+## Jobs and organizations
+
+Post, manage and read job openings and the verified organizations behind them
+with the `jobs:read` / `jobs:write` scopes: `GET /jobs` (the board),
+`GET /jobs/:id`, `POST /jobs` (create or publish), `PATCH /jobs/:id`,
+`POST /jobs/:id/closure`, `DELETE /jobs/:id`, plus `GET /organizations` and
+`GET /organizations/:slug`. The 90-day lifecycle, the anti-spam gate, salary and
+location validations and the `job.published` webhook all live in the dedicated
+[Jobs API](/developers/jobs) chapter.
+
 ## Notifications
 
 ### GET /api/2.0/notifications · POST /api/2.0/notifications/read
@@ -408,6 +418,7 @@ belong server-side or in the user's own hands.
 [Authentication & tokens](/developers/authentication) (PATs, OAuth 2,
 scopes, errors, rate limits), the [cookbook](/developers/cookbook)
 (task-by-task recipes), [the data model](/developers/data-model) (what the
-entities mean and who sees what) and [Webhooks](/developers/webhooks)
-(signed event deliveries instead of polling). This reference only ever
-documents what is actually live.
+entities mean and who sees what), the [Jobs API](/developers/jobs) (postings,
+organizations, the lifecycle and the `job.published` webhook) and
+[Webhooks](/developers/webhooks) (signed event deliveries instead of polling).
+This reference only ever documents what is actually live.

--- a/priv/dev_docs/webhooks.md
+++ b/priv/dev_docs/webhooks.md
@@ -33,8 +33,18 @@ Two rules shape everything:
 | `post.liked` | `posts:read` | `by`, `post_id` |
 | `post.replied` | `posts:read` | `by`, `post_id` |
 | `message.created` | `messages:read` | `from`, `conversation_id` |
+| `job.published` | `jobs:read` | the posting's public fields (see below) |
 
 Plus `ping`, the test event you can trigger from the app page.
+
+`job.published` is the one exception to rule 2 above: because a published
+posting is public, its `data` carries the same structured fields the board
+shows (`id`, `url`, `title`, `employer`, `employment_type`, `workplace_type`,
+`zip_code`, `city`, `country`, `remote_countries`, `salary`, `tags`), so you can
+mirror a new opening without a follow-up fetch. It never carries anything that
+is not already on the public posting. It rides on the **poster's** own
+`jobs:read` grant — an app watching its own user's openings. See the
+[Jobs API](/developers/jobs) for the full payload.
 
 ## The delivery
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -4916,7 +4916,7 @@ msgstr "API-Token erstellen"
 msgid "Developers"
 msgstr "Entwickler"
 
-#: lib/vutuv/api_auth/scopes.ex:46
+#: lib/vutuv/api_auth/scopes.ex:47
 #, elixir-autogen, elixir-format
 msgid "Edit your profile and its sections"
 msgstr "Ihr Profil und seine Bereiche bearbeiten"
@@ -4932,7 +4932,7 @@ msgstr "Ihr Profil und seine Bereiche bearbeiten"
 msgid "Expires"
 msgstr "Gültig bis"
 
-#: lib/vutuv/api_auth/scopes.ex:52
+#: lib/vutuv/api_auth/scopes.ex:53
 #, elixir-autogen, elixir-format
 msgid "Follow people, manage connections and endorse tags for you"
 msgstr ""
@@ -4964,17 +4964,17 @@ msgstr ""
 "auswählen. Ein widerrufenes Token verliert seinen Zugriff sofort. "
 "Dokumentation: "
 
-#: lib/vutuv/api_auth/scopes.ex:55
+#: lib/vutuv/api_auth/scopes.ex:56
 #, elixir-autogen, elixir-format
 msgid "Read posts visible to you"
 msgstr "Beiträge lesen, die für Sie sichtbar sind"
 
-#: lib/vutuv/api_auth/scopes.ex:61
+#: lib/vutuv/api_auth/scopes.ex:62
 #, elixir-autogen, elixir-format
 msgid "Read your messages"
 msgstr "Ihre Nachrichten lesen"
 
-#: lib/vutuv/api_auth/scopes.ex:43
+#: lib/vutuv/api_auth/scopes.ex:44
 #, elixir-autogen, elixir-format
 msgid "Read your profile, including entries only you can see"
 msgstr "Ihr Profil lesen, einschließlich Einträgen, die nur Sie sehen können"
@@ -5003,13 +5003,13 @@ msgstr ""
 msgid "Revoke all tokens"
 msgstr "Alle Tokens widerrufen"
 
-#: lib/vutuv/api_auth/scopes.ex:49
+#: lib/vutuv/api_auth/scopes.ex:50
 #, elixir-autogen, elixir-format
 msgid "See your followers, who you follow, and your connections"
 msgstr ""
 "Ihre Follower, die Mitglieder, denen Sie folgen, und Ihre Vernetzungen sehen"
 
-#: lib/vutuv/api_auth/scopes.ex:64
+#: lib/vutuv/api_auth/scopes.ex:65
 #, elixir-autogen, elixir-format
 msgid "Send messages as you"
 msgstr "Nachrichten in Ihrem Namen senden"
@@ -5019,7 +5019,7 @@ msgstr "Nachrichten in Ihrem Namen senden"
 msgid "The token \"%{name}\" no longer works."
 msgstr "Das Token \"%{name}\" funktioniert nicht mehr."
 
-#: lib/vutuv/api_auth/scopes.ex:58
+#: lib/vutuv/api_auth/scopes.ex:59
 #, elixir-autogen, elixir-format
 msgid "Write, edit and delete your posts"
 msgstr "Ihre Beiträge schreiben, bearbeiten und löschen"
@@ -5846,7 +5846,7 @@ msgstr "Sprache der Oberfläche"
 msgid "Language & region"
 msgstr "Sprache & Region"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:294
+#: lib/vutuv_web/controllers/settings_controller.ex:302
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr "Sprache aktualisiert."
@@ -6138,7 +6138,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] "vor %{count} Minute"
 msgstr[1] "vor %{count} Minuten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:380
+#: lib/vutuv_web/controllers/settings_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
@@ -6178,7 +6178,7 @@ msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
 msgid "Signed-in devices"
 msgstr "Angemeldete Geräte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:369
+#: lib/vutuv_web/controllers/settings_controller.ex:377
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
@@ -6544,7 +6544,7 @@ msgstr "Empfehlung zurücknehmen"
 msgid "Default map"
 msgstr "Standardkarte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:309
+#: lib/vutuv_web/controllers/settings_controller.ex:317
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr "Karteneinstellungen gespeichert."
@@ -11331,7 +11331,7 @@ msgstr ""
 "Längere Beiträge erhalten einen „Weiterlesen“-Link. Mit 0 (oder leer) wird "
 "nie gekürzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:322
+#: lib/vutuv_web/controllers/settings_controller.ex:330
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
@@ -11390,7 +11390,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr "Standard der Installation (%{value})"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:344
+#: lib/vutuv_web/controllers/settings_controller.ex:352
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr "Karten-Einstellungen auf die Standardwerte zurückgesetzt."
@@ -11409,7 +11409,7 @@ msgstr ""
 "Eigener Wert; leeren Sie das Feld, um zum Standard der Installation "
 "zurückzukehren."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:340
+#: lib/vutuv_web/controllers/settings_controller.ex:348
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -13318,7 +13318,7 @@ msgstr "Tipp: Ein Geschlechtszusatz wie (m/w/d) hilft Ihrer Anzeige, dem AGG zu 
 msgid "Verified organization"
 msgstr "Verifizierte Organisation"
 
-#: lib/vutuv_web/agent_docs/job_posting_doc.ex:114
+#: lib/vutuv_web/agent_docs/job_posting_doc.ex:143
 #: lib/vutuv_web/components/job_components.ex:180
 #: lib/vutuv_web/live/job_posting_live/show.ex:309
 #, elixir-autogen, elixir-format, fuzzy
@@ -13870,7 +13870,7 @@ msgstr "Speichere eine Suche in der Stellenbörse oder in der Personensuche, und
 msgid "Save search"
 msgstr "Suche speichern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:268
+#: lib/vutuv_web/controllers/settings_controller.ex:273
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
@@ -13895,8 +13895,8 @@ msgstr "Suche gespeichert."
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr "E-Mail-Benachrichtigungen für deine gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:258
-#: lib/vutuv_web/controllers/settings_controller.ex:271
+#: lib/vutuv_web/controllers/settings_controller.ex:260
+#: lib/vutuv_web/controllers/settings_controller.ex:278
 #: lib/vutuv_web/live/job_board_live.ex:137
 #: lib/vutuv_web/live/search_live.ex:138
 #, elixir-autogen, elixir-format
@@ -13975,3 +13975,13 @@ msgstr "Die Suche selbst bleibt erhalten. Nur ihre E-Mails werden gestoppt, und 
 #, elixir-autogen, elixir-format
 msgid "matches my tags"
 msgstr "passt zu meinen Tags"
+
+#: lib/vutuv/api_auth/scopes.ex:71
+#, elixir-autogen, elixir-format
+msgid "Post, edit and close job openings as you"
+msgstr "Stellenanzeigen in Ihrem Namen veröffentlichen, bearbeiten und schließen"
+
+#: lib/vutuv/api_auth/scopes.ex:68
+#, elixir-autogen, elixir-format
+msgid "Read job postings and organization pages visible to you"
+msgstr "Für Sie sichtbare Stellenanzeigen und Unternehmensseiten lesen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -4724,7 +4724,7 @@ msgstr ""
 msgid "Developers"
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:46
+#: lib/vutuv/api_auth/scopes.ex:47
 #, elixir-autogen, elixir-format
 msgid "Edit your profile and its sections"
 msgstr ""
@@ -4740,7 +4740,7 @@ msgstr ""
 msgid "Expires"
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:52
+#: lib/vutuv/api_auth/scopes.ex:53
 #, elixir-autogen, elixir-format
 msgid "Follow people, manage connections and endorse tags for you"
 msgstr ""
@@ -4767,17 +4767,17 @@ msgstr ""
 msgid "Personal access tokens let scripts and third-party tools use the vutuv API as you, limited to the permissions you pick. Revoking a token cuts off its access immediately. Documentation: "
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:55
+#: lib/vutuv/api_auth/scopes.ex:56
 #, elixir-autogen, elixir-format
 msgid "Read posts visible to you"
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:61
+#: lib/vutuv/api_auth/scopes.ex:62
 #, elixir-autogen, elixir-format
 msgid "Read your messages"
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:43
+#: lib/vutuv/api_auth/scopes.ex:44
 #, elixir-autogen, elixir-format
 msgid "Read your profile, including entries only you can see"
 msgstr ""
@@ -4802,12 +4802,12 @@ msgstr ""
 msgid "Revoke all tokens"
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:49
+#: lib/vutuv/api_auth/scopes.ex:50
 #, elixir-autogen, elixir-format
 msgid "See your followers, who you follow, and your connections"
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:64
+#: lib/vutuv/api_auth/scopes.ex:65
 #, elixir-autogen, elixir-format
 msgid "Send messages as you"
 msgstr ""
@@ -4817,7 +4817,7 @@ msgstr ""
 msgid "The token \"%{name}\" no longer works."
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:58
+#: lib/vutuv/api_auth/scopes.ex:59
 #, elixir-autogen, elixir-format
 msgid "Write, edit and delete your posts"
 msgstr ""
@@ -5603,7 +5603,7 @@ msgstr ""
 msgid "Language & region"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:294
+#: lib/vutuv_web/controllers/settings_controller.ex:302
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr ""
@@ -5889,7 +5889,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:380
+#: lib/vutuv_web/controllers/settings_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5929,7 +5929,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:369
+#: lib/vutuv_web/controllers/settings_controller.ex:377
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -6277,7 +6277,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:309
+#: lib/vutuv_web/controllers/settings_controller.ex:317
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -10710,7 +10710,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:322
+#: lib/vutuv_web/controllers/settings_controller.ex:330
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10759,7 +10759,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:344
+#: lib/vutuv_web/controllers/settings_controller.ex:352
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10774,7 +10774,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:340
+#: lib/vutuv_web/controllers/settings_controller.ex:348
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -12587,7 +12587,7 @@ msgstr ""
 msgid "Verified organization"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_posting_doc.ex:114
+#: lib/vutuv_web/agent_docs/job_posting_doc.ex:143
 #: lib/vutuv_web/components/job_components.ex:180
 #: lib/vutuv_web/live/job_posting_live/show.ex:309
 #, elixir-autogen, elixir-format
@@ -13139,7 +13139,7 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:268
+#: lib/vutuv_web/controllers/settings_controller.ex:273
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
@@ -13164,8 +13164,8 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:258
-#: lib/vutuv_web/controllers/settings_controller.ex:271
+#: lib/vutuv_web/controllers/settings_controller.ex:260
+#: lib/vutuv_web/controllers/settings_controller.ex:278
 #: lib/vutuv_web/live/job_board_live.ex:137
 #: lib/vutuv_web/live/search_live.ex:138
 #, elixir-autogen, elixir-format
@@ -13243,4 +13243,14 @@ msgstr ""
 #: lib/vutuv/saved_searches.ex:247
 #, elixir-autogen, elixir-format
 msgid "matches my tags"
+msgstr ""
+
+#: lib/vutuv/api_auth/scopes.ex:71
+#, elixir-autogen, elixir-format
+msgid "Post, edit and close job openings as you"
+msgstr ""
+
+#: lib/vutuv/api_auth/scopes.ex:68
+#, elixir-autogen, elixir-format
+msgid "Read job postings and organization pages visible to you"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -4722,7 +4722,7 @@ msgstr ""
 msgid "Developers"
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:46
+#: lib/vutuv/api_auth/scopes.ex:47
 #, elixir-autogen, elixir-format
 msgid "Edit your profile and its sections"
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Expires"
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:52
+#: lib/vutuv/api_auth/scopes.ex:53
 #, elixir-autogen, elixir-format
 msgid "Follow people, manage connections and endorse tags for you"
 msgstr ""
@@ -4765,17 +4765,17 @@ msgstr ""
 msgid "Personal access tokens let scripts and third-party tools use the vutuv API as you, limited to the permissions you pick. Revoking a token cuts off its access immediately. Documentation: "
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:55
+#: lib/vutuv/api_auth/scopes.ex:56
 #, elixir-autogen, elixir-format
 msgid "Read posts visible to you"
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:61
+#: lib/vutuv/api_auth/scopes.ex:62
 #, elixir-autogen, elixir-format
 msgid "Read your messages"
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:43
+#: lib/vutuv/api_auth/scopes.ex:44
 #, elixir-autogen, elixir-format
 msgid "Read your profile, including entries only you can see"
 msgstr ""
@@ -4800,12 +4800,12 @@ msgstr ""
 msgid "Revoke all tokens"
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:49
+#: lib/vutuv/api_auth/scopes.ex:50
 #, elixir-autogen, elixir-format
 msgid "See your followers, who you follow, and your connections"
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:64
+#: lib/vutuv/api_auth/scopes.ex:65
 #, elixir-autogen, elixir-format
 msgid "Send messages as you"
 msgstr ""
@@ -4815,7 +4815,7 @@ msgstr ""
 msgid "The token \"%{name}\" no longer works."
 msgstr ""
 
-#: lib/vutuv/api_auth/scopes.ex:58
+#: lib/vutuv/api_auth/scopes.ex:59
 #, elixir-autogen, elixir-format
 msgid "Write, edit and delete your posts"
 msgstr ""
@@ -5601,7 +5601,7 @@ msgstr ""
 msgid "Language & region"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:294
+#: lib/vutuv_web/controllers/settings_controller.ex:302
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr ""
@@ -5887,7 +5887,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:380
+#: lib/vutuv_web/controllers/settings_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5927,7 +5927,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:369
+#: lib/vutuv_web/controllers/settings_controller.ex:377
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -6275,7 +6275,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:309
+#: lib/vutuv_web/controllers/settings_controller.ex:317
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -10708,7 +10708,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:322
+#: lib/vutuv_web/controllers/settings_controller.ex:330
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10757,7 +10757,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:344
+#: lib/vutuv_web/controllers/settings_controller.ex:352
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10772,7 +10772,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:340
+#: lib/vutuv_web/controllers/settings_controller.ex:348
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -12585,7 +12585,7 @@ msgstr ""
 msgid "Verified organization"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/job_posting_doc.ex:114
+#: lib/vutuv_web/agent_docs/job_posting_doc.ex:143
 #: lib/vutuv_web/components/job_components.ex:180
 #: lib/vutuv_web/live/job_posting_live/show.ex:309
 #, elixir-autogen, elixir-format, fuzzy
@@ -13137,7 +13137,7 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:268
+#: lib/vutuv_web/controllers/settings_controller.ex:273
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
@@ -13162,8 +13162,8 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:258
-#: lib/vutuv_web/controllers/settings_controller.ex:271
+#: lib/vutuv_web/controllers/settings_controller.ex:260
+#: lib/vutuv_web/controllers/settings_controller.ex:278
 #: lib/vutuv_web/live/job_board_live.ex:137
 #: lib/vutuv_web/live/search_live.ex:138
 #, elixir-autogen, elixir-format
@@ -13241,4 +13241,14 @@ msgstr ""
 #: lib/vutuv/saved_searches.ex:247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "matches my tags"
+msgstr ""
+
+#: lib/vutuv/api_auth/scopes.ex:71
+#, elixir-autogen, elixir-format
+msgid "Post, edit and close job openings as you"
+msgstr ""
+
+#: lib/vutuv/api_auth/scopes.ex:68
+#, elixir-autogen, elixir-format
+msgid "Read job postings and organization pages visible to you"
 msgstr ""

--- a/test/vutuv/webhooks_test.exs
+++ b/test/vutuv/webhooks_test.exs
@@ -48,6 +48,17 @@ defmodule Vutuv.WebhooksTest do
     on_exit(fn -> Application.delete_env(:vutuv, :webhook_req_options) end)
   end
 
+  # Age `user` past the job publish gate (a confirmed account >= 3 days old).
+  defp age_past_publish_gate(user) do
+    old = NaiveDateTime.add(NaiveDateTime.utc_now(), -5 * 86_400, :second)
+
+    Repo.update_all(from(u in Vutuv.Accounts.User, where: u.id == ^user.id),
+      set: [inserted_at: old]
+    )
+
+    Repo.reload!(user)
+  end
+
   describe "subscriptions" do
     test "validates url and events", %{app: app} do
       assert {:error, changeset} =
@@ -179,6 +190,51 @@ defmodule Vutuv.WebhooksTest do
       assert [delivery] = Repo.all(Delivery)
       assert delivery.event == "follower.created"
       assert delivery.payload["data"]["follower"] == follower.username
+    end
+
+    test "the real chokepoint queues it: publishing a job emits job.published", %{
+      member: member,
+      app: app
+    } do
+      subscribe!(app, ["job.published"])
+      grant!(member, app, ["jobs:read"])
+
+      poster = age_past_publish_gate(member)
+
+      posting =
+        Vutuv.JobsHelpers.publish_job!(
+          poster,
+          %{"title" => "Backend Engineer", "required_tags" => "elixir, phoenix"}
+        )
+
+      assert [delivery] = Repo.all(Delivery)
+      assert delivery.event == "job.published"
+      # The event rides on the poster's own grant.
+      assert delivery.payload["member"] == member.username
+
+      # The one event that carries public structured fields, so an integrator can
+      # mirror the opening without a follow-up fetch — never anything private.
+      data = delivery.payload["data"]
+      assert data["id"] == posting.id
+      assert data["title"] == "Backend Engineer"
+      assert data["url"] =~ "/jobs/#{posting.slug}"
+      assert data["city"] == "Köln"
+      assert data["country"] == "DE"
+      assert data["workplace_type"] == "onsite"
+      assert data["salary"]["max"] == 70_000
+      assert Enum.sort(data["tags"]) == ["elixir", "phoenix"]
+    end
+
+    test "re-publishing (an edit) does not re-emit job.published", %{member: member, app: app} do
+      subscribe!(app, ["job.published"])
+      grant!(member, app, ["jobs:read"])
+      poster = age_past_publish_gate(member)
+
+      posting = Vutuv.JobsHelpers.publish_job!(poster, %{"title" => "First"})
+      assert Repo.aggregate(Delivery, :count) == 1
+
+      {:ok, _} = Vutuv.Jobs.publish(posting, poster, Vutuv.JobsHelpers.job_attrs())
+      assert Repo.aggregate(Delivery, :count) == 1
     end
   end
 

--- a/test/vutuv_web/controllers/api_v2/jobs_api_test.exs
+++ b/test/vutuv_web/controllers/api_v2/jobs_api_test.exs
@@ -1,0 +1,346 @@
+defmodule VutuvWeb.ApiV2.JobsApiTest do
+  use VutuvWeb.ConnCase
+
+  alias Vutuv.ApiAuth
+  alias Vutuv.Jobs
+  alias Vutuv.JobsHelpers
+
+  # A confirmed account old enough to clear the publish gate, plus a jobs:write
+  # token. The `other` reader carries only jobs:read.
+  setup %{conn: conn} do
+    Vutuv.RateLimiter.reset()
+    me = JobsHelpers.poster_fixture()
+    other = insert_activated_user()
+
+    {:ok, write, _} = ApiAuth.create_pat(me, %{"name" => "w", "scopes" => ["jobs:write"]})
+    {:ok, read, _} = ApiAuth.create_pat(other, %{"name" => "r", "scopes" => ["jobs:read"]})
+
+    {:ok, conn: conn, me: me, other: other, write: write, read: read}
+  end
+
+  # Full publish payload as a JSON body (string amounts like the form sends).
+  defp publish_attrs(overrides \\ %{}) do
+    Map.merge(
+      %{
+        title: "Backend Engineer (m/w/d)",
+        employment_type: "full_time",
+        workplace_type: "onsite",
+        zip_code: "50667",
+        city: "Köln",
+        country: "DE",
+        salary_min: 55_000,
+        salary_max: 70_000,
+        salary_currency: "EUR",
+        salary_period: "year",
+        apply_kind: "url",
+        apply_url: "https://example.com/apply",
+        required_tags: "elixir, phoenix"
+      },
+      overrides
+    )
+  end
+
+  describe "create" do
+    test "POST /jobs without publish creates a draft", %{conn: conn, write: write} do
+      conn = json_req(conn, :post, write, "/api/2.0/jobs", %{title: "Just a draft"})
+      body = json_response(conn, 201)
+
+      assert body["status"] == "draft"
+      assert body["title"] == "Just a draft"
+      assert is_binary(body["id"])
+      # A draft has no expiry yet.
+      assert body["expires_on"] == nil
+    end
+
+    test "POST /jobs with publish=true goes live with a 90-day expiry", %{
+      conn: conn,
+      write: write
+    } do
+      conn =
+        json_req(conn, :post, write, "/api/2.0/jobs", Map.put(publish_attrs(), :publish, true))
+
+      body = json_response(conn, 201)
+
+      assert body["status"] == "published"
+      assert body["location"]["city"] == "Köln"
+      assert body["salary"]["min"] == 55_000
+      assert body["street_address"] == nil
+      expires = Date.from_iso8601!(body["expires_on"])
+      assert Date.diff(expires, Vutuv.BerlinTime.today()) == Jobs.runtime_days()
+      assert Enum.sort(Enum.map(body["required_tags"], & &1["name"])) == ["elixir", "phoenix"]
+    end
+
+    test "publishing an onsite posting with no salary and no location is a 422", %{
+      conn: conn,
+      me: me,
+      write: write
+    } do
+      conn =
+        json_req(conn, :post, write, "/api/2.0/jobs", %{
+          title: "Incomplete",
+          workplace_type: "onsite",
+          apply_kind: "url",
+          apply_url: "https://example.com/apply",
+          publish: true
+        })
+
+      assert conn.status == 422
+      errors = json_response(conn, 422)["errors"]
+      assert errors["salary_min"]
+      assert errors["city"]
+      # The failed atomic publish leaves no orphan draft.
+      assert Jobs.own_status_counts(me) == %{}
+    end
+
+    test "attributing a posting to an organization you cannot manage is a 403", %{
+      conn: conn,
+      other: other,
+      write: write
+    } do
+      org = insert(:organization, created_by_user_id: other.id)
+
+      conn =
+        json_req(
+          conn,
+          :post,
+          write,
+          "/api/2.0/jobs",
+          Map.put(publish_attrs(), :organization, org.slug)
+        )
+
+      assert conn.status == 403
+      assert json_response(conn, 403)["reason"] == "attribution_denied"
+    end
+  end
+
+  describe "the draft → publish flow (the smoke-test path)" do
+    test "POST a draft, a bad publish stays a 422, then PATCH publishes it", %{
+      conn: conn,
+      me: me,
+      write: write
+    } do
+      %{"id" => id} =
+        json_response(json_req(conn, :post, write, "/api/2.0/jobs", %{title: "Grows up"}), 201)
+
+      # Trying to publish the bare draft fails and keeps the draft.
+      bad = json_req(build_conn(), :patch, write, "/api/2.0/jobs/#{id}", %{publish: true})
+      assert bad.status == 422
+      assert Jobs.get_job_posting(id).status == :draft
+
+      good =
+        json_req(
+          build_conn(),
+          :patch,
+          write,
+          "/api/2.0/jobs/#{id}",
+          Map.put(publish_attrs(%{title: "Grows up"}), :publish, true)
+        )
+
+      assert json_response(good, 200)["status"] == "published"
+      assert Jobs.get_job_posting(id).status == :published
+      assert Jobs.get_job_posting(id).user_id == me.id
+    end
+  end
+
+  describe "read" do
+    test "GET /jobs/:id returns status and dates; the owner sees a draft", %{
+      conn: conn,
+      me: me,
+      write: write,
+      read: read
+    } do
+      {:ok, draft} = Jobs.create_draft(me, %{"title" => "Owner draft"})
+
+      # The owner reads their own draft.
+      mine = get(authed(conn, write), "/api/2.0/jobs/#{draft.id}")
+      assert json_response(mine, 200)["status"] == "draft"
+
+      # A stranger cannot see a draft.
+      theirs = get(authed(build_conn(), read), "/api/2.0/jobs/#{draft.id}")
+      assert theirs.status == 404
+    end
+
+    test "a stranger sees a published posting but not an expired one", %{
+      conn: _conn,
+      me: me,
+      read: read
+    } do
+      live = JobsHelpers.publish_job!(me)
+      assert get(authed(build_conn(), read), "/api/2.0/jobs/#{live.id}").status == 200
+
+      expired = JobsHelpers.publish_job!(me)
+      {:ok, _} = expired |> Ecto.Changeset.change(status: :expired) |> Vutuv.Repo.update()
+      assert get(authed(build_conn(), read), "/api/2.0/jobs/#{expired.id}").status == 404
+    end
+
+    test "GET /jobs lists published postings and filters by salary", %{
+      conn: conn,
+      me: me,
+      read: read
+    } do
+      JobsHelpers.publish_job!(me, %{"title" => "Well paid", "salary_max" => "90000"})
+
+      JobsHelpers.publish_job!(me, %{
+        "title" => "Modest",
+        "salary_min" => "30000",
+        "salary_max" => "40000"
+      })
+
+      all = json_response(get(authed(conn, read), "/api/2.0/jobs"), 200)
+      assert all["type"] == "jobs"
+      assert length(all["jobs"]) == 2
+      assert Enum.all?(all["jobs"], &is_binary(&1["id"]))
+
+      filtered =
+        json_response(get(authed(build_conn(), read), "/api/2.0/jobs?salary_min=80000"), 200)
+
+      assert Enum.map(filtered["jobs"], & &1["title"]) == ["Well paid"]
+    end
+
+    test "GET /jobs pages by cursor", %{conn: conn, me: me, read: read} do
+      for n <- 1..3, do: JobsHelpers.publish_job!(me, %{"title" => "Role #{n}"})
+
+      page1 = json_response(get(authed(conn, read), "/api/2.0/jobs?limit=2"), 200)
+      assert length(page1["jobs"]) == 2
+      assert page1["more"] == true
+      assert is_binary(page1["next_cursor"])
+
+      page2 =
+        json_response(
+          get(
+            authed(build_conn(), read),
+            "/api/2.0/jobs?limit=2&cursor=#{URI.encode_www_form(page1["next_cursor"])}"
+          ),
+          200
+        )
+
+      assert length(page2["jobs"]) == 1
+      assert page2["more"] == false
+    end
+  end
+
+  describe "edit" do
+    test "PATCH edits an own live posting", %{conn: conn, me: me, write: write} do
+      posting = JobsHelpers.publish_job!(me)
+
+      conn =
+        json_req(conn, :patch, write, "/api/2.0/jobs/#{posting.id}", %{title: "Renamed role"})
+
+      assert json_response(conn, 200)["title"] == "Renamed role"
+    end
+
+    test "PATCH on a closed posting is a clean 409", %{conn: conn, me: me, write: write} do
+      posting = JobsHelpers.publish_job!(me)
+      {:ok, _} = Jobs.close(posting, :filled)
+
+      conn = json_req(conn, :patch, write, "/api/2.0/jobs/#{posting.id}", %{title: "Reopen?"})
+      assert conn.status == 409
+      assert json_response(conn, 409)["reason"] == "not_editable"
+    end
+
+    test "cannot edit someone else's posting", %{conn: conn, other: other, write: write} do
+      posting = JobsHelpers.publish_job!(JobsHelpers.poster_fixture())
+      _ = other
+
+      conn = json_req(conn, :patch, write, "/api/2.0/jobs/#{posting.id}", %{title: "hijack"})
+      assert conn.status == 404
+    end
+  end
+
+  describe "closure and deletion" do
+    test "POST /jobs/:id/closure closes a live posting", %{conn: conn, me: me, write: write} do
+      posting = JobsHelpers.publish_job!(me)
+
+      conn =
+        json_req(conn, :post, write, "/api/2.0/jobs/#{posting.id}/closure", %{reason: "filled"})
+
+      assert json_response(conn, 200)["status"] == "closed"
+      assert Jobs.get_job_posting(posting.id).close_reason == :filled
+    end
+
+    test "closure rejects an unknown reason", %{conn: conn, me: me, write: write} do
+      posting = JobsHelpers.publish_job!(me)
+
+      conn =
+        json_req(conn, :post, write, "/api/2.0/jobs/#{posting.id}/closure", %{reason: "bored"})
+
+      assert conn.status == 422
+    end
+
+    test "DELETE discards a draft but refuses a published posting", %{
+      conn: conn,
+      me: me,
+      write: write
+    } do
+      {:ok, draft} = Jobs.create_draft(me, %{"title" => "throwaway"})
+      assert delete(authed(conn, write), "/api/2.0/jobs/#{draft.id}").status == 204
+      assert Jobs.get_job_posting(draft.id) == nil
+
+      live = JobsHelpers.publish_job!(me)
+      refused = delete(authed(build_conn(), write), "/api/2.0/jobs/#{live.id}")
+      assert refused.status == 409
+      assert Jobs.get_job_posting(live.id)
+    end
+  end
+
+  describe "scopes" do
+    test "jobs:read reads but cannot write", %{conn: conn, me: me, read: read} do
+      posting = JobsHelpers.publish_job!(me)
+
+      assert get(authed(conn, read), "/api/2.0/jobs/#{posting.id}").status == 200
+      assert json_req(build_conn(), :post, read, "/api/2.0/jobs", %{title: "x"}).status == 403
+    end
+
+    test "a token without a jobs scope is refused", %{conn: conn, me: me} do
+      {:ok, profile_only, _} =
+        ApiAuth.create_pat(me, %{"name" => "p", "scopes" => ["profile:read"]})
+
+      posting = JobsHelpers.publish_job!(me)
+      assert get(authed(conn, profile_only), "/api/2.0/jobs/#{posting.id}").status == 403
+    end
+  end
+
+  describe "organizations" do
+    test "GET /organizations lists verified organizations and filters by ?q=", %{
+      conn: conn,
+      read: read
+    } do
+      insert(:organization, name: "Acme Rockets", slug: "acme-rockets")
+      insert(:organization, name: "Globex", slug: "globex")
+
+      all = json_response(get(authed(conn, read), "/api/2.0/organizations"), 200)
+      assert all["total"] == 2
+
+      filtered =
+        json_response(get(authed(build_conn(), read), "/api/2.0/organizations?q=Acme"), 200)
+
+      assert Enum.map(filtered["organizations"], & &1["name"]) == ["Acme Rockets"]
+    end
+
+    test "GET /organizations/:slug returns the page with aliases and domains", %{
+      conn: conn,
+      read: read
+    } do
+      org = insert(:organization, name: "Acme Corp", slug: "acme-corp")
+
+      body = json_response(get(authed(conn, read), "/api/2.0/organizations/#{org.slug}"), 200)
+      assert body["name"] == "Acme Corp"
+      assert body["slug"] == "acme-corp"
+      assert is_list(body["verified_domains"])
+      assert is_list(body["aliases"])
+    end
+
+    test "GET /organizations/:slug also resolves a claimed root handle", %{conn: conn, read: read} do
+      # A handle-holding organization is canonical at /:handle, and the listing's
+      # url points there — so the show endpoint must resolve by handle too.
+      org = insert(:organization, name: "Handle Co", slug: "handle-co", username: "handleco")
+
+      body = json_response(get(authed(conn, read), "/api/2.0/organizations/#{org.username}"), 200)
+      assert body["name"] == "Handle Co"
+    end
+
+    test "an unknown organization is a 404", %{conn: conn, read: read} do
+      assert get(authed(conn, read), "/api/2.0/organizations/nope").status == 404
+    end
+  end
+end

--- a/test/vutuv_web/controllers/dev_doc_controller_test.exs
+++ b/test/vutuv_web/controllers/dev_doc_controller_test.exs
@@ -127,7 +127,7 @@ defmodule VutuvWeb.DevDocControllerTest do
   test "every docs page links every other docs page in the nav", %{conn: conn} do
     response = conn |> get(~p"/developers") |> html_response(200)
 
-    for page <- ["authentication", "cookbook", "data-model", "reference", "webhooks"] do
+    for page <- ["authentication", "cookbook", "data-model", "reference", "jobs", "webhooks"] do
       assert response =~ "/developers/#{page}", "docs nav is missing #{page}"
     end
   end


### PR DESCRIPTION
Closes #936 — the final issue in the Jobs & Organizations milestone.

## What

Opens the jobs milestone to third-party HR tooling via `/api/2.0`. The API is a **second door on the same room, never a side channel**: every write runs through the exact `Vutuv.Jobs` changesets and policies as the `/jobs` forms (90-day lifecycle, anti-abuse gate, org attribution only with a role, salary/AGG/location validations, rate limiter), so an API posting is indistinguishable from a form one.

### Scopes
New `jobs:read` / `jobs:write` (write implies read). They surface automatically in the PAT form, OAuth consent and connected-apps view because those derive from `Scopes.all/1` + `description/1`.

### Endpoints
| Verb | Path | Scope | |
|------|------|-------|---|
| GET | `/jobs` | `jobs:read` | viewer-scoped board, same filters as `/jobs`, keyset cursor |
| GET | `/jobs/:id` | `jobs:read` | one posting incl. status + dates; owner sees any state, stranger only a live one |
| POST | `/jobs` | `jobs:write` | create a draft, or `publish: true` to go live atomically |
| PATCH | `/jobs/:id` | `jobs:write` | edit, or publish a draft; expired/closed refuse edits |
| POST | `/jobs/:id/closure` | `jobs:write` | close with `filled` \| `withdrawn` |
| DELETE | `/jobs/:id` | `jobs:write` | discard a draft |
| GET | `/organizations` | `jobs:read` | verified orgs, paginated, `?q=` |
| GET | `/organizations/:slug` | `jobs:read` | one page incl. aliases + domains; resolves a slug **or** a claimed root handle |

Responses reuse the AgentDocs doc maps (`JobPostingDoc`/`OrganizationDoc`) so the API and the public `.json` siblings speak one schema; `api_show/1` augments the public show doc with owner-only `id`/`status`/`street_address`/`coordinates`/close fields without drifting the shared shape.

### Webhook
New topic `job.published`, emitted from `Vutuv.Jobs.publish/4` on the first `draft → published` transition (never on an edit), scoped to the poster's own `jobs:read` grant. It is the one topic whose payload carries structured public fields (title, location, salary, tags) rather than a thin envelope — a published posting is public, so integrators mirror new openings without a follow-up fetch.

### Docs
A new `/developers/jobs` chapter (auth, every endpoint with curl, the lifecycle state machine, the error catalogue, the webhook payload), plus the scope table, webhooks event table, reference see-also, `llms.txt` and the `api`/`jobs` architecture docs. German translations for the two new scope descriptions.

## Testing
- New `jobs_api_test.exs` (35 assertions across lifecycle, scopes, validation, orgs) + `job.published` cases in `webhooks_test.exs`; full `mix precommit` green (3760 tests).
- Smoke-tested end to end with curl against a live server: draft → failed publish (422) → PATCH publish (90-day expiry) → board find via `near`+`salary_min` → closure → 409 `not_editable`; plus 401 no-token, 403 missing-scope, org list/show, 404 unknown.

