### PR TITLE
Cap profiles at 15 tags (v7.113.0)

### DIFF
--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -494,6 +494,7 @@ defmodule Vutuv.Accounts.User do
     model
     |> changeset(params)
     |> validate_minimum_tags()
+    |> validate_maximum_tags()
     |> cast_assoc(:emails)
   end
 
@@ -502,16 +503,17 @@ defmodule Vutuv.Accounts.User do
 
   # Counts exactly what Accounts.register_user/3 later materializes as tags:
   # the tag_list split on commas/spaces (Vutuv.Tags.parse_tag_names/1), then
-  # case-insensitively de-duplicated — so a padded "Go, go, GO" is one tag,
+  # case-insensitively de-duplicated, so a padded "Go, go, GO" is one tag,
   # not three.
-  defp validate_minimum_tags(changeset) do
-    distinct_tags =
-      changeset
-      |> get_field(:tag_list)
-      |> Vutuv.Tags.parse_tag_names()
-      |> Enum.uniq_by(&String.downcase/1)
+  defp distinct_tag_names(changeset) do
+    changeset
+    |> get_field(:tag_list)
+    |> Vutuv.Tags.parse_tag_names()
+    |> Enum.uniq_by(&String.downcase/1)
+  end
 
-    if length(distinct_tags) >= @min_registration_tags do
+  defp validate_minimum_tags(changeset) do
+    if length(distinct_tag_names(changeset)) >= @min_registration_tags do
       changeset
     else
       add_error(
@@ -520,6 +522,19 @@ defmodule Vutuv.Accounts.User do
         "Please enter at least %{min} different tags.",
         min: @min_registration_tags
       )
+    end
+  end
+
+  # The profile tag ceiling (Vutuv.Tags.max_user_tags/0) applies to new accounts
+  # too: account setup only materializes tags up to the cap, so rejecting the
+  # excess here keeps the form honest instead of silently dropping tags.
+  defp validate_maximum_tags(changeset) do
+    max = Vutuv.Tags.max_user_tags()
+
+    if length(distinct_tag_names(changeset)) <= max do
+      changeset
+    else
+      add_error(changeset, :tag_list, "Please enter at most %{max} different tags.", max: max)
     end
   end
 

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -22,6 +22,12 @@ defmodule Vutuv.Tags do
   @endorser_sorts ~w(name username date)
   @endorsers_per_page 25
 
+  # The most tags one profile may carry. A handful of members overdid it, so a
+  # profile is capped here. The cap bites only when tags *change*: a profile
+  # already over it (from before the cap) keeps every tag but can add none, and
+  # the sign-up form validates the same ceiling up front.
+  @max_user_tags 15
+
   # Matches one token: either a `"…"` quoted phrase (capturing its inside, which
   # may hold spaces) or a run of non-space, non-comma characters. Tried
   # left-to-right at each position, so a well-formed `"…"` is always taken whole
@@ -98,30 +104,71 @@ defmodule Vutuv.Tags do
     end
   end
 
+  @doc "The most tags one profile may carry (see `@max_user_tags`)."
+  def max_user_tags, do: @max_user_tags
+
+  @doc """
+  Whether `user` already holds the maximum number of tags, so `add_user_tag/2`
+  would refuse the next one. Counts the live rows, so it reflects removals.
+  """
+  def at_user_tag_limit?(%User{} = user), do: user_tag_count(user.id) >= @max_user_tags
+
   @doc """
   Tags `user` with `name`, creating the global tag or linking the existing
   one. Returns the `Repo.insert` result; a duplicate or invalid name comes
   back as `{:error, changeset}`.
 
-  An **honor** tag is reserved: a member typing its name here is refused
-  with `{:error, changeset}` (the tag can only be granted through
-  `admin_assign_tag/2`). This is the single self-assign chokepoint — the tags
-  page, the JSON API, the LinkedIn import and account setup all reach it — so
-  one guard covers every member entry point.
+  Two guards, both returning `{:error, changeset}`:
+
+    * The profile is **at the tag ceiling** (`max_user_tags/0`) — refused, so a
+      member who overdid it keeps their tags but adds no more until they drop
+      back under the cap.
+    * The tag is an **honor** tag — reserved, granted only through
+      `admin_assign_tag/2`.
+
+  This is the single self-assign chokepoint — the tags page, the JSON API, the
+  LinkedIn import and account setup all reach it — so both guards cover every
+  member entry point.
   """
   def add_user_tag(%User{} = user, name) when is_binary(name) do
