### PR TITLE
Birthday visibility: full / age / day+month / hidden [v7.108.0]

### DIFF
--- a/docs/architecture/profiles.md
+++ b/docs/architecture/profiles.md
@@ -19,6 +19,34 @@ inert (the profile ignores it).
 The profile-section pages behave the same way: `/:slug/<section>` IS the public
 view for everyone, and editing happens at `/settings/<section>`.
 
+## Birthday visibility (General Info card)
+
+A member enters their birthday on the Basics form but chooses **how much of it
+is public** with the neighbouring `users.birthdate_visibility` select. Unlike
+the three-way audience gate below, this is a **granularity** knob that applies
+to every viewer alike:
+
+| value       | profile shows            | agent formats                        | public CV        |
+| ----------- | ------------------------ | ------------------------------------ | ---------------- |
+| `full`      | full date + age (default)| `birthdate` (ISO) + `age`            | full date        |
+| `age`       | age only                 | `age` only                           | no DOB line      |
+| `day_month` | day + month, no year     | `birthday_month_day` (`MM-DD`)       | day + month      |
+| `hidden`    | nothing                  | nothing                              | no DOB line      |
+
+`Vutuv.Accounts.User.birthdate_mode/1` is the single seam — it folds `hidden`
+and "no birthday set" into one `:none` so a call site gates the whole display on
+one value (a nil/legacy setting falls back to `:full`, the historical public
+behaviour, so existing members are unchanged). The profile card
+(`show.html.heex`), the anonymous agent docs (`ProfileDoc` merges gated
+`birthdate` / `birthday_month_day` / `age` fields, so md/txt/json/xml and the
+vCard's `BDAY` — which is only emitted for the full date, vCard 3.0 having no
+year-less form — stay in sync) and the **public** CV builder (`VutuvWeb.CV`,
+`/:slug/cv`) all read it, so none of them can reveal more than the profile does.
+The owner's own **GDPR export** and the admin **newsletter age segmentation**
+deliberately keep the raw stored `birthdate` — the setting is about public
+display, not deletion. `birthdate_visibility_test.exs` asserts both sides of
+each of the four modes across every surface.
+
 ## Employment-status badge & visibility (issues #870, #928)
 
 Members can advertise a job-availability signal shown as a small pill in the

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -49,6 +49,15 @@ defmodule Vutuv.Accounts.User do
     field(:desired_salary_period, :string, default: "year")
     field(:desired_salary_visibility, :string, default: "hidden")
     field(:birthdate, :date)
+    # How much of the birthday the public profile (and its agent-format
+    # siblings + the public CV) reveal: "full" (date + age, the historical
+    # default), "age" (only the age in years), "day_month" (day and month
+    # without the year, so no age can be derived) or "hidden" (stored but never
+    # shown publicly). The granularity applies to every viewer alike — unlike
+    # the three-way audience visibilities above it is not an everyone/members
+    # gate. Resolved for display through birthdate_mode/1. Members set it beside
+    # the birthday field on the Basics form.
+    field(:birthdate_visibility, :string, default: "full")
     field(:locale, :string)
     # An admin checked this person's physical ID against their name: this IS that
     # person. Admin-only (deliberately NOT in @optional_fields); drives the
@@ -268,7 +277,7 @@ defmodule Vutuv.Accounts.User do
   # :email_confirmed? is NOT here either: it flips only via the login-PIN path
   # (Accounts.activate_user/1, its own narrow cast) — castable, it would let a
   # registration self-activate without ever proving control of an email.
-  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? newsletter_emails? saved_search_emails? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility first_name last_name middle_name nickname honorific_prefix honorific_suffix gender birthdate locale tag_list)a
+  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? newsletter_emails? saved_search_emails? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility first_name last_name middle_name nickname honorific_prefix honorific_suffix gender birthdate birthdate_visibility locale tag_list)a
 
   # The job-availability values a member can advertise (issue #870), other
   # than the "not specified" default which is stored as nil. The single source
@@ -291,6 +300,20 @@ defmodule Vutuv.Accounts.User do
   @visibilities ~w(everyone members hidden)
 
   def visibilities, do: @visibilities
+
+  # The birthday visibility granularity: how much of the birthday the public
+  # profile (and every agent format + the public CV) reveals. "full" = the
+  # date and the derived age (the historical default); "age" = only the age in
+  # years; "day_month" = the day and month without the year (so no age can be
+  # back-computed); "hidden" = stored but never shown publicly. The single
+  # source for the changeset's validate_inclusion and, via
+  # birthdate_visibility_options/0, the Basics-form select, so the form can
+  # never offer a value the changeset would reject. Resolve it for a given
+  # member with birthdate_mode/1 (which also folds "hidden" and "no birthday"
+  # together into :none).
+  @birthdate_visibilities ~w(full age day_month hidden)
+
+  def birthdate_visibilities, do: @birthdate_visibilities
 
   # The delay presets the notifications settings page offers (minutes a message
   # may sit unread before the nudge email goes out). The single source of truth
@@ -409,6 +432,7 @@ defmodule Vutuv.Accounts.User do
     |> validate_inclusion(:desired_salary_visibility, @visibilities)
     |> nullify_default_birthdate()
     |> validate_birthdate()
+    |> validate_inclusion(:birthdate_visibility, @birthdate_visibilities)
     |> revoke_verification_on_identity_change()
   end
 
@@ -578,6 +602,44 @@ defmodule Vutuv.Accounts.User do
   def visibility_label("hidden"), do: Gettext.gettext(VutuvWeb.Gettext, "No one")
 
   def visibility_label(_), do: nil
+
+  @doc """
+  The translated label for a birthday visibility choice, shared by the
+  Basics-form select (via `VutuvWeb.UserHelpers.birthdate_visibility_options/0`)
+  so the wording lives in one place.
+  """
+  def birthdate_visibility_label("full"),
+    do: Gettext.gettext(VutuvWeb.Gettext, "Full date and age")
+
+  def birthdate_visibility_label("age"),
+    do: Gettext.gettext(VutuvWeb.Gettext, "Age only, without the date")
+
+  def birthdate_visibility_label("day_month"),
+    do: Gettext.gettext(VutuvWeb.Gettext, "Day and month, without the year")
+
+  def birthdate_visibility_label("hidden"),
+    do: Gettext.gettext(VutuvWeb.Gettext, "Do not show my birthday")
+
+  def birthdate_visibility_label(_), do: nil
+
+  @doc """
+  The effective birthday display mode for `user`, the single seam the profile
+  card, the agent-format `ProfileDoc` and the public CV all read:
+
+    * `:full` — show the full date and the derived age (the default);
+    * `:age` — show only the age in years, not the date;
+    * `:day_month` — show the day and month, but not the year (so no age);
+    * `:none` — show nothing, because the member hid it *or* has no birthday.
+
+  Folding "hidden" and "no birthday set" into one `:none` lets a call site gate
+  the whole birthday display on a single value. A nil/legacy `birthdate_visibility`
+  falls back to `:full`, the historical public behaviour.
+  """
+  def birthdate_mode(%__MODULE__{birthdate: nil}), do: :none
+  def birthdate_mode(%__MODULE__{birthdate_visibility: "hidden"}), do: :none
+  def birthdate_mode(%__MODULE__{birthdate_visibility: "age"}), do: :age
+  def birthdate_mode(%__MODULE__{birthdate_visibility: "day_month"}), do: :day_month
+  def birthdate_mode(%__MODULE__{}), do: :full
 
   # The shared three-way visibility gate (issue #928): "everyone" shows to all
   # (incl. the anonymous public view crawlers/extension URLs get, `viewer`

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -412,6 +412,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       count_facts(doc.counts),
       doc.gender && "- #{gettext("Gender")}: #{User.gender_gettext(doc.gender)}",
       doc.birthdate && "- #{gettext("Birthday")}: #{doc.birthdate}",
+      doc.birthday_month_day && "- #{gettext("Birthday")}: #{doc.birthday_month_day}",
       doc.age && "- #{gettext("Age")}: #{doc.age}"
     ]
     |> List.flatten()

