### PR TITLE
Whole-app /simplify sweep (v7.117.1)

### DIFF
--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -9,6 +9,9 @@ defmodule Vutuv.Accounts do
   import Vutuv.SearchText, only: [escape_like: 1, name_ilike: 3, normalize_search: 1]
   require Logger
 
+  # Enables the bare `gettext/1` macro for the PIN / status strings below.
+  use Gettext, backend: VutuvWeb.Gettext
+
   alias Plug.Conn
   alias Vutuv.Accounts.Email
   alias Vutuv.Accounts.HandleChangeNotification
@@ -880,7 +883,7 @@ defmodule Vutuv.Accounts do
   # unknown email reaches after step 1's identical PIN screen, so it must
   # read exactly like a wrong PIN — never "no such account".
   defp verify_pin(nil, _pin) do
-    {:error, Gettext.gettext(VutuvWeb.Gettext, "Incorrect PIN")}
+    {:error, gettext("Incorrect PIN")}
   end
 
   defp verify_pin(%LoginPin{} = login_pin, pin) do
@@ -892,12 +895,12 @@ defmodule Vutuv.Accounts do
       # (issue #839).
       consumed?(login_pin) ->
         log_pin_rejected(login_pin, "already_used")
-        {:already_used, Gettext.gettext(VutuvWeb.Gettext, "This PIN has already been used.")}
+        {:already_used, gettext("This PIN has already been used.")}
 
       pin_expired?(login_pin) ->
         expire_pin(login_pin)
         log_pin_rejected(login_pin, "expired")
-        {:expired, Gettext.gettext(VutuvWeb.Gettext, "PIN expired")}
+        {:expired, gettext("PIN expired")}
 
       valid_pin?(login_pin, pin) ->
         mark_consumed(login_pin)
@@ -929,7 +932,7 @@ defmodule Vutuv.Accounts do
       |> LoginPin.changeset(%{pin_login_attempts: attempts})
       |> Repo.update!()
 
-      {:error, Gettext.gettext(VutuvWeb.Gettext, "Incorrect PIN")}
+      {:error, gettext("Incorrect PIN")}
     end
   end
 

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -2,6 +2,9 @@ defmodule Vutuv.Accounts.User do
   @moduledoc false
 
   use VutuvWeb, :model
+  # Enables the bare `gettext/1` macro (and extraction), like the sibling schemas.
+  use Gettext, backend: VutuvWeb.Gettext
+
   alias Vutuv.Handles
   alias Vutuv.Mentions
   alias Vutuv.Prefs
@@ -600,10 +603,10 @@ defmodule Vutuv.Accounts.User do
   edit form and the agent documents all read, so the wording lives in one
   place. "open" = employed but listening, "looking" = actively job-hunting.
   """
-  def employment_status_label("open"), do: Gettext.gettext(VutuvWeb.Gettext, "Open to offers")
+  def employment_status_label("open"), do: gettext("Open to offers")
 
   def employment_status_label("looking"),
-    do: Gettext.gettext(VutuvWeb.Gettext, "Looking for a job")
+    do: gettext("Looking for a job")
 
   def employment_status_label(_), do: nil
 
@@ -615,12 +618,12 @@ defmodule Vutuv.Accounts.User do
   can create an account too).
   """
   def visibility_label("everyone"),
-    do: Gettext.gettext(VutuvWeb.Gettext, "Everyone, including logged-out visitors")
+    do: gettext("Everyone, including logged-out visitors")
 
   def visibility_label("members"),
-    do: Gettext.gettext(VutuvWeb.Gettext, "Signed-in members only")
+    do: gettext("Signed-in members only")
 
-  def visibility_label("hidden"), do: Gettext.gettext(VutuvWeb.Gettext, "No one")
+  def visibility_label("hidden"), do: gettext("No one")
 
   def visibility_label(_), do: nil
 
@@ -630,16 +633,16 @@ defmodule Vutuv.Accounts.User do
   so the wording lives in one place.
   """
   def birthdate_visibility_label("full"),
-    do: Gettext.gettext(VutuvWeb.Gettext, "Full date and age")
+    do: gettext("Full date and age")
 
   def birthdate_visibility_label("age"),
-    do: Gettext.gettext(VutuvWeb.Gettext, "Age only, without the date")
+    do: gettext("Age only, without the date")
 
   def birthdate_visibility_label("day_month"),
-    do: Gettext.gettext(VutuvWeb.Gettext, "Day and month, without the year")
+    do: gettext("Day and month, without the year")
 
   def birthdate_visibility_label("hidden"),
-    do: Gettext.gettext(VutuvWeb.Gettext, "Do not show my birthday")
+    do: gettext("Do not show my birthday")
 
   def birthdate_visibility_label(_), do: nil
 
@@ -725,11 +728,11 @@ defmodule Vutuv.Accounts.User do
     )
   end
 
-  def gender_gettext("male"), do: Gettext.gettext(VutuvWeb.Gettext, "Male")
-  def gender_gettext("female"), do: Gettext.gettext(VutuvWeb.Gettext, "Female")
+  def gender_gettext("male"), do: gettext("Male")
+  def gender_gettext("female"), do: gettext("Female")
   # The third gender ("other") displays as "divers" - its own label, decoupled
   # from the email-type "Other"/"Andere" string they used to share.
-  def gender_gettext(_), do: Gettext.gettext(VutuvWeb.Gettext, "Diverse")
+  def gender_gettext(_), do: gettext("Diverse")
 
   defp nullify_default_birthdate(changeset) do
     case get_field(changeset, :birthdate) do

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -705,12 +705,9 @@ defmodule Vutuv.Activity do
   end
 
   defp protection_item(id, status, at, reported) do
-    Map.merge(actor_fields(reported), %{
-      id: id,
-      kind: "report_protection",
-      status: status,
-      at: at
-    })
+    id
+    |> actor_item("report_protection", at, reported)
+    |> Map.put(:status, status)
   end
 
   defp restored_at_or_before(query, nil), do: query

--- a/lib/vutuv/code_stats.ex
+++ b/lib/vutuv/code_stats.ex
@@ -32,6 +32,7 @@ defmodule Vutuv.CodeStats do
 
   alias Vutuv.Activity
   alias Vutuv.CodeStats.Fetcher
+  alias Vutuv.CodeStats.Snapshot
   alias Vutuv.Profiles.SocialMediaAccount
   alias Vutuv.RemoteFetch.Backoff
 
@@ -90,7 +91,7 @@ defmodule Vutuv.CodeStats do
   carry the raw timestamp).
   """
   def dormant_since(last_active_at) when is_binary(last_active_at) do
-    with {:ok, dt, _offset} <- DateTime.from_iso8601(last_active_at),
+    with %DateTime{} = dt <- Snapshot.datetime(last_active_at),
          :lt <-
            DateTime.compare(dt, DateTime.add(DateTime.utc_now(), -@dormant_after_days, :day)) do
       DateTime.to_date(dt)

--- a/lib/vutuv/dashboard.ex
+++ b/lib/vutuv/dashboard.ex
@@ -73,13 +73,8 @@ defmodule Vutuv.Dashboard do
   dashboard can link to each profile with its avatar and name.
   """
   def newest_members(limit \\ @people_list_limit) do
-    from(u in User,
-      where: u.email_confirmed? == true,
-      order_by: [desc: u.id],
-      limit: ^limit,
-      select: struct(u, ^User.listing_fields())
-    )
-    |> Repo.all()
+    from(u in User, where: u.email_confirmed? == true)
+    |> recent_listing(limit)
   end
 
   @doc """
@@ -94,13 +89,18 @@ defmodule Vutuv.Dashboard do
         []
 
       ids ->
-        from(u in User,
-          where: u.id in ^ids,
-          order_by: [desc: u.id],
-          limit: ^limit,
-          select: struct(u, ^User.listing_fields())
-        )
-        |> Repo.all()
+        from(u in User, where: u.id in ^ids)
+        |> recent_listing(limit)
     end
+  end
+
+  # Newest-first page of listing-field rows over an already-filtered user query.
+  defp recent_listing(query, limit) do
+    from(u in query,
+      order_by: [desc: u.id],
+      limit: ^limit,
+      select: struct(u, ^User.listing_fields())
+    )
+    |> Repo.all()
   end
 end

--- a/lib/vutuv/directory.ex
+++ b/lib/vutuv/directory.ex
@@ -133,7 +133,7 @@ defmodule Vutuv.Directory do
   end
 
   @doc "The directory's member total: the sum of `letter_entries/0`."
-  def total(entries), do: entries |> Enum.map(& &1.count) |> Enum.sum()
+  def total(entries), do: Enum.sum_by(entries, & &1.count)
 
   @doc """
   One page of a letter's members as `%{users: users, total: total}`, sorted

--- a/lib/vutuv/jobs.ex
+++ b/lib/vutuv/jobs.ex
@@ -869,12 +869,7 @@ defmodule Vutuv.Jobs do
     viewer
     |> board_scope()
     |> apply_board_filters(filters, viewer)
-    |> after_board_cursor(Keyword.get(opts, :cursor))
-    |> order_by([p], desc: p.first_published_at, desc: p.id)
-    |> limit(^(limit + 1))
-    |> preload([:organization, :user, job_posting_tags: :tag])
-    |> Repo.all()
-    |> board_result(limit)
+    |> finish_board(limit, Keyword.get(opts, :cursor))
   end
 
   @doc """
@@ -890,7 +885,15 @@ defmodule Vutuv.Jobs do
 
     live_public_query(today)
     |> where([p], p.geo?)
-    |> after_board_cursor(Keyword.get(opts, :cursor))
+    |> finish_board(limit, Keyword.get(opts, :cursor))
+  end
+
+  # Newest-first keyset page tail shared by board_page/3 and agent_board_page/1:
+  # apply the cursor, order, over-fetch one to detect `more?`, preload, and fold
+  # into `board_result/2`'s `%{entries:, more?:, cursor:}`.
+  defp finish_board(query, limit, cursor) do
+    query
+    |> after_board_cursor(cursor)
     |> order_by([p], desc: p.first_published_at, desc: p.id)
     |> limit(^(limit + 1))
     |> preload([:organization, :user, job_posting_tags: :tag])

--- a/lib/vutuv/jobs/job_posting.ex
+++ b/lib/vutuv/jobs/job_posting.ex
@@ -341,8 +341,6 @@ defmodule Vutuv.Jobs.JobPosting do
     end)
   end
 
