### PR TITLE
Paginate the tag page's post list (#946 follow-up)

### DIFF
--- a/docs/architecture/search.md
+++ b/docs/architecture/search.md
@@ -42,6 +42,8 @@ posts out of the results is covered in [posts-and-feed.md](posts-and-feed.md).
 A `tag:` filter narrows the same `search_public/2` to posts carrying that tag
 (an `EXISTS` over `post_tags`, name/slug match), and a bare `tag:php` with no
 body words is a pure tag listing (newest first) — the post twin of the tag
-page's "Posts with this tag" section (`Vutuv.Posts.list_tag_posts/1`, issue
+page's "Posts with this tag" section (`Vutuv.Posts.list_tag_posts/3`, issue
 #946), which lists the public posts filed under a tag so a tag used only in
-posts no longer opens an empty page.
+posts no longer opens an empty page. The tag page offset-paginates those posts
+with the numbered `<.pager>` (`?page`, like the tag index); its front matter
+(description, most-endorsed members, jobs) rides only on page 1.

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -70,6 +70,7 @@ defmodule Vutuv.Posts do
   @default_thread_limit 100
   @pending_max_age_hours 24
   @max_tags 5
+  @tag_posts_per_page 20
 
   def max_images_per_post, do: Keyword.fetch!(config(), :max_per_post)
   def max_image_filesize, do: Keyword.fetch!(config(), :max_filesize)
@@ -977,28 +978,52 @@ defmodule Vutuv.Posts do
     where(query, [], exists(subquery(sub)))
   end
 
+  @doc "Posts per page in the tag page's \"Posts with this tag\" section (#946)."
+  def tag_posts_per_page, do: @tag_posts_per_page
+
   @doc """
-  The public posts carrying `tag`, newest first, for the tag page's "Posts
-  with this tag" section (issue #946). Anonymous view: only posts every
-  visitor may read surface (`scope_visible(nil)`), same gate as
+  How many public posts carry `tag` (the total behind the tag page's post
+  pager). Same anonymous-visibility gate as `list_tag_posts/3`.
+  """
+  def count_tag_posts(%Tag{} = tag) do
+    tag |> tag_posts_query() |> Repo.aggregate(:count)
+  end
+
+  @doc """
+  One page of the public posts carrying `tag`, newest first, for the tag
+  page's "Posts with this tag" section (issue #946). Anonymous view: only posts
+  every visitor may read surface (`scope_visible(nil)`), same gate as
   `search_public/2`. Matches the exact tag (its id), not a name substring —
   this is "posts filed under this tag", not a search. Preloaded like every
   rendered post.
-  """
-  def list_tag_posts(%Tag{} = tag, opts \\ []) do
-    limit = Keyword.get(opts, :limit, 20)
 
+  Offset-paginated from the `?page` param via `Vutuv.Pages` (like the tag
+  index and the member directory), `tag_posts_per_page/0` rows per page. Pass
+  `total:` (from `count_tag_posts/1`) to reuse a count the caller already has;
+  `per_page:` overrides the page size (tests). Both must match the `<.pager>`.
+  """
+  def list_tag_posts(%Tag{} = tag, params \\ %{}, opts \\ []) do
+    per_page = Keyword.get(opts, :per_page, @tag_posts_per_page)
+    total = Keyword.get(opts, :total) || count_tag_posts(tag)
+
+    tag
+    |> tag_posts_query()
+    |> order_by([p], desc: p.id)
+    |> Pages.paginate(params, total, per_page)
+    |> Repo.all()
+    |> Repo.preload(post_preloads())
+  end
+
+  # The public posts carrying `tag` (unordered, unpaginated), shared by the
+  # count and the page query so both apply the exact same visibility gate.
+  defp tag_posts_query(%Tag{} = tag) do
     from(p in Post,
       join: u in assoc(p, :user),
       join: pt in PostTag,
       on: pt.post_id == p.id,
-      where: pt.tag_id == ^tag.id and u.email_confirmed? == true,
-      order_by: [desc: p.id],
-      limit: ^limit
+      where: pt.tag_id == ^tag.id and u.email_confirmed? == true
     )
     |> scope_visible(nil)
-    |> Repo.all()
-    |> Repo.preload(post_preloads())
   end
 
   @doc """

