### PR TITLE
Daily report: detail lists for every metric (v7.111.0)

### DIFF
--- a/docs/architecture/admin.md
+++ b/docs/architecture/admin.md
@@ -383,4 +383,14 @@ The email **subject lists only the non-zero numbers** (e.g. "vutuv Tagesbericht
 20.06.2026: 5 Registrierungen, 12 Beiträge, 1 eingefrorenes Konto"), so the
 day's signal is readable at a glance.
 
+Beyond the counts, every metric carries a capped **detail list**
+(`DailyReport.detail_limit/0` = 25 rows, oldest first) so the report names *who*
+and *what*: the new members (name, `@handle`, profile link), the created posts
+(first line + permalink), the reposters / likers / bookmarkers, the new
+Fediverse followers, the bounced / deactivated / frozen / thawed addresses and
+the removed spam accounts. `VutuvWeb.ReportDetails.sections/1` normalizes the
+sample into linked `%{primary, secondary, path}` lines that the email (HTML +
+text) and the `/admin/reports` page all render, so the three surfaces stay in
+sync; a busier day than the cap ends each section with a "… und N weitere" note.
+
 Behind `config :vutuv, :daily_report_email` (off in tests, on by default).

--- a/lib/vutuv/deliverability.ex
+++ b/lib/vutuv/deliverability.ex
@@ -284,6 +284,30 @@ defmodule Vutuv.Deliverability do
     }
   end
 
+  @doc """
+  Capped sample rows behind `activity_between/2`, for the daily report's detail
+  lists (up to `limit` rows per kind, oldest first). Bounces name the affected
+  address and its status; deactivations the address; freezes and thaws also
+  resolve the account owner (by `user_id`, a plain ledger value, not an
+  association) so the report can link the member's profile — `user` is `nil`
+  when the account is already gone.
+  """
+  def activity_details_between(%NaiveDateTime{} = start, %NaiveDateTime{} = stop, limit) do
+    %{
+      bounces:
+        from(b in EmailBounce,
+          where: b.inserted_at >= ^start and b.inserted_at < ^stop,
+          order_by: [asc: b.inserted_at, asc: b.id],
+          limit: ^limit,
+          select: %{email: b.email_value, status: b.status}
+        )
+        |> Repo.all(),
+      deactivations: event_sample("address_deactivated", start, stop, limit),
+      freezes: event_sample("account_frozen", start, stop, limit),
+      thaws: event_sample("account_thawed", start, stop, limit)
+    }
+  end
+
   defp count_in(schema, start, stop) do
     Repo.aggregate(
       from(r in schema, where: r.inserted_at >= ^start and r.inserted_at < ^stop),
@@ -298,6 +322,29 @@ defmodule Vutuv.Deliverability do
       ),
       :count
     )
+  end
+
+  # A capped, oldest-first sample of one event kind, each row carrying the
+  # affected address and its (batch-resolved) owner for the daily report.
+  defp event_sample(action, start, stop, limit) do
+    events =
+      Repo.all(
+        from(ev in Event,
+          where: ev.action == ^action and ev.inserted_at >= ^start and ev.inserted_at < ^stop,
+          order_by: [asc: ev.inserted_at, asc: ev.id],
+          limit: ^limit
+        )
+      )
+
+    users = users_by_id(events)
+    Enum.map(events, &%{email: &1.email_value, user: Map.get(users, &1.user_id)})
+  end
+
+  defp users_by_id(events) do
+    case events |> Enum.map(& &1.user_id) |> Enum.reject(&is_nil/1) |> Enum.uniq() do
+      [] -> %{}
+      ids -> from(u in User, where: u.id in ^ids) |> Repo.all() |> Map.new(&{&1.id, &1})
+    end
   end
 
   defp user_for_address(address) do

--- a/lib/vutuv/reports.ex
+++ b/lib/vutuv/reports.ex
@@ -34,6 +34,8 @@ defmodule Vutuv.Reports do
   def daily(%Date{} = date) do
     {day_start, day_end} = BerlinTime.day_bounds_utc(date)
     deliverability = Deliverability.activity_between(day_start, day_end)