--- a/lib/vutuv_web/agent_docs/profile_doc.ex
+++ b/lib/vutuv_web/agent_docs/profile_doc.ex
@@ -11,6 +11,7 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
   """
 
   alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
   alias Vutuv.CodeStats
   alias Vutuv.Profiles.Address
   alias Vutuv.Profiles.Education
@@ -109,8 +110,6 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
       work_info: work_info,
       current_position: current_position(job),
       gender: public_gender(user),
-      birthdate: user.birthdate,
-      age: UserHelpers.age(user),
       member_since: NaiveDateTime.to_date(user.inserted_at),
       avatar_url: avatar_url(user),
       counts: %{
@@ -142,7 +141,26 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
       code_stats: Enum.map(CodeStats.visible_accounts(user), &code_stats_entry/1),
       posts: Enum.map(posts, &post_entry/1)
     })
+    |> Map.merge(birthday_fields(user))
     |> maybe_include_photo(user, opts)
+  end
+
+  # The birthday facts, gated by the member's birthdate_visibility setting so
+  # the anonymous documents reveal exactly what the profile card (and the public
+  # CV) do: :full → the ISO date + derived age; :age → the age only; :day_month
+  # → the month-day without the year (a stable "MM-DD", so the year and thus the
+  # age can't be back-computed); :none (the member hid it, or has no birthday) →
+  # nothing. Kept in one place so md/txt/json/xml and the vCard (which keys BDAY
+  # on `birthdate`, hence absent unless the full date is public) stay in sync.
+  defp birthday_fields(user) do
+    base = %{birthdate: nil, birthday_month_day: nil, age: nil}
+
+    case User.birthdate_mode(user) do
+      :full -> %{base | birthdate: user.birthdate, age: UserHelpers.age(user)}
+      :age -> %{base | age: UserHelpers.age(user)}
+      :day_month -> %{base | birthday_month_day: Calendar.strftime(user.birthdate, "%m-%d")}
+      :none -> base
+    end
   end
 
   # The same associations the profile page preloads (user_controller.ex),

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -417,6 +417,7 @@ defmodule VutuvWeb.AgentDocs.Text do
       count_facts(doc.counts),
       doc.gender && "#{gettext("Gender")}: #{User.gender_gettext(doc.gender)}",
       doc.birthdate && "#{gettext("Birthday")}: #{doc.birthdate}",
+      doc.birthday_month_day && "#{gettext("Birthday")}: #{doc.birthday_month_day}",
       doc.age && "#{gettext("Age")}: #{doc.age}"
     ]
     |> List.flatten()

--- a/lib/vutuv_web/cv/cv.ex
+++ b/lib/vutuv_web/cv/cv.ex
@@ -385,9 +385,20 @@ defmodule VutuvWeb.CV do
 
   defp social_handle(%{value: value}), do: value
 
-  # The member's date of birth as the formatted string the profile shows
-  # (locale-aware via UserHelpers.format_birthdate/1), nil when unset.
-  defp birthdate(user), do: presence(UserHelpers.format_birthdate(user))
+  # The member's date of birth line, obeying the same birthday-visibility gate
+  # the public profile does (birthdate_mode/1) — the CV builder is a PUBLIC page
+  # (/:slug/cv), so it must not reveal more than the profile: :full → the
+  # locale-aware full date; :day_month → day and month without the year; :age
+  # and :none → no date-of-birth line at all (a labelled "date of birth" field
+  # is the wrong home for a bare age). nil (any of the latter, or no birthday)
+  # simply drops the DOB toggle from the builder and the line from every export.
+  defp birthdate(user) do
+    case User.birthdate_mode(user) do
+      :full -> presence(UserHelpers.format_birthdate(user))
+      :day_month -> presence(UserHelpers.format_birthdate_day_month(user))
+      _age_or_none -> nil
+    end
+  end
 
   # The gender label, following the profile's rule: shown only for a concrete
   # value, hidden for the unset default ("other"/nil).

--- a/lib/vutuv_web/gettext_extraction_anchors.ex
+++ b/lib/vutuv_web/gettext_extraction_anchors.ex
@@ -51,6 +51,12 @@ defmodule VutuvWeb.GettextExtractionAnchors do
       gettext("Everyone, including logged-out visitors"),
       gettext("Signed-in members only"),
       gettext("No one"),
+      # The birthday-visibility granularity labels,
+      # Vutuv.Accounts.User.birthdate_visibility_label/1
+      gettext("Full date and age"),
+      gettext("Age only, without the date"),
+      gettext("Day and month, without the year"),
+      gettext("Do not show my birthday"),
       # The salary-expectation period nouns (issue #928),
       # Vutuv.Accounts.User.desired_salary_period_label/1
       gettext("hour"),

--- a/lib/vutuv_web/templates/user/edit.html.heex
+++ b/lib/vutuv_web/templates/user/edit.html.heex
@@ -320,6 +320,20 @@ lands here). --%>
               {gettext("Remove date of birth")}
             </button>
           </div>
+
+          <%!-- How much of the birthday the public profile (and its agent
+          formats + public CV) reveals. The granularity applies to every viewer
+          alike; "full" keeps the historical behaviour. --%>
+          <div>
+            <%= label f, :birthdate_visibility, gettext("Show my birthday as"), class: "block text-sm font-medium text-slate-900 dark:text-white" %>
+            <%= select f, :birthdate_visibility, birthdate_visibility_options(), class: input_class() %>
+            <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+              {gettext(
+                "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
+              )}
+            </p>
+            <%= error_tag f, :birthdate_visibility %>
+          </div>
         </div>
       </div>
     </.card>

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -758,15 +758,17 @@ the resulting ~200px rail width. --%>
   a real box again at md+. --%>
   <aside class="contents md:block md:space-y-6">
     <%!-- General info leads the rail: who the person is (gender + birthday).
-    The headline already lives in the header. --%>
-    <.card
-      :if={@user.birthdate || (@user.gender && @user.gender != "other") || @as_owner?}
-      id="profile-about"
-    >
+    The headline already lives in the header. The birthday obeys the member's
+    chosen granularity (birthdate_mode/1): full date + age, age only, day and
+    month without the year, or hidden — the same gate the agent formats and the
+    public CV honour. --%>
+    <% birthday_mode = birthdate_mode(@user) %>
+    <% has_gender = @user.gender && @user.gender != "other" %>
+    <% has_general_info = birthday_mode != :none || has_gender %>
+    <.card :if={has_general_info || @as_owner?} id="profile-about">
       <%!-- General Info edits the profile form (no list). While empty it shows
       the dashed "add personal details" onboarding tile; once gender/birthday are
       set it is a clean showcase with a quiet "Ändern" footer to /edit. --%>
-      <% has_general_info = @user.birthdate || (@user.gender && @user.gender != "other") %>
       <.section_header title={gettext("General Info")} />
       <.empty_add :if={@as_owner? && !has_general_info} href={~p"/settings/profile"}>
         {gettext("Add personal details")}
@@ -781,17 +783,26 @@ the resulting ~200px rail width. --%>
           <dt class="sr-only">{gettext("Gender")}</dt>
           <dd class="my-0 font-medium text-slate-800 dark:text-slate-100">{Vutuv.Accounts.User.gender_gettext(@user.gender)}</dd>
         </div>
-        <div :if={@user.birthdate} class="flex items-center gap-2.5">
+        <div :if={birthday_mode != :none} class="flex items-center gap-2.5">
           <.detail_icon name="cake" class="h-4 w-4 shrink-0 text-slate-400 dark:text-slate-500" />
           <dt class="sr-only">{gettext("Birthday")}</dt>
           <dd class="my-0 font-medium text-slate-800 dark:text-slate-100">
-            {format_birthdate(@user)}
-            <%= if years = age(@user) do %>
-              <span class="font-normal text-slate-600 dark:text-slate-400">({ngettext(
-                "%{count} year old",
-                "%{count} years old",
-                years
-              )})</span>
+            <%= case birthday_mode do %>
+              <% :full -> %>
+                {format_birthdate(@user)}
+                <%= if years = age(@user) do %>
+                  <span class="font-normal text-slate-600 dark:text-slate-400">({ngettext(
+                    "%{count} year old",
+                    "%{count} years old",
+                    years
+                  )})</span>
+                <% end %>
+              <% :day_month -> %>
+                {format_birthdate_day_month(@user)}
+              <% :age -> %>
+                <%= if years = age(@user) do %>
+                  {ngettext("%{count} year old", "%{count} years old", years)}
+                <% end %>
             <% end %>
           </dd>
         </div>

--- a/lib/vutuv_web/views/user_helpers.ex
+++ b/lib/vutuv_web/views/user_helpers.ex
@@ -54,6 +54,25 @@ defmodule VutuvWeb.UserHelpers do
   end
 
   @doc """
+  The `{label, value}` options for the Basics form's birthday-visibility select:
+  the four granularity choices (full date + age → age only → day and month →
+  hidden) from the schema's single source (`User.birthdate_visibilities/0`
+  through `User.birthdate_visibility_label/1`), so the form can never offer a
+  value the changeset would reject.
+  """
+  def birthdate_visibility_options do
+    Enum.map(User.birthdate_visibilities(), &{User.birthdate_visibility_label(&1), &1})
+  end
+
+  @doc """
+  The effective birthday display mode for a member (`:full` / `:age` /
+  `:day_month` / `:none`). Re-exported here so the profile template can gate the
+  General Info card on one imported call; the logic lives in
+  `Vutuv.Accounts.User.birthdate_mode/1`.
+  """
+  defdelegate birthdate_mode(user), to: User
+
+  @doc """
   The `{label, value}` options for the salary-expectation currency select
   (issue #928): the whitelisted codes shown with their symbol (e.g. `€ EUR`).
   """
@@ -548,6 +567,32 @@ defmodule VutuvWeb.UserHelpers do
   end
 
   defp format_usa(_), do: ""
+
+  @doc """
+  The birthday's day and month **without the year**, in the same locale-shaped
+  numeric style `format_birthdate/1` uses (German `23.04.`, otherwise the USA
+  `04/23`). For the "day_month" birthday visibility, where the year (and thus
+  the age) stays private. `""` for a member without a birthdate.
+  """
+  def format_birthdate_day_month(%User{locale: "de", birthdate: birthdate}) do
+    format_pyramid_day_month(birthdate)
+  end
+
+  def format_birthdate_day_month(%User{birthdate: birthdate}) do
+    format_usa_day_month(birthdate)
+  end
+
+  defp format_pyramid_day_month(%Date{month: month, day: day}) do
+    "#{String.pad_leading(Integer.to_string(day), 2, "0")}.#{String.pad_leading(Integer.to_string(month), 2, "0")}."
+  end
+
+  defp format_pyramid_day_month(_), do: ""
+
+  defp format_usa_day_month(%Date{month: month, day: day}) do
+    "#{String.pad_leading(Integer.to_string(month), 2, "0")}/#{String.pad_leading(Integer.to_string(day), 2, "0")}"
+  end
+
+  defp format_usa_day_month(_), do: ""
 
   @doc """
   The member's age in whole years on the current German calendar day

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.107.0",
+      version: "7.108.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -34,7 +34,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1078
+#: lib/vutuv_web/templates/user/show.html.heex:1089
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -94,8 +94,10 @@ msgid "Birthdate"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:414
+#: lib/vutuv_web/agent_docs/markdown.ex:415
 #: lib/vutuv_web/agent_docs/text.ex:419
-#: lib/vutuv_web/templates/user/show.html.heex:786
+#: lib/vutuv_web/agent_docs/text.ex:420
+#: lib/vutuv_web/templates/user/show.html.heex:788
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
@@ -116,8 +118,8 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:25
 #: lib/vutuv_web/templates/user/edit.html.heex:50
 #: lib/vutuv_web/templates/user/edit.html.heex:103
-#: lib/vutuv_web/templates/user/edit.html.heex:333
-#: lib/vutuv_web/templates/user/edit.html.heex:368
+#: lib/vutuv_web/templates/user/edit.html.heex:347
+#: lib/vutuv_web/templates/user/edit.html.heex:382
 #, elixir-autogen
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -141,7 +143,7 @@ msgstr "Wählen Sie einen Typ aus"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:51
 #: lib/vutuv_web/agent_docs/text.ex:50
-#: lib/vutuv_web/templates/user/show.html.heex:815
+#: lib/vutuv_web/templates/user/show.html.heex:826
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -217,7 +219,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/url/edit.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:800
+#: lib/vutuv_web/templates/user/show.html.heex:811
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #, elixir-autogen
 msgid "Edit"
@@ -318,8 +320,8 @@ msgstr "Fax"
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:425
-#: lib/vutuv_web/agent_docs/text.ex:430
+#: lib/vutuv_web/agent_docs/markdown.ex:426
+#: lib/vutuv_web/agent_docs/text.ex:431
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -327,8 +329,8 @@ msgstr "Vorname"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:426
-#: lib/vutuv_web/agent_docs/text.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:427
+#: lib/vutuv_web/agent_docs/text.ex:432
 #: lib/vutuv_web/components/ui.ex:1248
 #: lib/vutuv_web/components/ui.ex:1273
 #: lib/vutuv_web/components/ui.ex:1276
@@ -353,7 +355,7 @@ msgstr "Folge ich"
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:64
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:781
+#: lib/vutuv_web/templates/user/show.html.heex:783
 #, elixir-autogen
 msgid "Gender"
 msgstr "Geschlecht"
@@ -654,7 +656,7 @@ msgstr "Öffentlich (für alle sichtbar) oder Privat (nur für Sie sichtbar)"
 #: lib/vutuv_web/templates/settings/privacy.html.heex:125
 #: lib/vutuv_web/templates/settings/privacy.html.heex:157
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
-#: lib/vutuv_web/templates/user/edit.html.heex:328
+#: lib/vutuv_web/templates/user/edit.html.heex:342
 #, elixir-autogen
 msgid "Save"
 msgstr "Speichern"
@@ -706,13 +708,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:925
+#: lib/vutuv_web/templates/user/show.html.heex:936
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:927
+#: lib/vutuv_web/templates/user/show.html.heex:938
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -1128,7 +1130,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:770
+#: lib/vutuv_web/templates/user/show.html.heex:772
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1483,10 +1485,10 @@ msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:31
 #: lib/vutuv_web/agent_docs/markdown.ex:353
-#: lib/vutuv_web/agent_docs/markdown.ex:727
+#: lib/vutuv_web/agent_docs/markdown.ex:728
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:387
-#: lib/vutuv_web/agent_docs/text.ex:538
+#: lib/vutuv_web/agent_docs/text.ex:539
 #: lib/vutuv_web/components/ui.ex:2774
 #: lib/vutuv_web/controllers/user_tag_controller.ex:37
 #: lib/vutuv_web/controllers/user_tag_controller.ex:54
@@ -1958,7 +1960,7 @@ msgstr ""
 "unten ein, um die Adresse zu bestätigen."
 
 #: lib/vutuv_web/live/post_live/feed.ex:611
-#: lib/vutuv_web/templates/user/show.html.heex:1162
+#: lib/vutuv_web/templates/user/show.html.heex:1173
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
@@ -2305,7 +2307,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/controllers/post_controller.ex:54
 #: lib/vutuv_web/controllers/post_controller.ex:62
 #: lib/vutuv_web/controllers/user_controller.ex:73
-#: lib/vutuv_web/gettext_extraction_anchors.ex:71
+#: lib/vutuv_web/gettext_extraction_anchors.ex:77
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:181
@@ -2316,13 +2318,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1031
-#: lib/vutuv_web/components/post_components.ex:1035
+#: lib/vutuv_web/components/post_components.ex:1039
+#: lib/vutuv_web/components/post_components.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:1032
+#: lib/vutuv_web/components/post_components.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
@@ -2420,22 +2422,22 @@ msgstr "Was gibt's Neues? Markdown wird unterstützt."
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:1233
+#: lib/vutuv_web/components/post_components.ex:1241
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:1237
+#: lib/vutuv_web/components/post_components.ex:1245
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:1235
+#: lib/vutuv_web/components/post_components.ex:1243
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:1236
+#: lib/vutuv_web/components/post_components.ex:1244
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2476,7 +2478,7 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1305
+#: lib/vutuv_web/components/post_components.ex:1313
 #: lib/vutuv_web/components/ui.ex:1528
 #: lib/vutuv_web/components/ui.ex:1528
 #: lib/vutuv_web/components/ui.ex:2136
@@ -2485,7 +2487,7 @@ msgstr "Alle Beiträge"
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:760
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:318
@@ -2495,7 +2497,7 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1272
+#: lib/vutuv_web/components/post_components.ex:1280
 #: lib/vutuv_web/components/ui.ex:1557
 #: lib/vutuv_web/components/ui.ex:1557
 #: lib/vutuv_web/components/ui.ex:2122
@@ -2505,7 +2507,7 @@ msgstr "Lesezeichen"
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:759
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:387
@@ -2524,12 +2526,12 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:1294
+#: lib/vutuv_web/components/post_components.ex:1302
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1305
+#: lib/vutuv_web/components/post_components.ex:1313
 #: lib/vutuv_web/components/ui.ex:1518
 #: lib/vutuv_web/components/ui.ex:1518
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2538,23 +2540,23 @@ msgstr "Nur öffentliche Beiträge können repostet werden."
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1291
+#: lib/vutuv_web/components/post_components.ex:1299
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1112
+#: lib/vutuv_web/components/post_components.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1291
+#: lib/vutuv_web/components/post_components.ex:1299
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:1272
+#: lib/vutuv_web/components/post_components.ex:1280
 #: lib/vutuv_web/components/ui.ex:1547
 #: lib/vutuv_web/components/ui.ex:1547
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2575,7 +2577,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:1345
+#: lib/vutuv_web/components/post_components.ex:1353
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2587,8 +2589,8 @@ msgstr "Nur öffentliche Beiträge können beantwortet werden."
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1328
-#: lib/vutuv_web/components/post_components.ex:1329
+#: lib/vutuv_web/components/post_components.ex:1336
+#: lib/vutuv_web/components/post_components.ex:1337
 #: lib/vutuv_web/live/notification_live/index.ex:207
 #: lib/vutuv_web/live/notification_live/index.ex:280
 #: lib/vutuv_web/live/post_live/reply.ex:25
@@ -2820,24 +2822,24 @@ msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:889
+#: lib/vutuv_web/templates/user/show.html.heex:900
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1080
+#: lib/vutuv_web/templates/user/show.html.heex:1091
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:817
+#: lib/vutuv_web/templates/user/show.html.heex:828
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:772
+#: lib/vutuv_web/templates/user/show.html.heex:774
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
@@ -2872,14 +2874,14 @@ msgstr "Verwalten"
 msgid "Write a post"
 msgstr "Beitrag schreiben"
 
-#: lib/vutuv_web/views/user_helpers.ex:84
+#: lib/vutuv_web/views/user_helpers.ex:103
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] "%{count} Tag hinzugefügt."
 msgstr[1] "%{count} Tags hinzugefügt."
 
