### PR TITLE
Gloss the language-proficiency CEFR badge with a tooltip (v7.114.3)

### DIFF
--- a/lib/vutuv_web/live/section_reorder_live.ex
+++ b/lib/vutuv_web/live/section_reorder_live.ex
@@ -36,7 +36,10 @@ defmodule VutuvWeb.SectionReorderLive do
   import VutuvWeb.UrlHTML, only: [linkable_url: 1, display_url: 1]
   import VutuvWeb.EmailHTML, only: [email_type_label: 1]
   import VutuvWeb.PhoneNumberHTML, only: [phone_type_label: 1]
-  import VutuvWeb.LanguageHTML, only: [language_name: 1, proficiency_badge: 1]
+
+  import VutuvWeb.LanguageHTML,
+    only: [language_name: 1, proficiency_badge: 1, proficiency_label: 1]
+
   import VutuvWeb.UserHelpers, only: [format_address: 2]
 
   alias Vutuv.Profiles.SocialMediaAccount
@@ -242,7 +245,10 @@ defmodule VutuvWeb.SectionReorderLive do
     <div class="reorder__text">
       <div class="reorder__title">
         {language_name(@entry.language_code)}
-        <span class="ml-1 inline-flex items-center rounded-lg bg-brand-50 px-2 py-0.5 text-xs font-medium text-brand-700 dark:bg-brand-900/40 dark:text-brand-100">
+        <span
+          class="ml-1 inline-flex cursor-help items-center rounded-lg bg-brand-50 px-2 py-0.5 text-xs font-medium text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
+          title={proficiency_label(@entry.proficiency)}
+        >
           {proficiency_badge(@entry.proficiency)}
         </span>
       </div>

--- a/lib/vutuv_web/templates/language/card_list.html.heex
+++ b/lib/vutuv_web/templates/language/card_list.html.heex
@@ -16,7 +16,10 @@ preferred contact language (issue #894). --%>
     >
       {language_name(language.language_code)}
     </.link>
-    <span class="shrink-0 inline-flex items-center rounded-lg bg-brand-50 px-2 py-0.5 text-xs font-medium text-brand-700 dark:bg-brand-900/40 dark:text-brand-100">
+    <span
+      class="shrink-0 inline-flex cursor-help items-center rounded-lg bg-brand-50 px-2 py-0.5 text-xs font-medium text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
+      title={proficiency_label(language.proficiency)}
+    >
       {proficiency_badge(language.proficiency)}
     </span>
     <.language_preferred_badge :if={idx == 0 and length(@languages) > 1} />

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -588,7 +588,10 @@ the resulting ~200px rail width. --%>
           <span class="font-medium text-slate-900 dark:text-white">
             {VutuvWeb.LanguageHTML.language_name(language.language_code)}
           </span>
-          <span class="inline-flex items-center rounded bg-brand-50 px-1.5 py-0.5 text-xs font-medium text-brand-700 dark:bg-brand-900/40 dark:text-brand-100">
+          <span
+            class="inline-flex cursor-help items-center rounded bg-brand-50 px-1.5 py-0.5 text-xs font-medium text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
+            title={VutuvWeb.LanguageHTML.proficiency_label(language.proficiency)}
+          >
             {VutuvWeb.LanguageHTML.proficiency_badge(language.proficiency)}
           </span>
         </.link>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.114.2",
+      version: "7.114.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/language_controller_test.exs
+++ b/test/vutuv_web/controllers/language_controller_test.exs
@@ -14,6 +14,17 @@ defmodule VutuvWeb.LanguageControllerTest do
     assert html =~ "Native"
   end
 
+  test "the opaque CEFR badge carries a plain-language tooltip (issue #888)", %{conn: conn} do
+    {_conn, user} = create_and_login_user(conn)
+    insert(:language, user: user, language_code: "en", proficiency: "b2")
+
+    html = build_conn() |> get(~p"/#{user}/languages") |> html_response(200)
+    # The badge still shows the bare code, now with a `title` gloss so a reader
+    # who does not know the CEFR scale learns what "B2" means on hover.
+    assert html =~ "B2"
+    assert html =~ "title=\"B2 (Upper intermediate)\""
+  end
+
   test "redirect when creating a valid language", %{conn: conn} do
     {conn, user} = create_and_login_user(conn)
 

--- a/test/vutuv_web/live/user_profile_live_test.exs
+++ b/test/vutuv_web/live/user_profile_live_test.exs
@@ -544,6 +544,11 @@ defmodule VutuvWeb.UserProfileLiveTest do
       assert html =~ "Native"
       assert html =~ "A2"
 
+      # ...and the opaque CEFR badge carries a native tooltip glossing the level
+      # (issue #888): hovering "A2" explains it in plain language.
+      assert has_element?(view, "#profile-languages [title=\"A2 (Elementary)\"]", "A2")
+      assert has_element?(view, "#profile-languages [title=\"Native speaker\"]", "Native")
+
       # ...but the profile card drops the quieter "Preferred" contact-language
       # marker; that detail lives on the dedicated /:slug/languages page.
       refute has_element?(view, "#profile-languages", "Preferred")


### PR DESCRIPTION
Closes #888.

## What

The profile Languages card, the public `/:slug/languages` list, and the owner reorder tool render language proficiency as a bare CEFR code (`B2`, `A2`, …). As #888 notes, those codes are opaque to many readers.

This adds a native `title` tooltip to the badge on all three surfaces, glossing the level in plain language on hover, plus a `cursor-help` affordance.

## How

- Reuses the already-translated `proficiency_label/1` strings (`B2 (Upper intermediate)`, German `B2 (Obere Mittelstufe)`) as the `title` — **no new gettext strings**, no JS, no CSS component.
- Surfaces touched: `user/show.html.heex` (profile card), `language/card_list.html.heex` (public list + settings editor), `section_reorder_live.ex` (reorder tool).

## Tests

- Profile card (LiveView) asserts the badge `title` for a CEFR level and for native.
- Public section list (controller) asserts the CEFR `title` gloss.
- Full `mix precommit` green; browser smoke-tested in English and German renders.