-  # Format only (presence is a publish rule): a stored apply URL is offered as an
-  # outbound link, so the same literal SSRF guard the org website check uses runs here.
   # Format only (presence is a publish rule). A stored apply URL is offered as
   # an outbound link, so the shared http(s) + SSRF guard runs here too.
   defp validate_apply_format(changeset) do

--- a/lib/vutuv/mentions.ex
+++ b/lib/vutuv/mentions.ex
@@ -32,6 +32,7 @@ defmodule Vutuv.Mentions do
   alias Vutuv.Accounts.User
   alias Vutuv.Ads.Ad
   alias Vutuv.Chat.Message
+  alias Vutuv.Handles
   alias Vutuv.Jobs.JobPosting
   alias Vutuv.Organizations.Organization
   alias Vutuv.Posts.Post
@@ -401,9 +402,7 @@ defmodule Vutuv.Mentions do
   defp surface_key(JobPosting), do: :job_postings
   defp surface_key(Ad), do: :ads
 
-  defp normalize(value) when is_binary(value) do
-    value |> String.trim() |> String.trim_leading("@") |> String.downcase()
-  end
+  defp normalize(value) when is_binary(value), do: Handles.normalize(value)
 
   defp normalize(_), do: ""
 end

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -268,14 +268,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
       from(u in User,
         where: u.id == ^scan.subject_id and field(u, ^config.fingerprint) == ^scan.fingerprint
       )
-      |> Repo.update_all(
-        set: [
-          {config.file, nil},
-          {config.fingerprint, nil},
-          {config.crop, nil},
-          {config.moderation, nil}
-        ]
-      )
+      |> Repo.update_all(set: clear_profile_columns(config))
 
     case cleared do
       {1, _} ->
@@ -369,19 +362,22 @@ defmodule Vutuv.Moderation.ImageSubjects do
           field(u, ^config.fingerprint) == ^scan.fingerprint and
           field(u, ^config.moderation) == "pending"
     )
-    |> Repo.update_all(
-      set: [
-        {config.file, nil},
-        {config.fingerprint, nil},
-        {config.crop, nil},
-        {config.moderation, nil}
-      ]
-    )
+    |> Repo.update_all(set: clear_profile_columns(config))
 
     :ok
   end
 
   def cleanup_canceled(%ImageScan{}), do: :ok
+
+  # The four profile-image columns (file, fingerprint, crop, moderation) reset to
+  # nil when a scan rejects the image or cancels a pending one.
+  defp clear_profile_columns(config),
+    do: [
+      {config.file, nil},
+      {config.fingerprint, nil},
+      {config.crop, nil},
+      {config.moderation, nil}
+    ]
 
   ## Drift repair source
 

--- a/lib/vutuv/newsletters.ex
+++ b/lib/vutuv/newsletters.ex
@@ -463,6 +463,7 @@ defmodule Vutuv.Newsletters do
   # group's snapshot, replacing any previous membership, and caches the count.
   defp materialize(%NewsletterGroup{} = group) do
     ids = audience_user_ids(criteria_from_group(group), group.max_size, group.random_sample)
+    count = length(ids)
     now = NaiveDateTime.utc_now(:second)
 
     # insert_all does not run the schema's UUID v7 autogenerate, so mint ids here.
@@ -483,11 +484,11 @@ defmodule Vutuv.Newsletters do
         Repo.insert_all(NewsletterGroupMember, rows)
 
         Repo.update_all(from(g in NewsletterGroup, where: g.id == ^group.id),
-          set: [member_count: length(ids), updated_at: now]
+          set: [member_count: count, updated_at: now]
         )
       end)
 
-    %{group | member_count: length(ids)}
+    %{group | member_count: count}
   end
 
   defp criteria_from_group(%NewsletterGroup{} = group) do

--- a/lib/vutuv/newsletters/newsletter_group.ex
+++ b/lib/vutuv/newsletters/newsletter_group.ex
@@ -16,6 +16,8 @@ defmodule Vutuv.Newsletters.NewsletterGroup do
 
   use VutuvWeb, :model
 
+  import Vutuv.ChangesetHelpers, only: [trim_fields: 2]
+
   alias Vutuv.Newsletters.NewsletterGroupMember
   alias Vutuv.Tags.Tag
 
@@ -77,8 +79,7 @@ defmodule Vutuv.Newsletters.NewsletterGroup do
     |> validate_length(:country, max: @max_name)
     |> validate_length(:username, max: @max_name)
     |> clean_locales()
-    |> clean_blank_to_nil(:country)
-    |> clean_blank_to_nil(:username)
+    |> trim_fields([:country, :username])
     |> clean_ids(:included_group_ids)
     |> clean_ids(:excluded_group_ids)
     |> clean_ids(:included_user_ids)
@@ -97,20 +98,6 @@ defmodule Vutuv.Newsletters.NewsletterGroup do
       :error -> changeset
     end
   end
-
-  # Trim a free-text field, collapsing a blank to nil (country, @handle).
-  defp clean_blank_to_nil(changeset, field) do
-    case fetch_change(changeset, field) do
-      {:ok, value} when is_binary(value) ->
-        put_change(changeset, field, value |> String.trim() |> blank_to_nil())
-
-      _ ->
-        changeset
-    end
-  end
-
-  defp blank_to_nil(""), do: nil
-  defp blank_to_nil(value), do: value
 
   # Drop the empty hidden-input value and any blanks from an id-array field (the
   # included/excluded audiences and the per-account include/exclude lists).

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -1328,16 +1328,15 @@ defmodule Vutuv.Organizations do
 
   @doc "Overview tile counts for /admin/organizations (live / pending / frozen)."
   def admin_overview_counts do
-    %{
-      active:
-        Repo.aggregate(
-          from(c in Organization, where: organization_public_row(c)),
-          :count,
-          :id
-        ),
-      pending: Repo.aggregate(from(c in Organization, where: c.status == "pending"), :count, :id),
-      frozen: Repo.aggregate(from(c in Organization, where: not is_nil(c.frozen_at)), :count, :id)
-    }
+    Repo.one(
+      from(c in Organization,
+        select: %{
+          active: filter(count(c.id), organization_public_row(c)),
+          pending: filter(count(c.id), c.status == "pending"),
+          frozen: filter(count(c.id), not is_nil(c.frozen_at))
+        }
+      )
+    )
   end
 
   @doc """

--- a/lib/vutuv/pages.ex
+++ b/lib/vutuv/pages.ex
@@ -63,6 +63,17 @@ defmodule Vutuv.Pages do
     %{entries: shown, more?: more?, next_offset: offset + length(shown)}
   end
 
+  @doc """
+  Normalizes a free-text filter param (e.g. `?q`): trims it, collapsing a blank
+  or `nil` to `nil` so the browse LiveViews treat "no filter" uniformly.
+  """
+  def blank_to_nil(value) do
+    case value && String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
   @doc "Parses the `?page` param (any map with a `\"page\"` key) to an integer >= 1, defaulting to 1."
   def page_param(params) do
     case Integer.parse(to_string(params["page"])) do

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1175,7 +1175,7 @@ defmodule Vutuv.Posts do
       fragment(
         "CASE WHEN ? = ? THEN ? ELSE ? END",
         b.blocker_id,
-        type(^user_id, Vutuv.UUIDv7),
+        type(^user_id, UUIDv7),
         b.blocked_id,
         b.blocker_id
       )
@@ -2030,14 +2030,7 @@ defmodule Vutuv.Posts do
   vanished before the capture finished.
   """
   def broadcast_screenshot_ready(post_id) when is_binary(post_id) do
-    case Repo.get(Post, post_id) do
-      nil ->
-        :ok
-
-      %Post{user_id: author_id} ->
-        event = {:post_screenshot_ready, %{post_id: post_id, author_id: author_id}}
-        broadcast_to_followers(author_id, event)
-    end
+    broadcast_post_followers_event(post_id, :post_screenshot_ready)
   end
 
   @doc """
@@ -2046,13 +2039,19 @@ defmodule Vutuv.Posts do
   reload. Fans out to the same recipients (author topic + followers' feeds).
   """
   def broadcast_screenshot_removed(post_id) when is_binary(post_id) do
+    broadcast_post_followers_event(post_id, :post_screenshot_removed)
+  end
+
+  # Fan a `{event_name, %{post_id:, author_id:}}` out to the post author's own
+  # topic and every follower's feed. A no-op for a post that vanished before the
+  # broadcast fired.
+  defp broadcast_post_followers_event(post_id, event_name) when is_binary(post_id) do
     case Repo.get(Post, post_id) do
       nil ->
         :ok
 
       %Post{user_id: author_id} ->
-        event = {:post_screenshot_removed, %{post_id: post_id, author_id: author_id}}
-        broadcast_to_followers(author_id, event)
+        broadcast_to_followers(author_id, {event_name, %{post_id: post_id, author_id: author_id}})
     end
   end
 
@@ -2164,5 +2163,5 @@ defmodule Vutuv.Posts do
 
   # Ids are UUID strings; anything that does not cast (stale form payloads,
   # tampering) is dropped rather than raising in the changeset cast.
-  defp parse_id(id), do: Vutuv.UUIDv7.cast_or_nil(id)
+  defp parse_id(id), do: UUIDv7.cast_or_nil(id)
 end

--- a/lib/vutuv/profiles/cv_section.ex
+++ b/lib/vutuv/profiles/cv_section.ex
@@ -8,6 +8,7 @@ defmodule Vutuv.Profiles.CvSection do
   """
 
   import Ecto.Query
+  import Ecto.Changeset, only: [get_change: 2, get_field: 2, put_change: 3]
 
   @doc """
   Splits an already-ordered `entries` list into `{kind, entries}` pairs in
@@ -32,5 +33,19 @@ defmodule Vutuv.Profiles.CvSection do
       desc: x.start_year,
       desc: x.start_month
     )
+  end
+
+  @doc """
+  Builds the `slug` from `fields` (via each schema's `String.Chars`) when any of
+  them changed, unique per owner. `module` is the CV-section schema and `fields`
+  its slug source columns. Shared by both sections' slug step.
+  """
+  def put_slug(changeset, module, fields) do
+    if Enum.any?(fields, &get_change(changeset, &1)) do
+      model = struct(module, Map.new(fields, &{&1, get_field(changeset, &1)}))
+      put_change(changeset, :slug, Vutuv.SlugHelpers.gen_slug_unique(model, :slug))
+    else
+      changeset
+    end
   end
 end