-#: lib/vutuv_web/views/user_helpers.ex:88
+#: lib/vutuv_web/views/user_helpers.ex:107
 #, elixir-autogen, elixir-format
 msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
 msgstr ""
@@ -2900,8 +2902,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 weiteres Tag"
 msgstr[1] "+%{formatted} weitere Tags"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:427
-#: lib/vutuv_web/agent_docs/text.ex:432
+#: lib/vutuv_web/agent_docs/markdown.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:433
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2946,7 +2948,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:1234
+#: lib/vutuv_web/components/post_components.ex:1242
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3219,8 +3221,8 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:857
-#: lib/vutuv_web/templates/user/show.html.heex:858
+#: lib/vutuv_web/templates/user/show.html.heex:868
+#: lib/vutuv_web/templates/user/show.html.heex:869
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
@@ -4020,12 +4022,12 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:514
+#: lib/vutuv_web/agent_docs/markdown.ex:515
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:772
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -4039,11 +4041,11 @@ msgstr "%{count} Beiträge von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/markdown.ex:137
 #: lib/vutuv_web/agent_docs/markdown.ex:150
-#: lib/vutuv_web/agent_docs/markdown.ex:727
+#: lib/vutuv_web/agent_docs/markdown.ex:728
 #: lib/vutuv_web/agent_docs/text.ex:75
 #: lib/vutuv_web/agent_docs/text.ex:134
 #: lib/vutuv_web/agent_docs/text.ex:147
-#: lib/vutuv_web/agent_docs/text.ex:538
+#: lib/vutuv_web/agent_docs/text.ex:539
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
@@ -4060,20 +4062,20 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:745
-#: lib/vutuv_web/agent_docs/text.ex:549
+#: lib/vutuv_web/agent_docs/markdown.ex:746
+#: lib/vutuv_web/agent_docs/text.ex:550
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:742
-#: lib/vutuv_web/agent_docs/text.ex:546
+#: lib/vutuv_web/agent_docs/markdown.ex:743
+#: lib/vutuv_web/agent_docs/text.ex:547
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:749
-#: lib/vutuv_web/agent_docs/text.ex:552
+#: lib/vutuv_web/agent_docs/markdown.ex:750
+#: lib/vutuv_web/agent_docs/text.ex:553
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
@@ -4125,17 +4127,17 @@ msgstr "Beiträge (insgesamt %{count})"
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:696
+#: lib/vutuv_web/agent_docs/markdown.ex:697
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:635
+#: lib/vutuv_web/agent_docs/markdown.ex:636
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:636
+#: lib/vutuv_web/agent_docs/markdown.ex:637
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -5686,9 +5688,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:759
-#: lib/vutuv_web/components/post_components.ex:806
-#: lib/vutuv_web/components/post_components.ex:819
+#: lib/vutuv_web/components/post_components.ex:753
+#: lib/vutuv_web/components/post_components.ex:802
+#: lib/vutuv_web/components/post_components.ex:815
 #: lib/vutuv_web/live/post_live/feed.ex:672
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6383,7 +6385,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1127
+#: lib/vutuv_web/templates/user/show.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6428,15 +6430,16 @@ msgstr "Foto verwenden"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:790
+#: lib/vutuv_web/templates/user/show.html.heex:794
+#: lib/vutuv_web/templates/user/show.html.heex:804
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:415
-#: lib/vutuv_web/agent_docs/text.ex:420
+#: lib/vutuv_web/agent_docs/markdown.ex:416
+#: lib/vutuv_web/agent_docs/text.ex:421
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Alter"
@@ -6470,12 +6473,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:904
+#: lib/vutuv_web/templates/user/show.html.heex:915
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:915
+#: lib/vutuv_web/templates/user/show.html.heex:926
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6510,13 +6513,13 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:759
 #: lib/vutuv_web/views/admin/report_html.ex:16
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:913
+#: lib/vutuv_web/templates/user/show.html.heex:924
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6550,7 +6553,7 @@ msgstr "Nach oben"
 msgid "Remove endorsement"
 msgstr "Empfehlung zurücknehmen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:68
+#: lib/vutuv_web/gettext_extraction_anchors.ex:74
 #: lib/vutuv_web/templates/settings/preferences.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Default map"
@@ -6566,20 +6569,20 @@ msgstr "Karteneinstellungen gespeichert."
 msgid "Map services to show"
 msgstr "Anzuzeigende Kartendienste"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:72
+#: lib/vutuv_web/gettext_extraction_anchors.ex:78
 #: lib/vutuv_web/templates/settings/preferences.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1113
-#: lib/vutuv_web/templates/user/show.html.heex:1121
-#: lib/vutuv_web/templates/user/show.html.heex:1133
+#: lib/vutuv_web/templates/user/show.html.heex:1124
+#: lib/vutuv_web/templates/user/show.html.heex:1132
+#: lib/vutuv_web/templates/user/show.html.heex:1144
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:70
+#: lib/vutuv_web/gettext_extraction_anchors.ex:76
 #: lib/vutuv_web/templates/settings/preferences.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6615,7 +6618,7 @@ msgstr "Noch keine Empfehlungen."
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:740
+#: lib/vutuv_web/agent_docs/markdown.ex:741
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -7848,17 +7851,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:776
+#: lib/vutuv_web/agent_docs/markdown.ex:777
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Dein Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:779
+#: lib/vutuv_web/agent_docs/markdown.ex:780
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:786
+#: lib/vutuv_web/agent_docs/markdown.ex:787
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -8739,7 +8742,7 @@ msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:103
-#: lib/vutuv_web/templates/user/show.html.heex:984
+#: lib/vutuv_web/templates/user/show.html.heex:995
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8831,7 +8834,7 @@ msgstr "Basisdaten & Fotos"
 msgid "Language & display"
 msgstr "Sprache & Anzeige"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:387
+#: lib/vutuv_web/templates/user/edit.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
@@ -9208,7 +9211,7 @@ msgid "Employment"
 msgstr "Anstellung"
 
 #: lib/vutuv/jobs/job_posting.ex:152
-#: lib/vutuv_web/agent_docs/markdown.ex:554
+#: lib/vutuv_web/agent_docs/markdown.ex:555
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -9231,7 +9234,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr "Berufserfahrung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:555
+#: lib/vutuv_web/agent_docs/markdown.ex:556
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -9269,13 +9272,13 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:593
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:591
+#: lib/vutuv_web/agent_docs/markdown.ex:592
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9304,14 +9307,14 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:1115
+#: lib/vutuv_web/components/post_components.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:699
+#: lib/vutuv_web/agent_docs/markdown.ex:700
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9404,14 +9407,14 @@ msgstr ""
 "Der Lebenslauf von %{name} auf vutuv: Berufserfahrung, Ausbildung und "
 "Kenntnisse zum Ansehen und Herunterladen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:553
+#: lib/vutuv_web/agent_docs/markdown.ex:554
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr "Freiberuflich / Selbstständig"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:556
+#: lib/vutuv_web/agent_docs/markdown.ex:557
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9563,8 +9566,8 @@ msgstr "Ehren-Tag"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Ehren-Tag (nur Admins können es vergeben)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:436
-#: lib/vutuv_web/agent_docs/text.ex:439
+#: lib/vutuv_web/agent_docs/markdown.ex:437
+#: lib/vutuv_web/agent_docs/text.ex:440
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "Ehren-Tag"
@@ -10100,7 +10103,7 @@ msgstr[1] "%{count} Zertifikate oder Lizenzen"
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:629
+#: lib/vutuv_web/agent_docs/markdown.ex:630
 #: lib/vutuv_web/views/qualification_html.ex:10
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -10187,7 +10190,7 @@ msgstr "Ablaufmonat"
 msgid "Expiry year"
 msgstr "Ablaufjahr"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:621
+#: lib/vutuv_web/agent_docs/markdown.ex:622
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10213,7 +10216,7 @@ msgstr "Ausstellungsjahr"
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:628
+#: lib/vutuv_web/agent_docs/markdown.ex:629
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10243,7 +10246,7 @@ msgstr "Nachweis"
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:619
+#: lib/vutuv_web/agent_docs/markdown.ex:620
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10258,7 +10261,7 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:620
+#: lib/vutuv_web/agent_docs/markdown.ex:621
 #: lib/vutuv_web/views/qualification_html.ex:60
 #: lib/vutuv_web/views/qualification_html.ex:63
 #, elixir-autogen, elixir-format
@@ -10277,15 +10280,15 @@ msgstr ""
 msgid "Preferred"
 msgstr "Bevorzugt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:523