+    limit = DailyReport.detail_limit()
+    deliverability_details = Deliverability.activity_details_between(day_start, day_end, limit)
 
     %DailyReport{
       date: date,
@@ -47,8 +49,59 @@ defmodule Vutuv.Reports do
       deactivations: deliverability.deactivations,
       freezes: deliverability.freezes,
       thaws: deliverability.thaws,
-      spam_removals: count_spam_removals(day_start, day_end)
+      spam_removals: count_spam_removals(day_start, day_end),
+      details: %{
+        registrations: registration_sample(day_start, day_end, limit),
+        posts: sample(Post, [:user], day_start, day_end, limit),
+        reposts: sample(PostRepost, [:user, :post], day_start, day_end, limit),
+        likes: sample(PostLike, [:user, :post], day_start, day_end, limit),
+        bookmarks: sample(PostBookmark, [:user, :post], day_start, day_end, limit),
+        fediverse_followers: sample(Follower, [:user], day_start, day_end, limit),
+        bounces: deliverability_details.bounces,
+        deactivations: deliverability_details.deactivations,
+        freezes: deliverability_details.freezes,
+        thaws: deliverability_details.thaws,
+        spam_removals: spam_removal_sample(day_start, day_end, limit)
+      }
     }
+  end
+
+  # A capped, oldest-first sample of `schema`'s rows in the window, with the
+  # given associations preloaded so the report can name who/what. Oldest-first
+  # so the list reads in the order the day happened.
+  defp sample(schema, preloads, day_start, day_end, limit) do
+    from(r in schema,
+      where: r.inserted_at >= ^day_start and r.inserted_at < ^day_end,
+      order_by: [asc: r.inserted_at, asc: r.id],
+      limit: ^limit
+    )
+    |> Repo.all()
+    |> Repo.preload(preloads)
+  end
+
+  defp registration_sample(day_start, day_end, limit) do
+    Repo.all(
+      from(u in User,
+        where: u.email_confirmed? == true,
+        where: u.inserted_at >= ^day_start and u.inserted_at < ^day_end,
+        order_by: [asc: u.inserted_at, asc: u.id],
+        limit: ^limit
+      )
+    )
+  end
+
+  # Mirrors count_spam_removals/2, carrying the removed account (case → owner)
+  # so the report can link the member.
+  defp spam_removal_sample(day_start, day_end, limit) do
+    Repo.all(
+      from(e in Vutuv.Moderation.Event,
+        where: e.action == "owner_removed",
+        where: e.inserted_at >= ^day_start and e.inserted_at < ^day_end,
+        order_by: [asc: e.inserted_at, asc: e.id],
+        limit: ^limit,
+        preload: [case: :owner]
+      )
+    )
   end
 
   # Accounts an admin removed as spam from a moderation case that day. Counts the

--- a/lib/vutuv/reports/daily_report.ex
+++ b/lib/vutuv/reports/daily_report.ex
@@ -7,10 +7,23 @@ defmodule Vutuv.Reports.DailyReport do
   accounts an admin removed as spam from a moderation case, on one German
   calendar day (`Vutuv.BerlinTime`).
 