--- a/lib/vutuv/profiles/education.ex
+++ b/lib/vutuv/profiles/education.ex
@@ -65,24 +65,11 @@ defmodule Vutuv.Profiles.Education do
     |> validate_length(:description, max: 10_000)
     |> Mentions.validate_mentions_exist(:description)
     |> ChangesetHelpers.validate_period()
-    |> create_slug
+    |> CvSection.put_slug(__MODULE__, [:school, :degree])
     # The slug derives from the school name, so a near-cap value can still
     # overrun its own varchar(255) column.
     |> validate_length(:slug, max: 255)
     |> unique_constraint(:slug)
-  end
-
-  defp create_slug(changeset) do
-    if get_change(changeset, :school) || get_change(changeset, :degree) do
-      model = %__MODULE__{
-        school: get_field(changeset, :school),
-        degree: get_field(changeset, :degree)
-      }
-
-      put_change(changeset, :slug, Vutuv.SlugHelpers.gen_slug_unique(model, :slug))
-    else
-      changeset
-    end
   end
 
   @doc """

--- a/lib/vutuv/profiles/work_experience.ex
+++ b/lib/vutuv/profiles/work_experience.ex
@@ -62,7 +62,7 @@ defmodule Vutuv.Profiles.WorkExperience do
     |> Mentions.validate_mentions_exist(:description)
     |> ChangesetHelpers.validate_period()
     |> validate_organization_link()
-    |> create_slug
+    |> CvSection.put_slug(__MODULE__, [:title, :organization])
     # The slug derives from title + organization, so two near-cap values can
     # still overrun its own varchar(255) column.
     |> validate_length(:slug, max: 255)
@@ -97,19 +97,6 @@ defmodule Vutuv.Profiles.WorkExperience do
         where: c.id == ^organization_id and organization_public_row(c)
       )
     )
-  end
-
-  defp create_slug(changeset) do
-    if get_change(changeset, :title) || get_change(changeset, :organization) do
-      model = %__MODULE__{
-        title: get_field(changeset, :title),
-        organization: get_field(changeset, :organization)
-      }
-
-      put_change(changeset, :slug, Vutuv.SlugHelpers.gen_slug_unique(model, :slug))
-    else
-      changeset
-    end
   end
 
   @doc """

--- a/lib/vutuv/search.ex
+++ b/lib/vutuv/search.ex
@@ -14,7 +14,7 @@ defmodule Vutuv.Search do
 
   import Ecto.Query
   import Vutuv.Moderation.Query, only: [account_hidden_row: 1, account_confirmed_row: 1]
-  import Vutuv.SearchText, only: [escape_like: 1]
+  import Vutuv.SearchText, only: [contains: 1]
 
   alias Vutuv.Accounts
   alias Vutuv.Accounts.SearchTerm
@@ -379,7 +379,7 @@ defmodule Vutuv.Search do
               (fragment("lower(?)", t.name) == ^tag or t.slug == ^tag)
         )
       else
-        infix = "%" <> escape_like(tag) <> "%"
+        infix = contains(tag)
 
         from(ut in Vutuv.Tags.UserTag,
           join: t in assoc(ut, :tag),
@@ -401,7 +401,7 @@ defmodule Vutuv.Search do
           where: a.user_id == parent_as(:user).id and fragment("lower(?)", a.city) == ^city
         )
       else