+#: lib/vutuv_web/agent_docs/markdown.ex:524
 #: lib/vutuv_web/live/section_reorder_live.ex:252
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:879
-#: lib/vutuv_web/templates/user/show.html.heex:880
+#: lib/vutuv_web/templates/user/show.html.heex:890
+#: lib/vutuv_web/templates/user/show.html.heex:891
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10300,17 +10303,17 @@ msgid "Date of birth"
 msgstr "Geburtsdatum"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:320
-#: lib/vutuv_web/templates/user/edit.html.heex:375
+#: lib/vutuv_web/templates/user/edit.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr "Geburtsdatum entfernen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:355
+#: lib/vutuv_web/templates/user/edit.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr "Geburtsdatum entfernen?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:358
+#: lib/vutuv_web/templates/user/edit.html.heex:372
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10980,21 +10983,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr "auf diesem Gerät einrichten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:491
+#: lib/vutuv_web/agent_docs/markdown.ex:492
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} Follower"
 msgstr[1] "%{count} Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:489
+#: lib/vutuv_web/agent_docs/markdown.ex:490
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} Repository"
 msgstr[1] "%{count} Repositories"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:487
+#: lib/vutuv_web/agent_docs/markdown.ex:488
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -11017,7 +11020,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:56
 #: lib/vutuv_web/agent_docs/text.ex:55
-#: lib/vutuv_web/templates/user/show.html.heex:958
+#: lib/vutuv_web/templates/user/show.html.heex:969
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -11052,12 +11055,12 @@ msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten nur als einfache "
 "Links."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:506
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:492
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "seit %{date}"
@@ -11313,13 +11316,13 @@ msgstr ""
 "Wie Beiträge, die Sie lesen, in Ihrem Feed und auf Profilen gekürzt werden. "
 "Das sind Ihre eigenen Anzeige-Einstellungen."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:63
+#: lib/vutuv_web/gettext_extraction_anchors.ex:69
 #: lib/vutuv_web/templates/settings/preferences.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr "Silbentrennung am Desktop"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:64
+#: lib/vutuv_web/gettext_extraction_anchors.ex:70
 #: lib/vutuv_web/templates/settings/preferences.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
@@ -11330,13 +11333,13 @@ msgstr "Silbentrennung auf dem Smartphone"
 msgid "Hyphenation"
 msgstr "Silbentrennung"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:61
+#: lib/vutuv_web/gettext_extraction_anchors.ex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr "Zeilen am Desktop"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:62
+#: lib/vutuv_web/gettext_extraction_anchors.ex:68
 #: lib/vutuv_web/templates/settings/preferences.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
@@ -11489,32 +11492,32 @@ msgstr ""
 "wählt, und was ausgeloggte Besucher sehen. Änderungen gelten sofort; "
 "Mitglieder mit eigenem Wert sind nicht betroffen."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:69
+#: lib/vutuv_web/gettext_extraction_anchors.ex:75
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr "0 bedeutet: Beiträge werden nie gekürzt."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:74
+#: lib/vutuv_web/gettext_extraction_anchors.ex:80
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Aus"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:73
+#: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "An"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:67
+#: lib/vutuv_web/gettext_extraction_anchors.ex:73
 #, elixir-autogen, elixir-format
 msgid "Show Apple Maps"
 msgstr "Apple Maps anzeigen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:65
+#: lib/vutuv_web/gettext_extraction_anchors.ex:71
 #, elixir-autogen, elixir-format
 msgid "Show Google Maps"
 msgstr "Google Maps anzeigen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:66
+#: lib/vutuv_web/gettext_extraction_anchors.ex:72
 #, elixir-autogen, elixir-format
 msgid "Show OpenStreetMap"
 msgstr "OpenStreetMap anzeigen"
@@ -11713,31 +11716,31 @@ msgid "Who can see your salary expectation?"
 msgstr "Wer kann Ihre Gehaltsvorstellung sehen?"
 
 #: lib/vutuv/salary.ex:48
-#: lib/vutuv_web/gettext_extraction_anchors.ex:57
+#: lib/vutuv_web/gettext_extraction_anchors.ex:63
 #, elixir-autogen, elixir-format
 msgid "day"
 msgstr "Tag"
 
 #: lib/vutuv/salary.ex:47
-#: lib/vutuv_web/gettext_extraction_anchors.ex:56
+#: lib/vutuv_web/gettext_extraction_anchors.ex:62
 #, elixir-autogen, elixir-format
 msgid "hour"
 msgstr "Stunde"
 
 #: lib/vutuv/salary.ex:50
-#: lib/vutuv_web/gettext_extraction_anchors.ex:59
+#: lib/vutuv_web/gettext_extraction_anchors.ex:65
 #, elixir-autogen, elixir-format
 msgid "month"
 msgstr "Monat"
 
 #: lib/vutuv/salary.ex:49
-#: lib/vutuv_web/gettext_extraction_anchors.ex:58
+#: lib/vutuv_web/gettext_extraction_anchors.ex:64
 #, elixir-autogen, elixir-format
 msgid "week"
 msgstr "Woche"
 
 #: lib/vutuv/salary.ex:51
-#: lib/vutuv_web/gettext_extraction_anchors.ex:60
+#: lib/vutuv_web/gettext_extraction_anchors.ex:66
 #, elixir-autogen, elixir-format
 msgid "year"
 msgstr "Jahr"
@@ -12480,8 +12483,8 @@ msgstr ""
 "Wir konnten den Nachweis noch nicht finden. Die Verbreitung kann etwas "
 "dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:649
-#: lib/vutuv_web/agent_docs/text.ex:519
+#: lib/vutuv_web/agent_docs/markdown.ex:650
+#: lib/vutuv_web/agent_docs/text.ex:520
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -14175,7 +14178,7 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "An image was removed from your vutuv account"
 msgstr "Ein Bild wurde aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/components/post_components.ex:891
+#: lib/vutuv_web/components/post_components.ex:887
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -14183,7 +14186,7 @@ msgstr "Ein Bild wurde aus Ihrem vutuv-Konto entfernt"
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:881
+#: lib/vutuv_web/components/post_components.ex:877
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr "Bild wird geprüft"
@@ -14233,3 +14236,33 @@ msgstr "Screenshot entfernt."
 #, elixir-autogen, elixir-format
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:57
+#, elixir-autogen, elixir-format
+msgid "Age only, without the date"
+msgstr "Nur das Alter, ohne das Datum"
+
+#: lib/vutuv_web/templates/user/edit.html.heex:331
+#, elixir-autogen, elixir-format
+msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
+msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:58
+#, elixir-autogen, elixir-format
+msgid "Day and month, without the year"
+msgstr "Tag und Monat, ohne das Jahr"
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:59
+#, elixir-autogen, elixir-format
+msgid "Do not show my birthday"
+msgstr "Geburtstag nicht anzeigen"
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:56
+#, elixir-autogen, elixir-format
+msgid "Full date and age"
+msgstr "Vollständiges Datum und Alter"
+
+#: lib/vutuv_web/templates/user/edit.html.heex:328
+#, elixir-autogen, elixir-format
+msgid "Show my birthday as"
+msgstr "Geburtstag anzeigen als"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -36,7 +36,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1078
+#: lib/vutuv_web/templates/user/show.html.heex:1089
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -96,8 +96,10 @@ msgid "Birthdate"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:414
+#: lib/vutuv_web/agent_docs/markdown.ex:415
 #: lib/vutuv_web/agent_docs/text.ex:419
-#: lib/vutuv_web/templates/user/show.html.heex:786
+#: lib/vutuv_web/agent_docs/text.ex:420
+#: lib/vutuv_web/templates/user/show.html.heex:788
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -118,8 +120,8 @@ msgstr ""
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:25
 #: lib/vutuv_web/templates/user/edit.html.heex:50
 #: lib/vutuv_web/templates/user/edit.html.heex:103
-#: lib/vutuv_web/templates/user/edit.html.heex:333
-#: lib/vutuv_web/templates/user/edit.html.heex:368
+#: lib/vutuv_web/templates/user/edit.html.heex:347
+#: lib/vutuv_web/templates/user/edit.html.heex:382
 #, elixir-autogen
 msgid "Cancel"
 msgstr ""
@@ -141,7 +143,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:51
 #: lib/vutuv_web/agent_docs/text.ex:50
-#: lib/vutuv_web/templates/user/show.html.heex:815
+#: lib/vutuv_web/templates/user/show.html.heex:826
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -217,7 +219,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/url/edit.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:800
+#: lib/vutuv_web/templates/user/show.html.heex:811
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #, elixir-autogen
 msgid "Edit"
@@ -318,8 +320,8 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:425
-#: lib/vutuv_web/agent_docs/text.ex:430
+#: lib/vutuv_web/agent_docs/markdown.ex:426
+#: lib/vutuv_web/agent_docs/text.ex:431
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -327,8 +329,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:426
-#: lib/vutuv_web/agent_docs/text.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:427
+#: lib/vutuv_web/agent_docs/text.ex:432
 #: lib/vutuv_web/components/ui.ex:1248
 #: lib/vutuv_web/components/ui.ex:1273
 #: lib/vutuv_web/components/ui.ex:1276
@@ -353,7 +355,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:64
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:781
+#: lib/vutuv_web/templates/user/show.html.heex:783
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -654,7 +656,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:125
 #: lib/vutuv_web/templates/settings/privacy.html.heex:157
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
-#: lib/vutuv_web/templates/user/edit.html.heex:328
+#: lib/vutuv_web/templates/user/edit.html.heex:342
 #, elixir-autogen
 msgid "Save"
 msgstr ""
@@ -706,13 +708,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:925
+#: lib/vutuv_web/templates/user/show.html.heex:936
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:927
+#: lib/vutuv_web/templates/user/show.html.heex:938
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -1106,7 +1108,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:770
+#: lib/vutuv_web/templates/user/show.html.heex:772
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1455,10 +1457,10 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:31
 #: lib/vutuv_web/agent_docs/markdown.ex:353
-#: lib/vutuv_web/agent_docs/markdown.ex:727
+#: lib/vutuv_web/agent_docs/markdown.ex:728
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:387
-#: lib/vutuv_web/agent_docs/text.ex:538
+#: lib/vutuv_web/agent_docs/text.ex:539
 #: lib/vutuv_web/components/ui.ex:2774
 #: lib/vutuv_web/controllers/user_tag_controller.ex:37
 #: lib/vutuv_web/controllers/user_tag_controller.ex:54
@@ -1916,7 +1918,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:611
-#: lib/vutuv_web/templates/user/show.html.heex:1162
+#: lib/vutuv_web/templates/user/show.html.heex:1173
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -2257,7 +2259,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/post_controller.ex:54
 #: lib/vutuv_web/controllers/post_controller.ex:62
 #: lib/vutuv_web/controllers/user_controller.ex:73
-#: lib/vutuv_web/gettext_extraction_anchors.ex:71
+#: lib/vutuv_web/gettext_extraction_anchors.ex:77
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:181
@@ -2268,13 +2270,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1031
-#: lib/vutuv_web/components/post_components.ex:1035
+#: lib/vutuv_web/components/post_components.ex:1039
+#: lib/vutuv_web/components/post_components.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1032
+#: lib/vutuv_web/components/post_components.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2370,22 +2372,22 @@ msgstr ""
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1233
+#: lib/vutuv_web/components/post_components.ex:1241
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1237
+#: lib/vutuv_web/components/post_components.ex:1245
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1235
+#: lib/vutuv_web/components/post_components.ex:1243
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1236
+#: lib/vutuv_web/components/post_components.ex:1244
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2426,7 +2428,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1305
+#: lib/vutuv_web/components/post_components.ex:1313
 #: lib/vutuv_web/components/ui.ex:1528
 #: lib/vutuv_web/components/ui.ex:1528
 #: lib/vutuv_web/components/ui.ex:2136