+  Every metric also carries a capped `details` sample (`detail_limit/0` rows,
+  oldest first) so the report can name *who* and *what*, not just how many:
+  the new members, the created posts, the reposters/likers/bookmarkers, the
+  new Fediverse followers, the bounced/deactivated/frozen/thawed addresses and
+  the removed spam accounts. `Vutuv.Reports.daily/1` fills the sample;
+  `VutuvWeb.ReportDetails.sections/1` turns it into linked lines for the email
+  and the admin page.
+
   Built by `Vutuv.Reports.daily/1`, rendered on the admin reports page
   (`VutuvWeb.Admin.ReportController`) and mailed each night by
   `Vutuv.Reports.DailyReporter`.
   """
+
+  # How many sample rows each metric carries in `details`. The email lists up
+  # to this many entries per metric and notes "… und N weitere" beyond it, so
+  # a busy day stays a readable overview rather than a wall of every like.
+  @detail_limit 25
 
   @enforce_keys [:date]
   defstruct [
@@ -25,7 +38,10 @@ defmodule Vutuv.Reports.DailyReport do
     deactivations: 0,
     freezes: 0,
     thaws: 0,
-    spam_removals: 0
+    spam_removals: 0,
+    # Per-metric sample lists keyed by the metric atom (see the moduledoc); the
+    # element shape varies by metric and is normalized in `VutuvWeb.ReportDetails`.
+    details: %{}
   ]
 
   @type t :: %__MODULE__{
@@ -40,8 +56,12 @@ defmodule Vutuv.Reports.DailyReport do
           deactivations: non_neg_integer(),
           freezes: non_neg_integer(),
           thaws: non_neg_integer(),
-          spam_removals: non_neg_integer()
+          spam_removals: non_neg_integer(),
+          details: %{optional(atom()) => list()}
         }
+
+  @doc "How many sample rows each metric's `details` list holds at most."
+  def detail_limit, do: @detail_limit
 
   # Each metric with its German singular/plural label, in subject order. The
   # report email is German-only, so the labels live here rather than in gettext.

--- a/lib/vutuv_web/report_details.ex
+++ b/lib/vutuv_web/report_details.ex
@@ -1,0 +1,139 @@
+defmodule VutuvWeb.ReportDetails do
+  @moduledoc """
+  Turns a `Vutuv.Reports.DailyReport`'s per-metric `details` sample into ordered,
+  ready-to-render sections for the operator's daily report. The nightly email
+  (HTML + text) and the admin reports page all render from `sections/1`, so the
+  detail lines stay identical across the three surfaces.
+
+  Each section is `%{key, label, count, more, entries}`:
+
+    * `key`     — the metric atom (`:registrations`, `:posts`, …).
+    * `label`   — the German section heading (the report email is German-only;
+                  the admin page localizes its own heading from `key` instead).
+    * `count`   — the true total for the day (the sample is capped, see
+                  `Vutuv.Reports.DailyReport.detail_limit/0`).
+    * `more`    — `count` minus the shown entries, `0` when nothing was dropped.
+    * `entries` — normalized `%{primary, secondary, path}` lines: `primary` the
+                  link / main text (never blank), `secondary` a muted suffix
+                  (`@handle`, a bounce status, …) or `nil`, and `path` the
+                  internal profile / post path to link `primary` to, or `nil`.
+
+  Only metrics with at least one sampled entry get a section; a quiet day yields
+  `[]`. This module builds *data* (locale-neutral apart from the German
+  headings): it renders no HTML, so the email and the admin page each apply
+  their own markup and link style (relative for the page, absolute for the mail).
+  """
+
+  import VutuvWeb.UserHelpers, only: [full_name: 1]
+
+  alias VutuvWeb.AgentDocs
+
+  # Section order + German headings for the email; the admin page keys its own
+  # gettext heading off `:key` and ignores `label`.
+  @order [
+    {:registrations, "Neue bestätigte Registrierungen (per PIN)"},
+    {:posts, "Neue Beiträge"},
+    {:reposts, "Reposts"},
+    {:likes, "Likes"},
+    {:bookmarks, "Lesezeichen"},
+    {:fediverse_followers, "Neue Fediverse-Follower"},
+    {:bounces, "Bounces"},
+    {:deactivations, "Deaktivierte Adressen"},
+    {:freezes, "Eingefrorene Konten"},
+    {:thaws, "Aufgetaute Konten"},
+    {:spam_removals, "Als Spam entfernte Konten"}
+  ]
+
+  @doc """
+  The detail sections as a plain-text block for the text/plain mail part, each
+  entry's internal `path` resolved against `url` (the absolute base, trailing
+  slash). Returns `""` for a quiet day, so the caller can drop it cleanly. The
+  URL rides on its own indented line (no dash, per the project copy rules).
+  """
+  def text_block(report, url) do
+    case sections(report) do
+      [] -> ""
+      sections -> "Details\n=======\n\n" <> Enum.map_join(sections, "\n", &text_section(&1, url))
+    end
+  end
+
+  defp text_section(section, url) do
+    header = "#{section.label}: #{section.count}"
+    lines = Enum.map(section.entries, &text_entry(&1, url))
+    more = if section.more > 0, do: ["  … und #{section.more} weitere"], else: []
+    Enum.join([header | lines] ++ more, "\n") <> "\n"
+  end
+
+  defp text_entry(entry, url) do
+    head = "  - " <> entry.primary <> if(entry.secondary, do: " (#{entry.secondary})", else: "")
+
+    case entry.path do
+      nil -> head
+      path -> head <> "\n    " <> url <> String.trim_leading(path, "/")
+    end
+  end
+
+  @doc "The report's non-empty detail sections, in display order."
+  def sections(report) do
+    for {key, label} <- @order,
+        entries = Enum.map(Map.get(report.details, key, []), &entry(key, &1)),
+        entries != [] do
+      count = Map.fetch!(report, key)
+
+      %{
+        key: key,
+        label: label,
+        count: count,
+        more: max(count - length(entries), 0),
+        entries: entries
+      }
+    end
+  end
+
+  defp entry(:registrations, user), do: person_entry(user)
+  defp entry(:spam_removals, event), do: person_entry(event.case.owner)
+
+  defp entry(:posts, post), do: post_entry(post, post.user)
+  defp entry(:reposts, repost), do: post_entry(repost.post, repost.user)
+  defp entry(:likes, like), do: post_entry(like.post, like.user)
+  defp entry(:bookmarks, bookmark), do: post_entry(bookmark.post, bookmark.user)
+
+  defp entry(:fediverse_followers, follower) do
+    %{
+      primary: follower_display(follower),
+      secondary: "@" <> follower.user.username,
+      path: "/" <> follower.user.username
+    }
+  end
+
+  defp entry(:bounces, %{email: email, status: status}),
+    do: %{primary: email, secondary: status, path: nil}
+
+  defp entry(:deactivations, %{email: email}),
+    do: %{primary: email, secondary: nil, path: nil}
+
+  defp entry(kind, %{email: email, user: user}) when kind in [:freezes, :thaws] do
+    if user, do: person_entry(user), else: %{primary: email, secondary: nil, path: nil}
+  end
+
+  defp person_entry(user) do
+    %{primary: full_name(user), secondary: "@" <> user.username, path: "/" <> user.username}
+  end
+
+  # The post's first line links to its permalink; the actor (author / reposter /
+  # liker / bookmarker) is the muted suffix. A text-less (photo-only) post has no
+  # first line, so the actor's handle becomes the link text instead of a blank
+  # line.
+  defp post_entry(post, actor) do
+    case AgentDocs.excerpt(post.body) do
+      "" -> %{primary: "@" <> actor.username, secondary: nil, path: "/posts/" <> post.id}
+      line -> %{primary: line, secondary: "@" <> actor.username, path: "/posts/" <> post.id}
+    end
+  end
+
+  # The remote actor's own label, best first: its @handle, then its display
+  # name, falling back to the raw actor URI (always present).
+  defp follower_display(%{handle: handle}) when is_binary(handle) and handle != "", do: handle
+  defp follower_display(%{name: name}) when is_binary(name) and name != "", do: name
+  defp follower_display(%{actor_uri: uri}), do: uri
+end

--- a/lib/vutuv_web/templates/admin/report/index.html.heex
+++ b/lib/vutuv_web/templates/admin/report/index.html.heex
@@ -65,5 +65,31 @@
     <p :if={Vutuv.Reports.DailyReport.all_zero?(@report)} class="card__empty">
       {gettext("No activity on this day.")}
     </p>
+
+    <div class="mt-8 space-y-6">
+      <div :for={section <- VutuvWeb.ReportDetails.sections(@report)}>
+        <h2 class="card__label">
+          {VutuvWeb.Admin.ReportHTML.metric_label(section.key)}: {delimited_count(section.count)}
+        </h2>
+        <ul class="mt-2 space-y-1">
+          <li :for={entry <- section.entries} class="text-sm">
+            <.link
+              :if={entry.path}
+              href={entry.path}
+              class="font-semibold text-brand-600 hover:text-brand-700"
+            >
+              {entry.primary}
+            </.link>
+            <span :if={!entry.path} class="text-slate-800 dark:text-slate-200">{entry.primary}</span>
+            <span :if={entry.secondary} class="text-slate-600 dark:text-slate-400">
+              {entry.secondary}
+            </span>
+          </li>
+          <li :if={section.more > 0} class="text-sm text-slate-600 dark:text-slate-400">
+            {gettext("… and %{count} more", count: section.more)}
+          </li>
+        </ul>
+      </div>
+    </div>
   </section>
 </div>

--- a/lib/vutuv_web/templates/email/daily_report_de.text.eex
+++ b/lib/vutuv_web/templates/email/daily_report_de.text.eex
@@ -19,5 +19,6 @@ Moderation
 ----------
 Als Spam entfernte Konten:                  <%= @report.spam_removals %>
 
+<%= VutuvWeb.ReportDetails.text_block(@report, @url) %>
 Vollständiger Bericht (mit Zeitreise zu anderen Tagen):
 <%= @url %>admin/reports?date=<%= Date.to_iso8601(@report.date) %>

--- a/lib/vutuv_web/templates/email_body/daily_report_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/daily_report_de.html.heex
@@ -19,6 +19,25 @@
   <.email_panel>
     <.email_row label="Als Spam entfernte Konten">{@report.spam_removals}</.email_row>
   </.email_panel>
+
+  <%= for section <- VutuvWeb.ReportDetails.sections(@report) do %>
+    <.email_divider />
+    <.email_link_list
+      title={"#{section.label}: #{section.count}"}
+      more={section.more}
+      items={
+        Enum.map(section.entries, fn entry ->
+          %{
+            text: entry.primary,
+            muted: entry.secondary,
+            href: entry.path && "#{@url}#{String.trim_leading(entry.path, "/")}"
+          }
+        end)
+      }
+    />
+  <% end %>
+
+  <.email_divider />
   <.email_p>Vollständiger Bericht (mit Zeitreise zu anderen Tagen):</.email_p>
   <.email_button href={"#{@url}admin/reports?date=#{Date.to_iso8601(@report.date)}"}>
     Vollständiger Bericht

--- a/lib/vutuv_web/views/admin/report_html.ex
+++ b/lib/vutuv_web/views/admin/report_html.ex
@@ -4,23 +4,41 @@ defmodule VutuvWeb.Admin.ReportHTML do
 
   embed_templates("../../templates/admin/report/*")
 
+  # Every metric in table/detail order. Drives metrics/1 and the detail
+  # sections, so the two stay in sync and each label lives in exactly one place.
+  @metric_order [
+    :registrations,
+    :posts,
+    :reposts,
+    :likes,
+    :bookmarks,
+    :fediverse_followers,
+    :bounces,
+    :deactivations,
+    :freezes,
+    :thaws,
+    :spam_removals
+  ]
+
   @doc """
