### PR TITLE
Show tagged posts on the tag page and in search (#946)

### DIFF
--- a/docs/architecture/search.md
+++ b/docs/architecture/search.md
@@ -10,12 +10,15 @@ similar-sounding name matches clearly separated, `?q=` plus the filters keeps
 the URL shareable and a settled query is recorded once) with scope chips
 (all/people/tags/posts), an exact-only toggle and query operators parsed by
 `Vutuv.Search.parse/2`: `vorname:`/`nachname:` (aka `first:`/`last:`),
-`@handle`, double quotes for exact, plus the combinable people filters
-`tag:`/`skill:` (has the tag), `ort:`/`stadt:`/`city:` (address in that
-city) and `status:looking` / `status:open` (job-availability, #928 — honored
-only for a signed-in viewer, logged-out search ignores it and a `hidden`
-status never matches), e.g. `müller tag:php`, `müller ort:koblenz` or
-`elixir status:open`.
+`@handle`, double quotes for exact, the combinable filter `tag:`/`skill:`
+(has the tag) which finds **both people and posts** carrying it (issue #946),
+plus the combinable people-only filters `ort:`/`stadt:`/`city:` (address in
+that city) and `status:looking` / `status:open` (job-availability, #928 —
+honored only for a signed-in viewer, logged-out search ignores it and a
+`hidden` status never matches), e.g. `müller tag:php`, `müller ort:koblenz` or
+`elixir status:open`. Only the people-only operators pin the scope to people
+(`scope_pinned?`); `tag:` leaves the scope free, so its chips still narrow to
+just people or just posts.
 
 ## Saved searches (issue #935)
 
@@ -36,3 +39,9 @@ status searches) and never leaks a member's private salary expectation.
 The search page also finds words in **fully public** posts via Postgres
 full-text search (`Vutuv.Posts.search_public/2`); how audiences keep restricted
 posts out of the results is covered in [posts-and-feed.md](posts-and-feed.md).
+A `tag:` filter narrows the same `search_public/2` to posts carrying that tag
+(an `EXISTS` over `post_tags`, name/slug match), and a bare `tag:php` with no
+body words is a pure tag listing (newest first) — the post twin of the tag
+page's "Posts with this tag" section (`Vutuv.Posts.list_tag_posts/1`, issue
+#946), which lists the public posts filed under a tag so a tag used only in
+posts no longer opens an empty page.

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -891,27 +891,114 @@ defmodule Vutuv.Posts do
   config, no language stemming — bodies are mixed German/English), so plain
   words, "quoted phrases" and `-exclusions` all work and garbage never
   raises. Authors come preloaded.
