### PR TITLE
Landing page: reword member counter and founder quote (v7.113.2)

### DIFF
--- a/lib/vutuv_web/live/member_count_live.ex
+++ b/lib/vutuv_web/live/member_count_live.ex
@@ -1,6 +1,6 @@
 defmodule VutuvWeb.MemberCountLive do
   @moduledoc """
-  The "Number of Members" pill on the logged-out landing page, as a tiny
+  The "Active Members" pill on the logged-out landing page, as a tiny
   embedded LiveView so the exact total ticks up live as people register.
 
   Embedded via `live_render` in `page/index.html.heex` (like `ShellLive` in the
@@ -44,7 +44,7 @@ defmodule VutuvWeb.MemberCountLive do
       id="member-count"
       class="mt-6 inline-flex items-center gap-2 rounded-full bg-white/15 px-4 py-1.5 text-sm font-semibold text-white backdrop-blur"
     >
-      {gettext("Number of Members")}:
+      {gettext("Active Members")}:
       <span class="tabular-nums">{delimited_count(@count)}</span>
     </p>
     """

--- a/lib/vutuv_web/templates/page/index.html.heex
+++ b/lib/vutuv_web/templates/page/index.html.heex
@@ -1,16 +1,14 @@
-<.auth_layout title={gettext("“Tired of LinkedIn, Facebook, or X? Same here. Welcome aboard!”")}>
+<.auth_layout title={gettext("“Tired of LinkedIn, and want your data to stay in Germany? I can help.”")}>
   <:headline>
-    <% founder_quote_main = gettext("“Tired of LinkedIn, Facebook, or X? Same here.") %>
-    <% founder_welcome = gettext("Welcome aboard!”") %>
+    <% founder_quote = gettext("“Tired of LinkedIn, and want your data to stay in Germany? I can help.”") %>
     <% founder_name = "Stefan Wintermeyer" %>
     <% founder_role = gettext("Founder of vutuv") %>
-    <%!-- Founder hero: the whole quote in one heading at a single size (setup
-          and "Welcome aboard!" flow together), then a right-aligned signature
-          with the name above the role, set snug. The member-count pill below
-          is shared from the :hero slot. --%>
+    <%!-- Founder hero: the whole quote in one heading at a single size, then a
+          right-aligned signature with the name above the role, set snug. The
+          member-count pill below is shared from the :hero slot. --%>
     <div>
       <h1 class="text-2xl font-bold leading-tight md:text-3xl">
-        {founder_quote_main} {founder_welcome}
+        {founder_quote}
       </h1>
       <div class="mt-6 text-right">
         <p class="font-serif text-2xl leading-none text-white">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.113.1",
+      version: "7.113.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1876,8 +1876,8 @@ msgstr "Mitteilungen"
 
 #: lib/vutuv_web/live/member_count_live.ex:47
 #, elixir-autogen, elixir-format
-msgid "Number of Members"
-msgstr "Mitgliederzahl"
+msgid "Active Members"
+msgstr "Aktive Mitglieder"
 
 #: lib/vutuv_web/live/admin/user_detail_live.ex:99
 #: lib/vutuv_web/live/admin/user_live.ex:345
@@ -2764,20 +2764,10 @@ msgstr "Gründer von vutuv"
 
 #: lib/vutuv_web/templates/page/index.html.heex:1
 #, elixir-autogen, elixir-format
-msgid "“Tired of LinkedIn, Facebook, or X? Same here. Welcome aboard!”"
+msgid "“Tired of LinkedIn, and want your data to stay in Germany? I can help.”"
 msgstr ""
-"„Genervt von LinkedIn, Facebook und X? Ging mir genauso. Herzlich willkommen"
-" bei vutuv!“"
-
-#: lib/vutuv_web/templates/page/index.html.heex:4
-#, elixir-autogen, elixir-format
-msgid "Welcome aboard!”"
-msgstr "Herzlich willkommen bei vutuv!“"
-
-#: lib/vutuv_web/templates/page/index.html.heex:3
-#, elixir-autogen, elixir-format
-msgid "“Tired of LinkedIn, Facebook, or X? Same here."
-msgstr "„Genervt von LinkedIn, Facebook und X? Ging mir genauso."
+"„Genervt von LinkedIn und Ihre Daten sollen in Deutschland bleiben? Da kann"
+" ich helfen.“"
 
 #: lib/vutuv_web/templates/page/index.html.heex:142
 #: lib/vutuv_web/templates/settings/privacy.html.heex:53

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1840,7 +1840,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/member_count_live.ex:47
 #, elixir-autogen, elixir-format