@@ -2435,7 +2437,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:760
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:318
@@ -2445,7 +2447,7 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1272
+#: lib/vutuv_web/components/post_components.ex:1280
 #: lib/vutuv_web/components/ui.ex:1557
 #: lib/vutuv_web/components/ui.ex:1557
 #: lib/vutuv_web/components/ui.ex:2122
@@ -2455,7 +2457,7 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:759
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:387
@@ -2474,12 +2476,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1294
+#: lib/vutuv_web/components/post_components.ex:1302
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1305
+#: lib/vutuv_web/components/post_components.ex:1313
 #: lib/vutuv_web/components/ui.ex:1518
 #: lib/vutuv_web/components/ui.ex:1518
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2488,23 +2490,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1291
+#: lib/vutuv_web/components/post_components.ex:1299
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1112
+#: lib/vutuv_web/components/post_components.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1291
+#: lib/vutuv_web/components/post_components.ex:1299
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1272
+#: lib/vutuv_web/components/post_components.ex:1280
 #: lib/vutuv_web/components/ui.ex:1547
 #: lib/vutuv_web/components/ui.ex:1547
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2525,7 +2527,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1345
+#: lib/vutuv_web/components/post_components.ex:1353
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2537,8 +2539,8 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1328
-#: lib/vutuv_web/components/post_components.ex:1329
+#: lib/vutuv_web/components/post_components.ex:1336
+#: lib/vutuv_web/components/post_components.ex:1337
 #: lib/vutuv_web/live/notification_live/index.ex:207
 #: lib/vutuv_web/live/notification_live/index.ex:280
 #: lib/vutuv_web/live/post_live/reply.ex:25
@@ -2762,24 +2764,24 @@ msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:889
+#: lib/vutuv_web/templates/user/show.html.heex:900
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1080
+#: lib/vutuv_web/templates/user/show.html.heex:1091
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:817
+#: lib/vutuv_web/templates/user/show.html.heex:828
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:772
+#: lib/vutuv_web/templates/user/show.html.heex:774
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
@@ -2814,14 +2816,14 @@ msgstr ""
 msgid "Write a post"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:84
+#: lib/vutuv_web/views/user_helpers.ex:103
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_helpers.ex:88
+#: lib/vutuv_web/views/user_helpers.ex:107
 #, elixir-autogen, elixir-format
 msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
 msgstr ""
@@ -2840,8 +2842,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:427
-#: lib/vutuv_web/agent_docs/text.ex:432
+#: lib/vutuv_web/agent_docs/markdown.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:433
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2886,7 +2888,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1234
+#: lib/vutuv_web/components/post_components.ex:1242
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3141,8 +3143,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:857
-#: lib/vutuv_web/templates/user/show.html.heex:858
+#: lib/vutuv_web/templates/user/show.html.heex:868
+#: lib/vutuv_web/templates/user/show.html.heex:869
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -3877,12 +3879,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:514
+#: lib/vutuv_web/agent_docs/markdown.ex:515
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:772
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3896,11 +3898,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/markdown.ex:137
 #: lib/vutuv_web/agent_docs/markdown.ex:150
-#: lib/vutuv_web/agent_docs/markdown.ex:727
+#: lib/vutuv_web/agent_docs/markdown.ex:728
 #: lib/vutuv_web/agent_docs/text.ex:75
 #: lib/vutuv_web/agent_docs/text.ex:134
 #: lib/vutuv_web/agent_docs/text.ex:147
-#: lib/vutuv_web/agent_docs/text.ex:538
+#: lib/vutuv_web/agent_docs/text.ex:539
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3917,20 +3919,20 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:745
-#: lib/vutuv_web/agent_docs/text.ex:549
+#: lib/vutuv_web/agent_docs/markdown.ex:746
+#: lib/vutuv_web/agent_docs/text.ex:550
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:742
-#: lib/vutuv_web/agent_docs/text.ex:546
+#: lib/vutuv_web/agent_docs/markdown.ex:743
+#: lib/vutuv_web/agent_docs/text.ex:547
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:749
-#: lib/vutuv_web/agent_docs/text.ex:552
+#: lib/vutuv_web/agent_docs/markdown.ex:750
+#: lib/vutuv_web/agent_docs/text.ex:553
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
@@ -3982,17 +3984,17 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:696
+#: lib/vutuv_web/agent_docs/markdown.ex:697
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:635
+#: lib/vutuv_web/agent_docs/markdown.ex:636
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:636
+#: lib/vutuv_web/agent_docs/markdown.ex:637
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -5444,9 +5446,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:759
-#: lib/vutuv_web/components/post_components.ex:806
-#: lib/vutuv_web/components/post_components.ex:819
+#: lib/vutuv_web/components/post_components.ex:753
+#: lib/vutuv_web/components/post_components.ex:802
+#: lib/vutuv_web/components/post_components.ex:815
 #: lib/vutuv_web/live/post_live/feed.ex:672
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6122,7 +6124,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1127
+#: lib/vutuv_web/templates/user/show.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6165,15 +6167,16 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:790
+#: lib/vutuv_web/templates/user/show.html.heex:794
+#: lib/vutuv_web/templates/user/show.html.heex:804
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:415
-#: lib/vutuv_web/agent_docs/text.ex:420
+#: lib/vutuv_web/agent_docs/markdown.ex:416
+#: lib/vutuv_web/agent_docs/text.ex:421
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6205,12 +6208,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:904
+#: lib/vutuv_web/templates/user/show.html.heex:915
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:915
+#: lib/vutuv_web/templates/user/show.html.heex:926
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6245,13 +6248,13 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:759
 #: lib/vutuv_web/views/admin/report_html.ex:16
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:913
+#: lib/vutuv_web/templates/user/show.html.heex:924
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6283,7 +6286,7 @@ msgstr ""
 msgid "Remove endorsement"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:68
+#: lib/vutuv_web/gettext_extraction_anchors.ex:74
 #: lib/vutuv_web/templates/settings/preferences.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Default map"
@@ -6299,20 +6302,20 @@ msgstr ""
 msgid "Map services to show"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:72
+#: lib/vutuv_web/gettext_extraction_anchors.ex:78
 #: lib/vutuv_web/templates/settings/preferences.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1113
-#: lib/vutuv_web/templates/user/show.html.heex:1121
-#: lib/vutuv_web/templates/user/show.html.heex:1133
+#: lib/vutuv_web/templates/user/show.html.heex:1124
+#: lib/vutuv_web/templates/user/show.html.heex:1132
+#: lib/vutuv_web/templates/user/show.html.heex:1144
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:70
+#: lib/vutuv_web/gettext_extraction_anchors.ex:76
 #: lib/vutuv_web/templates/settings/preferences.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6344,7 +6347,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:740
+#: lib/vutuv_web/agent_docs/markdown.ex:741
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -7509,17 +7512,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:776
+#: lib/vutuv_web/agent_docs/markdown.ex:777
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:779
+#: lib/vutuv_web/agent_docs/markdown.ex:780
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:786
+#: lib/vutuv_web/agent_docs/markdown.ex:787
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8330,7 +8333,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:103
-#: lib/vutuv_web/templates/user/show.html.heex:984
+#: lib/vutuv_web/templates/user/show.html.heex:995
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8403,7 +8406,7 @@ msgstr ""
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:387
+#: lib/vutuv_web/templates/user/edit.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
@@ -8730,7 +8733,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:152
-#: lib/vutuv_web/agent_docs/markdown.ex:554
+#: lib/vutuv_web/agent_docs/markdown.ex:555
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8751,7 +8754,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:555
+#: lib/vutuv_web/agent_docs/markdown.ex:556
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8787,13 +8790,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:593
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:591
+#: lib/vutuv_web/agent_docs/markdown.ex:592
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8819,14 +8822,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1115
+#: lib/vutuv_web/components/post_components.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:699
+#: lib/vutuv_web/agent_docs/markdown.ex:700
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8904,14 +8907,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:553
+#: lib/vutuv_web/agent_docs/markdown.ex:554
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:556
+#: lib/vutuv_web/agent_docs/markdown.ex:557
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9051,8 +9054,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:436
-#: lib/vutuv_web/agent_docs/text.ex:439
+#: lib/vutuv_web/agent_docs/markdown.ex:437
+#: lib/vutuv_web/agent_docs/text.ex:440
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9577,7 +9580,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:629
+#: lib/vutuv_web/agent_docs/markdown.ex:630
 #: lib/vutuv_web/views/qualification_html.ex:10
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9664,7 +9667,7 @@ msgstr ""
 msgid "Expiry year"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:621
+#: lib/vutuv_web/agent_docs/markdown.ex:622
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9690,7 +9693,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:628
+#: lib/vutuv_web/agent_docs/markdown.ex:629
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9717,7 +9720,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:619
+#: lib/vutuv_web/agent_docs/markdown.ex:620
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9732,7 +9735,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:620
+#: lib/vutuv_web/agent_docs/markdown.ex:621
 #: lib/vutuv_web/views/qualification_html.ex:60
 #: lib/vutuv_web/views/qualification_html.ex:63
 #, elixir-autogen, elixir-format
@@ -9749,15 +9752,15 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:523
+#: lib/vutuv_web/agent_docs/markdown.ex:524
 #: lib/vutuv_web/live/section_reorder_live.ex:252
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:879
-#: lib/vutuv_web/templates/user/show.html.heex:880
+#: lib/vutuv_web/templates/user/show.html.heex:890
+#: lib/vutuv_web/templates/user/show.html.heex:891
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9772,17 +9775,17 @@ msgid "Date of birth"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:320
-#: lib/vutuv_web/templates/user/edit.html.heex:375
+#: lib/vutuv_web/templates/user/edit.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:355
+#: lib/vutuv_web/templates/user/edit.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:358
+#: lib/vutuv_web/templates/user/edit.html.heex:372
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10390,21 +10393,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:491
+#: lib/vutuv_web/agent_docs/markdown.ex:492
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:489
+#: lib/vutuv_web/agent_docs/markdown.ex:490
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:487
+#: lib/vutuv_web/agent_docs/markdown.ex:488
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10427,7 +10430,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:56
 #: lib/vutuv_web/agent_docs/text.ex:55
-#: lib/vutuv_web/templates/user/show.html.heex:958
+#: lib/vutuv_web/templates/user/show.html.heex:969
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10457,12 +10460,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:506
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:492
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10694,13 +10697,13 @@ msgstr ""
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:63
+#: lib/vutuv_web/gettext_extraction_anchors.ex:69
 #: lib/vutuv_web/templates/settings/preferences.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:64
+#: lib/vutuv_web/gettext_extraction_anchors.ex:70
 #: lib/vutuv_web/templates/settings/preferences.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
@@ -10711,13 +10714,13 @@ msgstr ""
 msgid "Hyphenation"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:61
+#: lib/vutuv_web/gettext_extraction_anchors.ex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:62
+#: lib/vutuv_web/gettext_extraction_anchors.ex:68
 #: lib/vutuv_web/templates/settings/preferences.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
@@ -10850,32 +10853,32 @@ msgstr ""
 msgid "What every member gets until they choose for themselves on their settings pages, and what logged-out visitors see. Changes apply immediately; members who set their own value are not affected."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:69
+#: lib/vutuv_web/gettext_extraction_anchors.ex:75
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:74
+#: lib/vutuv_web/gettext_extraction_anchors.ex:80
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:73
+#: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:67
+#: lib/vutuv_web/gettext_extraction_anchors.ex:73
 #, elixir-autogen, elixir-format
 msgid "Show Apple Maps"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:65
+#: lib/vutuv_web/gettext_extraction_anchors.ex:71
 #, elixir-autogen, elixir-format
 msgid "Show Google Maps"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:66
+#: lib/vutuv_web/gettext_extraction_anchors.ex:72
 #, elixir-autogen, elixir-format
 msgid "Show OpenStreetMap"
 msgstr ""
@@ -11052,31 +11055,31 @@ msgid "Who can see your salary expectation?"
 msgstr ""
 
 #: lib/vutuv/salary.ex:48
