### PR TITLE
Bump version to 7.112.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.111.0",
+      version: "7.112.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
PR #959 (daily-report detail lists) landed the same day as #958, and both committed v7.111.0, so main carried the version twice. Bump to a unique, monotonic version so the release tag and /about surfaces stay correct. mix.exs-only.

*Written with this GitHub account, but not necessarily by the human behind it — this may just be a note-taking issue that gets deleted later without ever being tackled.*