### PR TITLE
Add an explicit Profile menu item on desktop and mobile

### DIFF
--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -289,6 +289,18 @@ defmodule VutuvWeb.ShellLive do
             >
               {gettext("Feed")}
             </.link>
+            <%!-- An explicit "Profile" item makes the member's own profile a
+                 named, discoverable destination (the logo's deep-link on /feed
+                 is too subtle). Only rendered for a logged-in member — it needs
+                 @user_param, which only a valid session carries. --%>
+            <.link
+              :if={@user_id}
+              href={~p"/#{@user_param}"}
+              data-nav-profile
+              class="rounded-md px-3 py-2 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+            >
+              {gettext("Profile")}
+            </.link>
             <.link
               href={~p"/listings/most_followed_users"}
               class="rounded-md px-3 py-2 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
@@ -456,7 +468,7 @@ defmodule VutuvWeb.ShellLive do
         aria-label={gettext("Main navigation")}
         class={[
           "fixed inset-x-0 bottom-0 z-30 grid h-16 border-t border-slate-200 bg-white/95 backdrop-blur md:hidden dark:border-slate-800 dark:bg-slate-900/95",
-          if(@user_id, do: "grid-cols-4", else: "grid-cols-2")
+          if(@user_id, do: "grid-cols-5", else: "grid-cols-2")
         ]}
       >
         <%= if @user_id do %>
@@ -466,6 +478,18 @@ defmodule VutuvWeb.ShellLive do
         <%= if @user_id do %>
           <.tab href={~p"/messages"} label={gettext("Messages")} count={@messages_count}><.icon_envelope /></.tab>
           <.tab href={~p"/notifications"} label={gettext("Alerts")} count={@notifications_count}><.icon_bell /></.tab>
+          <%!-- The member's own avatar is the Profile tab — the universal mobile
+          convention for "you", so the profile is reachable on phones too, not
+          just via the desktop nav or the logo's /feed deep-link. --%>
+          <.tab href={~p"/#{@user_param}"} label={gettext("Profile")} data-mobile-profile>
+            <%= if @user_avatar do %>
+              <img src={@user_avatar} alt="" class="h-6 w-6 rounded-full object-cover" />
+            <% else %>
+              <span class="flex h-6 w-6 items-center justify-center rounded-full bg-brand-700 text-[10px] font-bold text-white">
+                {@user_initials}
+              </span>
+            <% end %>
+          </.tab>
         <% else %>
           <.tab href={~p"/login"} label={gettext("Log in")}><.icon_login /></.tab>
         <% end %>
@@ -479,11 +503,12 @@ defmodule VutuvWeb.ShellLive do
   attr(:href, :string, required: true)
   attr(:label, :string, required: true)
   attr(:count, :integer, default: 0)
+  attr(:rest, :global)
   slot(:inner_block, required: true)
 
   defp tab(assigns) do
     ~H"""
-    <.link href={@href} class="flex flex-col items-center justify-center gap-0.5 text-slate-600 dark:text-slate-400">
+    <.link href={@href} class="flex flex-col items-center justify-center gap-0.5 text-slate-600 dark:text-slate-400" {@rest}>
       <span class="relative">
         {render_slot(@inner_block)}
         <.count_badge

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.110.5",
+      version: "7.111.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/shell_live_test.exs
+++ b/test/vutuv_web/live/shell_live_test.exs
@@ -268,6 +268,38 @@ defmodule VutuvWeb.ShellLiveTest do
     assert html =~ ~s(href="/notifications")
   end
 
+  describe "profile navigation" do
+    test "the desktop nav carries an explicit Profile link to the member's profile", %{
+      conn: conn
+    } do
+      # The logo already deep-links to the profile on /feed, but that is not
+      # obvious; a named "Profile" nav item makes the member's own profile a
+      # first-class, discoverable destination.
+      user = insert(:user)
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+
+      assert has_element?(view, ~s(nav a[data-nav-profile][href="/stefan"]), "Profile")
+    end
+
+    test "the mobile tab bar carries a Profile tab to the member's profile", %{conn: conn} do
+      # Desktop is not the only surface: the bottom tab bar gets a Profile tab
+      # too, so phone visitors can reach their profile without hunting for it.
+      user = insert(:user)
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+
+      assert has_element?(view, ~s(nav a[data-mobile-profile][href="/stefan"]), "Profile")
+      # Five tabs now (Feed, Search, Messages, Alerts, Profile), so the grid grows.
+      assert has_element?(view, "nav.grid-cols-5")
+    end
+
+    test "logged out there is no Profile nav link or tab", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: %{})
+
+      refute has_element?(view, "[data-nav-profile]")
+      refute has_element?(view, "[data-mobile-profile]")
+    end
+  end
+
   test "renders the anonymous shell for a stale cookie user_id with no profile data", %{
     conn: conn
   } do


### PR DESCRIPTION
## What

Adds an explicit **Profile** menu point so a member's own profile is a first-class, discoverable destination — not just something reachable via the top-bar avatar menu or the subtle logo→profile deep-link on `/feed`.

- **Desktop:** a "Profile" link in the top-bar main nav, right after Feed (logged-in only).
- **Mobile:** a Profile tab (the member's own avatar, the universal "you" convention) in the bottom tab bar, growing it from 4 to 5 columns when logged in — so the profile is reachable on phones too.

The logo's `/feed` deep-link stays. `"Profile"` was already translated (`Profil`) and `grid-cols-5` already compiled elsewhere, so no gettext or Tailwind changes were needed.

## Tests

Three new cases in `shell_live_test.exs` cover the desktop link, the mobile tab + `grid-cols-5`, and their absence when logged out. Full `mix precommit` green (3966 tests).

Version bumped 7.110.4 → 7.111.0 (minor, new user-facing navigation).