-  The report's metrics as `{label, value}` rows, in the order both the page
-  and the email list them. Keeps the labels in one place so the table stays in
-  sync with the struct.
+  The report's metrics as `{label, value}` rows, in the order the page lists
+  them. Keeps the labels in one place (`metric_label/1`) so the summary table,
+  the detail sections and the struct stay in sync.
   """
   def metrics(report) do
-    [
-      {gettext("New confirmed registrations (by PIN)"), report.registrations},
-      {gettext("Posts"), report.posts},
-      {gettext("Reposts"), report.reposts},
-      {gettext("Likes"), report.likes},
-      {gettext("Bookmarks"), report.bookmarks},
-      {gettext("Bounces"), report.bounces},
-      {gettext("Deactivated addresses"), report.deactivations},
-      {gettext("Frozen accounts"), report.freezes},
-      {gettext("Thawed accounts"), report.thaws},
-      {gettext("Accounts removed as spam"), report.spam_removals}
-    ]
+    Enum.map(@metric_order, fn key -> {metric_label(key), Map.fetch!(report, key)} end)
   end
+
+  @doc "The localized heading for one metric, shared by the table and the detail sections."
+  def metric_label(:registrations), do: gettext("New confirmed registrations (by PIN)")
+  def metric_label(:posts), do: gettext("Posts")
+  def metric_label(:reposts), do: gettext("Reposts")
+  def metric_label(:likes), do: gettext("Likes")
+  def metric_label(:bookmarks), do: gettext("Bookmarks")
+  def metric_label(:fediverse_followers), do: gettext("New Fediverse followers")
+  def metric_label(:bounces), do: gettext("Bounces")
+  def metric_label(:deactivations), do: gettext("Deactivated addresses")
+  def metric_label(:freezes), do: gettext("Frozen accounts")
+  def metric_label(:thaws), do: gettext("Thawed accounts")
+  def metric_label(:spam_removals), do: gettext("Accounts removed as spam")
 end

--- a/lib/vutuv_web/views/email_components.ex
+++ b/lib/vutuv_web/views/email_components.ex
@@ -287,6 +287,49 @@ defmodule VutuvWeb.EmailComponents do
     """
   end
 