-    changeset =
-      user
-      |> Ecto.build_assoc(:user_tags, %{})
-      |> UserTag.changeset()
-      |> Tag.create_or_link_tag(%{"value" => name})
-
-    if reserved_tag?(changeset) do
-      {:error, reserved_tag_error(changeset)}
+    if at_user_tag_limit?(user) do
+      {:error, tag_limit_changeset(user)}
     else
-      Repo.insert(changeset)
+      changeset =
+        user
+        |> Ecto.build_assoc(:user_tags, %{})
+        |> UserTag.changeset()
+        |> Tag.create_or_link_tag(%{"value" => name})
+
+      if reserved_tag?(changeset) do
+        {:error, reserved_tag_error(changeset)}
+      else
+        Repo.insert(changeset)
+      end
     end
   end
+
+  @doc """
+  The `{:error, changeset}` a save is refused with once `user` is at the tag
+  ceiling: an empty `UserTag` changeset carrying a clear, member-facing error
+  and the `:insert` action, so the tags editor shows it inline and the JSON API
+  returns a 422. Shared by `add_user_tag/2` and `VutuvWeb.TagNewLive` (which
+  guards up front, so a full batch shows one clear message, not N failures).
+  """
+  def tag_limit_changeset(%User{} = user) do
+    user
+    |> Ecto.build_assoc(:user_tags, %{})
+    |> UserTag.changeset(%{})
+    |> Ecto.Changeset.add_error(
+      :tag_id,
+      "You can have at most %{max} tags. Remove one before adding another.",
+      max: @max_user_tags
+    )
+    |> Map.put(:action, :insert)
+  end
+
+  defp user_tag_count(user_id),
+    do: Repo.aggregate(from(ut in UserTag, where: ut.user_id == ^user_id), :count)
 
   # `Tag.create_or_link_tag/2` always resolves to a `:tag_id` (it either links an
   # existing tag or mints a fresh one and links that). A member can only reach an

--- a/lib/vutuv_web/live/tag_new_live.ex
+++ b/lib/vutuv_web/live/tag_new_live.ex
@@ -67,6 +67,7 @@ defmodule VutuvWeb.TagNewLive do
             phx-debounce="150"
           />
           {@changeset && error_tag(@changeset, :user_id_tag_id)}
+          {@changeset && error_tag(@changeset, :tag_id)}
         </div>
 
         <div :if={@preview != []} id="tag-preview" class="editform__field">
@@ -94,6 +95,20 @@ defmodule VutuvWeb.TagNewLive do
   def handle_event("save", %{"tag_param" => %{"value" => value}}, socket) do
     user = socket.assigns.current_user
 
+    if Tags.at_user_tag_limit?(user) do
+      # Profile already at the tag ceiling: surface it inline (like a form
+      # error) and attach nothing, for a single tag or a whole batch alike, so
+      # the member sees one clear reason rather than a pile of failures.
+      {:noreply,
+       socket
+       |> assign(:changeset, Tags.tag_limit_changeset(user))
+       |> assign_input(value)}
+    else
+      save_tags(socket, user, value)
+    end
+  end
+
+  defp save_tags(socket, user, value) do
     case value |> Tags.parse_tag_names() |> Enum.uniq_by(&String.downcase/1) do
       # Nothing usable typed: keep the form, show the error banner (the same
       # empty-changeset re-render the controller create used to do).

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.112.1",
+      version: "7.113.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -115,6 +115,18 @@ msgstr "darf keine Leerzeichen enthalten"
 msgid "Please enter at least %{min} different tags."
 msgstr "Bitte geben Sie mindestens %{min} verschiedene Tags ein."
 
+## Custom message from the sign-up tag ceiling
+## (Vutuv.Accounts.User.registration_changeset/2).
+msgid "Please enter at most %{max} different tags."
+msgstr "Bitte geben Sie höchstens %{max} verschiedene Tags ein."
+
+## Custom message from the profile tag ceiling
+## (Vutuv.Tags.tag_limit_changeset/1).
+msgid "You can have at most %{max} tags. Remove one before adding another."
+msgstr ""
+"Sie können höchstens %{max} Tags haben. Entfernen Sie zuerst eines, bevor Sie "
+"ein weiteres hinzufügen."
+
 ## Custom message from the duplicate-tag unique constraint
 ## (Vutuv.Tags.UserTag.changeset/2).
 msgid "You already have this tag."

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -115,6 +115,16 @@ msgstr ""
 msgid "Please enter at least %{min} different tags."
 msgstr ""
 