-        infix = "%" <> escape_like(city) <> "%"
+        infix = contains(city)
 
         from(a in Vutuv.Profiles.Address,
           where: a.user_id == parent_as(:user).id and ilike(a.city, ^infix)
@@ -419,7 +419,7 @@ defmodule Vutuv.Search do
   end
 
   defp by_field(query, field, value, false) do
-    where(query, [user: u], ilike(field(u, ^field), ^("%" <> escape_like(value) <> "%")))
+    where(query, [user: u], ilike(field(u, ^field), ^contains(value)))
   end
 
   defp list_people(query) do
@@ -501,7 +501,7 @@ defmodule Vutuv.Search do
   defp phonetic_term_match(query, value) do
     cologne = phoneticize_search_value(value, :cologne)
     soundex = phoneticize_search_value(value, :soundex)
-    infix = "%" <> escape_like(value) <> "%"
+    infix = contains(value)
 
     from([t, user: u] in query,
       where:
@@ -534,7 +534,7 @@ defmodule Vutuv.Search do
   end
 
   defp visible_tags(needle, false) do
-    infix = "%" <> escape_like(needle) <> "%"
+    infix = contains(needle)
     from(t in Vutuv.Tags.Tag, where: ilike(t.name, ^infix) or ilike(t.slug, ^infix))
   end
 

--- a/lib/vutuv/search_text.ex
+++ b/lib/vutuv/search_text.ex
@@ -28,6 +28,12 @@ defmodule Vutuv.SearchText do
   def escape_like(term), do: String.replace(term, ~r/[\\%_]/, &("\\" <> &1))
 
   @doc """
+  The LIKE "contains" pattern for `term`: the escaped term wrapped in `%…%`,
+  ready for `ilike`/`like`.
+  """
+  def contains(term), do: "%" <> escape_like(term) <> "%"
+
+  @doc """
   Query macro: case-insensitive name match on `first`, `last`, or the
   "first last" concatenation, against `pattern`. Compose it with `or` and a
   site's own extra columns inside a `where`. The bound columns are passed

--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -48,9 +48,11 @@ defmodule Vutuv.Social do
   end
 
   defp do_follow(follower, followee_id) do
+    follower_id = follower_id(follower)
+
     result =
       %Follow{}
-      |> Follow.changeset(%{follower_id: follower_id(follower), followee_id: followee_id})
+      |> Follow.changeset(%{follower_id: follower_id, followee_id: followee_id})
       |> Repo.insert()
 
     with {:ok, _follow} <- result do
@@ -60,7 +62,7 @@ defmodule Vutuv.Social do
       # (connected): announce that meaningful milestone to the followee instead
       # of a second plain "started following you". A first/one-way follow stays
       # the ordinary new-follower event.
-      if user_follows_user?(followee_id, follower_id(follower)) do
+      if user_follows_user?(followee_id, follower_id) do
         Vutuv.Activity.notify_connection(followee_id, actor)
       else
         Vutuv.Activity.notify_new_follower(followee_id, actor)
@@ -68,7 +70,7 @@ defmodule Vutuv.Social do
 
       # Bump the live counts on both members' open profiles (follower / following
       # / connection, and the viewer's follow-state pill).
-      broadcast_social_graph_changed([follower_id(follower), followee_id])
+      broadcast_social_graph_changed([follower_id, followee_id])
     end
 
     result

--- a/lib/vutuv/uploaders/screenshot.ex
+++ b/lib/vutuv/uploaders/screenshot.ex
@@ -35,7 +35,7 @@ defmodule Vutuv.Screenshot do
   `{:error, :invalid_file}`.
   """
   def store({%Plug.Upload{} = upload, scope}) do
-    if valid_extension?(upload.filename) do
+    if Vutuv.Uploads.valid_extension?(upload.filename, @extension_whitelist) do
       dir = disk_dir(scope)
       hash = Vutuv.Uploads.content_hash(upload.path)
       ext = Path.extname(upload.filename)
@@ -199,9 +199,4 @@ defmodule Vutuv.Screenshot do
 
   defp rootname(value) when is_binary(value),
     do: value |> Vutuv.Uploads.strip_query() |> Path.rootname()
-
-  defp valid_extension?(file_name) do
-    extension = file_name |> Path.extname() |> String.downcase()
-    extension in @extension_whitelist
-  end
 end

--- a/lib/vutuv/uploads.ex
+++ b/lib/vutuv/uploads.ex
@@ -587,10 +587,16 @@ defmodule Vutuv.Uploads do
     |> Path.extname()
   end
 
-  defp valid_extension?(file_name) do
+  @doc """
+  Whether `file_name`'s extension (case-insensitive) is in `whitelist`. The
+  screenshot uploader reuses this with its own wider whitelist.
+  """
+  def valid_extension?(file_name, whitelist) do
     extension = file_name |> Path.extname() |> String.downcase()
-    extension in @extension_whitelist
+    extension in whitelist
   end
+
+  defp valid_extension?(file_name), do: valid_extension?(file_name, @extension_whitelist)
 
   @doc """
   The one regeneration driver (used by every uploader's `regenerate/2`, which

--- a/lib/vutuv_web/controllers/admin/user_pref_controller.ex
+++ b/lib/vutuv_web/controllers/admin/user_pref_controller.ex
@@ -72,11 +72,9 @@ defmodule VutuvWeb.Admin.UserPrefController do
   end
 
   defp with_member(conn, id, fun) do
-    with {:ok, _uuid} <- Ecto.UUID.cast(id),
-         %User{} = member <- Repo.get(User, id) do
-      fun.(member)
-    else
-      _ -> ControllerHelpers.render_error(conn, 404)
+    case ControllerHelpers.get_user(id) do
+      %User{} = member -> fun.(member)
+      nil -> ControllerHelpers.render_error(conn, 404)
     end
   end
 end

--- a/lib/vutuv_web/controllers/api_v2/api_v2.ex
+++ b/lib/vutuv_web/controllers/api_v2/api_v2.ex
@@ -76,6 +76,18 @@ defmodule VutuvWeb.ApiV2 do
     end
   end
 
+  @doc """
+  Like `with_cursor/3`, but falls back to the first page (`nil`) on a
+  foreign/expired cursor instead of answering 400. For the agent-doc pages,
+  where the worst case is re-showing the latest entries.
+  """
+  def cursor_or_nil(params) do
+    case decode_cursor(params["cursor"]) do
+      {:ok, cursor} -> cursor
+      :error -> nil
+    end
+  end
+
   @doc "The shared tail of every cursor-paginated response."
   def page_fields(page) do
     %{more: page.more?, next_cursor: encode_cursor(page.more? && page.next_cursor)}

--- a/lib/vutuv_web/controllers/controller_helpers.ex
+++ b/lib/vutuv_web/controllers/controller_helpers.ex
@@ -79,6 +79,20 @@ defmodule VutuvWeb.ControllerHelpers do
   end
 
   @doc """
+  The base session map every controller-embedded LiveView needs: the viewer id,
+  resolved locale and request path. A LiveView mounted outside the
+  `live_session` must be handed these explicitly (the profile/CV/board/feed
+  pattern); pages layer their own extra keys on top with `Map.put/3`.
+  """
+  def live_render_session(%Conn{} = conn) do
+    %{
+      "user_id" => conn.assigns[:current_user_id],
+      "locale" => conn.assigns[:locale],
+      "request_path" => conn.request_path
+    }
+  end
+
+  @doc """
   Renders the bare `VutuvWeb.ErrorHTML` 403/404 page and halts: the one shape
   every auth/resolve plug and the controller-side guards use to refuse a
   request.

--- a/lib/vutuv_web/controllers/cv_controller.ex
+++ b/lib/vutuv_web/controllers/cv_controller.ex
@@ -43,12 +43,7 @@ defmodule VutuvWeb.CVController do
     |> ContentPolicy.put_robots_header(user.noindex?, user.noai?)
     |> put_layout(html: false)
     |> live_render(VutuvWeb.CVLive,
-      session: %{
-        "profile_user_id" => user.id,
-        "locale" => conn.assigns[:locale],
-        "request_path" => conn.request_path,
-        "user_id" => conn.assigns[:current_user_id]
-      }
+      session: Map.put(ControllerHelpers.live_render_session(conn), "profile_user_id", user.id)
     )
   end
 

--- a/lib/vutuv_web/controllers/email_controller.ex
+++ b/lib/vutuv_web/controllers/email_controller.ex
@@ -171,7 +171,7 @@ defmodule VutuvWeb.EmailController do
            conn.assigns[:user],
            conn.assigns[:current_user]
          ) do
-        Vutuv.UUIDv7.with_cast(id, &Repo.get(assoc(conn.assigns[:user], :emails), &1))
+        ControllerHelpers.get_owned(conn.assigns[:user], :emails, id)
       else
         public_email(conn, id)
       end

--- a/lib/vutuv_web/controllers/job_posting_controller.ex
+++ b/lib/vutuv_web/controllers/job_posting_controller.ex
@@ -34,7 +34,7 @@ defmodule VutuvWeb.JobPostingController do
         |> AgentDocs.put_html_alternates()
         |> put_layout(html: false)
         |> live_render(VutuvWeb.JobBoardLive,
-          session: Map.put(base_session(conn), "params", conn.params)
+          session: Map.put(ControllerHelpers.live_render_session(conn), "params", conn.params)
         )
 
       format ->
@@ -43,11 +43,7 @@ defmodule VutuvWeb.JobPostingController do
   end
 
   defp send_board_doc(conn, format) do
-    cursor =
-      case ApiV2.decode_cursor(conn.params["cursor"]) do
-        {:ok, cursor} -> cursor
-        :error -> nil
-      end
+    cursor = ApiV2.cursor_or_nil(conn.params)
 
     page = Jobs.agent_board_page(cursor: cursor)
     next = if page.more?, do: ApiV2.encode_cursor(page.cursor)
@@ -68,7 +64,7 @@ defmodule VutuvWeb.JobPostingController do
         |> AgentDocs.put_html_alternates()
         |> put_layout(html: false)
         |> live_render(VutuvWeb.JobPostingLive.Show,
-          session: Map.put(base_session(conn), "slug", posting.slug)
+          session: Map.put(ControllerHelpers.live_render_session(conn), "slug", posting.slug)
         )
 
       format ->
@@ -126,12 +122,4 @@ defmodule VutuvWeb.JobPostingController do
   end
 
   defp do_apply(conn, _posting, _viewer), do: ControllerHelpers.render_error(conn, 404)
-
-  defp base_session(conn) do
-    %{
-      "user_id" => conn.assigns[:current_user_id],
-      "locale" => conn.assigns[:locale],
-      "request_path" => conn.request_path
-    }
-  end
 end

--- a/lib/vutuv_web/controllers/newsfeed_controller.ex
+++ b/lib/vutuv_web/controllers/newsfeed_controller.ex
@@ -45,13 +45,7 @@ defmodule VutuvWeb.NewsfeedController do
     conn
     |> AgentDocs.put_html_alternates()
     |> put_layout(html: false)
-    |> live_render(VutuvWeb.PostLive.Feed,
-      session: %{
-        "user_id" => conn.assigns[:current_user_id],
-        "locale" => conn.assigns[:locale],
-        "request_path" => conn.request_path
-      }
-    )
+    |> live_render(VutuvWeb.PostLive.Feed, session: ControllerHelpers.live_render_session(conn))
   end
 
   defp send_feed_doc(conn, format, params) do
@@ -61,12 +55,8 @@ defmodule VutuvWeb.NewsfeedController do
 
       viewer ->
         # A foreign/expired `?cursor=` falls back to the first page rather than
-        # erroring — the worst case is re-showing the latest posts.
-        cursor =
-          case ApiV2.decode_cursor(params["cursor"]) do
-            {:ok, cursor} -> cursor
-            :error -> nil
-          end
+        # erroring: the worst case is re-showing the latest posts.
+        cursor = ApiV2.cursor_or_nil(params)
 
         page = Posts.feed_page(viewer, limit: @page_size, cursor: cursor)
         AgentDocs.send_doc(conn, format, FeedDoc.build(viewer, page), cache: "private, no-store")

--- a/lib/vutuv_web/controllers/organization_controller.ex
+++ b/lib/vutuv_web/controllers/organization_controller.ex
@@ -27,7 +27,7 @@ defmodule VutuvWeb.OrganizationController do
     case AgentDocs.negotiate(conn) do
       :html ->
         session =
-          base_session(conn)
+          ControllerHelpers.live_render_session(conn)
           |> Map.put("q", conn.params["q"])
           |> Map.put("page", conn.params["page"])
 
@@ -73,7 +73,12 @@ defmodule VutuvWeb.OrganizationController do
         |> AgentDocs.put_html_alternates()
         |> put_layout(html: false)
         |> live_render(VutuvWeb.OrganizationLive.Show,
-          session: Map.put(base_session(conn), "organization_id", organization.id)
+          session:
+            Map.put(
+              ControllerHelpers.live_render_session(conn),
+              "organization_id",
+              organization.id
+            )
         )
 
       format ->
@@ -95,7 +100,9 @@ defmodule VutuvWeb.OrganizationController do
       %{email_confirmed?: true} ->
         conn
         |> put_layout(html: false)
-        |> live_render(VutuvWeb.OrganizationLive.New, session: base_session(conn))
+        |> live_render(VutuvWeb.OrganizationLive.New,
+          session: ControllerHelpers.live_render_session(conn)
+        )
 
       %{} ->
         conn
@@ -141,7 +148,12 @@ defmodule VutuvWeb.OrganizationController do
         conn
         |> put_layout(html: false)
         |> live_render(live_view,
-          session: Map.put(base_session(conn), "organization_id", organization.id)
+          session:
+            Map.put(
+              ControllerHelpers.live_render_session(conn),
+              "organization_id",
+              organization.id
+            )
         )
 
       true ->
@@ -158,13 +170,5 @@ defmodule VutuvWeb.OrganizationController do
     else
       ControllerHelpers.render_error(conn, 404)
     end
-  end
-
-  defp base_session(conn) do
-    %{
-      "user_id" => conn.assigns[:current_user_id],
-      "locale" => conn.assigns[:locale],
-      "request_path" => conn.request_path
-    }
   end
 end

--- a/lib/vutuv_web/controllers/tag_controller.ex
+++ b/lib/vutuv_web/controllers/tag_controller.ex
@@ -16,11 +16,11 @@ defmodule VutuvWeb.TagController do
   )
 
   def index(conn, _params) do
-    tags_count = Repo.one(from(t in Tag, select: count(t.id)))
+    tags_count = Repo.aggregate(Tag, :count)
 
     tags =
       from(t in Tag, order_by: fragment("lower(coalesce(?, ?))", t.name, t.slug))
-      |> Vutuv.Pages.paginate(conn.params, tags_count)
+      |> Pages.paginate(conn.params, tags_count)
       |> Repo.all()
 
     render(conn, "index.html", tags: tags, tags_count: tags_count)

--- a/lib/vutuv_web/controllers/username_controller.ex
+++ b/lib/vutuv_web/controllers/username_controller.ex
@@ -27,9 +27,11 @@ defmodule VutuvWeb.UsernameController do
         |> redirect(to: ~p"/#{user}")
 
       {:error, changeset} ->
+        # The rename did not persist, so `user.username` still holds the old
+        # handle and `affected` already counted its mentions: reuse it.
         conn
         |> put_status(:unprocessable_entity)
-        |> render_new(user, changeset)
+        |> render_new(user, changeset, affected)
     end
   end
 
@@ -47,11 +49,14 @@ defmodule VutuvWeb.UsernameController do
       )
   end
 
-  defp render_new(conn, user, changeset) do
+  defp render_new(conn, user, changeset),
+    do: render_new(conn, user, changeset, Mentions.count_post_mentions(user.username))
+
+  defp render_new(conn, user, changeset, mention_count) do
     render(conn, "new.html",
       changeset: changeset,
       quota: Accounts.username_change_quota(user),
-      mention_count: Mentions.count_post_mentions(user.username)
+      mention_count: mention_count
     )
   end
 

--- a/lib/vutuv_web/cv/html.ex
+++ b/lib/vutuv_web/cv/html.ex
@@ -146,10 +146,9 @@ defmodule VutuvWeb.CV.Html do
     markdown
     |> Markdown.render()
     |> Phoenix.HTML.safe_to_string()