+  @doc """
+  A titled list of linked lines — the daily report's detail sections. Each item
+  is `%{text, href, muted}`: `text` is the line (linked when `href` is set, else
+  plain), with `muted` appended as a dimmed suffix when present. `more` appends a
+  "… und N weitere" note when the day had more rows than are listed. Generic on
+  purpose: the caller resolves each entry's internal path into an absolute
+  `href` before passing it here.
+  """
+  attr(:title, :string, required: true)
+  attr(:more, :integer, default: 0)
+  attr(:items, :list, required: true)
+
+  def email_link_list(assigns) do
+    ~H"""
+    <.email_p><strong>{@title}</strong></.email_p>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="email-panel" style="margin:0 0 16px;background:#f8fafc;border:1px solid #e2e8f0;border-radius:12px;">
+      <tr>
+        <td style="padding:6px 16px;">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+            <tr :for={item <- @items}>
+              <td class="email-text" style={row_value_style()}>
+                <a
+                  :if={item.href}
+                  href={item.href}
+                  class="email-a"
+                  style="color:#1d4ed8;text-decoration:underline;"
+                >{item.text}</a><span :if={!item.href}>{item.text}</span><span
+                  :if={item.muted}
+                  class="email-muted"
+                  style="color:#64748b;"
+                >{" " <> item.muted}</span>
+              </td>
+            </tr>
+            <tr :if={@more > 0}>
+              <td class="email-muted" style={row_label_style()}>… und {@more} weitere</td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+    """
+  end
+
   @doc "A hairline divider."
   def email_divider(assigns) do
     ~H"""

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.110.4",
+      version: "7.111.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -6715,6 +6715,16 @@ msgstr ""
 msgid "Deactivated addresses"
 msgstr "Deaktivierte Adressen"
 
+#: lib/vutuv_web/views/admin/report_html.ex:37
+#, elixir-autogen, elixir-format
+msgid "New Fediverse followers"
+msgstr "Neue Fediverse-Follower"
+
+#: lib/vutuv_web/templates/admin/report/index.html.heex:87
+#, elixir-autogen, elixir-format
+msgid "… and %{count} more"
+msgstr "… und %{count} weitere"
+
 #: lib/vutuv_web/live/admin/deliverability_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Dead addresses"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -6435,6 +6435,16 @@ msgstr ""
 msgid "Deactivated addresses"
 msgstr ""
 
+#: lib/vutuv_web/views/admin/report_html.ex:37
+#, elixir-autogen, elixir-format
+msgid "New Fediverse followers"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/report/index.html.heex:87
+#, elixir-autogen, elixir-format
+msgid "… and %{count} more"
+msgstr ""
+
 #: lib/vutuv_web/live/admin/deliverability_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Dead addresses"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -6433,6 +6433,16 @@ msgstr ""
 msgid "Deactivated addresses"
 msgstr ""
 
+#: lib/vutuv_web/views/admin/report_html.ex:37
+#, elixir-autogen, elixir-format
+msgid "New Fediverse followers"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/report/index.html.heex:87
+#, elixir-autogen, elixir-format
+msgid "… and %{count} more"
+msgstr ""
+
 #: lib/vutuv_web/live/admin/deliverability_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Dead addresses"

--- a/test/vutuv/reports_test.exs
+++ b/test/vutuv/reports_test.exs
@@ -56,14 +56,35 @@ defmodule Vutuv.ReportsTest do
       like(post, insert(:user), @on_day)
       bookmark(post, insert(:user), @on_day)
 
-      assert Reports.daily(@date) == %DailyReport{
+      report = Reports.daily(@date)
+
+      assert %DailyReport{
                date: @date,
                registrations: 2,
                posts: 2,
                reposts: 1,
                likes: 1,
                bookmarks: 1
-             }
+             } = report
+
+      # Every counted metric also carries a sample of the same rows, so the
+      # report can name who/what, not just how many.
+      assert length(report.details.registrations) == 2
+      assert length(report.details.posts) == 2
+      assert length(report.details.reposts) == 1
+      assert length(report.details.likes) == 1
+      assert length(report.details.bookmarks) == 1
+    end
+
+    test "the detail sample is capped at detail_limit/0, and the count stays exact" do
+      author = insert(:user)
+      over = DailyReport.detail_limit() + 3
+      for _ <- 1..over, do: insert(:post, [user: author] ++ at(@on_day))
+
+      report = Reports.daily(@date)
+
+      assert report.posts == over
+      assert length(report.details.posts) == DailyReport.detail_limit()
     end
 
     test "counts new Fediverse followers gained that Berlin day" do
@@ -118,6 +139,32 @@ defmodule Vutuv.ReportsTest do
         assert email.text_body =~ "Fediverse-Follower"
         assert email.text_body =~ "Zustellbarkeit"
         assert email.text_body =~ "admin/reports?date=2026-01-15"
+      end)
+    end
+
+    test "lists the new members and posts with names, handles and links" do
+      alice =
+        insert(
+          :activated_user,
+          [username: "alice", first_name: "Alice", last_name: "Adams"] ++ at(@on_day)
+        )
+
+      post = insert(:post, [user: alice, body: "Hello world\nsecond line"] ++ at(@on_day))
+
+      assert {:ok, _report} = Reports.deliver_daily_email(@date)
+
+      assert_email_sent(fn email ->
+        # Registration detail: name, @handle and the profile link.
+        assert email.text_body =~ "Alice Adams"
+        assert email.text_body =~ "@alice"
+        assert email.text_body =~ "/alice"
+        assert email.html_body =~ "Alice Adams"
+
+        # Post detail: only the first line, plus the permalink.
+        assert email.text_body =~ "Hello world"
+        refute email.text_body =~ "second line"
+        assert email.text_body =~ "posts/#{post.id}"
+        assert email.html_body =~ post.id
       end)
     end
 

--- a/test/vutuv_web/controllers/admin/report_controller_test.exs
+++ b/test/vutuv_web/controllers/admin/report_controller_test.exs
@@ -76,6 +76,29 @@ defmodule VutuvWeb.Admin.ReportControllerTest do
       assert html =~ "Kennzahl"
       assert html =~ "Anzahl"
       assert html =~ "Neue bestätigte Registrierungen (per PIN)"
+      # The Fediverse-followers count now has its own row (it was missing).
+      assert html =~ "Neue Fediverse-Follower"
+    end
+
+    test "lists detail entries with names, handles and profile links", %{conn: conn} do
+      {conn, _admin} = create_and_login_admin(conn)
+
+      insert(:activated_user,
+        username: "alice",
+        first_name: "Alice",
+        last_name: "Adams",
+        inserted_at: ~N[2026-01-15 12:00:00],
+        updated_at: ~N[2026-01-15 12:00:00]
+      )
+
+      html =
+        conn
+        |> get(~p"/admin/reports?#{%{date: "2026-01-15"}}")
+        |> html_response(200)
+
+      assert html =~ "Alice Adams"
+      assert html =~ "@alice"
+      assert html =~ ~s(href="/alice")
     end
   end
 end

--- a/test/vutuv_web/report_details_test.exs
+++ b/test/vutuv_web/report_details_test.exs
@@ -1,0 +1,103 @@
+defmodule VutuvWeb.ReportDetailsTest do
+  @moduledoc """
+  The daily report's shared detail normalization: `sections/1` and the plain
+  text block both surfaces (email + admin page) render from.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Reports
+  alias Vutuv.Reports.DailyReport
+  alias VutuvWeb.ReportDetails
+
+  @date ~D[2026-01-15]
+  @on_day ~N[2026-01-15 12:00:00]
+
+  defp at(naive), do: [inserted_at: naive, updated_at: naive]
+
+  defp section(report, key) do
+    Enum.find(ReportDetails.sections(report), &(&1.key == key))
+  end
+
+  describe "sections/1" do
+    test "a registration entry carries the name, @handle and profile path" do
+      insert(
+        :activated_user,
+        [username: "alice", first_name: "Alice", last_name: "Adams"] ++ at(@on_day)
+      )
+
+      report = Reports.daily(@date)
+      registrations = section(report, :registrations)
+
+      assert registrations.count == 1
+      assert registrations.more == 0
+
+      assert registrations.entries == [
+               %{primary: "Alice Adams", secondary: "@alice", path: "/alice"}
+             ]
+    end
+
+    test "a post entry is the first line, the author @handle and the permalink" do
+      author = insert(:user, username: "bob")
+      post = insert(:post, [user: author, body: "First line\nSecond line"] ++ at(@on_day))
+
+      assert section(Reports.daily(@date), :posts).entries == [
+               %{primary: "First line", secondary: "@bob", path: "/posts/#{post.id}"}
+             ]
+    end
+
+    test "a text-less (photo-only) post falls back to the author handle as the line" do
+      author = insert(:user, username: "carol")
+      post = insert(:post, [user: author, body: ""] ++ at(@on_day))
+
+      assert section(Reports.daily(@date), :posts).entries == [
+               %{primary: "@carol", secondary: nil, path: "/posts/#{post.id}"}
+             ]
+    end
+
+    test "a bounce names the address and its status, with no link" do
+      insert(:email_bounce,
+        email_value: "dead@example.com",
+        status: "5.1.1",
+        inserted_at: @on_day
+      )
+
+      assert section(Reports.daily(@date), :bounces).entries == [
+               %{primary: "dead@example.com", secondary: "5.1.1", path: nil}
+             ]
+    end
+
+    test "more/1 reports how many rows were dropped past the cap" do
+      author = insert(:user)
+      over = DailyReport.detail_limit() + 2
+      for _ <- 1..over, do: insert(:post, [user: author] ++ at(@on_day))
+
+      posts = section(Reports.daily(@date), :posts)
+      assert length(posts.entries) == DailyReport.detail_limit()
+      assert posts.more == 2
+    end
+
+    test "a quiet day yields no sections" do
+      assert ReportDetails.sections(Reports.daily(@date)) == []
+    end
+  end
+
+  describe "text_block/2" do
+    test "renders headings, entries and the resolved URL on its own line" do
+      insert(
+        :activated_user,
+        [username: "alice", first_name: "Alice", last_name: "Adams"] ++ at(@on_day)
+      )
+
+      block = ReportDetails.text_block(Reports.daily(@date), "https://vutuv.de/")
+
+      assert block =~ "Details"
+      assert block =~ "Neue bestätigte Registrierungen (per PIN): 1"
+      assert block =~ "- Alice Adams (@alice)"
+      assert block =~ "https://vutuv.de/alice"
+    end
+
+    test "is empty on a quiet day" do
+      assert ReportDetails.text_block(Reports.daily(@date), "https://vutuv.de/") == ""
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** The operator's daily report (email + `/admin/reports`) showed only a count per metric. Now every metric also carries a capped detail list, so the report names *who* and *what*.

