### PR TITLE
Re-enable the Fax phone number type (v7.115.1) (#948)

### DIFF
--- a/lib/vutuv/imports/linked_in.ex
+++ b/lib/vutuv/imports/linked_in.ex
@@ -558,8 +558,7 @@ defmodule Vutuv.Imports.LinkedIn do
     case downcase(type) do
       "home" -> "Home"
       "work" -> "Work"
-      # Fax is no longer a vutuv type (issue #948); a fax line is a work number.
-      "fax" -> "Work"
+      "fax" -> "Fax"
       # mobile / cell / unknown all map to the default (private mobile).
       _ -> "Cell"
     end

--- a/lib/vutuv/profiles/phone_number.ex
+++ b/lib/vutuv/profiles/phone_number.ex
@@ -22,12 +22,12 @@ defmodule Vutuv.Profiles.PhoneNumber do
   @requred_message ~s/This field is required/
 
   # The allowed `number_type` labels, in the order the HTML form lists them: a
-  # private/work × landline/mobile matrix (issue #948). "Home"/"Cell" are the
-  # private landline / mobile, "Work"/"Work Cell" the work landline / mobile.
-  # Fax was dropped (obsolete); legacy "Fax"/other rows still display via
-  # `PhoneNumberHTML.phone_type_label/1` but can no longer be created or saved.
-  # Mirrors Email.email_types: enforced in the schema, not just the <select>.
-  @number_types ["Home", "Cell", "Work", "Work Cell"]
+  # private/work × landline/mobile matrix (issue #948), plus Fax. "Home"/"Cell"
+  # are the private landline / mobile, "Work"/"Work Cell" the work landline /
+  # mobile. Fax is kept because it is still relevant in some regions (dropping
+  # it was an overcorrection). Mirrors Email.email_types: enforced in the
+  # schema, not just the <select>.
+  @number_types ["Home", "Cell", "Work", "Work Cell", "Fax"]
 
   @doc "The allowed `number_type` values, in the order the forms list them."
   def number_types, do: @number_types

--- a/lib/vutuv_web/views/phone_number_html.ex
+++ b/lib/vutuv_web/views/phone_number_html.ex
@@ -5,9 +5,9 @@ defmodule VutuvWeb.PhoneNumberHTML do
 
   @doc """
   The stored type values are the English option values from the form ("Home",
-  "Cell", "Work", "Work Cell" since issue #948); render them through gettext so
-  the page speaks the visitor's language. "Fax" and any other unknown legacy
-  value still render (Fax is no longer offered, only grandfathered).
+  "Cell", "Work", "Work Cell", "Fax" since issue #948); render them through
+  gettext so the page speaks the visitor's language. Any unknown legacy value
+  passes through unchanged.
   """
   # "Home" reuses the "Private" msgid ("Privat"), so the private landline no
   # longer collides with the navigation "Home" ("Startseite") and needs no

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.115.0",
+      version: "7.115.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/imports/linked_in_test.exs
+++ b/test/vutuv/imports/linked_in_test.exs
@@ -165,11 +165,11 @@ defmodule Vutuv.Imports.LinkedInTest do
       assert [%{params: %{"value" => "+49 30 1234567", "number_type" => "Cell"}}] = result.phones
     end
 
-    test "maps a fax line to Work now that Fax is no longer a vutuv type (#948)" do
+    test "maps a fax line to the Fax type (#948)" do
       csv = "Extension,Number,Type\n,+49 30 1234567,Fax\n"
       {:ok, result} = LinkedIn.parse(zip([{"PhoneNumbers.csv", csv}]))
 
-      assert [%{params: %{"value" => "+49 30 1234567", "number_type" => "Work"}}] = result.phones
+      assert [%{params: %{"value" => "+49 30 1234567", "number_type" => "Fax"}}] = result.phones
     end
 
     # Real archives list the same number more than once (and in more than one

--- a/test/vutuv/profiles/phone_number_test.exs
+++ b/test/vutuv/profiles/phone_number_test.exs
@@ -40,21 +40,16 @@ defmodule Vutuv.Profiles.PhoneNumberTest do
   end
 
   describe "number_type" do
-    test "offers the private/work landline & mobile matrix (issue #948)" do
-      assert PhoneNumber.number_types() == ["Home", "Cell", "Work", "Work Cell"]
+    test "offers the private/work landline & mobile matrix plus Fax (issue #948)" do
+      # Fax stays offered: it is still used in some regions. Removing it in the
+      # first pass at #948 was an overcorrection, reverted here.
+      assert PhoneNumber.number_types() == ["Home", "Cell", "Work", "Work Cell", "Fax"]
     end
 
-    test "accepts every offered type" do
+    test "accepts every offered type (including Fax)" do
       for type <- PhoneNumber.number_types() do
         assert changeset(%{"number_type" => type}).valid?, "expected #{type} to be accepted"
       end
-    end
-
-    test "no longer accepts Fax (dropped in #948; legacy rows stay display-only)" do
-      cs = changeset(%{"number_type" => "Fax"})
-
-      refute cs.valid?
-      assert %{number_type: [_]} = errors_on(cs)
     end
 
     test "rejects a value outside the allowed set" do

--- a/test/vutuv_web/phone_type_i18n_test.exs
+++ b/test/vutuv_web/phone_type_i18n_test.exs
@@ -1,10 +1,9 @@
 defmodule VutuvWeb.PhoneTypeI18nTest do
   @moduledoc """
-  The phone-number types (issue #948: private/work × landline/mobile) render
-  through gettext so the page speaks the visitor's language. The private
+  The phone-number types (issue #948: private/work × landline/mobile, plus Fax)
+  render through gettext so the page speaks the visitor's language. The private
   landline reuses the "Private" msgid ("Privat"), so it no longer collides with
-  the navigation "Home" ("Startseite") and needs no gettext context. "Fax" is
-  no longer offered but legacy rows must still render their German label.
+  the navigation "Home" ("Startseite") and needs no gettext context.
   """
   use ExUnit.Case, async: true
 
@@ -22,7 +21,6 @@ defmodule VutuvWeb.PhoneTypeI18nTest do
     assert PhoneNumberHTML.phone_type_label("Cell") == "Mobil (privat)"
     assert PhoneNumberHTML.phone_type_label("Work") == "Arbeit"
     assert PhoneNumberHTML.phone_type_label("Work Cell") == "Mobil (Arbeit)"
-    # Fax is no longer offered, but legacy rows keep their German label.
     assert PhoneNumberHTML.phone_type_label("Fax") == "Fax"
   end
 


### PR DESCRIPTION
Follow-up to #948 / #968.

Dropping **Fax** in the taxonomy rework was an overcorrection. Fax is obsolete in much of the world, but it can still be relevant in some regions, so it should stay available.

This re-enables `Fax` as an offered and accepted phone-number type (the fifth option, after the private/work landline & mobile matrix), and maps a LinkedIn fax line back to `Fax` on import. The private/work × landline/mobile options are unchanged; Fax simply sits alongside them again.

## Verification

- Tests updated: the type set now includes `Fax`, `Fax` is accepted by the changeset, and the LinkedIn fax mapping asserts `Fax`.
- `mix precommit` green.
- Browser check (German): the new-phone-number dropdown offers all five options, with **Fax** present.