+## Custom message from the sign-up tag ceiling
+## (Vutuv.Accounts.User.registration_changeset/2).
+msgid "Please enter at most %{max} different tags."
+msgstr ""
+
+## Custom message from the profile tag ceiling
+## (Vutuv.Tags.tag_limit_changeset/1).
+msgid "You can have at most %{max} tags. Remove one before adding another."
+msgstr ""
+
 ## Custom message from the duplicate-tag unique constraint
 ## (Vutuv.Tags.UserTag.changeset/2).
 msgid "You already have this tag."

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -118,6 +118,16 @@ msgstr ""
 msgid "Please enter at least %{min} different tags."
 msgstr ""
 
+## Custom message from the sign-up tag ceiling
+## (Vutuv.Accounts.User.registration_changeset/2).
+msgid "Please enter at most %{max} different tags."
+msgstr ""
+
+## Custom message from the profile tag ceiling
+## (Vutuv.Tags.tag_limit_changeset/1).
+msgid "You can have at most %{max} tags. Remove one before adding another."
+msgstr ""
+
 ## Custom message from the duplicate-tag unique constraint
 ## (Vutuv.Tags.UserTag.changeset/2).
 msgid "You already have this tag."

--- a/test/vutuv/accounts_test.exs
+++ b/test/vutuv/accounts_test.exs
@@ -145,6 +145,27 @@ defmodule Vutuv.AccountsTest do
       assert {:error, changeset} = Accounts.register_user(conn, attrs)
       assert "Please enter at least 3 different tags." in errors_on(changeset).tag_list
     end
+
+    test "rejects a registration over the tag ceiling" do
+      conn = build_conn()
+      max = Vutuv.Tags.max_user_tags()
+      too_many = Enum.map_join(1..(max + 1), " ", &"Skill#{&1}")
+      attrs = Map.put(@valid_registration, "tag_list", too_many)
+
+      assert {:error, changeset} = Accounts.register_user(conn, attrs)
+      assert "Please enter at most #{max} different tags." in errors_on(changeset).tag_list
+      refute Repo.get_by(User, first_name: "Test")
+    end
+
+    test "accepts a registration exactly at the tag ceiling" do
+      conn = build_conn()
+      max = Vutuv.Tags.max_user_tags()
+      exactly = Enum.map_join(1..max, " ", &"Skill#{&1}")
+      attrs = Map.put(@valid_registration, "tag_list", exactly)
+
+      assert {:ok, user} = Accounts.register_user(conn, attrs)
+      assert length(user.user_tags) == max
+    end
   end
 
   describe "update_user/2" do

--- a/test/vutuv/tags_test.exs
+++ b/test/vutuv/tags_test.exs
@@ -129,6 +129,69 @@ defmodule Vutuv.TagsTest do
     end
   end
 