-#: lib/vutuv_web/gettext_extraction_anchors.ex:57
+#: lib/vutuv_web/gettext_extraction_anchors.ex:63
 #, elixir-autogen, elixir-format
 msgid "day"
 msgstr ""
 
 #: lib/vutuv/salary.ex:47
-#: lib/vutuv_web/gettext_extraction_anchors.ex:56
+#: lib/vutuv_web/gettext_extraction_anchors.ex:62
 #, elixir-autogen, elixir-format
 msgid "hour"
 msgstr ""
 
 #: lib/vutuv/salary.ex:50
-#: lib/vutuv_web/gettext_extraction_anchors.ex:59
+#: lib/vutuv_web/gettext_extraction_anchors.ex:65
 #, elixir-autogen, elixir-format
 msgid "month"
 msgstr ""
 
 #: lib/vutuv/salary.ex:49
-#: lib/vutuv_web/gettext_extraction_anchors.ex:58
+#: lib/vutuv_web/gettext_extraction_anchors.ex:64
 #, elixir-autogen, elixir-format
 msgid "week"
 msgstr ""
 
 #: lib/vutuv/salary.ex:51
-#: lib/vutuv_web/gettext_extraction_anchors.ex:60
+#: lib/vutuv_web/gettext_extraction_anchors.ex:66
 #, elixir-autogen, elixir-format
 msgid "year"
 msgstr ""
@@ -11784,8 +11787,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:649
-#: lib/vutuv_web/agent_docs/text.ex:519
+#: lib/vutuv_web/agent_docs/markdown.ex:650
+#: lib/vutuv_web/agent_docs/text.ex:520
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -13444,7 +13447,7 @@ msgstr ""
 msgid "An image was removed from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:891
+#: lib/vutuv_web/components/post_components.ex:887
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -13452,7 +13455,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:881
+#: lib/vutuv_web/components/post_components.ex:877
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr ""
@@ -13501,4 +13504,34 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/edit.ex:80
 #, elixir-autogen, elixir-format
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:57
+#, elixir-autogen, elixir-format
+msgid "Age only, without the date"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/edit.html.heex:331
+#, elixir-autogen, elixir-format
+msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:58
+#, elixir-autogen, elixir-format
+msgid "Day and month, without the year"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:59
+#, elixir-autogen, elixir-format
+msgid "Do not show my birthday"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:56
+#, elixir-autogen, elixir-format
+msgid "Full date and age"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/edit.html.heex:328
+#, elixir-autogen, elixir-format
+msgid "Show my birthday as"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -34,7 +34,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1078
+#: lib/vutuv_web/templates/user/show.html.heex:1089
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -94,8 +94,10 @@ msgid "Birthdate"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:414
+#: lib/vutuv_web/agent_docs/markdown.ex:415
 #: lib/vutuv_web/agent_docs/text.ex:419
-#: lib/vutuv_web/templates/user/show.html.heex:786
+#: lib/vutuv_web/agent_docs/text.ex:420
+#: lib/vutuv_web/templates/user/show.html.heex:788
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -116,8 +118,8 @@ msgstr ""
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:25
 #: lib/vutuv_web/templates/user/edit.html.heex:50
 #: lib/vutuv_web/templates/user/edit.html.heex:103
-#: lib/vutuv_web/templates/user/edit.html.heex:333
-#: lib/vutuv_web/templates/user/edit.html.heex:368
+#: lib/vutuv_web/templates/user/edit.html.heex:347
+#: lib/vutuv_web/templates/user/edit.html.heex:382
 #, elixir-autogen
 msgid "Cancel"
 msgstr ""
@@ -139,7 +141,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:51
 #: lib/vutuv_web/agent_docs/text.ex:50
-#: lib/vutuv_web/templates/user/show.html.heex:815
+#: lib/vutuv_web/templates/user/show.html.heex:826
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -215,7 +217,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/url/edit.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:800
+#: lib/vutuv_web/templates/user/show.html.heex:811
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #, elixir-autogen
 msgid "Edit"
@@ -316,8 +318,8 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:425
-#: lib/vutuv_web/agent_docs/text.ex:430
+#: lib/vutuv_web/agent_docs/markdown.ex:426
+#: lib/vutuv_web/agent_docs/text.ex:431
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -325,8 +327,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:426
-#: lib/vutuv_web/agent_docs/text.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:427
+#: lib/vutuv_web/agent_docs/text.ex:432
 #: lib/vutuv_web/components/ui.ex:1248
 #: lib/vutuv_web/components/ui.ex:1273
 #: lib/vutuv_web/components/ui.ex:1276
@@ -351,7 +353,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:64
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:781
+#: lib/vutuv_web/templates/user/show.html.heex:783
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -652,7 +654,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:125
 #: lib/vutuv_web/templates/settings/privacy.html.heex:157
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
-#: lib/vutuv_web/templates/user/edit.html.heex:328
+#: lib/vutuv_web/templates/user/edit.html.heex:342
 #, elixir-autogen
 msgid "Save"
 msgstr ""
@@ -704,13 +706,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:925
+#: lib/vutuv_web/templates/user/show.html.heex:936
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:927
+#: lib/vutuv_web/templates/user/show.html.heex:938
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -1104,7 +1106,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:770
+#: lib/vutuv_web/templates/user/show.html.heex:772
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1453,10 +1455,10 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:31
 #: lib/vutuv_web/agent_docs/markdown.ex:353
-#: lib/vutuv_web/agent_docs/markdown.ex:727
+#: lib/vutuv_web/agent_docs/markdown.ex:728
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:387
-#: lib/vutuv_web/agent_docs/text.ex:538
+#: lib/vutuv_web/agent_docs/text.ex:539
 #: lib/vutuv_web/components/ui.ex:2774
 #: lib/vutuv_web/controllers/user_tag_controller.ex:37
 #: lib/vutuv_web/controllers/user_tag_controller.ex:54
@@ -1914,7 +1916,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:611
-#: lib/vutuv_web/templates/user/show.html.heex:1162
+#: lib/vutuv_web/templates/user/show.html.heex:1173
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -2255,7 +2257,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/post_controller.ex:54
 #: lib/vutuv_web/controllers/post_controller.ex:62
 #: lib/vutuv_web/controllers/user_controller.ex:73
-#: lib/vutuv_web/gettext_extraction_anchors.ex:71
+#: lib/vutuv_web/gettext_extraction_anchors.ex:77
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:181
@@ -2266,13 +2268,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1031
-#: lib/vutuv_web/components/post_components.ex:1035
+#: lib/vutuv_web/components/post_components.ex:1039
+#: lib/vutuv_web/components/post_components.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1032
+#: lib/vutuv_web/components/post_components.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2368,22 +2370,22 @@ msgstr ""
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1233
+#: lib/vutuv_web/components/post_components.ex:1241
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1237
+#: lib/vutuv_web/components/post_components.ex:1245
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1235
+#: lib/vutuv_web/components/post_components.ex:1243
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1236
+#: lib/vutuv_web/components/post_components.ex:1244
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2424,7 +2426,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1305
+#: lib/vutuv_web/components/post_components.ex:1313
 #: lib/vutuv_web/components/ui.ex:1528
 #: lib/vutuv_web/components/ui.ex:1528
 #: lib/vutuv_web/components/ui.ex:2136
@@ -2433,7 +2435,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:760
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:318
@@ -2443,7 +2445,7 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1272
+#: lib/vutuv_web/components/post_components.ex:1280
 #: lib/vutuv_web/components/ui.ex:1557
 #: lib/vutuv_web/components/ui.ex:1557
 #: lib/vutuv_web/components/ui.ex:2122
@@ -2453,7 +2455,7 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:759
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:387
@@ -2472,12 +2474,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1294
+#: lib/vutuv_web/components/post_components.ex:1302
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1305
+#: lib/vutuv_web/components/post_components.ex:1313
 #: lib/vutuv_web/components/ui.ex:1518
 #: lib/vutuv_web/components/ui.ex:1518
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2486,23 +2488,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1291
+#: lib/vutuv_web/components/post_components.ex:1299
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1112
+#: lib/vutuv_web/components/post_components.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1291
+#: lib/vutuv_web/components/post_components.ex:1299
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1272
+#: lib/vutuv_web/components/post_components.ex:1280
 #: lib/vutuv_web/components/ui.ex:1547
 #: lib/vutuv_web/components/ui.ex:1547
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2523,7 +2525,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1345
+#: lib/vutuv_web/components/post_components.ex:1353
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2535,8 +2537,8 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1328
-#: lib/vutuv_web/components/post_components.ex:1329
+#: lib/vutuv_web/components/post_components.ex:1336
+#: lib/vutuv_web/components/post_components.ex:1337
 #: lib/vutuv_web/live/notification_live/index.ex:207
 #: lib/vutuv_web/live/notification_live/index.ex:280
 #: lib/vutuv_web/live/post_live/reply.ex:25
@@ -2760,24 +2762,24 @@ msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:889
+#: lib/vutuv_web/templates/user/show.html.heex:900
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1080
+#: lib/vutuv_web/templates/user/show.html.heex:1091
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:817
+#: lib/vutuv_web/templates/user/show.html.heex:828
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:772
+#: lib/vutuv_web/templates/user/show.html.heex:774
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
@@ -2812,14 +2814,14 @@ msgstr ""
 msgid "Write a post"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:84
+#: lib/vutuv_web/views/user_helpers.ex:103
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_helpers.ex:88
+#: lib/vutuv_web/views/user_helpers.ex:107
 #, elixir-autogen, elixir-format
 msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
 msgstr ""
@@ -2838,8 +2840,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:427
-#: lib/vutuv_web/agent_docs/text.ex:432
+#: lib/vutuv_web/agent_docs/markdown.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:433
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2884,7 +2886,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1234
+#: lib/vutuv_web/components/post_components.ex:1242
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3139,8 +3141,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:857
-#: lib/vutuv_web/templates/user/show.html.heex:858
+#: lib/vutuv_web/templates/user/show.html.heex:868
+#: lib/vutuv_web/templates/user/show.html.heex:869
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -3875,12 +3877,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:514
+#: lib/vutuv_web/agent_docs/markdown.ex:515
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:772
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3894,11 +3896,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/markdown.ex:137
 #: lib/vutuv_web/agent_docs/markdown.ex:150
-#: lib/vutuv_web/agent_docs/markdown.ex:727
+#: lib/vutuv_web/agent_docs/markdown.ex:728
 #: lib/vutuv_web/agent_docs/text.ex:75
 #: lib/vutuv_web/agent_docs/text.ex:134
 #: lib/vutuv_web/agent_docs/text.ex:147
-#: lib/vutuv_web/agent_docs/text.ex:538
+#: lib/vutuv_web/agent_docs/text.ex:539
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3915,20 +3917,20 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:745
-#: lib/vutuv_web/agent_docs/text.ex:549
+#: lib/vutuv_web/agent_docs/markdown.ex:746
+#: lib/vutuv_web/agent_docs/text.ex:550
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:742
-#: lib/vutuv_web/agent_docs/text.ex:546
+#: lib/vutuv_web/agent_docs/markdown.ex:743
+#: lib/vutuv_web/agent_docs/text.ex:547
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:749
-#: lib/vutuv_web/agent_docs/text.ex:552
+#: lib/vutuv_web/agent_docs/markdown.ex:750
+#: lib/vutuv_web/agent_docs/text.ex:553
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
@@ -3980,17 +3982,17 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:696
+#: lib/vutuv_web/agent_docs/markdown.ex:697
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:635
+#: lib/vutuv_web/agent_docs/markdown.ex:636
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:636
+#: lib/vutuv_web/agent_docs/markdown.ex:637
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -5442,9 +5444,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:759
-#: lib/vutuv_web/components/post_components.ex:806
-#: lib/vutuv_web/components/post_components.ex:819
+#: lib/vutuv_web/components/post_components.ex:753
+#: lib/vutuv_web/components/post_components.ex:802
+#: lib/vutuv_web/components/post_components.ex:815
 #: lib/vutuv_web/live/post_live/feed.ex:672
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6120,7 +6122,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1127
+#: lib/vutuv_web/templates/user/show.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6163,15 +6165,16 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:790
+#: lib/vutuv_web/templates/user/show.html.heex:794
+#: lib/vutuv_web/templates/user/show.html.heex:804
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:415
-#: lib/vutuv_web/agent_docs/text.ex:420
+#: lib/vutuv_web/agent_docs/markdown.ex:416
+#: lib/vutuv_web/agent_docs/text.ex:421
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6203,12 +6206,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:904
+#: lib/vutuv_web/templates/user/show.html.heex:915
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:915
+#: lib/vutuv_web/templates/user/show.html.heex:926
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6243,13 +6246,13 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:759
 #: lib/vutuv_web/views/admin/report_html.ex:16
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:913
+#: lib/vutuv_web/templates/user/show.html.heex:924
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6281,7 +6284,7 @@ msgstr ""
 msgid "Remove endorsement"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:68