--- a/lib/vutuv_web/agent_docs/list_docs.ex
+++ b/lib/vutuv_web/agent_docs/list_docs.ex
@@ -73,11 +73,20 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
   @doc """
   The tag page: description, the most endorsed members, the open positions
   (#933) and the public posts carrying the tag (#946). `posts` is a plain list
-  of preloaded `%Vutuv.Posts.Post{}` (from `Vutuv.Posts.list_tag_posts/1`),
-  rendered with the shared timeline-entry shape so the md / text formats read
-  a post the same way the feed and archive do.
+  of preloaded `%Vutuv.Posts.Post{}` (one offset page, from
+  `Vutuv.Posts.list_tag_posts/3`), rendered with the shared timeline-entry
+  shape so the md / text formats read a post the same way the feed and archive
+  do; `post_count` is the total across all pages. The overview (members / jobs)
+  rides only on page 1, so the caller passes `[]` for both on later pages.
   """
-  def build_tag(tag, recommended_users, work_info_by_id, open_positions \\ [], posts \\ []) do
+  def build_tag(
+        tag,
+        recommended_users,
+        work_info_by_id,
+        open_positions \\ [],
+        posts \\ [],
+        post_count \\ 0
+      ) do
     AgentDocs.doc_meta("tag", "/tags/#{tag.slug}")
     |> Map.merge(%{
       title: tag.name,
@@ -85,6 +94,7 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
       name: tag.name,
       slug: tag.slug,
       most_endorsed_users: Enum.map(recommended_users, &person_entry(&1, work_info_by_id)),
+      post_count: post_count,
       posts: Enum.map(posts, &PostDoc.timeline_entry(%{post: &1})),
       open_positions: Enum.map(open_positions, &JobPostingDoc.summary/1),
       jobs_url: AgentDocs.abs_url("/jobs?" <> URI.encode_query(%{"tag" => tag.slug}))

--- a/lib/vutuv_web/controllers/tag_controller.ex
+++ b/lib/vutuv_web/controllers/tag_controller.ex
@@ -2,6 +2,7 @@ defmodule VutuvWeb.TagController do
   use VutuvWeb, :controller
 
   alias Vutuv.Jobs
+  alias Vutuv.Pages
   alias Vutuv.Posts
   alias Vutuv.Tags.Tag
   alias VutuvWeb.AgentDocs
@@ -32,33 +33,44 @@ defmodule VutuvWeb.TagController do
   def show(conn, _params) do
     tag = conn.assigns[:tag]
 
-    # The tag page's "Offene Stellen" section (#933): live public postings that
-    # carry this tag. The HTML page subtracts what the signed-in viewer may not
-    # see (#939 exclusions / blocks); the agent formats stay the anonymous
-    # public view, so the two branches load their own list (only one runs).
-    #
-    # "Posts with this tag" (#946): the public posts carrying the tag, the
-    # anonymous view for both branches (`Posts.list_tag_posts/1` is
-    # viewer-independent), so a tag used only in posts no longer opens an
-    # empty page.
+    # "Posts with this tag" (#946) is offset-paginated (`?page`). The overview —
+    # description, most-endorsed members and the "Offene Stellen" jobs (#933) —
+    # is the tag's front matter, so it rides only on page 1; pages 2+ are just
+    # more posts. The post total is computed once and reused by both branches
+    # and the pager.
+    posts_total = Posts.count_tag_posts(tag)
+    first_page? = Pages.effective_page(conn.params, posts_total, Posts.tag_posts_per_page()) == 1
+
+    # The HTML page subtracts what the signed-in viewer may not see from the
+    # jobs (#939 exclusions / blocks); the agent formats stay the anonymous
+    # public view, so each branch loads its own list (only one runs).
     AgentDocs.respond(conn,
       html:
         &render(&1, "show.html",
           tag: tag,
-          open_positions: Jobs.list_tag_postings(tag, conn.assigns[:current_user]),
-          tag_posts: Posts.list_tag_posts(tag),
+          overview?: first_page?,
+          open_positions:
+            if(first_page?,
+              do: Jobs.list_tag_postings(tag, conn.assigns[:current_user]),
+              else: []
+            ),
+          tag_posts: Posts.list_tag_posts(tag, conn.params, total: posts_total),
+          posts_total: posts_total,
+          posts_per_page: Posts.tag_posts_per_page(),
           meta_description: gettext("Members on vutuv tagged %{tag}.", tag: tag.name || tag.slug)
         ),
       doc: fn ->
-        recommended = Tag.recommended_users(tag)
+        recommended = if first_page?, do: Tag.recommended_users(tag), else: []
         work_info_by_id = VutuvWeb.UserHelpers.work_information_map(recommended, 45)
+        jobs = if first_page?, do: Jobs.list_tag_postings(tag, nil), else: []
 
         ListDocs.build_tag(
           tag,
           recommended,
           work_info_by_id,
-          Jobs.list_tag_postings(tag, nil),
-          Posts.list_tag_posts(tag)
+          jobs,
+          Posts.list_tag_posts(tag, conn.params, total: posts_total),
+          posts_total
         )
       end
     )

--- a/lib/vutuv_web/templates/tag/show.html.heex
+++ b/lib/vutuv_web/templates/tag/show.html.heex
@@ -10,13 +10,16 @@ card stretch edge to edge with a huge line length and dead space. --%>
     ]}
   />
 