+  describe "a profile is capped at max_user_tags/0 tags" do
+    # A few members overdid the tag count, so a profile may hold at most
+    # `max_user_tags/0` tags. The cap bites only when tags *change*: an existing
+    # profile that already exceeds it (from before the cap) keeps every tag, but
+    # can add none until it drops back under the ceiling.
+    defp count_tags(user),
+      do: Repo.aggregate(from(ut in UserTag, where: ut.user_id == ^user.id), :count)
+
+    # Fill a user right up to the cap through the real chokepoint.
+    defp fill_to_limit(user) do
+      for n <- 1..Tags.max_user_tags() do
+        assert {:ok, _} = Tags.add_user_tag(user, "Skill#{n}")
+      end
+
+      user
+    end
+
+    test "adding tags up to the limit is allowed" do
+      user = fill_to_limit(insert(:user))
+      assert count_tags(user) == Tags.max_user_tags()
+    end
+
+    test "the tag one over the limit is refused and not stored" do
+      user = fill_to_limit(insert(:user))
+
+      assert {:error, %Ecto.Changeset{} = changeset} = Tags.add_user_tag(user, "OneTooMany")
+      refute changeset.valid?
+      assert count_tags(user) == Tags.max_user_tags()
+      refute Repo.exists?(from(t in Tag, where: t.name == "OneTooMany"))
+    end
+
+    test "at_user_tag_limit?/1 flips once the profile is full" do
+      user = insert(:user)
+      refute Tags.at_user_tag_limit?(user)
+
+      fill_to_limit(user)
+      assert Tags.at_user_tag_limit?(user)
+    end
+
+    test "a profile already over the limit keeps its tags but can add none (grandfathered)" do
+      # Legacy profiles from before the cap are inserted straight, bypassing the
+      # chokepoint, to reproduce the over-limit state.
+      user = insert(:user)
+      for _ <- 1..(Tags.max_user_tags() + 5), do: insert(:user_tag, user: user, tag: build(:tag))
+
+      assert count_tags(user) == Tags.max_user_tags() + 5
+      assert {:error, _} = Tags.add_user_tag(user, "Nope")
+      assert count_tags(user) == Tags.max_user_tags() + 5
+    end
+
+    test "removing a tag frees a slot again" do
+      user = insert(:user)
+      {:ok, first} = Tags.add_user_tag(user, "First")
+
+      for n <- 2..Tags.max_user_tags(), do: {:ok, _} = Tags.add_user_tag(user, "Skill#{n}")
+      assert {:error, _} = Tags.add_user_tag(user, "Blocked")
+
+      {:ok, _} = Tags.delete_user_tag(first)
+      assert {:ok, _} = Tags.add_user_tag(user, "NowFits")
+      assert count_tags(user) == Tags.max_user_tags()
+    end
+  end
+
   describe "parse_tag_names/1" do
     test "an unquoted comma or space still separates tags" do
       assert Tags.parse_tag_names("Elixir, Phoenix Go") == ["Elixir", "Phoenix", "Go"]

--- a/test/vutuv_web/live/tag_new_live_test.exs
+++ b/test/vutuv_web/live/tag_new_live_test.exs
@@ -191,5 +191,23 @@ defmodule VutuvWeb.TagNewLiveTest do
       assert flash["info"] == "Added 1 of 2 tags (the rest were duplicates or invalid)."
       assert tag_count(user) == base + 2
     end
+
+    test "refuses a new tag once the profile is at the tag limit", %{
+      live: live,
+      user: user
+    } do
+      # Fill the profile up to the cap (bypassing the form so we test its guard).
+      for _ <- 1..Vutuv.Tags.max_user_tags(),
+          do: insert(:user_tag, user: user, tag: build(:tag))
+
+      full = tag_count(user)
+
+      html = live |> form("#tag-form", tag_param: %{value: "OneMore"}) |> render_submit()
+
+      # No redirect (the form stays put) and a clear message naming the ceiling.
+      assert html =~ "at most"
+      assert tag_count(user) == full
+      refute Repo.exists?(from(t in Vutuv.Tags.Tag, where: t.name == "OneMore"))
+    end
   end
 end


### PR DESCRIPTION
## What

Caps a profile at **15 tags** (`Vutuv.Tags.max_user_tags/0`, the single source). A few members overdid the tag count, so this puts a ceiling on it.

## Behaviour

A soft, **on-add** limit enforced at the one self-assign chokepoint `Vutuv.Tags.add_user_tag/2` (beside the honor-tag guard), so it covers the tags editor, the JSON API, the LinkedIn import and account setup in one place.

It bites only when tags **change**: an existing profile already over the cap (from before it existed) keeps every tag but can add none until it drops back under, and removing a tag frees a slot again. That satisfies "only new accounts, or when existing accounts change their tags" without touching anyone's current data. No DB constraint backs it — a rare concurrent-add race that nudges one over is harmless.

- **Sign-up form** validates the same ceiling up front (`validate_maximum_tags`), so a new account is rejected at the form instead of silently having the excess dropped in account setup.
- **Tags editor** guards up front and renders the ceiling **inline** (a flash would not show in that LiveView's own render), for a single tag or a whole batch alike.
- German error strings added to `errors.po`.

## Tests

- `tags_test.exs`: cap / grandfathering / slot-freeing.
- `accounts_test.exs`: registration over and exactly at the ceiling.
- `tag_new_live_test.exs`: editor refusal at the limit.

`mix precommit` green (compile, format, `credo --strict`, 3998 tests).

*Written with this GitHub account, but not necessarily by the human behind it.*