+#: lib/vutuv_web/gettext_extraction_anchors.ex:74
 #: lib/vutuv_web/templates/settings/preferences.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "Default map"
@@ -6297,20 +6300,20 @@ msgstr ""
 msgid "Map services to show"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:72
+#: lib/vutuv_web/gettext_extraction_anchors.ex:78
 #: lib/vutuv_web/templates/settings/preferences.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1113
-#: lib/vutuv_web/templates/user/show.html.heex:1121
-#: lib/vutuv_web/templates/user/show.html.heex:1133
+#: lib/vutuv_web/templates/user/show.html.heex:1124
+#: lib/vutuv_web/templates/user/show.html.heex:1132
+#: lib/vutuv_web/templates/user/show.html.heex:1144
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:70
+#: lib/vutuv_web/gettext_extraction_anchors.ex:76
 #: lib/vutuv_web/templates/settings/preferences.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6342,7 +6345,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:740
+#: lib/vutuv_web/agent_docs/markdown.ex:741
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -7507,17 +7510,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:776
+#: lib/vutuv_web/agent_docs/markdown.ex:777
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:779
+#: lib/vutuv_web/agent_docs/markdown.ex:780
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:786
+#: lib/vutuv_web/agent_docs/markdown.ex:787
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8328,7 +8331,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:103
-#: lib/vutuv_web/templates/user/show.html.heex:984
+#: lib/vutuv_web/templates/user/show.html.heex:995
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8401,7 +8404,7 @@ msgstr ""
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:387
+#: lib/vutuv_web/templates/user/edit.html.heex:401
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
@@ -8728,7 +8731,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:152
-#: lib/vutuv_web/agent_docs/markdown.ex:554
+#: lib/vutuv_web/agent_docs/markdown.ex:555
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8749,7 +8752,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:555
+#: lib/vutuv_web/agent_docs/markdown.ex:556
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8785,13 +8788,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:593
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:591
+#: lib/vutuv_web/agent_docs/markdown.ex:592
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8817,14 +8820,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1115
+#: lib/vutuv_web/components/post_components.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:699
+#: lib/vutuv_web/agent_docs/markdown.ex:700
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8902,14 +8905,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:553
+#: lib/vutuv_web/agent_docs/markdown.ex:554
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:556
+#: lib/vutuv_web/agent_docs/markdown.ex:557
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9049,8 +9052,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:436
-#: lib/vutuv_web/agent_docs/text.ex:439
+#: lib/vutuv_web/agent_docs/markdown.ex:437
+#: lib/vutuv_web/agent_docs/text.ex:440
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9575,7 +9578,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:629
+#: lib/vutuv_web/agent_docs/markdown.ex:630
 #: lib/vutuv_web/views/qualification_html.ex:10
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9662,7 +9665,7 @@ msgstr ""
 msgid "Expiry year"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:621
+#: lib/vutuv_web/agent_docs/markdown.ex:622
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9688,7 +9691,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:628
+#: lib/vutuv_web/agent_docs/markdown.ex:629
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9715,7 +9718,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:619
+#: lib/vutuv_web/agent_docs/markdown.ex:620
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9730,7 +9733,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:620
+#: lib/vutuv_web/agent_docs/markdown.ex:621
 #: lib/vutuv_web/views/qualification_html.ex:60
 #: lib/vutuv_web/views/qualification_html.ex:63
 #, elixir-autogen, elixir-format
@@ -9747,15 +9750,15 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:523
+#: lib/vutuv_web/agent_docs/markdown.ex:524
 #: lib/vutuv_web/live/section_reorder_live.ex:252
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:879
-#: lib/vutuv_web/templates/user/show.html.heex:880
+#: lib/vutuv_web/templates/user/show.html.heex:890
+#: lib/vutuv_web/templates/user/show.html.heex:891
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9770,17 +9773,17 @@ msgid "Date of birth"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:320
-#: lib/vutuv_web/templates/user/edit.html.heex:375
+#: lib/vutuv_web/templates/user/edit.html.heex:389
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:355
+#: lib/vutuv_web/templates/user/edit.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:358
+#: lib/vutuv_web/templates/user/edit.html.heex:372
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10388,21 +10391,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:491
+#: lib/vutuv_web/agent_docs/markdown.ex:492
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:489
+#: lib/vutuv_web/agent_docs/markdown.ex:490
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:487
+#: lib/vutuv_web/agent_docs/markdown.ex:488
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10425,7 +10428,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:56
 #: lib/vutuv_web/agent_docs/text.ex:55
-#: lib/vutuv_web/templates/user/show.html.heex:958
+#: lib/vutuv_web/templates/user/show.html.heex:969
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10455,12 +10458,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:506
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:492
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10692,13 +10695,13 @@ msgstr ""
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:63
+#: lib/vutuv_web/gettext_extraction_anchors.ex:69
 #: lib/vutuv_web/templates/settings/preferences.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:64
+#: lib/vutuv_web/gettext_extraction_anchors.ex:70
 #: lib/vutuv_web/templates/settings/preferences.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
@@ -10709,13 +10712,13 @@ msgstr ""
 msgid "Hyphenation"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:61
+#: lib/vutuv_web/gettext_extraction_anchors.ex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:62
+#: lib/vutuv_web/gettext_extraction_anchors.ex:68
 #: lib/vutuv_web/templates/settings/preferences.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
@@ -10848,32 +10851,32 @@ msgstr ""
 msgid "What every member gets until they choose for themselves on their settings pages, and what logged-out visitors see. Changes apply immediately; members who set their own value are not affected."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:69
+#: lib/vutuv_web/gettext_extraction_anchors.ex:75
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:74
+#: lib/vutuv_web/gettext_extraction_anchors.ex:80
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:73
+#: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:67
+#: lib/vutuv_web/gettext_extraction_anchors.ex:73
 #, elixir-autogen, elixir-format
 msgid "Show Apple Maps"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:65
+#: lib/vutuv_web/gettext_extraction_anchors.ex:71
 #, elixir-autogen, elixir-format
 msgid "Show Google Maps"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:66
+#: lib/vutuv_web/gettext_extraction_anchors.ex:72
 #, elixir-autogen, elixir-format
 msgid "Show OpenStreetMap"
 msgstr ""
@@ -11050,31 +11053,31 @@ msgid "Who can see your salary expectation?"
 msgstr ""
 
 #: lib/vutuv/salary.ex:48
-#: lib/vutuv_web/gettext_extraction_anchors.ex:57
+#: lib/vutuv_web/gettext_extraction_anchors.ex:63
 #, elixir-autogen, elixir-format
 msgid "day"
 msgstr ""
 
 #: lib/vutuv/salary.ex:47
-#: lib/vutuv_web/gettext_extraction_anchors.ex:56
+#: lib/vutuv_web/gettext_extraction_anchors.ex:62
 #, elixir-autogen, elixir-format
 msgid "hour"
 msgstr ""
 
 #: lib/vutuv/salary.ex:50
-#: lib/vutuv_web/gettext_extraction_anchors.ex:59
+#: lib/vutuv_web/gettext_extraction_anchors.ex:65
 #, elixir-autogen, elixir-format
 msgid "month"
 msgstr ""
 
 #: lib/vutuv/salary.ex:49
-#: lib/vutuv_web/gettext_extraction_anchors.ex:58
+#: lib/vutuv_web/gettext_extraction_anchors.ex:64
 #, elixir-autogen, elixir-format
 msgid "week"
 msgstr ""
 
 #: lib/vutuv/salary.ex:51
-#: lib/vutuv_web/gettext_extraction_anchors.ex:60
+#: lib/vutuv_web/gettext_extraction_anchors.ex:66
 #, elixir-autogen, elixir-format
 msgid "year"
 msgstr ""
@@ -11782,8 +11785,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:649
-#: lib/vutuv_web/agent_docs/text.ex:519
+#: lib/vutuv_web/agent_docs/markdown.ex:650
+#: lib/vutuv_web/agent_docs/text.ex:520
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -13442,7 +13445,7 @@ msgstr ""
 msgid "An image was removed from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:891
+#: lib/vutuv_web/components/post_components.ex:887
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -13450,7 +13453,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:881
+#: lib/vutuv_web/components/post_components.ex:877
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr ""
@@ -13499,4 +13502,34 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/edit.ex:80
 #, elixir-autogen, elixir-format
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:57
+#, elixir-autogen, elixir-format
+msgid "Age only, without the date"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/edit.html.heex:331
+#, elixir-autogen, elixir-format
+msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:58
+#, elixir-autogen, elixir-format
+msgid "Day and month, without the year"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:59
+#, elixir-autogen, elixir-format
+msgid "Do not show my birthday"
+msgstr ""
+
+#: lib/vutuv_web/gettext_extraction_anchors.ex:56
+#, elixir-autogen, elixir-format
+msgid "Full date and age"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/edit.html.heex:328
+#, elixir-autogen, elixir-format
+msgid "Show my birthday as"
 msgstr ""

--- a/priv/repo/migrations/20260719160442_add_birthdate_visibility_to_users.exs
+++ b/priv/repo/migrations/20260719160442_add_birthdate_visibility_to_users.exs
@@ -1,0 +1,17 @@
+defmodule Vutuv.Repo.Migrations.AddBirthdateVisibilityToUsers do
+  use Ecto.Migration
+
+  # How much of a member's birthday the public profile (and its agent-format
+  # siblings) reveal: "full" (date + age, the historical behaviour), "age"
+  # (age only), "day_month" (day and month, no year) or "hidden" (stored but
+  # never shown publicly). A plain additive column with a NOT NULL default, so
+  # it is N-1 safe: the currently deployed release, which doesn't know the
+  # column, keeps inserting without it and the default backfills. Defaulting to
+  # "full" keeps every existing member's birthday exactly as public as it is
+  # today — more privacy is opt-in.
+  def change do
+    alter table(:users) do
+      add(:birthdate_visibility, :string, null: false, default: "full")
+    end
+  end
+end

--- a/test/vutuv/accounts/user_test.exs
+++ b/test/vutuv/accounts/user_test.exs
@@ -148,6 +148,59 @@ defmodule Vutuv.Accounts.UserTest do
     end
   end
 