## What changed
Each metric gets a detail sample (`DailyReport.detail_limit/0` = 25 rows, oldest first) beside its count:

- **Registrations** → name + `@handle`, linked to the profile
- **Posts** → first line + permalink (author as muted suffix; a photo-only post shows the author handle instead of a blank line)
- **Reposts / likes / bookmarks** → the post's first line + the actor
- **Fediverse followers** → the remote actor + the member who gained them
- **Bounces / deactivations / freezes / thaws** → the affected address (profile link where an account is behind it)
- **Spam removals** → the removed account

Above them, the summary panels with the plain numbers stay as the at-a-glance overview; a day busier than the cap ends each section with a "… und N weitere" note.

## How
One shared source, three surfaces:
- `Reports.daily/1` loads preloaded samples into the new `DailyReport.details` map; `Deliverability.activity_details_between/3` supplies the deliverability kinds.
- New `VutuvWeb.ReportDetails` normalizes them to `%{primary, secondary, path}` lines that the **HTML mail**, the **text mail** and the **admin page** all render, so the three can't drift.
- New generic email component `email_link_list/1`.

## Also
Fixed a pre-existing gap: the Fediverse-followers count had no row in the `/admin/reports` table (the struct carried it, the table omitted it).

No migration (code + templates + gettext only). The report email still goes only to the configured operator recipient, so the member names and bounce addresses it now lists stay internal.

## Tests
`reports_test`, new `report_details_test`, `admin/report_controller_test`; full `mix precommit` green (the HTML mail was also rendered and checked in a browser).

---
*Written with this GitHub account, but not necessarily by the human behind it — this may just be a note-taking issue that gets deleted later without ever being tackled.*