+
+  Options:
+
+    * `:tag` — also require a tag whose name or slug matches the string
+      (issue #946: the `tag:` search operator finds posts, not just people).
+      Combines with the body query (AND); with an empty body it becomes a
+      pure tag listing (newest first). Substring by default, equality when
+      `:exact` is set.
+    * `:exact` — the `tag:` match is equality (`"php"` doesn't hit `phpstorm`).
+    * `:limit` — result cap (default 25).
   """
   def search_public(value, opts \\ []) when is_binary(value) do
+    do_search_public(value, Keyword.get(opts, :tag), opts)
+  end
+
+  # Nothing to search: an empty query with no tag filter matches no post
+  # (rather than every post). A tag: filter alone is a valid pure listing.
+  defp do_search_public("", nil, _opts), do: []
+
+  defp do_search_public(value, tag, opts) do
     limit = Keyword.get(opts, :limit, 25)
 
     # scope_visible(nil) supplies the three anonymous-visibility conditions
     # (no denials, unfrozen, non-hidden author); only the search-specific
     # filters stay here. Search keeps the stricter `email_confirmed? == true`
     # (not the confirmed-or-legacy-NULL gate) deliberately.
+    from(p in Post, as: :post, join: u in assoc(p, :user), where: u.email_confirmed? == true)
+    |> filter_body_search(value)
+    |> filter_posts_by_tag(tag, Keyword.get(opts, :exact, false))
+    |> order_public_search(value)
+    |> limit(^limit)
+    |> preload([p, u], user: u)
+    |> scope_visible(nil)
+    |> Repo.all()
+  end
+
+  defp filter_body_search(query, ""), do: query
+
+  defp filter_body_search(query, value) do
+    where(query, [p], fragment("? @@ websearch_to_tsquery('simple', ?)", p.search_tsv, ^value))
+  end
+
+  # Best full-text match first; a tag-only listing (no body query) is newest
+  # first, so ranking never collapses every post to the same score.
+  defp order_public_search(query, ""), do: order_by(query, [p], desc: p.id)
+
+  defp order_public_search(query, value) do
+    order_by(query, [p],
+      desc: fragment("ts_rank(?, websearch_to_tsquery('simple', ?))", p.search_tsv, ^value),
+      desc: p.id
+    )
+  end
+
+  # The post side of the `tag:` search operator (issue #946): keep only posts
+  # carrying a tag whose name or slug matches. An EXISTS subquery (not a join)
+  # so a post with several matching tags is not duplicated. Same match shape as
+  # the people-side `Vutuv.Search.filter_tag/3`: substring by default, equality
+  # when the query is `exact?`.
+  defp filter_posts_by_tag(query, nil, _exact?), do: query
+
+  defp filter_posts_by_tag(query, tag, true) do
+    sub =
+      from(pt in PostTag,
+        join: t in assoc(pt, :tag),
+        where:
+          pt.post_id == parent_as(:post).id and
+            (fragment("lower(?)", t.name) == ^tag or t.slug == ^tag)
+      )
+
+    where(query, [], exists(subquery(sub)))
+  end
+
+  defp filter_posts_by_tag(query, tag, false) do
+    infix = "%" <> escape_like(tag) <> "%"
+
+    sub =
+      from(pt in PostTag,
+        join: t in assoc(pt, :tag),
+        where:
+          pt.post_id == parent_as(:post).id and
+            (ilike(t.name, ^infix) or ilike(t.slug, ^infix))
+      )
+
+    where(query, [], exists(subquery(sub)))
+  end
+
+  @doc """
+  The public posts carrying `tag`, newest first, for the tag page's "Posts
+  with this tag" section (issue #946). Anonymous view: only posts every
+  visitor may read surface (`scope_visible(nil)`), same gate as
+  `search_public/2`. Matches the exact tag (its id), not a name substring —
+  this is "posts filed under this tag", not a search. Preloaded like every
+  rendered post.
+  """
+  def list_tag_posts(%Tag{} = tag, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 20)
+
     from(p in Post,
       join: u in assoc(p, :user),
-      where: fragment("? @@ websearch_to_tsquery('simple', ?)", p.search_tsv, ^value),
-      where: u.email_confirmed? == true,
-      order_by: [
-        desc: fragment("ts_rank(?, websearch_to_tsquery('simple', ?))", p.search_tsv, ^value),
-        desc: p.id
-      ],
-      limit: ^limit,
-      preload: [user: u]
+      join: pt in PostTag,
+      on: pt.post_id == p.id,
+      where: pt.tag_id == ^tag.id and u.email_confirmed? == true,
+      order_by: [desc: p.id],
+      limit: ^limit
     )
     |> scope_visible(nil)
     |> Repo.all()
+    |> Repo.preload(post_preloads())
   end
 
   @doc """

--- a/lib/vutuv/search.ex
+++ b/lib/vutuv/search.ex
@@ -5,11 +5,11 @@ defmodule Vutuv.Search do
   `instant/2` powers the live search page: one call returns people (split
   into exact prefix matches and phonetically similar ones), tags and public
   posts. Queries support operators, parsed by `parse/2`: `vorname:`/`first:`
-  and `nachname:`/`last:` search one name field, `tag:`/`skill:` only tags,
-  `@handle` the username, and a fully quoted query (or `exact: true`) turns
-  off prefix and phonetic matching. `record_query/2` persists a settled query
-  for the search history. The original `search/2` stays as the low-level
-  name/email matcher.
+  and `nachname:`/`last:` search one name field, `tag:`/`skill:` filters both
+  people and posts carrying that tag (issue #946), `@handle` the username, and
+  a fully quoted query (or `exact: true`) turns off prefix and phonetic
+  matching. `record_query/2` persists a settled query for the search history.
+  The original `search/2` stays as the low-level name/email matcher.
   """
 
   import Ecto.Query
@@ -72,10 +72,11 @@ defmodule Vutuv.Search do
   @doc """
   Parses a raw query into what to search where. Operators: `vorname:x` /
   `first:x` and `nachname:x` / `last:x` search a single name field, `@x` the
-  username, and the people filters `tag:x` / `skill:x` (has that tag) and
-  `ort:x` / `stadt:x` / `city:x` (has an address in that city) - both
-  combinable with a name ("müller tag:php"). `status:open` / `status:looking`
-  (issue #935) filters by job-availability, honored only for a signed-in viewer.
+  username, `tag:x` / `skill:x` (has that tag) filters **both people and
+  posts** (issue #946), and the people-only filter `ort:x` / `stadt:x` /
+  `city:x` (has an address in that city) - both combinable with a name
+  ("müller tag:php"). `status:open` / `status:looking` (issue #935) filters by
+  job-availability, honored only for a signed-in viewer.
   A query wrapped in double quotes sets `exact?` (equality instead of substring
   + phonetics). Options: `:scope` (`:all | :people | :tags | :posts`, the UI
   filter; operators override it, reported back as `scope_pinned?`) and `:exact`
@@ -99,10 +100,12 @@ defmodule Vutuv.Search do
     # word (so "status:foo" degrades to free text rather than matching nothing).
     status = if fields[:status] in @status_values, do: fields[:status]
 
-    # People operators pin the scope: the UI chips cannot override them, so
-    # `scope_pinned?` lets the search page render them as disabled (#846).
+    # The people-only operators pin the scope: the UI chips cannot override
+    # them, so `scope_pinned?` lets the search page render them as disabled
+    # (#846). `tag:` is deliberately NOT here: since issue #946 it finds both
+    # people and posts, so it leaves the scope free for the chips to narrow.
     scope_pinned? =
-      Enum.any?([:tag, :first_name, :last_name, :slug, :city], &fields[&1]) or status != nil
+      Enum.any?([:first_name, :last_name, :slug, :city], &fields[&1]) or status != nil
 
     scope = if scope_pinned?, do: :people, else: valid_scope(opts[:scope])
 
@@ -559,14 +562,17 @@ defmodule Vutuv.Search do
     |> Map.new()
   end
 
-  # Posts are matched by Postgres full-text search, which is word-exact
-  # already; operators and the exact toggle do not apply to them.
+  # Posts are matched by Postgres full-text search over the body, which is
+  # word-exact already; the `tag:` operator (issue #946) additionally filters
+  # by tag, so a bare `tag:php` lists posts carrying that tag even with no body
+  # words. The exact toggle applies only to the tag match (the body query is
+  # always full-text). Nothing to search — no words and no tag — yields nothing.
   defp posts(%{scope: scope}) when scope not in [:all, :posts], do: []
-  defp posts(%{text: text}) when byte_size(text) == 0, do: []
+  defp posts(%{text: "", tag: nil}), do: []
 
   defp posts(parsed) do
     limit = if parsed.scope == :posts, do: @post_scope_limit, else: @post_limit
-    Vutuv.Posts.search_public(parsed.text, limit: limit)
+    Vutuv.Posts.search_public(parsed.text, tag: parsed.tag, exact: parsed.exact?, limit: limit)
   end
 
   @doc """

--- a/lib/vutuv_web/agent_docs/list_docs.ex
+++ b/lib/vutuv_web/agent_docs/list_docs.ex
@@ -18,6 +18,7 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
 
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.JobPostingDoc
+  alias VutuvWeb.AgentDocs.PostDoc
   alias VutuvWeb.UserHelpers
 
   alias Vutuv.Tags.UserTag
@@ -69,8 +70,14 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
     })
   end
 
-  @doc "The tag page: description, the most endorsed members and the open positions (#933)."
-  def build_tag(tag, recommended_users, work_info_by_id, open_positions \\ []) do
+  @doc """
+  The tag page: description, the most endorsed members, the open positions
+  (#933) and the public posts carrying the tag (#946). `posts` is a plain list
+  of preloaded `%Vutuv.Posts.Post{}` (from `Vutuv.Posts.list_tag_posts/1`),
+  rendered with the shared timeline-entry shape so the md / text formats read
+  a post the same way the feed and archive do.
+  """
+  def build_tag(tag, recommended_users, work_info_by_id, open_positions \\ [], posts \\ []) do
     AgentDocs.doc_meta("tag", "/tags/#{tag.slug}")
     |> Map.merge(%{
       title: tag.name,
@@ -78,6 +85,7 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
       name: tag.name,
       slug: tag.slug,
       most_endorsed_users: Enum.map(recommended_users, &person_entry(&1, work_info_by_id)),
+      posts: Enum.map(posts, &PostDoc.timeline_entry(%{post: &1})),
       open_positions: Enum.map(open_positions, &JobPostingDoc.summary/1),
       jobs_url: AgentDocs.abs_url("/jobs?" <> URI.encode_query(%{"tag" => tag.slug}))
     })

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -163,6 +163,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
         gettext("Most endorsed members"),
         Enum.map(doc.most_endorsed_users, &person_line/1)
       ),
+      section(gettext("Posts with this tag"), Enum.map(doc.posts, &post_line/1)),
       tag_open_positions(doc)
     ]
     |> join_blocks()

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -160,6 +160,7 @@ defmodule VutuvWeb.AgentDocs.Text do
         gettext("Most endorsed members"),
         Enum.map(doc.most_endorsed_users, &person_line/1)
       ),
+      section(gettext("Posts with this tag"), Enum.map(doc.posts, &post_lines/1)),
       tag_open_positions(doc),
       footer(doc)
     ]

--- a/lib/vutuv_web/controllers/tag_controller.ex
+++ b/lib/vutuv_web/controllers/tag_controller.ex
@@ -2,6 +2,7 @@ defmodule VutuvWeb.TagController do
   use VutuvWeb, :controller
 
   alias Vutuv.Jobs
+  alias Vutuv.Posts
   alias Vutuv.Tags.Tag
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.ListDocs
@@ -25,9 +26,9 @@ defmodule VutuvWeb.TagController do
   end
 
   # Also served as Markdown / text / JSON via VutuvWeb.AgentDocs.ListDocs
-  # (anonymous view: the description plus the most endorsed members, not the
-  # viewer-dependent "people you may know"). Keep show.html and the doc
-  # builder in sync (agent_docs_drift_test.exs).
+  # (anonymous view: the description, the most endorsed members and the public
+  # posts carrying this tag — not the viewer-dependent "people you may know").
+  # Keep show.html and the doc builder in sync (agent_docs_drift_test.exs).
   def show(conn, _params) do
     tag = conn.assigns[:tag]
 
@@ -35,17 +36,30 @@ defmodule VutuvWeb.TagController do
     # carry this tag. The HTML page subtracts what the signed-in viewer may not
     # see (#939 exclusions / blocks); the agent formats stay the anonymous
     # public view, so the two branches load their own list (only one runs).
+    #
+    # "Posts with this tag" (#946): the public posts carrying the tag, the
+    # anonymous view for both branches (`Posts.list_tag_posts/1` is
+    # viewer-independent), so a tag used only in posts no longer opens an
+    # empty page.
     AgentDocs.respond(conn,
       html:
         &render(&1, "show.html",
           tag: tag,
           open_positions: Jobs.list_tag_postings(tag, conn.assigns[:current_user]),
+          tag_posts: Posts.list_tag_posts(tag),
           meta_description: gettext("Members on vutuv tagged %{tag}.", tag: tag.name || tag.slug)
         ),
       doc: fn ->
         recommended = Tag.recommended_users(tag)
         work_info_by_id = VutuvWeb.UserHelpers.work_information_map(recommended, 45)
-        ListDocs.build_tag(tag, recommended, work_info_by_id, Jobs.list_tag_postings(tag, nil))
+
+        ListDocs.build_tag(
+          tag,
+          recommended,
+          work_info_by_id,
+          Jobs.list_tag_postings(tag, nil),
+          Posts.list_tag_posts(tag)
+        )
       end
     )
   end

--- a/lib/vutuv_web/live/search_live.ex
+++ b/lib/vutuv_web/live/search_live.ex
@@ -267,7 +267,7 @@ defmodule VutuvWeb.SearchLive do
         id="search-scope-pinned-hint"
         class="mt-2 text-xs text-slate-600 dark:text-slate-400"
       >
-        {gettext("Your search uses a people filter such as tag: or city:, so it only finds people.")}
+        {gettext("Your search uses a people-only filter such as city: or status:, so it only finds people.")}
       </p>
 
       <p
@@ -294,7 +294,7 @@ defmodule VutuvWeb.SearchLive do
           <dt class="m-0 font-mono text-slate-700 dark:text-slate-200">{gettext("first:stefan")}</dt>
           <dd class="m-0 font-normal text-slate-600 dark:text-slate-400">{gettext("searches first names only (last: for last names)")}</dd>
           <dt class="m-0 font-mono text-slate-700 dark:text-slate-200">tag:php</dt>
-          <dd class="m-0 font-normal text-slate-600 dark:text-slate-400">{gettext("only people with this tag, combinable: miller tag:php")}</dd>
+          <dd class="m-0 font-normal text-slate-600 dark:text-slate-400">{gettext("people and posts with this tag, combinable: miller tag:php")}</dd>
           <dt class="m-0 font-mono text-slate-700 dark:text-slate-200">{gettext("city:koblenz")}</dt>
           <dd class="m-0 font-normal text-slate-600 dark:text-slate-400">{gettext("only people with an address in this city")}</dd>
           <dt class="m-0 font-mono text-slate-700 dark:text-slate-200">status:looking</dt>

--- a/lib/vutuv_web/templates/tag/show.html.heex
+++ b/lib/vutuv_web/templates/tag/show.html.heex
@@ -10,6 +10,21 @@
     <%= render "single_card.html", assigns %>
 </div>
 
+<section :if={@tag_posts != []} id="tag-posts" class="mt-6">
+  <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+    {gettext("Posts with this tag")}
+  </h2>
+  <div class="mt-3 space-y-4">
+    <.post_card
+      :for={post <- @tag_posts}
+      post={post}
+      viewer={@current_user}
+      mode={:preview}
+      conn_or_socket={@conn}
+    />
+  </div>
+</section>
+
 <section :if={@open_positions != []} class="mt-6">
   <div class="flex items-center justify-between gap-2">
     <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">

--- a/lib/vutuv_web/views/tag_html.ex
+++ b/lib/vutuv_web/views/tag_html.ex
@@ -3,6 +3,7 @@ defmodule VutuvWeb.TagHTML do
   use VutuvWeb, :html
   import VutuvWeb.UserHelpers
   import VutuvWeb.JobComponents, only: [job_card: 1]
+  import VutuvWeb.PostComponents, only: [post_card: 1]
   alias Vutuv.Tags.Tag
 
   defp update_assigns(assigns) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.113.2",
+      version: "7.114.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -24,9 +24,9 @@ msgstr "Impressum"
 msgid "Add"
 msgstr "Eintrag hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:193
+#: lib/vutuv_web/agent_docs/markdown.ex:194
 #: lib/vutuv_web/agent_docs/section_docs.ex:114
-#: lib/vutuv_web/agent_docs/text.ex:190
+#: lib/vutuv_web/agent_docs/text.ex:191
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:110
@@ -93,10 +93,10 @@ msgstr "Avatar"
 msgid "Birthdate"
 msgstr "Geburtstag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:414
 #: lib/vutuv_web/agent_docs/markdown.ex:415
-#: lib/vutuv_web/agent_docs/text.ex:419
+#: lib/vutuv_web/agent_docs/markdown.ex:416
 #: lib/vutuv_web/agent_docs/text.ex:420
+#: lib/vutuv_web/agent_docs/text.ex:421
 #: lib/vutuv_web/templates/user/show.html.heex:788
 #, elixir-autogen
 msgid "Birthday"
@@ -152,7 +152,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "Konnte nicht zu %{name} zurückfolgen."
 
-#: lib/vutuv_web/components/post_components.ex:700
+#: lib/vutuv_web/components/post_components.ex:711
 #: lib/vutuv_web/components/ui.ex:2566
 #: lib/vutuv_web/live/admin/job_live.ex:500
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -197,7 +197,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:693
+#: lib/vutuv_web/components/post_components.ex:704
 #: lib/vutuv_web/components/ui.ex:2557
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -320,8 +320,8 @@ msgstr "Fax"
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:426
-#: lib/vutuv_web/agent_docs/text.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:427
+#: lib/vutuv_web/agent_docs/text.ex:432
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -329,8 +329,8 @@ msgstr "Vorname"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:427
-#: lib/vutuv_web/agent_docs/text.ex:432
+#: lib/vutuv_web/agent_docs/markdown.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:433
 #: lib/vutuv_web/components/ui.ex:1283
 #: lib/vutuv_web/components/ui.ex:1308
 #: lib/vutuv_web/components/ui.ex:1311
@@ -345,8 +345,8 @@ msgstr "Follower"
 msgid "Following"
 msgstr "Folge ich"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:413
-#: lib/vutuv_web/agent_docs/text.ex:418
+#: lib/vutuv_web/agent_docs/markdown.ex:414
+#: lib/vutuv_web/agent_docs/text.ex:419
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -459,9 +459,9 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:445
-#: lib/vutuv_web/live/shell_live.ex:470
-#: lib/vutuv_web/templates/post/teaser.html.heex:33
+#: lib/vutuv_web/live/shell_live.ex:482
+#: lib/vutuv_web/live/shell_live.ex:519
+#: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
 msgid "Log in"
@@ -628,7 +628,7 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:568
+#: lib/vutuv_web/live/post_live/composer.ex:574
 #: lib/vutuv_web/live/section_reorder_live.ex:233
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
@@ -643,7 +643,7 @@ msgid "Public (Everyone can view) or Private (Only you can view)"
 msgstr "Öffentlich (für alle sichtbar) oder Privat (nur für Sie sichtbar)"
 
 #: lib/vutuv_web/live/organization_live/edit.ex:327
-#: lib/vutuv_web/live/post_live/composer.ex:577
+#: lib/vutuv_web/live/post_live/composer.ex:583
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:83
@@ -666,8 +666,8 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/job_board_live.ex:295
 #: lib/vutuv_web/live/search_live.ex:35
 #: lib/vutuv_web/live/search_live.ex:231
-#: lib/vutuv_web/live/shell_live.ex:309
-#: lib/vutuv_web/live/shell_live.ex:465
+#: lib/vutuv_web/live/shell_live.ex:346
+#: lib/vutuv_web/live/shell_live.ex:502
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
 #: lib/vutuv_web/templates/layout/app.html.heex:120
 #, elixir-autogen
@@ -1181,7 +1181,7 @@ msgstr "User mit den meisten Followern"
 msgid "The 1,000 Users with the most Followers"
 msgstr "Die 1.000 User mit den meisten Followern"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:126
+#: lib/vutuv_web/agent_docs/list_docs.ex:134
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
 msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
@@ -1275,7 +1275,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:177
-#: lib/vutuv_web/live/shell_live.ex:417
+#: lib/vutuv_web/live/shell_live.ex:454
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
 #: lib/vutuv_web/templates/admin/ad/show.html.heex:4
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:1
@@ -1484,11 +1484,11 @@ msgid "Tag urls"
 msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:31
-#: lib/vutuv_web/agent_docs/markdown.ex:353
-#: lib/vutuv_web/agent_docs/markdown.ex:728
+#: lib/vutuv_web/agent_docs/markdown.ex:354
+#: lib/vutuv_web/agent_docs/markdown.ex:729
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:387
-#: lib/vutuv_web/agent_docs/text.ex:539
+#: lib/vutuv_web/agent_docs/text.ex:388
+#: lib/vutuv_web/agent_docs/text.ex:540
 #: lib/vutuv_web/components/ui.ex:2809
 #: lib/vutuv_web/controllers/user_tag_controller.ex:37
 #: lib/vutuv_web/controllers/user_tag_controller.ex:54
@@ -1641,7 +1641,7 @@ msgstr "Die am häufigsten empfohlenen Mitglieder mit diesem Tag"
 msgid "Unendorsed tag successfully."
 msgstr "Empfehlung zurückgenommen."
 
-#: lib/vutuv_web/live/tag_new_live.ex:109
+#: lib/vutuv_web/live/tag_new_live.ex:124
 #, elixir-autogen
 msgid "User tag created successfully."
 msgstr "Tag erfolgreich hinzugefügt."
@@ -1715,7 +1715,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:468
+#: lib/vutuv_web/live/shell_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1735,8 +1735,8 @@ msgstr "Schauen Sie in Ihr Postfach"
 #: lib/vutuv_web/live/admin/job_live.ex:332
 #: lib/vutuv_web/live/admin/job_live.ex:491
 #: lib/vutuv_web/live/admin/organization_live.ex:306
-#: lib/vutuv_web/live/post_live/composer.ex:454
-#: lib/vutuv_web/live/post_live/composer.ex:455
+#: lib/vutuv_web/live/post_live/composer.ex:460
+#: lib/vutuv_web/live/post_live/composer.ex:461
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1815,7 +1815,7 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:436
+#: lib/vutuv_web/live/shell_live.ex:473
 #: lib/vutuv_web/views/settings_html.ex:181
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1839,14 +1839,14 @@ msgstr "Nachricht"
 
 #: lib/vutuv_web/live/message_live/index.ex:45
 #: lib/vutuv_web/live/message_live/index.ex:496
-#: lib/vutuv_web/live/shell_live.ex:325
-#: lib/vutuv_web/live/shell_live.ex:467
+#: lib/vutuv_web/live/shell_live.ex:362
+#: lib/vutuv_web/live/shell_live.ex:504
 #: lib/vutuv_web/templates/layout/app.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/shell_live.ex:296
+#: lib/vutuv_web/live/shell_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr "Netzwerk"
@@ -1854,7 +1854,7 @@ msgstr "Netzwerk"
 #: lib/vutuv_web/components/ui.ex:2666
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
-#: lib/vutuv_web/templates/post/index.html.heex:43
+#: lib/vutuv_web/templates/post/index.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr "Hier gibt es noch nichts."
@@ -1867,7 +1867,7 @@ msgstr "Noch nichts Neues."
 #: lib/vutuv_web/components/ui.ex:2823
 #: lib/vutuv_web/live/notification_live/index.ex:66
 #: lib/vutuv_web/live/notification_live/index.ex:135
-#: lib/vutuv_web/live/shell_live.ex:336
+#: lib/vutuv_web/live/shell_live.ex:373
 #: lib/vutuv_web/templates/layout/app.html.heex:118
 #: lib/vutuv_web/templates/settings/notifications.html.heex:7
 #, elixir-autogen, elixir-format
@@ -2178,12 +2178,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:557
+#: lib/vutuv_web/live/post_live/composer.ex:563
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:685
+#: lib/vutuv_web/live/post_live/composer.ex:691
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2196,7 +2196,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:525
+#: lib/vutuv_web/live/post_live/composer.ex:531
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2206,13 +2206,13 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:697
+#: lib/vutuv_web/components/post_components.ex:708
 #: lib/vutuv_web/live/post_live/edit.ex:117
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
 msgstr "Diesen Beitrag endgültig löschen?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:490
+#: lib/vutuv_web/live/post_live/composer.ex:496
 #, elixir-autogen, elixir-format
 msgid "Describe this image (alt text)"
 msgstr "Beschreiben Sie dieses Bild (Alt-Text)"
@@ -2225,46 +2225,46 @@ msgstr "Beitrag bearbeiten"
 
 #: lib/vutuv_web/live/post_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:517
-#: lib/vutuv_web/live/shell_live.ex:290
-#: lib/vutuv_web/live/shell_live.ex:463
+#: lib/vutuv_web/live/shell_live.ex:312
+#: lib/vutuv_web/live/shell_live.ex:500
 #: lib/vutuv_web/templates/layout/app.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Feed"
 msgstr "Feed"
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:26
+#: lib/vutuv_web/templates/post/teaser.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Follow %{name} to read it."
 msgstr "Folgen Sie %{name}, um ihn zu lesen."
 
-#: lib/vutuv_web/templates/post/show.html.heex:13
+#: lib/vutuv_web/templates/post/show.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:661
+#: lib/vutuv_web/live/post_live/composer.ex:667
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:589
+#: lib/vutuv_web/live/post_live/composer.ex:595
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:682
-#: lib/vutuv_web/components/post_components.ex:684
+#: lib/vutuv_web/components/post_components.ex:693
+#: lib/vutuv_web/components/post_components.ex:695
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:631
+#: lib/vutuv_web/live/post_live/composer.ex:637
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:277
-#: lib/vutuv_web/live/post_live/composer.ex:337
+#: lib/vutuv_web/live/post_live/composer.ex:278
+#: lib/vutuv_web/live/post_live/composer.ex:338
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
@@ -2276,23 +2276,23 @@ msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:271
+#: lib/vutuv_web/live/post_live/composer.ex:272
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:621
+#: lib/vutuv_web/live/post_live/composer.ex:627
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:611
+#: lib/vutuv_web/live/post_live/composer.ex:617
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:121
-#: lib/vutuv_web/live/post_live/composer.ex:577
+#: lib/vutuv_web/live/post_live/composer.ex:583
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2313,18 +2313,18 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/search_live.ex:181
 #: lib/vutuv_web/live/search_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:114
-#: lib/vutuv_web/views/admin/report_html.ex:15
+#: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1042
-#: lib/vutuv_web/components/post_components.ex:1046
+#: lib/vutuv_web/components/post_components.ex:1093
+#: lib/vutuv_web/components/post_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:1043
+#: lib/vutuv_web/components/post_components.ex:1094
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
@@ -2334,7 +2334,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/organization_live/domains.ex:209
 #: lib/vutuv_web/live/organization_live/edit.ex:359
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:647
+#: lib/vutuv_web/live/post_live/composer.ex:653
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2343,19 +2343,19 @@ msgstr "Weniger anzeigen"
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:508
+#: lib/vutuv_web/live/post_live/composer.ex:514
 #, elixir-autogen, elixir-format
 msgid "Remove image"
 msgstr "Bild entfernen"
 
-#: lib/vutuv_web/templates/post/show.html.heex:16
+#: lib/vutuv_web/templates/post/show.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:575
+#: lib/vutuv_web/live/post_live/composer.ex:581
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
@@ -2373,71 +2373,71 @@ msgstr[1] "Zeige %{formatted} neue Beiträge"
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:361
+#: lib/vutuv_web/live/post_live/composer.ex:362
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:265
+#: lib/vutuv_web/live/post_live/composer.ex:266
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:19
+#: lib/vutuv_web/templates/post/teaser.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:716
+#: lib/vutuv_web/live/post_live/composer.ex:722
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:717
+#: lib/vutuv_web/live/post_live/composer.ex:723
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
 #: lib/vutuv_web/components/ui.ex:2982
-#: lib/vutuv_web/live/shell_live.ex:379
-#: lib/vutuv_web/templates/post/index.html.heex:12
-#: lib/vutuv_web/templates/post/teaser.html.heex:54
+#: lib/vutuv_web/live/shell_live.ex:416
+#: lib/vutuv_web/templates/post/index.html.heex:13
+#: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:128
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:466
+#: lib/vutuv_web/live/post_live/composer.ex:472
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:467
+#: lib/vutuv_web/live/post_live/composer.ex:473
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:679
+#: lib/vutuv_web/components/post_components.ex:690
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:1252
+#: lib/vutuv_web/components/post_components.ex:1303
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:1256
+#: lib/vutuv_web/components/post_components.ex:1307
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:1254
+#: lib/vutuv_web/components/post_components.ex:1305
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:1255
+#: lib/vutuv_web/components/post_components.ex:1306
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2448,22 +2448,22 @@ msgstr "Personen, denen Sie nicht folgen"
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:540
+#: lib/vutuv_web/live/post_live/composer.ex:546
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr "Tags, durch Komma oder Leerzeichen getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:707
+#: lib/vutuv_web/live/post_live/composer.ex:713
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:711
+#: lib/vutuv_web/live/post_live/composer.ex:717
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
 
-#: lib/vutuv_web/templates/post/index.html.heex:5
+#: lib/vutuv_web/templates/post/index.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Posts by %{name}"
 msgstr "Beiträge von %{name}"
@@ -2478,7 +2478,7 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1324
+#: lib/vutuv_web/components/post_components.ex:1375
 #: lib/vutuv_web/components/ui.ex:1563
 #: lib/vutuv_web/components/ui.ex:1563
 #: lib/vutuv_web/components/ui.ex:2171
@@ -2487,17 +2487,17 @@ msgstr "Alle Beiträge"
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:760
+#: lib/vutuv_web/agent_docs/markdown.ex:761
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
-#: lib/vutuv_web/live/shell_live.ex:318
-#: lib/vutuv_web/live/shell_live.ex:384
-#: lib/vutuv_web/views/admin/report_html.ex:18
+#: lib/vutuv_web/live/shell_live.ex:355
+#: lib/vutuv_web/live/shell_live.ex:421
+#: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1291
+#: lib/vutuv_web/components/post_components.ex:1342
 #: lib/vutuv_web/components/ui.ex:1592
 #: lib/vutuv_web/components/ui.ex:1592
 #: lib/vutuv_web/components/ui.ex:2157
@@ -2507,11 +2507,11 @@ msgstr "Lesezeichen"
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:760
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
-#: lib/vutuv_web/live/shell_live.ex:387
-#: lib/vutuv_web/views/admin/report_html.ex:17
+#: lib/vutuv_web/live/shell_live.ex:424
+#: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Likes"
 msgstr "Likes"
@@ -2526,12 +2526,12 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:1313
+#: lib/vutuv_web/components/post_components.ex:1364
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1324
+#: lib/vutuv_web/components/post_components.ex:1375
 #: lib/vutuv_web/components/ui.ex:1553
 #: lib/vutuv_web/components/ui.ex:1553
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2540,23 +2540,23 @@ msgstr "Nur öffentliche Beiträge können repostet werden."
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1310
+#: lib/vutuv_web/components/post_components.ex:1361
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1123
+#: lib/vutuv_web/components/post_components.ex:1182
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1310
+#: lib/vutuv_web/components/post_components.ex:1361
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:1291
+#: lib/vutuv_web/components/post_components.ex:1342
 #: lib/vutuv_web/components/ui.ex:1582
 #: lib/vutuv_web/components/ui.ex:1582
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2577,20 +2577,20 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:1364
+#: lib/vutuv_web/components/post_components.ex:1415
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:102
 #: lib/vutuv_web/agent_docs/text.ex:100
-#: lib/vutuv_web/templates/post/show.html.heex:27
+#: lib/vutuv_web/templates/post/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1347
-#: lib/vutuv_web/components/post_components.ex:1348
+#: lib/vutuv_web/components/post_components.ex:1398
+#: lib/vutuv_web/components/post_components.ex:1399
 #: lib/vutuv_web/live/notification_live/index.ex:207
 #: lib/vutuv_web/live/notification_live/index.ex:299
 #: lib/vutuv_web/live/post_live/reply.ex:25
@@ -2598,20 +2598,20 @@ msgstr "Antworten"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:650
+#: lib/vutuv_web/components/post_components.ex:661
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:268
-#: lib/vutuv_web/live/post_live/composer.ex:565
+#: lib/vutuv_web/live/post_live/composer.ex:269
+#: lib/vutuv_web/live/post_live/composer.ex:571
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 "Die Sichtbarkeit kann nicht eingeschränkt werden, solange Reposts oder "
 "Antworten existieren."
 
-#: lib/vutuv_web/live/post_live/composer.ex:692
+#: lib/vutuv_web/live/post_live/composer.ex:698
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2628,12 +2628,12 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:645
+#: lib/vutuv_web/components/post_components.ex:656
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:639
+#: lib/vutuv_web/components/post_components.ex:650
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2892,8 +2892,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 weiteres Tag"
 msgstr[1] "+%{formatted} weitere Tags"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:428
-#: lib/vutuv_web/agent_docs/text.ex:433
+#: lib/vutuv_web/agent_docs/markdown.ex:429
+#: lib/vutuv_web/agent_docs/text.ex:434
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2915,7 +2915,7 @@ msgstr "Noch keine Vernetzungen."
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:601
+#: lib/vutuv_web/live/post_live/composer.ex:607
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
@@ -2925,7 +2925,7 @@ msgstr "Personen, mit denen ich nicht vernetzt bin"
 msgid "Text only"
 msgstr "Nur Text"
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:17
+#: lib/vutuv_web/templates/post/teaser.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "This post is for the connections of %{name}"
 msgstr "Dieser Beitrag ist für die Vernetzungen von %{name}"
@@ -2938,7 +2938,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:1253
+#: lib/vutuv_web/components/post_components.ex:1304
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3043,8 +3043,8 @@ msgstr "Gibt es etwas, das unsere Admins wissen sollten? (optional)"
 msgid "Bullying or harassment"
 msgstr "Mobbing oder Belästigung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:272
-#: lib/vutuv_web/agent_docs/text.ex:265
+#: lib/vutuv_web/agent_docs/markdown.ex:273
+#: lib/vutuv_web/agent_docs/text.ex:266
 #: lib/vutuv_web/controllers/page_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3217,7 +3217,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:627
+#: lib/vutuv_web/components/post_components.ex:638
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3273,6 +3273,8 @@ msgid "Private message"
 msgstr "Private Nachricht"
 
 #: lib/vutuv_web/components/ui.ex:2797
+#: lib/vutuv_web/live/shell_live.ex:325
+#: lib/vutuv_web/live/shell_live.ex:509
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3296,7 +3298,7 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:721
+#: lib/vutuv_web/components/post_components.ex:732
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4006,12 +4008,12 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:515
+#: lib/vutuv_web/agent_docs/markdown.ex:516
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:772
+#: lib/vutuv_web/agent_docs/markdown.ex:773
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -4025,16 +4027,16 @@ msgstr "%{count} Beiträge von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/markdown.ex:137
 #: lib/vutuv_web/agent_docs/markdown.ex:150
-#: lib/vutuv_web/agent_docs/markdown.ex:728
+#: lib/vutuv_web/agent_docs/markdown.ex:729
 #: lib/vutuv_web/agent_docs/text.ex:75
 #: lib/vutuv_web/agent_docs/text.ex:134
 #: lib/vutuv_web/agent_docs/text.ex:147
-#: lib/vutuv_web/agent_docs/text.ex:539
+#: lib/vutuv_web/agent_docs/text.ex:540
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:45
+#: lib/vutuv_web/agent_docs/list_docs.ex:46
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr "Follower von %{name}"
@@ -4046,26 +4048,26 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:746
-#: lib/vutuv_web/agent_docs/text.ex:550
+#: lib/vutuv_web/agent_docs/markdown.ex:747
+#: lib/vutuv_web/agent_docs/text.ex:551
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:743
-#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/markdown.ex:744
+#: lib/vutuv_web/agent_docs/text.ex:548
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:750
-#: lib/vutuv_web/agent_docs/text.ex:553
+#: lib/vutuv_web/agent_docs/markdown.ex:751
+#: lib/vutuv_web/agent_docs/text.ex:554
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:411
-#: lib/vutuv_web/agent_docs/text.ex:416
+#: lib/vutuv_web/agent_docs/markdown.ex:412
+#: lib/vutuv_web/agent_docs/text.ex:417
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Mitglied seit"
@@ -4076,12 +4078,12 @@ msgstr "Mitglied seit"
 msgid "Most endorsed members"
 msgstr "Am häufigsten empfohlene Mitglieder"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:124
+#: lib/vutuv_web/agent_docs/list_docs.ex:132
 #, elixir-autogen, elixir-format
 msgid "Most followed members"
 msgstr "Mitglieder mit den meisten Followern"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:46
+#: lib/vutuv_web/agent_docs/list_docs.ex:47
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr "Wem %{name} folgt"
@@ -4094,7 +4096,7 @@ msgstr "Beitragsarchiv von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:96
 #: lib/vutuv_web/agent_docs/text.ex:93
 #: lib/vutuv_web/live/admin/screenshot_live.ex:96
-#: lib/vutuv_web/templates/post/show.html.heex:6
+#: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
 msgstr "Beitrag von %{name}"
@@ -4105,23 +4107,23 @@ msgstr "Beitrag von %{name}"
 msgid "Posts (%{count} total)"
 msgstr "Beiträge (insgesamt %{count})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:407
-#: lib/vutuv_web/agent_docs/text.ex:412
+#: lib/vutuv_web/agent_docs/markdown.ex:408
+#: lib/vutuv_web/agent_docs/text.ex:413
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:697
+#: lib/vutuv_web/agent_docs/markdown.ex:698
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:636
+#: lib/vutuv_web/agent_docs/markdown.ex:637
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:637
+#: lib/vutuv_web/agent_docs/markdown.ex:638
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4131,7 +4133,7 @@ msgstr "bis %{date}"
 msgid "This page in %{language}: %{url}"
 msgstr "Diese Seite auf %{language}: %{url}"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:47
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr "Vernetzungen von %{name}"
@@ -4198,8 +4200,8 @@ msgstr ""
 msgid "Billing name"
 msgstr "Name für die Rechnung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:287
+#: lib/vutuv_web/agent_docs/text.ex:274
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr "Online buchen (Login erforderlich): %{url}"
@@ -4248,8 +4250,8 @@ msgstr "Tag"
 msgid "Markdown is supported. At most %{max} characters."
 msgstr "Markdown wird unterstützt. Höchstens %{max} Zeichen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:276
-#: lib/vutuv_web/agent_docs/text.ex:269
+#: lib/vutuv_web/agent_docs/markdown.ex:277
+#: lib/vutuv_web/agent_docs/text.ex:270
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4265,8 +4267,8 @@ msgstr "Ein Tag. Eine Anzeige. Alle Besucher."
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr "Eine reine Textanzeige pro Kalendertag, gesehen von allen Besuchern."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:273
-#: lib/vutuv_web/agent_docs/text.ex:266
+#: lib/vutuv_web/agent_docs/markdown.ex:274
+#: lib/vutuv_web/agent_docs/text.ex:267
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4500,14 +4502,14 @@ msgstr "gebucht am"
 msgid "deleted account"
 msgstr "gelöschtes Konto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:278
-#: lib/vutuv_web/agent_docs/text.ex:271
+#: lib/vutuv_web/agent_docs/markdown.ex:279
+#: lib/vutuv_web/agent_docs/text.ex:272
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr "Bereits gebucht"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:274
-#: lib/vutuv_web/agent_docs/text.ex:267
+#: lib/vutuv_web/agent_docs/markdown.ex:275
+#: lib/vutuv_web/agent_docs/text.ex:268
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr "Buchungszeitraum"
@@ -4620,7 +4622,7 @@ msgid "Edit the ad"
 msgstr "Anzeige bearbeiten"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1004
-#: lib/vutuv_web/live/tag_new_live.ex:73
+#: lib/vutuv_web/live/tag_new_live.ex:74
 #: lib/vutuv_web/templates/ad/preview.html.heex:3
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:122
 #, elixir-autogen, elixir-format
@@ -4789,8 +4791,8 @@ msgstr "Keine Ergebnisse für \"%{query}\""
 msgid "Not an exact match, but sounds like your search."
 msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:301
-#: lib/vutuv_web/agent_docs/text.ex:335
+#: lib/vutuv_web/agent_docs/markdown.ex:302
+#: lib/vutuv_web/agent_docs/text.ex:336
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
@@ -4876,11 +4878,6 @@ msgstr "Nach Personen, Tags oder Beiträgen suchen"
 msgid "This tag doesn't have a description yet."
 msgstr "Für dieses Tag gibt es noch keine Beschreibung."
 
-#: lib/vutuv_web/live/search_live.ex:297
-#, elixir-autogen, elixir-format
-msgid "only people with this tag, combinable: miller tag:php"
-msgstr "nur Personen mit diesem Tag, kombinierbar: müller tag:php"
-
 #: lib/vutuv_web/templates/access_token/index.html.heex:1
 #: lib/vutuv_web/templates/access_token/index.html.heex:1
 #: lib/vutuv_web/templates/access_token/new.html.heex:1
@@ -4916,8 +4913,8 @@ msgstr "Entwickler"
 msgid "Edit your profile and its sections"
 msgstr "Ihr Profil und seine Bereiche bearbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:215
-#: lib/vutuv_web/agent_docs/text.ex:211
+#: lib/vutuv_web/agent_docs/markdown.ex:216
+#: lib/vutuv_web/agent_docs/text.ex:212
 #: lib/vutuv_web/live/admin/job_live.ex:400
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:135
@@ -5539,7 +5536,7 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:274
+#: lib/vutuv_web/live/post_live/composer.ex:275
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
@@ -5549,7 +5546,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:366
+#: lib/vutuv_web/live/shell_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5569,7 +5566,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:427
+#: lib/vutuv_web/live/shell_live.ex:464
 #: lib/vutuv_web/templates/layout/app.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5584,7 +5581,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/components/ui.ex:2906
 #: lib/vutuv_web/components/ui.ex:2974
 #: lib/vutuv_web/controllers/settings_controller.ex:51
-#: lib/vutuv_web/live/shell_live.ex:407
+#: lib/vutuv_web/live/shell_live.ex:444
 #: lib/vutuv_web/live/tag_new_live.ex:44
 #: lib/vutuv_web/templates/address/edit.html.heex:2
 #: lib/vutuv_web/templates/address/new.html.heex:2
@@ -5661,8 +5658,8 @@ msgstr "Nächster Beitrag im Feed"
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:284
-#: lib/vutuv_web/live/shell_live.ex:456
+#: lib/vutuv_web/live/shell_live.ex:305
+#: lib/vutuv_web/live/shell_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -5672,9 +5669,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:756
-#: lib/vutuv_web/components/post_components.ex:805
-#: lib/vutuv_web/components/post_components.ex:818
+#: lib/vutuv_web/components/post_components.ex:774
+#: lib/vutuv_web/components/post_components.ex:825
+#: lib/vutuv_web/components/post_components.ex:838
 #: lib/vutuv_web/live/post_live/feed.ex:672
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6422,8 +6419,8 @@ msgid_plural "%{count} years old"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:416
-#: lib/vutuv_web/agent_docs/text.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:417
+#: lib/vutuv_web/agent_docs/text.ex:422
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Alter"
@@ -6472,7 +6469,7 @@ msgstr "Telefon verwalten"
 msgid "Metric"
 msgstr "Kennzahl"
 
-#: lib/vutuv_web/views/admin/report_html.ex:14
+#: lib/vutuv_web/views/admin/report_html.ex:33
 #, elixir-autogen, elixir-format
 msgid "New confirmed registrations (by PIN)"
 msgstr "Neue bestätigte Registrierungen (per PIN)"
@@ -6497,8 +6494,8 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
-#: lib/vutuv_web/views/admin/report_html.ex:16
+#: lib/vutuv_web/agent_docs/markdown.ex:760
+#: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr "Reposts"
@@ -6586,7 +6583,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr "Empfohlen am"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:97
+#: lib/vutuv_web/agent_docs/list_docs.ex:105
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -6603,7 +6600,7 @@ msgstr "Noch keine Empfehlungen."
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:741
+#: lib/vutuv_web/agent_docs/markdown.ex:742
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -6700,17 +6697,17 @@ msgstr ""
 "auf."
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:153
-#: lib/vutuv_web/views/admin/report_html.ex:20
+#: lib/vutuv_web/views/admin/report_html.ex:40
 #, elixir-autogen, elixir-format
 msgid "Deactivated addresses"
 msgstr "Deaktivierte Adressen"
 
-#: lib/vutuv_web/views/admin/report_html.ex:37
+#: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "New Fediverse followers"
 msgstr "Neue Fediverse-Follower"
 
-#: lib/vutuv_web/templates/admin/report/index.html.heex:87
+#: lib/vutuv_web/templates/admin/report/index.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "… and %{count} more"
 msgstr "… und %{count} weitere"
@@ -6736,7 +6733,7 @@ msgstr ""
 "zuerst."
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:102
-#: lib/vutuv_web/views/admin/report_html.ex:21
+#: lib/vutuv_web/views/admin/report_html.ex:41
 #, elixir-autogen, elixir-format
 msgid "Frozen accounts"
 msgstr "Eingefrorene Konten"
@@ -6855,12 +6852,12 @@ msgstr "wiederholte harte Bounces"
 msgid "system"
 msgstr "System"
 
-#: lib/vutuv_web/views/admin/report_html.ex:19
+#: lib/vutuv_web/views/admin/report_html.ex:39
 #, elixir-autogen, elixir-format
 msgid "Bounces"
 msgstr "Bounces"
 
-#: lib/vutuv_web/views/admin/report_html.ex:22
+#: lib/vutuv_web/views/admin/report_html.ex:42
 #, elixir-autogen, elixir-format
 msgid "Thawed accounts"
 msgstr "Aufgetaute Konten"
@@ -6935,18 +6932,18 @@ msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
 "Stummschaltung aufgehoben. Die Beiträge erscheinen wieder in Ihrem Feed."
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:24
+#: lib/vutuv_web/templates/post/teaser.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Follow each other to connect with %{name} and read it."
 msgstr ""
 "Folgt euch gegenseitig, um mit %{name} vernetzt zu sein und ihn zu lesen."
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:39
+#: lib/vutuv_web/templates/post/teaser.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:718
+#: lib/vutuv_web/components/post_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6956,7 +6953,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:717
+#: lib/vutuv_web/components/post_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7161,8 +7158,8 @@ msgstr "Filtern"
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:189
-#: lib/vutuv_web/agent_docs/text.ex:186
+#: lib/vutuv_web/agent_docs/markdown.ex:190
+#: lib/vutuv_web/agent_docs/text.ex:187
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -7846,17 +7843,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:777
+#: lib/vutuv_web/agent_docs/markdown.ex:778
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Dein Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:780
+#: lib/vutuv_web/agent_docs/markdown.ex:781
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:787
+#: lib/vutuv_web/agent_docs/markdown.ex:788
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -8940,14 +8937,14 @@ msgstr ""
 "Alle %{count} Mitglieder, deren Profile für Suchmaschinen freigegeben sind, "
 "alphabetisch nach Nachnamen sortiert."
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:143
+#: lib/vutuv_web/agent_docs/list_docs.ex:151
 #, elixir-autogen, elixir-format
 msgid "All members who allow search engines to index their profile, grouped by the first letter of their last name."
 msgstr ""
 "Alle Mitglieder, die die Indexierung ihres Profils durch Suchmaschinen "
 "erlauben, gruppiert nach dem Anfangsbuchstaben des Nachnamens."
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:141
+#: lib/vutuv_web/agent_docs/list_docs.ex:149
 #: lib/vutuv_web/controllers/directory_controller.ex:28
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8963,7 +8960,7 @@ msgstr "Mitgliederverzeichnis"
 msgid "Members by initial"
 msgstr "Mitglieder nach Anfangsbuchstaben"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:160
+#: lib/vutuv_web/agent_docs/list_docs.ex:168
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8982,7 +8979,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] "Ein Mitglied"
 msgstr[1] "%{formatted} Mitglieder"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:166
+#: lib/vutuv_web/agent_docs/list_docs.ex:174
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -9206,7 +9203,7 @@ msgid "Employment"
 msgstr "Anstellung"
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:555
+#: lib/vutuv_web/agent_docs/markdown.ex:556
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -9229,7 +9226,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr "Berufserfahrung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:556
+#: lib/vutuv_web/agent_docs/markdown.ex:557
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -9240,13 +9237,6 @@ msgstr "Ehrenamt, Hobby & Freiwilligenarbeit"
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr "Nicht verfügbar, solange die Suche einen Personen-Filter verwendet."
-
-#: lib/vutuv_web/live/search_live.ex:270
-#, elixir-autogen, elixir-format
-msgid "Your search uses a people filter such as tag: or city:, so it only finds people."
-msgstr ""
-"Ihre Suche verwendet einen Personen-Filter wie tag: oder ort:, daher findet "
-"sie nur Personen."
 
 #: lib/vutuv_web/cv/html.ex:57
 #: lib/vutuv_web/cv/html.ex:58
@@ -9267,19 +9257,19 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:593
+#: lib/vutuv_web/agent_docs/markdown.ex:594
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:593
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
 msgstr "Berufsausbildung"
 
-#: lib/vutuv_web/live/tag_new_live.ex:74
+#: lib/vutuv_web/live/tag_new_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "This will create the following tags:"
 msgstr "Die folgenden Tags werden erstellt:"
@@ -9302,14 +9292,14 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:1126
+#: lib/vutuv_web/components/post_components.ex:1185
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:700
+#: lib/vutuv_web/agent_docs/markdown.ex:701
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9402,14 +9392,14 @@ msgstr ""
 "Der Lebenslauf von %{name} auf vutuv: Berufserfahrung, Ausbildung und "
 "Kenntnisse zum Ansehen und Herunterladen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:554
+#: lib/vutuv_web/agent_docs/markdown.ex:555
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr "Freiberuflich / Selbstständig"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:557
+#: lib/vutuv_web/agent_docs/markdown.ex:558
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9561,8 +9551,8 @@ msgstr "Ehren-Tag"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Ehren-Tag (nur Admins können es vergeben)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:437
-#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:438
+#: lib/vutuv_web/agent_docs/text.ex:441
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "Ehren-Tag"
@@ -9984,8 +9974,8 @@ msgstr "Walisisch"
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:409
-#: lib/vutuv_web/agent_docs/text.ex:414
+#: lib/vutuv_web/agent_docs/markdown.ex:410
+#: lib/vutuv_web/agent_docs/text.ex:415
 #: lib/vutuv_web/templates/user/edit.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Employment status"
@@ -10098,7 +10088,7 @@ msgstr[1] "%{count} Zertifikate oder Lizenzen"
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/markdown.ex:631
 #: lib/vutuv_web/views/qualification_html.ex:10
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -10185,7 +10175,7 @@ msgstr "Ablaufmonat"
 msgid "Expiry year"
 msgstr "Ablaufjahr"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:622
+#: lib/vutuv_web/agent_docs/markdown.ex:623
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10211,7 +10201,7 @@ msgstr "Ausstellungsjahr"
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:629
+#: lib/vutuv_web/agent_docs/markdown.ex:630
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10241,7 +10231,7 @@ msgstr "Nachweis"
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:620
+#: lib/vutuv_web/agent_docs/markdown.ex:621
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10256,7 +10246,7 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:621
+#: lib/vutuv_web/agent_docs/markdown.ex:622
 #: lib/vutuv_web/views/qualification_html.ex:60
 #: lib/vutuv_web/views/qualification_html.ex:63
 #, elixir-autogen, elixir-format
@@ -10275,7 +10265,7 @@ msgstr ""
 msgid "Preferred"
 msgstr "Bevorzugt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:524
+#: lib/vutuv_web/agent_docs/markdown.ex:525
 #: lib/vutuv_web/live/section_reorder_live.ex:252
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -10355,7 +10345,7 @@ msgid "First name"
 msgstr "Vorname"
 
 #: lib/vutuv_web/controllers/invitation_controller.ex:54
-#: lib/vutuv_web/live/shell_live.ex:398
+#: lib/vutuv_web/live/shell_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Invite a friend"
 msgstr "Freunde einladen"
@@ -10597,7 +10587,7 @@ msgstr "Konto entfernt"
 msgid "Account restored. The member can sign in again."
 msgstr "Konto wiederhergestellt. Das Mitglied kann sich wieder anmelden."
 
-#: lib/vutuv_web/views/admin/report_html.ex:23
+#: lib/vutuv_web/views/admin/report_html.ex:43
 #, elixir-autogen, elixir-format
 msgid "Accounts removed as spam"
 msgstr "Als Spam entfernte Konten"
@@ -10978,21 +10968,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr "auf diesem Gerät einrichten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:492
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} Follower"
 msgstr[1] "%{count} Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:490
+#: lib/vutuv_web/agent_docs/markdown.ex:491
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} Repository"
 msgstr[1] "%{count} Repositories"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:488
+#: lib/vutuv_web/agent_docs/markdown.ex:489
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -11050,12 +11040,12 @@ msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten nur als einfache "
 "Links."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:506
+#: lib/vutuv_web/agent_docs/markdown.ex:507
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:493
+#: lib/vutuv_web/agent_docs/markdown.ex:494
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "seit %{date}"
@@ -11214,7 +11204,7 @@ msgstr ""
 "Verwalten Sie Ihr vutuv-Konto: Profil, Privatsphäre, Benachrichtigungen und "
 "Anmeldung."
 
-#: lib/vutuv_web/controllers/tag_controller.ex:43
+#: lib/vutuv_web/controllers/tag_controller.ex:50
 #, elixir-autogen, elixir-format
 msgid "Members on vutuv tagged %{tag}."
 msgstr "Mitglieder auf vutuv mit dem Tag %{tag}."
@@ -11976,8 +11966,8 @@ msgstr "Verifizierungsmethode"
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:190
-#: lib/vutuv_web/agent_docs/text.ex:187
+#: lib/vutuv_web/agent_docs/markdown.ex:191
+#: lib/vutuv_web/agent_docs/text.ex:188
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr "Verifiziert über"
@@ -12006,8 +11996,8 @@ msgstr ""
 "Wir konnten den Eintrag oder die Datei noch nicht finden. Die Verbreitung "
 "kann etwas dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:192
-#: lib/vutuv_web/agent_docs/text.ex:189
+#: lib/vutuv_web/agent_docs/markdown.ex:193
+#: lib/vutuv_web/agent_docs/text.ex:190
 #: lib/vutuv_web/live/organization_live/edit.ex:273
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -12093,8 +12083,8 @@ msgstr "Alias hinzugefügt."
 msgid "Alias removed."
 msgstr "Alias entfernt."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:293
-#: lib/vutuv_web/agent_docs/text.ex:328
+#: lib/vutuv_web/agent_docs/markdown.ex:294
+#: lib/vutuv_web/agent_docs/text.ex:329
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
@@ -12336,8 +12326,8 @@ msgstr "ausstehend"
 msgid "primary"
 msgstr "primär"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:314
-#: lib/vutuv_web/agent_docs/text.ex:348
+#: lib/vutuv_web/agent_docs/markdown.ex:315
+#: lib/vutuv_web/agent_docs/text.ex:349
 #: lib/vutuv_web/live/admin/organization_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -12478,8 +12468,8 @@ msgstr ""
 "Wir konnten den Nachweis noch nicht finden. Die Verbreitung kann etwas "
 "dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:650
-#: lib/vutuv_web/agent_docs/text.ex:520
+#: lib/vutuv_web/agent_docs/markdown.ex:651
+#: lib/vutuv_web/agent_docs/text.ex:521
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -12515,8 +12505,8 @@ msgstr "Verknüpft mit {name}"
 msgid "Remove link"
 msgstr "Verknüpfung entfernen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:305
-#: lib/vutuv_web/agent_docs/text.ex:339
+#: lib/vutuv_web/agent_docs/markdown.ex:306
+#: lib/vutuv_web/agent_docs/text.ex:340
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr "ehemalig"
@@ -12735,7 +12725,7 @@ msgstr "Organisation"
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
 #: lib/vutuv_web/live/post_live/saved.ex:455
-#: lib/vutuv_web/live/shell_live.ex:394
+#: lib/vutuv_web/live/shell_live.ex:431
 #: lib/vutuv_web/templates/layout/app.html.heex:79
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
@@ -12993,10 +12983,10 @@ msgstr "Entwürfe"
 msgid "Edit posting"
 msgstr "Anzeige bearbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:209
-#: lib/vutuv_web/agent_docs/markdown.ex:338
-#: lib/vutuv_web/agent_docs/text.ex:205
-#: lib/vutuv_web/agent_docs/text.ex:372
+#: lib/vutuv_web/agent_docs/markdown.ex:210
+#: lib/vutuv_web/agent_docs/markdown.ex:339
+#: lib/vutuv_web/agent_docs/text.ex:206
+#: lib/vutuv_web/agent_docs/text.ex:373
 #: lib/vutuv_web/live/admin/job_live.ex:351
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employer"
@@ -13007,10 +12997,10 @@ msgstr "Arbeitgeber"
 msgid "Employer name (optional)"
 msgstr "Name des Arbeitgebers (optional)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:210
-#: lib/vutuv_web/agent_docs/markdown.ex:339
-#: lib/vutuv_web/agent_docs/text.ex:206
-#: lib/vutuv_web/agent_docs/text.ex:373
+#: lib/vutuv_web/agent_docs/markdown.ex:211
+#: lib/vutuv_web/agent_docs/markdown.ex:340
+#: lib/vutuv_web/agent_docs/text.ex:207
+#: lib/vutuv_web/agent_docs/text.ex:374
 #: lib/vutuv_web/live/job_board_live.ex:280
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format, fuzzy
@@ -13072,7 +13062,7 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:40
 #: lib/vutuv_web/live/job_board_live.ex:145
 #: lib/vutuv_web/live/post_live/saved.ex:458
-#: lib/vutuv_web/live/shell_live.ex:302
+#: lib/vutuv_web/live/shell_live.ex:339
 #: lib/vutuv_web/templates/layout/app.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -13083,12 +13073,12 @@ msgstr "Jobs"
 msgid "Let search engines index this posting."
 msgstr "Suchmaschinen dürfen diese Anzeige indexieren."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:320
-#: lib/vutuv_web/agent_docs/markdown.ex:324
-#: lib/vutuv_web/agent_docs/markdown.ex:326
-#: lib/vutuv_web/agent_docs/text.ex:354
-#: lib/vutuv_web/agent_docs/text.ex:358
-#: lib/vutuv_web/agent_docs/text.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:321
+#: lib/vutuv_web/agent_docs/markdown.ex:325
+#: lib/vutuv_web/agent_docs/markdown.ex:327
+#: lib/vutuv_web/agent_docs/text.ex:355
+#: lib/vutuv_web/agent_docs/text.ex:359
+#: lib/vutuv_web/agent_docs/text.ex:361
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
@@ -13137,8 +13127,8 @@ msgstr "Neue Konten können nach einigen Tagen veröffentlichen."
 msgid "New posting"
 msgstr "Neue Anzeige"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:221
-#: lib/vutuv_web/agent_docs/text.ex:216
+#: lib/vutuv_web/agent_docs/markdown.ex:222
+#: lib/vutuv_web/agent_docs/text.ex:217
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
 #: lib/vutuv_web/live/job_posting_live/show.ex:153
 #, elixir-autogen, elixir-format
@@ -13222,10 +13212,10 @@ msgstr "Veröffentlichen als"
 msgid "Postal code"
 msgstr "Postleitzahl"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:214
-#: lib/vutuv_web/agent_docs/markdown.ex:343
-#: lib/vutuv_web/agent_docs/text.ex:210
-#: lib/vutuv_web/agent_docs/text.ex:377
+#: lib/vutuv_web/agent_docs/markdown.ex:215
+#: lib/vutuv_web/agent_docs/markdown.ex:344
+#: lib/vutuv_web/agent_docs/text.ex:211
+#: lib/vutuv_web/agent_docs/text.ex:378
 #: lib/vutuv_web/live/job_posting_live/show.ex:132
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posted"
@@ -13249,10 +13239,10 @@ msgstr "Veröffentlichen"
 
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
-#: lib/vutuv_web/agent_docs/markdown.ex:324
-#: lib/vutuv_web/agent_docs/markdown.ex:326
-#: lib/vutuv_web/agent_docs/text.ex:358
-#: lib/vutuv_web/agent_docs/text.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:325
+#: lib/vutuv_web/agent_docs/markdown.ex:327
+#: lib/vutuv_web/agent_docs/text.ex:359
+#: lib/vutuv_web/agent_docs/text.ex:361
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format
@@ -13264,18 +13254,18 @@ msgstr "Remote"
 msgid "Report this posting"
 msgstr "Diese Anzeige melden"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:220
-#: lib/vutuv_web/agent_docs/text.ex:215
+#: lib/vutuv_web/agent_docs/markdown.ex:221
+#: lib/vutuv_web/agent_docs/text.ex:216
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #: lib/vutuv_web/live/job_posting_live/show.ex:148
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Erforderlich"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:213
-#: lib/vutuv_web/agent_docs/markdown.ex:342
-#: lib/vutuv_web/agent_docs/text.ex:209
-#: lib/vutuv_web/agent_docs/text.ex:376
+#: lib/vutuv_web/agent_docs/markdown.ex:214
+#: lib/vutuv_web/agent_docs/markdown.ex:343
+#: lib/vutuv_web/agent_docs/text.ex:210
+#: lib/vutuv_web/agent_docs/text.ex:377
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Salary"
 msgstr "Gehalt"
@@ -13367,10 +13357,10 @@ msgstr "Wer kann sie sehen"
 msgid "Working student"
 msgstr "Werkstudent:in"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:211
-#: lib/vutuv_web/agent_docs/markdown.ex:340
-#: lib/vutuv_web/agent_docs/text.ex:207
-#: lib/vutuv_web/agent_docs/text.ex:374
+#: lib/vutuv_web/agent_docs/markdown.ex:212
+#: lib/vutuv_web/agent_docs/markdown.ex:341
+#: lib/vutuv_web/agent_docs/text.ex:208
+#: lib/vutuv_web/agent_docs/text.ex:375
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Workplace"
@@ -13543,13 +13533,13 @@ msgstr "%{km} km"
 msgid "All countries"
 msgstr "Alle Länder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/templates/tag/show.html.heex:22
+#: lib/vutuv_web/agent_docs/markdown.ex:362
+#: lib/vutuv_web/templates/tag/show.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Alle Stellen mit diesem Tag"
 
-#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/agent_docs/text.ex:395
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr "Alle Stellen mit diesem Tag: %{url}"
@@ -13585,12 +13575,12 @@ msgstr "Passend zu meinen Tags"
 msgid "More jobs"
 msgstr "Weitere Stellen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:233
+#: lib/vutuv_web/agent_docs/markdown.ex:234
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr "Nächste Seite"
 
-#: lib/vutuv_web/agent_docs/text.ex:228
+#: lib/vutuv_web/agent_docs/text.ex:229
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr "Nächste Seite: %{url}"
@@ -13605,12 +13595,12 @@ msgstr "Noch keine Stellenanzeigen."
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Keine passenden Stellen. Passe die Filter an."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:359
-#: lib/vutuv_web/agent_docs/markdown.ex:371
-#: lib/vutuv_web/agent_docs/text.ex:392
-#: lib/vutuv_web/agent_docs/text.ex:404
+#: lib/vutuv_web/agent_docs/markdown.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:372
+#: lib/vutuv_web/agent_docs/text.ex:393
+#: lib/vutuv_web/agent_docs/text.ex:405
 #: lib/vutuv_web/live/organization_live/show.ex:329
-#: lib/vutuv_web/templates/tag/show.html.heex:16
+#: lib/vutuv_web/templates/tag/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Open positions"
 msgstr "Offene Stellen"
@@ -14173,7 +14163,7 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "An image was removed from your vutuv account"
 msgstr "Ein Bild wurde aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/components/post_components.ex:890
+#: lib/vutuv_web/components/post_components.ex:910
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -14181,7 +14171,7 @@ msgstr "Ein Bild wurde aus Ihrem vutuv-Konto entfernt"
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:880
+#: lib/vutuv_web/components/post_components.ex:900
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr "Bild wird geprüft"
@@ -14311,7 +14301,7 @@ msgstr "Rechtsbündig (Text umfließt)"
 msgid "Full width"
 msgstr "Volle Breite"
 
-#: lib/vutuv_web/live/post_live/composer.ex:501
+#: lib/vutuv_web/live/post_live/composer.ex:507
 #, elixir-autogen, elixir-format
 msgid "Insert"
 msgstr "Einfügen"
@@ -14321,7 +14311,26 @@ msgstr "Einfügen"
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:498
+#: lib/vutuv_web/live/post_live/composer.ex:504
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:166
+#: lib/vutuv_web/agent_docs/text.ex:163
+#: lib/vutuv_web/templates/tag/show.html.heex:15
+#, elixir-autogen, elixir-format
+msgid "Posts with this tag"
+msgstr "Beiträge mit diesem Tag"
+
+#: lib/vutuv_web/live/search_live.ex:270
+#, elixir-autogen, elixir-format
+msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
+msgstr ""
+"Diese Suche nutzt einen reinen Personenfilter wie city: oder status: und "
+"findet daher nur Personen."
+
+#: lib/vutuv_web/live/search_live.ex:297
+#, elixir-autogen, elixir-format
+msgid "people and posts with this tag, combinable: miller tag:php"
+msgstr "Personen und Beiträge mit diesem Tag, kombinierbar: müller tag:php"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -26,9 +26,9 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:193
+#: lib/vutuv_web/agent_docs/markdown.ex:194
 #: lib/vutuv_web/agent_docs/section_docs.ex:114
-#: lib/vutuv_web/agent_docs/text.ex:190
+#: lib/vutuv_web/agent_docs/text.ex:191
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:110
@@ -95,10 +95,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:414
 #: lib/vutuv_web/agent_docs/markdown.ex:415
-#: lib/vutuv_web/agent_docs/text.ex:419
+#: lib/vutuv_web/agent_docs/markdown.ex:416
 #: lib/vutuv_web/agent_docs/text.ex:420
+#: lib/vutuv_web/agent_docs/text.ex:421
 #: lib/vutuv_web/templates/user/show.html.heex:788
 #, elixir-autogen
 msgid "Birthday"
@@ -152,7 +152,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:700
+#: lib/vutuv_web/components/post_components.ex:711
 #: lib/vutuv_web/components/ui.ex:2566
 #: lib/vutuv_web/live/admin/job_live.ex:500
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:693
+#: lib/vutuv_web/components/post_components.ex:704
 #: lib/vutuv_web/components/ui.ex:2557
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -320,8 +320,8 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:426
-#: lib/vutuv_web/agent_docs/text.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:427
+#: lib/vutuv_web/agent_docs/text.ex:432
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -329,8 +329,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:427
-#: lib/vutuv_web/agent_docs/text.ex:432
+#: lib/vutuv_web/agent_docs/markdown.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:433
 #: lib/vutuv_web/components/ui.ex:1283
 #: lib/vutuv_web/components/ui.ex:1308
 #: lib/vutuv_web/components/ui.ex:1311
@@ -345,8 +345,8 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:413
-#: lib/vutuv_web/agent_docs/text.ex:418
+#: lib/vutuv_web/agent_docs/markdown.ex:414
+#: lib/vutuv_web/agent_docs/text.ex:419
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -459,9 +459,9 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:445
-#: lib/vutuv_web/live/shell_live.ex:470
-#: lib/vutuv_web/templates/post/teaser.html.heex:33
+#: lib/vutuv_web/live/shell_live.ex:482
+#: lib/vutuv_web/live/shell_live.ex:519
+#: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
 msgid "Log in"
@@ -628,7 +628,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:568
+#: lib/vutuv_web/live/post_live/composer.ex:574
 #: lib/vutuv_web/live/section_reorder_live.ex:233
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
@@ -643,7 +643,7 @@ msgid "Public (Everyone can view) or Private (Only you can view)"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:327
-#: lib/vutuv_web/live/post_live/composer.ex:577
+#: lib/vutuv_web/live/post_live/composer.ex:583
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:83
@@ -666,8 +666,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:295
 #: lib/vutuv_web/live/search_live.ex:35
 #: lib/vutuv_web/live/search_live.ex:231
-#: lib/vutuv_web/live/shell_live.ex:309
-#: lib/vutuv_web/live/shell_live.ex:465
+#: lib/vutuv_web/live/shell_live.ex:346
+#: lib/vutuv_web/live/shell_live.ex:502
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
 #: lib/vutuv_web/templates/layout/app.html.heex:120
 #, elixir-autogen
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "The 1,000 Users with the most Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:126
+#: lib/vutuv_web/agent_docs/list_docs.ex:134
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
 msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
@@ -1250,7 +1250,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:177
-#: lib/vutuv_web/live/shell_live.ex:417
+#: lib/vutuv_web/live/shell_live.ex:454
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
 #: lib/vutuv_web/templates/admin/ad/show.html.heex:4
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:1
@@ -1456,11 +1456,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:31
-#: lib/vutuv_web/agent_docs/markdown.ex:353
-#: lib/vutuv_web/agent_docs/markdown.ex:728
+#: lib/vutuv_web/agent_docs/markdown.ex:354
+#: lib/vutuv_web/agent_docs/markdown.ex:729
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:387
-#: lib/vutuv_web/agent_docs/text.ex:539
+#: lib/vutuv_web/agent_docs/text.ex:388
+#: lib/vutuv_web/agent_docs/text.ex:540
 #: lib/vutuv_web/components/ui.ex:2809
 #: lib/vutuv_web/controllers/user_tag_controller.ex:37
 #: lib/vutuv_web/controllers/user_tag_controller.ex:54
@@ -1610,7 +1610,7 @@ msgstr ""
 msgid "Unendorsed tag successfully."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:109
+#: lib/vutuv_web/live/tag_new_live.ex:124
 #, elixir-autogen
 msgid "User tag created successfully."
 msgstr ""
@@ -1682,7 +1682,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:468
+#: lib/vutuv_web/live/shell_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1702,8 +1702,8 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:332
 #: lib/vutuv_web/live/admin/job_live.ex:491
 #: lib/vutuv_web/live/admin/organization_live.ex:306
-#: lib/vutuv_web/live/post_live/composer.ex:454
-#: lib/vutuv_web/live/post_live/composer.ex:455
+#: lib/vutuv_web/live/post_live/composer.ex:460
+#: lib/vutuv_web/live/post_live/composer.ex:461
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1779,7 +1779,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:436
+#: lib/vutuv_web/live/shell_live.ex:473
 #: lib/vutuv_web/views/settings_html.ex:181
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1803,14 +1803,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:45
 #: lib/vutuv_web/live/message_live/index.ex:496
-#: lib/vutuv_web/live/shell_live.ex:325
-#: lib/vutuv_web/live/shell_live.ex:467
+#: lib/vutuv_web/live/shell_live.ex:362
+#: lib/vutuv_web/live/shell_live.ex:504
 #: lib/vutuv_web/templates/layout/app.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:296
+#: lib/vutuv_web/live/shell_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
@@ -1818,7 +1818,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2666
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
-#: lib/vutuv_web/templates/post/index.html.heex:43
+#: lib/vutuv_web/templates/post/index.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
@@ -1831,7 +1831,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2823
 #: lib/vutuv_web/live/notification_live/index.ex:66
 #: lib/vutuv_web/live/notification_live/index.ex:135
-#: lib/vutuv_web/live/shell_live.ex:336
+#: lib/vutuv_web/live/shell_live.ex:373
 #: lib/vutuv_web/templates/layout/app.html.heex:118
 #: lib/vutuv_web/templates/settings/notifications.html.heex:7
 #, elixir-autogen, elixir-format
@@ -2134,12 +2134,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:557
+#: lib/vutuv_web/live/post_live/composer.ex:563
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:685
+#: lib/vutuv_web/live/post_live/composer.ex:691
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2150,7 +2150,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:525
+#: lib/vutuv_web/live/post_live/composer.ex:531
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2160,13 +2160,13 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:697
+#: lib/vutuv_web/components/post_components.ex:708
 #: lib/vutuv_web/live/post_live/edit.ex:117
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:490
+#: lib/vutuv_web/live/post_live/composer.ex:496
 #, elixir-autogen, elixir-format
 msgid "Describe this image (alt text)"
 msgstr ""
@@ -2179,46 +2179,46 @@ msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:517
-#: lib/vutuv_web/live/shell_live.ex:290
-#: lib/vutuv_web/live/shell_live.ex:463
+#: lib/vutuv_web/live/shell_live.ex:312
+#: lib/vutuv_web/live/shell_live.ex:500
 #: lib/vutuv_web/templates/layout/app.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Feed"
 msgstr ""
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:26
+#: lib/vutuv_web/templates/post/teaser.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Follow %{name} to read it."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/show.html.heex:13
+#: lib/vutuv_web/templates/post/show.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:661
+#: lib/vutuv_web/live/post_live/composer.ex:667
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:589
+#: lib/vutuv_web/live/post_live/composer.ex:595
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:682
-#: lib/vutuv_web/components/post_components.ex:684
+#: lib/vutuv_web/components/post_components.ex:693
+#: lib/vutuv_web/components/post_components.ex:695
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:631
+#: lib/vutuv_web/live/post_live/composer.ex:637
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:277
-#: lib/vutuv_web/live/post_live/composer.ex:337
+#: lib/vutuv_web/live/post_live/composer.ex:278
+#: lib/vutuv_web/live/post_live/composer.ex:338
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2228,23 +2228,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:271
+#: lib/vutuv_web/live/post_live/composer.ex:272
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:621
+#: lib/vutuv_web/live/post_live/composer.ex:627
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:611
+#: lib/vutuv_web/live/post_live/composer.ex:617
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:121
-#: lib/vutuv_web/live/post_live/composer.ex:577
+#: lib/vutuv_web/live/post_live/composer.ex:583
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2265,18 +2265,18 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:181
 #: lib/vutuv_web/live/search_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:114
-#: lib/vutuv_web/views/admin/report_html.ex:15
+#: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1042
-#: lib/vutuv_web/components/post_components.ex:1046
+#: lib/vutuv_web/components/post_components.ex:1093
+#: lib/vutuv_web/components/post_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1043
+#: lib/vutuv_web/components/post_components.ex:1094
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2286,7 +2286,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:209
 #: lib/vutuv_web/live/organization_live/edit.ex:359
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:647
+#: lib/vutuv_web/live/post_live/composer.ex:653
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2295,17 +2295,17 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:508
+#: lib/vutuv_web/live/post_live/composer.ex:514
 #, elixir-autogen, elixir-format
 msgid "Remove image"
 msgstr ""
 
-#: lib/vutuv_web/templates/post/show.html.heex:16
+#: lib/vutuv_web/templates/post/show.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:575
+#: lib/vutuv_web/live/post_live/composer.ex:581
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2323,71 +2323,71 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:361
+#: lib/vutuv_web/live/post_live/composer.ex:362
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:265
+#: lib/vutuv_web/live/post_live/composer.ex:266
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:19
+#: lib/vutuv_web/templates/post/teaser.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:716
+#: lib/vutuv_web/live/post_live/composer.ex:722
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:717
+#: lib/vutuv_web/live/post_live/composer.ex:723
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2982
-#: lib/vutuv_web/live/shell_live.ex:379
-#: lib/vutuv_web/templates/post/index.html.heex:12
-#: lib/vutuv_web/templates/post/teaser.html.heex:54
+#: lib/vutuv_web/live/shell_live.ex:416
+#: lib/vutuv_web/templates/post/index.html.heex:13
+#: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:128
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:466
+#: lib/vutuv_web/live/post_live/composer.ex:472
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:467
+#: lib/vutuv_web/live/post_live/composer.ex:473
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:679
+#: lib/vutuv_web/components/post_components.ex:690
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1252
+#: lib/vutuv_web/components/post_components.ex:1303
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1256
+#: lib/vutuv_web/components/post_components.ex:1307
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1254
+#: lib/vutuv_web/components/post_components.ex:1305
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1255
+#: lib/vutuv_web/components/post_components.ex:1306
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2398,22 +2398,22 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:540
+#: lib/vutuv_web/live/post_live/composer.ex:546
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:707
+#: lib/vutuv_web/live/post_live/composer.ex:713
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:711
+#: lib/vutuv_web/live/post_live/composer.ex:717
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/index.html.heex:5
+#: lib/vutuv_web/templates/post/index.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Posts by %{name}"
 msgstr ""
@@ -2428,7 +2428,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1324
+#: lib/vutuv_web/components/post_components.ex:1375
 #: lib/vutuv_web/components/ui.ex:1563
 #: lib/vutuv_web/components/ui.ex:1563
 #: lib/vutuv_web/components/ui.ex:2171
@@ -2437,17 +2437,17 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:760
+#: lib/vutuv_web/agent_docs/markdown.ex:761
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
-#: lib/vutuv_web/live/shell_live.ex:318
-#: lib/vutuv_web/live/shell_live.ex:384
-#: lib/vutuv_web/views/admin/report_html.ex:18
+#: lib/vutuv_web/live/shell_live.ex:355
+#: lib/vutuv_web/live/shell_live.ex:421
+#: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1291
+#: lib/vutuv_web/components/post_components.ex:1342
 #: lib/vutuv_web/components/ui.ex:1592
 #: lib/vutuv_web/components/ui.ex:1592
 #: lib/vutuv_web/components/ui.ex:2157
@@ -2457,11 +2457,11 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:760
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
-#: lib/vutuv_web/live/shell_live.ex:387
-#: lib/vutuv_web/views/admin/report_html.ex:17
+#: lib/vutuv_web/live/shell_live.ex:424
+#: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Likes"
 msgstr ""
@@ -2476,12 +2476,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1313
+#: lib/vutuv_web/components/post_components.ex:1364
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1324
+#: lib/vutuv_web/components/post_components.ex:1375
 #: lib/vutuv_web/components/ui.ex:1553
 #: lib/vutuv_web/components/ui.ex:1553
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2490,23 +2490,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1310
+#: lib/vutuv_web/components/post_components.ex:1361
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1123
+#: lib/vutuv_web/components/post_components.ex:1182
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1310
+#: lib/vutuv_web/components/post_components.ex:1361
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1291
+#: lib/vutuv_web/components/post_components.ex:1342
 #: lib/vutuv_web/components/ui.ex:1582
 #: lib/vutuv_web/components/ui.ex:1582
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2527,20 +2527,20 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1364
+#: lib/vutuv_web/components/post_components.ex:1415
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:102
 #: lib/vutuv_web/agent_docs/text.ex:100
-#: lib/vutuv_web/templates/post/show.html.heex:27
+#: lib/vutuv_web/templates/post/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1347
-#: lib/vutuv_web/components/post_components.ex:1348
+#: lib/vutuv_web/components/post_components.ex:1398
+#: lib/vutuv_web/components/post_components.ex:1399
 #: lib/vutuv_web/live/notification_live/index.ex:207
 #: lib/vutuv_web/live/notification_live/index.ex:299
 #: lib/vutuv_web/live/post_live/reply.ex:25
@@ -2548,18 +2548,18 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:650
+#: lib/vutuv_web/components/post_components.ex:661
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:268
-#: lib/vutuv_web/live/post_live/composer.ex:565
+#: lib/vutuv_web/live/post_live/composer.ex:269
+#: lib/vutuv_web/live/post_live/composer.ex:571
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:692
+#: lib/vutuv_web/live/post_live/composer.ex:698
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2574,12 +2574,12 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:645
+#: lib/vutuv_web/components/post_components.ex:656
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:639
+#: lib/vutuv_web/components/post_components.ex:650
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2832,8 +2832,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:428
-#: lib/vutuv_web/agent_docs/text.ex:433
+#: lib/vutuv_web/agent_docs/markdown.ex:429
+#: lib/vutuv_web/agent_docs/text.ex:434
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2855,7 +2855,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:601
+#: lib/vutuv_web/live/post_live/composer.ex:607
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "Text only"
 msgstr ""
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:17
+#: lib/vutuv_web/templates/post/teaser.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "This post is for the connections of %{name}"
 msgstr ""
@@ -2878,7 +2878,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1253
+#: lib/vutuv_web/components/post_components.ex:1304
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2983,8 +2983,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:272
-#: lib/vutuv_web/agent_docs/text.ex:265
+#: lib/vutuv_web/agent_docs/markdown.ex:273
+#: lib/vutuv_web/agent_docs/text.ex:266
 #: lib/vutuv_web/controllers/page_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3139,7 +3139,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:627
+#: lib/vutuv_web/components/post_components.ex:638
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3189,6 +3189,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2797
+#: lib/vutuv_web/live/shell_live.ex:325
+#: lib/vutuv_web/live/shell_live.ex:509
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3212,7 +3214,7 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:721
+#: lib/vutuv_web/components/post_components.ex:732
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3865,12 +3867,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:515
+#: lib/vutuv_web/agent_docs/markdown.ex:516
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:772
+#: lib/vutuv_web/agent_docs/markdown.ex:773
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3884,16 +3886,16 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/markdown.ex:137
 #: lib/vutuv_web/agent_docs/markdown.ex:150
-#: lib/vutuv_web/agent_docs/markdown.ex:728
+#: lib/vutuv_web/agent_docs/markdown.ex:729
 #: lib/vutuv_web/agent_docs/text.ex:75
 #: lib/vutuv_web/agent_docs/text.ex:134
 #: lib/vutuv_web/agent_docs/text.ex:147
-#: lib/vutuv_web/agent_docs/text.ex:539
+#: lib/vutuv_web/agent_docs/text.ex:540
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:45
+#: lib/vutuv_web/agent_docs/list_docs.ex:46
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr ""
@@ -3905,26 +3907,26 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:746
-#: lib/vutuv_web/agent_docs/text.ex:550
+#: lib/vutuv_web/agent_docs/markdown.ex:747
+#: lib/vutuv_web/agent_docs/text.ex:551
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:743
-#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/markdown.ex:744
+#: lib/vutuv_web/agent_docs/text.ex:548
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:750
-#: lib/vutuv_web/agent_docs/text.ex:553
+#: lib/vutuv_web/agent_docs/markdown.ex:751
+#: lib/vutuv_web/agent_docs/text.ex:554
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:411
-#: lib/vutuv_web/agent_docs/text.ex:416
+#: lib/vutuv_web/agent_docs/markdown.ex:412
+#: lib/vutuv_web/agent_docs/text.ex:417
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
@@ -3935,12 +3937,12 @@ msgstr ""
 msgid "Most endorsed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:124
+#: lib/vutuv_web/agent_docs/list_docs.ex:132
 #, elixir-autogen, elixir-format
 msgid "Most followed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:46
+#: lib/vutuv_web/agent_docs/list_docs.ex:47
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr ""
@@ -3953,7 +3955,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:96
 #: lib/vutuv_web/agent_docs/text.ex:93
 #: lib/vutuv_web/live/admin/screenshot_live.ex:96
-#: lib/vutuv_web/templates/post/show.html.heex:6
+#: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
 msgstr ""
@@ -3964,23 +3966,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:407
-#: lib/vutuv_web/agent_docs/text.ex:412
+#: lib/vutuv_web/agent_docs/markdown.ex:408
+#: lib/vutuv_web/agent_docs/text.ex:413
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:697
+#: lib/vutuv_web/agent_docs/markdown.ex:698
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:636
+#: lib/vutuv_web/agent_docs/markdown.ex:637
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:637
+#: lib/vutuv_web/agent_docs/markdown.ex:638
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -3990,7 +3992,7 @@ msgstr ""
 msgid "This page in %{language}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:47
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr ""
@@ -4055,8 +4057,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:287
+#: lib/vutuv_web/agent_docs/text.ex:274
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4105,8 +4107,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:276
-#: lib/vutuv_web/agent_docs/text.ex:269
+#: lib/vutuv_web/agent_docs/markdown.ex:277
+#: lib/vutuv_web/agent_docs/text.ex:270
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4122,8 +4124,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:273
-#: lib/vutuv_web/agent_docs/text.ex:266
+#: lib/vutuv_web/agent_docs/markdown.ex:274
+#: lib/vutuv_web/agent_docs/text.ex:267
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4337,14 +4339,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:278
-#: lib/vutuv_web/agent_docs/text.ex:271
+#: lib/vutuv_web/agent_docs/markdown.ex:279
+#: lib/vutuv_web/agent_docs/text.ex:272
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:274
-#: lib/vutuv_web/agent_docs/text.ex:267
+#: lib/vutuv_web/agent_docs/markdown.ex:275
+#: lib/vutuv_web/agent_docs/text.ex:268
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4453,7 +4455,7 @@ msgid "Edit the ad"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1004
-#: lib/vutuv_web/live/tag_new_live.ex:73
+#: lib/vutuv_web/live/tag_new_live.ex:74
 #: lib/vutuv_web/templates/ad/preview.html.heex:3
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:122
 #, elixir-autogen, elixir-format
@@ -4603,8 +4605,8 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:301
-#: lib/vutuv_web/agent_docs/text.ex:335
+#: lib/vutuv_web/agent_docs/markdown.ex:302
+#: lib/vutuv_web/agent_docs/text.ex:336
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
@@ -4688,11 +4690,6 @@ msgstr ""
 msgid "This tag doesn't have a description yet."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:297
-#, elixir-autogen, elixir-format
-msgid "only people with this tag, combinable: miller tag:php"
-msgstr ""
-
 #: lib/vutuv_web/templates/access_token/index.html.heex:1
 #: lib/vutuv_web/templates/access_token/index.html.heex:1
 #: lib/vutuv_web/templates/access_token/new.html.heex:1
@@ -4726,8 +4723,8 @@ msgstr ""
 msgid "Edit your profile and its sections"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:215
-#: lib/vutuv_web/agent_docs/text.ex:211
+#: lib/vutuv_web/agent_docs/markdown.ex:216
+#: lib/vutuv_web/agent_docs/text.ex:212
 #: lib/vutuv_web/live/admin/job_live.ex:400
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:135
@@ -5301,7 +5298,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:274
+#: lib/vutuv_web/live/post_live/composer.ex:275
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5311,7 +5308,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:366
+#: lib/vutuv_web/live/shell_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5331,7 +5328,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:427
+#: lib/vutuv_web/live/shell_live.ex:464
 #: lib/vutuv_web/templates/layout/app.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5346,7 +5343,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2906
 #: lib/vutuv_web/components/ui.ex:2974
 #: lib/vutuv_web/controllers/settings_controller.ex:51
-#: lib/vutuv_web/live/shell_live.ex:407
+#: lib/vutuv_web/live/shell_live.ex:444
 #: lib/vutuv_web/live/tag_new_live.ex:44
 #: lib/vutuv_web/templates/address/edit.html.heex:2
 #: lib/vutuv_web/templates/address/new.html.heex:2
@@ -5421,8 +5418,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:284
-#: lib/vutuv_web/live/shell_live.ex:456
+#: lib/vutuv_web/live/shell_live.ex:305
+#: lib/vutuv_web/live/shell_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5432,9 +5429,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:756
-#: lib/vutuv_web/components/post_components.ex:805
-#: lib/vutuv_web/components/post_components.ex:818
+#: lib/vutuv_web/components/post_components.ex:774
+#: lib/vutuv_web/components/post_components.ex:825
+#: lib/vutuv_web/components/post_components.ex:838
 #: lib/vutuv_web/live/post_live/feed.ex:672
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6161,8 +6158,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:416
-#: lib/vutuv_web/agent_docs/text.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:417
+#: lib/vutuv_web/agent_docs/text.ex:422
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6209,7 +6206,7 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:14
+#: lib/vutuv_web/views/admin/report_html.ex:33
 #, elixir-autogen, elixir-format
 msgid "New confirmed registrations (by PIN)"
 msgstr ""
@@ -6234,8 +6231,8 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
-#: lib/vutuv_web/views/admin/report_html.ex:16
+#: lib/vutuv_web/agent_docs/markdown.ex:760
+#: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
@@ -6317,7 +6314,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:97
+#: lib/vutuv_web/agent_docs/list_docs.ex:105
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -6334,7 +6331,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:741
+#: lib/vutuv_web/agent_docs/markdown.ex:742
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6420,17 +6417,17 @@ msgid "Confirmed members whose every email address bounced, so they can no longe
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:153
-#: lib/vutuv_web/views/admin/report_html.ex:20
+#: lib/vutuv_web/views/admin/report_html.ex:40
 #, elixir-autogen, elixir-format
 msgid "Deactivated addresses"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:37
+#: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "New Fediverse followers"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/report/index.html.heex:87
+#: lib/vutuv_web/templates/admin/report/index.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "… and %{count} more"
 msgstr ""
@@ -6454,7 +6451,7 @@ msgid "Every deactivation, recovery, freeze and thaw, newest first."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:102
-#: lib/vutuv_web/views/admin/report_html.ex:21
+#: lib/vutuv_web/views/admin/report_html.ex:41
 #, elixir-autogen, elixir-format
 msgid "Frozen accounts"
 msgstr ""
@@ -6568,12 +6565,12 @@ msgstr ""
 msgid "system"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:19
+#: lib/vutuv_web/views/admin/report_html.ex:39
 #, elixir-autogen, elixir-format
 msgid "Bounces"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:22
+#: lib/vutuv_web/views/admin/report_html.ex:42
 #, elixir-autogen, elixir-format
 msgid "Thawed accounts"
 msgstr ""
@@ -6637,17 +6634,17 @@ msgstr ""
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:24
+#: lib/vutuv_web/templates/post/teaser.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Follow each other to connect with %{name} and read it."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:39
+#: lib/vutuv_web/templates/post/teaser.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:718
+#: lib/vutuv_web/components/post_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6657,7 +6654,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:717
+#: lib/vutuv_web/components/post_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -6852,8 +6849,8 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:189
-#: lib/vutuv_web/agent_docs/text.ex:186
+#: lib/vutuv_web/agent_docs/markdown.ex:190
+#: lib/vutuv_web/agent_docs/text.ex:187
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -7509,17 +7506,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:777
+#: lib/vutuv_web/agent_docs/markdown.ex:778
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:780
+#: lib/vutuv_web/agent_docs/markdown.ex:781
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:787
+#: lib/vutuv_web/agent_docs/markdown.ex:788
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8500,12 +8497,12 @@ msgstr ""
 msgid "All %{count} members whose profiles are open to search engines, filed alphabetically by last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:143
+#: lib/vutuv_web/agent_docs/list_docs.ex:151
 #, elixir-autogen, elixir-format
 msgid "All members who allow search engines to index their profile, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:141
+#: lib/vutuv_web/agent_docs/list_docs.ex:149
 #: lib/vutuv_web/controllers/directory_controller.ex:28
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8521,7 +8518,7 @@ msgstr ""
 msgid "Members by initial"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:160
+#: lib/vutuv_web/agent_docs/list_docs.ex:168
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8540,7 +8537,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:166
+#: lib/vutuv_web/agent_docs/list_docs.ex:174
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -8730,7 +8727,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:555
+#: lib/vutuv_web/agent_docs/markdown.ex:556
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8751,7 +8748,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:556
+#: lib/vutuv_web/agent_docs/markdown.ex:557
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8761,11 +8758,6 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
-msgstr ""
-
-#: lib/vutuv_web/live/search_live.ex:270
-#, elixir-autogen, elixir-format
-msgid "Your search uses a people filter such as tag: or city:, so it only finds people."
 msgstr ""
 
 #: lib/vutuv_web/cv/html.ex:57
@@ -8787,19 +8779,19 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:593
+#: lib/vutuv_web/agent_docs/markdown.ex:594
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:593
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:74
+#: lib/vutuv_web/live/tag_new_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "This will create the following tags:"
 msgstr ""
@@ -8819,14 +8811,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1126
+#: lib/vutuv_web/components/post_components.ex:1185
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:700
+#: lib/vutuv_web/agent_docs/markdown.ex:701
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8904,14 +8896,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:554
+#: lib/vutuv_web/agent_docs/markdown.ex:555
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:557
+#: lib/vutuv_web/agent_docs/markdown.ex:558
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9051,8 +9043,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:437
-#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:438
+#: lib/vutuv_web/agent_docs/text.ex:441
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9474,8 +9466,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:409
-#: lib/vutuv_web/agent_docs/text.ex:414
+#: lib/vutuv_web/agent_docs/markdown.ex:410
+#: lib/vutuv_web/agent_docs/text.ex:415
 #: lib/vutuv_web/templates/user/edit.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Employment status"
@@ -9577,7 +9569,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/markdown.ex:631
 #: lib/vutuv_web/views/qualification_html.ex:10
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9664,7 +9656,7 @@ msgstr ""
 msgid "Expiry year"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:622
+#: lib/vutuv_web/agent_docs/markdown.ex:623
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9690,7 +9682,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:629
+#: lib/vutuv_web/agent_docs/markdown.ex:630
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9717,7 +9709,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:620
+#: lib/vutuv_web/agent_docs/markdown.ex:621
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9732,7 +9724,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:621
+#: lib/vutuv_web/agent_docs/markdown.ex:622
 #: lib/vutuv_web/views/qualification_html.ex:60
 #: lib/vutuv_web/views/qualification_html.ex:63
 #, elixir-autogen, elixir-format
@@ -9749,7 +9741,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:524
+#: lib/vutuv_web/agent_docs/markdown.ex:525
 #: lib/vutuv_web/live/section_reorder_live.ex:252
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -9824,7 +9816,7 @@ msgid "First name"
 msgstr ""
 
 #: lib/vutuv_web/controllers/invitation_controller.ex:54
-#: lib/vutuv_web/live/shell_live.ex:398
+#: lib/vutuv_web/live/shell_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Invite a friend"
 msgstr ""
@@ -10051,7 +10043,7 @@ msgstr ""
 msgid "Account restored. The member can sign in again."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:23
+#: lib/vutuv_web/views/admin/report_html.ex:43
 #, elixir-autogen, elixir-format
 msgid "Accounts removed as spam"
 msgstr ""
@@ -10390,21 +10382,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:492
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:490
+#: lib/vutuv_web/agent_docs/markdown.ex:491
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:488
+#: lib/vutuv_web/agent_docs/markdown.ex:489
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10457,12 +10449,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:506
+#: lib/vutuv_web/agent_docs/markdown.ex:507
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:493
+#: lib/vutuv_web/agent_docs/markdown.ex:494
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10607,7 +10599,7 @@ msgstr ""
 msgid "Manage your vutuv account: profile, privacy, notifications and sign-in."
 msgstr ""
 
-#: lib/vutuv_web/controllers/tag_controller.ex:43
+#: lib/vutuv_web/controllers/tag_controller.ex:50
 #, elixir-autogen, elixir-format
 msgid "Members on vutuv tagged %{tag}."
 msgstr ""
@@ -11303,8 +11295,8 @@ msgstr ""
 msgid "Verified domains"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:190
-#: lib/vutuv_web/agent_docs/text.ex:187
+#: lib/vutuv_web/agent_docs/markdown.ex:191
+#: lib/vutuv_web/agent_docs/text.ex:188
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr ""
@@ -11331,8 +11323,8 @@ msgstr ""
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:192
-#: lib/vutuv_web/agent_docs/text.ex:189
+#: lib/vutuv_web/agent_docs/markdown.ex:193
+#: lib/vutuv_web/agent_docs/text.ex:190
 #: lib/vutuv_web/live/organization_live/edit.ex:273
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -11416,8 +11408,8 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:293
-#: lib/vutuv_web/agent_docs/text.ex:328
+#: lib/vutuv_web/agent_docs/markdown.ex:294
+#: lib/vutuv_web/agent_docs/text.ex:329
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
@@ -11650,8 +11642,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:314
-#: lib/vutuv_web/agent_docs/text.ex:348
+#: lib/vutuv_web/agent_docs/markdown.ex:315
+#: lib/vutuv_web/agent_docs/text.ex:349
 #: lib/vutuv_web/live/admin/organization_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11784,8 +11776,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:650
-#: lib/vutuv_web/agent_docs/text.ex:520
+#: lib/vutuv_web/agent_docs/markdown.ex:651
+#: lib/vutuv_web/agent_docs/text.ex:521
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11821,8 +11813,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:305
-#: lib/vutuv_web/agent_docs/text.ex:339
+#: lib/vutuv_web/agent_docs/markdown.ex:306
+#: lib/vutuv_web/agent_docs/text.ex:340
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -12021,7 +12013,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
 #: lib/vutuv_web/live/post_live/saved.ex:455
-#: lib/vutuv_web/live/shell_live.ex:394
+#: lib/vutuv_web/live/shell_live.ex:431
 #: lib/vutuv_web/templates/layout/app.html.heex:79
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
@@ -12266,10 +12258,10 @@ msgstr ""
 msgid "Edit posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:209
-#: lib/vutuv_web/agent_docs/markdown.ex:338
-#: lib/vutuv_web/agent_docs/text.ex:205
-#: lib/vutuv_web/agent_docs/text.ex:372
+#: lib/vutuv_web/agent_docs/markdown.ex:210
+#: lib/vutuv_web/agent_docs/markdown.ex:339
+#: lib/vutuv_web/agent_docs/text.ex:206
+#: lib/vutuv_web/agent_docs/text.ex:373
 #: lib/vutuv_web/live/admin/job_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Employer"
@@ -12280,10 +12272,10 @@ msgstr ""
 msgid "Employer name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:210
-#: lib/vutuv_web/agent_docs/markdown.ex:339
-#: lib/vutuv_web/agent_docs/text.ex:206
-#: lib/vutuv_web/agent_docs/text.ex:373
+#: lib/vutuv_web/agent_docs/markdown.ex:211
+#: lib/vutuv_web/agent_docs/markdown.ex:340
+#: lib/vutuv_web/agent_docs/text.ex:207
+#: lib/vutuv_web/agent_docs/text.ex:374
 #: lib/vutuv_web/live/job_board_live.ex:280
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
@@ -12345,7 +12337,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:40
 #: lib/vutuv_web/live/job_board_live.ex:145
 #: lib/vutuv_web/live/post_live/saved.ex:458
-#: lib/vutuv_web/live/shell_live.ex:302
+#: lib/vutuv_web/live/shell_live.ex:339
 #: lib/vutuv_web/templates/layout/app.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12356,12 +12348,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:320
-#: lib/vutuv_web/agent_docs/markdown.ex:324
-#: lib/vutuv_web/agent_docs/markdown.ex:326
-#: lib/vutuv_web/agent_docs/text.ex:354
-#: lib/vutuv_web/agent_docs/text.ex:358
-#: lib/vutuv_web/agent_docs/text.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:321
+#: lib/vutuv_web/agent_docs/markdown.ex:325
+#: lib/vutuv_web/agent_docs/markdown.ex:327
+#: lib/vutuv_web/agent_docs/text.ex:355
+#: lib/vutuv_web/agent_docs/text.ex:359
+#: lib/vutuv_web/agent_docs/text.ex:361
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12410,8 +12402,8 @@ msgstr ""
 msgid "New posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:221
-#: lib/vutuv_web/agent_docs/text.ex:216
+#: lib/vutuv_web/agent_docs/markdown.ex:222
+#: lib/vutuv_web/agent_docs/text.ex:217
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
 #: lib/vutuv_web/live/job_posting_live/show.ex:153
 #, elixir-autogen, elixir-format
@@ -12493,10 +12485,10 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:214
-#: lib/vutuv_web/agent_docs/markdown.ex:343
-#: lib/vutuv_web/agent_docs/text.ex:210
-#: lib/vutuv_web/agent_docs/text.ex:377
+#: lib/vutuv_web/agent_docs/markdown.ex:215
+#: lib/vutuv_web/agent_docs/markdown.ex:344
+#: lib/vutuv_web/agent_docs/text.ex:211
+#: lib/vutuv_web/agent_docs/text.ex:378
 #: lib/vutuv_web/live/job_posting_live/show.ex:132
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12520,10 +12512,10 @@ msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
-#: lib/vutuv_web/agent_docs/markdown.ex:324
-#: lib/vutuv_web/agent_docs/markdown.ex:326
-#: lib/vutuv_web/agent_docs/text.ex:358
-#: lib/vutuv_web/agent_docs/text.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:325
+#: lib/vutuv_web/agent_docs/markdown.ex:327
+#: lib/vutuv_web/agent_docs/text.ex:359
+#: lib/vutuv_web/agent_docs/text.ex:361
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format
@@ -12535,18 +12527,18 @@ msgstr ""
 msgid "Report this posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:220
-#: lib/vutuv_web/agent_docs/text.ex:215
+#: lib/vutuv_web/agent_docs/markdown.ex:221
+#: lib/vutuv_web/agent_docs/text.ex:216
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #: lib/vutuv_web/live/job_posting_live/show.ex:148
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:213
-#: lib/vutuv_web/agent_docs/markdown.ex:342
-#: lib/vutuv_web/agent_docs/text.ex:209
-#: lib/vutuv_web/agent_docs/text.ex:376
+#: lib/vutuv_web/agent_docs/markdown.ex:214
+#: lib/vutuv_web/agent_docs/markdown.ex:343
+#: lib/vutuv_web/agent_docs/text.ex:210
+#: lib/vutuv_web/agent_docs/text.ex:377
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12638,10 +12630,10 @@ msgstr ""
 msgid "Working student"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:211
-#: lib/vutuv_web/agent_docs/markdown.ex:340
-#: lib/vutuv_web/agent_docs/text.ex:207
-#: lib/vutuv_web/agent_docs/text.ex:374
+#: lib/vutuv_web/agent_docs/markdown.ex:212
+#: lib/vutuv_web/agent_docs/markdown.ex:341
+#: lib/vutuv_web/agent_docs/text.ex:208
+#: lib/vutuv_web/agent_docs/text.ex:375
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -12814,13 +12806,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/templates/tag/show.html.heex:22
+#: lib/vutuv_web/agent_docs/markdown.ex:362
+#: lib/vutuv_web/templates/tag/show.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/agent_docs/text.ex:395
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12856,12 +12848,12 @@ msgstr ""
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:233
+#: lib/vutuv_web/agent_docs/markdown.ex:234
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:228
+#: lib/vutuv_web/agent_docs/text.ex:229
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
@@ -12876,12 +12868,12 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:359
-#: lib/vutuv_web/agent_docs/markdown.ex:371
-#: lib/vutuv_web/agent_docs/text.ex:392
-#: lib/vutuv_web/agent_docs/text.ex:404
+#: lib/vutuv_web/agent_docs/markdown.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:372
+#: lib/vutuv_web/agent_docs/text.ex:393
+#: lib/vutuv_web/agent_docs/text.ex:405
 #: lib/vutuv_web/live/organization_live/show.ex:329
-#: lib/vutuv_web/templates/tag/show.html.heex:16
+#: lib/vutuv_web/templates/tag/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Open positions"
 msgstr ""
@@ -13444,7 +13436,7 @@ msgstr ""
 msgid "An image was removed from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:890
+#: lib/vutuv_web/components/post_components.ex:910
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -13452,7 +13444,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:880
+#: lib/vutuv_web/components/post_components.ex:900
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr ""
@@ -13582,7 +13574,7 @@ msgstr ""
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:501
+#: lib/vutuv_web/live/post_live/composer.ex:507
 #, elixir-autogen, elixir-format
 msgid "Insert"
 msgstr ""
@@ -13592,7 +13584,24 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:498
+#: lib/vutuv_web/live/post_live/composer.ex:504
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:166
+#: lib/vutuv_web/agent_docs/text.ex:163
+#: lib/vutuv_web/templates/tag/show.html.heex:15
+#, elixir-autogen, elixir-format
+msgid "Posts with this tag"
+msgstr ""
+
+#: lib/vutuv_web/live/search_live.ex:270
+#, elixir-autogen, elixir-format
+msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
+msgstr ""
+
+#: lib/vutuv_web/live/search_live.ex:297
+#, elixir-autogen, elixir-format
+msgid "people and posts with this tag, combinable: miller tag:php"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -24,9 +24,9 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:193
+#: lib/vutuv_web/agent_docs/markdown.ex:194
 #: lib/vutuv_web/agent_docs/section_docs.ex:114
-#: lib/vutuv_web/agent_docs/text.ex:190
+#: lib/vutuv_web/agent_docs/text.ex:191
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:110
@@ -93,10 +93,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:414
 #: lib/vutuv_web/agent_docs/markdown.ex:415
-#: lib/vutuv_web/agent_docs/text.ex:419
+#: lib/vutuv_web/agent_docs/markdown.ex:416
 #: lib/vutuv_web/agent_docs/text.ex:420
+#: lib/vutuv_web/agent_docs/text.ex:421
 #: lib/vutuv_web/templates/user/show.html.heex:788
 #, elixir-autogen
 msgid "Birthday"
@@ -150,7 +150,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:700
+#: lib/vutuv_web/components/post_components.ex:711
 #: lib/vutuv_web/components/ui.ex:2566
 #: lib/vutuv_web/live/admin/job_live.ex:500
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -195,7 +195,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:693
+#: lib/vutuv_web/components/post_components.ex:704
 #: lib/vutuv_web/components/ui.ex:2557
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -318,8 +318,8 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:426
-#: lib/vutuv_web/agent_docs/text.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:427
+#: lib/vutuv_web/agent_docs/text.ex:432
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -327,8 +327,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:427
-#: lib/vutuv_web/agent_docs/text.ex:432
+#: lib/vutuv_web/agent_docs/markdown.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:433
 #: lib/vutuv_web/components/ui.ex:1283
 #: lib/vutuv_web/components/ui.ex:1308
 #: lib/vutuv_web/components/ui.ex:1311
@@ -343,8 +343,8 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:413
-#: lib/vutuv_web/agent_docs/text.ex:418
+#: lib/vutuv_web/agent_docs/markdown.ex:414
+#: lib/vutuv_web/agent_docs/text.ex:419
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -457,9 +457,9 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:445
-#: lib/vutuv_web/live/shell_live.ex:470
-#: lib/vutuv_web/templates/post/teaser.html.heex:33
+#: lib/vutuv_web/live/shell_live.ex:482
+#: lib/vutuv_web/live/shell_live.ex:519
+#: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
 msgid "Log in"
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:568
+#: lib/vutuv_web/live/post_live/composer.ex:574
 #: lib/vutuv_web/live/section_reorder_live.ex:233
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
@@ -641,7 +641,7 @@ msgid "Public (Everyone can view) or Private (Only you can view)"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:327
-#: lib/vutuv_web/live/post_live/composer.ex:577
+#: lib/vutuv_web/live/post_live/composer.ex:583
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:83
@@ -664,8 +664,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:295
 #: lib/vutuv_web/live/search_live.ex:35
 #: lib/vutuv_web/live/search_live.ex:231
-#: lib/vutuv_web/live/shell_live.ex:309
-#: lib/vutuv_web/live/shell_live.ex:465
+#: lib/vutuv_web/live/shell_live.ex:346
+#: lib/vutuv_web/live/shell_live.ex:502
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
 #: lib/vutuv_web/templates/layout/app.html.heex:120
 #, elixir-autogen
@@ -1157,7 +1157,7 @@ msgstr ""
 msgid "The 1,000 Users with the most Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:126
+#: lib/vutuv_web/agent_docs/list_docs.ex:134
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
 msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
@@ -1248,7 +1248,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:177
-#: lib/vutuv_web/live/shell_live.ex:417
+#: lib/vutuv_web/live/shell_live.ex:454
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
 #: lib/vutuv_web/templates/admin/ad/show.html.heex:4
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:1
@@ -1454,11 +1454,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:31
-#: lib/vutuv_web/agent_docs/markdown.ex:353
-#: lib/vutuv_web/agent_docs/markdown.ex:728
+#: lib/vutuv_web/agent_docs/markdown.ex:354
+#: lib/vutuv_web/agent_docs/markdown.ex:729
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:387
-#: lib/vutuv_web/agent_docs/text.ex:539
+#: lib/vutuv_web/agent_docs/text.ex:388
+#: lib/vutuv_web/agent_docs/text.ex:540
 #: lib/vutuv_web/components/ui.ex:2809
 #: lib/vutuv_web/controllers/user_tag_controller.ex:37
 #: lib/vutuv_web/controllers/user_tag_controller.ex:54
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Unendorsed tag successfully."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:109
+#: lib/vutuv_web/live/tag_new_live.ex:124
 #, elixir-autogen
 msgid "User tag created successfully."
 msgstr ""
@@ -1680,7 +1680,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:468
+#: lib/vutuv_web/live/shell_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1700,8 +1700,8 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:332
 #: lib/vutuv_web/live/admin/job_live.ex:491
 #: lib/vutuv_web/live/admin/organization_live.ex:306
-#: lib/vutuv_web/live/post_live/composer.ex:454
-#: lib/vutuv_web/live/post_live/composer.ex:455
+#: lib/vutuv_web/live/post_live/composer.ex:460
+#: lib/vutuv_web/live/post_live/composer.ex:461
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1777,7 +1777,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:436
+#: lib/vutuv_web/live/shell_live.ex:473
 #: lib/vutuv_web/views/settings_html.ex:181
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1801,14 +1801,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:45
 #: lib/vutuv_web/live/message_live/index.ex:496
-#: lib/vutuv_web/live/shell_live.ex:325
-#: lib/vutuv_web/live/shell_live.ex:467
+#: lib/vutuv_web/live/shell_live.ex:362
+#: lib/vutuv_web/live/shell_live.ex:504
 #: lib/vutuv_web/templates/layout/app.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:296
+#: lib/vutuv_web/live/shell_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
@@ -1816,7 +1816,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2666
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
-#: lib/vutuv_web/templates/post/index.html.heex:43
+#: lib/vutuv_web/templates/post/index.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
@@ -1829,7 +1829,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2823
 #: lib/vutuv_web/live/notification_live/index.ex:66
 #: lib/vutuv_web/live/notification_live/index.ex:135
-#: lib/vutuv_web/live/shell_live.ex:336
+#: lib/vutuv_web/live/shell_live.ex:373
 #: lib/vutuv_web/templates/layout/app.html.heex:118
 #: lib/vutuv_web/templates/settings/notifications.html.heex:7
 #, elixir-autogen, elixir-format
@@ -2132,12 +2132,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:557
+#: lib/vutuv_web/live/post_live/composer.ex:563
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:685
+#: lib/vutuv_web/live/post_live/composer.ex:691
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2148,7 +2148,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:525
+#: lib/vutuv_web/live/post_live/composer.ex:531
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2158,13 +2158,13 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:697
+#: lib/vutuv_web/components/post_components.ex:708
 #: lib/vutuv_web/live/post_live/edit.ex:117
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:490
+#: lib/vutuv_web/live/post_live/composer.ex:496
 #, elixir-autogen, elixir-format
 msgid "Describe this image (alt text)"
 msgstr ""
@@ -2177,46 +2177,46 @@ msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:517
-#: lib/vutuv_web/live/shell_live.ex:290
-#: lib/vutuv_web/live/shell_live.ex:463
+#: lib/vutuv_web/live/shell_live.ex:312
+#: lib/vutuv_web/live/shell_live.ex:500
 #: lib/vutuv_web/templates/layout/app.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Feed"
 msgstr ""
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:26
+#: lib/vutuv_web/templates/post/teaser.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Follow %{name} to read it."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/show.html.heex:13
+#: lib/vutuv_web/templates/post/show.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:661
+#: lib/vutuv_web/live/post_live/composer.ex:667
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:589
+#: lib/vutuv_web/live/post_live/composer.ex:595
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:682
-#: lib/vutuv_web/components/post_components.ex:684
+#: lib/vutuv_web/components/post_components.ex:693
+#: lib/vutuv_web/components/post_components.ex:695
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:631
+#: lib/vutuv_web/live/post_live/composer.ex:637
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:277
-#: lib/vutuv_web/live/post_live/composer.ex:337
+#: lib/vutuv_web/live/post_live/composer.ex:278
+#: lib/vutuv_web/live/post_live/composer.ex:338
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2226,23 +2226,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:271
+#: lib/vutuv_web/live/post_live/composer.ex:272
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:621
+#: lib/vutuv_web/live/post_live/composer.ex:627
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:611
+#: lib/vutuv_web/live/post_live/composer.ex:617
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:121
-#: lib/vutuv_web/live/post_live/composer.ex:577
+#: lib/vutuv_web/live/post_live/composer.ex:583
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2263,18 +2263,18 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:181
 #: lib/vutuv_web/live/search_live.ex:377
 #: lib/vutuv_web/templates/settings/preferences.html.heex:114
-#: lib/vutuv_web/views/admin/report_html.ex:15
+#: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1042
-#: lib/vutuv_web/components/post_components.ex:1046
+#: lib/vutuv_web/components/post_components.ex:1093
+#: lib/vutuv_web/components/post_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1043
+#: lib/vutuv_web/components/post_components.ex:1094
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2284,7 +2284,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:209
 #: lib/vutuv_web/live/organization_live/edit.ex:359
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:647
+#: lib/vutuv_web/live/post_live/composer.ex:653
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2293,17 +2293,17 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:508
+#: lib/vutuv_web/live/post_live/composer.ex:514
 #, elixir-autogen, elixir-format
 msgid "Remove image"
 msgstr ""
 
-#: lib/vutuv_web/templates/post/show.html.heex:16
+#: lib/vutuv_web/templates/post/show.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:575
+#: lib/vutuv_web/live/post_live/composer.ex:581
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2321,71 +2321,71 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:361
+#: lib/vutuv_web/live/post_live/composer.ex:362
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:265
+#: lib/vutuv_web/live/post_live/composer.ex:266
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:19
+#: lib/vutuv_web/templates/post/teaser.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:716
+#: lib/vutuv_web/live/post_live/composer.ex:722
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:717
+#: lib/vutuv_web/live/post_live/composer.ex:723
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2982
-#: lib/vutuv_web/live/shell_live.ex:379
-#: lib/vutuv_web/templates/post/index.html.heex:12
-#: lib/vutuv_web/templates/post/teaser.html.heex:54
+#: lib/vutuv_web/live/shell_live.ex:416
+#: lib/vutuv_web/templates/post/index.html.heex:13
+#: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:128
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:466
+#: lib/vutuv_web/live/post_live/composer.ex:472
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:467
+#: lib/vutuv_web/live/post_live/composer.ex:473
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:679
+#: lib/vutuv_web/components/post_components.ex:690
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1252
+#: lib/vutuv_web/components/post_components.ex:1303
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1256
+#: lib/vutuv_web/components/post_components.ex:1307
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1254
+#: lib/vutuv_web/components/post_components.ex:1305
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1255
+#: lib/vutuv_web/components/post_components.ex:1306
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2396,22 +2396,22 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:540
+#: lib/vutuv_web/live/post_live/composer.ex:546
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:707
+#: lib/vutuv_web/live/post_live/composer.ex:713
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:711
+#: lib/vutuv_web/live/post_live/composer.ex:717
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/index.html.heex:5
+#: lib/vutuv_web/templates/post/index.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Posts by %{name}"
 msgstr ""
@@ -2426,7 +2426,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1324
+#: lib/vutuv_web/components/post_components.ex:1375
 #: lib/vutuv_web/components/ui.ex:1563
 #: lib/vutuv_web/components/ui.ex:1563
 #: lib/vutuv_web/components/ui.ex:2171
@@ -2435,17 +2435,17 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:760
+#: lib/vutuv_web/agent_docs/markdown.ex:761
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
-#: lib/vutuv_web/live/shell_live.ex:318
-#: lib/vutuv_web/live/shell_live.ex:384
-#: lib/vutuv_web/views/admin/report_html.ex:18
+#: lib/vutuv_web/live/shell_live.ex:355
+#: lib/vutuv_web/live/shell_live.ex:421
+#: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1291
+#: lib/vutuv_web/components/post_components.ex:1342
 #: lib/vutuv_web/components/ui.ex:1592
 #: lib/vutuv_web/components/ui.ex:1592
 #: lib/vutuv_web/components/ui.ex:2157
@@ -2455,11 +2455,11 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
+#: lib/vutuv_web/agent_docs/markdown.ex:760
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
-#: lib/vutuv_web/live/shell_live.ex:387
-#: lib/vutuv_web/views/admin/report_html.ex:17
+#: lib/vutuv_web/live/shell_live.ex:424
+#: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Likes"
 msgstr ""
@@ -2474,12 +2474,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1313
+#: lib/vutuv_web/components/post_components.ex:1364
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1324
+#: lib/vutuv_web/components/post_components.ex:1375
 #: lib/vutuv_web/components/ui.ex:1553
 #: lib/vutuv_web/components/ui.ex:1553
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2488,23 +2488,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1310
+#: lib/vutuv_web/components/post_components.ex:1361
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1123
+#: lib/vutuv_web/components/post_components.ex:1182
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1310
+#: lib/vutuv_web/components/post_components.ex:1361
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1291
+#: lib/vutuv_web/components/post_components.ex:1342
 #: lib/vutuv_web/components/ui.ex:1582
 #: lib/vutuv_web/components/ui.ex:1582
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2525,20 +2525,20 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1364
+#: lib/vutuv_web/components/post_components.ex:1415
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:102
 #: lib/vutuv_web/agent_docs/text.ex:100
-#: lib/vutuv_web/templates/post/show.html.heex:27
+#: lib/vutuv_web/templates/post/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1347
-#: lib/vutuv_web/components/post_components.ex:1348
+#: lib/vutuv_web/components/post_components.ex:1398
+#: lib/vutuv_web/components/post_components.ex:1399
 #: lib/vutuv_web/live/notification_live/index.ex:207
 #: lib/vutuv_web/live/notification_live/index.ex:299
 #: lib/vutuv_web/live/post_live/reply.ex:25
@@ -2546,18 +2546,18 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:650
+#: lib/vutuv_web/components/post_components.ex:661
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:268
-#: lib/vutuv_web/live/post_live/composer.ex:565
+#: lib/vutuv_web/live/post_live/composer.ex:269
+#: lib/vutuv_web/live/post_live/composer.ex:571
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:692
+#: lib/vutuv_web/live/post_live/composer.ex:698
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2572,12 +2572,12 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:645
+#: lib/vutuv_web/components/post_components.ex:656
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:639
+#: lib/vutuv_web/components/post_components.ex:650
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2830,8 +2830,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:428
-#: lib/vutuv_web/agent_docs/text.ex:433
+#: lib/vutuv_web/agent_docs/markdown.ex:429
+#: lib/vutuv_web/agent_docs/text.ex:434
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2853,7 +2853,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:601
+#: lib/vutuv_web/live/post_live/composer.ex:607
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2863,7 +2863,7 @@ msgstr ""
 msgid "Text only"
 msgstr ""
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:17
+#: lib/vutuv_web/templates/post/teaser.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "This post is for the connections of %{name}"
 msgstr ""
@@ -2876,7 +2876,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1253
+#: lib/vutuv_web/components/post_components.ex:1304
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2981,8 +2981,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:272
-#: lib/vutuv_web/agent_docs/text.ex:265
+#: lib/vutuv_web/agent_docs/markdown.ex:273
+#: lib/vutuv_web/agent_docs/text.ex:266
 #: lib/vutuv_web/controllers/page_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3137,7 +3137,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:627
+#: lib/vutuv_web/components/post_components.ex:638
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3187,6 +3187,8 @@ msgid "Private message"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2797
+#: lib/vutuv_web/live/shell_live.ex:325
+#: lib/vutuv_web/live/shell_live.ex:509
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3210,7 +3212,7 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:721
+#: lib/vutuv_web/components/post_components.ex:732
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3863,12 +3865,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:515
+#: lib/vutuv_web/agent_docs/markdown.ex:516
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:772
+#: lib/vutuv_web/agent_docs/markdown.ex:773
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3882,16 +3884,16 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:76
 #: lib/vutuv_web/agent_docs/markdown.ex:137
 #: lib/vutuv_web/agent_docs/markdown.ex:150
-#: lib/vutuv_web/agent_docs/markdown.ex:728
+#: lib/vutuv_web/agent_docs/markdown.ex:729
 #: lib/vutuv_web/agent_docs/text.ex:75
 #: lib/vutuv_web/agent_docs/text.ex:134
 #: lib/vutuv_web/agent_docs/text.ex:147
-#: lib/vutuv_web/agent_docs/text.ex:539
+#: lib/vutuv_web/agent_docs/text.ex:540
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:45
+#: lib/vutuv_web/agent_docs/list_docs.ex:46
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr ""
@@ -3903,26 +3905,26 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:746
-#: lib/vutuv_web/agent_docs/text.ex:550
+#: lib/vutuv_web/agent_docs/markdown.ex:747
+#: lib/vutuv_web/agent_docs/text.ex:551
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:743
-#: lib/vutuv_web/agent_docs/text.ex:547
+#: lib/vutuv_web/agent_docs/markdown.ex:744
+#: lib/vutuv_web/agent_docs/text.ex:548
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:750
-#: lib/vutuv_web/agent_docs/text.ex:553
+#: lib/vutuv_web/agent_docs/markdown.ex:751
+#: lib/vutuv_web/agent_docs/text.ex:554
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:411
-#: lib/vutuv_web/agent_docs/text.ex:416
+#: lib/vutuv_web/agent_docs/markdown.ex:412
+#: lib/vutuv_web/agent_docs/text.ex:417
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
@@ -3933,12 +3935,12 @@ msgstr ""
 msgid "Most endorsed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:124
+#: lib/vutuv_web/agent_docs/list_docs.ex:132
 #, elixir-autogen, elixir-format
 msgid "Most followed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:46
+#: lib/vutuv_web/agent_docs/list_docs.ex:47
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr ""
@@ -3951,7 +3953,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:96
 #: lib/vutuv_web/agent_docs/text.ex:93
 #: lib/vutuv_web/live/admin/screenshot_live.ex:96
-#: lib/vutuv_web/templates/post/show.html.heex:6
+#: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
 msgstr ""
@@ -3962,23 +3964,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:407
-#: lib/vutuv_web/agent_docs/text.ex:412
+#: lib/vutuv_web/agent_docs/markdown.ex:408
+#: lib/vutuv_web/agent_docs/text.ex:413
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:697
+#: lib/vutuv_web/agent_docs/markdown.ex:698
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:636
+#: lib/vutuv_web/agent_docs/markdown.ex:637
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:637
+#: lib/vutuv_web/agent_docs/markdown.ex:638
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -3988,7 +3990,7 @@ msgstr ""
 msgid "This page in %{language}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:47
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr ""
@@ -4053,8 +4055,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:287
+#: lib/vutuv_web/agent_docs/text.ex:274
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4103,8 +4105,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:276
-#: lib/vutuv_web/agent_docs/text.ex:269
+#: lib/vutuv_web/agent_docs/markdown.ex:277
+#: lib/vutuv_web/agent_docs/text.ex:270
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4120,8 +4122,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:273
-#: lib/vutuv_web/agent_docs/text.ex:266
+#: lib/vutuv_web/agent_docs/markdown.ex:274
+#: lib/vutuv_web/agent_docs/text.ex:267
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4335,14 +4337,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:278
-#: lib/vutuv_web/agent_docs/text.ex:271
+#: lib/vutuv_web/agent_docs/markdown.ex:279
+#: lib/vutuv_web/agent_docs/text.ex:272
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:274
-#: lib/vutuv_web/agent_docs/text.ex:267
+#: lib/vutuv_web/agent_docs/markdown.ex:275
+#: lib/vutuv_web/agent_docs/text.ex:268
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4451,7 +4453,7 @@ msgid "Edit the ad"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1004
-#: lib/vutuv_web/live/tag_new_live.ex:73
+#: lib/vutuv_web/live/tag_new_live.ex:74
 #: lib/vutuv_web/templates/ad/preview.html.heex:3
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:122
 #, elixir-autogen, elixir-format
@@ -4601,8 +4603,8 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:301
-#: lib/vutuv_web/agent_docs/text.ex:335
+#: lib/vutuv_web/agent_docs/markdown.ex:302
+#: lib/vutuv_web/agent_docs/text.ex:336
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
@@ -4686,11 +4688,6 @@ msgstr ""
 msgid "This tag doesn't have a description yet."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:297
-#, elixir-autogen, elixir-format
-msgid "only people with this tag, combinable: miller tag:php"
-msgstr ""
-
 #: lib/vutuv_web/templates/access_token/index.html.heex:1
 #: lib/vutuv_web/templates/access_token/index.html.heex:1
 #: lib/vutuv_web/templates/access_token/new.html.heex:1
@@ -4724,8 +4721,8 @@ msgstr ""
 msgid "Edit your profile and its sections"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:215
-#: lib/vutuv_web/agent_docs/text.ex:211
+#: lib/vutuv_web/agent_docs/markdown.ex:216
+#: lib/vutuv_web/agent_docs/text.ex:212
 #: lib/vutuv_web/live/admin/job_live.ex:400
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:135
@@ -5299,7 +5296,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:274
+#: lib/vutuv_web/live/post_live/composer.ex:275
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5309,7 +5306,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:366
+#: lib/vutuv_web/live/shell_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5329,7 +5326,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:427
+#: lib/vutuv_web/live/shell_live.ex:464
 #: lib/vutuv_web/templates/layout/app.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5344,7 +5341,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:2906
 #: lib/vutuv_web/components/ui.ex:2974
 #: lib/vutuv_web/controllers/settings_controller.ex:51
-#: lib/vutuv_web/live/shell_live.ex:407
+#: lib/vutuv_web/live/shell_live.ex:444
 #: lib/vutuv_web/live/tag_new_live.ex:44
 #: lib/vutuv_web/templates/address/edit.html.heex:2
 #: lib/vutuv_web/templates/address/new.html.heex:2
@@ -5419,8 +5416,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:284
-#: lib/vutuv_web/live/shell_live.ex:456
+#: lib/vutuv_web/live/shell_live.ex:305
+#: lib/vutuv_web/live/shell_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5430,9 +5427,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:756
-#: lib/vutuv_web/components/post_components.ex:805
-#: lib/vutuv_web/components/post_components.ex:818
+#: lib/vutuv_web/components/post_components.ex:774
+#: lib/vutuv_web/components/post_components.ex:825
+#: lib/vutuv_web/components/post_components.ex:838
 #: lib/vutuv_web/live/post_live/feed.ex:672
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6159,8 +6156,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:416
-#: lib/vutuv_web/agent_docs/text.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:417
+#: lib/vutuv_web/agent_docs/text.ex:422
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6207,7 +6204,7 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:14
+#: lib/vutuv_web/views/admin/report_html.ex:33
 #, elixir-autogen, elixir-format
 msgid "New confirmed registrations (by PIN)"
 msgstr ""
@@ -6232,8 +6229,8 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:759
-#: lib/vutuv_web/views/admin/report_html.ex:16
+#: lib/vutuv_web/agent_docs/markdown.ex:760
+#: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
@@ -6315,7 +6312,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:97
+#: lib/vutuv_web/agent_docs/list_docs.ex:105
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -6332,7 +6329,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:741
+#: lib/vutuv_web/agent_docs/markdown.ex:742
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6418,17 +6415,17 @@ msgid "Confirmed members whose every email address bounced, so they can no longe
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:153
-#: lib/vutuv_web/views/admin/report_html.ex:20
+#: lib/vutuv_web/views/admin/report_html.ex:40
 #, elixir-autogen, elixir-format
 msgid "Deactivated addresses"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:37
+#: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "New Fediverse followers"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/report/index.html.heex:87
+#: lib/vutuv_web/templates/admin/report/index.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "… and %{count} more"
 msgstr ""
@@ -6452,7 +6449,7 @@ msgid "Every deactivation, recovery, freeze and thaw, newest first."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:102
-#: lib/vutuv_web/views/admin/report_html.ex:21
+#: lib/vutuv_web/views/admin/report_html.ex:41
 #, elixir-autogen, elixir-format
 msgid "Frozen accounts"
 msgstr ""
@@ -6566,12 +6563,12 @@ msgstr ""
 msgid "system"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:19
+#: lib/vutuv_web/views/admin/report_html.ex:39
 #, elixir-autogen, elixir-format
 msgid "Bounces"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:22
+#: lib/vutuv_web/views/admin/report_html.ex:42
 #, elixir-autogen, elixir-format
 msgid "Thawed accounts"
 msgstr ""
@@ -6635,17 +6632,17 @@ msgstr ""
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:24
+#: lib/vutuv_web/templates/post/teaser.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Follow each other to connect with %{name} and read it."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/teaser.html.heex:39
+#: lib/vutuv_web/templates/post/teaser.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:718
+#: lib/vutuv_web/components/post_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6655,7 +6652,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:717
+#: lib/vutuv_web/components/post_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -6850,8 +6847,8 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:189
-#: lib/vutuv_web/agent_docs/text.ex:186
+#: lib/vutuv_web/agent_docs/markdown.ex:190
+#: lib/vutuv_web/agent_docs/text.ex:187
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -7507,17 +7504,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:777
+#: lib/vutuv_web/agent_docs/markdown.ex:778
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:780
+#: lib/vutuv_web/agent_docs/markdown.ex:781
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:787
+#: lib/vutuv_web/agent_docs/markdown.ex:788
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8498,12 +8495,12 @@ msgstr ""
 msgid "All %{count} members whose profiles are open to search engines, filed alphabetically by last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:143
+#: lib/vutuv_web/agent_docs/list_docs.ex:151
 #, elixir-autogen, elixir-format
 msgid "All members who allow search engines to index their profile, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:141
+#: lib/vutuv_web/agent_docs/list_docs.ex:149
 #: lib/vutuv_web/controllers/directory_controller.ex:28
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8519,7 +8516,7 @@ msgstr ""
 msgid "Members by initial"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:160
+#: lib/vutuv_web/agent_docs/list_docs.ex:168
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8538,7 +8535,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:166
+#: lib/vutuv_web/agent_docs/list_docs.ex:174
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -8728,7 +8725,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:555
+#: lib/vutuv_web/agent_docs/markdown.ex:556
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8749,7 +8746,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:556
+#: lib/vutuv_web/agent_docs/markdown.ex:557
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8759,11 +8756,6 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
-msgstr ""
-
-#: lib/vutuv_web/live/search_live.ex:270
-#, elixir-autogen, elixir-format
-msgid "Your search uses a people filter such as tag: or city:, so it only finds people."
 msgstr ""
 
 #: lib/vutuv_web/cv/html.ex:57
@@ -8785,19 +8777,19 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:593
+#: lib/vutuv_web/agent_docs/markdown.ex:594
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:593
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_new_live.ex:74
+#: lib/vutuv_web/live/tag_new_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "This will create the following tags:"
 msgstr ""
@@ -8817,14 +8809,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1126
+#: lib/vutuv_web/components/post_components.ex:1185
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:700
+#: lib/vutuv_web/agent_docs/markdown.ex:701
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8902,14 +8894,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:554
+#: lib/vutuv_web/agent_docs/markdown.ex:555
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:557
+#: lib/vutuv_web/agent_docs/markdown.ex:558
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9049,8 +9041,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:437
-#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:438
+#: lib/vutuv_web/agent_docs/text.ex:441
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9472,8 +9464,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:409
-#: lib/vutuv_web/agent_docs/text.ex:414
+#: lib/vutuv_web/agent_docs/markdown.ex:410
+#: lib/vutuv_web/agent_docs/text.ex:415
 #: lib/vutuv_web/templates/user/edit.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Employment status"
@@ -9575,7 +9567,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/markdown.ex:631
 #: lib/vutuv_web/views/qualification_html.ex:10
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9662,7 +9654,7 @@ msgstr ""
 msgid "Expiry year"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:622
+#: lib/vutuv_web/agent_docs/markdown.ex:623
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9688,7 +9680,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:629
+#: lib/vutuv_web/agent_docs/markdown.ex:630
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9715,7 +9707,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:620
+#: lib/vutuv_web/agent_docs/markdown.ex:621
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9730,7 +9722,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:621
+#: lib/vutuv_web/agent_docs/markdown.ex:622
 #: lib/vutuv_web/views/qualification_html.ex:60
 #: lib/vutuv_web/views/qualification_html.ex:63
 #, elixir-autogen, elixir-format
@@ -9747,7 +9739,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:524
+#: lib/vutuv_web/agent_docs/markdown.ex:525
 #: lib/vutuv_web/live/section_reorder_live.ex:252
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -9822,7 +9814,7 @@ msgid "First name"
 msgstr ""
 
 #: lib/vutuv_web/controllers/invitation_controller.ex:54
-#: lib/vutuv_web/live/shell_live.ex:398
+#: lib/vutuv_web/live/shell_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Invite a friend"
 msgstr ""
@@ -10049,7 +10041,7 @@ msgstr ""
 msgid "Account restored. The member can sign in again."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:23
+#: lib/vutuv_web/views/admin/report_html.ex:43
 #, elixir-autogen, elixir-format
 msgid "Accounts removed as spam"
 msgstr ""
@@ -10388,21 +10380,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:492
+#: lib/vutuv_web/agent_docs/markdown.ex:493
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:490
+#: lib/vutuv_web/agent_docs/markdown.ex:491
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:488
+#: lib/vutuv_web/agent_docs/markdown.ex:489
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10455,12 +10447,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:506
+#: lib/vutuv_web/agent_docs/markdown.ex:507
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:493
+#: lib/vutuv_web/agent_docs/markdown.ex:494
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10605,7 +10597,7 @@ msgstr ""
 msgid "Manage your vutuv account: profile, privacy, notifications and sign-in."
 msgstr ""
 
-#: lib/vutuv_web/controllers/tag_controller.ex:43
+#: lib/vutuv_web/controllers/tag_controller.ex:50
 #, elixir-autogen, elixir-format
 msgid "Members on vutuv tagged %{tag}."
 msgstr ""
@@ -11301,8 +11293,8 @@ msgstr ""
 msgid "Verified domains"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:190
-#: lib/vutuv_web/agent_docs/text.ex:187
+#: lib/vutuv_web/agent_docs/markdown.ex:191
+#: lib/vutuv_web/agent_docs/text.ex:188
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr ""
@@ -11329,8 +11321,8 @@ msgstr ""
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:192
-#: lib/vutuv_web/agent_docs/text.ex:189
+#: lib/vutuv_web/agent_docs/markdown.ex:193
+#: lib/vutuv_web/agent_docs/text.ex:190
 #: lib/vutuv_web/live/organization_live/edit.ex:273
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -11414,8 +11406,8 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:293
-#: lib/vutuv_web/agent_docs/text.ex:328
+#: lib/vutuv_web/agent_docs/markdown.ex:294
+#: lib/vutuv_web/agent_docs/text.ex:329
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
@@ -11648,8 +11640,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:314
-#: lib/vutuv_web/agent_docs/text.ex:348
+#: lib/vutuv_web/agent_docs/markdown.ex:315
+#: lib/vutuv_web/agent_docs/text.ex:349
 #: lib/vutuv_web/live/admin/organization_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11782,8 +11774,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:650
-#: lib/vutuv_web/agent_docs/text.ex:520
+#: lib/vutuv_web/agent_docs/markdown.ex:651
+#: lib/vutuv_web/agent_docs/text.ex:521
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11819,8 +11811,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:305
-#: lib/vutuv_web/agent_docs/text.ex:339
+#: lib/vutuv_web/agent_docs/markdown.ex:306
+#: lib/vutuv_web/agent_docs/text.ex:340
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -12019,7 +12011,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
 #: lib/vutuv_web/live/post_live/saved.ex:455
-#: lib/vutuv_web/live/shell_live.ex:394
+#: lib/vutuv_web/live/shell_live.ex:431
 #: lib/vutuv_web/templates/layout/app.html.heex:79
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
@@ -12264,10 +12256,10 @@ msgstr ""
 msgid "Edit posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:209
-#: lib/vutuv_web/agent_docs/markdown.ex:338
-#: lib/vutuv_web/agent_docs/text.ex:205
-#: lib/vutuv_web/agent_docs/text.ex:372
+#: lib/vutuv_web/agent_docs/markdown.ex:210
+#: lib/vutuv_web/agent_docs/markdown.ex:339
+#: lib/vutuv_web/agent_docs/text.ex:206
+#: lib/vutuv_web/agent_docs/text.ex:373
 #: lib/vutuv_web/live/admin/job_live.ex:351
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employer"
@@ -12278,10 +12270,10 @@ msgstr ""
 msgid "Employer name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:210
-#: lib/vutuv_web/agent_docs/markdown.ex:339
-#: lib/vutuv_web/agent_docs/text.ex:206
-#: lib/vutuv_web/agent_docs/text.ex:373
+#: lib/vutuv_web/agent_docs/markdown.ex:211
+#: lib/vutuv_web/agent_docs/markdown.ex:340
+#: lib/vutuv_web/agent_docs/text.ex:207
+#: lib/vutuv_web/agent_docs/text.ex:374
 #: lib/vutuv_web/live/job_board_live.ex:280
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format, fuzzy
@@ -12343,7 +12335,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:40
 #: lib/vutuv_web/live/job_board_live.ex:145
 #: lib/vutuv_web/live/post_live/saved.ex:458
-#: lib/vutuv_web/live/shell_live.ex:302
+#: lib/vutuv_web/live/shell_live.ex:339
 #: lib/vutuv_web/templates/layout/app.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12354,12 +12346,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:320
-#: lib/vutuv_web/agent_docs/markdown.ex:324
-#: lib/vutuv_web/agent_docs/markdown.ex:326
-#: lib/vutuv_web/agent_docs/text.ex:354
-#: lib/vutuv_web/agent_docs/text.ex:358
-#: lib/vutuv_web/agent_docs/text.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:321
+#: lib/vutuv_web/agent_docs/markdown.ex:325
+#: lib/vutuv_web/agent_docs/markdown.ex:327
+#: lib/vutuv_web/agent_docs/text.ex:355
+#: lib/vutuv_web/agent_docs/text.ex:359
+#: lib/vutuv_web/agent_docs/text.ex:361
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
@@ -12408,8 +12400,8 @@ msgstr ""
 msgid "New posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:221
-#: lib/vutuv_web/agent_docs/text.ex:216
+#: lib/vutuv_web/agent_docs/markdown.ex:222
+#: lib/vutuv_web/agent_docs/text.ex:217
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
 #: lib/vutuv_web/live/job_posting_live/show.ex:153
 #, elixir-autogen, elixir-format
@@ -12491,10 +12483,10 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:214
-#: lib/vutuv_web/agent_docs/markdown.ex:343
-#: lib/vutuv_web/agent_docs/text.ex:210
-#: lib/vutuv_web/agent_docs/text.ex:377
+#: lib/vutuv_web/agent_docs/markdown.ex:215
+#: lib/vutuv_web/agent_docs/markdown.ex:344
+#: lib/vutuv_web/agent_docs/text.ex:211
+#: lib/vutuv_web/agent_docs/text.ex:378
 #: lib/vutuv_web/live/job_posting_live/show.ex:132
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posted"
@@ -12518,10 +12510,10 @@ msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
-#: lib/vutuv_web/agent_docs/markdown.ex:324
-#: lib/vutuv_web/agent_docs/markdown.ex:326
-#: lib/vutuv_web/agent_docs/text.ex:358
-#: lib/vutuv_web/agent_docs/text.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:325
+#: lib/vutuv_web/agent_docs/markdown.ex:327
+#: lib/vutuv_web/agent_docs/text.ex:359
+#: lib/vutuv_web/agent_docs/text.ex:361
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format, fuzzy
@@ -12533,18 +12525,18 @@ msgstr ""
 msgid "Report this posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:220
-#: lib/vutuv_web/agent_docs/text.ex:215
+#: lib/vutuv_web/agent_docs/markdown.ex:221
+#: lib/vutuv_web/agent_docs/text.ex:216
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #: lib/vutuv_web/live/job_posting_live/show.ex:148
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:213
-#: lib/vutuv_web/agent_docs/markdown.ex:342
-#: lib/vutuv_web/agent_docs/text.ex:209
-#: lib/vutuv_web/agent_docs/text.ex:376
+#: lib/vutuv_web/agent_docs/markdown.ex:214
+#: lib/vutuv_web/agent_docs/markdown.ex:343
+#: lib/vutuv_web/agent_docs/text.ex:210
+#: lib/vutuv_web/agent_docs/text.ex:377
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Salary"
 msgstr ""
@@ -12636,10 +12628,10 @@ msgstr ""
 msgid "Working student"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:211
-#: lib/vutuv_web/agent_docs/markdown.ex:340
-#: lib/vutuv_web/agent_docs/text.ex:207
-#: lib/vutuv_web/agent_docs/text.ex:374
+#: lib/vutuv_web/agent_docs/markdown.ex:212
+#: lib/vutuv_web/agent_docs/markdown.ex:341
+#: lib/vutuv_web/agent_docs/text.ex:208
+#: lib/vutuv_web/agent_docs/text.ex:375
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Workplace"
@@ -12812,13 +12804,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/templates/tag/show.html.heex:22
+#: lib/vutuv_web/agent_docs/markdown.ex:362
+#: lib/vutuv_web/templates/tag/show.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/agent_docs/text.ex:395
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12854,12 +12846,12 @@ msgstr ""
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:233
+#: lib/vutuv_web/agent_docs/markdown.ex:234
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:228
+#: lib/vutuv_web/agent_docs/text.ex:229
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
@@ -12874,12 +12866,12 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:359
-#: lib/vutuv_web/agent_docs/markdown.ex:371
-#: lib/vutuv_web/agent_docs/text.ex:392
-#: lib/vutuv_web/agent_docs/text.ex:404
+#: lib/vutuv_web/agent_docs/markdown.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:372
+#: lib/vutuv_web/agent_docs/text.ex:393
+#: lib/vutuv_web/agent_docs/text.ex:405
 #: lib/vutuv_web/live/organization_live/show.ex:329
-#: lib/vutuv_web/templates/tag/show.html.heex:16
+#: lib/vutuv_web/templates/tag/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Open positions"
 msgstr ""
@@ -13442,7 +13434,7 @@ msgstr ""
 msgid "An image was removed from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:890
+#: lib/vutuv_web/components/post_components.ex:910
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -13450,7 +13442,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:880
+#: lib/vutuv_web/components/post_components.ex:900
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr ""
@@ -13580,7 +13572,7 @@ msgstr ""
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:501
+#: lib/vutuv_web/live/post_live/composer.ex:507
 #, elixir-autogen, elixir-format
 msgid "Insert"
 msgstr ""
@@ -13590,7 +13582,24 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:498
+#: lib/vutuv_web/live/post_live/composer.ex:504
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:166
+#: lib/vutuv_web/agent_docs/text.ex:163
+#: lib/vutuv_web/templates/tag/show.html.heex:15
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Posts with this tag"
+msgstr ""
+
+#: lib/vutuv_web/live/search_live.ex:270
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
+msgstr ""
+
+#: lib/vutuv_web/live/search_live.ex:297
+#, elixir-autogen, elixir-format, fuzzy
+msgid "people and posts with this tag, combinable: miller tag:php"
 msgstr ""

--- a/test/vutuv/posts/list_tag_posts_test.exs
+++ b/test/vutuv/posts/list_tag_posts_test.exs
@@ -1,0 +1,77 @@
+defmodule Vutuv.Posts.ListTagPostsTest do
+  @moduledoc """
+  The tag page's "Posts with this tag" list (`Vutuv.Posts.list_tag_posts/1`,
+  issue #946). The anonymous public view: a post surfaces only if every
+  visitor may read it, so the same visibility gate as `search_public/2`
+  applies here.
+  """
+  use Vutuv.DataCase, async: true
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Posts
+  alias Vutuv.Tags.Tag
+
+  defp author(attrs \\ []), do: insert(:activated_user, attrs)
+
+  defp tag_by_name(name), do: Repo.get_by!(Tag, name: name)
+
+  test "lists public posts carrying the exact tag, newest first" do
+    a = author()
+    older = create_post!(a, %{body: "First", tags: "elixir"})
+    newer = create_post!(a, %{body: "Second", tags: "elixir"})
+    _other = create_post!(a, %{body: "Ruby", tags: "ruby"})
+
+    ids = tag_by_name("elixir") |> Posts.list_tag_posts() |> Enum.map(& &1.id)
+    assert ids == [newer.id, older.id]
+  end
+
+  test "author and tags are preloaded for rendering" do
+    a = author()
+    create_post!(a, %{body: "Hello", tags: "elixir"})
+
+    assert [post] = Posts.list_tag_posts(tag_by_name("elixir"))
+    assert post.user.id == a.id
+    assert Enum.map(post.tags, & &1.name) == ["elixir"]
+  end
+
+  test "hides denied, frozen, unactivated and moderation-hidden posts" do
+    a = author()
+
+    create_post!(a, %{
+      body: "followers only",
+      tags: "elixir",
+      denials: [%{"wildcard" => "non_followers"}]
+    })
+
+    frozen = create_post!(a, %{body: "frozen", tags: "elixir"})
+
+    Repo.update_all(from(p in Posts.Post, where: p.id == ^frozen.id),
+      set: [frozen_at: NaiveDateTime.utc_now(:second)]
+    )
+
+    unconfirmed = insert(:user, email_confirmed?: false)
+    create_post!(unconfirmed, %{body: "spam", tags: "elixir"})
+
+    assert Posts.list_tag_posts(tag_by_name("elixir")) == []
+  end
+
+  test "a tag used only in posts (no endorsed members) still returns its posts" do
+    a = author()
+    post = create_post!(a, %{body: "orphan tag", tags: "obscure"})
+
+    assert [found] = Posts.list_tag_posts(tag_by_name("obscure"))
+    assert found.id == post.id
+  end
+
+  test "respects the limit" do
+    a = author()
+    for i <- 1..4, do: create_post!(a, %{body: "post #{i}", tags: "elixir"})
+
+    assert length(Posts.list_tag_posts(tag_by_name("elixir"), limit: 2)) == 2
+  end
+
+  test "an empty tag returns no posts" do
+    tag = insert(:tag, name: "lonely", slug: "lonely")
+    assert Posts.list_tag_posts(tag) == []
+  end
+end

--- a/test/vutuv/posts/post_search_test.exs
+++ b/test/vutuv/posts/post_search_test.exs
@@ -81,4 +81,50 @@ defmodule Vutuv.Posts.PostSearchTest do
     # websearch_to_tsquery treats operators as literal text - must not raise.
     assert is_list(Posts.search_public(~s{"unbalanced & | ! (}))
   end
+
+  describe "tag: filter (issue #946)" do
+    test "a bare tag filter lists posts carrying that tag, newest first" do
+      a = author()
+      older = create_post!(a, %{body: "First elixir note", tags: "elixir"})
+      newer = create_post!(a, %{body: "Second elixir note", tags: "elixir"})
+      _other = create_post!(a, %{body: "A ruby note", tags: "ruby"})
+
+      # Empty body + a tag: filter is a pure tag listing.
+      ids = Posts.search_public("", tag: "elixir") |> Enum.map(& &1.id)
+      assert ids == [newer.id, older.id]
+    end
+
+    test "combines with body words (AND)" do
+      a = author()
+      match = create_post!(a, %{body: "Koblenz elixir meetup", tags: "elixir"})
+      _wrong_body = create_post!(a, %{body: "Berlin elixir meetup", tags: "elixir"})
+      _wrong_tag = create_post!(a, %{body: "Koblenz ruby meetup", tags: "ruby"})
+
+      assert [found] = Posts.search_public("koblenz", tag: "elixir")
+      assert found.id == match.id
+    end
+
+    test "substring matches the tag name, exact does not" do
+      a = author()
+      post = create_post!(a, %{body: "phpstorm tips", tags: "phpstorm"})
+
+      assert [found] = Posts.search_public("", tag: "php")
+      assert found.id == post.id
+      assert Posts.search_public("", tag: "php", exact: true) == []
+      assert [exact] = Posts.search_public("", tag: "phpstorm", exact: true)
+      assert exact.id == post.id
+    end
+
+    test "a tag filter still hides posts a visitor may not read" do
+      a = author()
+
+      create_post!(a, %{
+        body: "elixir for followers",
+        tags: "elixir",
+        denials: [%{"wildcard" => "non_followers"}]
+      })
+
+      assert Posts.search_public("", tag: "elixir") == []
+    end
+  end
 end

--- a/test/vutuv/search_test.exs
+++ b/test/vutuv/search_test.exs
@@ -167,8 +167,10 @@ defmodule Vutuv.SearchTest do
       assert %{first_name: "stefan", last_name: "meier"} =
                Search.parse("first:stefan last:meier")
 
-      assert %{tag: "elixir", scope: :people} = Search.parse("tag:elixir")
-      assert %{tag: "elixir", scope: :people} = Search.parse("skill:elixir")
+      # tag:/skill: now spans people and posts (issue #946), so it no longer
+      # pins the scope to :people — it leaves the scope free (default :all).
+      assert %{tag: "elixir", scope: :all, scope_pinned?: false} = Search.parse("tag:elixir")
+      assert %{tag: "elixir", scope: :all} = Search.parse("skill:elixir")
       assert %{slug: "stefan", scope: :people} = Search.parse("@stefan")
       assert %{city: "koblenz", scope: :people} = Search.parse("ort:koblenz")
       assert %{city: "koblenz"} = Search.parse("stadt:koblenz")
@@ -190,12 +192,15 @@ defmodule Vutuv.SearchTest do
       assert %{scope: :all} = Search.parse("meier", scope: :bogus)
     end
 
-    test "people operators mark the scope as pinned, plain queries do not" do
-      assert %{scope_pinned?: true} = Search.parse("tag:php", scope: :tags)
+    test "people-only operators mark the scope as pinned, plain queries do not" do
       assert %{scope_pinned?: true} = Search.parse("city:hamburg", scope: :posts)
       assert %{scope_pinned?: true} = Search.parse("@stefan")
       assert %{scope_pinned?: false} = Search.parse("meier", scope: :tags)
       assert %{scope_pinned?: false} = Search.parse("meier")
+      # tag: spans people and posts now, so it does not pin (issue #946); it
+      # honors the chip scope like a plain query does.
+      assert %{scope_pinned?: false, scope: :posts} = Search.parse("tag:php", scope: :posts)
+      assert %{scope_pinned?: false, scope: :tags} = Search.parse("tag:php", scope: :tags)
     end
 
     test "an unknown operator stays ordinary text" do
@@ -328,6 +333,37 @@ defmodule Vutuv.SearchTest do
       results = Search.instant("müller tag:php")
 
       assert Enum.map(results.exact_people, & &1.id) == [php_mueller.id]
+    end
+
+    test "tag: also finds posts carrying that tag, matching the tag not the body (issue #946)" do
+      tag = insert(:tag, name: "PHP", slug: "php")
+      with_tag = insert(:activated_user)
+      insert(:user_tag, tag: tag, user: with_tag)
+
+      author = insert(:activated_user)
+      tagged = Vutuv.PostsHelpers.create_post!(author, %{body: "My write-up", tags: "php"})
+      _untagged = Vutuv.PostsHelpers.create_post!(author, %{body: "php but not tagged"})
+
+      results = Search.instant("tag:php")
+
+      # People AND posts both respond to the tag filter now; the untagged post
+      # that merely mentions "php" in its body stays out.
+      assert with_tag.id in Enum.map(results.exact_people, & &1.id)
+      assert Enum.map(results.posts, & &1.id) == [tagged.id]
+    end
+
+    test "the Posts scope with a tag: filter returns only posts" do
+      tag = insert(:tag, name: "PHP", slug: "php")
+      with_tag = insert(:activated_user)
+      insert(:user_tag, tag: tag, user: with_tag)
+
+      tagged =
+        Vutuv.PostsHelpers.create_post!(insert(:activated_user), %{body: "hi", tags: "php"})
+
+      results = Search.instant("tag:php", scope: :posts)
+
+      assert results.exact_people == []
+      assert Enum.map(results.posts, & &1.id) == [tagged.id]
     end
 
     test "a name combines with the city filter" do

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -412,7 +412,8 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert Jason.decode!(rendered.json)["type"] == "following"
   end
 
-  test "tag page: description, endorsed members and open positions in every format", %{tag: tag} do
+  test "tag page: description, endorsed members, open positions and posts in every format",
+       %{tag: tag, user: user} do
     tag
     |> Ecto.Changeset.change(description: "The art of connecting shores")
     |> Repo.update!()
@@ -424,9 +425,19 @@ defmodule VutuvWeb.AgentDocsDriftTest do
       "required_tags" => "Bridgebuilding"
     })
 
+    # "Posts with this tag" (#946): a public post carrying the tag surfaces on
+    # the HTML page and in every agent format.
+    create_post!(user, %{body: "Spanning the great divide today", tags: "Bridgebuilding"})
+
     rendered = formats_for("/tags/bridgebuilding")
 
-    for fact <- ["Bridgebuilding", "connecting shores", "Greta Gradient", "Bridge Architect"],
+    for fact <- [
+          "Bridgebuilding",
+          "connecting shores",
+          "Greta Gradient",
+          "Bridge Architect",
+          "Spanning the great divide"
+        ],
         do: assert_fact_everywhere(rendered, fact)
   end
 

--- a/test/vutuv_web/controllers/tag_controller_test.exs
+++ b/test/vutuv_web/controllers/tag_controller_test.exs
@@ -29,6 +29,31 @@ defmodule VutuvWeb.TagControllerTest do
     end
   end
 
+  # Issue #946: a tag used only in posts (no endorsed members) used to open an
+  # empty page. The tag page now lists the public posts carrying the tag.
+  describe "posts with this tag (issue #946)" do
+    test "a tag used only in posts still shows those posts", %{conn: conn} do
+      author = insert(:activated_user)
+
+      post =
+        Vutuv.PostsHelpers.create_post!(author, %{body: "Elixir meetup notes", tags: "elixir"})
+
+      html = conn |> get(~p"/tags/elixir") |> html_response(200)
+
+      assert html =~ "tag-posts"
+      assert html =~ "Elixir meetup notes"
+      assert html =~ "/#{author.username}/posts/#{post.id}"
+    end
+
+    test "the posts section is absent when no public post carries the tag", %{conn: conn} do
+      insert(:tag, name: "Empty", slug: "empty")
+
+      html = conn |> get(~p"/tags/empty") |> html_response(200)
+
+      refute html =~ ~s(id="tag-posts")
+    end
+  end
+
   # Issue #877: the "Add this tag" button was removed from the public tag page.
   # "Add this tag" was ambiguous ("create/define this tag" vs "add it to my
   # profile" — it misled the #844 reporter into a 404), redundant with the

--- a/test/vutuv_web/live/search_live_test.exs
+++ b/test/vutuv_web/live/search_live_test.exs
@@ -292,14 +292,15 @@ defmodule VutuvWeb.SearchLiveTest do
       assert has_element?(view, "#search-tags", "1")
     end
 
-    # Issue #846: with a people operator in the query the parser pins the
+    # Issue #846: with a people-only operator in the query the parser pins the
     # search to people, so the other scope chips did nothing when clicked.
-    # They must read as disabled instead of as working tabs.
-    test "a people operator disables the other scope chips with a hint", %{conn: conn} do
-      tag = insert(:tag, name: "PHP", slug: "php")
-      insert(:user_tag, tag: tag, user: insert(:activated_user))
+    # They must read as disabled instead of as working tabs. (`tag:` no longer
+    # pins since issue #946 — it spans people and posts — so this uses `ort:`.)
+    test "a people-only operator disables the other scope chips with a hint", %{conn: conn} do
+      user = insert(:activated_user)
+      insert(:address, user: user, city: "Koblenz")
 
-      {:ok, view, _html} = live(conn, ~p"/search?q=tag:php")
+      {:ok, view, _html} = live(conn, ~p"/search?q=ort:koblenz")
 
       # People is highlighted as what the search actually did ...
       assert has_element?(view, "#search-scope-people.bg-brand-600")
@@ -315,17 +316,17 @@ defmodule VutuvWeb.SearchLiveTest do
     end
 
     test "clearing the operator re-enables the scope chips", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/search?q=tag:php")
+      {:ok, view, _html} = live(conn, ~p"/search?q=ort:koblenz")
       refute has_element?(view, "a#search-scope-tags")
 
-      view |> form("#search-form") |> render_change(%{q: "php"})
-      assert_patch(view, ~p"/search?q=php")
+      view |> form("#search-form") |> render_change(%{q: "koblenz"})
+      assert_patch(view, ~p"/search?q=koblenz")
 
       assert has_element?(view, "a#search-scope-tags")
       refute has_element?(view, "#search-scope-pinned-hint")
     end
 
-    test "tag: lists the people with that tag instead of the tag itself", %{conn: conn} do
+    test "tag: lists the people with that tag, not the tag itself", %{conn: conn} do
       tag = insert(:tag, name: "PHP", slug: "php")
       tagged = insert(:activated_user, first_name: "Paula", last_name: "Programmer")
       insert(:user_tag, tag: tag, user: tagged)
@@ -336,6 +337,24 @@ defmodule VutuvWeb.SearchLiveTest do
       assert has_element?(view, "#search-people-exact", "Paula Programmer")
       refute has_element?(view, "#search-people-exact", "Norbert NoTag")
       refute has_element?(view, "#search-tags")
+    end
+
+    test "tag: also lists posts carrying that tag, and keeps the chips enabled (issue #946)",
+         %{conn: conn} do
+      tag = insert(:tag, name: "PHP", slug: "php")
+      tagged = insert(:activated_user, first_name: "Paula", last_name: "Programmer")
+      insert(:user_tag, tag: tag, user: tagged)
+      author = insert(:activated_user)
+      create_post!(author, %{body: "My php write-up today", tags: "php"})
+
+      {:ok, view, _html} = live(conn, ~p"/search?q=tag:php")
+
+      # Both the person and the post carrying the tag show.
+      assert has_element?(view, "#search-people-exact", "Paula Programmer")
+      assert has_element?(view, "#search-posts", "My php write-up")
+      # tag: does not pin the scope now, so the chips stay clickable links.
+      assert has_element?(view, "a#search-scope-posts")
+      refute has_element?(view, "#search-scope-pinned-hint")
     end
 
     test "a name combines with tag and city filters", %{conn: conn} do


### PR DESCRIPTION
Closes #946.

Tagged posts were undiscoverable: clicking a tag on a post landed on `/tags/:slug`, which only listed endorsed members and open job postings, so a tag used only in posts opened an empty page — and the `tag:` search operator was people-only.

This does both things the issue asked for (it proposed *either*):

**A. Tag page shows posts.** A new `Posts.list_tag_posts/1` lists the public posts filed under a tag (anonymous view via the existing `scope_visible(nil)` gate, newest first, capped), rendered with the shared post card in a "Posts with this tag" section. The agent-format siblings carry them too (`ListDocs.build_tag` + the Markdown/text renderers; JSON/XML generically), guarded by the agent-docs drift test.

**B. `tag:` search finds posts.** `tag:`/`skill:` now spans people *and* posts and no longer pins the scope to people, so the scope chips still narrow a tag search to just people or just posts. `Posts.search_public/2` gained an optional `:tag` filter (an `EXISTS` over `post_tags`, name/slug, substring or exact); a bare `tag:php` is a pure tag listing. `ort:`/`city:`/`status:` stay people-only and keep pinning.

Also: `docs/architecture/search.md` and the German translations updated; `mix.exs` bumped to 7.114.0 (minor, no migration).

## Tests
`list_tag_posts_test`, `post_search_test` (tag filter), `search_test` + `search_live_test` (tag: spans people+posts, pinning), `tag_controller_test` (posts section) and the agent-docs drift test. Full `mix precommit` green (4015 passing).

## Smoke test
Drove a real browser: the tag page shows a "Beiträge mit diesem Tag" section for a members-free tag, `tag:` search returns the post with the scope chips enabled (not pinned), and the `.json`/`.md` siblings carry the posts.