+  describe "birthdate_visibility" do
+    test "defaults to \"full\" so a new member's birthday stays as public as before" do
+      assert %User{}.birthdate_visibility == "full"
+    end
+
+    test "the changeset accepts every valid granularity" do
+      for value <- User.birthdate_visibilities() do
+        changeset =
+          User.changeset(%User{}, %{"first_name" => "first_name", "birthdate_visibility" => value})
+
+        assert changeset.valid?, "expected #{inspect(value)} to be a valid birthdate_visibility"
+      end
+    end
+
+    test "the changeset rejects an unknown granularity" do
+      changeset =
+        User.changeset(%User{}, %{"first_name" => "first_name", "birthdate_visibility" => "nope"})
+
+      refute changeset.valid?
+      assert %{birthdate_visibility: [_]} = errors_on(changeset)
+    end
+
+    test "every offered value has a label" do
+      for value <- User.birthdate_visibilities() do
+        assert User.birthdate_visibility_label(value)
+      end
+    end
+  end
+
+  describe "birthdate_mode/1" do
+    test ":none whenever there is no birthday, regardless of the setting" do
+      for value <- User.birthdate_visibilities() do
+        assert User.birthdate_mode(%User{birthdate: nil, birthdate_visibility: value}) == :none
+      end
+    end
+
+    test "maps the setting to a display mode when a birthday is set" do
+      born = ~D[1990-05-15]
+      assert User.birthdate_mode(%User{birthdate: born, birthdate_visibility: "full"}) == :full
+      assert User.birthdate_mode(%User{birthdate: born, birthdate_visibility: "age"}) == :age
+
+      assert User.birthdate_mode(%User{birthdate: born, birthdate_visibility: "day_month"}) ==
+               :day_month
+
+      assert User.birthdate_mode(%User{birthdate: born, birthdate_visibility: "hidden"}) == :none
+    end
+
+    test "a nil/legacy setting falls back to :full (the historical public view)" do
+      assert User.birthdate_mode(%User{birthdate: ~D[1990-05-15], birthdate_visibility: nil}) ==
+               :full
+    end
+  end
+
   describe "identity verification revocation" do
     # A member an admin has already verified (their physical ID was checked
     # against this name and birthday).

--- a/test/vutuv_web/birthdate_visibility_test.exs
+++ b/test/vutuv_web/birthdate_visibility_test.exs
@@ -1,0 +1,141 @@
+defmodule VutuvWeb.BirthdateVisibilityTest do
+  @moduledoc """
+  The birthday-visibility setting (full / age only / day+month / hidden) must
+  gate the birthday consistently across every PUBLIC surface: the profile card,
+  the md/txt/json/xml/vCard agent siblings, and the public CV builder. Both
+  sides of each gate are asserted here — what shows and, just as important, what
+  must never leak (the year, the age, or the whole date).
+
+  The birthdate is 1990-04-23 and the factory locale is "en", so the profile
+  renders the date as "04/23/1990" and the day-month as "04/23". Negative
+  assertions lean on strings that carry a "/" (never present in the base64url
+  LiveView tokens) rather than the bare year to stay token-collision-proof.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  alias Vutuv.Repo
+  alias VutuvWeb.UserHelpers
+
+  @born ~D[1990-04-23]
+
+  defp profile_with(visibility) do
+    insert_activated_user(
+      username: "born_#{visibility}",
+      first_name: "Bea",
+      last_name: "Born",
+      birthdate: @born,
+      birthdate_visibility: visibility
+    )
+  end
+
+  defp formats(user) do
+    path = "/" <> user.username
+
+    %{
+      html: build_conn() |> get(path) |> html_response(200),
+      md: get(build_conn(), path <> ".md").resp_body,
+      txt: get(build_conn(), path <> ".txt").resp_body,
+      json: Jason.decode!(get(build_conn(), path <> ".json").resp_body),
+      xml: get(build_conn(), path <> ".xml").resp_body,
+      vcf: get(build_conn(), path <> ".vcf").resp_body
+    }
+  end
+
+  test "\"full\" shows the date and the derived age everywhere (the default)" do
+    user = profile_with("full")
+    age = UserHelpers.age(user)
+    r = formats(user)
+
+    assert r.html =~ "04/23/1990"
+    assert r.html =~ "#{age} year"
+
+    assert r.md =~ "Birthday: 1990-04-23"
+    assert r.md =~ "Age: #{age}"
+    assert r.txt =~ "Birthday: 1990-04-23"
+    assert r.txt =~ "Age: #{age}"
+
+    assert r.json["birthdate"] == "1990-04-23"
+    assert r.json["age"] == age
+    assert r.json["birthday_month_day"] == nil
+
+    assert r.xml =~ "<birthdate>1990-04-23</birthdate>"
+    assert r.xml =~ "<age>#{age}</age>"
+
+    assert r.vcf =~ "BDAY:1990-04-23"
+  end
+
+  test "\"age\" shows only the age, never the date" do
+    user = profile_with("age")
+    age = UserHelpers.age(user)
+    r = formats(user)
+
+    assert r.html =~ "#{age} year"
+    # No date at all, so neither the full date nor the day-month appears.
+    refute r.html =~ "04/23"
+
+    refute r.md =~ "Birthday:"
+    assert r.md =~ "Age: #{age}"
+    refute r.txt =~ "Birthday:"
+    assert r.txt =~ "Age: #{age}"
+
+    assert r.json["age"] == age
+    assert r.json["birthdate"] == nil
+    assert r.json["birthday_month_day"] == nil
+
+    refute r.vcf =~ "BDAY:"
+  end
+
+  test "\"day_month\" shows the day and month but never the year or the age" do
+    user = profile_with("day_month")
+    r = formats(user)
+
+    assert r.html =~ "04/23"
+    # The year (and therefore the age) is gone: the full date and the age line
+    # must both be absent.
+    refute r.html =~ "04/23/1990"
+    refute r.html =~ "year old"
+
+    assert r.md =~ "Birthday: 04-23"
+    refute r.md =~ "Age:"
+    assert r.txt =~ "Birthday: 04-23"
+    refute r.txt =~ "Age:"
+
+    assert r.json["birthday_month_day"] == "04-23"
+    assert r.json["birthdate"] == nil
+    assert r.json["age"] == nil
+    assert r.xml =~ "<birthday_month_day>04-23</birthday_month_day>"
+
+    # vCard 3.0 BDAY needs a year, so a year-less birthday carries no BDAY.
+    refute r.vcf =~ "BDAY:"
+  end
+
+  test "\"hidden\" shows nothing publicly, yet keeps the stored birthday" do
+    user = profile_with("hidden")
+    r = formats(user)
+
+    refute r.html =~ "04/23"
+    refute r.html =~ "year old"
+    refute r.md =~ "Birthday:"
+    refute r.md =~ "Age:"
+    refute r.txt =~ "Birthday:"
+    refute r.txt =~ "Age:"
+
+    assert r.json["birthdate"] == nil
+    assert r.json["age"] == nil
+    assert r.json["birthday_month_day"] == nil
+    refute r.vcf =~ "BDAY:"
+
+    # Hidden is about display, not deletion: the value is still stored so the
+    # member can flip the setting back or use it in their own GDPR export.
+    assert Repo.reload(user).birthdate == @born
+  end
+
+  describe "the public CV (/:slug/cv) never reveals more than the profile" do
+    test "full keeps the date, day_month drops the year, age/hidden drop the DOB line" do
+      assert VutuvWeb.CV.build(profile_with("full")).birthdate =~ "1990"
+      assert VutuvWeb.CV.build(profile_with("day_month")).birthdate == "04/23"
+      assert VutuvWeb.CV.build(profile_with("age")).birthdate == nil
+      assert VutuvWeb.CV.build(profile_with("hidden")).birthdate == nil
+    end
+  end
+end

--- a/test/vutuv_web/controllers/user_controller_test.exs
+++ b/test/vutuv_web/controllers/user_controller_test.exs
@@ -88,6 +88,42 @@ defmodule VutuvWeb.UserControllerTest do
     end
   end
 
+  describe "birthday visibility on the Basics form" do
+    test "the edit form renders the visibility select with every granularity option", %{
+      conn: conn
+    } do
+      {conn, _user} = create_and_login_user(conn)
+
+      html = conn |> get(~p"/settings/profile") |> html_response(200)
+
+      assert html =~ ~s(name="user[birthdate_visibility]")
+
+      for value <- User.birthdate_visibilities() do
+        assert html =~ ~s(value="#{value}"),
+               "expected the form to offer birthdate_visibility=#{value}"
+      end
+    end
+
+    test "submitting the form persists the chosen visibility", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      put(conn, ~p"/settings/profile", user: %{"birthdate_visibility" => "day_month"})
+
+      assert Repo.get!(User, user.id).birthdate_visibility == "day_month"
+    end
+
+    test "an out-of-range visibility is rejected, leaving the stored value untouched", %{
+      conn: conn
+    } do
+      {conn, user} = create_and_login_user(conn)
+
+      conn = put(conn, ~p"/settings/profile", user: %{"birthdate_visibility" => "bogus"})
+
+      assert html_response(conn, 422)
+      assert Repo.get!(User, user.id).birthdate_visibility == "full"
+    end
+  end
+
   test "shows chosen resource", %{conn: conn} do
     {conn, user} = create_and_login_user(conn)
     conn = get(conn, ~p"/#{user}")

--- a/test/vutuv_web/views/user_helpers_test.exs
+++ b/test/vutuv_web/views/user_helpers_test.exs
@@ -260,6 +260,34 @@ defmodule VutuvWeb.UserHelpersTest do
     end
   end
 
+  describe "format_birthdate_day_month/1 (day + month, no year)" do
+    test "German locale drops the year, keeps the dd.mm. shape" do
+      assert UserHelpers.format_birthdate_day_month(%User{
+               locale: "de",
+               birthdate: ~D[1990-04-23]
+             }) == "23.04."
+    end
+
+    test "other locales use the mm/dd shape without the year" do
+      assert UserHelpers.format_birthdate_day_month(%User{
+               locale: "en",
+               birthdate: ~D[1990-04-23]
+             }) == "04/23"
+    end
+
+    test "no birthdate yields an empty string" do
+      assert UserHelpers.format_birthdate_day_month(%User{birthdate: nil}) == ""
+    end
+  end
+
+  describe "birthdate_visibility_options/0" do
+    test "offers every schema-valid granularity with a label" do
+      options = UserHelpers.birthdate_visibility_options()
+      assert Enum.map(options, &elem(&1, 1)) == User.birthdate_visibilities()
+      assert Enum.all?(options, fn {label, _value} -> is_binary(label) and label != "" end)
+    end
+  end
+
   describe "following_map/2" do
     test "returns followee_id => follow_id for followed users only" do
       follower = insert(:user)


### PR DESCRIPTION
## TL;DR
Members can now choose how much of their birthday is public — full date + age (the default), age only, day + month without the year, or nothing at all.

## Why
People want to enter a birthday without necessarily publishing it: some want only their age shown, some the day and month but not the year, some nothing. This adds all four variants.

## What
- New `users.birthdate_visibility` setting (`full` / `age` / `day_month` / `hidden`), picked from a select beside the birthday field on the Basics form (`/settings/profile`).
- Single seam `Vutuv.Accounts.User.birthdate_mode/1` → `:full` / `:age` / `:day_month` / `:none` (folds "hidden" and "no birthday" into `:none`; nil/legacy → `:full`).
- Every **public** surface reads it so none leaks more than the profile: the General Info card, the agent-format siblings (`ProfileDoc` gates `birthdate` / `birthday_month_day` / `age`; md/txt/json/xml and the vCard `BDAY` stay in sync), and the public CV builder at `/:slug/cv`.
- Owner **GDPR export** and admin **newsletter age-segmentation** keep the raw stored `birthdate` — the setting is about public display, not deletion.

## Compatibility
- Default `"full"`, so every existing member's birthday stays exactly as public as before; more privacy is strictly opt-in.
- Migration is a plain additive `NOT NULL` column with a default → N-1 backward compatible (one deploy).
- Version bumped to `7.107.0`.

## Tests
- `test/vutuv_web/birthdate_visibility_test.exs` asserts both sides of all four modes across profile HTML, every agent format, vCard and the CV.
- Plus changeset / helper unit tests and a Basics-form controller test (rendered field + save + rejects out-of-range).
- `mix precommit` green (the one failure on the first run was the known unrelated `register_user` async deadlock flake; passed clean on retry).

_Written with this GitHub account, but not necessarily by the human behind it._

https://claude.ai/code/session_013D6AfkGf6bLYJBsym2MgK9