### PR TITLE
Restructure phone number types into a private/work landline & mobile set (#948)

### DIFF
--- a/lib/vutuv/imports/linked_in.ex
+++ b/lib/vutuv/imports/linked_in.ex
@@ -558,8 +558,9 @@ defmodule Vutuv.Imports.LinkedIn do
     case downcase(type) do
       "home" -> "Home"
       "work" -> "Work"
-      "fax" -> "Fax"
-      # mobile / cell / unknown all map to the default.
+      # Fax is no longer a vutuv type (issue #948); a fax line is a work number.
+      "fax" -> "Work"
+      # mobile / cell / unknown all map to the default (private mobile).
       _ -> "Cell"
     end
   end

--- a/lib/vutuv/profiles/phone_number.ex
+++ b/lib/vutuv/profiles/phone_number.ex
@@ -21,9 +21,13 @@ defmodule Vutuv.Profiles.PhoneNumber do
   @format_message ~s/Please enter a valid phone number/
   @requred_message ~s/This field is required/
 
-  # The allowed `number_type` labels, in the order the HTML form lists them.
+  # The allowed `number_type` labels, in the order the HTML form lists them: a
+  # private/work × landline/mobile matrix (issue #948). "Home"/"Cell" are the
+  # private landline / mobile, "Work"/"Work Cell" the work landline / mobile.
+  # Fax was dropped (obsolete); legacy "Fax"/other rows still display via
+  # `PhoneNumberHTML.phone_type_label/1` but can no longer be created or saved.
   # Mirrors Email.email_types: enforced in the schema, not just the <select>.
-  @number_types ~w(Work Cell Home Fax)
+  @number_types ["Home", "Cell", "Work", "Work Cell"]
 
   @doc "The allowed `number_type` values, in the order the forms list them."
   def number_types, do: @number_types

--- a/lib/vutuv_web/views/phone_number_html.ex
+++ b/lib/vutuv_web/views/phone_number_html.ex
@@ -4,15 +4,18 @@ defmodule VutuvWeb.PhoneNumberHTML do
   import VutuvWeb.UserHelpers
 
   @doc """
-  The stored type values are the English option values from the form
-  ("Work", "Cell", ...); render them through gettext so the page speaks the
-  visitor's language. Unknown legacy values pass through unchanged.
+  The stored type values are the English option values from the form ("Home",
+  "Cell", "Work", "Work Cell" since issue #948); render them through gettext so
+  the page speaks the visitor's language. "Fax" and any other unknown legacy
+  value still render (Fax is no longer offered, only grandfathered).
   """
+  # "Home" reuses the "Private" msgid ("Privat"), so the private landline no
+  # longer collides with the navigation "Home" ("Startseite") and needs no
+  # gettext context. "Cell" is the private mobile, "Work Cell" the work mobile.
+  def phone_type_label("Home"), do: gettext("Private")
+  def phone_type_label("Cell"), do: gettext("Private mobile")
   def phone_type_label("Work"), do: gettext("Work")
-  def phone_type_label("Cell"), do: gettext("Cell")
-  # "Home" is disambiguated from the navigation "Home" (Startseite): as a phone
-  # type it is the private/home number, "Privat" in German.
-  def phone_type_label("Home"), do: pgettext("phone number type", "Home")
+  def phone_type_label("Work Cell"), do: gettext("Work mobile")
   def phone_type_label("Fax"), do: gettext("Fax")
   def phone_type_label(other), do: other
 

--- a/lib/vutuv_web/views/user_html.ex
+++ b/lib/vutuv_web/views/user_html.ex
@@ -484,17 +484,18 @@ defmodule VutuvWeb.UserHTML do
   @doc """
   Splits the profile's contact channels into the Beruflich/Privat buckets the
   contact card shows. E-mails are work unless explicitly typed "Personal";
-  phone numbers count as private only when typed "Home" (so an unspecified
-  e-mail, defaulting to "Other", lands in work). Returns the non-empty groups
-  in `[work, private]` order, each `{label, emails, phones}` with e-mails before
-  phones (the card's row order). A single bucket renders without a heading.
+  phone numbers count as private when typed "Home" or "Cell" (private landline /
+  mobile, issue #948), so a work or unlabeled number lands in work. Returns the
+  non-empty groups in `[work, private]` order, each `{label, emails, phones}`
+  with e-mails before phones (the card's row order). A single bucket renders
+  without a heading.
   """
   def contact_groups(emails, phone_numbers) do
     {work_emails, private_emails} =
       Enum.split_with(emails, fn email -> email.email_type != "Personal" end)
 
     {private_phones, work_phones} =
-      Enum.split_with(phone_numbers, fn number -> number.number_type == "Home" end)
+      Enum.split_with(phone_numbers, fn number -> number.number_type in ["Home", "Cell"] end)
 
     [{:work, work_emails, work_phones}, {:private, private_emails, private_phones}]
     |> Enum.reject(fn {_label, group_emails, group_phones} ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.114.3",
+      version: "7.115.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -71,7 +71,7 @@ msgstr "Eine Adresse wurde geändert."
 msgid "Addresses"
 msgstr "Adressen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:173
+#: lib/vutuv_web/templates/page/index.html.heex:171
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
@@ -130,11 +130,6 @@ msgid "Cannot delete final email."
 msgstr ""
 "Eine E-Mail-Adresse muss immer vorhanden sein. Diese kann nicht gelöscht "
 "werden."
-
-#: lib/vutuv_web/views/phone_number_html.ex:12
-#, elixir-autogen
-msgid "Cell"
-msgstr "Mobil-Telefon"
 
 #: lib/vutuv_web/templates/phone_number/form_content.html.heex:12
 #, elixir-autogen
@@ -278,18 +273,18 @@ msgstr "Empfehlung eingetragen."
 msgid "English"
 msgstr "Englisch"
 
-#: lib/vutuv_web/templates/page/index.html.heex:116
+#: lib/vutuv_web/templates/page/index.html.heex:114
 #: lib/vutuv_web/templates/session/new.html.heex:37
 #, elixir-autogen
 msgid "Enter your email address"
 msgstr "E-Mail-Adresse eingeben"
 
-#: lib/vutuv_web/templates/page/index.html.heex:77
+#: lib/vutuv_web/templates/page/index.html.heex:75
 #, elixir-autogen
 msgid "Enter your first name"
 msgstr "Vorname eingeben"
 
-#: lib/vutuv_web/templates/page/index.html.heex:81
+#: lib/vutuv_web/templates/page/index.html.heex:79
 #, elixir-autogen
 msgid "Enter your last name"
 msgstr "Nachname eingeben"
@@ -310,7 +305,7 @@ msgstr "Nachname eingeben"
 msgid "Experience"
 msgstr "Lebenslauf"
 
-#: lib/vutuv_web/views/phone_number_html.ex:16
+#: lib/vutuv_web/views/phone_number_html.ex:19
 #, elixir-autogen
 msgid "Fax"
 msgstr "Fax"
@@ -353,7 +348,7 @@ msgstr "Folge ich"
 #: lib/vutuv_web/cv/odt.ex:109
 #: lib/vutuv_web/live/cv_live.ex:113
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
-#: lib/vutuv_web/templates/page/index.html.heex:64
+#: lib/vutuv_web/templates/page/index.html.heex:62
 #: lib/vutuv_web/templates/user/edit.html.heex:125
 #: lib/vutuv_web/templates/user/show.html.heex:783
 #, elixir-autogen
@@ -377,12 +372,6 @@ msgstr "Ihr gratis Account ist in nicht mal 30 Sekunden fertig."
 #, elixir-autogen
 msgid "Home"
 msgstr "Startseite"
-
-#: lib/vutuv_web/views/phone_number_html.ex:15
-#, elixir-autogen
-msgctxt "phone number type"
-msgid "Home"
-msgstr "Privat"
 
 #: web/templates/followee/index.html.eex:21
 msgid "It doesn't look like you're following anyone yet. Find someone a profile of someone you know, or someone you're interested in, and click the follow button!"
@@ -608,6 +597,7 @@ msgstr "Datenschutzerklärung"
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
+#: lib/vutuv_web/views/phone_number_html.ex:15
 #, elixir-autogen
 msgid "Private"
 msgstr "Privat"
@@ -676,13 +666,13 @@ msgstr "Suche"
 
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
-#: lib/vutuv_web/templates/tag/show.html.heex:5
+#: lib/vutuv_web/templates/tag/show.html.heex:9
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
 #, elixir-autogen
 msgid "Show"
 msgstr "Anzeigen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:152
+#: lib/vutuv_web/templates/page/index.html.heex:150
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr "Gratis Account erstellen"
@@ -883,7 +873,7 @@ msgstr "Sichtbarkeit"
 msgid "We can't find em' cap'n!"
 msgstr "Nichts zu finden, Käpt'n!"
 
-#: lib/vutuv_web/templates/page/index.html.heex:176
+#: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -896,9 +886,9 @@ msgid "Welcome back!"
 msgstr "Willkommen zurück!"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:42
+#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/email_html.ex:11
-#: lib/vutuv_web/views/phone_number_html.ex:11
+#: lib/vutuv_web/views/phone_number_html.ex:17
 #, elixir-autogen
 msgid "Work"
 msgstr "Arbeit"
@@ -964,12 +954,12 @@ msgstr "unserem Blog"
 msgid "An email has been sent to your email address with instructions on how to delete your account."
 msgstr "Eine E-Mail mit einem Löschlink wurde gerade an Sie verschickt."
 
-#: lib/vutuv_web/templates/page/index.html.heex:124
+#: lib/vutuv_web/templates/page/index.html.heex:122
 #, elixir-autogen
 msgid "Allow others to view your email address"
 msgstr "Diese E-Mail-Adresse soll auf meinem Profil öffentlich sichtbar sein."
 
-#: lib/vutuv_web/templates/page/index.html.heex:162
+#: lib/vutuv_web/templates/page/index.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1181,7 +1171,7 @@ msgstr "User mit den meisten Followern"
 msgid "The 1,000 Users with the most Followers"
 msgstr "Die 1.000 User mit den meisten Followern"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:134
+#: lib/vutuv_web/agent_docs/list_docs.ex:144
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
 msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
@@ -1231,19 +1221,19 @@ msgstr "Die Suche nach Vor- und Nachnamen ist fuzzy (unscharf)."
 msgid "Search Tips"
 msgstr "Hilfe bei der Suche"
 
-#: lib/vutuv_web/templates/page/index.html.heex:41
+#: lib/vutuv_web/templates/page/index.html.heex:39
 #: lib/vutuv_web/templates/user/edit.html.heex:126
 #, elixir-autogen
 msgid "female"
 msgstr "weiblich"
 
-#: lib/vutuv_web/templates/page/index.html.heex:41
+#: lib/vutuv_web/templates/page/index.html.heex:39
 #: lib/vutuv_web/templates/user/edit.html.heex:126
 #, elixir-autogen
 msgid "male"
 msgstr "männlich"
 
-#: lib/vutuv_web/templates/page/index.html.heex:41
+#: lib/vutuv_web/templates/page/index.html.heex:39
 #: lib/vutuv_web/templates/user/edit.html.heex:126
 #, elixir-autogen
 msgid "other"
@@ -1512,7 +1502,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/import/preview.html.heex:36
 #: lib/vutuv_web/templates/invitation/new.html.heex:64
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/tag/show.html.heex:4
+#: lib/vutuv_web/templates/tag/show.html.heex:8
 #: lib/vutuv_web/templates/user/show.html.heex:429
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:10
@@ -1756,7 +1746,7 @@ msgstr "Kontolöschung bestätigen"
 
 #: lib/vutuv_web/controllers/page_controller.ex:75
 #: lib/vutuv_web/templates/layout/app.html.heex:89
-#: lib/vutuv_web/templates/page/index.html.heex:169
+#: lib/vutuv_web/templates/page/index.html.heex:167
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
@@ -1764,7 +1754,7 @@ msgstr "Datenschutzerklärung"
 
 #: lib/vutuv_web/controllers/page_controller.ex:81
 #: lib/vutuv_web/templates/layout/app.html.heex:91
-#: lib/vutuv_web/templates/page/index.html.heex:169
+#: lib/vutuv_web/templates/page/index.html.heex:167
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -2318,13 +2308,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1093
-#: lib/vutuv_web/components/post_components.ex:1097
+#: lib/vutuv_web/components/post_components.ex:1075
+#: lib/vutuv_web/components/post_components.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:1094
+#: lib/vutuv_web/components/post_components.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
@@ -2422,22 +2412,22 @@ msgstr "Was gibt's Neues? Markdown wird unterstützt."
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:1303
+#: lib/vutuv_web/components/post_components.ex:1331
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:1307
+#: lib/vutuv_web/components/post_components.ex:1335
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:1305
+#: lib/vutuv_web/components/post_components.ex:1333
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:1306
+#: lib/vutuv_web/components/post_components.ex:1334
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2478,7 +2468,7 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1375
+#: lib/vutuv_web/components/post_components.ex:1403
 #: lib/vutuv_web/components/ui.ex:1563
 #: lib/vutuv_web/components/ui.ex:1563
 #: lib/vutuv_web/components/ui.ex:2171
@@ -2497,7 +2487,7 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1342
+#: lib/vutuv_web/components/post_components.ex:1370
 #: lib/vutuv_web/components/ui.ex:1592
 #: lib/vutuv_web/components/ui.ex:1592
 #: lib/vutuv_web/components/ui.ex:2157
@@ -2526,12 +2516,12 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:1364
+#: lib/vutuv_web/components/post_components.ex:1392
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1375
+#: lib/vutuv_web/components/post_components.ex:1403
 #: lib/vutuv_web/components/ui.ex:1553
 #: lib/vutuv_web/components/ui.ex:1553
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2540,23 +2530,23 @@ msgstr "Nur öffentliche Beiträge können repostet werden."
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1361
+#: lib/vutuv_web/components/post_components.ex:1389
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1182
+#: lib/vutuv_web/components/post_components.ex:1210
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1361
+#: lib/vutuv_web/components/post_components.ex:1389
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:1342
+#: lib/vutuv_web/components/post_components.ex:1370
 #: lib/vutuv_web/components/ui.ex:1582
 #: lib/vutuv_web/components/ui.ex:1582
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2577,7 +2567,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:1415
+#: lib/vutuv_web/components/post_components.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2589,8 +2579,8 @@ msgstr "Nur öffentliche Beiträge können beantwortet werden."
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1398
-#: lib/vutuv_web/components/post_components.ex:1399
+#: lib/vutuv_web/components/post_components.ex:1426
+#: lib/vutuv_web/components/post_components.ex:1427
 #: lib/vutuv_web/live/notification_live/index.ex:207
 #: lib/vutuv_web/live/notification_live/index.ex:299
 #: lib/vutuv_web/live/post_live/reply.ex:25
@@ -2725,7 +2715,7 @@ msgstr "Diese Nachricht konnte nicht gesendet werden."
 msgid "Too many new conversations. Please try again later."
 msgstr "Zu viele neue Unterhaltungen. Bitte versuchen Sie es später erneut."
 
-#: lib/vutuv_web/templates/page/index.html.heex:33
+#: lib/vutuv_web/templates/page/index.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Create your free account"
 msgstr "Erstellen Sie Ihren Account"
@@ -2757,19 +2747,20 @@ msgstr "Hier registrieren."
 msgid "Welcome back"
 msgstr "Willkommen zurück!"
 
-#: lib/vutuv_web/templates/page/index.html.heex:6
+#: lib/vutuv_web/templates/page/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Founder of vutuv"
 msgstr "Gründer von vutuv"
 
 #: lib/vutuv_web/templates/page/index.html.heex:1
+#: lib/vutuv_web/templates/page/index.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "“Tired of LinkedIn, and want your data to stay in Germany? I can help.”"
 msgstr ""
 "„Genervt von LinkedIn und Ihre Daten sollen in Deutschland bleiben? Da kann"
 " ich helfen.“"
 
-#: lib/vutuv_web/templates/page/index.html.heex:142
+#: lib/vutuv_web/templates/page/index.html.heex:140
 #: lib/vutuv_web/templates/settings/privacy.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
@@ -2938,7 +2929,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:1304
+#: lib/vutuv_web/components/post_components.ex:1332
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -4078,7 +4069,7 @@ msgstr "Mitglied seit"
 msgid "Most endorsed members"
 msgstr "Am häufigsten empfohlene Mitglieder"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:132
+#: lib/vutuv_web/agent_docs/list_docs.ex:142
 #, elixir-autogen, elixir-format
 msgid "Most followed members"
 msgstr "Mitglieder mit den meisten Followern"
@@ -5479,7 +5470,7 @@ msgstr ""
 "Webhook-Dokumentation). Nur https://; http://localhost ist für die "
 "Entwicklung erlaubt."
 
-#: lib/vutuv_web/templates/page/index.html.heex:147
+#: lib/vutuv_web/templates/page/index.html.heex:145
 #: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
@@ -5670,8 +5661,8 @@ msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
 #: lib/vutuv_web/components/post_components.ex:774
-#: lib/vutuv_web/components/post_components.ex:825
-#: lib/vutuv_web/components/post_components.ex:838
+#: lib/vutuv_web/components/post_components.ex:828
+#: lib/vutuv_web/components/post_components.ex:1137
 #: lib/vutuv_web/live/post_live/feed.ex:672
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5682,7 +5673,7 @@ msgstr "Beitrag ansehen"
 msgid "Someone tried to register with your email address"
 msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
 
-#: lib/vutuv_web/templates/page/index.html.heex:86
+#: lib/vutuv_web/templates/page/index.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr "Ihre Tags (z.B. JavaScript, Kochen, Origami, Katze)"
@@ -5693,7 +5684,7 @@ msgid "Diverse"
 msgstr "divers"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:42
+#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/directory_html.ex:8
 #: lib/vutuv_web/views/email_html.ex:13
 #: lib/vutuv_web/views/invitation_html.ex:18
@@ -5702,9 +5693,9 @@ msgid "Other"
 msgstr "Andere"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:42
+#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:507
+#: lib/vutuv_web/views/user_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Privat"
@@ -5714,7 +5705,7 @@ msgstr "Privat"
 msgid "Type of Email"
 msgstr "Art der E-Mail"
 
-#: lib/vutuv_web/templates/page/index.html.heex:104
+#: lib/vutuv_web/templates/page/index.html.heex:102
 #, elixir-autogen, elixir-format
 msgid "Type of email address"
 msgstr "Art der E-Mail-Adresse"
@@ -6583,7 +6574,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr "Empfohlen am"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:105
+#: lib/vutuv_web/agent_docs/list_docs.ex:115
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -6948,7 +6939,7 @@ msgstr "Zum Profil, um zu folgen"
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
 
-#: lib/vutuv_web/views/user_html.ex:506
+#: lib/vutuv_web/views/user_html.ex:507
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr "Beruflich"
@@ -8937,14 +8928,14 @@ msgstr ""
 "Alle %{count} Mitglieder, deren Profile für Suchmaschinen freigegeben sind, "
 "alphabetisch nach Nachnamen sortiert."
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:151
+#: lib/vutuv_web/agent_docs/list_docs.ex:161
 #, elixir-autogen, elixir-format
 msgid "All members who allow search engines to index their profile, grouped by the first letter of their last name."
 msgstr ""
 "Alle Mitglieder, die die Indexierung ihres Profils durch Suchmaschinen "
 "erlauben, gruppiert nach dem Anfangsbuchstaben des Nachnamens."
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:149
+#: lib/vutuv_web/agent_docs/list_docs.ex:159
 #: lib/vutuv_web/controllers/directory_controller.ex:28
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8960,7 +8951,7 @@ msgstr "Mitgliederverzeichnis"
 msgid "Members by initial"
 msgstr "Mitglieder nach Anfangsbuchstaben"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:168
+#: lib/vutuv_web/agent_docs/list_docs.ex:178
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8979,7 +8970,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] "Ein Mitglied"
 msgstr[1] "%{formatted} Mitglieder"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:174
+#: lib/vutuv_web/agent_docs/list_docs.ex:184
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -9292,7 +9283,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:1185
+#: lib/vutuv_web/components/post_components.ex:1213
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -11204,7 +11195,7 @@ msgstr ""
 "Verwalten Sie Ihr vutuv-Konto: Profil, Privatsphäre, Benachrichtigungen und "
 "Anmeldung."
 
-#: lib/vutuv_web/controllers/tag_controller.ex:50
+#: lib/vutuv_web/controllers/tag_controller.ex:60
 #, elixir-autogen, elixir-format
 msgid "Members on vutuv tagged %{tag}."
 msgstr "Mitglieder auf vutuv mit dem Tag %{tag}."
@@ -11251,7 +11242,7 @@ msgstr ""
 "vutuv ist das offene Business-Netzwerk. Fachleute vernetzen sich, tauschen "
 "sich aus und werden gefunden. Kostenlos dabei."
 
-#: lib/vutuv_web/templates/page/index.html.heex:93
+#: lib/vutuv_web/templates/page/index.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "At least three tags, separated by a comma or a space. Multi-word tags go in quotes: \"Ruby on Rails\"."
 msgstr ""
@@ -13534,7 +13525,7 @@ msgid "All countries"
 msgstr "Alle Länder"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:362
-#: lib/vutuv_web/templates/tag/show.html.heex:37
+#: lib/vutuv_web/templates/tag/show.html.heex:49
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Alle Stellen mit diesem Tag"
@@ -13600,7 +13591,7 @@ msgstr "Keine passenden Stellen. Passe die Filter an."
 #: lib/vutuv_web/agent_docs/text.ex:393
 #: lib/vutuv_web/agent_docs/text.ex:405
 #: lib/vutuv_web/live/organization_live/show.ex:329
-#: lib/vutuv_web/templates/tag/show.html.heex:31
+#: lib/vutuv_web/templates/tag/show.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Open positions"
 msgstr "Offene Stellen"
@@ -14163,7 +14154,7 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "An image was removed from your vutuv account"
 msgstr "Ein Bild wurde aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/components/post_components.ex:910
+#: lib/vutuv_web/components/post_components.ex:892
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -14171,7 +14162,7 @@ msgstr "Ein Bild wurde aus Ihrem vutuv-Konto entfernt"
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:900
+#: lib/vutuv_web/components/post_components.ex:882
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr "Bild wird geprüft"
@@ -14318,7 +14309,7 @@ msgstr "In den Text einfügen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:166
 #: lib/vutuv_web/agent_docs/text.ex:163
-#: lib/vutuv_web/templates/tag/show.html.heex:15
+#: lib/vutuv_web/templates/tag/show.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr "Beiträge mit diesem Tag"
@@ -14334,3 +14325,13 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "people and posts with this tag, combinable: miller tag:php"
 msgstr "Personen und Beiträge mit diesem Tag, kombinierbar: müller tag:php"
+
+#: lib/vutuv_web/views/phone_number_html.ex:16
+#, elixir-autogen, elixir-format
+msgid "Private mobile"
+msgstr "Mobil (privat)"
+
+#: lib/vutuv_web/views/phone_number_html.ex:18
+#, elixir-autogen, elixir-format
+msgid "Work mobile"
+msgstr "Mobil (Arbeit)"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:173
+#: lib/vutuv_web/templates/page/index.html.heex:171
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
@@ -129,11 +129,6 @@ msgstr ""
 #: lib/vutuv_web/controllers/email_controller.ex:255
 #, elixir-autogen
 msgid "Cannot delete final email."
-msgstr ""
-
-#: lib/vutuv_web/views/phone_number_html.ex:12
-#, elixir-autogen
-msgid "Cell"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/form_content.html.heex:12
@@ -278,18 +273,18 @@ msgstr ""
 msgid "English"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:116
+#: lib/vutuv_web/templates/page/index.html.heex:114
 #: lib/vutuv_web/templates/session/new.html.heex:37
 #, elixir-autogen
 msgid "Enter your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:77
+#: lib/vutuv_web/templates/page/index.html.heex:75
 #, elixir-autogen
 msgid "Enter your first name"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:81
+#: lib/vutuv_web/templates/page/index.html.heex:79
 #, elixir-autogen
 msgid "Enter your last name"
 msgstr ""
@@ -310,7 +305,7 @@ msgstr ""
 msgid "Experience"
 msgstr ""
 
-#: lib/vutuv_web/views/phone_number_html.ex:16
+#: lib/vutuv_web/views/phone_number_html.ex:19
 #, elixir-autogen
 msgid "Fax"
 msgstr ""
@@ -353,7 +348,7 @@ msgstr ""
 #: lib/vutuv_web/cv/odt.ex:109
 #: lib/vutuv_web/live/cv_live.ex:113
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
-#: lib/vutuv_web/templates/page/index.html.heex:64
+#: lib/vutuv_web/templates/page/index.html.heex:62
 #: lib/vutuv_web/templates/user/edit.html.heex:125
 #: lib/vutuv_web/templates/user/show.html.heex:783
 #, elixir-autogen
@@ -375,12 +370,6 @@ msgstr ""
 #: lib/vutuv_web/templates/layout/app.html.heex:115
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:2
 #, elixir-autogen
-msgid "Home"
-msgstr ""
-
-#: lib/vutuv_web/views/phone_number_html.ex:15
-#, elixir-autogen
-msgctxt "phone number type"
 msgid "Home"
 msgstr ""
 
@@ -608,6 +597,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
+#: lib/vutuv_web/views/phone_number_html.ex:15
 #, elixir-autogen
 msgid "Private"
 msgstr ""
@@ -676,13 +666,13 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
-#: lib/vutuv_web/templates/tag/show.html.heex:5
+#: lib/vutuv_web/templates/tag/show.html.heex:9
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
 #, elixir-autogen
 msgid "Show"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:152
+#: lib/vutuv_web/templates/page/index.html.heex:150
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr ""
@@ -880,7 +870,7 @@ msgstr ""
 msgid "We can't find em' cap'n!"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:176
+#: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -891,9 +881,9 @@ msgid "Welcome back!"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:42
+#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/email_html.ex:11
-#: lib/vutuv_web/views/phone_number_html.ex:11
+#: lib/vutuv_web/views/phone_number_html.ex:17
 #, elixir-autogen
 msgid "Work"
 msgstr ""
@@ -955,12 +945,12 @@ msgstr ""
 msgid "An email has been sent to your email address with instructions on how to delete your account."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:124
+#: lib/vutuv_web/templates/page/index.html.heex:122
 #, elixir-autogen
 msgid "Allow others to view your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:162
+#: lib/vutuv_web/templates/page/index.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1159,7 +1149,7 @@ msgstr ""
 msgid "The 1,000 Users with the most Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:134
+#: lib/vutuv_web/agent_docs/list_docs.ex:144
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
 msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
@@ -1206,19 +1196,19 @@ msgstr ""
 msgid "Search Tips"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:41
+#: lib/vutuv_web/templates/page/index.html.heex:39
 #: lib/vutuv_web/templates/user/edit.html.heex:126
 #, elixir-autogen
 msgid "female"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:41
+#: lib/vutuv_web/templates/page/index.html.heex:39
 #: lib/vutuv_web/templates/user/edit.html.heex:126
 #, elixir-autogen
 msgid "male"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:41
+#: lib/vutuv_web/templates/page/index.html.heex:39
 #: lib/vutuv_web/templates/user/edit.html.heex:126
 #, elixir-autogen
 msgid "other"
@@ -1484,7 +1474,7 @@ msgstr ""
 #: lib/vutuv_web/templates/import/preview.html.heex:36
 #: lib/vutuv_web/templates/invitation/new.html.heex:64
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/tag/show.html.heex:4
+#: lib/vutuv_web/templates/tag/show.html.heex:8
 #: lib/vutuv_web/templates/user/show.html.heex:429
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:10
@@ -1723,7 +1713,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:75
 #: lib/vutuv_web/templates/layout/app.html.heex:89
-#: lib/vutuv_web/templates/page/index.html.heex:169
+#: lib/vutuv_web/templates/page/index.html.heex:167
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
@@ -1731,7 +1721,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:81
 #: lib/vutuv_web/templates/layout/app.html.heex:91
-#: lib/vutuv_web/templates/page/index.html.heex:169
+#: lib/vutuv_web/templates/page/index.html.heex:167
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -2270,13 +2260,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1093
-#: lib/vutuv_web/components/post_components.ex:1097
+#: lib/vutuv_web/components/post_components.ex:1075
+#: lib/vutuv_web/components/post_components.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1094
+#: lib/vutuv_web/components/post_components.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2372,22 +2362,22 @@ msgstr ""
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1303
+#: lib/vutuv_web/components/post_components.ex:1331
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1307
+#: lib/vutuv_web/components/post_components.ex:1335
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1305
+#: lib/vutuv_web/components/post_components.ex:1333
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1306
+#: lib/vutuv_web/components/post_components.ex:1334
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2428,7 +2418,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1375
+#: lib/vutuv_web/components/post_components.ex:1403
 #: lib/vutuv_web/components/ui.ex:1563
 #: lib/vutuv_web/components/ui.ex:1563
 #: lib/vutuv_web/components/ui.ex:2171
@@ -2447,7 +2437,7 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1342
+#: lib/vutuv_web/components/post_components.ex:1370
 #: lib/vutuv_web/components/ui.ex:1592
 #: lib/vutuv_web/components/ui.ex:1592
 #: lib/vutuv_web/components/ui.ex:2157
@@ -2476,12 +2466,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1364
+#: lib/vutuv_web/components/post_components.ex:1392
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1375
+#: lib/vutuv_web/components/post_components.ex:1403
 #: lib/vutuv_web/components/ui.ex:1553
 #: lib/vutuv_web/components/ui.ex:1553
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2490,23 +2480,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1361
+#: lib/vutuv_web/components/post_components.ex:1389
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1182
+#: lib/vutuv_web/components/post_components.ex:1210
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1361
+#: lib/vutuv_web/components/post_components.ex:1389
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1342
+#: lib/vutuv_web/components/post_components.ex:1370
 #: lib/vutuv_web/components/ui.ex:1582
 #: lib/vutuv_web/components/ui.ex:1582
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2527,7 +2517,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1415
+#: lib/vutuv_web/components/post_components.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2539,8 +2529,8 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1398
-#: lib/vutuv_web/components/post_components.ex:1399
+#: lib/vutuv_web/components/post_components.ex:1426
+#: lib/vutuv_web/components/post_components.ex:1427
 #: lib/vutuv_web/live/notification_live/index.ex:207
 #: lib/vutuv_web/live/notification_live/index.ex:299
 #: lib/vutuv_web/live/post_live/reply.ex:25
@@ -2671,7 +2661,7 @@ msgstr ""
 msgid "Too many new conversations. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:33
+#: lib/vutuv_web/templates/page/index.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Create your free account"
 msgstr ""
@@ -2701,17 +2691,18 @@ msgstr ""
 msgid "Welcome back"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:6
+#: lib/vutuv_web/templates/page/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Founder of vutuv"
 msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:1
+#: lib/vutuv_web/templates/page/index.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "“Tired of LinkedIn, and want your data to stay in Germany? I can help.”"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:142
+#: lib/vutuv_web/templates/page/index.html.heex:140
 #: lib/vutuv_web/templates/settings/privacy.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
@@ -2878,7 +2869,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1304
+#: lib/vutuv_web/components/post_components.ex:1332
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3937,7 +3928,7 @@ msgstr ""
 msgid "Most endorsed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:132
+#: lib/vutuv_web/agent_docs/list_docs.ex:142
 #, elixir-autogen, elixir-format
 msgid "Most followed members"
 msgstr ""
@@ -5246,7 +5237,7 @@ msgstr ""
 msgid "vutuv POSTs signed JSON envelopes here (see the webhooks documentation). https:// only; http://localhost is allowed for development."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:147
+#: lib/vutuv_web/templates/page/index.html.heex:145
 #: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
@@ -5430,8 +5421,8 @@ msgid "Footer navigation"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:774
-#: lib/vutuv_web/components/post_components.ex:825
-#: lib/vutuv_web/components/post_components.ex:838
+#: lib/vutuv_web/components/post_components.ex:828
+#: lib/vutuv_web/components/post_components.ex:1137
 #: lib/vutuv_web/live/post_live/feed.ex:672
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5442,7 +5433,7 @@ msgstr ""
 msgid "Someone tried to register with your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:86
+#: lib/vutuv_web/templates/page/index.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
@@ -5453,7 +5444,7 @@ msgid "Diverse"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:42
+#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/directory_html.ex:8
 #: lib/vutuv_web/views/email_html.ex:13
 #: lib/vutuv_web/views/invitation_html.ex:18
@@ -5462,9 +5453,9 @@ msgid "Other"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:42
+#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:507
+#: lib/vutuv_web/views/user_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -5474,7 +5465,7 @@ msgstr ""
 msgid "Type of Email"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:104
+#: lib/vutuv_web/templates/page/index.html.heex:102
 #, elixir-autogen, elixir-format
 msgid "Type of email address"
 msgstr ""
@@ -6314,7 +6305,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:105
+#: lib/vutuv_web/agent_docs/list_docs.ex:115
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -6649,7 +6640,7 @@ msgstr ""
 msgid "Mute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:506
+#: lib/vutuv_web/views/user_html.ex:507
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
@@ -8497,12 +8488,12 @@ msgstr ""
 msgid "All %{count} members whose profiles are open to search engines, filed alphabetically by last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:151
+#: lib/vutuv_web/agent_docs/list_docs.ex:161
 #, elixir-autogen, elixir-format
 msgid "All members who allow search engines to index their profile, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:149
+#: lib/vutuv_web/agent_docs/list_docs.ex:159
 #: lib/vutuv_web/controllers/directory_controller.ex:28
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8518,7 +8509,7 @@ msgstr ""
 msgid "Members by initial"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:168
+#: lib/vutuv_web/agent_docs/list_docs.ex:178
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8537,7 +8528,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:174
+#: lib/vutuv_web/agent_docs/list_docs.ex:184
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -8811,7 +8802,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1185
+#: lib/vutuv_web/components/post_components.ex:1213
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -10599,7 +10590,7 @@ msgstr ""
 msgid "Manage your vutuv account: profile, privacy, notifications and sign-in."
 msgstr ""
 
-#: lib/vutuv_web/controllers/tag_controller.ex:50
+#: lib/vutuv_web/controllers/tag_controller.ex:60
 #, elixir-autogen, elixir-format
 msgid "Members on vutuv tagged %{tag}."
 msgstr ""
@@ -10644,7 +10635,7 @@ msgstr ""
 msgid "vutuv is the open business network where professionals connect, share, and get found. Free to join."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:93
+#: lib/vutuv_web/templates/page/index.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "At least three tags, separated by a comma or a space. Multi-word tags go in quotes: \"Ruby on Rails\"."
 msgstr ""
@@ -12807,7 +12798,7 @@ msgid "All countries"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:362
-#: lib/vutuv_web/templates/tag/show.html.heex:37
+#: lib/vutuv_web/templates/tag/show.html.heex:49
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
@@ -12873,7 +12864,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:393
 #: lib/vutuv_web/agent_docs/text.ex:405
 #: lib/vutuv_web/live/organization_live/show.ex:329
-#: lib/vutuv_web/templates/tag/show.html.heex:31
+#: lib/vutuv_web/templates/tag/show.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Open positions"
 msgstr ""
@@ -13436,7 +13427,7 @@ msgstr ""
 msgid "An image was removed from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:910
+#: lib/vutuv_web/components/post_components.ex:892
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -13444,7 +13435,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:900
+#: lib/vutuv_web/components/post_components.ex:882
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr ""
@@ -13591,7 +13582,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:166
 #: lib/vutuv_web/agent_docs/text.ex:163
-#: lib/vutuv_web/templates/tag/show.html.heex:15
+#: lib/vutuv_web/templates/tag/show.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr ""
@@ -13604,4 +13595,14 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "people and posts with this tag, combinable: miller tag:php"
+msgstr ""
+
+#: lib/vutuv_web/views/phone_number_html.ex:16
+#, elixir-autogen, elixir-format
+msgid "Private mobile"
+msgstr ""
+
+#: lib/vutuv_web/views/phone_number_html.ex:18
+#, elixir-autogen, elixir-format
+msgid "Work mobile"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -71,7 +71,7 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:173
+#: lib/vutuv_web/templates/page/index.html.heex:171
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
@@ -127,11 +127,6 @@ msgstr ""
 #: lib/vutuv_web/controllers/email_controller.ex:255
 #, elixir-autogen
 msgid "Cannot delete final email."
-msgstr ""
-
-#: lib/vutuv_web/views/phone_number_html.ex:12
-#, elixir-autogen
-msgid "Cell"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/form_content.html.heex:12
@@ -276,18 +271,18 @@ msgstr ""
 msgid "English"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:116
+#: lib/vutuv_web/templates/page/index.html.heex:114
 #: lib/vutuv_web/templates/session/new.html.heex:37
 #, elixir-autogen
 msgid "Enter your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:77
+#: lib/vutuv_web/templates/page/index.html.heex:75
 #, elixir-autogen
 msgid "Enter your first name"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:81
+#: lib/vutuv_web/templates/page/index.html.heex:79
 #, elixir-autogen
 msgid "Enter your last name"
 msgstr ""
@@ -308,7 +303,7 @@ msgstr ""
 msgid "Experience"
 msgstr ""
 
-#: lib/vutuv_web/views/phone_number_html.ex:16
+#: lib/vutuv_web/views/phone_number_html.ex:19
 #, elixir-autogen
 msgid "Fax"
 msgstr ""
@@ -351,7 +346,7 @@ msgstr ""
 #: lib/vutuv_web/cv/odt.ex:109
 #: lib/vutuv_web/live/cv_live.ex:113
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
-#: lib/vutuv_web/templates/page/index.html.heex:64
+#: lib/vutuv_web/templates/page/index.html.heex:62
 #: lib/vutuv_web/templates/user/edit.html.heex:125
 #: lib/vutuv_web/templates/user/show.html.heex:783
 #, elixir-autogen
@@ -373,12 +368,6 @@ msgstr ""
 #: lib/vutuv_web/templates/layout/app.html.heex:115
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:2
 #, elixir-autogen
-msgid "Home"
-msgstr ""
-
-#: lib/vutuv_web/views/phone_number_html.ex:15
-#, elixir-autogen
-msgctxt "phone number type"
 msgid "Home"
 msgstr ""
 
@@ -606,6 +595,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
+#: lib/vutuv_web/views/phone_number_html.ex:15
 #, elixir-autogen
 msgid "Private"
 msgstr ""
@@ -674,13 +664,13 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
-#: lib/vutuv_web/templates/tag/show.html.heex:5
+#: lib/vutuv_web/templates/tag/show.html.heex:9
 #: lib/vutuv_web/templates/user_tag/show.html.heex:7
 #, elixir-autogen
 msgid "Show"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:152
+#: lib/vutuv_web/templates/page/index.html.heex:150
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr ""
@@ -878,7 +868,7 @@ msgstr ""
 msgid "We can't find em' cap'n!"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:176
+#: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -889,9 +879,9 @@ msgid "Welcome back!"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:42
+#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/email_html.ex:11
-#: lib/vutuv_web/views/phone_number_html.ex:11
+#: lib/vutuv_web/views/phone_number_html.ex:17
 #, elixir-autogen
 msgid "Work"
 msgstr ""
@@ -953,12 +943,12 @@ msgstr ""
 msgid "An email has been sent to your email address with instructions on how to delete your account."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:124
+#: lib/vutuv_web/templates/page/index.html.heex:122
 #, elixir-autogen
 msgid "Allow others to view your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:162
+#: lib/vutuv_web/templates/page/index.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1157,7 +1147,7 @@ msgstr ""
 msgid "The 1,000 Users with the most Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:134
+#: lib/vutuv_web/agent_docs/list_docs.ex:144
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
 msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
@@ -1204,19 +1194,19 @@ msgstr ""
 msgid "Search Tips"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:41
+#: lib/vutuv_web/templates/page/index.html.heex:39
 #: lib/vutuv_web/templates/user/edit.html.heex:126
 #, elixir-autogen
 msgid "female"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:41
+#: lib/vutuv_web/templates/page/index.html.heex:39
 #: lib/vutuv_web/templates/user/edit.html.heex:126
 #, elixir-autogen
 msgid "male"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:41
+#: lib/vutuv_web/templates/page/index.html.heex:39
 #: lib/vutuv_web/templates/user/edit.html.heex:126
 #, elixir-autogen
 msgid "other"
@@ -1482,7 +1472,7 @@ msgstr ""
 #: lib/vutuv_web/templates/import/preview.html.heex:36
 #: lib/vutuv_web/templates/invitation/new.html.heex:64
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/tag/show.html.heex:4
+#: lib/vutuv_web/templates/tag/show.html.heex:8
 #: lib/vutuv_web/templates/user/show.html.heex:429
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:10
@@ -1721,7 +1711,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:75
 #: lib/vutuv_web/templates/layout/app.html.heex:89
-#: lib/vutuv_web/templates/page/index.html.heex:169
+#: lib/vutuv_web/templates/page/index.html.heex:167
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
@@ -1729,7 +1719,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/page_controller.ex:81
 #: lib/vutuv_web/templates/layout/app.html.heex:91
-#: lib/vutuv_web/templates/page/index.html.heex:169
+#: lib/vutuv_web/templates/page/index.html.heex:167
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -2268,13 +2258,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1093
-#: lib/vutuv_web/components/post_components.ex:1097
+#: lib/vutuv_web/components/post_components.ex:1075
+#: lib/vutuv_web/components/post_components.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1094
+#: lib/vutuv_web/components/post_components.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2370,22 +2360,22 @@ msgstr ""
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1303
+#: lib/vutuv_web/components/post_components.ex:1331
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1307
+#: lib/vutuv_web/components/post_components.ex:1335
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1305
+#: lib/vutuv_web/components/post_components.ex:1333
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1306
+#: lib/vutuv_web/components/post_components.ex:1334
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2426,7 +2416,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1375
+#: lib/vutuv_web/components/post_components.ex:1403
 #: lib/vutuv_web/components/ui.ex:1563
 #: lib/vutuv_web/components/ui.ex:1563
 #: lib/vutuv_web/components/ui.ex:2171
@@ -2445,7 +2435,7 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1342
+#: lib/vutuv_web/components/post_components.ex:1370
 #: lib/vutuv_web/components/ui.ex:1592
 #: lib/vutuv_web/components/ui.ex:1592
 #: lib/vutuv_web/components/ui.ex:2157
@@ -2474,12 +2464,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1364
+#: lib/vutuv_web/components/post_components.ex:1392
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1375
+#: lib/vutuv_web/components/post_components.ex:1403
 #: lib/vutuv_web/components/ui.ex:1553
 #: lib/vutuv_web/components/ui.ex:1553
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2488,23 +2478,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1361
+#: lib/vutuv_web/components/post_components.ex:1389
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1182
+#: lib/vutuv_web/components/post_components.ex:1210
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1361
+#: lib/vutuv_web/components/post_components.ex:1389
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1342
+#: lib/vutuv_web/components/post_components.ex:1370
 #: lib/vutuv_web/components/ui.ex:1582
 #: lib/vutuv_web/components/ui.ex:1582
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2525,7 +2515,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1415
+#: lib/vutuv_web/components/post_components.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2537,8 +2527,8 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1398
-#: lib/vutuv_web/components/post_components.ex:1399
+#: lib/vutuv_web/components/post_components.ex:1426
+#: lib/vutuv_web/components/post_components.ex:1427
 #: lib/vutuv_web/live/notification_live/index.ex:207
 #: lib/vutuv_web/live/notification_live/index.ex:299
 #: lib/vutuv_web/live/post_live/reply.ex:25
@@ -2669,7 +2659,7 @@ msgstr ""
 msgid "Too many new conversations. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:33
+#: lib/vutuv_web/templates/page/index.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Create your free account"
 msgstr ""
@@ -2699,17 +2689,18 @@ msgstr ""
 msgid "Welcome back"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:6
+#: lib/vutuv_web/templates/page/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Founder of vutuv"
 msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:1
+#: lib/vutuv_web/templates/page/index.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "“Tired of LinkedIn, and want your data to stay in Germany? I can help.”"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:142
+#: lib/vutuv_web/templates/page/index.html.heex:140
 #: lib/vutuv_web/templates/settings/privacy.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
@@ -2876,7 +2867,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1304
+#: lib/vutuv_web/components/post_components.ex:1332
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3935,7 +3926,7 @@ msgstr ""
 msgid "Most endorsed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:132
+#: lib/vutuv_web/agent_docs/list_docs.ex:142
 #, elixir-autogen, elixir-format
 msgid "Most followed members"
 msgstr ""
@@ -5244,7 +5235,7 @@ msgstr ""
 msgid "vutuv POSTs signed JSON envelopes here (see the webhooks documentation). https:// only; http://localhost is allowed for development."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:147
+#: lib/vutuv_web/templates/page/index.html.heex:145
 #: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
@@ -5428,8 +5419,8 @@ msgid "Footer navigation"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:774
-#: lib/vutuv_web/components/post_components.ex:825
-#: lib/vutuv_web/components/post_components.ex:838
+#: lib/vutuv_web/components/post_components.ex:828
+#: lib/vutuv_web/components/post_components.ex:1137
 #: lib/vutuv_web/live/post_live/feed.ex:672
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5440,7 +5431,7 @@ msgstr ""
 msgid "Someone tried to register with your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:86
+#: lib/vutuv_web/templates/page/index.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
@@ -5451,7 +5442,7 @@ msgid "Diverse"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:42
+#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/directory_html.ex:8
 #: lib/vutuv_web/views/email_html.ex:13
 #: lib/vutuv_web/views/invitation_html.ex:18
@@ -5460,9 +5451,9 @@ msgid "Other"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:42
+#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:507
+#: lib/vutuv_web/views/user_html.ex:508
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -5472,7 +5463,7 @@ msgstr ""
 msgid "Type of Email"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:104
+#: lib/vutuv_web/templates/page/index.html.heex:102
 #, elixir-autogen, elixir-format
 msgid "Type of email address"
 msgstr ""
@@ -6312,7 +6303,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:105
+#: lib/vutuv_web/agent_docs/list_docs.ex:115
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -6647,7 +6638,7 @@ msgstr ""
 msgid "Mute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:506
+#: lib/vutuv_web/views/user_html.ex:507
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
@@ -8495,12 +8486,12 @@ msgstr ""
 msgid "All %{count} members whose profiles are open to search engines, filed alphabetically by last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:151
+#: lib/vutuv_web/agent_docs/list_docs.ex:161
 #, elixir-autogen, elixir-format
 msgid "All members who allow search engines to index their profile, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:149
+#: lib/vutuv_web/agent_docs/list_docs.ex:159
 #: lib/vutuv_web/controllers/directory_controller.ex:28
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8516,7 +8507,7 @@ msgstr ""
 msgid "Members by initial"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:168
+#: lib/vutuv_web/agent_docs/list_docs.ex:178
 #: lib/vutuv_web/controllers/directory_controller.ex:54
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8535,7 +8526,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:174
+#: lib/vutuv_web/agent_docs/list_docs.ex:184
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -8809,7 +8800,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1185
+#: lib/vutuv_web/components/post_components.ex:1213
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -10597,7 +10588,7 @@ msgstr ""
 msgid "Manage your vutuv account: profile, privacy, notifications and sign-in."
 msgstr ""
 
-#: lib/vutuv_web/controllers/tag_controller.ex:50
+#: lib/vutuv_web/controllers/tag_controller.ex:60
 #, elixir-autogen, elixir-format
 msgid "Members on vutuv tagged %{tag}."
 msgstr ""
@@ -10642,7 +10633,7 @@ msgstr ""
 msgid "vutuv is the open business network where professionals connect, share, and get found. Free to join."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:93
+#: lib/vutuv_web/templates/page/index.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "At least three tags, separated by a comma or a space. Multi-word tags go in quotes: \"Ruby on Rails\"."
 msgstr ""
@@ -12805,7 +12796,7 @@ msgid "All countries"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:362
-#: lib/vutuv_web/templates/tag/show.html.heex:37
+#: lib/vutuv_web/templates/tag/show.html.heex:49
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
@@ -12871,7 +12862,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:393
 #: lib/vutuv_web/agent_docs/text.ex:405
 #: lib/vutuv_web/live/organization_live/show.ex:329
-#: lib/vutuv_web/templates/tag/show.html.heex:31
+#: lib/vutuv_web/templates/tag/show.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Open positions"
 msgstr ""
@@ -13434,7 +13425,7 @@ msgstr ""
 msgid "An image was removed from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:910
+#: lib/vutuv_web/components/post_components.ex:892
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -13442,7 +13433,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:900
+#: lib/vutuv_web/components/post_components.ex:882
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr ""
@@ -13589,7 +13580,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:166
 #: lib/vutuv_web/agent_docs/text.ex:163
-#: lib/vutuv_web/templates/tag/show.html.heex:15
+#: lib/vutuv_web/templates/tag/show.html.heex:25
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts with this tag"
 msgstr ""
@@ -13602,4 +13593,14 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:297
 #, elixir-autogen, elixir-format, fuzzy
 msgid "people and posts with this tag, combinable: miller tag:php"
+msgstr ""
+
+#: lib/vutuv_web/views/phone_number_html.ex:16
+#, elixir-autogen, elixir-format
+msgid "Private mobile"
+msgstr ""
+
+#: lib/vutuv_web/views/phone_number_html.ex:18
+#, elixir-autogen, elixir-format
+msgid "Work mobile"
 msgstr ""

--- a/test/vutuv/imports/linked_in_test.exs
+++ b/test/vutuv/imports/linked_in_test.exs
@@ -165,6 +165,13 @@ defmodule Vutuv.Imports.LinkedInTest do
       assert [%{params: %{"value" => "+49 30 1234567", "number_type" => "Cell"}}] = result.phones
     end
 
+    test "maps a fax line to Work now that Fax is no longer a vutuv type (#948)" do
+      csv = "Extension,Number,Type\n,+49 30 1234567,Fax\n"
+      {:ok, result} = LinkedIn.parse(zip([{"PhoneNumbers.csv", csv}]))
+
+      assert [%{params: %{"value" => "+49 30 1234567", "number_type" => "Work"}}] = result.phones
+    end
+
     # Real archives list the same number more than once (and in more than one
     # format); the digit-based candidate id collapses them so the preview shows
     # one row, not a run of duplicate checkboxes.

--- a/test/vutuv/profiles/phone_number_test.exs
+++ b/test/vutuv/profiles/phone_number_test.exs
@@ -40,10 +40,21 @@ defmodule Vutuv.Profiles.PhoneNumberTest do
   end
 
   describe "number_type" do
-    test "accepts the allowed Work/Cell/Home/Fax values" do
+    test "offers the private/work landline & mobile matrix (issue #948)" do
+      assert PhoneNumber.number_types() == ["Home", "Cell", "Work", "Work Cell"]
+    end
+
+    test "accepts every offered type" do
       for type <- PhoneNumber.number_types() do
         assert changeset(%{"number_type" => type}).valid?, "expected #{type} to be accepted"
       end
+    end
+
+    test "no longer accepts Fax (dropped in #948; legacy rows stay display-only)" do
+      cs = changeset(%{"number_type" => "Fax"})
+
+      refute cs.valid?
+      assert %{number_type: [_]} = errors_on(cs)
     end
 
     test "rejects a value outside the allowed set" do

--- a/test/vutuv_web/controllers/section_ordering_test.exs
+++ b/test/vutuv_web/controllers/section_ordering_test.exs
@@ -44,8 +44,8 @@ defmodule VutuvWeb.SectionOrderingTest do
         |> get("/#{owner.username}/phone_numbers")
         |> html_response(200)
 
-      # The reorder row must render "Mobil-Telefon", never the raw stored "Cell".
-      assert html =~ "Mobil-Telefon"
+      # The reorder row must render "Mobil (privat)", never the raw stored "Cell".
+      assert html =~ "Mobil (privat)"
       refute html =~ ~r/reorder__sub[^>]*>\s*Cell/
     end
 
@@ -65,7 +65,7 @@ defmodule VutuvWeb.SectionOrderingTest do
       # A visitor gets the read-only card_list (no reorder tool); it must still
       # localize the type, like the owner's reorder rows do.
       refute html =~ ~s(phx-hook="Reorder")
-      assert html =~ "Mobil-Telefon"
+      assert html =~ "Mobil (privat)"
       refute html =~ ">Cell</a>"
     end
 

--- a/test/vutuv_web/controllers/user_controller_test.exs
+++ b/test/vutuv_web/controllers/user_controller_test.exs
@@ -357,9 +357,10 @@ defmodule VutuvWeb.UserControllerTest do
   end
 
   describe "contact card splits into Beruflich/Privat" do
-    # E-mails are work unless typed "Personal"; phone numbers are private only
-    # when typed "Home". When both buckets hold something the card grows two
-    # labeled groups (work first); a single bucket stays one bare list.
+    # E-mails are work unless typed "Personal"; phone numbers are private when
+    # typed "Home" or "Cell" (private landline / mobile). When both buckets hold
+    # something the card grows two labeled groups (work first); a single bucket
+    # stays one bare list.
 
     test "shows a work and a private group when both kinds are present", %{conn: conn} do
       user = insert_activated_user()
@@ -391,13 +392,26 @@ defmodule VutuvWeb.UserControllerTest do
     test "stays one ungrouped list when every channel is work", %{conn: conn} do
       user = insert_activated_user()
       insert(:email, user: user, value: "only.work@example.com", email_type: "Work")
-      insert(:phone_number, user: user, value: "+49 30 5551234", number_type: "Cell")
+      insert(:phone_number, user: user, value: "+49 30 5551234", number_type: "Work")
 
       html = conn |> get(~p"/#{user}") |> html_response(200)
 
       assert html =~ "only.work@example.com"
       refute html =~ ~s(data-contact-group="work")
       refute html =~ ~s(data-contact-group="private")
+    end
+
+    test "a private mobile (Cell) groups as private, not work (issue #948)", %{conn: conn} do
+      user = insert_activated_user()
+      insert(:email, user: user, value: "work.addr@example.com", email_type: "Work")
+      insert(:phone_number, user: user, value: "+49 30 5551234", number_type: "Cell")
+
+      html = conn |> get(~p"/#{user}") |> html_response(200)
+
+      assert html =~ ~s(data-contact-group="private")
+
+      assert source_pos(html, ~s(data-contact-group="private")) <
+               source_pos(html, "+49 30 5551234")
     end
   end
 

--- a/test/vutuv_web/phone_type_i18n_test.exs
+++ b/test/vutuv_web/phone_type_i18n_test.exs
@@ -1,9 +1,10 @@
 defmodule VutuvWeb.PhoneTypeI18nTest do
   @moduledoc """
-  The phone-number type "Home" must read as the German "Privat", not the bare
-  English "Home". The msgid "Home" was overloaded: it also names the navigation
-  target ("g h" shortcut, breadcrumb), which is "Startseite". One msgid cannot
-  carry both meanings, so the phone type is disambiguated with a gettext context.
+  The phone-number types (issue #948: private/work × landline/mobile) render
+  through gettext so the page speaks the visitor's language. The private
+  landline reuses the "Private" msgid ("Privat"), so it no longer collides with
+  the navigation "Home" ("Startseite") and needs no gettext context. "Fax" is
+  no longer offered but legacy rows must still render their German label.
   """
   use ExUnit.Case, async: true
 
@@ -17,9 +18,11 @@ defmodule VutuvWeb.PhoneTypeI18nTest do
   end
 
   test "the phone type labels are all German" do
-    assert PhoneNumberHTML.phone_type_label("Work") == "Arbeit"
-    assert PhoneNumberHTML.phone_type_label("Cell") == "Mobil-Telefon"
     assert PhoneNumberHTML.phone_type_label("Home") == "Privat"
+    assert PhoneNumberHTML.phone_type_label("Cell") == "Mobil (privat)"
+    assert PhoneNumberHTML.phone_type_label("Work") == "Arbeit"
+    assert PhoneNumberHTML.phone_type_label("Work Cell") == "Mobil (Arbeit)"
+    # Fax is no longer offered, but legacy rows keep their German label.
     assert PhoneNumberHTML.phone_type_label("Fax") == "Fax"
   end
 


### PR DESCRIPTION
Closes #948.

## What & why

@ddeimeke pointed out that the classic phone-number types don't fit how people carry numbers today: there's no way to add a *second* mobile, and Fax is obsolete.

The underlying problem was that the old flat list mixed two unrelated dimensions:

```
Work   Cell   Home   Fax
└loc┘ └dev┘  └loc┘ └dev┘   ← "whose number" vs "what kind of line", muddled
```

`Work`/`Home` say *whose* number it is; `Cell`/`Fax` say *what kind* of line. Sharing one list is why "work mobile" was inexpressible.

This replaces it with a clean 2×2 matrix:

| | landline | mobile |
|---|---|---|
| **private** | Privat (`Home`) | Mobil (privat) (`Cell`) |
| **work** | Arbeit (`Work`) | Mobil (Arbeit) (`Work Cell`) |

## Details

- **No data migration.** The type list is a code-level enum, and `Home`/`Cell`/`Work` keep their stored tokens, so existing rows keep working. Only the new `Work Cell` token is added.
- **`Home` → "Private"** reuses the existing `"Private"` msgid (`"Privat"`), which drops the old `pgettext("phone number type", "Home")` workaround that existed only to avoid colliding with the nav "Home" (`"Startseite"`).
- **Fax is dropped** from the form and rejected by the changeset, but legacy `Fax` rows still render their label (grandfathered), and the LinkedIn import now maps a fax line to a work number.
- **Contact-card grouping follows suit**: a private mobile (`Cell`) now groups under *Privat* instead of *Beruflich*.

## Tests & verification

- Updated/added tests: schema type set, i18n labels, reorder-row label, LinkedIn fax mapping, and profile contact grouping (private mobile → private bucket).
- `mix precommit` green (4021 tests).
- Browser smoke test in German: the dropdown offers exactly the four options (no Fax), a "Mobil (Arbeit)" number saves and round-trips, and it renders correctly on the settings list, the public profile contact card, the public section page, and the `.md` agent sibling.