-msgid "Number of Members"
+msgid "Active Members"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_detail_live.ex:99
@@ -2708,17 +2708,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:1
 #, elixir-autogen, elixir-format
-msgid "“Tired of LinkedIn, Facebook, or X? Same here. Welcome aboard!”"
-msgstr ""
-
-#: lib/vutuv_web/templates/page/index.html.heex:4
-#, elixir-autogen, elixir-format
-msgid "Welcome aboard!”"
-msgstr ""
-
-#: lib/vutuv_web/templates/page/index.html.heex:3
-#, elixir-autogen, elixir-format
-msgid "“Tired of LinkedIn, Facebook, or X? Same here."
+msgid "“Tired of LinkedIn, and want your data to stay in Germany? I can help.”"
 msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:142

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1838,7 +1838,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/member_count_live.ex:47
 #, elixir-autogen, elixir-format
-msgid "Number of Members"
+msgid "Active Members"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_detail_live.ex:99
@@ -2706,17 +2706,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:1
 #, elixir-autogen, elixir-format
-msgid "“Tired of LinkedIn, Facebook, or X? Same here. Welcome aboard!”"
-msgstr ""
-
-#: lib/vutuv_web/templates/page/index.html.heex:4
-#, elixir-autogen, elixir-format
-msgid "Welcome aboard!”"
-msgstr ""
-
-#: lib/vutuv_web/templates/page/index.html.heex:3
-#, elixir-autogen, elixir-format
-msgid "“Tired of LinkedIn, Facebook, or X? Same here."
+msgid "“Tired of LinkedIn, and want your data to stay in Germany? I can help.”"
 msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:142

--- a/test/vutuv_web/live/member_count_live_test.exs
+++ b/test/vutuv_web/live/member_count_live_test.exs
@@ -9,8 +9,15 @@ defmodule VutuvWeb.MemberCountLiveTest do
   test "renders the member-count pill", %{conn: conn} do
     {:ok, view, html} = live_isolated(conn, VutuvWeb.MemberCountLive)
 
-    assert html =~ "Number of Members"
+    assert html =~ "Active Members"
     assert has_element?(view, "#member-count")
+  end
+
+  test "renders the German label for German visitors", %{conn: conn} do
+    {:ok, _view, html} =
+      live_isolated(conn, VutuvWeb.MemberCountLive, session: %{"locale" => "de"})
+
+    assert html =~ "Aktive Mitglieder"
   end
 
   test "ticks the displayed total up when the counter broadcasts a new value", %{conn: conn} do


### PR DESCRIPTION
Two German-copy changes on the logged-out landing page.

**Member-count pill** — label changes from "Number of Members" ("Mitgliederzahl") to **"Active Members"** ("Aktive Mitglieder"). The figure is unchanged; the old label undersold that it counts active, confirmed members rather than raw signups.

**Founder hero quote** — shortened and refocused:
- Before: „Genervt von LinkedIn, Facebook und X? Ging mir genauso. Herzlich willkommen bei vutuv!"
- After: **„Genervt von LinkedIn und Ihre Daten sollen in Deutschland bleiben? Da kann ich helfen."** (EN source: "Tired of LinkedIn, and want your data to stay in Germany? I can help.")

Leads with the single strongest hook (LinkedIn fatigue) plus the data-residency argument, in the founder's own voice. The three split gettext strings collapse into one shared by the heading and the page title.

**Notes**
- Gettext catalogs hand-edited (not re-extracted) to avoid pruning unrelated translations; obsolete quote entries removed.
- Added a German-locale render assertion to the `MemberCountLive` test.
- `mix precommit` green (4000 tests). Version bumped to 7.113.2 (patch).