-    # Only root-relative `/path` hrefs are absolutized; the negative lookahead
-    # leaves a protocol-relative `//host` link alone (it already resolves, and
-    # prefixing it would corrupt it into `#{Endpoint.url()}//host`).
-    |> String.replace(~r{href="/(?!/)}, ~s(href="#{Endpoint.url()}/))
+    # Only root-relative `/path` hrefs are absolutized; the shared helper's
+    # negative lookahead leaves a protocol-relative `//host` link alone.
+    |> Markdown.absolutize_html(Endpoint.url(), ["href"])
   end
 
   defp skills([]), do: ""

--- a/lib/vutuv_web/email_markdown.ex
+++ b/lib/vutuv_web/email_markdown.ex
@@ -27,6 +27,8 @@ defmodule VutuvWeb.EmailMarkdown do
   and a spam-filter red flag).
   """
 
+  alias VutuvWeb.Markdown
+
   @doc "Render an invitation message's Markdown to safe HTML (`Phoenix.HTML.safe`)."
   def render(text) when is_binary(text) do
     text
@@ -36,21 +38,10 @@ defmodule VutuvWeb.EmailMarkdown do
     |> Earmark.as_html!(breaks: true, pure_links: true)
     |> String.replace("&amp;lt;", "&lt;")
     |> HtmlSanitizeEx.markdown_html()
-    |> strip_img_tags()
-    |> open_links_in_new_tab()
+    |> Markdown.strip_img_tags()
+    |> Markdown.open_links_in_new_tab()
     |> Phoenix.HTML.raw()
   end
 
   def render(_), do: Phoenix.HTML.raw("")
-
-  # An invitation email embeds no picture: a hotlinked remote image is a
-  # tracking pixel that leaks the recipient's IP and trips spam filters. The
-  # `HtmlSanitizeEx.markdown_html/1` scrubber keeps `<img>`, so drop it here.
-  defp strip_img_tags(html), do: String.replace(html, ~r/<img\b[^>]*>/i, "")
-
-  # Run after the sanitizer (which strips `target`/`rel`), so external links
-  # open in a new tab without leaking the referrer.
-  defp open_links_in_new_tab(html) do
-    String.replace(html, "<a href", ~s(<a target="_blank" rel="noopener noreferrer" href))
-  end
 end

--- a/lib/vutuv_web/endpoint.ex
+++ b/lib/vutuv_web/endpoint.ex
@@ -109,4 +109,11 @@ defmodule VutuvWeb.Endpoint do
   plug(Plug.Session, @session_options)
 
   plug(VutuvWeb.Router)
+
+  @doc """
+  The operator's public base URL (endpoint config `:public_url`). Used to build
+  the absolute unsubscribe / alert-off links the token modules mint outside a
+  request, where `url/0` is not available.
+  """
+  def public_url, do: config(:public_url)
 end

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -148,7 +148,7 @@ defmodule VutuvWeb.Fediverse.Docs do
   # own, so the negative lookahead leaves it alone instead of corrupting it
   # into `#{base()}//host` (the same guard as `VutuvWeb.Feeds.absolutize_urls/1`).
   defp absolutize(html) do
-    String.replace(html, ~r{(href|src)="/(?!/)}, "\\1=\"#{base()}/")
+    VutuvWeb.Markdown.absolutize_html(html, base())
   end
 
   # inReplyTo only when the parent's author federates too — otherwise the id

--- a/lib/vutuv_web/feeds.ex
+++ b/lib/vutuv_web/feeds.ex
@@ -100,7 +100,7 @@ defmodule VutuvWeb.Feeds do
   # a feed — readers resolve nothing. Protocol-relative (`//host`) URLs are
   # left alone.
   defp absolutize_urls(html) do
-    String.replace(html, ~r{(src|href)="/(?!/)}, "\\1=\"#{VutuvWeb.Endpoint.url()}/")
+    VutuvWeb.Markdown.absolutize_html(html, VutuvWeb.Endpoint.url())
   end
 
   # A literal "]]>" in the rendered body would close the CDATA section.

--- a/lib/vutuv_web/live/admin/job_live.ex
+++ b/lib/vutuv_web/live/admin/job_live.ex
@@ -34,7 +34,7 @@ defmodule VutuvWeb.Admin.JobLive do
   def handle_params(params, _uri, socket) do
     status = if params["status"] in @statuses, do: params["status"], else: "all"
     report = if params["report"] == "open", do: "open", else: nil
-    q = blank_to_nil(params["q"])
+    q = Pages.blank_to_nil(params["q"])
     page = Pages.page_param(params)
 
     result =
@@ -150,13 +150,6 @@ defmodule VutuvWeb.Admin.JobLive do
       |> Map.new()
 
     if query == %{}, do: ~p"/admin/jobs", else: ~p"/admin/jobs?#{query}"
-  end
-
-  defp blank_to_nil(value) do
-    case value && String.trim(value) do
-      "" -> nil
-      trimmed -> trimmed
-    end
   end
 
   # ── status / labels ──

--- a/lib/vutuv_web/live/admin/organization_live.ex
+++ b/lib/vutuv_web/live/admin/organization_live.ex
@@ -28,7 +28,7 @@ defmodule VutuvWeb.Admin.OrganizationLive do
   @impl true
   def handle_params(params, _uri, socket) do
     status = if params["status"] in @statuses, do: params["status"], else: "all"
-    q = blank_to_nil(params["q"])
+    q = Pages.blank_to_nil(params["q"])
     page = Pages.page_param(params)
 
     result =
@@ -156,13 +156,6 @@ defmodule VutuvWeb.Admin.OrganizationLive do
       |> Map.new()
 
     if query == %{}, do: ~p"/admin/organizations", else: ~p"/admin/organizations?#{query}"
-  end
-
-  defp blank_to_nil(value) do
-    case value && String.trim(value) do
-      "" -> nil
-      trimmed -> trimmed
-    end
   end
 
   defp status_chips, do: @statuses

--- a/lib/vutuv_web/live/job_posting_live/show.ex
+++ b/lib/vutuv_web/live/job_posting_live/show.ex
@@ -46,6 +46,7 @@ defmodule VutuvWeb.JobPostingLive.Show do
     |> assign(:effective_status, Jobs.effective_status(posting))
     |> assign(:engagement, Jobs.job_posting_engagement(posting, viewer))
     |> assign(:matching_tags, Jobs.matching_tag_slugs(posting, viewer))
+    |> assign(:location_line, location_line(posting))
   end
 
   @impl true
@@ -103,7 +104,7 @@ defmodule VutuvWeb.JobPostingLive.Show do
           <div class="flex flex-wrap gap-2">
             <.chip>{JobPosting.employment_type_label(@posting.employment_type)}</.chip>
             <.chip>{JobPosting.workplace_type_label(@posting.workplace_type)}</.chip>
-            <.chip :if={location_line(@posting)}>{location_line(@posting)}</.chip>
+            <.chip :if={@location_line}>{@location_line}</.chip>
           </div>
 
           <p class="text-lg font-semibold text-slate-900 dark:text-slate-100">

--- a/lib/vutuv_web/live/search_live.ex
+++ b/lib/vutuv_web/live/search_live.ex
@@ -115,13 +115,16 @@ defmodule VutuvWeb.SearchLive do
     save_search(socket, :people, query, notify)
   end
 
-  # The stored query string mirrors the /search URL (q + non-default scope +
-  # exact), so the sweeper and the "run now" link replay the same search.
-  defp search_query(q, scope, exact) do
+  # The non-default query params behind both the stored query string and the
+  # canonical /search URL: q, a non-default scope, and exact — blanks dropped.
+  defp search_params(q, scope, exact) do
     [q: q, scope: scope != :all && scope, exact: exact && "1"]
     |> Enum.reject(fn {_k, v} -> v in ["", false, nil] end)
-    |> URI.encode_query()
   end
+
+  # The stored query string mirrors the /search URL (q + non-default scope +
+  # exact), so the sweeper and the "run now" link replay the same search.
+  defp search_query(q, scope, exact), do: search_params(q, scope, exact) |> URI.encode_query()
 
   # The settle timer fired: this query stopped changing, so it counts.
   @impl true
@@ -138,12 +141,7 @@ defmodule VutuvWeb.SearchLive do
   # The canonical /search URL for a query + filter combination; defaults stay
   # out of the query string so plain searches keep plain URLs.
   defp search_path(q, scope, exact) do
-    params =
-      Enum.reject(
-        [q: q, scope: scope != :all && scope, exact: exact && "1"],
-        fn {_k, v} -> v in ["", false, nil] end
-      )
-
+    params = search_params(q, scope, exact)
     if params == [], do: ~p"/search", else: ~p"/search?#{params}"
   end
 

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -307,23 +307,19 @@ defmodule VutuvWeb.UserProfileLive do
   # A fresh list (new identity) is what makes change tracking re-render the
   # `:for` over @posts; content barely differs, only the relative wording.
   def handle_info(:day_changed, socket) do
-    posts = fetch_profile_posts(socket, socket.assigns.post_filter)
-
-    {:noreply, socket |> assign(:posts, posts) |> refresh_social_feed_stamps()}
+    {:noreply, socket |> reload_posts() |> refresh_social_feed_stamps()}
   end
 
   # A shown post's link screenshot finished capturing (fan-out reaches this page
   # over the profile owner's activity topic): re-fetch the posts so the card
   # gains its screenshot with no reload. A fresh list re-renders the `:for`.
   def handle_info({:post_screenshot_ready, _payload}, socket) do
-    posts = fetch_profile_posts(socket, socket.assigns.post_filter)
-    {:noreply, assign(socket, :posts, posts)}
+    {:noreply, reload_posts(socket)}
   end
 
   # The owner removed a bad link screenshot: re-fetch so the card drops it.
   def handle_info({:post_screenshot_removed, _payload}, socket) do
-    posts = fetch_profile_posts(socket, socket.assigns.post_filter)
-    {:noreply, assign(socket, :posts, posts)}
+    {:noreply, reload_posts(socket)}
   end
 
   # An AI image-moderation verdict landed for this profile's owner
@@ -360,8 +356,7 @@ defmodule VutuvWeb.UserProfileLive do
   end
 
   def handle_info({:image_moderation, "post_image", _subject_id, _verdict}, socket) do
-    posts = fetch_profile_posts(socket, socket.assigns.post_filter)
-    {:noreply, assign(socket, :posts, posts)}
+    {:noreply, reload_posts(socket)}
   end
 
   # The social feed cache answered a mount-time request (or a concurrent
@@ -530,6 +525,12 @@ defmodule VutuvWeb.UserProfileLive do
       type: Vutuv.Posts.normalize_post_filter(filter)
     )
   end
+
+  # Re-fetch the shown posts in the reader's current filter and re-assign them:
+  # the fresh list (new identity) re-renders the `:for` with no reload. Shared by
+  # the day-roll, screenshot and image-moderation handlers.
+  defp reload_posts(socket),
+    do: assign(socket, :posts, fetch_profile_posts(socket, socket.assigns.post_filter))
 
   # ── Initial load (ports UserController.show_html) ──
 

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -297,8 +297,13 @@ defmodule VutuvWeb.Markdown do
     end
   end
 
-  # Safe to do post-sanitization: every remaining <a> came out of the scrubber.
-  defp open_links_in_new_tab(html) do
+  @doc """
+  Adds `target="_blank" rel="noopener noreferrer"` to every `<a href` so
+  external links open in a new tab without leaking the referrer. Safe to run
+  post-sanitization: every remaining `<a>` came out of the scrubber. Shared with
+  `VutuvWeb.EmailMarkdown`.
+  """
+  def open_links_in_new_tab(html) do
     String.replace(html, "<a href", ~s(<a target="_blank" rel="noopener noreferrer" href))
   end
 
@@ -553,9 +558,12 @@ defmodule VutuvWeb.Markdown do
     ~s(<img src="#{escape(src)}" alt="#{escape(alt)}"#{dimensions} loading="lazy" class="#{class}">)
   end
 
-  # Every <img> the pipeline produced is untrusted (remote hotlinks, foreign
-  # attachments); only the marker-injected ones below may survive.
-  defp strip_img_tags(html) do
+  @doc """
+  Strips every `<img>` from HTML. Every `<img>` the pipeline produced is
+  untrusted (remote hotlinks, foreign attachments); only the marker-injected
+  ones below may survive. Shared with `VutuvWeb.EmailMarkdown`.
+  """
+  def strip_img_tags(html) do
     String.replace(html, ~r/<img\b[^>]*>/i, "")
   end
 

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -307,6 +307,19 @@ defmodule VutuvWeb.Markdown do
     String.replace(html, "<a href", ~s(<a target="_blank" rel="noopener noreferrer" href))
   end
 
+  @doc """
+  Rewrites root-relative `/path` URLs in rendered HTML to absolute `base/path`,
+  for a standalone context (an RSS/JSON feed, a downloaded CV, a federated
+  note). The negative lookahead leaves a protocol-relative `//host` URL alone:
+  it already resolves, and prefixing it would corrupt it into `base//host`.
+  `attrs` picks which URL attributes to rewrite (both `src` and `href` by
+  default; the CV passes just `["href"]`). Shared by VutuvWeb.Feeds,
+  VutuvWeb.Fediverse.Docs and VutuvWeb.CV.Html so the tricky guard lives once.
+  """
+  def absolutize_html(html, base, attrs \\ ["src", "href"]) do
+    String.replace(html, ~r{(#{Enum.join(attrs, "|")})="/(?!/)}, "\\1=\"#{base}/")
+  end
+
   ## @handle / fediverse mentions and #hashtags
 
   # Turns every `@handle` of an existing member into a same-tab link to their

--- a/lib/vutuv_web/saved_search_token.ex
+++ b/lib/vutuv_web/saved_search_token.ex
@@ -33,7 +33,5 @@ defmodule VutuvWeb.SavedSearchToken do
 
   @doc "The absolute URL that switches off alerts for one saved search."
   def url(%SavedSearch{} = saved_search),
-    do: public_url() <> "unsubscribe/search/" <> sign(saved_search)
-
-  defp public_url, do: Application.get_env(:vutuv, VutuvWeb.Endpoint)[:public_url]
+    do: VutuvWeb.Endpoint.public_url() <> "unsubscribe/search/" <> sign(saved_search)
 end

--- a/lib/vutuv_web/templates/admin/admin/index.html.heex
+++ b/lib/vutuv_web/templates/admin/admin/index.html.heex
@@ -54,9 +54,10 @@ per-IP rate limiter and the security email only ever see the proxy hop. --%>
         {gettext("No reported content waiting - the self-service flow is doing its job.")}
       <% else %>
         {ngettext(
-          "%{count} case is waiting for a ruling.",
-          "%{count} cases are waiting for a ruling.",
-          @moderation_count
+          "%{formatted} case is waiting for a ruling.",
+          "%{formatted} cases are waiting for a ruling.",
+          @moderation_count,
+          formatted: compact_count(@moderation_count)
         )}
       <% end %>
     </.admin_card>
@@ -122,9 +123,10 @@ per-IP rate limiter and the security email only ever see the proxy hop. --%>
         )}
       <% else %>
         {ngettext(
-          "%{count} account is frozen because every email address bounced.",
-          "%{count} accounts are frozen because every email address bounced.",
-          @frozen_accounts_count
+          "%{formatted} account is frozen because every email address bounced.",
+          "%{formatted} accounts are frozen because every email address bounced.",
+          @frozen_accounts_count,
+          formatted: compact_count(@frozen_accounts_count)
         )}
       <% end %>
     </.admin_card>
@@ -142,9 +144,10 @@ per-IP rate limiter and the security email only ever see the proxy hop. --%>
         {gettext("Every job posting: search, freeze/unfreeze, close or delete, with the poster's report history and cold-outreach counter.")}
       <% else %>
         {ngettext(
-          "%{count} job posting has an open moderation case.",
-          "%{count} job postings have an open moderation case.",
-          @jobs_open_cases_count
+          "%{formatted} job posting has an open moderation case.",
+          "%{formatted} job postings have an open moderation case.",
+          @jobs_open_cases_count,
+          formatted: compact_count(@jobs_open_cases_count)
         )}
       <% end %>
     </.admin_card>
@@ -234,9 +237,10 @@ per-IP rate limiter and the security email only ever see the proxy hop. --%>
         {gettext("Verified organization pages: domains, team roles, aliases and rename history. Freeze, archive or delete a page.")}
       <% else %>
         {ngettext(
-          "%{count} alias matches another verified organization and is flagged for review.",
-          "%{count} aliases match another verified organization and are flagged for review.",
-          @flagged_aliases_count
+          "%{formatted} alias matches another verified organization and is flagged for review.",
+          "%{formatted} aliases match another verified organization and are flagged for review.",
+          @flagged_aliases_count,
+          formatted: compact_count(@flagged_aliases_count)
         )}
       <% end %>
     </.admin_card>
@@ -323,9 +327,10 @@ per-IP rate limiter and the security email only ever see the proxy hop. --%>
       cta={gettext("Manage applications")}
     >
       {ngettext(
-        "%{count} registered third-party application. Suspending one cuts off all of its tokens.",
-        "%{count} registered third-party applications. Suspending one cuts off all of its tokens.",
-        @api_apps_count
+        "%{formatted} registered third-party application. Suspending one cuts off all of its tokens.",
+        "%{formatted} registered third-party applications. Suspending one cuts off all of its tokens.",
+        @api_apps_count,
+        formatted: compact_count(@api_apps_count)
       )}
     </.admin_card>
 
@@ -343,9 +348,10 @@ per-IP rate limiter and the security email only ever see the proxy hop. --%>
         {gettext("No ads waiting for approval.")}
       <% else %>
         {ngettext(
-          "%{count} ad is waiting for approval.",
-          "%{count} ads are waiting for approval.",
-          @pending_ads_count
+          "%{formatted} ad is waiting for approval.",
+          "%{formatted} ads are waiting for approval.",
+          @pending_ads_count,
+          formatted: compact_count(@pending_ads_count)
         )}
       <% end %>
     </.admin_card>

--- a/lib/vutuv_web/templates/settings/privacy.html.heex
+++ b/lib/vutuv_web/templates/settings/privacy.html.heex
@@ -70,94 +70,52 @@ which would otherwise render the hint heavier than its own heading. --%>
           (checked = shown), so a plain checkbox, unlike the inverted opt-out
           robot switches above. Off means VutuvWeb.Presence never tracks you, so
           you appear online to no one (not even on your own top-bar avatar). --%>
-    <.card>
-      <.section_title>{gettext("Online status")}</.section_title>
-      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-        {gettext("A green dot on your avatar tells other members you are online right now.")}
-      </p>
-
-      <.form
-        :let={f}
-        for={@changeset}
-        action={~p"/settings/privacy"}
-        id="online-status-form"
-        class="mt-5 space-y-5"
-      >
-        <.setting_toggle label={gettext("Show when I'm online")}>
-          <:checkbox><%= checkbox f, :show_online_status?, class: checkbox_class() %></:checkbox>
-          {gettext("When off, no one sees the green dot on your avatar, and you never show as online.")}
-        </.setting_toggle>
-
-        <div class="pt-1">
-          <.button type="submit">{gettext("Save")}</.button>
-        </div>
-      </.form>
-    </.card>
+    <.toggle_form_card
+      changeset={@changeset}
+      field={:show_online_status?}
+      form_id="online-status-form"
+      title={gettext("Online status")}
+      intro={gettext("A green dot on your avatar tells other members you are online right now.")}
+      label={gettext("Show when I'm online")}
+      hint={gettext("When off, no one sees the green dot on your avatar, and you never show as online.")}
+    />
 
     <%!-- Social media posts: the inline feed card on the profile
           (Vutuv.SocialFeed, Mastodon + Bluesky). A positive flag like the
           online dot above: default on, so a listed account shows its latest
           public posts until the member opts out here. The column keeps its
           historical name (show_mastodon_feed?) but gates the whole card. --%>
-    <.card>
-      <.section_title>{gettext("Social media posts")}</.section_title>
-      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-        {gettext(
+    <.toggle_form_card
+      changeset={@changeset}
+      field={:show_mastodon_feed?}
+      form_id="social-feed-form"
+      title={gettext("Social media posts")}
+      intro={
+        gettext(
           "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
-        )}
-      </p>
-
-      <.form
-        :let={f}
-        for={@changeset}
-        action={~p"/settings/privacy"}
-        id="social-feed-form"
-        class="mt-5 space-y-5"
-      >
-        <.setting_toggle label={gettext("Show my latest social media posts on my profile")}>
-          <:checkbox><%= checkbox f, :show_mastodon_feed?, class: checkbox_class() %></:checkbox>
-          {gettext(
-            "When off, the Social Media card lists your accounts without any posts."
-          )}
-        </.setting_toggle>
-
-        <div class="pt-1">
-          <.button type="submit">{gettext("Save")}</.button>
-        </div>
-      </.form>
-    </.card>
+        )
+      }
+      label={gettext("Show my latest social media posts on my profile")}
+      hint={gettext("When off, the Social Media card lists your accounts without any posts.")}
+    />
 
     <%!-- Code statistics: the profile's "Code" card (Vutuv.CodeStats, GitHub +
           GitLab + Codeberg). Same positive-flag pattern as the posts card
           above: default on, a listed forge account shows its public stats
           until the member opts out here. --%>
-    <.card>
-      <.section_title>{gettext("Code statistics")}</.section_title>
-      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-        {gettext(
+    <.toggle_form_card
+      changeset={@changeset}
+      field={:show_code_stats?}
+      form_id="code-stats-form"
+      title={gettext("Code statistics")}
+      intro={
+        gettext(
           "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
-        )}
-      </p>
-
-      <.form
-        :let={f}
-        for={@changeset}
-        action={~p"/settings/privacy"}
-        id="code-stats-form"
-        class="mt-5 space-y-5"
-      >
-        <.setting_toggle label={gettext("Show code statistics on my profile")}>
-          <:checkbox><%= checkbox f, :show_code_stats?, class: checkbox_class() %></:checkbox>
-          {gettext(
-            "When off, the Social Media card lists your accounts as plain links only."
-          )}
-        </.setting_toggle>
-
-        <div class="pt-1">
-          <.button type="submit">{gettext("Save")}</.button>
-        </div>
-      </.form>
-    </.card>
+        )
+      }
+      label={gettext("Show code statistics on my profile")}
+      hint={gettext("When off, the Social Media card lists your accounts as plain links only.")}
+    />
 
     <%!-- Safety: the two things you reach for when someone is a problem or your
           content is being looked at. Grouped in one card (two rows) so neither

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -445,14 +445,14 @@ the resulting ~200px rail width. --%>
     </.card>
 
     <%!-- Tags --%>
-    <.card :if={Enum.count(@user_tags) > 0 or @as_owner?}>
+    <.card :if={@user_tags != [] or @as_owner?}>
       <%!-- The dashed add tile is onboarding scaffolding: it shows only while the
       card is empty. Once there are entries the card is a clean showcase and
       "Verwalten" (manage_footer) leads to the page where tags are added/removed
       (tags have no edit form). --%>
       <.section_header title={gettext("Tags")} />
 
-      <.empty_add :if={@as_owner? and Enum.count(@user_tags) == 0} href={~p"/settings/tags/new"}>
+      <.empty_add :if={@as_owner? and @user_tags == []} href={~p"/settings/tags/new"}>
         {gettext("Add a tag")}
       </.empty_add>
 
@@ -461,7 +461,7 @@ the resulting ~200px rail width. --%>
       app.js drives it over fetch), and hovering raises the named voter roster (which
       includes the viewer the moment they endorse). Endorsements (and their users) are
       preloaded, so tag_vote works in memory (no per-tag query). --%>
-      <div :if={Enum.count(@user_tags) > 0} class="flex flex-wrap gap-2">
+      <div :if={@user_tags != []} class="flex flex-wrap gap-2">
         <.tag_vote
           :for={user_tag <- @user_tags}
           user={@user}
@@ -805,7 +805,7 @@ the resulting ~200px rail width. --%>
       to cancel the legacy global `dl dd { margin: 10px 0 }` in components.css,
       which otherwise pads each row; a tight `gap-1.5` then sets the row rhythm. --%>
       <dl :if={has_general_info} class="flex flex-col gap-1.5 text-sm">
-        <div :if={@user.gender && @user.gender != "other"} class="flex items-center gap-2.5">
+        <div :if={has_gender} class="flex items-center gap-2.5">
           <.detail_icon name="user" class="h-4 w-4 shrink-0 text-slate-400 dark:text-slate-500" />
           <dt class="sr-only">{gettext("Gender")}</dt>
           <dd class="my-0 font-medium text-slate-800 dark:text-slate-100">{Vutuv.Accounts.User.gender_gettext(@user.gender)}</dd>
@@ -847,11 +847,11 @@ the resulting ~200px rail width. --%>
     the rail previews, else the owner's "Manage". The whole row drops to nothing
     for a visitor who already sees everything. --%>
     <.card
-      :if={Enum.count(@emails) > 0 or @totals.numbers > 0 or @as_owner?}
+      :if={@emails != [] or @totals.numbers > 0 or @as_owner?}
       id="profile-contact"
     >
       <.section_header title={gettext("Contact")} />
-      <.empty_add :if={@as_owner? and Enum.count(@emails) == 0} href={~p"/settings/emails/new"}>
+      <.empty_add :if={@as_owner? and @emails == []} href={~p"/settings/emails/new"}>
         {gettext("Add an email address")}
       </.empty_add>
       <%!-- Contact channels grouped into Beruflich/Privat: e-mails are work
@@ -928,7 +928,7 @@ the resulting ~200px rail width. --%>
       </.empty_add>
       <%!-- One folded footer for both channels ("Manage emails · Manage phone
       numbers"), each link shown only when the viewer can act on it. --%>
-      <% show_email_manage = @as_owner? and Enum.count(@emails) >= 1 %>
+      <% show_email_manage = @as_owner? and @emails != [] %>
       <% show_phone_link = @totals.numbers > 3 or (@as_owner? and @totals.numbers >= 1) %>
       <div
         :if={show_email_manage or show_phone_link}
@@ -956,12 +956,13 @@ the resulting ~200px rail width. --%>
       </div>
     </.card>
 
+    <% smas_count = Enum.count(@user.social_media_accounts) %>
     <.card
-      :if={Enum.count(@user.social_media_accounts) > 0 or @as_owner?}
+      :if={smas_count > 0 or @as_owner?}
       id="profile-social-media"
     >
       <.section_header title={gettext("Profiles")} />
-      <.empty_add :if={@as_owner? and Enum.count(@user.social_media_accounts) == 0} href={~p"/settings/social_media_accounts/new"}>
+      <.empty_add :if={@as_owner? and smas_count == 0} href={~p"/settings/social_media_accounts/new"}>
         {gettext("Add a profile")}
       </.empty_add>
 
@@ -970,7 +971,7 @@ the resulting ~200px rail width. --%>
       the forges stop reading as "social media". One line per account: brand
       glyph + handle (the icon carries the provider name). --%>
       <.social_media_accounts
-        :if={Enum.count(@user.social_media_accounts) > 0}
+        :if={smas_count > 0}
         accounts={@user.social_media_accounts}
         social_feed_loading={@social_feed_loading}
       />
@@ -978,8 +979,8 @@ the resulting ~200px rail width. --%>
       <.manage_footer
         href={~p"/#{@user}/social_media_accounts"}
         manage_href={~p"/settings/social_media_accounts"}
-        total={Enum.count(@user.social_media_accounts)}
-        preview={Enum.count(@user.social_media_accounts)}
+        total={smas_count}
+        preview={smas_count}
         owner={@as_owner?}
       />
     </.card>
@@ -1193,7 +1194,7 @@ the resulting ~200px rail width. --%>
     links): the member's own card leads, discovery of other people follows.
     `order-1` groups it with Followers / Following at the end on a phone. --%>
     <.card
-      :if={Enum.count(@recommended_users) > 0}
+      :if={@recommended_users != []}
       id="profile-who-to-follow"
       class="order-1 md:order-none"
     >

--- a/lib/vutuv_web/unsubscribe_token.ex
+++ b/lib/vutuv_web/unsubscribe_token.ex
@@ -55,11 +55,9 @@ defmodule VutuvWeb.UnsubscribeToken do
   end
 
   @doc "The absolute unsubscribe URL for the master unread-messages switch."
-  def url(%User{} = user), do: public_url() <> "unsubscribe/" <> sign(user)
+  def url(%User{} = user), do: VutuvWeb.Endpoint.public_url() <> "unsubscribe/" <> sign(user)
 
   @doc "The absolute unsubscribe URL that switches off the named preference."
   def url(%User{} = user, field) when is_atom(field),
-    do: public_url() <> "unsubscribe/" <> sign(user, field)
-
-  defp public_url, do: Application.get_env(:vutuv, VutuvWeb.Endpoint)[:public_url]
+    do: VutuvWeb.Endpoint.public_url() <> "unsubscribe/" <> sign(user, field)
 end

--- a/lib/vutuv_web/views/settings_html.ex
+++ b/lib/vutuv_web/views/settings_html.ex
@@ -99,6 +99,47 @@ defmodule VutuvWeb.SettingsHTML do
   end
 
   @doc """
+  A privacy-settings card wrapping one boolean toggle in its own save form:
+  section title + intro paragraph, a `<.setting_toggle>` checkbox bound to
+  `field` on `changeset`, and a Save button. The three positive-flag privacy
+  switches (online status, social-media posts, code statistics) share it, so
+  they can never drift apart.
+  """
+  attr(:changeset, :any, required: true)
+  attr(:field, :atom, required: true)
+  attr(:form_id, :string, required: true)
+  attr(:title, :string, required: true)
+  attr(:intro, :string, required: true)
+  attr(:label, :string, required: true)
+  attr(:hint, :string, required: true)
+
+  def toggle_form_card(assigns) do
+    ~H"""
+    <.card>
+      <.section_title>{@title}</.section_title>
+      <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">{@intro}</p>
+
+      <.form
+        :let={f}
+        for={@changeset}
+        action={~p"/settings/privacy"}
+        id={@form_id}
+        class="mt-5 space-y-5"
+      >
+        <.setting_toggle label={@label}>
+          <:checkbox><%= checkbox f, @field, class: checkbox_class() %></:checkbox>
+          {@hint}
+        </.setting_toggle>
+
+        <div class="pt-1">
+          <.button type="submit">{gettext("Save")}</.button>
+        </div>
+      </.form>
+    </.card>
+    """
+  end
+
+  @doc """
   The desktop frame the hub shares with its subpages: the persistent
   `<.settings_sidebar>` on the left (md+), the "Settings" title + "View profile"
   link on the right, and the page body in the slot. This closes the gap the hub

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.117.0",
+      version: "7.117.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2988,10 +2988,10 @@ msgstr[1] "%{count} aktive Verwarnungspunkte"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:56
 #, elixir-autogen, elixir-format
-msgid "%{count} case is waiting for a ruling."
-msgid_plural "%{count} cases are waiting for a ruling."
-msgstr[0] "%{count} Fall wartet auf eine Entscheidung."
-msgstr[1] "%{count} Fälle warten auf eine Entscheidung."
+msgid "%{formatted} case is waiting for a ruling."
+msgid_plural "%{formatted} cases are waiting for a ruling."
+msgstr[0] "%{formatted} Fall wartet auf eine Entscheidung."
+msgstr[1] "%{formatted} Fälle warten auf eine Entscheidung."
 
 #: lib/vutuv_web/live/admin/job_live.ex:346
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:266
@@ -4330,10 +4330,10 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:345
 #, elixir-autogen, elixir-format
-msgid "%{count} ad is waiting for approval."
-msgid_plural "%{count} ads are waiting for approval."
-msgstr[0] "%{count} Anzeige wartet auf Freischaltung."
-msgstr[1] "%{count} Anzeigen warten auf Freischaltung."
+msgid "%{formatted} ad is waiting for approval."
+msgid_plural "%{formatted} ads are waiting for approval."
+msgstr[0] "%{formatted} Anzeige wartet auf Freischaltung."
+msgstr[1] "%{formatted} Anzeigen warten auf Freischaltung."
 
 #: lib/vutuv_web/controllers/admin/ad_controller.ex:20
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:2
@@ -5090,13 +5090,13 @@ msgstr "%{app} möchte auf Ihr vutuv-Konto zugreifen. Es dürfte:"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:325
 #, elixir-autogen, elixir-format
-msgid "%{count} registered third-party application. Suspending one cuts off all of its tokens."
-msgid_plural "%{count} registered third-party applications. Suspending one cuts off all of its tokens."
+msgid "%{formatted} registered third-party application. Suspending one cuts off all of its tokens."
+msgid_plural "%{formatted} registered third-party applications. Suspending one cuts off all of its tokens."
 msgstr[0] ""
-"%{count} registrierte Drittanbieter-Anwendung. Eine Sperrung schaltet alle "
+"%{formatted} registrierte Drittanbieter-Anwendung. Eine Sperrung schaltet alle "
 "ihre Tokens ab."
 msgstr[1] ""
-"%{count} registrierte Drittanbieter-Anwendungen. Eine Sperrung schaltet alle"
+"%{formatted} registrierte Drittanbieter-Anwendungen. Eine Sperrung schaltet alle"
 " ihre Tokens ab."
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:21
@@ -6607,12 +6607,12 @@ msgstr "empfohlen am %{date}"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:124
 #, elixir-autogen, elixir-format
-msgid "%{count} account is frozen because every email address bounced."
-msgid_plural "%{count} accounts are frozen because every email address bounced."
+msgid "%{formatted} account is frozen because every email address bounced."
+msgid_plural "%{formatted} accounts are frozen because every email address bounced."
 msgstr[0] ""
-"%{count} Konto ist eingefroren, weil jede E-Mail-Adresse unzustellbar wurde."
+"%{formatted} Konto ist eingefroren, weil jede E-Mail-Adresse unzustellbar wurde."
 msgstr[1] ""
-"%{count} Konten sind eingefroren, weil jede E-Mail-Adresse unzustellbar "
+"%{formatted} Konten sind eingefroren, weil jede E-Mail-Adresse unzustellbar "
 "wurde."
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:300
@@ -12513,13 +12513,13 @@ msgstr "ehemalig"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:236
 #, elixir-autogen, elixir-format
-msgid "%{count} alias matches another verified organization and is flagged for review."
-msgid_plural "%{count} aliases match another verified organization and are flagged for review."
+msgid "%{formatted} alias matches another verified organization and is flagged for review."
+msgid_plural "%{formatted} aliases match another verified organization and are flagged for review."
 msgstr[0] ""
-"%{count} Alias stimmt mit einer anderen verifizierten Organisation überein und "
+"%{formatted} Alias stimmt mit einer anderen verifizierten Organisation überein und "
 "wurde zur Prüfung markiert."
 msgstr[1] ""
-"%{count} Aliasse stimmen mit anderen verifizierten Organisationen überein und wurden"
+"%{formatted} Aliasse stimmen mit anderen verifizierten Organisationen überein und wurden"
 " zur Prüfung markiert."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:206
@@ -13633,10 +13633,10 @@ msgstr "Jobs durchsuchen"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:144
 #, elixir-autogen, elixir-format
-msgid "%{count} job posting has an open moderation case."
-msgid_plural "%{count} job postings have an open moderation case."
-msgstr[0] "%{count} Stellenanzeige hat einen offenen Moderationsfall."
-msgstr[1] "%{count} Stellenanzeigen haben einen offenen Moderationsfall."
+msgid "%{formatted} job posting has an open moderation case."
+msgid_plural "%{formatted} job postings have an open moderation case."
+msgstr[0] "%{formatted} Stellenanzeige hat einen offenen Moderationsfall."
+msgstr[1] "%{formatted} Stellenanzeigen haben einen offenen Moderationsfall."
 
 #: lib/vutuv_web/live/admin/job_live.ex:447
 #, elixir-autogen, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2928,8 +2928,8 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:56
 #, elixir-autogen, elixir-format
-msgid "%{count} case is waiting for a ruling."
-msgid_plural "%{count} cases are waiting for a ruling."
+msgid "%{formatted} case is waiting for a ruling."
+msgid_plural "%{formatted} cases are waiting for a ruling."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -4179,8 +4179,8 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:345
 #, elixir-autogen, elixir-format
-msgid "%{count} ad is waiting for approval."
-msgid_plural "%{count} ads are waiting for approval."
+msgid "%{formatted} ad is waiting for approval."
+msgid_plural "%{formatted} ads are waiting for approval."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -4889,8 +4889,8 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:325
 #, elixir-autogen, elixir-format
-msgid "%{count} registered third-party application. Suspending one cuts off all of its tokens."
-msgid_plural "%{count} registered third-party applications. Suspending one cuts off all of its tokens."
+msgid "%{formatted} registered third-party application. Suspending one cuts off all of its tokens."
+msgid_plural "%{formatted} registered third-party applications. Suspending one cuts off all of its tokens."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -6338,8 +6338,8 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:124
 #, elixir-autogen, elixir-format
-msgid "%{count} account is frozen because every email address bounced."
-msgid_plural "%{count} accounts are frozen because every email address bounced."
+msgid "%{formatted} account is frozen because every email address bounced."
+msgid_plural "%{formatted} accounts are frozen because every email address bounced."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -11821,8 +11821,8 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:236
 #, elixir-autogen, elixir-format
-msgid "%{count} alias matches another verified organization and is flagged for review."
-msgid_plural "%{count} aliases match another verified organization and are flagged for review."
+msgid "%{formatted} alias matches another verified organization and is flagged for review."
+msgid_plural "%{formatted} aliases match another verified organization and are flagged for review."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -12906,8 +12906,8 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:144
 #, elixir-autogen, elixir-format
-msgid "%{count} job posting has an open moderation case."
-msgid_plural "%{count} job postings have an open moderation case."
+msgid "%{formatted} job posting has an open moderation case."
+msgid_plural "%{formatted} job postings have an open moderation case."
 msgstr[0] ""
 msgstr[1] ""
 

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2926,8 +2926,8 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:56
 #, elixir-autogen, elixir-format
-msgid "%{count} case is waiting for a ruling."
-msgid_plural "%{count} cases are waiting for a ruling."
+msgid "%{formatted} case is waiting for a ruling."
+msgid_plural "%{formatted} cases are waiting for a ruling."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -4177,8 +4177,8 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:345
 #, elixir-autogen, elixir-format
-msgid "%{count} ad is waiting for approval."
-msgid_plural "%{count} ads are waiting for approval."
+msgid "%{formatted} ad is waiting for approval."
+msgid_plural "%{formatted} ads are waiting for approval."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -4887,8 +4887,8 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:325
 #, elixir-autogen, elixir-format
-msgid "%{count} registered third-party application. Suspending one cuts off all of its tokens."
-msgid_plural "%{count} registered third-party applications. Suspending one cuts off all of its tokens."
+msgid "%{formatted} registered third-party application. Suspending one cuts off all of its tokens."
+msgid_plural "%{formatted} registered third-party applications. Suspending one cuts off all of its tokens."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -6336,8 +6336,8 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:124
 #, elixir-autogen, elixir-format
-msgid "%{count} account is frozen because every email address bounced."
-msgid_plural "%{count} accounts are frozen because every email address bounced."
+msgid "%{formatted} account is frozen because every email address bounced."
+msgid_plural "%{formatted} accounts are frozen because every email address bounced."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -11819,8 +11819,8 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:236
 #, elixir-autogen, elixir-format
-msgid "%{count} alias matches another verified organization and is flagged for review."
-msgid_plural "%{count} aliases match another verified organization and are flagged for review."
+msgid "%{formatted} alias matches another verified organization and is flagged for review."
+msgid_plural "%{formatted} aliases match another verified organization and are flagged for review."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -12904,8 +12904,8 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:144
 #, elixir-autogen, elixir-format
-msgid "%{count} job posting has an open moderation case."
-msgid_plural "%{count} job postings have an open moderation case."
+msgid "%{formatted} job posting has an open moderation case."
+msgid_plural "%{formatted} job postings have an open moderation case."
 msgstr[0] ""
 msgstr[1] ""
 


### PR DESCRIPTION
Behaviour-preserving code-quality sweep across the whole app: reuse, dedup, efficiency and altitude cleanups only — no feature or behaviour changes. Every page's rendered output is unchanged (verified in a browser across feed, profile, settings, admin, jobs, landing, login and search).

## What changed, by layer

- **Contexts** — delegate to existing helpers instead of re-implementing (Handles.normalize, ChangesetHelpers.trim_fields, Snapshot.datetime, SearchText.contains/1, Uploads.valid_extension?/2, Markdown.strip_img_tags/open_links_in_new_tab); extract duplicated bodies into one home (CvSection.put_slug, Jobs.finish_board, ImageSubjects.clear_profile_columns, Posts.broadcast_post_followers_event, Dashboard.recent_listing); bind-once and single-query cleanups.
- **Controllers** — reuse ControllerHelpers.get_owned/get_user; extract ControllerHelpers.live_render_session/1 and ApiV2.cursor_or_nil/1; drop a redundant re-query.
- **LiveViews** — UserProfileLive.reload_posts/1, SearchLive.search_params/3, Pages.blank_to_nil/1 (was duplicated in two admin LiveViews), memoize location_line.
- **Web infra** — one Markdown.absolutize_html/3 owns the tricky root-relative URL rewrite guard (was copied in Feeds, Fediverse.Docs, CV.Html); Endpoint.public_url/0 accessor.
- **Templates** — reuse bindings, O(1) list-emptiness checks on preloaded lists, one shared SettingsHTML.toggle_form_card/1 for the three identical privacy toggle cards.
- **Admin dashboard** — format the six alert counts through compact_count/1 instead of a bare `%{count}` (the documented ngettext gotcha); German translations updated in place.

## How it was produced

A 19-slice multi-agent analysis (analyze + adversarial verify) surfaced 39 findings; 35 were applied and 4 skipped where the fix carried more risk than the duplication it removed (a backoff one-liner that would collide with the existing RemoteFetch.Backoff, a hot-path engagement-count SQL rewrite, an org domain-verification component whose two renderings diverge structurally, and an optional jobs-count collapse). Two flaws in the findings themselves were caught and corrected.

## Verification

- `mix precommit` green: compile --warnings-as-errors, format, credo --strict, **4059 tests pass**.
- Browser-verified the changed pages render identically (compact counts, toggle cards, search highlight, profile cards).

Patch bump to 7.117.1 (internal refactors only).