### PR TITLE
Add a free minimum-salary filter to the job board (v7.118.0)

### DIFF
--- a/docs/architecture/jobs.md
+++ b/docs/architecture/jobs.md
@@ -155,9 +155,18 @@ and the crawl path — the board is a shared-footer + top-bar nav link). PubSub
   description, `websearch_to_tsquery`), `tag` (slug), `workplace`, `employment`,
   `salary_min` (+ currency — same-currency only, the posting's yearly-normalised
   `salary_max` must reach the floor), `near` + `radius` + `country` (location),
-  and the signed-in-member chips `my_tags` ("Passend zu meinen Tags") and
-  `salary_min=mine` ("ab meiner Gehaltsvorstellung", resolved server-side from
-  the member's #928 expectation — the stored figure is never rendered).
+  and the signed-in-member chip `my_tags` ("Passend zu meinen Tags").
+- **Salary filter, two ways in (issue #953).** A `salary_min` number field
+  ("Mindestgehalt/Jahr", `#job-salary-min`) is open to **every** viewer —
+  logged out, or a member with no #928 expectation — and files a bare yearly
+  figure compared in `Jobs.default_currency/0` (the installation's first
+  `Vutuv.Salary` currency, EUR on vutuv.de). A signed-in member who has stored
+  a minimum-salary expectation additionally gets the one-tap
+  `salary_min=mine` chip ("ab meiner Gehaltsvorstellung", resolved server-side
+  from the #928 figure — the stored figure is never rendered). The two share
+  the one `salary_min` slot, so they are mutually exclusive: while `mine` is
+  active the number field is disabled and a hidden `mine` token rides along,
+  so the private figure is never seeded into the field or submitted.
 - **Location.** `near` (a city or zip) resolves to a point offline via
   `Vutuv.Geo.resolve_point/2` (zip first, then city); onsite/hybrid postings
   match within `radius` km by a great-circle (haversine) predicate in SQL, or by

--- a/lib/vutuv/jobs.ex
+++ b/lib/vutuv/jobs.ex
@@ -1020,7 +1020,11 @@ defmodule Vutuv.Jobs do
 
   defp parse_country(_value), do: nil
 
-  defp default_currency, do: hd(Salary.currencies())
+  @doc """
+  The installation's default salary currency — the one a bare numeric board
+  filter (a typed `salary_min` with no currency, issue #953) is compared in.
+  """
+  def default_currency, do: hd(Salary.currencies())
 
   @doc """
   New live board postings matching `filters` that `viewer` may see and were

--- a/lib/vutuv_web/live/job_board_live.ex
+++ b/lib/vutuv_web/live/job_board_live.ex
@@ -23,6 +23,7 @@ defmodule VutuvWeb.JobBoardLive do
   alias Vutuv.Geo
   alias Vutuv.Jobs
   alias Vutuv.Jobs.JobPosting
+  alias Vutuv.Salary
   alias VutuvWeb.ApiV2
   alias VutuvWeb.Live.InitAssigns
 
@@ -288,6 +289,24 @@ defmodule VutuvWeb.JobBoardLive do
         </option>
       </select>
 
+      <%!-- Free minimum-salary filter, open to everyone (issue #953). While the
+            "from my expectation" chip drives it, the field is disabled and a
+            hidden `mine` token rides along, so the member's private figure is
+            never seeded into it or submitted (issue #935). --%>
+      <input
+        type="number"
+        name="salary_min"
+        id="job-salary-min"
+        min="1"
+        step="1000"
+        inputmode="numeric"
+        value={salary_field_value(@params)}
+        disabled={@params["salary_min"] == "mine"}
+        placeholder={salary_placeholder()}
+        aria-label={gettext("Minimum yearly salary")}
+        class={[input_class(), "disabled:cursor-not-allowed disabled:opacity-60"]}
+      />
+
       <button
         type="submit"
         class="rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
@@ -299,9 +318,25 @@ defmodule VutuvWeb.JobBoardLive do
       <input :if={@params["workplace"]} type="hidden" name="workplace" value={@params["workplace"]} />
       <input :if={@params["tag"]} type="hidden" name="tag" value={@params["tag"]} />
       <input :if={@params["my_tags"]} type="hidden" name="my_tags" value={@params["my_tags"]} />
-      <input :if={@params["salary_min"]} type="hidden" name="salary_min" value={@params["salary_min"]} />
+      <%!-- The visible number field owns a typed `salary_min`; only the "mine"
+            token needs a hidden carrier (its field is disabled, so it can't). --%>
+      <input :if={@params["salary_min"] == "mine"} type="hidden" name="salary_min" value="mine" />
     </form>
     """
+  end
+
+  # The number field's value: a typed `salary_min`, but never the `mine` token
+  # (which stands in for the member's private expectation — issue #935) and
+  # empty by default, so the field starts blank for a logged-out visitor or a
+  # member without an expectation (issue #953).
+  defp salary_field_value(%{"salary_min" => "mine"}), do: nil
+  defp salary_field_value(%{"salary_min" => value}), do: value
+  defp salary_field_value(_params), do: nil
+
+  defp salary_placeholder do
+    gettext("Min. salary/year (%{currency})",
+      currency: Salary.currency_symbol(Jobs.default_currency())
+    )
   end
 
   defp chip_class(active?) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.117.2",
+      version: "7.118.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -13569,6 +13569,16 @@ msgstr "Ab meiner Gehaltsvorstellung"
 msgid "Matches my tags"
 msgstr "Passend zu meinen Tags"
 
+#: lib/vutuv_web/live/job_board_live.ex:337
+#, elixir-autogen, elixir-format
+msgid "Min. salary/year (%{currency})"
+msgstr "Mindestgehalt/Jahr (%{currency})"
+
+#: lib/vutuv_web/live/job_board_live.ex:306
+#, elixir-autogen, elixir-format
+msgid "Minimum yearly salary"
+msgstr "Mindestgehalt pro Jahr"
+
 #: lib/vutuv_web/live/job_board_live.ex:238
 #: lib/vutuv_web/live/organization_live/show.ex:342
 #, elixir-autogen, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -12842,6 +12842,16 @@ msgstr ""
 msgid "Matches my tags"
 msgstr ""
 
+#: lib/vutuv_web/live/job_board_live.ex:337
+#, elixir-autogen, elixir-format
+msgid "Min. salary/year (%{currency})"
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:306
+#, elixir-autogen, elixir-format
+msgid "Minimum yearly salary"
+msgstr ""
+
 #: lib/vutuv_web/live/job_board_live.ex:238
 #: lib/vutuv_web/live/organization_live/show.ex:342
 #, elixir-autogen, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -12840,6 +12840,16 @@ msgstr ""
 msgid "Matches my tags"
 msgstr ""
 
+#: lib/vutuv_web/live/job_board_live.ex:337
+#, elixir-autogen, elixir-format
+msgid "Min. salary/year (%{currency})"
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:306
+#, elixir-autogen, elixir-format
+msgid "Minimum yearly salary"
+msgstr ""
+
 #: lib/vutuv_web/live/job_board_live.ex:238
 #: lib/vutuv_web/live/organization_live/show.ex:342
 #, elixir-autogen, elixir-format

--- a/test/vutuv/jobs_board_test.exs
+++ b/test/vutuv/jobs_board_test.exs
@@ -139,6 +139,39 @@ defmodule Vutuv.JobsBoardTest do
       refute year.id in high
       refute monthly.id in high
     end
+
+    test "a typed minimum-salary param filters for any viewer (issue #953)" do
+      poster = poster_fixture()
+
+      high =
+        publish_job!(poster, %{
+          "title" => "Pays well",
+          "salary_min" => "70000",
+          "salary_max" => "90000",
+          "salary_period" => "year",
+          "salary_currency" => "EUR"
+        })
+
+      low =
+        publish_job!(poster, %{
+          "title" => "Pays little",
+          "salary_min" => "30000",
+          "salary_max" => "45000",
+          "salary_period" => "year",
+          "salary_currency" => "EUR"
+        })
+
+      # A logged-out visitor with no stored expectation still filters by a typed
+      # figure: board_filters/2 turns the raw string into the same filter the
+      # "mine" token would, at the installation's default currency.
+      filters = Jobs.board_filters(%{"salary_min" => "60000"}, nil)
+      assert filters.salary_min == 60_000
+      assert filters.salary_currency == Jobs.default_currency()
+
+      matched = Jobs.board_page(nil, filters) |> ids()
+      assert high.id in matched
+      refute low.id in matched
+    end
   end
 
   describe "location filter" do

--- a/test/vutuv_web/live/job_board_live_test.exs
+++ b/test/vutuv_web/live/job_board_live_test.exs
@@ -77,6 +77,51 @@ defmodule VutuvWeb.JobBoardLiveTest do
     assert render(view) =~ "Just appeared"
   end
 
+  describe "salary field (#953)" do
+    test "everyone gets a minimum-salary input, even logged out", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/jobs")
+      assert has_element?(view, "input#job-salary-min[name='salary_min']")
+    end
+
+    test "a typed minimum salary narrows the board and stays shareable", %{conn: conn} do
+      poster = poster_fixture()
+
+      publish_job!(poster, %{
+        "title" => "Pays well",
+        "salary_min" => "70000",
+        "salary_max" => "90000"
+      })
+
+      publish_job!(poster, %{
+        "title" => "Pays little",
+        "salary_min" => "30000",
+        "salary_max" => "45000"
+      })
+
+      {:ok, _view, html} = live(conn, ~p"/jobs?#{[salary_min: "60000"]}")
+
+      assert html =~ "Pays well"
+      refute html =~ "Pays little"
+      # The field echoes the shared figure so the URL is a faithful, shareable state.
+      assert html =~ ~s(value="60000")
+    end
+
+    test "the 'from my expectation' chip never renders the private figure", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      user
+      |> Ecto.Changeset.change(desired_salary_min: 60_000, desired_salary_currency: "EUR")
+      |> Vutuv.Repo.update!()
+
+      {:ok, view, html} = live(conn, ~p"/jobs?#{[salary_min: "mine"]}")
+
+      # The chip resolves against the stored expectation, but the raw figure is
+      # never rendered and the number field is disabled (not seeded with it).
+      refute html =~ "60000"
+      assert has_element?(view, "input#job-salary-min[disabled]")
+    end
+  end
+
   describe "save search (#935)" do
     test "no save control without active filters", %{conn: conn} do
       {conn, _user} = create_and_login_user(conn)


### PR DESCRIPTION
Closes #953.

## What
The `/jobs` board's only salary control was the one-tap "ab meiner Gehaltsvorstellung" chip. It is gated on a member having stored a job-search-status salary expectation (#928) and only toggles that exact figure on or off. So a member who wants a *different* figure than their stored one, or who has no expectation at all, had no way to filter by salary. That is the gap #953 reports.

This adds a **"Mindestgehalt/Jahr" number field** to the board's search form, open to **every** viewer (logged out, or a member without an expectation). It files a bare yearly figure compared in the installation's default currency (`Jobs.default_currency/0`, EUR on vutuv.de). The query layer already accepted a numeric `salary_min`, so no filter logic changed.

## Privacy preserved
The field and the existing chip share the one `salary_min` slot and stay mutually exclusive: while the chip drives the filter, the field is disabled and a hidden `mine` token rides along, so the member's private expectation is never seeded into the field or submitted. That keeps the #935 privacy design where the stored figure is never rendered.

## Verification
- `mix precommit` green: 4069 tests pass (compile `--warnings-as-errors`, `credo --strict`, format, tests).
- New tests: 1 context (a typed figure filters for any viewer, incl. logged-out) + 3 LiveView (field present for all viewers; typed figure narrows and stays shareable; the chip never leaks the private figure and disables the field).
- Browser smoke on the dev server: field renders in German and English; `/jobs?salary_min=65000` seeds the enabled field with no stray token; a signed-in member without an expectation sees the field while the `mine` chip is correctly absent.
- Docs: `docs/architecture/jobs.md` updated; German + English gettext added.