-  <div class="card-list">
+  <%!-- The tag's front matter (description, most-endorsed members, jobs) rides
+  only on page 1; pages 2+ of the post pager are just more posts. --%>
+  <div :if={@overview?} class="card-list">
     <%= render "single_card.html", assigns %>
   </div>
 
   <%!-- Posts carrying this tag (#946), rendered as flat divide-y rows inside one
   card via <.post_thread_entry> — the same treatment as the feed, the profile and
-  the author archive (a reply nests the post it answers inline). --%>
+  the author archive (a reply nests the post it answers inline). Offset-paginated
+  with the numbered <.pager>, like the tag index. --%>
   <section :if={@tag_posts != []} id="tag-posts" class="mt-6">
     <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
       {gettext("Posts with this tag")}
@@ -31,9 +34,10 @@ card stretch edge to edge with a huge line length and dead space. --%>
         />
       </div>
     </.post_list>
+    <.pager params={@conn.params} total={@posts_total} per_page={@posts_per_page} />
   </section>
 
-  <section :if={@open_positions != []} class="mt-6">
+  <section :if={@overview? and @open_positions != []} class="mt-6">
     <div class="flex items-center justify-between gap-2">
       <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
         {gettext("Open positions")}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.114.1",
+      version: "7.114.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/posts/list_tag_posts_test.exs
+++ b/test/vutuv/posts/list_tag_posts_test.exs
@@ -63,15 +63,38 @@ defmodule Vutuv.Posts.ListTagPostsTest do
     assert found.id == post.id
   end
 
-  test "respects the limit" do
+  test "count_tag_posts counts only the visible posts" do
     a = author()
-    for i <- 1..4, do: create_post!(a, %{body: "post #{i}", tags: "elixir"})
+    for i <- 1..3, do: create_post!(a, %{body: "post #{i}", tags: "elixir"})
 
-    assert length(Posts.list_tag_posts(tag_by_name("elixir"), limit: 2)) == 2
+    create_post!(a, %{
+      body: "hidden from strangers",
+      tags: "elixir",
+      denials: [%{"wildcard" => "everyone"}]
+    })
+
+    assert Posts.count_tag_posts(tag_by_name("elixir")) == 3
   end
 
-  test "an empty tag returns no posts" do
+  test "offset-paginates from the ?page param, newest first" do
+    a = author()
+    # Oldest -> newest; UUID v7 ids sort by creation, so p5 is newest.
+    posts = for i <- 1..5, do: create_post!(a, %{body: "post #{i}", tags: "elixir"})
+    [_p1, p2, p3, p4, p5] = posts
+    tag = tag_by_name("elixir")
+
+    page1 = Posts.list_tag_posts(tag, %{"page" => "1"}, per_page: 2)
+    page2 = Posts.list_tag_posts(tag, %{"page" => "2"}, per_page: 2)
+    page3 = Posts.list_tag_posts(tag, %{"page" => "3"}, per_page: 2)
+
+    assert Enum.map(page1, & &1.id) == [p5.id, p4.id]
+    assert Enum.map(page2, & &1.id) == [p3.id, p2.id]
+    assert length(page3) == 1
+  end
+
+  test "an empty tag returns no posts and a zero count" do
     tag = insert(:tag, name: "lonely", slug: "lonely")
     assert Posts.list_tag_posts(tag) == []
+    assert Posts.count_tag_posts(tag) == 0
   end
 end

--- a/test/vutuv_web/controllers/tag_controller_test.exs
+++ b/test/vutuv_web/controllers/tag_controller_test.exs
@@ -48,6 +48,42 @@ defmodule VutuvWeb.TagControllerTest do
       assert html =~ "data-post-list"
     end
 
+    test "posts are paginated; page 2 drops the overview and shows older posts", %{conn: conn} do
+      author = insert(:activated_user)
+      per_page = Vutuv.Posts.tag_posts_per_page()
+
+      tag =
+        insert(:tag, name: "Busy", slug: "busy", description: "A very busy tag indeed.")
+
+      # A recommended member so the overview card has visible content to gate on.
+      insert(:user_tag, tag: tag, user: insert(:activated_user))
+
+      posts =
+        for i <- 1..(per_page + 1) do
+          Vutuv.PostsHelpers.create_post!(author, %{body: "Busy post number #{i}", tags: "busy"})
+        end
+
+      # UUID v7 ids sort by creation, so the last-created is newest.
+      oldest = List.first(posts)
+      newest = List.last(posts)
+      oldest_link = "/#{author.username}/posts/#{oldest.id}"
+      newest_link = "/#{author.username}/posts/#{newest.id}"
+
+      # Page 1: the overview (description) shows, the newest post shows, the
+      # oldest is pushed to page 2, and there is a link to page 2.
+      page1 = conn |> get(~p"/tags/busy") |> html_response(200)
+      assert page1 =~ "A very busy tag indeed."
+      assert page1 =~ "page=2"
+      assert page1 =~ newest_link
+      refute page1 =~ oldest_link
+
+      # Page 2: the overview is gone and only the remaining (oldest) post shows.
+      page2 = conn |> get(~p"/tags/busy?page=2") |> html_response(200)
+      refute page2 =~ "A very busy tag indeed."
+      assert page2 =~ oldest_link
+      refute page2 =~ newest_link
+    end
+
     test "the posts section is absent when no public post carries the tag", %{conn: conn} do
       insert(:tag, name: "Empty", slug: "empty")
 


### PR DESCRIPTION
Follow-up to #965 / #966 (issue #946).

The "Posts with this tag" section listed only the newest 20 posts, with no hint there were more and no way to reach older ones — a silent ceiling on a busy tag (e.g. `#vutuv` already has 20+).

Adds in-place offset pagination with the numbered `<.pager>`, the same pattern the `/tags` index and the member directory use:
- `Vutuv.Posts.list_tag_posts/3` takes the `?page` param and pages through `Vutuv.Pages` (20/page); `count_tag_posts/1` gives the total behind the pager.
- The tag's front matter (description, most-endorsed members, "Offene Stellen" jobs) is the overview, so it rides only on page 1; pages 2+ are just more posts.
- The agent-format siblings (.md/.json/.xml) paginate the same way and carry a `post_count` total.

Verified in a real browser: page 1 shows the newest 20 + the "1 2" pager; page 2 drops the overview and shows the remaining posts. `mix.exs` bumped to 7.114.2, `mix precommit` green (4017 passing).