### PR TITLE
Bump version to 7.117.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.117.1",
+      version: "7.117.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Restores a monotonic version after #974 (the @handle underscore-mention fix) merged at 7.117.1 without its own bump: the pre-push hook blocks the whole shell command before it runs, so the `git commit --amend` that carried the bump never executed. This is a one-line follow-up.