### PR TITLE
Tidy the tag page's post list on desktop (#946 follow-up)

### DIFF
--- a/lib/vutuv_web/templates/tag/show.html.heex
+++ b/lib/vutuv_web/templates/tag/show.html.heex
@@ -1,43 +1,52 @@
-<.page_header
-  title={@tag.name}
-  crumbs={[
-    {gettext("Tags"), ~p"/tags"},
-    gettext("Show")
-  ]}
-/>
+<%!-- Constrain to the same readable measure the post archive/permalink use
+(mx-auto max-w-3xl): on a wide desktop the full max-w-6xl width made each post
+card stretch edge to edge with a huge line length and dead space. --%>
+<div class="mx-auto max-w-3xl">
+  <.page_header
+    title={@tag.name}
+    crumbs={[
+      {gettext("Tags"), ~p"/tags"},
+      gettext("Show")
+    ]}
+  />
 
-<div class="card-list">
+  <div class="card-list">
     <%= render "single_card.html", assigns %>
-</div>
-
-<section :if={@tag_posts != []} id="tag-posts" class="mt-6">
-  <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-    {gettext("Posts with this tag")}
-  </h2>
-  <div class="mt-3 space-y-4">
-    <.post_card
-      :for={post <- @tag_posts}
-      post={post}
-      viewer={@current_user}
-      mode={:preview}
-      conn_or_socket={@conn}
-    />
   </div>
-</section>
 
-<section :if={@open_positions != []} class="mt-6">
-  <div class="flex items-center justify-between gap-2">
+  <%!-- Posts carrying this tag (#946), rendered as flat divide-y rows inside one
+  card via <.post_thread_entry> — the same treatment as the feed, the profile and
+  the author archive (a reply nests the post it answers inline). --%>
+  <section :if={@tag_posts != []} id="tag-posts" class="mt-6">
     <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-      {gettext("Open positions")}
+      {gettext("Posts with this tag")}
     </h2>
-    <.link
-      navigate={~p"/jobs?#{[tag: @tag.slug]}"}
-      class="text-sm font-semibold text-brand-600 hover:text-brand-700"
-    >
-      {gettext("All jobs with this tag")} →
-    </.link>
-  </div>
-  <div class="mt-3 grid gap-4 sm:grid-cols-2">
-    <.job_card :for={posting <- @open_positions} posting={posting} />
-  </div>
-</section>
+    <.post_list class="mt-3" data-post-list>
+      <div :for={post <- @tag_posts} class={post_row_class()}>
+        <.post_thread_entry
+          post={post}
+          conn_or_socket={@conn}
+          viewer={@current_user}
+          surface={:flat}
+        />
+      </div>
+    </.post_list>
+  </section>
+
+  <section :if={@open_positions != []} class="mt-6">
+    <div class="flex items-center justify-between gap-2">
+      <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        {gettext("Open positions")}
+      </h2>
+      <.link
+        navigate={~p"/jobs?#{[tag: @tag.slug]}"}
+        class="text-sm font-semibold text-brand-600 hover:text-brand-700"
+      >
+        {gettext("All jobs with this tag")} →
+      </.link>
+    </div>
+    <div class="mt-3 grid gap-4 sm:grid-cols-2">
+      <.job_card :for={posting <- @open_positions} posting={posting} />
+    </div>
+  </section>
+</div>

--- a/lib/vutuv_web/views/tag_html.ex
+++ b/lib/vutuv_web/views/tag_html.ex
@@ -3,7 +3,7 @@ defmodule VutuvWeb.TagHTML do
   use VutuvWeb, :html
   import VutuvWeb.UserHelpers
   import VutuvWeb.JobComponents, only: [job_card: 1]
-  import VutuvWeb.PostComponents, only: [post_card: 1]
+  import VutuvWeb.PostComponents, only: [post_list: 1, post_thread_entry: 1, post_row_class: 0]
   alias Vutuv.Tags.Tag
 
   defp update_assigns(assigns) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.114.0",
+      version: "7.114.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/tag_controller_test.exs
+++ b/test/vutuv_web/controllers/tag_controller_test.exs
@@ -43,6 +43,9 @@ defmodule VutuvWeb.TagControllerTest do
       assert html =~ "tag-posts"
       assert html =~ "Elixir meetup notes"
       assert html =~ "/#{author.username}/posts/#{post.id}"
+      # The posts render as flat rows in one card (the feed/archive treatment),
+      # not separate full-width cards - keeps the desktop layout tidy.
+      assert html =~ "data-post-list"
     end
 
     test "the posts section is absent when no public post carries the tag", %{conn: conn} do


### PR DESCRIPTION
Follow-up to #965 (issue #946).

The new "Posts with this tag" section rendered each post as its own card at the full page width, so on a wide desktop every post stretched edge to edge — huge line length, action-bar icons flung to the corners, lots of dead space.

This matches the post archive / permalink layout instead:
- constrains the whole tag page to a centered `max-w-3xl` reading column, and
- renders the posts as flat divide-y rows inside one card via `<.post_thread_entry surface={:flat}>` — the same treatment the feed, the profile and the author archive use, so a reply nests the post it answers inline (with the connector rail) rather than a standalone "Replying to" banner.

Purely presentational — no new query or data. Verified in a real browser (desktop width): the column is readable, posts sit in one tidy card, and a real reply nests its parent inline. `mix.exs` bumped to 7.114.1 (patch).