### PR TITLE
OR + wildcard search grammar for the job board (#952)

### DIFF
--- a/docs/architecture/jobs.md
+++ b/docs/architecture/jobs.md
@@ -152,7 +152,7 @@ and the crawl path — the board is a shared-footer + top-bar nav link). PubSub
   keyset-paginated (`%{entries:, more?:, cursor:}`; the web layer signs the
   `{first_published_at, id}` cursor with `VutuvWeb.ApiV2`).
 - **Filters** (all URL params): `q` (Postgres full-text over title +
-  description, `websearch_to_tsquery`), `tag` (slug), `workplace`, `employment`,
+  description; see the search grammar below), `tag` (slug), `workplace`, `employment`,
   `salary_min` (+ currency — same-currency only, the posting's yearly-normalised
   `salary_max` must reach the floor), `near` + `radius` + `country` (location),
   and the signed-in-member chip `my_tags` ("Passend zu meinen Tags").
@@ -167,6 +167,21 @@ and the crawl path — the board is a shared-footer + top-bar nav link). PubSub
   the one `salary_min` slot, so they are mutually exclusive: while `mine` is
   active the number field is disabled and a hidden `mine` token rides along,
   so the private figure is never seeded into the field or submitted.
+- **Search grammar (`q`, issue #952).** A role has no single canonical title, so
+  the box lets one search cover several. `Vutuv.Jobs.SearchQuery.to_tsquery/1`
+  turns the human box into a **`to_tsquery('simple', …)`** string (not
+  `websearch_to_tsquery` any more, which only speaks the English `or` keyword):
+  **comma / newline / `|` / a standalone `or`|`oder`** → OR between titles
+  (locale-neutral, so a German visitor's `oder` works); **space** → AND;
+  **trailing `*`** → prefix wildcard (`entwickl*` → Entwickler/Entwicklung,
+  valuable because `simple` does no stemming); **`"quoted words"`** → adjacent
+  phrase; **leading `-`** → global exclusion. Every token is reduced to
+  lexeme-safe characters and the expression assembled from well-formed pieces
+  only, so visitor input can never make `to_tsquery` raise (unit-tested in
+  `search_query_test.exs`); a query with no searchable token is a no-op. The
+  board renders a "Suchtipps" disclosure with worked examples. Because
+  `board_page/3` and the alert sweeper share `apply_board_filters/3`, a saved
+  OR/wildcard search alerts on the same grammar.
 - **Location.** `near` (a city or zip) resolves to a point offline via
   `Vutuv.Geo.resolve_point/2` (zip first, then city); onsite/hybrid postings
   match within `radius` km by a great-circle (haversine) predicate in SQL, or by

--- a/lib/vutuv/jobs.ex
+++ b/lib/vutuv/jobs.ex
@@ -42,6 +42,7 @@ defmodule Vutuv.Jobs do
   alias Vutuv.Jobs.JobPostingImage
   alias Vutuv.Jobs.JobPostingLike
   alias Vutuv.Jobs.JobPostingTag
+  alias Vutuv.Jobs.SearchQuery
   alias Vutuv.Moderation.Case
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Organizations
@@ -1062,19 +1063,27 @@ defmodule Vutuv.Jobs do
     |> filter_my_tags(filters[:my_tags?], viewer)
   end
 
-  # Postgres full-text over title + description (websearch grammar, like post
-  # search). An empty query is a no-op.
+  # Postgres full-text over title + description, with the board's own search
+  # grammar (issue #952: comma/`or` → OR between titles, `*` prefix wildcard,
+  # `"…"` phrase, `-` exclusion). `SearchQuery` sanitises the box into a safe
+  # `to_tsquery` string; a query with no searchable token is a no-op.
   defp filter_q(query, q) when is_binary(q) and q != "" do
-    where(
-      query,
-      [p],
-      fragment(
-        "to_tsvector('simple', coalesce(?,'') || ' ' || coalesce(?,'')) @@ websearch_to_tsquery('simple', ?)",
-        p.title,
-        p.description,
-        ^q
-      )
-    )
+    case SearchQuery.to_tsquery(q) do
+      nil ->
+        query
+
+      tsquery ->
+        where(
+          query,
+          [p],
+          fragment(
+            "to_tsvector('simple', coalesce(?,'') || ' ' || coalesce(?,'')) @@ to_tsquery('simple', ?)",
+            p.title,
+            p.description,
+            ^tsquery
+          )
+        )
+    end
   end
 
   defp filter_q(query, _q), do: query

--- a/lib/vutuv/jobs/search_query.ex
+++ b/lib/vutuv/jobs/search_query.ex
@@ -1,0 +1,162 @@
+defmodule Vutuv.Jobs.SearchQuery do
+  @moduledoc """
+  Turns the human `/jobs` board search box into a safe Postgres `to_tsquery`
+  string (issue #952).
+
+  The board's motivation is that a role has no single canonical title
+  ("Webentwickler" / "Full-Stack Developer" / "PHP Developer" / …), so the box
+  has to let one search cover several at once. The grammar it understands, all
+  documented on the board itself:
+
+    * **comma / newline / `|` / the word `or`|`oder`** → OR between titles, so
+      `Webentwickler, PHP-Entwickler` matches a posting with *either*. This is
+      the headline feature and is locale-neutral (unlike Postgres's own English
+      `or` keyword, useless to a German visitor typing `oder`).
+    * **space between words** → every word must appear (AND).
+    * **trailing `*`** → prefix wildcard: `entwickl*` matches Entwickler,
+      Entwicklung, … Especially useful because the board indexes with the
+      `simple` dictionary (no stemming), so word variants are otherwise distinct.
+    * **"quoted words"** → exact phrase (the words adjacent, in order).
+    * **leading `-`** → exclude a word from the whole search.
+
+  Every token is reduced to lexeme-safe characters before it reaches SQL, and
+  the expression is assembled from non-empty, well-formed pieces only, so
+  `to_tsquery('simple', …)` can never raise on visitor input — the reason we
+  build the query here rather than hand the raw string to `to_tsquery`, which
+  throws on stray punctuation. Returns `nil` when nothing searchable survives
+  (the caller treats that as "no text filter").
+  """
+
+  # A private-use codepoint no visitor types, used to fence quoted phrases out
+  # of the OR/word splitting so a phrase's inner spaces and commas stay intact.
+  @sentinel ""
+
+  # Split OR-groups on comma / newline / pipe, or on a standalone `or`/`oder`
+  # word (case-insensitive, whitespace- or edge-bounded so "editor"/"corridor"
+  # are untouched).
+  @or_split ~r/[,\n\r|]+|(?:(?<=\s)|^)(?:or|oder)(?:(?=\s)|$)/iu
+
+  # Lexeme boundary: anything that is not a letter or digit (Unicode-aware, so
+  # umlauts stay inside a lexeme and hyphens/`+`/quotes split it).
+  @non_lexeme ~r/[^\p{L}\p{N}]+/u
+
+  @doc """
+  Builds a `to_tsquery('simple', …)` argument from the raw search box string,
+  or `nil` when the input holds no searchable token.
+  """
+  @spec to_tsquery(binary() | nil) :: binary() | nil
+  def to_tsquery(q) when is_binary(q) do
+    {protected, phrases} = protect_phrases(q)
+
+    {positive_groups, negatives} =
+      protected
+      |> String.split(@or_split, trim: true)
+      |> Enum.reduce({[], []}, fn group, {groups, negatives} ->
+        {pieces, group_negatives} = classify(group, phrases)
+
+        case pieces do
+          [] -> {groups, negatives ++ group_negatives}
+          _ -> {groups ++ [join_and(pieces)], negatives ++ group_negatives}
+        end
+      end)
+
+    combine(positive_groups, Enum.uniq(negatives))
+  end
+
+  def to_tsquery(_), do: nil
+
+  # --- phrase fencing -------------------------------------------------------
+
+  defp protect_phrases(q) do
+    ~r/"[^"]*"/u
+    |> Regex.split(q, include_captures: true)
+    |> Enum.reduce({[], %{}, 0}, fn part, {parts, phrases, i} ->
+      if String.starts_with?(part, ~s(")) and String.ends_with?(part, ~s(")) do
+        key = @sentinel <> Integer.to_string(i) <> @sentinel
+        {[key | parts], Map.put(phrases, key, String.slice(part, 1..-2//1)), i + 1}
+      else
+        {[part | parts], phrases, i}
+      end
+    end)
+    |> then(fn {parts, phrases, _i} -> {parts |> Enum.reverse() |> Enum.join(), phrases} end)
+  end
+
+  # --- per-group token classification --------------------------------------
+
+  defp classify(group, phrases) do
+    group
+    |> String.split()
+    |> Enum.reduce({[], []}, fn token, {pieces, negatives} ->
+      cond do
+        Map.has_key?(phrases, token) ->
+          add(pieces, negatives, phrase_piece(phrases[token]), :positive)
+
+        String.starts_with?(token, "-") or String.starts_with?(token, "!") ->
+          add(pieces, negatives, word_expr(strip_negation(token)), :negative)
+
+        true ->
+          add(pieces, negatives, word_expr(token), :positive)
+      end
+    end)
+  end
+
+  defp add(pieces, negatives, nil, _side), do: {pieces, negatives}
+  defp add(pieces, negatives, expr, :positive), do: {pieces ++ [expr], negatives}
+  defp add(pieces, negatives, expr, :negative), do: {pieces, negatives ++ [expr]}
+
+  defp strip_negation(token) do
+    token |> String.replace_prefix("-", "") |> String.replace_prefix("!", "")
+  end
+
+  # --- token → tsquery piece -----------------------------------------------
+
+  defp phrase_piece(text) do
+    case lexemes(text) do
+      [] -> nil
+      words -> "(" <> Enum.join(words, " <-> ") <> ")"
+    end
+  end
+
+  defp word_expr(token) do
+    prefix? = String.ends_with?(token, "*")
+    core = String.trim_trailing(token, "*")
+
+    case lexemes(core) do
+      [] -> nil
+      words -> words |> maybe_prefix(prefix?) |> join_and()
+    end
+  end
+
+  defp maybe_prefix(words, false), do: words
+
+  defp maybe_prefix(words, true) do
+    {init, [last]} = Enum.split(words, -1)
+    init ++ [last <> ":*"]
+  end
+
+  defp lexemes(text) do
+    text |> String.downcase() |> String.split(@non_lexeme, trim: true)
+  end
+
+  # --- assembly -------------------------------------------------------------
+
+  defp join_and([one]), do: one
+  defp join_and(pieces), do: "(" <> Enum.join(pieces, " & ") <> ")"
+
+  defp combine([], []), do: nil
+
+  defp combine(positive_groups, negatives) do
+    positive =
+      case positive_groups do
+        [] -> nil
+        [one] -> one
+        many -> "(" <> Enum.join(many, " | ") <> ")"
+      end
+
+    negated = Enum.map(negatives, &("!(" <> &1 <> ")"))
+
+    [positive | negated]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" & ")
+  end
+end

--- a/lib/vutuv_web/live/job_board_live.ex
+++ b/lib/vutuv_web/live/job_board_live.ex
@@ -314,6 +314,26 @@ defmodule VutuvWeb.JobBoardLive do
         {gettext("Search")}
       </button>
 
+      <details class="group text-sm text-slate-600 dark:text-slate-400 sm:col-span-2 lg:col-span-4">
+        <summary class="inline-flex cursor-pointer list-none items-center gap-1 font-medium text-slate-700 hover:text-brand-700 [&::-webkit-details-marker]:hidden dark:text-slate-300 dark:hover:text-brand-300">
+          <span aria-hidden="true" class="transition-transform group-open:rotate-90">›</span>
+          {gettext("Search tips")}
+        </summary>
+        <div class="mt-2 space-y-2">
+          <p>
+            {gettext(
+              "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
+            )}
+          </p>
+          <ul class="space-y-1.5">
+            <li :for={{example, gloss} <- search_tips()} class="flex flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-2">
+              <code class="w-fit rounded bg-slate-100 px-1.5 py-0.5 font-mono text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200">{example}</code>
+              <span>{gloss}</span>
+            </li>
+          </ul>
+        </div>
+      </details>
+
       <%!-- Chip-driven filters ride along so a search submit keeps them. --%>
       <input :if={@params["workplace"]} type="hidden" name="workplace" value={@params["workplace"]} />
       <input :if={@params["tag"]} type="hidden" name="tag" value={@params["tag"]} />
@@ -347,6 +367,18 @@ defmodule VutuvWeb.JobBoardLive do
         else:
           "bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
       )
+    ]
+  end
+
+  # Worked examples for the "Search tips" disclosure under the box (issue #952),
+  # each an {example, plain-language gloss} pair. The examples are literal search
+  # syntax (locale-independent); the glosses translate.
+  defp search_tips do
+    [
+      {"Webentwickler, PHP-Entwickler, Full-Stack Developer", gettext("any of these titles")},
+      {"entwickl*", gettext("word start: also finds Entwickler, Entwicklung")},
+      {~s("Full Stack Developer"), gettext("exact wording")},
+      {"Entwickler -Praktikum", gettext("without internships")}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.118.0",
+      version: "7.119.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -34,7 +34,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1117
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -149,10 +149,10 @@ msgstr "Konnte nicht zu %{name} zurückfolgen."
 
 #: lib/vutuv_web/components/post_components.ex:806
 #: lib/vutuv_web/components/ui.ex:2611
-#: lib/vutuv_web/live/admin/job_live.ex:500
+#: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
-#: lib/vutuv_web/live/admin/organization_live.ex:408
+#: lib/vutuv_web/live/admin/organization_live.ex:401
 #: lib/vutuv_web/live/admin/user_delete_live.ex:172
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
@@ -197,7 +197,7 @@ msgstr "Download"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
-#: lib/vutuv_web/live/job_posting_live/show.ex:177
+#: lib/vutuv_web/live/job_posting_live/show.ex:178
 #: lib/vutuv_web/live/organization_live/show.ex:263
 #: lib/vutuv_web/templates/address/edit.html.heex:4
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
@@ -416,7 +416,7 @@ msgstr "Link wurde geändert."
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
 #: lib/vutuv_web/cv/docx.ex:206
-#: lib/vutuv_web/cv/html.ex:206
+#: lib/vutuv_web/cv/html.ex:205
 #: lib/vutuv_web/cv/latex.ex:164
 #: lib/vutuv_web/cv/odt.ex:176
 #: lib/vutuv_web/live/cv_live.ex:296
@@ -535,7 +535,7 @@ msgid "Number type"
 msgstr "Typ"
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:168
-#: lib/vutuv_web/live/admin/organization_live.ex:251
+#: lib/vutuv_web/live/admin/organization_live.ex:244
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:5
 #, elixir-autogen
 msgid "Organization"
@@ -642,20 +642,18 @@ msgstr "Öffentlich (für alle sichtbar) oder Privat (nur für Sie sichtbar)"
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
 #: lib/vutuv_web/templates/settings/preferences.html.heex:180
 #: lib/vutuv_web/templates/settings/privacy.html.heex:64
-#: lib/vutuv_web/templates/settings/privacy.html.heex:92
-#: lib/vutuv_web/templates/settings/privacy.html.heex:125
-#: lib/vutuv_web/templates/settings/privacy.html.heex:157
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:342
+#: lib/vutuv_web/views/settings_html.ex:135
 #, elixir-autogen
 msgid "Save"
 msgstr "Speichern"
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:231
-#: lib/vutuv_web/live/job_board_live.ex:295
+#: lib/vutuv_web/live/job_board_live.ex:314
 #: lib/vutuv_web/live/search_live.ex:35
-#: lib/vutuv_web/live/search_live.ex:231
+#: lib/vutuv_web/live/search_live.ex:229
 #: lib/vutuv_web/live/shell_live.ex:346
 #: lib/vutuv_web/live/shell_live.ex:502
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
@@ -690,7 +688,7 @@ msgstr "Slug"
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
-#: lib/vutuv_web/cv/html.ex:227
+#: lib/vutuv_web/cv/html.ex:226
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
 #: lib/vutuv_web/live/cv_live.ex:370
@@ -699,13 +697,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:963
+#: lib/vutuv_web/templates/user/show.html.heex:964
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:965
+#: lib/vutuv_web/templates/user/show.html.heex:966
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -1049,12 +1047,14 @@ msgstr "Wählen Sie einen Monat"
 msgid "Select a year"
 msgstr "Wählen Sie ein Jahr"
 
+#: lib/vutuv/accounts/user.ex:732
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr "Frau"
 
+#: lib/vutuv/accounts/user.ex:731
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1212,12 +1212,12 @@ msgstr "Die URL ist ungültig"
 msgid "Can't find URL"
 msgstr "Die URL kann nicht gefunden werden"
 
-#: lib/vutuv_web/live/search_live.ex:287
+#: lib/vutuv_web/live/search_live.ex:285
 #, elixir-autogen
 msgid "Our search will try to match similar names to your search, so don't worry about spelling."
 msgstr "Die Suche nach Vor- und Nachnamen ist fuzzy (unscharf)."
 
-#: lib/vutuv_web/live/search_live.ex:282
+#: lib/vutuv_web/live/search_live.ex:280
 #, elixir-autogen
 msgid "Search Tips"
 msgstr "Hilfe bei der Suche"
@@ -1253,7 +1253,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/components/organization_components.ex:245
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
-#: lib/vutuv_web/live/admin/job_live.ex:206
+#: lib/vutuv_web/live/admin/job_live.ex:199
 #: lib/vutuv_web/live/admin/member_badges.ex:19
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:135
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
@@ -1261,7 +1261,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
-#: lib/vutuv_web/live/admin/organization_live.ex:196
+#: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:52
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
@@ -1484,17 +1484,17 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/controllers/user_tag_controller.ex:37
 #: lib/vutuv_web/controllers/user_tag_controller.ex:54
 #: lib/vutuv_web/cv/docx.ex:174
-#: lib/vutuv_web/cv/html.ex:160
+#: lib/vutuv_web/cv/html.ex:159
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
 #: lib/vutuv_web/live/cv_live.ex:275
 #: lib/vutuv_web/live/job_posting_live/form.ex:509
-#: lib/vutuv_web/live/search_live.ex:180
-#: lib/vutuv_web/live/search_live.ex:363
+#: lib/vutuv_web/live/search_live.ex:178
+#: lib/vutuv_web/live/search_live.ex:361
 #: lib/vutuv_web/live/tag_new_live.ex:35
 #: lib/vutuv_web/live/tag_new_live.ex:45
 #: lib/vutuv_web/live/tag_new_live.ex:54
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:192
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:195
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:5
@@ -1668,7 +1668,7 @@ msgstr ""
 "Link."
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
-#: lib/vutuv_web/live/job_board_live.ex:273
+#: lib/vutuv_web/live/job_board_live.ex:274
 #: lib/vutuv_web/live/job_posting_live/form.ex:410
 #: lib/vutuv_web/live/organization_live/edit.ex:282
 #: lib/vutuv_web/live/organization_live/new.ex:127
@@ -1724,9 +1724,9 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/live/admin/job_live.ex:332
-#: lib/vutuv_web/live/admin/job_live.ex:491
-#: lib/vutuv_web/live/admin/organization_live.ex:306
+#: lib/vutuv_web/live/admin/job_live.ex:325
+#: lib/vutuv_web/live/admin/job_live.ex:484
+#: lib/vutuv_web/live/admin/organization_live.ex:299
 #: lib/vutuv_web/live/post_live/composer.ex:460
 #: lib/vutuv_web/live/post_live/composer.ex:461
 #: lib/vutuv_web/templates/layout/app.html.heex:152
@@ -1809,7 +1809,7 @@ msgstr ""
 "Folgen!"
 
 #: lib/vutuv_web/live/shell_live.ex:473
-#: lib/vutuv_web/views/settings_html.ex:181
+#: lib/vutuv_web/views/settings_html.ex:222
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr "Ausloggen"
@@ -1953,7 +1953,7 @@ msgstr ""
 "unten ein, um die Adresse zu bestätigen."
 
 #: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1200
+#: lib/vutuv_web/templates/user/show.html.heex:1201
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
@@ -2304,8 +2304,8 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/gettext_extraction_anchors.ex:77
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
 #: lib/vutuv_web/live/post_live/saved.ex:449
-#: lib/vutuv_web/live/search_live.ex:181
-#: lib/vutuv_web/live/search_live.ex:377
+#: lib/vutuv_web/live/search_live.ex:179
+#: lib/vutuv_web/live/search_live.ex:375
 #: lib/vutuv_web/templates/settings/preferences.html.heex:114
 #: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
@@ -2332,7 +2332,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:227
+#: lib/vutuv_web/views/settings_html.ex:268
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
@@ -2396,7 +2396,7 @@ msgstr "Upload fehlgeschlagen."
 #: lib/vutuv_web/live/shell_live.ex:416
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:128
+#: lib/vutuv_web/views/settings_html.ex:169
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr "Profil ansehen"
@@ -2437,7 +2437,7 @@ msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:256
+#: lib/vutuv_web/views/settings_html.ex:297
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "unbekannt"
@@ -2816,7 +2816,7 @@ msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1118
+#: lib/vutuv_web/templates/user/show.html.heex:1119
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
@@ -2838,7 +2838,7 @@ msgstr "Persönliche Angaben hinzufügen"
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
-#: lib/vutuv_web/live/user_profile_live.ex:955
+#: lib/vutuv_web/live/user_profile_live.ex:956
 #: lib/vutuv_web/templates/user/show.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
@@ -2849,7 +2849,7 @@ msgstr "Ersten Beitrag schreiben"
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
-#: lib/vutuv_web/templates/settings/privacy.html.heex:172
+#: lib/vutuv_web/templates/settings/privacy.html.heex:130
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
 #, elixir-autogen, elixir-format
@@ -2993,7 +2993,7 @@ msgid_plural "%{formatted} cases are waiting for a ruling."
 msgstr[0] "%{formatted} Fall wartet auf eine Entscheidung."
 msgstr[1] "%{formatted} Fälle warten auf eine Entscheidung."
 
-#: lib/vutuv_web/live/admin/job_live.ex:346
+#: lib/vutuv_web/live/admin/job_live.ex:339
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:266
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
@@ -3229,7 +3229,7 @@ msgstr ""
 "Nur Sie können Ihr Profil gerade sehen, es ist verborgen, solange eine "
 "Meldung bearbeitet wird."
 
-#: lib/vutuv_web/live/admin/job_live.ex:213
+#: lib/vutuv_web/live/admin/job_live.ex:206
 #: lib/vutuv_web/live/admin/moderation_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Open cases"
@@ -3433,10 +3433,10 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:74
 #: lib/vutuv_web/live/admin/deliverability_live.ex:252
-#: lib/vutuv_web/live/admin/job_live.ex:273
-#: lib/vutuv_web/live/admin/job_live.ex:372
+#: lib/vutuv_web/live/admin/job_live.ex:266
+#: lib/vutuv_web/live/admin/job_live.ex:365
 #: lib/vutuv_web/live/admin/moderation_live.ex:53
-#: lib/vutuv_web/live/admin/organization_live.ex:253
+#: lib/vutuv_web/live/admin/organization_live.ex:246
 #: lib/vutuv_web/live/admin/screenshot_live.ex:119
 #: lib/vutuv_web/live/admin/user_live.ex:315
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:59
@@ -3676,12 +3676,12 @@ msgstr "Ihr vutuv-Konto wurde deaktiviert"
 msgid "Your vutuv account is suspended"
 msgstr "Ihr vutuv-Konto ist gesperrt"
 
-#: lib/vutuv_web/controllers/username_controller.ex:72
+#: lib/vutuv_web/controllers/username_controller.ex:77
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is already taken."
 msgstr "@%{handle} ist bereits vergeben."
 
-#: lib/vutuv_web/controllers/username_controller.ex:81
+#: lib/vutuv_web/controllers/username_controller.ex:86
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is available."
 msgstr "@%{handle} ist frei."
@@ -3691,8 +3691,8 @@ msgstr "@%{handle} ist frei."
 msgid "New username"
 msgstr "Neuer Benutzername"
 
-#: lib/vutuv_web/controllers/username_controller.ex:37
-#: lib/vutuv_web/controllers/username_controller.ex:40
+#: lib/vutuv_web/controllers/username_controller.ex:39
+#: lib/vutuv_web/controllers/username_controller.ex:42
 #, elixir-autogen, elixir-format
 msgid "Your username is now @%{handle}."
 msgstr "Ihr Benutzername ist jetzt @%{handle}."
@@ -4222,7 +4222,7 @@ msgstr "Buchung online durch eingeloggte Mitglieder. Zahlung per Rechnung."
 msgid "Booking requires a vutuv login."
 msgstr "Für die Buchung ist ein vutuv-Login erforderlich."
 
-#: lib/vutuv_web/live/admin/organization_live.ex:252
+#: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:404
 #: lib/vutuv_web/live/organization_live/edit.ex:278
 #: lib/vutuv_web/live/organization_live/new.ex:123
@@ -4328,7 +4328,7 @@ msgstr ""
 "vutuv zeigt eine einzige, reine Textanzeige pro Kalendertag: dezent, "
 "zwischen Navigation und Inhalt, im Stil klassischer Textanzeigen."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:345
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:350
 #, elixir-autogen, elixir-format
 msgid "%{formatted} ad is waiting for approval."
 msgid_plural "%{formatted} ads are waiting for approval."
@@ -4343,7 +4343,7 @@ msgstr "Anzeigen-Abnahme"
 
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:5
 #: lib/vutuv_web/templates/admin/ad/show.html.heex:5
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:335
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:340
 #, elixir-autogen, elixir-format
 msgid "Ads"
 msgstr "Anzeigen"
@@ -4414,7 +4414,7 @@ msgstr "Meine Anzeigenbuchungen"
 msgid "My bookings"
 msgstr "Meine Buchungen"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:343
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:348
 #, elixir-autogen, elixir-format
 msgid "No ads waiting for approval."
 msgstr "Keine Anzeigen warten auf Freischaltung."
@@ -4424,7 +4424,7 @@ msgstr "Keine Anzeigen warten auf Freischaltung."
 msgid "No upcoming ads."
 msgstr "Keine anstehenden Anzeigen."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:340
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Open the ad review"
 msgstr "Zur Anzeigen-Abnahme"
@@ -4580,8 +4580,8 @@ msgstr "Anzeige für den %{day}"
 msgid "Approved on"
 msgstr "Freigeschaltet am"
 
-#: lib/vutuv_web/live/admin/job_live.ex:297
-#: lib/vutuv_web/live/admin/organization_live.ex:272
+#: lib/vutuv_web/live/admin/job_live.ex:290
+#: lib/vutuv_web/live/admin/organization_live.ex:265
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Details"
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "Undeliverable"
 msgstr "Unzustellbar"
 
-#: lib/vutuv_web/live/search_live.ex:284
+#: lib/vutuv_web/live/search_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
@@ -4690,7 +4690,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:1
 #: lib/vutuv_web/templates/block/index.html.heex:1
-#: lib/vutuv_web/templates/settings/privacy.html.heex:169
+#: lib/vutuv_web/templates/settings/privacy.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Blocked members"
 msgstr "Blockierte Mitglieder"
@@ -4779,12 +4779,12 @@ msgstr "Folgt noch niemandem."
 msgid "This area is reserved for administrators."
 msgstr "Dieser Bereich ist Administratoren vorbehalten."
 
-#: lib/vutuv_web/live/search_live.ex:409
+#: lib/vutuv_web/live/search_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No results for \"%{query}\""
 msgstr "Keine Ergebnisse für \"%{query}\""
 
-#: lib/vutuv_web/live/search_live.ex:346
+#: lib/vutuv_web/live/search_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Not an exact match, but sounds like your search."
 msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
@@ -4794,80 +4794,80 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
-#: lib/vutuv_web/live/search_live.ex:179
-#: lib/vutuv_web/live/search_live.ex:319
+#: lib/vutuv_web/live/search_live.ex:177
+#: lib/vutuv_web/live/search_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Personen"
 
-#: lib/vutuv_web/live/search_live.ex:278
+#: lib/vutuv_web/live/search_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Results appear once you have typed at least three letters."
 msgstr ""
 "Ergebnisse erscheinen, sobald Sie mindestens drei Buchstaben eingegeben "
 "haben."
 
-#: lib/vutuv_web/live/search_live.ex:343
+#: lib/vutuv_web/live/search_live.ex:341
 #, elixir-autogen, elixir-format
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
 #: lib/vutuv_web/components/post_components.ex:261
-#: lib/vutuv_web/live/admin/job_live.ex:166
-#: lib/vutuv_web/live/admin/organization_live.ex:170
-#: lib/vutuv_web/live/search_live.ex:178
+#: lib/vutuv_web/live/admin/job_live.ex:159
+#: lib/vutuv_web/live/admin/organization_live.ex:163
+#: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:73
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr "Alle"
 
-#: lib/vutuv_web/live/search_live.ex:261
+#: lib/vutuv_web/live/search_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Exact matches only"
 msgstr "Nur exakte Treffer"
 
-#: lib/vutuv_web/live/search_live.ex:305
+#: lib/vutuv_web/live/search_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "in quotes: exact matches only, no similar names"
 msgstr "in Anführungszeichen: nur exakte Treffer, keine ähnlichen Namen"
 
-#: lib/vutuv_web/live/search_live.ex:303
+#: lib/vutuv_web/live/search_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "searches usernames"
 msgstr "sucht Benutzernamen"
 
-#: lib/vutuv_web/live/search_live.ex:299
+#: lib/vutuv_web/live/search_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "only people with an address in this city"
 msgstr "nur Personen mit einer Adresse in diesem Ort (auch stadt: / city:)"
 
-#: lib/vutuv_web/live/search_live.ex:298
+#: lib/vutuv_web/live/search_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "city:koblenz"
 msgstr "ort:koblenz"
 
-#: lib/vutuv_web/live/search_live.ex:294
+#: lib/vutuv_web/live/search_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "first:stefan"
 msgstr "vorname:stefan"
 
-#: lib/vutuv_web/live/search_live.ex:304
+#: lib/vutuv_web/live/search_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "miller"
 msgstr "müller"
 
-#: lib/vutuv_web/live/search_live.ex:295
+#: lib/vutuv_web/live/search_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "searches first names only (last: for last names)"
 msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
-#: lib/vutuv_web/live/user_profile_live.ex:943
+#: lib/vutuv_web/live/user_profile_live.ex:944
 #: lib/vutuv_web/templates/user/show.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Tag hinzufügen"
 
-#: lib/vutuv_web/live/search_live.ex:238
+#: lib/vutuv_web/live/search_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, or posts"
 msgstr "Nach Personen, Tags oder Beiträgen suchen"
@@ -4914,9 +4914,9 @@ msgstr "Ihr Profil und seine Bereiche bearbeiten"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:216
 #: lib/vutuv_web/agent_docs/text.ex:212
-#: lib/vutuv_web/live/admin/job_live.ex:400
+#: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
-#: lib/vutuv_web/live/job_posting_live/show.ex:135
+#: lib/vutuv_web/live/job_posting_live/show.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:39
 #: lib/vutuv_web/templates/qualification/show.html.heex:33
 #, elixir-autogen, elixir-format
@@ -5088,7 +5088,7 @@ msgstr "\"%{name}\" hat keinen Zugriff mehr auf Ihr Konto."
 msgid "%{app} wants to access your vutuv account. It would be allowed to:"
 msgstr "%{app} möchte auf Ihr vutuv-Konto zugreifen. Es dürfte:"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:325
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "%{formatted} registered third-party application. Suspending one cuts off all of its tokens."
 msgid_plural "%{formatted} registered third-party applications. Suspending one cuts off all of its tokens."
@@ -5102,7 +5102,7 @@ msgstr[1] ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:21
 #: lib/vutuv_web/live/admin/api_app_live.ex:57
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:319
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:323
 #, elixir-autogen, elixir-format
 msgid "API applications"
 msgstr "API-Anwendungen"
@@ -5110,7 +5110,7 @@ msgstr "API-Anwendungen"
 #: lib/vutuv_web/live/admin/api_app_live.ex:94
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:31
-#: lib/vutuv_web/views/settings_html.ex:172
+#: lib/vutuv_web/views/settings_html.ex:213
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
@@ -5195,7 +5195,7 @@ msgid "Generate a new client secret? The current one stops working."
 msgstr ""
 "Neues Client-Secret erzeugen? Das aktuelle funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:323
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:327
 #, elixir-autogen, elixir-format
 msgid "Manage applications"
 msgstr "Anwendungen verwalten"
@@ -5502,7 +5502,7 @@ msgstr "API-Dokumentation"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_delete_live.ex:109
 #: lib/vutuv_web/live/admin/user_delete_live.ex:221
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:100
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:101
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:9
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:11
 #, elixir-autogen, elixir-format
@@ -5540,7 +5540,7 @@ msgstr ""
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:175
+#: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
@@ -5605,7 +5605,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/templates/username/new.html.heex:4
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:2
 #: lib/vutuv_web/templates/work_experience/new.html.heex:2
-#: lib/vutuv_web/views/settings_html.ex:123
+#: lib/vutuv_web/views/settings_html.ex:164
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -5642,7 +5642,7 @@ msgstr "Profil vervollständigen"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/live/user_profile_live.ex:945
+#: lib/vutuv_web/live/user_profile_live.ex:946
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -5686,6 +5686,7 @@ msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr "Ihre Tags (z.B. JavaScript, Kochen, Origami, Katze)"
 
+#: lib/vutuv/accounts/user.ex:735
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5763,7 +5764,7 @@ msgstr "E-Mail-Adressen"
 msgid "Notification settings saved."
 msgstr "Benachrichtigungseinstellungen gespeichert."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:170
+#: lib/vutuv_web/templates/settings/privacy.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you."
 msgstr "Personen, die nicht mit Ihnen interagieren können."
@@ -5794,7 +5795,7 @@ msgstr "Datenschutzeinstellungen gespeichert."
 msgid "Third-party apps you authorized."
 msgstr "Apps von Drittanbietern, die Sie autorisiert haben."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:178
+#: lib/vutuv_web/templates/settings/privacy.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Ansehen"
@@ -5809,7 +5810,7 @@ msgstr "Ihr Name"
 msgid "Your post"
 msgstr "Ihr Beitrag"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:176
+#: lib/vutuv_web/templates/settings/privacy.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Your posts or profile a moderator is looking at."
 msgstr "Ihre Beiträge oder Ihr Profil, die ein Moderator gerade prüft."
@@ -5946,7 +5947,7 @@ msgstr "Privatsphäre-Einstellungen"
 msgid "Replies to and likes on your posts"
 msgstr "Antworten und Likes zu Ihren Beiträgen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:166
+#: lib/vutuv_web/templates/settings/privacy.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr "Sicherheit"
@@ -6111,21 +6112,21 @@ msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:174
-#: lib/vutuv_web/views/settings_html.ex:265
+#: lib/vutuv_web/views/settings_html.ex:306
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/views/settings_html.ex:264
+#: lib/vutuv_web/views/settings_html.ex:305
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/views/settings_html.ex:263
+#: lib/vutuv_web/views/settings_html.ex:304
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -6142,7 +6143,7 @@ msgstr "Alle anderen Geräte wurden abgemeldet."
 msgid "Another session was already active on your account."
 msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
 
-#: lib/vutuv_web/views/settings_html.ex:161
+#: lib/vutuv_web/views/settings_html.ex:202
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr "Zuletzt aktiv"
@@ -6157,7 +6158,7 @@ msgstr "Alle anderen Geräte abmelden"
 msgid "Log out of every device except this one?"
 msgstr "Von allen Geräten außer diesem abmelden?"
 
-#: lib/vutuv_web/views/settings_html.ex:178
+#: lib/vutuv_web/views/settings_html.ex:219
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
@@ -6182,7 +6183,7 @@ msgstr "Dieses Gerät wurde abgemeldet."
 msgid "The location looks different from where you usually sign in."
 msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
 
-#: lib/vutuv_web/views/settings_html.ex:162
+#: lib/vutuv_web/views/settings_html.ex:203
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Dieses Gerät"
@@ -6194,29 +6195,29 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/views/settings_html.ex:262
+#: lib/vutuv_web/views/settings_html.ex:303
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:76
+#: lib/vutuv_web/templates/settings/privacy.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 "Ein grüner Punkt auf Ihrem Avatar zeigt anderen Mitgliedern, dass Sie gerade"
 " online sind."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:74
+#: lib/vutuv_web/templates/settings/privacy.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr "Online-Status"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:86
+#: lib/vutuv_web/templates/settings/privacy.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Show when I'm online"
 msgstr "Anzeigen, wenn ich online bin"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:88
+#: lib/vutuv_web/templates/settings/privacy.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
@@ -6229,7 +6230,7 @@ msgid "Add a passkey"
 msgstr "Passkey hinzufügen"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/views/settings_html.ex:213
+#: lib/vutuv_web/views/settings_html.ex:254
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Hinzugefügt"
@@ -6240,7 +6241,7 @@ msgid "Could not add the passkey. Please try again."
 msgstr ""
 "Der Passkey konnte nicht hinzugefügt werden. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/views/settings_html.ex:216
+#: lib/vutuv_web/views/settings_html.ex:257
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr "Zuletzt verwendet"
@@ -6250,7 +6251,7 @@ msgstr "Zuletzt verwendet"
 msgid "Name (optional)"
 msgstr "Name (optional)"
 
-#: lib/vutuv_web/views/settings_html.ex:210
+#: lib/vutuv_web/views/settings_html.ex:251
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr "Passkey"
@@ -6270,7 +6271,7 @@ msgstr "Passkey entfernt."
 msgid "Passkeys"
 msgstr "Passkeys"
 
-#: lib/vutuv_web/views/settings_html.ex:224
+#: lib/vutuv_web/views/settings_html.ex:265
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr "Diesen Passkey entfernen?"
@@ -6330,7 +6331,7 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/live/user_profile_live.ex:949
+#: lib/vutuv_web/live/user_profile_live.ex:950
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
@@ -6365,7 +6366,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1166
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6424,7 +6425,7 @@ msgstr[1] "%{count} Jahre"
 msgid "Age"
 msgstr "Alter"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:253
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "Confirmed new registrations and the day's posts, reposts, likes and bookmarks. Time-travel to any past day."
 msgstr ""
@@ -6436,7 +6437,7 @@ msgstr ""
 msgid "Count"
 msgstr "Anzahl"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:248
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:252
 #: lib/vutuv_web/templates/admin/report/index.html.heex:2
 #: lib/vutuv_web/templates/admin/report/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -6483,7 +6484,7 @@ msgstr "Nächster Tag"
 msgid "No activity on this day."
 msgstr "An diesem Tag gab es keine Aktivität."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:251
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:255
 #, elixir-autogen, elixir-format
 msgid "Open the daily report"
 msgstr "Tagesbericht öffnen"
@@ -6556,9 +6557,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1151
-#: lib/vutuv_web/templates/user/show.html.heex:1159
-#: lib/vutuv_web/templates/user/show.html.heex:1171
+#: lib/vutuv_web/templates/user/show.html.heex:1152
+#: lib/vutuv_web/templates/user/show.html.heex:1160
+#: lib/vutuv_web/templates/user/show.html.heex:1172
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6605,7 +6606,7 @@ msgstr "und %{count} weitere"
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:124
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "%{formatted} account is frozen because every email address bounced."
 msgid_plural "%{formatted} accounts are frozen because every email address bounced."
@@ -6682,7 +6683,7 @@ msgid "By"
 msgstr "Von"
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:192
-#: lib/vutuv_web/live/admin/organization_live.ex:364
+#: lib/vutuv_web/live/admin/organization_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "Clear"
 msgstr "Aufheben"
@@ -6720,7 +6721,7 @@ msgstr "Tote Adressen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:27
 #: lib/vutuv_web/live/admin/deliverability_live.ex:95
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:112
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Deliverability"
 msgstr "Zustellbarkeit"
@@ -6753,7 +6754,7 @@ msgstr "Mitglied / Adresse"
 msgid "No accounts are frozen for unreachability."
 msgstr "Keine Konten wegen Nichterreichbarkeit eingefroren."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:120
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "No accounts frozen for unreachability. Bounced addresses and the audit trail are here too."
 msgstr ""
@@ -6783,7 +6784,7 @@ msgstr ""
 "mehr. Wenn Sie Ihrem vutuv-Konto weitere Adressen hinzugefügt haben, melden "
 "Sie sich stattdessen mit einer davon an."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:117
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Open deliverability"
 msgstr "Zustellbarkeit öffnen"
@@ -7062,7 +7063,7 @@ msgstr ""
 msgid "Cap group size (optional)"
 msgstr "Gruppengröße begrenzen (optional)"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:173
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Compose a newsletter, save it as a draft, test it, then send it to all members."
 msgstr ""
@@ -7109,8 +7110,8 @@ msgstr "Dev-Postfach"
 msgid "Development:"
 msgstr "Entwicklung:"
 
-#: lib/vutuv_web/live/admin/job_live.ex:172
-#: lib/vutuv_web/live/admin/job_live.ex:193
+#: lib/vutuv_web/live/admin/job_live.ex:165
+#: lib/vutuv_web/live/admin/job_live.ex:186
 #: lib/vutuv_web/views/admin/newsletter_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Draft"
@@ -7166,7 +7167,7 @@ msgstr "Filter"
 msgid "Kind"
 msgstr "Art"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:181
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:184
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Manage audiences"
@@ -7189,7 +7190,7 @@ msgstr "Höchstalter"
 #: lib/vutuv_web/live/admin/user_live.ex:176
 #: lib/vutuv_web/live/admin/user_live.ex:177
 #: lib/vutuv_web/live/admin/user_live.ex:184
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:88
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:89
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:45
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:90
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:9
@@ -7221,7 +7222,7 @@ msgstr "Neue Zielgruppe"
 msgid "New newsletter"
 msgstr "Neuer Newsletter"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:168
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:171
 #: lib/vutuv_web/templates/settings/notifications.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "Newsletter"
@@ -7229,7 +7230,7 @@ msgstr "Newsletter"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:33
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:178
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Newsletter audiences"
 msgstr "Newsletter-Zielgruppen"
@@ -7290,7 +7291,7 @@ msgstr "Gelegentliche vutuv-Neuigkeiten und Ankündigungen."
 msgid "Off: take the oldest members first (by join date)."
 msgstr "Aus: zuerst die ältesten Mitglieder (nach Beitrittsdatum)."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:171
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Open newsletters"
 msgstr "Newsletter öffnen"
@@ -7419,7 +7420,7 @@ msgid "Suppressed (bounced address)"
 msgstr "Unterdrückt (unzustellbare Adresse)"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
-#: lib/vutuv_web/live/job_board_live.ex:204
+#: lib/vutuv_web/live/job_board_live.ex:205
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Tag"
@@ -7873,53 +7874,53 @@ msgstr "Zuletzt bereitgestellt (Berliner Zeit)"
 msgid "Moderation & queues"
 msgstr "Moderation & Warteschlangen"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:165
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Communication"
 msgstr "Kommunikation"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:189
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Content & taxonomy"
 msgstr "Inhalte & Taxonomie"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:245
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "System & insights"
 msgstr "System & Auswertungen"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:196
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Manage tags"
 msgstr "Tags verwalten"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:198
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Create, rename and remove the tags members can add to their profile."
 msgstr ""
 "Tags anlegen, umbenennen und entfernen, die Mitglieder ihrem Profil "
 "hinzufügen können."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:216
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:219
 #: lib/vutuv_web/templates/admin/username/index.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Usernames"
 msgstr "Benutzernamen"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:219
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:222
 #: lib/vutuv_web/templates/admin/username/index.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Disable a username"
 msgstr "Benutzernamen deaktivieren"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:221
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:224
 #, elixir-autogen, elixir-format
 msgid "Take an unwanted username away from a member by force-renaming the account."
 msgstr ""
 "Einem Mitglied einen unerwünschten Benutzernamen entziehen, indem das Konto "
 "zwangsumbenannt wird."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:183
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Build fixed recipient groups from filters (language, country, age, tag) to target a newsletter."
 msgstr ""
@@ -7963,7 +7964,7 @@ msgstr ""
 "Alles, was vutuv am Laufen hält, an einem Ort. Karten mit offener Arbeit "
 "leuchten in Koralle."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:95
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Search, filter and sort every account, and verify a member's identity."
 msgstr ""
@@ -8265,7 +8266,7 @@ msgid "Awaiting verification"
 msgstr "Prüfung ausstehend"
 
 #: lib/vutuv_web/live/admin/user_live.ex:196
-#: lib/vutuv_web/live/job_board_live.ex:191
+#: lib/vutuv_web/live/job_board_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr "Filter zurücksetzen"
@@ -8296,20 +8297,20 @@ msgstr ""
 "mehr). Das Mitglied erhält keine E-Mail; ein Protokoll geht an den "
 "Betreiber."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:105
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Find an account by name, @handle or email and delete it, with everything it owns, behind a confirmation."
 msgstr ""
 "Finden Sie ein Konto über Name, @Handle oder E-Mail-Adresse und löschen Sie "
 "es mitsamt allem, was dazugehört, hinter einer Sicherheitsabfrage."
 
-#: lib/vutuv_web/live/admin/job_live.ex:169
-#: lib/vutuv_web/live/admin/job_live.ex:178
-#: lib/vutuv_web/live/admin/job_live.ex:212
+#: lib/vutuv_web/live/admin/job_live.ex:162
+#: lib/vutuv_web/live/admin/job_live.ex:171
+#: lib/vutuv_web/live/admin/job_live.ex:205
 #: lib/vutuv_web/live/admin/member_badges.ex:21
-#: lib/vutuv_web/live/admin/organization_live.ex:173
-#: lib/vutuv_web/live/admin/organization_live.ex:178
-#: lib/vutuv_web/live/admin/organization_live.ex:202
+#: lib/vutuv_web/live/admin/organization_live.ex:166
+#: lib/vutuv_web/live/admin/organization_live.ex:171
+#: lib/vutuv_web/live/admin/organization_live.ex:195
 #: lib/vutuv_web/live/admin/user_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Frozen"
@@ -8325,6 +8326,8 @@ msgstr "Identität verifiziert. Das Mitglied wurde per E-Mail benachrichtigt."
 msgid "Identity-verified"
 msgstr "Identität verifiziert"
 
+#: lib/vutuv/accounts.ex:886
+#: lib/vutuv/accounts.ex:935
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8359,11 +8362,12 @@ msgstr "Keine Mitglieder entsprechen Ihren Filtern."
 msgid "Not confirmed"
 msgstr "Nicht bestätigt"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:93
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "Open the member browser"
 msgstr "Mitgliederübersicht öffnen"
 
+#: lib/vutuv/accounts.ex:903
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8384,7 +8388,7 @@ msgstr "Seite %{page} von %{pages}"
 msgid "Registration"
 msgstr "Registrierung"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:103
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:104
 #, elixir-autogen, elixir-format
 msgid "Search and delete"
 msgstr "Suchen und löschen"
@@ -8704,7 +8708,7 @@ msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 msgid "A photo and a short tagline make your profile complete."
 msgstr "Ein Foto und eine Kurzbeschreibung machen Ihr Profil komplett."
 
-#: lib/vutuv_web/live/user_profile_live.ex:968
+#: lib/vutuv_web/live/user_profile_live.ex:969
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr "Zum Beispiel ein Gedanke zu %{tag}."
@@ -8733,8 +8737,8 @@ msgstr[1] ""
 msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:103
-#: lib/vutuv_web/templates/user/show.html.heex:1022
+#: lib/vutuv_web/templates/settings/privacy.html.heex:92
+#: lib/vutuv_web/templates/user/show.html.heex:1023
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8878,19 +8882,19 @@ msgstr "Andere Beiträge anzeigen"
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:105
+#: lib/vutuv_web/templates/settings/privacy.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 "Wenn Sie ein Mastodon- oder Bluesky-Konto angeben, kann Ihr Profil Ihre "
 "neuesten öffentlichen Beiträge von dort anzeigen."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:117
+#: lib/vutuv_web/templates/settings/privacy.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Show my latest social media posts on my profile"
 msgstr "Meine neuesten Social-Media-Beiträge auf meinem Profil anzeigen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:119
+#: lib/vutuv_web/templates/settings/privacy.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
@@ -9004,7 +9008,7 @@ msgstr ""
 msgid "Content"
 msgstr "Inhalt"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:288
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "Edit the legal pages"
 msgstr "Rechtstexte bearbeiten"
@@ -9022,7 +9026,7 @@ msgstr ""
 msgid "Impressum"
 msgstr "Impressum"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:290
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "Impressum, Datenschutzerklärung and Nutzungsbedingungen: every installation publishes its own operator identity here."
 msgstr ""
@@ -9035,7 +9039,7 @@ msgid "Last edited"
 msgstr "Zuletzt bearbeitet"
 
 #: lib/vutuv_web/controllers/admin/legal_page_controller.ex:22
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:285
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:289
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:2
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:3
@@ -9066,7 +9070,7 @@ msgstr "Seite"
 msgid "Publish page"
 msgstr "Seite veröffentlichen"
 
-#: lib/vutuv_web/live/admin/job_live.ex:390
+#: lib/vutuv_web/live/admin/job_live.ex:383
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Published"
@@ -9095,7 +9099,7 @@ msgstr "Follower aus dem Fediverse erlauben"
 
 #: lib/vutuv_web/components/ui.ex:2867
 #: lib/vutuv_web/controllers/settings_controller.ex:186
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:261
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:265
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:8
 #, elixir-autogen, elixir-format
@@ -9177,6 +9181,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
 
+#: lib/vutuv/accounts.ex:898
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9233,7 +9238,7 @@ msgstr "Berufserfahrung"
 msgid "Volunteering & hobbies"
 msgstr "Ehrenamt, Hobby & Freiwilligenarbeit"
 
-#: lib/vutuv_web/live/search_live.ex:253
+#: lib/vutuv_web/live/search_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr "Nicht verfügbar, solange die Suche einen Personen-Filter verwendet."
@@ -9784,7 +9789,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
-#: lib/vutuv_web/cv/html.ex:189
+#: lib/vutuv_web/cv/html.ex:188
 #: lib/vutuv_web/cv/latex.ex:149
 #: lib/vutuv_web/cv/odt.ex:163
 #: lib/vutuv_web/live/cv_live.ex:346
@@ -9981,6 +9986,7 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
+#: lib/vutuv/accounts/user.ex:609
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9991,6 +9997,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
+#: lib/vutuv/accounts/user.ex:606
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10014,7 +10021,7 @@ msgstr "Ehren-Tag erstellen"
 msgid "Enter a single word with no spaces."
 msgstr "Bitte ein einzelnes Wort ohne Leerzeichen eingeben."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:203
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:206
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:2
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -10035,7 +10042,7 @@ msgstr ""
 msgid "Honor tags ›"
 msgstr "Ehren-Tags ›"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:207
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Manage honor tags"
 msgstr "Ehren-Tags verwalten"
@@ -10055,7 +10062,7 @@ msgstr "Neuer Ehren-Tag (ein einzelnes Wort)"
 msgid "No honor tags yet. Create one above."
 msgstr "Noch keine Ehren-Tags. Erstellen Sie oben einen."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:209
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "Official badges you grant, like vutuv_developer for the core team. See who holds each and add or remove members."
 msgstr ""
@@ -10121,7 +10128,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/controllers/qualification_controller.ex:49
 #: lib/vutuv_web/controllers/qualification_controller.ex:88
 #: lib/vutuv_web/cv/docx.ex:183
-#: lib/vutuv_web/cv/html.ex:173
+#: lib/vutuv_web/cv/html.ex:172
 #: lib/vutuv_web/cv/latex.ex:140
 #: lib/vutuv_web/cv/odt.ex:154
 #: lib/vutuv_web/live/cv_live.ex:321
@@ -10157,8 +10164,8 @@ msgstr "Ausweisnummer"
 msgid "Does not expire"
 msgstr "Läuft nicht ab"
 
-#: lib/vutuv_web/live/admin/job_live.ex:171
-#: lib/vutuv_web/live/admin/job_live.ex:187
+#: lib/vutuv_web/live/admin/job_live.ex:164
+#: lib/vutuv_web/live/admin/job_live.ex:180
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
 #: lib/vutuv_web/views/qualification_html.ex:133
 #, elixir-autogen, elixir-format
@@ -10501,23 +10508,23 @@ msgid "Pick a section from the menu on the left to view or change it."
 msgstr ""
 "Wählen Sie links im Menü einen Bereich, um ihn anzusehen oder zu ändern."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:277
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:281
 #, elixir-autogen, elixir-format
 msgid "%{followers} remote followers, %{queue} queued for delivery."
 msgstr ""
 "%{followers} Fediverse-Follower, %{queue} in der Zustellwarteschlange."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:269
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Attention:"
 msgstr "Achtung:"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:275
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "Outbound federation is healthy."
 msgstr "Die ausgehende Föderation läuft störungsfrei."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:266
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:270
 #, elixir-autogen, elixir-format
 msgid "See the daily trend"
 msgstr "Zum Tagesbericht"
@@ -10527,7 +10534,7 @@ msgstr "Zum Tagesbericht"
 msgid "Showing the most recent %{shown} of %{total}."
 msgstr "Die neuesten %{shown} von %{total} werden angezeigt."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:269
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "stuck outbound delivery."
 msgid_plural "stuck outbound deliveries."
@@ -11005,17 +11012,17 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:56
 #: lib/vutuv_web/agent_docs/text.ex:55
-#: lib/vutuv_web/templates/user/show.html.heex:996
+#: lib/vutuv_web/templates/user/show.html.heex:997
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:135
+#: lib/vutuv_web/templates/settings/privacy.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr "Code-Statistiken"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:137
+#: lib/vutuv_web/templates/settings/privacy.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
@@ -11028,12 +11035,12 @@ msgstr ""
 msgid "Last active %{date}"
 msgstr "Zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:149
+#: lib/vutuv_web/templates/settings/privacy.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Show code statistics on my profile"
 msgstr "Code-Statistiken auf meinem Profil anzeigen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:151
+#: lib/vutuv_web/templates/settings/privacy.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
@@ -11363,7 +11370,7 @@ msgstr[1] ""
 msgid "Changed for this installation."
 msgstr "Für diese Installation geändert."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:301
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:305
 #, elixir-autogen, elixir-format
 msgid "Edit the defaults"
 msgstr "Voreinstellungen bearbeiten"
@@ -11373,7 +11380,7 @@ msgstr "Voreinstellungen bearbeiten"
 msgid "Follows the installation default."
 msgstr "Folgt dem Standard der Installation."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:308
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:312
 #, elixir-autogen, elixir-format
 msgid "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} default differs from the shipped value."
 msgid_plural "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} defaults differ from the shipped values."
@@ -11384,7 +11391,7 @@ msgstr[1] ""
 "Wie sich Beiträge und Karten für alle verhalten, die nicht selbst gewählt "
 "haben. %{formatted} Standards weichen von den mitgelieferten Werten ab."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:304
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "How posts and maps behave for everyone who has not chosen for themselves. This installation runs on the shipped defaults."
 msgstr ""
@@ -11422,7 +11429,7 @@ msgstr ""
 "Anzeige-Einstellungen für Beiträge auf die Standardwerte zurückgesetzt."
 
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:55
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:297
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:301
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:6
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:7
 #, elixir-autogen, elixir-format
@@ -11516,7 +11523,7 @@ msgstr ""
 "die Voreinstellungen-Seite vorgibt, jetzt und in Zukunft; ein gesetzter Wert"
 " bleibt, bis das Mitglied (oder ein Admin) ihn wieder ändert."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:159
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Auto-generated screenshots for single-link posts: watch the capture queue and browse the gallery of finished shots, each linked to its post."
 msgstr ""
@@ -11567,7 +11574,7 @@ msgstr "Letzter Fehler"
 #: lib/vutuv_web/live/admin/screenshot_live.ex:33
 #: lib/vutuv_web/live/admin/screenshot_live.ex:51
 #: lib/vutuv_web/live/admin/screenshot_live.ex:52
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:154
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Link screenshots"
 msgstr "Link-Screenshots"
@@ -11577,14 +11584,14 @@ msgstr "Link-Screenshots"
 msgid "No screenshots captured yet."
 msgstr "Noch keine Screenshots aufgenommen."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:157
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "Open the screenshot queue"
 msgstr "Screenshot-Warteschlange öffnen"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:172
-#: lib/vutuv_web/live/admin/organization_live.ex:186
-#: lib/vutuv_web/live/admin/organization_live.ex:201
+#: lib/vutuv_web/live/admin/organization_live.ex:165
+#: lib/vutuv_web/live/admin/organization_live.ex:179
+#: lib/vutuv_web/live/admin/organization_live.ex:194
 #: lib/vutuv_web/live/admin/screenshot_live.ex:196
 #: lib/vutuv_web/live/organization_live/domains.ex:181
 #, elixir-autogen, elixir-format
@@ -11631,16 +11638,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
+#: lib/vutuv/accounts/user.ex:621
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
+#: lib/vutuv/accounts/user.ex:626
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
+#: lib/vutuv/accounts/user.ex:624
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
@@ -11895,7 +11905,7 @@ msgstr ""
 "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) anbieten und für KI-"
 "Agenten auflisten."
 
-#: lib/vutuv_web/controllers/organization_controller.ex:137
+#: lib/vutuv_web/controllers/organization_controller.ex:144
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
@@ -12096,18 +12106,18 @@ msgstr "Auch bekannt als"
 msgid "Alternative name"
 msgstr "Alternativer Name"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:399
+#: lib/vutuv_web/live/admin/organization_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "Archive"
 msgstr "Archivieren"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:396
+#: lib/vutuv_web/live/admin/organization_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Archive this page?"
 msgstr "Diese Seite archivieren?"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:174
-#: lib/vutuv_web/live/admin/organization_live.ex:189
+#: lib/vutuv_web/live/admin/organization_live.ex:167
+#: lib/vutuv_web/live/admin/organization_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "Archived"
 msgstr "Archiviert"
@@ -12118,7 +12128,7 @@ msgstr "Archiviert"
 msgid "Brand"
 msgstr "Marke"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:335
+#: lib/vutuv_web/live/admin/organization_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "Claimed by"
 msgstr "Beansprucht von"
@@ -12128,7 +12138,7 @@ msgstr "Beansprucht von"
 msgid "Current team"
 msgstr "Aktuelles Team"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:405
+#: lib/vutuv_web/live/admin/organization_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Delete this page and everything it owns? This cannot be undone."
 msgstr ""
@@ -12153,7 +12163,7 @@ msgid "Domain verified."
 msgstr "Domain verifiziert."
 
 #: lib/vutuv_web/components/organization_components.ex:211
-#: lib/vutuv_web/live/admin/organization_live.ex:312
+#: lib/vutuv_web/live/admin/organization_live.ex:305
 #: lib/vutuv_web/live/organization_live/domains.ex:161
 #: lib/vutuv_web/live/organization_live/show.ex:277
 #, elixir-autogen, elixir-format
@@ -12170,13 +12180,13 @@ msgstr "Domains – %{name}"
 msgid "Former name"
 msgstr "Früherer Name"
 
-#: lib/vutuv_web/live/admin/job_live.ex:472
-#: lib/vutuv_web/live/admin/organization_live.ex:380
+#: lib/vutuv_web/live/admin/job_live.ex:465
+#: lib/vutuv_web/live/admin/organization_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Freeze"
 msgstr "Einfrieren"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:377
+#: lib/vutuv_web/live/admin/organization_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
@@ -12202,12 +12212,12 @@ msgstr "Zuletzt geprüft"
 msgid "Leave"
 msgstr "Verlassen"
 
-#: lib/vutuv_web/live/admin/job_live.ex:167
-#: lib/vutuv_web/live/admin/job_live.ex:183
-#: lib/vutuv_web/live/admin/job_live.ex:210
-#: lib/vutuv_web/live/admin/organization_live.ex:171
-#: lib/vutuv_web/live/admin/organization_live.ex:182
-#: lib/vutuv_web/live/admin/organization_live.ex:200
+#: lib/vutuv_web/live/admin/job_live.ex:160
+#: lib/vutuv_web/live/admin/job_live.ex:176
+#: lib/vutuv_web/live/admin/job_live.ex:203
+#: lib/vutuv_web/live/admin/organization_live.ex:164
+#: lib/vutuv_web/live/admin/organization_live.ex:175
+#: lib/vutuv_web/live/admin/organization_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr "Live"
@@ -12227,7 +12237,7 @@ msgstr "Mitglied entfernt."
 msgid "Method"
 msgstr "Methode"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:341
+#: lib/vutuv_web/live/admin/organization_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Names & aliases"
 msgstr "Namen & Aliasse"
@@ -12277,13 +12287,13 @@ msgstr "Diesen Namen entfernen?"
 msgid "Role updated."
 msgstr "Rolle aktualisiert."
 
-#: lib/vutuv_web/live/admin/organization_live.ex:240
+#: lib/vutuv_web/live/admin/organization_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Search name, alias or domain"
 msgstr "Name, Alias oder Domain suchen"
 
 #: lib/vutuv_web/components/organization_components.ex:208
-#: lib/vutuv_web/live/admin/organization_live.ex:328
+#: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:153
 #: lib/vutuv_web/live/organization_live/show.ex:270
 #, elixir-autogen, elixir-format
@@ -12310,25 +12320,25 @@ msgstr "Das ist keine gültige Domain."
 msgid "That member could not be added."
 msgstr "Dieses Mitglied konnte nicht hinzugefügt werden."
 
-#: lib/vutuv_web/live/admin/job_live.ex:481
-#: lib/vutuv_web/live/admin/organization_live.ex:389
+#: lib/vutuv_web/live/admin/job_live.ex:474
+#: lib/vutuv_web/live/admin/organization_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Unfreeze"
 msgstr "Freigeben"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:318
+#: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "pending"
 msgstr "ausstehend"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:316
+#: lib/vutuv_web/live/admin/organization_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "primary"
 msgstr "primär"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:315
 #: lib/vutuv_web/agent_docs/text.ex:349
-#: lib/vutuv_web/live/admin/organization_live.ex:318
+#: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
 msgstr "verifiziert"
@@ -12511,7 +12521,7 @@ msgstr "Verknüpfung entfernen"
 msgid "former"
 msgstr "ehemalig"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:236
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:239
 #, elixir-autogen, elixir-format
 msgid "%{formatted} alias matches another verified organization and is flagged for review."
 msgid_plural "%{formatted} aliases match another verified organization and are flagged for review."
@@ -12522,7 +12532,7 @@ msgstr[1] ""
 "%{formatted} Aliasse stimmen mit anderen verifizierten Organisationen überein und wurden"
 " zur Prüfung markiert."
 
-#: lib/vutuv_web/live/admin/organization_live.ex:206
+#: lib/vutuv_web/live/admin/organization_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "%{count} alias matches another verified organization and is flagged for review. Open an organization below to see it."
 msgid_plural "%{count} aliases match another verified organization and are flagged for review. Open an organization below to see them."
@@ -12635,12 +12645,12 @@ msgstr "Art der Organisation"
 msgid "Leave this organization team?"
 msgstr "Dieses Organisations-Team verlassen?"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:355
+#: lib/vutuv_web/live/admin/organization_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Matches another verified organization"
 msgstr "Stimmt mit einer anderen verifizierten Organisation überein"
 
-#: lib/vutuv_web/live/admin/organization_live.ex:245
+#: lib/vutuv_web/live/admin/organization_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "No organization pages match."
 msgstr "Keine passenden Organisationsseiten."
@@ -12670,7 +12680,7 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Organizations you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:231
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "Open organization oversight"
 msgstr "Organisations-Aufsicht öffnen"
@@ -12702,9 +12712,9 @@ msgid "Organization page"
 msgstr "Organisation"
 
 #: lib/vutuv_web/live/admin/organization_live.ex:25
-#: lib/vutuv_web/live/admin/organization_live.ex:195
-#: lib/vutuv_web/live/admin/organization_live.ex:196
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:226
+#: lib/vutuv_web/live/admin/organization_live.ex:188
+#: lib/vutuv_web/live/admin/organization_live.ex:189
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "Organization pages"
 msgstr "Organisation"
@@ -12737,14 +12747,14 @@ msgstr "Organisationen"
 msgid "Please choose"
 msgstr "Bitte wählen"
 
-#: lib/vutuv_web/controllers/organization_controller.ex:104
+#: lib/vutuv_web/controllers/organization_controller.ex:111
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before claiming an organization page."
 msgstr ""
 "Bitte bestätigen Sie Ihre E-Mail-Adresse, bevor Sie eine Organisationsseite "
 "beanspruchen."
 
-#: lib/vutuv_web/controllers/organization_controller.ex:110
+#: lib/vutuv_web/controllers/organization_controller.ex:117
 #, elixir-autogen, elixir-format
 msgid "Please log in to claim an organization page."
 msgstr "Bitte loggen Sie sich ein, um eine Organisationsseite zu beanspruchen."
@@ -12793,7 +12803,7 @@ msgstr ""
 msgid "Verified organization pages on vutuv."
 msgstr "Verifizierte Organisationsseiten auf vutuv."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:234
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:237
 #, elixir-autogen, elixir-format
 msgid "Verified organization pages: domains, team roles, aliases and rename history. Freeze, archive or delete a page."
 msgstr ""
@@ -12885,7 +12895,7 @@ msgstr "Sonstige"
 msgid "Public authority"
 msgstr "Behörde / Öffentlich"
 
-#: lib/vutuv_web/live/admin/job_live.ex:382
+#: lib/vutuv_web/live/admin/job_live.ex:375
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:138
 #, elixir-autogen, elixir-format
 msgid "%{views} views · %{clicks} apply clicks"
@@ -12931,7 +12941,7 @@ msgstr "Bewerbungs-URL"
 msgid "Application e-mail"
 msgstr "Bewerbungs-E-Mail"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:110
+#: lib/vutuv_web/controllers/job_posting_controller.ex:106
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Application: %{title}"
 msgstr "Bewerbung: %{title}"
@@ -12941,12 +12951,12 @@ msgstr "Bewerbung: %{title}"
 msgid "Applications go to"
 msgstr "Bewerbungen gehen an"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:270
+#: lib/vutuv_web/live/job_posting_live/show.ex:271
 #, elixir-autogen, elixir-format
 msgid "Apply by e-mail"
 msgstr "Per E-Mail bewerben"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:269
+#: lib/vutuv_web/live/job_posting_live/show.ex:270
 #, elixir-autogen, elixir-format
 msgid "Apply on website"
 msgstr "Auf Website bewerben"
@@ -12956,8 +12966,8 @@ msgstr "Auf Website bewerben"
 msgid "Apprenticeship"
 msgstr "Ausbildung"
 
-#: lib/vutuv_web/live/admin/job_live.ex:170
-#: lib/vutuv_web/live/admin/job_live.ex:190
+#: lib/vutuv_web/live/admin/job_live.ex:163
+#: lib/vutuv_web/live/admin/job_live.ex:183
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:184
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Closed"
@@ -12987,7 +12997,7 @@ msgstr "Anzeige bearbeiten"
 #: lib/vutuv_web/agent_docs/markdown.ex:339
 #: lib/vutuv_web/agent_docs/text.ex:206
 #: lib/vutuv_web/agent_docs/text.ex:373
-#: lib/vutuv_web/live/admin/job_live.ex:351
+#: lib/vutuv_web/live/admin/job_live.ex:344
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employer"
 msgstr "Arbeitgeber"
@@ -13001,7 +13011,7 @@ msgstr "Name des Arbeitgebers (optional)"
 #: lib/vutuv_web/agent_docs/markdown.ex:340
 #: lib/vutuv_web/agent_docs/text.ex:207
 #: lib/vutuv_web/agent_docs/text.ex:374
-#: lib/vutuv_web/live/job_board_live.ex:280
+#: lib/vutuv_web/live/job_board_live.ex:281
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment type"
@@ -13022,7 +13032,7 @@ msgstr "Von"
 msgid "Full-time"
 msgstr "Vollzeit"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:158
+#: lib/vutuv_web/live/job_posting_live/show.ex:159
 #, elixir-autogen, elixir-format
 msgid "Highlighted tags match your profile."
 msgstr "Hervorgehobene Tags passen zu Ihrem Profil."
@@ -13042,7 +13052,7 @@ msgstr "So bewerben Sie sich"
 msgid "Hybrid"
 msgstr "Hybrid"
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:124
+#: lib/vutuv_web/controllers/job_posting_controller.ex:120
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr "Ich interessiere mich für Ihre Anzeige: %{url}"
@@ -13059,8 +13069,8 @@ msgstr "Stellenbezeichnung"
 
 #: lib/vutuv_web/agent_docs/job_board_doc.ex:19
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:40
-#: lib/vutuv_web/live/job_board_live.ex:145
+#: lib/vutuv_web/live/job_board_live.ex:41
+#: lib/vutuv_web/live/job_board_live.ex:146
 #: lib/vutuv_web/live/post_live/saved.ex:458
 #: lib/vutuv_web/live/shell_live.ex:339
 #: lib/vutuv_web/templates/layout/app.html.heex:77
@@ -13094,7 +13104,7 @@ msgstr "Als besetzt markieren"
 msgid "Mark this posting as filled and close it?"
 msgstr "Diese Anzeige als besetzt markieren und schließen?"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:271
+#: lib/vutuv_web/live/job_posting_live/show.ex:272
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Message the poster"
 msgstr "Anbieter:in anschreiben"
@@ -13111,7 +13121,7 @@ msgstr "Irreführende Stellenanzeige"
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:25
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:101
-#: lib/vutuv_web/live/job_posting_live/show.ex:180
+#: lib/vutuv_web/live/job_posting_live/show.ex:181
 #, elixir-autogen, elixir-format, fuzzy
 msgid "My postings"
 msgstr "Meine Anzeigen"
@@ -13130,7 +13140,7 @@ msgstr "Neue Anzeige"
 #: lib/vutuv_web/agent_docs/markdown.ex:222
 #: lib/vutuv_web/agent_docs/text.ex:217
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
-#: lib/vutuv_web/live/job_posting_live/show.ex:153
+#: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
 msgstr "Wünschenswert"
@@ -13160,7 +13170,7 @@ msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbi
 msgid "On-site"
 msgstr "Vor Ort"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:87
+#: lib/vutuv_web/live/job_posting_live/show.ex:88
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this posting while a report about it is handled."
 msgstr "Nur Sie sehen diese Anzeige, während eine Meldung dazu bearbeitet wird."
@@ -13187,7 +13197,7 @@ msgstr "Bitte bestätigen Sie zuerst Ihre E-Mail-Adresse."
 msgid "Please confirm your email address before posting a job."
 msgstr "Bitte bestätigen Sie Ihre E-Mail-Adresse, bevor Sie eine Stelle ausschreiben."
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:116
+#: lib/vutuv_web/controllers/job_posting_controller.ex:112
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr "Bitte melden Sie sich an, um die Anbieter:in anzuschreiben."
@@ -13216,7 +13226,7 @@ msgstr "Postleitzahl"
 #: lib/vutuv_web/agent_docs/markdown.ex:344
 #: lib/vutuv_web/agent_docs/text.ex:211
 #: lib/vutuv_web/agent_docs/text.ex:378
-#: lib/vutuv_web/live/job_posting_live/show.ex:132
+#: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posted"
 msgstr "Veröffentlicht"
@@ -13249,7 +13259,7 @@ msgstr "Veröffentlichen"
 msgid "Remote"
 msgstr "Remote"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:168
+#: lib/vutuv_web/live/job_posting_live/show.ex:169
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this posting"
 msgstr "Diese Anzeige melden"
@@ -13257,7 +13267,7 @@ msgstr "Diese Anzeige melden"
 #: lib/vutuv_web/agent_docs/markdown.ex:221
 #: lib/vutuv_web/agent_docs/text.ex:216
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
-#: lib/vutuv_web/live/job_posting_live/show.ex:148
+#: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Erforderlich"
@@ -13320,7 +13330,7 @@ msgstr "Die Stelle"
 msgid "This organization has reached its published-postings limit."
 msgstr "Diese Organisation hat ihr Limit an veröffentlichten Anzeigen erreicht."
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:94
+#: lib/vutuv_web/live/job_posting_live/show.ex:95
 #, elixir-autogen, elixir-format
 msgid "This position is no longer available."
 msgstr "Diese Stelle ist nicht mehr verfügbar."
@@ -13331,7 +13341,7 @@ msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with t
 msgstr "Tipp: Ein Geschlechtszusatz wie (m/w/d) hilft Ihrer Anzeige, dem AGG zu entsprechen. Das ist ein Hinweis, keine Rechtsberatung."
 
 #: lib/vutuv_web/components/job_components.ex:108
-#: lib/vutuv_web/live/job_posting_live/show.ex:208
+#: lib/vutuv_web/live/job_posting_live/show.ex:209
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verified organization"
 msgstr "Verifizierte Organisation"
@@ -13376,7 +13386,7 @@ msgstr "Sie haben bereits die maximale Anzahl veröffentlichter Anzeigen."
 msgid "Your job posting on vutuv expires soon"
 msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:175
+#: lib/vutuv_web/live/job_posting_live/show.ex:176
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your posting"
 msgstr "Ihre Anzeige"
@@ -13523,12 +13533,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] "vor %{count} Woche"
 msgstr[1] "vor %{count} Wochen"
 
-#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/job_board_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr "%{km} km"
 
-#: lib/vutuv_web/live/job_board_live.ex:274
+#: lib/vutuv_web/live/job_board_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr "Alle Länder"
@@ -13544,32 +13554,32 @@ msgstr "Alle Stellen mit diesem Tag"
 msgid "All jobs with this tag: %{url}"
 msgstr "Alle Stellen mit diesem Tag: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:281
+#: lib/vutuv_web/live/job_board_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr "Alle Anstellungsarten"
 
-#: lib/vutuv_web/live/job_board_live.ex:263
+#: lib/vutuv_web/live/job_board_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr "Stadt oder Postleitzahl"
 
-#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/job_board_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr "Genau"
 
-#: lib/vutuv_web/live/job_board_live.ex:183
+#: lib/vutuv_web/live/job_board_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr "Ab meiner Gehaltsvorstellung"
 
-#: lib/vutuv_web/live/job_board_live.ex:175
+#: lib/vutuv_web/live/job_board_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr "Passend zu meinen Tags"
 
-#: lib/vutuv_web/live/job_board_live.ex:337
+#: lib/vutuv_web/live/job_board_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr "Mindestgehalt/Jahr (%{currency})"
@@ -13579,7 +13589,7 @@ msgstr "Mindestgehalt/Jahr (%{currency})"
 msgid "Minimum yearly salary"
 msgstr "Mindestgehalt pro Jahr"
 
-#: lib/vutuv_web/live/job_board_live.ex:238
+#: lib/vutuv_web/live/job_board_live.ex:239
 #: lib/vutuv_web/live/organization_live/show.ex:342
 #, elixir-autogen, elixir-format
 msgid "More jobs"
@@ -13595,12 +13605,12 @@ msgstr "Nächste Seite"
 msgid "Next page: %{url}"
 msgstr "Nächste Seite: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:328
+#: lib/vutuv_web/live/job_board_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr "Noch keine Stellenanzeigen."
 
-#: lib/vutuv_web/live/job_board_live.ex:326
+#: lib/vutuv_web/live/job_board_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Keine passenden Stellen. Passe die Filter an."
@@ -13616,92 +13626,92 @@ msgid "Open positions"
 msgstr "Offene Stellen"
 
 #: lib/vutuv_web/agent_docs/job_board_doc.ex:20
-#: lib/vutuv_web/live/job_board_live.ex:147
+#: lib/vutuv_web/live/job_board_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr "Offene Stellen auf vutuv, neueste zuerst."
 
-#: lib/vutuv_web/live/job_board_live.ex:155
+#: lib/vutuv_web/live/job_board_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr "Stelle ausschreiben"
 
-#: lib/vutuv_web/live/job_board_live.ex:220
+#: lib/vutuv_web/live/job_board_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr "Veröffentliche die erste"
 
-#: lib/vutuv_web/live/job_board_live.ex:267
+#: lib/vutuv_web/live/job_board_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr "Umkreis"
 
-#: lib/vutuv_web/live/job_board_live.ex:255
+#: lib/vutuv_web/live/job_board_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr "Jobs durchsuchen"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:144
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "%{formatted} job posting has an open moderation case."
 msgid_plural "%{formatted} job postings have an open moderation case."
 msgstr[0] "%{formatted} Stellenanzeige hat einen offenen Moderationsfall."
 msgstr[1] "%{formatted} Stellenanzeigen haben einen offenen Moderationsfall."
 
-#: lib/vutuv_web/live/admin/job_live.ex:447
+#: lib/vutuv_web/live/admin/job_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "%{count} report"
 msgid_plural "%{count} reports"
 msgstr[0] "%{count} Meldung"
 msgstr[1] "%{count} Meldungen"
 
-#: lib/vutuv_web/live/admin/job_live.ex:366
+#: lib/vutuv_web/live/admin/job_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "(free text, unverified)"
 msgstr "(Freitext, nicht verifiziert)"
 
-#: lib/vutuv_web/live/admin/job_live.ex:199
+#: lib/vutuv_web/live/admin/job_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "(no employer)"
 msgstr "(kein Arbeitgeber)"
 
-#: lib/vutuv_web/live/admin/job_live.ex:488
+#: lib/vutuv_web/live/admin/job_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Close this posting? It ends the listing (a regular ending, not a deletion)."
 msgstr "Diese Anzeige schließen? Das beendet die Anzeige regulär (keine Löschung)."
 
-#: lib/vutuv_web/live/admin/job_live.ex:425
+#: lib/vutuv_web/live/admin/job_live.ex:418
 #: lib/vutuv_web/live/admin/user_detail_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cold outreach"
 msgstr "Kaltakquise"
 
-#: lib/vutuv_web/live/admin/job_live.ex:380
+#: lib/vutuv_web/live/admin/job_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Counters"
 msgstr "Zähler"
 
-#: lib/vutuv_web/live/admin/job_live.ex:497
+#: lib/vutuv_web/live/admin/job_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "Delete this posting and everything it owns? This cannot be undone."
 msgstr "Diese Anzeige und alles, was dazugehört, löschen? Das kann nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:142
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Every job posting: search, freeze/unfreeze, close or delete, with the poster's report history and cold-outreach counter."
 msgstr "Jede Stellenanzeige: suchen, einfrieren/auftauen, schließen oder löschen, mit der Meldungshistorie und dem Kaltakquise-Zähler des Erstellers."
 
-#: lib/vutuv_web/live/admin/job_live.ex:168
+#: lib/vutuv_web/live/admin/job_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Expiring"
 msgstr "Läuft ab"
 
-#: lib/vutuv_web/live/admin/job_live.ex:211
+#: lib/vutuv_web/live/admin/job_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Expiring (7 days)"
 msgstr "Läuft ab (7 Tage)"
 
-#: lib/vutuv_web/live/admin/job_live.ex:469
+#: lib/vutuv_web/live/admin/job_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Freeze this posting? It disappears from the public board and its indexing but stays visible to its poster."
 msgstr "Diese Anzeige einfrieren? Sie verschwindet von der öffentlichen Stellenbörse und aus der Indexierung, bleibt aber für den Ersteller sichtbar."
@@ -13712,42 +13722,42 @@ msgid "Job posting"
 msgstr "Stellenanzeige"
 
 #: lib/vutuv_web/live/admin/job_live.ex:30
-#: lib/vutuv_web/live/admin/job_live.ex:205
-#: lib/vutuv_web/live/admin/job_live.ex:206
+#: lib/vutuv_web/live/admin/job_live.ex:198
+#: lib/vutuv_web/live/admin/job_live.ex:199
 #: lib/vutuv_web/live/admin/user_detail_live.ex:175
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:134
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Job postings"
 msgstr "Stellenanzeigen"
 
-#: lib/vutuv_web/live/admin/job_live.ex:413
+#: lib/vutuv_web/live/admin/job_live.ex:406
 #: lib/vutuv_web/live/admin/user_detail_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Live postings"
 msgstr "Aktive Anzeigen"
 
-#: lib/vutuv_web/live/admin/job_live.ex:265
+#: lib/vutuv_web/live/admin/job_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "No job postings match."
 msgstr "Keine Stellenanzeigen gefunden."
 
-#: lib/vutuv_web/live/admin/job_live.ex:457
+#: lib/vutuv_web/live/admin/job_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "Open case"
 msgstr "Fall öffnen"
 
-#: lib/vutuv_web/live/admin/job_live.ex:421
+#: lib/vutuv_web/live/admin/job_live.ex:414
 #: lib/vutuv_web/live/admin/user_detail_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "Open job cases"
 msgstr "Offene Job-Fälle"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:139
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Open job oversight"
 msgstr "Job-Übersicht öffnen"
 
-#: lib/vutuv_web/live/admin/job_live.ex:249
+#: lib/vutuv_web/live/admin/job_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Open reports"
 msgstr "Offene Meldungen"
@@ -13757,13 +13767,13 @@ msgstr "Offene Meldungen"
 msgid "Open the job posting"
 msgstr "Stellenanzeige öffnen"
 
-#: lib/vutuv_web/live/admin/job_live.ex:272
-#: lib/vutuv_web/live/admin/job_live.ex:338
+#: lib/vutuv_web/live/admin/job_live.ex:265
+#: lib/vutuv_web/live/admin/job_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Poster"
 msgstr "Ersteller"
 
-#: lib/vutuv_web/live/admin/job_live.ex:410
+#: lib/vutuv_web/live/admin/job_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Poster footprint"
 msgstr "Ersteller-Übersicht"
@@ -13788,38 +13798,38 @@ msgstr "Anzeige eingefroren."
 msgid "Posting unfrozen."
 msgstr "Anzeige aufgetaut."
 
-#: lib/vutuv_web/live/admin/job_live.ex:438
+#: lib/vutuv_web/live/admin/job_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Report history"
 msgstr "Meldungshistorie"
 
-#: lib/vutuv_web/live/admin/job_live.ex:260
+#: lib/vutuv_web/live/admin/job_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Search title, poster or organization"
 msgstr "Titel, Ersteller oder Organisation suchen"
 
-#: lib/vutuv_web/live/admin/job_live.ex:271
+#: lib/vutuv_web/live/admin/job_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
 
-#: lib/vutuv_web/live/admin/job_live.ex:417
+#: lib/vutuv_web/live/admin/job_live.ex:410
 #: lib/vutuv_web/live/admin/user_detail_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Total postings"
 msgstr "Anzeigen insgesamt"
 
-#: lib/vutuv_web/live/admin/job_live.ex:395
+#: lib/vutuv_web/live/admin/job_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "never"
 msgstr "nie"
 
-#: lib/vutuv_web/live/admin/job_live.ex:361
+#: lib/vutuv_web/live/admin/job_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "verified organization page"
 msgstr "verifizierte Organisationsseite"
 
-#: lib/vutuv_web/live/admin/job_live.ex:402
+#: lib/vutuv_web/live/admin/job_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "—"
 msgstr "—"
@@ -13974,7 +13984,7 @@ msgstr "Stellenbörse"
 msgid "job search"
 msgstr "Jobsuche"
 
-#: lib/vutuv_web/live/search_live.ex:301
+#: lib/vutuv_web/live/search_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "only people open to offers (status:open) or looking (status:looking)"
 msgstr "nur Personen, die offen für Angebote (status:open) oder auf Jobsuche (status:looking) sind"
@@ -14143,7 +14153,7 @@ msgstr "„%{title}“"
 msgid "Alias flag cleared."
 msgstr "Alias-Markierung entfernt."
 
-#: lib/vutuv_web/live/admin/organization_live.ex:361
+#: lib/vutuv_web/live/admin/organization_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "Reviewed, all fine: clear the flag"
 msgstr "Geprüft, alles in Ordnung: Markierung entfernen"
@@ -14163,7 +14173,7 @@ msgstr "Job-Übersicht"
 msgid "This member no longer exists."
 msgstr "Dieses Mitglied existiert nicht mehr."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:78
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 Tagen abgelehnt. Eine wachsende Warteschlange bedeutet meist, dass Ollama nicht erreichbar ist."
@@ -14187,12 +14197,12 @@ msgid "Image is being reviewed"
 msgstr "Bild wird geprüft"
 
 #: lib/vutuv_web/live/notification_live/index.ex:303
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:67
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
 msgstr "Bildprüfung"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:73
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
 msgstr "Keine Bilder in der KI-Prüfung. %{formatted} in den letzten 7 Tagen abgelehnt."
@@ -14232,6 +14242,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
+#: lib/vutuv/accounts/user.ex:639
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14242,16 +14253,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
+#: lib/vutuv/accounts/user.ex:642
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
+#: lib/vutuv/accounts/user.ex:645
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
+#: lib/vutuv/accounts/user.ex:636
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14279,7 +14293,7 @@ msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen 
 msgid "Handle change"
 msgstr "Handle-Änderung"
 
-#: lib/vutuv_web/controllers/username_controller.ex:42
+#: lib/vutuv_web/controllers/username_controller.ex:44
 #, elixir-autogen, elixir-format
 msgid "We updated %{formatted} post that mentioned your old handle and notified its author."
 msgid_plural "We updated %{formatted} posts that mentioned your old handle and notified their authors."
@@ -14333,14 +14347,14 @@ msgstr "In den Text einfügen"
 msgid "Posts with this tag"
 msgstr "Beiträge mit diesem Tag"
 
-#: lib/vutuv_web/live/search_live.ex:270
+#: lib/vutuv_web/live/search_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
 "Diese Suche nutzt einen reinen Personenfilter wie city: oder status: und "
 "findet daher nur Personen."
 
-#: lib/vutuv_web/live/search_live.ex:297
+#: lib/vutuv_web/live/search_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "people and posts with this tag, combinable: miller tag:php"
 msgstr "Personen und Beiträge mit diesem Tag, kombinierbar: müller tag:php"
@@ -14393,3 +14407,33 @@ msgstr "Tags, denen du folgst"
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
+
+#: lib/vutuv_web/live/job_board_live.ex:324
+#, elixir-autogen, elixir-format
+msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
+msgstr "Ein Beruf mit mehreren möglichen Titeln? Trenne sie mit Komma, dann zeigen wir Anzeigen, die zu einem davon passen."
+
+#: lib/vutuv_web/live/job_board_live.ex:320
+#, elixir-autogen, elixir-format
+msgid "Search tips"
+msgstr "Suchtipps"
+
+#: lib/vutuv_web/live/job_board_live.ex:378
+#, elixir-autogen, elixir-format
+msgid "any of these titles"
+msgstr "einer dieser Titel"
+
+#: lib/vutuv_web/live/job_board_live.ex:380
+#, elixir-autogen, elixir-format
+msgid "exact wording"
+msgstr "genaue Wortfolge"
+
+#: lib/vutuv_web/live/job_board_live.ex:381
+#, elixir-autogen, elixir-format
+msgid "without internships"
+msgstr "ohne Praktika"
+
+#: lib/vutuv_web/live/job_board_live.ex:379
+#, elixir-autogen, elixir-format
+msgid "word start: also finds Entwickler, Entwicklung"
+msgstr "Wortanfang: findet auch Entwickler, Entwicklung"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -36,7 +36,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1117
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -149,10 +149,10 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:806
 #: lib/vutuv_web/components/ui.ex:2611
-#: lib/vutuv_web/live/admin/job_live.ex:500
+#: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
-#: lib/vutuv_web/live/admin/organization_live.ex:408
+#: lib/vutuv_web/live/admin/organization_live.ex:401
 #: lib/vutuv_web/live/admin/user_delete_live.ex:172
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
@@ -197,7 +197,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
-#: lib/vutuv_web/live/job_posting_live/show.ex:177
+#: lib/vutuv_web/live/job_posting_live/show.ex:178
 #: lib/vutuv_web/live/organization_live/show.ex:263
 #: lib/vutuv_web/templates/address/edit.html.heex:4
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
@@ -416,7 +416,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
 #: lib/vutuv_web/cv/docx.ex:206
-#: lib/vutuv_web/cv/html.ex:206
+#: lib/vutuv_web/cv/html.ex:205
 #: lib/vutuv_web/cv/latex.ex:164
 #: lib/vutuv_web/cv/odt.ex:176
 #: lib/vutuv_web/live/cv_live.ex:296
@@ -535,7 +535,7 @@ msgid "Number type"
 msgstr ""
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:168
-#: lib/vutuv_web/live/admin/organization_live.ex:251
+#: lib/vutuv_web/live/admin/organization_live.ex:244
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:5
 #, elixir-autogen
 msgid "Organization"
@@ -642,20 +642,18 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
 #: lib/vutuv_web/templates/settings/preferences.html.heex:180
 #: lib/vutuv_web/templates/settings/privacy.html.heex:64
-#: lib/vutuv_web/templates/settings/privacy.html.heex:92
-#: lib/vutuv_web/templates/settings/privacy.html.heex:125
-#: lib/vutuv_web/templates/settings/privacy.html.heex:157
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:342
+#: lib/vutuv_web/views/settings_html.ex:135
 #, elixir-autogen
 msgid "Save"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:231
-#: lib/vutuv_web/live/job_board_live.ex:295
+#: lib/vutuv_web/live/job_board_live.ex:314
 #: lib/vutuv_web/live/search_live.ex:35
-#: lib/vutuv_web/live/search_live.ex:231
+#: lib/vutuv_web/live/search_live.ex:229
 #: lib/vutuv_web/live/shell_live.ex:346
 #: lib/vutuv_web/live/shell_live.ex:502
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
@@ -690,7 +688,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
-#: lib/vutuv_web/cv/html.ex:227
+#: lib/vutuv_web/cv/html.ex:226
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
 #: lib/vutuv_web/live/cv_live.ex:370
@@ -699,13 +697,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:963
+#: lib/vutuv_web/templates/user/show.html.heex:964
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:965
+#: lib/vutuv_web/templates/user/show.html.heex:966
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -1033,12 +1031,14 @@ msgstr ""
 msgid "Select a year"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:732
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:731
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1187,12 +1187,12 @@ msgstr ""
 msgid "Can't find URL"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:287
+#: lib/vutuv_web/live/search_live.ex:285
 #, elixir-autogen
 msgid "Our search will try to match similar names to your search, so don't worry about spelling."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:282
+#: lib/vutuv_web/live/search_live.ex:280
 #, elixir-autogen
 msgid "Search Tips"
 msgstr ""
@@ -1228,7 +1228,7 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:245
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
-#: lib/vutuv_web/live/admin/job_live.ex:206
+#: lib/vutuv_web/live/admin/job_live.ex:199
 #: lib/vutuv_web/live/admin/member_badges.ex:19
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:135
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
@@ -1236,7 +1236,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
-#: lib/vutuv_web/live/admin/organization_live.ex:196
+#: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:52
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
@@ -1456,17 +1456,17 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_tag_controller.ex:37
 #: lib/vutuv_web/controllers/user_tag_controller.ex:54
 #: lib/vutuv_web/cv/docx.ex:174
-#: lib/vutuv_web/cv/html.ex:160
+#: lib/vutuv_web/cv/html.ex:159
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
 #: lib/vutuv_web/live/cv_live.ex:275
 #: lib/vutuv_web/live/job_posting_live/form.ex:509
-#: lib/vutuv_web/live/search_live.ex:180
-#: lib/vutuv_web/live/search_live.ex:363
+#: lib/vutuv_web/live/search_live.ex:178
+#: lib/vutuv_web/live/search_live.ex:361
 #: lib/vutuv_web/live/tag_new_live.ex:35
 #: lib/vutuv_web/live/tag_new_live.ex:45
 #: lib/vutuv_web/live/tag_new_live.ex:54
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:192
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:195
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:5
@@ -1635,7 +1635,7 @@ msgid "You'll receive an email with a login link."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
-#: lib/vutuv_web/live/job_board_live.ex:273
+#: lib/vutuv_web/live/job_board_live.ex:274
 #: lib/vutuv_web/live/job_posting_live/form.ex:410
 #: lib/vutuv_web/live/organization_live/edit.ex:282
 #: lib/vutuv_web/live/organization_live/new.ex:127
@@ -1691,9 +1691,9 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:332
-#: lib/vutuv_web/live/admin/job_live.ex:491
-#: lib/vutuv_web/live/admin/organization_live.ex:306
+#: lib/vutuv_web/live/admin/job_live.ex:325
+#: lib/vutuv_web/live/admin/job_live.ex:484
+#: lib/vutuv_web/live/admin/organization_live.ex:299
 #: lib/vutuv_web/live/post_live/composer.ex:460
 #: lib/vutuv_web/live/post_live/composer.ex:461
 #: lib/vutuv_web/templates/layout/app.html.heex:152
@@ -1773,7 +1773,7 @@ msgid "It doesn't look like you're following anyone yet. Open the profile of som
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:473
-#: lib/vutuv_web/views/settings_html.ex:181
+#: lib/vutuv_web/views/settings_html.ex:222
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -1911,7 +1911,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1200
+#: lib/vutuv_web/templates/user/show.html.heex:1201
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -2256,8 +2256,8 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:77
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
 #: lib/vutuv_web/live/post_live/saved.ex:449
-#: lib/vutuv_web/live/search_live.ex:181
-#: lib/vutuv_web/live/search_live.ex:377
+#: lib/vutuv_web/live/search_live.ex:179
+#: lib/vutuv_web/live/search_live.ex:375
 #: lib/vutuv_web/templates/settings/preferences.html.heex:114
 #: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
@@ -2284,7 +2284,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:227
+#: lib/vutuv_web/views/settings_html.ex:268
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2346,7 +2346,7 @@ msgstr ""
 #: lib/vutuv_web/live/shell_live.ex:416
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:128
+#: lib/vutuv_web/views/settings_html.ex:169
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
@@ -2387,7 +2387,7 @@ msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:256
+#: lib/vutuv_web/views/settings_html.ex:297
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2758,7 +2758,7 @@ msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1118
+#: lib/vutuv_web/templates/user/show.html.heex:1119
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
@@ -2780,7 +2780,7 @@ msgstr ""
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:955
+#: lib/vutuv_web/live/user_profile_live.ex:956
 #: lib/vutuv_web/templates/user/show.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
@@ -2791,7 +2791,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
-#: lib/vutuv_web/templates/settings/privacy.html.heex:172
+#: lib/vutuv_web/templates/settings/privacy.html.heex:130
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
 #, elixir-autogen, elixir-format
@@ -2933,7 +2933,7 @@ msgid_plural "%{formatted} cases are waiting for a ruling."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:346
+#: lib/vutuv_web/live/admin/job_live.ex:339
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:266
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
@@ -3147,7 +3147,7 @@ msgstr ""
 msgid "Only you can see your profile right now - it is hidden while a report is handled."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:213
+#: lib/vutuv_web/live/admin/job_live.ex:206
 #: lib/vutuv_web/live/admin/moderation_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Open cases"
@@ -3339,10 +3339,10 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:74
 #: lib/vutuv_web/live/admin/deliverability_live.ex:252
-#: lib/vutuv_web/live/admin/job_live.ex:273
-#: lib/vutuv_web/live/admin/job_live.ex:372
+#: lib/vutuv_web/live/admin/job_live.ex:266
+#: lib/vutuv_web/live/admin/job_live.ex:365
 #: lib/vutuv_web/live/admin/moderation_live.ex:53
-#: lib/vutuv_web/live/admin/organization_live.ex:253
+#: lib/vutuv_web/live/admin/organization_live.ex:246
 #: lib/vutuv_web/live/admin/screenshot_live.ex:119
 #: lib/vutuv_web/live/admin/user_live.ex:315
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:59
@@ -3562,12 +3562,12 @@ msgstr ""
 msgid "Your vutuv account is suspended"
 msgstr ""
 
-#: lib/vutuv_web/controllers/username_controller.ex:72
+#: lib/vutuv_web/controllers/username_controller.ex:77
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is already taken."
 msgstr ""
 
-#: lib/vutuv_web/controllers/username_controller.ex:81
+#: lib/vutuv_web/controllers/username_controller.ex:86
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is available."
 msgstr ""
@@ -3577,8 +3577,8 @@ msgstr ""
 msgid "New username"
 msgstr ""
 
-#: lib/vutuv_web/controllers/username_controller.ex:37
-#: lib/vutuv_web/controllers/username_controller.ex:40
+#: lib/vutuv_web/controllers/username_controller.ex:39
+#: lib/vutuv_web/controllers/username_controller.ex:42
 #, elixir-autogen, elixir-format
 msgid "Your username is now @%{handle}."
 msgstr ""
@@ -4079,7 +4079,7 @@ msgstr ""
 msgid "Booking requires a vutuv login."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:252
+#: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:404
 #: lib/vutuv_web/live/organization_live/edit.ex:278
 #: lib/vutuv_web/live/organization_live/new.ex:123
@@ -4177,7 +4177,7 @@ msgstr ""
 msgid "vutuv shows a single, text-only ad per calendar day: discreet, between the navigation and the content, in the style of classic text ads."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:345
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:350
 #, elixir-autogen, elixir-format
 msgid "%{formatted} ad is waiting for approval."
 msgid_plural "%{formatted} ads are waiting for approval."
@@ -4192,7 +4192,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:5
 #: lib/vutuv_web/templates/admin/ad/show.html.heex:5
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:335
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:340
 #, elixir-autogen, elixir-format
 msgid "Ads"
 msgstr ""
@@ -4257,7 +4257,7 @@ msgstr ""
 msgid "My bookings"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:343
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:348
 #, elixir-autogen, elixir-format
 msgid "No ads waiting for approval."
 msgstr ""
@@ -4267,7 +4267,7 @@ msgstr ""
 msgid "No upcoming ads."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:340
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Open the ad review"
 msgstr ""
@@ -4415,8 +4415,8 @@ msgstr ""
 msgid "Approved on"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:297
-#: lib/vutuv_web/live/admin/organization_live.ex:272
+#: lib/vutuv_web/live/admin/job_live.ex:290
+#: lib/vutuv_web/live/admin/organization_live.ex:265
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Details"
@@ -4495,7 +4495,7 @@ msgstr ""
 msgid "Undeliverable"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:284
+#: lib/vutuv_web/live/search_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
@@ -4513,7 +4513,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:1
 #: lib/vutuv_web/templates/block/index.html.heex:1
-#: lib/vutuv_web/templates/settings/privacy.html.heex:169
+#: lib/vutuv_web/templates/settings/privacy.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Blocked members"
 msgstr ""
@@ -4593,12 +4593,12 @@ msgstr ""
 msgid "This area is reserved for administrators."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:409
+#: lib/vutuv_web/live/search_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No results for \"%{query}\""
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:346
+#: lib/vutuv_web/live/search_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
@@ -4608,78 +4608,78 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
-#: lib/vutuv_web/live/search_live.ex:179
-#: lib/vutuv_web/live/search_live.ex:319
+#: lib/vutuv_web/live/search_live.ex:177
+#: lib/vutuv_web/live/search_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:278
+#: lib/vutuv_web/live/search_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Results appear once you have typed at least three letters."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:343
+#: lib/vutuv_web/live/search_live.ex:341
 #, elixir-autogen, elixir-format
 msgid "Similar names"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:261
-#: lib/vutuv_web/live/admin/job_live.ex:166
-#: lib/vutuv_web/live/admin/organization_live.ex:170
-#: lib/vutuv_web/live/search_live.ex:178
+#: lib/vutuv_web/live/admin/job_live.ex:159
+#: lib/vutuv_web/live/admin/organization_live.ex:163
+#: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:73
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:261
+#: lib/vutuv_web/live/search_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Exact matches only"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:305
+#: lib/vutuv_web/live/search_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "in quotes: exact matches only, no similar names"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:303
+#: lib/vutuv_web/live/search_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "searches usernames"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:299
+#: lib/vutuv_web/live/search_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "only people with an address in this city"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:298
+#: lib/vutuv_web/live/search_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "city:koblenz"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:294
+#: lib/vutuv_web/live/search_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "first:stefan"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:304
+#: lib/vutuv_web/live/search_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "miller"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:295
+#: lib/vutuv_web/live/search_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:943
+#: lib/vutuv_web/live/user_profile_live.ex:944
 #: lib/vutuv_web/templates/user/show.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:238
+#: lib/vutuv_web/live/search_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, or posts"
 msgstr ""
@@ -4724,9 +4724,9 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:216
 #: lib/vutuv_web/agent_docs/text.ex:212
-#: lib/vutuv_web/live/admin/job_live.ex:400
+#: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
-#: lib/vutuv_web/live/job_posting_live/show.ex:135
+#: lib/vutuv_web/live/job_posting_live/show.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:39
 #: lib/vutuv_web/templates/qualification/show.html.heex:33
 #, elixir-autogen, elixir-format
@@ -4887,7 +4887,7 @@ msgstr ""
 msgid "%{app} wants to access your vutuv account. It would be allowed to:"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:325
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "%{formatted} registered third-party application. Suspending one cuts off all of its tokens."
 msgid_plural "%{formatted} registered third-party applications. Suspending one cuts off all of its tokens."
@@ -4897,7 +4897,7 @@ msgstr[1] ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:21
 #: lib/vutuv_web/live/admin/api_app_live.ex:57
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:319
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:323
 #, elixir-autogen, elixir-format
 msgid "API applications"
 msgstr ""
@@ -4905,7 +4905,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:94
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:31
-#: lib/vutuv_web/views/settings_html.ex:172
+#: lib/vutuv_web/views/settings_html.ex:213
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -4987,7 +4987,7 @@ msgstr ""
 msgid "Generate a new client secret? The current one stops working."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:323
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:327
 #, elixir-autogen, elixir-format
 msgid "Manage applications"
 msgstr ""
@@ -5269,7 +5269,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_delete_live.ex:109
 #: lib/vutuv_web/live/admin/user_delete_live.ex:221
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:100
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:101
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:9
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:11
 #, elixir-autogen, elixir-format
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "You can no longer reply to this post."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:175
+#: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Content under review"
 msgstr ""
@@ -5367,7 +5367,7 @@ msgstr ""
 #: lib/vutuv_web/templates/username/new.html.heex:4
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:2
 #: lib/vutuv_web/templates/work_experience/new.html.heex:2
-#: lib/vutuv_web/views/settings_html.ex:123
+#: lib/vutuv_web/views/settings_html.ex:164
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:945
+#: lib/vutuv_web/live/user_profile_live.ex:946
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5446,6 +5446,7 @@ msgstr ""
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:735
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5522,7 +5523,7 @@ msgstr ""
 msgid "Notification settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:170
+#: lib/vutuv_web/templates/settings/privacy.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you."
 msgstr ""
@@ -5553,7 +5554,7 @@ msgstr ""
 msgid "Third-party apps you authorized."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:178
+#: lib/vutuv_web/templates/settings/privacy.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -5568,7 +5569,7 @@ msgstr ""
 msgid "Your post"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:176
+#: lib/vutuv_web/templates/settings/privacy.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Your posts or profile a moderator is looking at."
 msgstr ""
@@ -5703,7 +5704,7 @@ msgstr ""
 msgid "Replies to and likes on your posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:166
+#: lib/vutuv_web/templates/settings/privacy.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr ""
@@ -5864,21 +5865,21 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:174
-#: lib/vutuv_web/views/settings_html.ex:265
+#: lib/vutuv_web/views/settings_html.ex:306
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:264
+#: lib/vutuv_web/views/settings_html.ex:305
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:263
+#: lib/vutuv_web/views/settings_html.ex:304
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5895,7 +5896,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:161
+#: lib/vutuv_web/views/settings_html.ex:202
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5910,7 +5911,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:178
+#: lib/vutuv_web/views/settings_html.ex:219
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5935,7 +5936,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:162
+#: lib/vutuv_web/views/settings_html.ex:203
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5945,27 +5946,27 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:262
+#: lib/vutuv_web/views/settings_html.ex:303
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:76
+#: lib/vutuv_web/templates/settings/privacy.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:74
+#: lib/vutuv_web/templates/settings/privacy.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:86
+#: lib/vutuv_web/templates/settings/privacy.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Show when I'm online"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:88
+#: lib/vutuv_web/templates/settings/privacy.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
@@ -5976,7 +5977,7 @@ msgid "Add a passkey"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/views/settings_html.ex:213
+#: lib/vutuv_web/views/settings_html.ex:254
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -5986,7 +5987,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:216
+#: lib/vutuv_web/views/settings_html.ex:257
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -5996,7 +5997,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:210
+#: lib/vutuv_web/views/settings_html.ex:251
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -6016,7 +6017,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:224
+#: lib/vutuv_web/views/settings_html.ex:265
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6071,7 +6072,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:949
+#: lib/vutuv_web/live/user_profile_live.ex:950
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6106,7 +6107,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1166
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6163,7 +6164,7 @@ msgstr[1] ""
 msgid "Age"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:253
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "Confirmed new registrations and the day's posts, reposts, likes and bookmarks. Time-travel to any past day."
 msgstr ""
@@ -6173,7 +6174,7 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:248
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:252
 #: lib/vutuv_web/templates/admin/report/index.html.heex:2
 #: lib/vutuv_web/templates/admin/report/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -6220,7 +6221,7 @@ msgstr ""
 msgid "No activity on this day."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:251
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:255
 #, elixir-autogen, elixir-format
 msgid "Open the daily report"
 msgstr ""
@@ -6291,9 +6292,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1151
-#: lib/vutuv_web/templates/user/show.html.heex:1159
-#: lib/vutuv_web/templates/user/show.html.heex:1171
+#: lib/vutuv_web/templates/user/show.html.heex:1152
+#: lib/vutuv_web/templates/user/show.html.heex:1160
+#: lib/vutuv_web/templates/user/show.html.heex:1172
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6336,7 +6337,7 @@ msgstr ""
 msgid "endorsed %{date}"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:124
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "%{formatted} account is frozen because every email address bounced."
 msgid_plural "%{formatted} accounts are frozen because every email address bounced."
@@ -6406,7 +6407,7 @@ msgid "By"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:192
-#: lib/vutuv_web/live/admin/organization_live.ex:364
+#: lib/vutuv_web/live/admin/organization_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "Clear"
 msgstr ""
@@ -6440,7 +6441,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:27
 #: lib/vutuv_web/live/admin/deliverability_live.ex:95
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:112
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Deliverability"
 msgstr ""
@@ -6471,7 +6472,7 @@ msgstr ""
 msgid "No accounts are frozen for unreachability."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:120
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "No accounts frozen for unreachability. Bounced addresses and the audit trail are here too."
 msgstr ""
@@ -6496,7 +6497,7 @@ msgstr ""
 msgid "Not getting the PIN? That email address may no longer be working. If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:117
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Open deliverability"
 msgstr ""
@@ -6760,7 +6761,7 @@ msgstr ""
 msgid "Cap group size (optional)"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:173
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Compose a newsletter, save it as a draft, test it, then send it to all members."
 msgstr ""
@@ -6802,8 +6803,8 @@ msgstr ""
 msgid "Development:"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:172
-#: lib/vutuv_web/live/admin/job_live.ex:193
+#: lib/vutuv_web/live/admin/job_live.ex:165
+#: lib/vutuv_web/live/admin/job_live.ex:186
 #: lib/vutuv_web/views/admin/newsletter_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Draft"
@@ -6857,7 +6858,7 @@ msgstr ""
 msgid "Kind"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:181
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:184
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Manage audiences"
@@ -6880,7 +6881,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_live.ex:176
 #: lib/vutuv_web/live/admin/user_live.ex:177
 #: lib/vutuv_web/live/admin/user_live.ex:184
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:88
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:89
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:45
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:90
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:9
@@ -6912,7 +6913,7 @@ msgstr ""
 msgid "New newsletter"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:168
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:171
 #: lib/vutuv_web/templates/settings/notifications.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "Newsletter"
@@ -6920,7 +6921,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:33
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:178
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Newsletter audiences"
 msgstr ""
@@ -6981,7 +6982,7 @@ msgstr ""
 msgid "Off: take the oldest members first (by join date)."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:171
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Open newsletters"
 msgstr ""
@@ -7106,7 +7107,7 @@ msgid "Suppressed (bounced address)"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
-#: lib/vutuv_web/live/job_board_live.ex:204
+#: lib/vutuv_web/live/job_board_live.ex:205
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Tag"
@@ -7536,49 +7537,49 @@ msgstr ""
 msgid "Moderation & queues"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:165
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Communication"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:189
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Content & taxonomy"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:245
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "System & insights"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:196
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Manage tags"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:198
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Create, rename and remove the tags members can add to their profile."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:216
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:219
 #: lib/vutuv_web/templates/admin/username/index.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Usernames"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:219
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:222
 #: lib/vutuv_web/templates/admin/username/index.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Disable a username"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:221
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:224
 #, elixir-autogen, elixir-format
 msgid "Take an unwanted username away from a member by force-renaming the account."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:183
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Build fixed recipient groups from filters (language, country, age, tag) to target a newsletter."
 msgstr ""
@@ -7614,7 +7615,7 @@ msgstr ""
 msgid "Everything that keeps vutuv running, in one place. Cards with open work glow in coral."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:95
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Search, filter and sort every account, and verify a member's identity."
 msgstr ""
@@ -7893,7 +7894,7 @@ msgid "Awaiting verification"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:196
-#: lib/vutuv_web/live/job_board_live.ex:191
+#: lib/vutuv_web/live/job_board_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -7919,18 +7920,18 @@ msgstr ""
 msgid "Find a member by name, @handle or email, then delete the account. Deletion is permanent: it removes the account and everything it owns (posts, phone numbers, email addresses, tags and more). The member is not emailed; a record is sent to the operator."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:105
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Find an account by name, @handle or email and delete it, with everything it owns, behind a confirmation."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:169
-#: lib/vutuv_web/live/admin/job_live.ex:178
-#: lib/vutuv_web/live/admin/job_live.ex:212
+#: lib/vutuv_web/live/admin/job_live.ex:162
+#: lib/vutuv_web/live/admin/job_live.ex:171
+#: lib/vutuv_web/live/admin/job_live.ex:205
 #: lib/vutuv_web/live/admin/member_badges.ex:21
-#: lib/vutuv_web/live/admin/organization_live.ex:173
-#: lib/vutuv_web/live/admin/organization_live.ex:178
-#: lib/vutuv_web/live/admin/organization_live.ex:202
+#: lib/vutuv_web/live/admin/organization_live.ex:166
+#: lib/vutuv_web/live/admin/organization_live.ex:171
+#: lib/vutuv_web/live/admin/organization_live.ex:195
 #: lib/vutuv_web/live/admin/user_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Frozen"
@@ -7946,6 +7947,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
+#: lib/vutuv/accounts.ex:886
+#: lib/vutuv/accounts.ex:935
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -7978,11 +7981,12 @@ msgstr ""
 msgid "Not confirmed"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:93
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "Open the member browser"
 msgstr ""
 
+#: lib/vutuv/accounts.ex:903
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8003,7 +8007,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:103
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:104
 #, elixir-autogen, elixir-format
 msgid "Search and delete"
 msgstr ""
@@ -8301,7 +8305,7 @@ msgstr ""
 msgid "A photo and a short tagline make your profile complete."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:968
+#: lib/vutuv_web/live/user_profile_live.ex:969
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
@@ -8326,8 +8330,8 @@ msgstr[1] ""
 msgid "Loading posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:103
-#: lib/vutuv_web/templates/user/show.html.heex:1022
+#: lib/vutuv_web/templates/settings/privacy.html.heex:92
+#: lib/vutuv_web/templates/user/show.html.heex:1023
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8447,17 +8451,17 @@ msgstr ""
 msgid "Suggested posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:105
+#: lib/vutuv_web/templates/settings/privacy.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:117
+#: lib/vutuv_web/templates/settings/privacy.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Show my latest social media posts on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:119
+#: lib/vutuv_web/templates/settings/privacy.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
@@ -8557,7 +8561,7 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:288
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "Edit the legal pages"
 msgstr ""
@@ -8572,7 +8576,7 @@ msgstr ""
 msgid "Impressum"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:290
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "Impressum, Datenschutzerklärung and Nutzungsbedingungen: every installation publishes its own operator identity here."
 msgstr ""
@@ -8583,7 +8587,7 @@ msgid "Last edited"
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/legal_page_controller.ex:22
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:285
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:289
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:2
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:3
@@ -8612,7 +8616,7 @@ msgstr ""
 msgid "Publish page"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:390
+#: lib/vutuv_web/live/admin/job_live.ex:383
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Published"
@@ -8640,7 +8644,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2867
 #: lib/vutuv_web/controllers/settings_controller.ex:186
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:261
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:265
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:8
 #, elixir-autogen, elixir-format
@@ -8703,6 +8707,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
+#: lib/vutuv/accounts.ex:898
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8755,7 +8760,7 @@ msgstr ""
 msgid "Volunteering & hobbies"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:253
+#: lib/vutuv_web/live/search_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr ""
@@ -9276,7 +9281,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
-#: lib/vutuv_web/cv/html.ex:189
+#: lib/vutuv_web/cv/html.ex:188
 #: lib/vutuv_web/cv/latex.ex:149
 #: lib/vutuv_web/cv/odt.ex:163
 #: lib/vutuv_web/live/cv_live.ex:346
@@ -9473,6 +9478,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:609
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9483,6 +9489,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:606
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9504,7 +9511,7 @@ msgstr ""
 msgid "Enter a single word with no spaces."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:203
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:206
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:2
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -9521,7 +9528,7 @@ msgstr ""
 msgid "Honor tags ›"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:207
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Manage honor tags"
 msgstr ""
@@ -9541,7 +9548,7 @@ msgstr ""
 msgid "No honor tags yet. Create one above."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:209
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "Official badges you grant, like vutuv_developer for the core team. See who holds each and add or remove members."
 msgstr ""
@@ -9602,7 +9609,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/qualification_controller.ex:49
 #: lib/vutuv_web/controllers/qualification_controller.ex:88
 #: lib/vutuv_web/cv/docx.ex:183
-#: lib/vutuv_web/cv/html.ex:173
+#: lib/vutuv_web/cv/html.ex:172
 #: lib/vutuv_web/cv/latex.ex:140
 #: lib/vutuv_web/cv/odt.ex:154
 #: lib/vutuv_web/live/cv_live.ex:321
@@ -9638,8 +9645,8 @@ msgstr ""
 msgid "Does not expire"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:171
-#: lib/vutuv_web/live/admin/job_live.ex:187
+#: lib/vutuv_web/live/admin/job_live.ex:164
+#: lib/vutuv_web/live/admin/job_live.ex:180
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
 #: lib/vutuv_web/views/qualification_html.ex:133
 #, elixir-autogen, elixir-format
@@ -9960,22 +9967,22 @@ msgstr ""
 msgid "Pick a section from the menu on the left to view or change it."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:277
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:281
 #, elixir-autogen, elixir-format
 msgid "%{followers} remote followers, %{queue} queued for delivery."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:269
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Attention:"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:275
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "Outbound federation is healthy."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:266
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:270
 #, elixir-autogen, elixir-format
 msgid "See the daily trend"
 msgstr ""
@@ -9985,7 +9992,7 @@ msgstr ""
 msgid "Showing the most recent %{shown} of %{total}."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:269
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "stuck outbound delivery."
 msgid_plural "stuck outbound deliveries."
@@ -10419,17 +10426,17 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:56
 #: lib/vutuv_web/agent_docs/text.ex:55
-#: lib/vutuv_web/templates/user/show.html.heex:996
+#: lib/vutuv_web/templates/user/show.html.heex:997
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:135
+#: lib/vutuv_web/templates/settings/privacy.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:137
+#: lib/vutuv_web/templates/settings/privacy.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
@@ -10439,12 +10446,12 @@ msgstr ""
 msgid "Last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:149
+#: lib/vutuv_web/templates/settings/privacy.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Show code statistics on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:151
+#: lib/vutuv_web/templates/settings/privacy.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
@@ -10742,7 +10749,7 @@ msgstr[1] ""
 msgid "Changed for this installation."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:301
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:305
 #, elixir-autogen, elixir-format
 msgid "Edit the defaults"
 msgstr ""
@@ -10752,14 +10759,14 @@ msgstr ""
 msgid "Follows the installation default."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:308
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:312
 #, elixir-autogen, elixir-format
 msgid "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} default differs from the shipped value."
 msgid_plural "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} defaults differ from the shipped values."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:304
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "How posts and maps behave for everyone who has not chosen for themselves. This installation runs on the shipped defaults."
 msgstr ""
@@ -10790,7 +10797,7 @@ msgid "Post display settings reset to the site defaults."
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:55
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:297
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:301
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:6
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:7
 #, elixir-autogen, elixir-format
@@ -10877,7 +10884,7 @@ msgstr ""
 msgid "These are the member's own settings: change them here only for support. A field on \"installation default\" follows whatever the defaults page says, now and in the future; a set value stays until the member (or an admin) changes it again."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:159
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Auto-generated screenshots for single-link posts: watch the capture queue and browse the gallery of finished shots, each linked to its post."
 msgstr ""
@@ -10920,7 +10927,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/screenshot_live.ex:33
 #: lib/vutuv_web/live/admin/screenshot_live.ex:51
 #: lib/vutuv_web/live/admin/screenshot_live.ex:52
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:154
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Link screenshots"
 msgstr ""
@@ -10930,14 +10937,14 @@ msgstr ""
 msgid "No screenshots captured yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:157
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "Open the screenshot queue"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:172
-#: lib/vutuv_web/live/admin/organization_live.ex:186
-#: lib/vutuv_web/live/admin/organization_live.ex:201
+#: lib/vutuv_web/live/admin/organization_live.ex:165
+#: lib/vutuv_web/live/admin/organization_live.ex:179
+#: lib/vutuv_web/live/admin/organization_live.ex:194
 #: lib/vutuv_web/live/admin/screenshot_live.ex:196
 #: lib/vutuv_web/live/organization_live/domains.ex:181
 #, elixir-autogen, elixir-format
@@ -10980,16 +10987,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:621
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:626
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:624
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
@@ -11226,7 +11236,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:137
+#: lib/vutuv_web/controllers/organization_controller.ex:144
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
@@ -11421,18 +11431,18 @@ msgstr ""
 msgid "Alternative name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:399
+#: lib/vutuv_web/live/admin/organization_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "Archive"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:396
+#: lib/vutuv_web/live/admin/organization_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Archive this page?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:174
-#: lib/vutuv_web/live/admin/organization_live.ex:189
+#: lib/vutuv_web/live/admin/organization_live.ex:167
+#: lib/vutuv_web/live/admin/organization_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "Archived"
 msgstr ""
@@ -11443,7 +11453,7 @@ msgstr ""
 msgid "Brand"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:335
+#: lib/vutuv_web/live/admin/organization_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "Claimed by"
 msgstr ""
@@ -11453,7 +11463,7 @@ msgstr ""
 msgid "Current team"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:405
+#: lib/vutuv_web/live/admin/organization_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Delete this page and everything it owns? This cannot be undone."
 msgstr ""
@@ -11474,7 +11484,7 @@ msgid "Domain verified."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:211
-#: lib/vutuv_web/live/admin/organization_live.ex:312
+#: lib/vutuv_web/live/admin/organization_live.ex:305
 #: lib/vutuv_web/live/organization_live/domains.ex:161
 #: lib/vutuv_web/live/organization_live/show.ex:277
 #, elixir-autogen, elixir-format
@@ -11491,13 +11501,13 @@ msgstr ""
 msgid "Former name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:472
-#: lib/vutuv_web/live/admin/organization_live.ex:380
+#: lib/vutuv_web/live/admin/job_live.ex:465
+#: lib/vutuv_web/live/admin/organization_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Freeze"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:377
+#: lib/vutuv_web/live/admin/organization_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
@@ -11518,12 +11528,12 @@ msgstr ""
 msgid "Leave"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:167
-#: lib/vutuv_web/live/admin/job_live.ex:183
-#: lib/vutuv_web/live/admin/job_live.ex:210
-#: lib/vutuv_web/live/admin/organization_live.ex:171
-#: lib/vutuv_web/live/admin/organization_live.ex:182
-#: lib/vutuv_web/live/admin/organization_live.ex:200
+#: lib/vutuv_web/live/admin/job_live.ex:160
+#: lib/vutuv_web/live/admin/job_live.ex:176
+#: lib/vutuv_web/live/admin/job_live.ex:203
+#: lib/vutuv_web/live/admin/organization_live.ex:164
+#: lib/vutuv_web/live/admin/organization_live.ex:175
+#: lib/vutuv_web/live/admin/organization_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr ""
@@ -11543,7 +11553,7 @@ msgstr ""
 msgid "Method"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:341
+#: lib/vutuv_web/live/admin/organization_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Names & aliases"
 msgstr ""
@@ -11593,13 +11603,13 @@ msgstr ""
 msgid "Role updated."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:240
+#: lib/vutuv_web/live/admin/organization_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Search name, alias or domain"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:208
-#: lib/vutuv_web/live/admin/organization_live.ex:328
+#: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:153
 #: lib/vutuv_web/live/organization_live/show.ex:270
 #, elixir-autogen, elixir-format
@@ -11626,25 +11636,25 @@ msgstr ""
 msgid "That member could not be added."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:481
-#: lib/vutuv_web/live/admin/organization_live.ex:389
+#: lib/vutuv_web/live/admin/job_live.ex:474
+#: lib/vutuv_web/live/admin/organization_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Unfreeze"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:318
+#: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "pending"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:316
+#: lib/vutuv_web/live/admin/organization_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "primary"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:315
 #: lib/vutuv_web/agent_docs/text.ex:349
-#: lib/vutuv_web/live/admin/organization_live.ex:318
+#: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
 msgstr ""
@@ -11819,14 +11829,14 @@ msgstr ""
 msgid "former"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:236
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:239
 #, elixir-autogen, elixir-format
 msgid "%{formatted} alias matches another verified organization and is flagged for review."
 msgid_plural "%{formatted} aliases match another verified organization and are flagged for review."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:206
+#: lib/vutuv_web/live/admin/organization_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "%{count} alias matches another verified organization and is flagged for review. Open an organization below to see it."
 msgid_plural "%{count} aliases match another verified organization and are flagged for review. Open an organization below to see them."
@@ -11923,12 +11933,12 @@ msgstr ""
 msgid "Leave this organization team?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:355
+#: lib/vutuv_web/live/admin/organization_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Matches another verified organization"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:245
+#: lib/vutuv_web/live/admin/organization_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "No organization pages match."
 msgstr ""
@@ -11958,7 +11968,7 @@ msgstr ""
 msgid "Nothing here yet. Organizations you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:231
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "Open organization oversight"
 msgstr ""
@@ -11990,9 +12000,9 @@ msgid "Organization page"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:25
-#: lib/vutuv_web/live/admin/organization_live.ex:195
-#: lib/vutuv_web/live/admin/organization_live.ex:196
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:226
+#: lib/vutuv_web/live/admin/organization_live.ex:188
+#: lib/vutuv_web/live/admin/organization_live.ex:189
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "Organization pages"
 msgstr ""
@@ -12025,12 +12035,12 @@ msgstr ""
 msgid "Please choose"
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:104
+#: lib/vutuv_web/controllers/organization_controller.ex:111
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before claiming an organization page."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:110
+#: lib/vutuv_web/controllers/organization_controller.ex:117
 #, elixir-autogen, elixir-format
 msgid "Please log in to claim an organization page."
 msgstr ""
@@ -12075,7 +12085,7 @@ msgstr ""
 msgid "Verified organization pages on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:234
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:237
 #, elixir-autogen, elixir-format
 msgid "Verified organization pages: domains, team roles, aliases and rename history. Freeze, archive or delete a page."
 msgstr ""
@@ -12160,7 +12170,7 @@ msgstr ""
 msgid "Public authority"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:382
+#: lib/vutuv_web/live/admin/job_live.ex:375
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:138
 #, elixir-autogen, elixir-format
 msgid "%{views} views · %{clicks} apply clicks"
@@ -12206,7 +12216,7 @@ msgstr ""
 msgid "Application e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:110
+#: lib/vutuv_web/controllers/job_posting_controller.ex:106
 #, elixir-autogen, elixir-format
 msgid "Application: %{title}"
 msgstr ""
@@ -12216,12 +12226,12 @@ msgstr ""
 msgid "Applications go to"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:270
+#: lib/vutuv_web/live/job_posting_live/show.ex:271
 #, elixir-autogen, elixir-format
 msgid "Apply by e-mail"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:269
+#: lib/vutuv_web/live/job_posting_live/show.ex:270
 #, elixir-autogen, elixir-format
 msgid "Apply on website"
 msgstr ""
@@ -12231,8 +12241,8 @@ msgstr ""
 msgid "Apprenticeship"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:170
-#: lib/vutuv_web/live/admin/job_live.ex:190
+#: lib/vutuv_web/live/admin/job_live.ex:163
+#: lib/vutuv_web/live/admin/job_live.ex:183
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:184
 #, elixir-autogen, elixir-format
 msgid "Closed"
@@ -12262,7 +12272,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:339
 #: lib/vutuv_web/agent_docs/text.ex:206
 #: lib/vutuv_web/agent_docs/text.ex:373
-#: lib/vutuv_web/live/admin/job_live.ex:351
+#: lib/vutuv_web/live/admin/job_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Employer"
 msgstr ""
@@ -12276,7 +12286,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:340
 #: lib/vutuv_web/agent_docs/text.ex:207
 #: lib/vutuv_web/agent_docs/text.ex:374
-#: lib/vutuv_web/live/job_board_live.ex:280
+#: lib/vutuv_web/live/job_board_live.ex:281
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
 msgid "Employment type"
@@ -12297,7 +12307,7 @@ msgstr ""
 msgid "Full-time"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:158
+#: lib/vutuv_web/live/job_posting_live/show.ex:159
 #, elixir-autogen, elixir-format
 msgid "Highlighted tags match your profile."
 msgstr ""
@@ -12317,7 +12327,7 @@ msgstr ""
 msgid "Hybrid"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:124
+#: lib/vutuv_web/controllers/job_posting_controller.ex:120
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
@@ -12334,8 +12344,8 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/job_board_doc.ex:19
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:40
-#: lib/vutuv_web/live/job_board_live.ex:145
+#: lib/vutuv_web/live/job_board_live.ex:41
+#: lib/vutuv_web/live/job_board_live.ex:146
 #: lib/vutuv_web/live/post_live/saved.ex:458
 #: lib/vutuv_web/live/shell_live.ex:339
 #: lib/vutuv_web/templates/layout/app.html.heex:77
@@ -12369,7 +12379,7 @@ msgstr ""
 msgid "Mark this posting as filled and close it?"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:271
+#: lib/vutuv_web/live/job_posting_live/show.ex:272
 #, elixir-autogen, elixir-format
 msgid "Message the poster"
 msgstr ""
@@ -12386,7 +12396,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:25
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:101
-#: lib/vutuv_web/live/job_posting_live/show.ex:180
+#: lib/vutuv_web/live/job_posting_live/show.ex:181
 #, elixir-autogen, elixir-format
 msgid "My postings"
 msgstr ""
@@ -12405,7 +12415,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:222
 #: lib/vutuv_web/agent_docs/text.ex:217
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
-#: lib/vutuv_web/live/job_posting_live/show.ex:153
+#: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
 msgstr ""
@@ -12435,7 +12445,7 @@ msgstr ""
 msgid "On-site"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:87
+#: lib/vutuv_web/live/job_posting_live/show.ex:88
 #, elixir-autogen, elixir-format
 msgid "Only you can see this posting while a report about it is handled."
 msgstr ""
@@ -12460,7 +12470,7 @@ msgstr ""
 msgid "Please confirm your email address before posting a job."
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:116
+#: lib/vutuv_web/controllers/job_posting_controller.ex:112
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr ""
@@ -12489,7 +12499,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:344
 #: lib/vutuv_web/agent_docs/text.ex:211
 #: lib/vutuv_web/agent_docs/text.ex:378
-#: lib/vutuv_web/live/job_posting_live/show.ex:132
+#: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
 msgstr ""
@@ -12522,7 +12532,7 @@ msgstr ""
 msgid "Remote"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:168
+#: lib/vutuv_web/live/job_posting_live/show.ex:169
 #, elixir-autogen, elixir-format
 msgid "Report this posting"
 msgstr ""
@@ -12530,7 +12540,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:221
 #: lib/vutuv_web/agent_docs/text.ex:216
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
-#: lib/vutuv_web/live/job_posting_live/show.ex:148
+#: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
@@ -12593,7 +12603,7 @@ msgstr ""
 msgid "This organization has reached its published-postings limit."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:94
+#: lib/vutuv_web/live/job_posting_live/show.ex:95
 #, elixir-autogen, elixir-format
 msgid "This position is no longer available."
 msgstr ""
@@ -12604,7 +12614,7 @@ msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with t
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:108
-#: lib/vutuv_web/live/job_posting_live/show.ex:208
+#: lib/vutuv_web/live/job_posting_live/show.ex:209
 #, elixir-autogen, elixir-format
 msgid "Verified organization"
 msgstr ""
@@ -12649,7 +12659,7 @@ msgstr ""
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:175
+#: lib/vutuv_web/live/job_posting_live/show.ex:176
 #, elixir-autogen, elixir-format
 msgid "Your posting"
 msgstr ""
@@ -12796,12 +12806,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/job_board_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:274
+#: lib/vutuv_web/live/job_board_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr ""
@@ -12817,32 +12827,32 @@ msgstr ""
 msgid "All jobs with this tag: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:281
+#: lib/vutuv_web/live/job_board_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:263
+#: lib/vutuv_web/live/job_board_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/job_board_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:183
+#: lib/vutuv_web/live/job_board_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:175
+#: lib/vutuv_web/live/job_board_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:337
+#: lib/vutuv_web/live/job_board_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr ""
@@ -12852,7 +12862,7 @@ msgstr ""
 msgid "Minimum yearly salary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:238
+#: lib/vutuv_web/live/job_board_live.ex:239
 #: lib/vutuv_web/live/organization_live/show.ex:342
 #, elixir-autogen, elixir-format
 msgid "More jobs"
@@ -12868,12 +12878,12 @@ msgstr ""
 msgid "Next page: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:328
+#: lib/vutuv_web/live/job_board_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:326
+#: lib/vutuv_web/live/job_board_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
@@ -12889,92 +12899,92 @@ msgid "Open positions"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/job_board_doc.ex:20
-#: lib/vutuv_web/live/job_board_live.ex:147
+#: lib/vutuv_web/live/job_board_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:155
+#: lib/vutuv_web/live/job_board_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:220
+#: lib/vutuv_web/live/job_board_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:267
+#: lib/vutuv_web/live/job_board_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:255
+#: lib/vutuv_web/live/job_board_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:144
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "%{formatted} job posting has an open moderation case."
 msgid_plural "%{formatted} job postings have an open moderation case."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:447
+#: lib/vutuv_web/live/admin/job_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "%{count} report"
 msgid_plural "%{count} reports"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:366
+#: lib/vutuv_web/live/admin/job_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "(free text, unverified)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:199
+#: lib/vutuv_web/live/admin/job_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "(no employer)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:488
+#: lib/vutuv_web/live/admin/job_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Close this posting? It ends the listing (a regular ending, not a deletion)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:425
+#: lib/vutuv_web/live/admin/job_live.ex:418
 #: lib/vutuv_web/live/admin/user_detail_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cold outreach"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:380
+#: lib/vutuv_web/live/admin/job_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Counters"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:497
+#: lib/vutuv_web/live/admin/job_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "Delete this posting and everything it owns? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:142
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Every job posting: search, freeze/unfreeze, close or delete, with the poster's report history and cold-outreach counter."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:168
+#: lib/vutuv_web/live/admin/job_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Expiring"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:211
+#: lib/vutuv_web/live/admin/job_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Expiring (7 days)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:469
+#: lib/vutuv_web/live/admin/job_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Freeze this posting? It disappears from the public board and its indexing but stays visible to its poster."
 msgstr ""
@@ -12985,42 +12995,42 @@ msgid "Job posting"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:30
-#: lib/vutuv_web/live/admin/job_live.ex:205
-#: lib/vutuv_web/live/admin/job_live.ex:206
+#: lib/vutuv_web/live/admin/job_live.ex:198
+#: lib/vutuv_web/live/admin/job_live.ex:199
 #: lib/vutuv_web/live/admin/user_detail_live.ex:175
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:134
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Job postings"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:413
+#: lib/vutuv_web/live/admin/job_live.ex:406
 #: lib/vutuv_web/live/admin/user_detail_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Live postings"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:265
+#: lib/vutuv_web/live/admin/job_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "No job postings match."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:457
+#: lib/vutuv_web/live/admin/job_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "Open case"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:421
+#: lib/vutuv_web/live/admin/job_live.ex:414
 #: lib/vutuv_web/live/admin/user_detail_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "Open job cases"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:139
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Open job oversight"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:249
+#: lib/vutuv_web/live/admin/job_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Open reports"
 msgstr ""
@@ -13030,13 +13040,13 @@ msgstr ""
 msgid "Open the job posting"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:272
-#: lib/vutuv_web/live/admin/job_live.ex:338
+#: lib/vutuv_web/live/admin/job_live.ex:265
+#: lib/vutuv_web/live/admin/job_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Poster"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:410
+#: lib/vutuv_web/live/admin/job_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Poster footprint"
 msgstr ""
@@ -13061,38 +13071,38 @@ msgstr ""
 msgid "Posting unfrozen."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:438
+#: lib/vutuv_web/live/admin/job_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Report history"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:260
+#: lib/vutuv_web/live/admin/job_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Search title, poster or organization"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:271
+#: lib/vutuv_web/live/admin/job_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:417
+#: lib/vutuv_web/live/admin/job_live.ex:410
 #: lib/vutuv_web/live/admin/user_detail_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Total postings"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:395
+#: lib/vutuv_web/live/admin/job_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "never"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:361
+#: lib/vutuv_web/live/admin/job_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "verified organization page"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:402
+#: lib/vutuv_web/live/admin/job_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "—"
 msgstr ""
@@ -13247,7 +13257,7 @@ msgstr ""
 msgid "job search"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:301
+#: lib/vutuv_web/live/search_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "only people open to offers (status:open) or looking (status:looking)"
 msgstr ""
@@ -13416,7 +13426,7 @@ msgstr ""
 msgid "Alias flag cleared."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:361
+#: lib/vutuv_web/live/admin/organization_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "Reviewed, all fine: clear the flag"
 msgstr ""
@@ -13436,7 +13446,7 @@ msgstr ""
 msgid "This member no longer exists."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:78
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr ""
@@ -13460,12 +13470,12 @@ msgid "Image is being reviewed"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:303
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:67
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:73
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
 msgstr ""
@@ -13505,6 +13515,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:639
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13515,16 +13526,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:642
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:645
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:636
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13552,7 +13566,7 @@ msgstr ""
 msgid "Handle change"
 msgstr ""
 
-#: lib/vutuv_web/controllers/username_controller.ex:42
+#: lib/vutuv_web/controllers/username_controller.ex:44
 #, elixir-autogen, elixir-format
 msgid "We updated %{formatted} post that mentioned your old handle and notified its author."
 msgid_plural "We updated %{formatted} posts that mentioned your old handle and notified their authors."
@@ -13606,12 +13620,12 @@ msgstr ""
 msgid "Posts with this tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:270
+#: lib/vutuv_web/live/search_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:297
+#: lib/vutuv_web/live/search_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "people and posts with this tag, combinable: miller tag:php"
 msgstr ""
@@ -13663,4 +13677,34 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:666
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:324
+#, elixir-autogen, elixir-format
+msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:320
+#, elixir-autogen, elixir-format
+msgid "Search tips"
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:378
+#, elixir-autogen, elixir-format
+msgid "any of these titles"
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:380
+#, elixir-autogen, elixir-format
+msgid "exact wording"
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:381
+#, elixir-autogen, elixir-format
+msgid "without internships"
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:379
+#, elixir-autogen, elixir-format
+msgid "word start: also finds Entwickler, Entwicklung"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -34,7 +34,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1116
+#: lib/vutuv_web/templates/user/show.html.heex:1117
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -147,10 +147,10 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:806
 #: lib/vutuv_web/components/ui.ex:2611
-#: lib/vutuv_web/live/admin/job_live.ex:500
+#: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
-#: lib/vutuv_web/live/admin/organization_live.ex:408
+#: lib/vutuv_web/live/admin/organization_live.ex:401
 #: lib/vutuv_web/live/admin/user_delete_live.ex:172
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:28
 #: lib/vutuv_web/templates/dev_app/show.html.heex:135
@@ -195,7 +195,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
-#: lib/vutuv_web/live/job_posting_live/show.ex:177
+#: lib/vutuv_web/live/job_posting_live/show.ex:178
 #: lib/vutuv_web/live/organization_live/show.ex:263
 #: lib/vutuv_web/templates/address/edit.html.heex:4
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:50
@@ -414,7 +414,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
 #: lib/vutuv_web/cv/docx.ex:206
-#: lib/vutuv_web/cv/html.ex:206
+#: lib/vutuv_web/cv/html.ex:205
 #: lib/vutuv_web/cv/latex.ex:164
 #: lib/vutuv_web/cv/odt.ex:176
 #: lib/vutuv_web/live/cv_live.ex:296
@@ -533,7 +533,7 @@ msgid "Number type"
 msgstr ""
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:168
-#: lib/vutuv_web/live/admin/organization_live.ex:251
+#: lib/vutuv_web/live/admin/organization_live.ex:244
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:5
 #, elixir-autogen
 msgid "Organization"
@@ -640,20 +640,18 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
 #: lib/vutuv_web/templates/settings/preferences.html.heex:180
 #: lib/vutuv_web/templates/settings/privacy.html.heex:64
-#: lib/vutuv_web/templates/settings/privacy.html.heex:92
-#: lib/vutuv_web/templates/settings/privacy.html.heex:125
-#: lib/vutuv_web/templates/settings/privacy.html.heex:157
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:342
+#: lib/vutuv_web/views/settings_html.ex:135
 #, elixir-autogen
 msgid "Save"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:231
-#: lib/vutuv_web/live/job_board_live.ex:295
+#: lib/vutuv_web/live/job_board_live.ex:314
 #: lib/vutuv_web/live/search_live.ex:35
-#: lib/vutuv_web/live/search_live.ex:231
+#: lib/vutuv_web/live/search_live.ex:229
 #: lib/vutuv_web/live/shell_live.ex:346
 #: lib/vutuv_web/live/shell_live.ex:502
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
@@ -688,7 +686,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
-#: lib/vutuv_web/cv/html.ex:227
+#: lib/vutuv_web/cv/html.ex:226
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
 #: lib/vutuv_web/live/cv_live.ex:370
@@ -697,13 +695,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:963
+#: lib/vutuv_web/templates/user/show.html.heex:964
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:965
+#: lib/vutuv_web/templates/user/show.html.heex:966
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -1031,12 +1029,14 @@ msgstr ""
 msgid "Select a year"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:732
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:731
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1185,12 +1185,12 @@ msgstr ""
 msgid "Can't find URL"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:287
+#: lib/vutuv_web/live/search_live.ex:285
 #, elixir-autogen
 msgid "Our search will try to match similar names to your search, so don't worry about spelling."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:282
+#: lib/vutuv_web/live/search_live.ex:280
 #, elixir-autogen
 msgid "Search Tips"
 msgstr ""
@@ -1226,7 +1226,7 @@ msgstr ""
 #: lib/vutuv_web/components/organization_components.ex:245
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
-#: lib/vutuv_web/live/admin/job_live.ex:206
+#: lib/vutuv_web/live/admin/job_live.ex:199
 #: lib/vutuv_web/live/admin/member_badges.ex:19
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:135
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
@@ -1234,7 +1234,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:638
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
-#: lib/vutuv_web/live/admin/organization_live.ex:196
+#: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:52
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
@@ -1454,17 +1454,17 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_tag_controller.ex:37
 #: lib/vutuv_web/controllers/user_tag_controller.ex:54
 #: lib/vutuv_web/cv/docx.ex:174
-#: lib/vutuv_web/cv/html.ex:160
+#: lib/vutuv_web/cv/html.ex:159
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
 #: lib/vutuv_web/live/cv_live.ex:275
 #: lib/vutuv_web/live/job_posting_live/form.ex:509
-#: lib/vutuv_web/live/search_live.ex:180
-#: lib/vutuv_web/live/search_live.ex:363
+#: lib/vutuv_web/live/search_live.ex:178
+#: lib/vutuv_web/live/search_live.ex:361
 #: lib/vutuv_web/live/tag_new_live.ex:35
 #: lib/vutuv_web/live/tag_new_live.ex:45
 #: lib/vutuv_web/live/tag_new_live.ex:54
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:192
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:195
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:5
@@ -1633,7 +1633,7 @@ msgid "You'll receive an email with a login link."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
-#: lib/vutuv_web/live/job_board_live.ex:273
+#: lib/vutuv_web/live/job_board_live.ex:274
 #: lib/vutuv_web/live/job_posting_live/form.ex:410
 #: lib/vutuv_web/live/organization_live/edit.ex:282
 #: lib/vutuv_web/live/organization_live/new.ex:127
@@ -1689,9 +1689,9 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:332
-#: lib/vutuv_web/live/admin/job_live.ex:491
-#: lib/vutuv_web/live/admin/organization_live.ex:306
+#: lib/vutuv_web/live/admin/job_live.ex:325
+#: lib/vutuv_web/live/admin/job_live.ex:484
+#: lib/vutuv_web/live/admin/organization_live.ex:299
 #: lib/vutuv_web/live/post_live/composer.ex:460
 #: lib/vutuv_web/live/post_live/composer.ex:461
 #: lib/vutuv_web/templates/layout/app.html.heex:152
@@ -1771,7 +1771,7 @@ msgid "It doesn't look like you're following anyone yet. Open the profile of som
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:473
-#: lib/vutuv_web/views/settings_html.ex:181
+#: lib/vutuv_web/views/settings_html.ex:222
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -1909,7 +1909,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1200
+#: lib/vutuv_web/templates/user/show.html.heex:1201
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -2254,8 +2254,8 @@ msgstr ""
 #: lib/vutuv_web/gettext_extraction_anchors.ex:77
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
 #: lib/vutuv_web/live/post_live/saved.ex:449
-#: lib/vutuv_web/live/search_live.ex:181
-#: lib/vutuv_web/live/search_live.ex:377
+#: lib/vutuv_web/live/search_live.ex:179
+#: lib/vutuv_web/live/search_live.ex:375
 #: lib/vutuv_web/templates/settings/preferences.html.heex:114
 #: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
@@ -2282,7 +2282,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:227
+#: lib/vutuv_web/views/settings_html.ex:268
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2344,7 +2344,7 @@ msgstr ""
 #: lib/vutuv_web/live/shell_live.ex:416
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:128
+#: lib/vutuv_web/views/settings_html.ex:169
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
@@ -2385,7 +2385,7 @@ msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:256
+#: lib/vutuv_web/views/settings_html.ex:297
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2756,7 +2756,7 @@ msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1118
+#: lib/vutuv_web/templates/user/show.html.heex:1119
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
@@ -2778,7 +2778,7 @@ msgstr ""
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:955
+#: lib/vutuv_web/live/user_profile_live.ex:956
 #: lib/vutuv_web/templates/user/show.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
@@ -2789,7 +2789,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
-#: lib/vutuv_web/templates/settings/privacy.html.heex:172
+#: lib/vutuv_web/templates/settings/privacy.html.heex:130
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
 #, elixir-autogen, elixir-format
@@ -2931,7 +2931,7 @@ msgid_plural "%{formatted} cases are waiting for a ruling."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:346
+#: lib/vutuv_web/live/admin/job_live.ex:339
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:266
 #: lib/vutuv_web/templates/moderation_evidence/show.html.heex:33
 #, elixir-autogen, elixir-format
@@ -3145,7 +3145,7 @@ msgstr ""
 msgid "Only you can see your profile right now - it is hidden while a report is handled."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:213
+#: lib/vutuv_web/live/admin/job_live.ex:206
 #: lib/vutuv_web/live/admin/moderation_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Open cases"
@@ -3337,10 +3337,10 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:74
 #: lib/vutuv_web/live/admin/deliverability_live.ex:252
-#: lib/vutuv_web/live/admin/job_live.ex:273
-#: lib/vutuv_web/live/admin/job_live.ex:372
+#: lib/vutuv_web/live/admin/job_live.ex:266
+#: lib/vutuv_web/live/admin/job_live.ex:365
 #: lib/vutuv_web/live/admin/moderation_live.ex:53
-#: lib/vutuv_web/live/admin/organization_live.ex:253
+#: lib/vutuv_web/live/admin/organization_live.ex:246
 #: lib/vutuv_web/live/admin/screenshot_live.ex:119
 #: lib/vutuv_web/live/admin/user_live.ex:315
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:59
@@ -3560,12 +3560,12 @@ msgstr ""
 msgid "Your vutuv account is suspended"
 msgstr ""
 
-#: lib/vutuv_web/controllers/username_controller.ex:72
+#: lib/vutuv_web/controllers/username_controller.ex:77
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is already taken."
 msgstr ""
 
-#: lib/vutuv_web/controllers/username_controller.ex:81
+#: lib/vutuv_web/controllers/username_controller.ex:86
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is available."
 msgstr ""
@@ -3575,8 +3575,8 @@ msgstr ""
 msgid "New username"
 msgstr ""
 
-#: lib/vutuv_web/controllers/username_controller.ex:37
-#: lib/vutuv_web/controllers/username_controller.ex:40
+#: lib/vutuv_web/controllers/username_controller.ex:39
+#: lib/vutuv_web/controllers/username_controller.ex:42
 #, elixir-autogen, elixir-format
 msgid "Your username is now @%{handle}."
 msgstr ""
@@ -4077,7 +4077,7 @@ msgstr ""
 msgid "Booking requires a vutuv login."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:252
+#: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:404
 #: lib/vutuv_web/live/organization_live/edit.ex:278
 #: lib/vutuv_web/live/organization_live/new.ex:123
@@ -4175,7 +4175,7 @@ msgstr ""
 msgid "vutuv shows a single, text-only ad per calendar day: discreet, between the navigation and the content, in the style of classic text ads."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:345
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:350
 #, elixir-autogen, elixir-format
 msgid "%{formatted} ad is waiting for approval."
 msgid_plural "%{formatted} ads are waiting for approval."
@@ -4190,7 +4190,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:5
 #: lib/vutuv_web/templates/admin/ad/show.html.heex:5
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:335
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:340
 #, elixir-autogen, elixir-format
 msgid "Ads"
 msgstr ""
@@ -4255,7 +4255,7 @@ msgstr ""
 msgid "My bookings"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:343
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:348
 #, elixir-autogen, elixir-format
 msgid "No ads waiting for approval."
 msgstr ""
@@ -4265,7 +4265,7 @@ msgstr ""
 msgid "No upcoming ads."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:340
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Open the ad review"
 msgstr ""
@@ -4413,8 +4413,8 @@ msgstr ""
 msgid "Approved on"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:297
-#: lib/vutuv_web/live/admin/organization_live.ex:272
+#: lib/vutuv_web/live/admin/job_live.ex:290
+#: lib/vutuv_web/live/admin/organization_live.ex:265
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Details"
@@ -4493,7 +4493,7 @@ msgstr ""
 msgid "Undeliverable"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:284
+#: lib/vutuv_web/live/search_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
@@ -4511,7 +4511,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:1
 #: lib/vutuv_web/templates/block/index.html.heex:1
-#: lib/vutuv_web/templates/settings/privacy.html.heex:169
+#: lib/vutuv_web/templates/settings/privacy.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Blocked members"
 msgstr ""
@@ -4591,12 +4591,12 @@ msgstr ""
 msgid "This area is reserved for administrators."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:409
+#: lib/vutuv_web/live/search_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No results for \"%{query}\""
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:346
+#: lib/vutuv_web/live/search_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
@@ -4606,78 +4606,78 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
-#: lib/vutuv_web/live/search_live.ex:179
-#: lib/vutuv_web/live/search_live.ex:319
+#: lib/vutuv_web/live/search_live.ex:177
+#: lib/vutuv_web/live/search_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:278
+#: lib/vutuv_web/live/search_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Results appear once you have typed at least three letters."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:343
+#: lib/vutuv_web/live/search_live.ex:341
 #, elixir-autogen, elixir-format
 msgid "Similar names"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:261
-#: lib/vutuv_web/live/admin/job_live.ex:166
-#: lib/vutuv_web/live/admin/organization_live.ex:170
-#: lib/vutuv_web/live/search_live.ex:178
+#: lib/vutuv_web/live/admin/job_live.ex:159
+#: lib/vutuv_web/live/admin/organization_live.ex:163
+#: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:73
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:261
+#: lib/vutuv_web/live/search_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Exact matches only"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:305
+#: lib/vutuv_web/live/search_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "in quotes: exact matches only, no similar names"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:303
+#: lib/vutuv_web/live/search_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "searches usernames"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:299
+#: lib/vutuv_web/live/search_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "only people with an address in this city"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:298
+#: lib/vutuv_web/live/search_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "city:koblenz"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:294
+#: lib/vutuv_web/live/search_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "first:stefan"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:304
+#: lib/vutuv_web/live/search_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "miller"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:295
+#: lib/vutuv_web/live/search_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:943
+#: lib/vutuv_web/live/user_profile_live.ex:944
 #: lib/vutuv_web/templates/user/show.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:238
+#: lib/vutuv_web/live/search_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, or posts"
 msgstr ""
@@ -4722,9 +4722,9 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:216
 #: lib/vutuv_web/agent_docs/text.ex:212
-#: lib/vutuv_web/live/admin/job_live.ex:400
+#: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
-#: lib/vutuv_web/live/job_posting_live/show.ex:135
+#: lib/vutuv_web/live/job_posting_live/show.ex:136
 #: lib/vutuv_web/templates/access_token/new.html.heex:39
 #: lib/vutuv_web/templates/qualification/show.html.heex:33
 #, elixir-autogen, elixir-format
@@ -4885,7 +4885,7 @@ msgstr ""
 msgid "%{app} wants to access your vutuv account. It would be allowed to:"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:325
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "%{formatted} registered third-party application. Suspending one cuts off all of its tokens."
 msgid_plural "%{formatted} registered third-party applications. Suspending one cuts off all of its tokens."
@@ -4895,7 +4895,7 @@ msgstr[1] ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:21
 #: lib/vutuv_web/live/admin/api_app_live.ex:57
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:319
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:323
 #, elixir-autogen, elixir-format
 msgid "API applications"
 msgstr ""
@@ -4903,7 +4903,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:94
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:31
-#: lib/vutuv_web/views/settings_html.ex:172
+#: lib/vutuv_web/views/settings_html.ex:213
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -4985,7 +4985,7 @@ msgstr ""
 msgid "Generate a new client secret? The current one stops working."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:323
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:327
 #, elixir-autogen, elixir-format
 msgid "Manage applications"
 msgstr ""
@@ -5267,7 +5267,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_delete_live.ex:109
 #: lib/vutuv_web/live/admin/user_delete_live.ex:221
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:100
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:101
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:9
 #: lib/vutuv_web/templates/settings/delete_account.html.heex:11
 #, elixir-autogen, elixir-format
@@ -5300,7 +5300,7 @@ msgstr ""
 msgid "You can no longer reply to this post."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:175
+#: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Content under review"
 msgstr ""
@@ -5365,7 +5365,7 @@ msgstr ""
 #: lib/vutuv_web/templates/username/new.html.heex:4
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:2
 #: lib/vutuv_web/templates/work_experience/new.html.heex:2
-#: lib/vutuv_web/views/settings_html.ex:123
+#: lib/vutuv_web/views/settings_html.ex:164
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5400,7 +5400,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:945
+#: lib/vutuv_web/live/user_profile_live.ex:946
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5444,6 +5444,7 @@ msgstr ""
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:735
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5520,7 +5521,7 @@ msgstr ""
 msgid "Notification settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:170
+#: lib/vutuv_web/templates/settings/privacy.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you."
 msgstr ""
@@ -5551,7 +5552,7 @@ msgstr ""
 msgid "Third-party apps you authorized."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:178
+#: lib/vutuv_web/templates/settings/privacy.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -5566,7 +5567,7 @@ msgstr ""
 msgid "Your post"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:176
+#: lib/vutuv_web/templates/settings/privacy.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Your posts or profile a moderator is looking at."
 msgstr ""
@@ -5701,7 +5702,7 @@ msgstr ""
 msgid "Replies to and likes on your posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:166
+#: lib/vutuv_web/templates/settings/privacy.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr ""
@@ -5862,21 +5863,21 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:174
-#: lib/vutuv_web/views/settings_html.ex:265
+#: lib/vutuv_web/views/settings_html.ex:306
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:264
+#: lib/vutuv_web/views/settings_html.ex:305
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:263
+#: lib/vutuv_web/views/settings_html.ex:304
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5893,7 +5894,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:161
+#: lib/vutuv_web/views/settings_html.ex:202
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5908,7 +5909,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:178
+#: lib/vutuv_web/views/settings_html.ex:219
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5933,7 +5934,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:162
+#: lib/vutuv_web/views/settings_html.ex:203
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5943,27 +5944,27 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:262
+#: lib/vutuv_web/views/settings_html.ex:303
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:76
+#: lib/vutuv_web/templates/settings/privacy.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:74
+#: lib/vutuv_web/templates/settings/privacy.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:86
+#: lib/vutuv_web/templates/settings/privacy.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Show when I'm online"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:88
+#: lib/vutuv_web/templates/settings/privacy.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
@@ -5974,7 +5975,7 @@ msgid "Add a passkey"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/views/settings_html.ex:213
+#: lib/vutuv_web/views/settings_html.ex:254
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -5984,7 +5985,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:216
+#: lib/vutuv_web/views/settings_html.ex:257
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -5994,7 +5995,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:210
+#: lib/vutuv_web/views/settings_html.ex:251
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -6014,7 +6015,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:224
+#: lib/vutuv_web/views/settings_html.ex:265
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6069,7 +6070,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:949
+#: lib/vutuv_web/live/user_profile_live.ex:950
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6104,7 +6105,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1166
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6161,7 +6162,7 @@ msgstr[1] ""
 msgid "Age"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:253
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "Confirmed new registrations and the day's posts, reposts, likes and bookmarks. Time-travel to any past day."
 msgstr ""
@@ -6171,7 +6172,7 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:248
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:252
 #: lib/vutuv_web/templates/admin/report/index.html.heex:2
 #: lib/vutuv_web/templates/admin/report/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -6218,7 +6219,7 @@ msgstr ""
 msgid "No activity on this day."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:251
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:255
 #, elixir-autogen, elixir-format
 msgid "Open the daily report"
 msgstr ""
@@ -6289,9 +6290,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1151
-#: lib/vutuv_web/templates/user/show.html.heex:1159
-#: lib/vutuv_web/templates/user/show.html.heex:1171
+#: lib/vutuv_web/templates/user/show.html.heex:1152
+#: lib/vutuv_web/templates/user/show.html.heex:1160
+#: lib/vutuv_web/templates/user/show.html.heex:1172
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6334,7 +6335,7 @@ msgstr ""
 msgid "endorsed %{date}"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:124
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "%{formatted} account is frozen because every email address bounced."
 msgid_plural "%{formatted} accounts are frozen because every email address bounced."
@@ -6404,7 +6405,7 @@ msgid "By"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:192
-#: lib/vutuv_web/live/admin/organization_live.ex:364
+#: lib/vutuv_web/live/admin/organization_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "Clear"
 msgstr ""
@@ -6438,7 +6439,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:27
 #: lib/vutuv_web/live/admin/deliverability_live.ex:95
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:112
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Deliverability"
 msgstr ""
@@ -6469,7 +6470,7 @@ msgstr ""
 msgid "No accounts are frozen for unreachability."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:120
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "No accounts frozen for unreachability. Bounced addresses and the audit trail are here too."
 msgstr ""
@@ -6494,7 +6495,7 @@ msgstr ""
 msgid "Not getting the PIN? That email address may no longer be working. If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:117
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Open deliverability"
 msgstr ""
@@ -6758,7 +6759,7 @@ msgstr ""
 msgid "Cap group size (optional)"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:173
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Compose a newsletter, save it as a draft, test it, then send it to all members."
 msgstr ""
@@ -6800,8 +6801,8 @@ msgstr ""
 msgid "Development:"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:172
-#: lib/vutuv_web/live/admin/job_live.ex:193
+#: lib/vutuv_web/live/admin/job_live.ex:165
+#: lib/vutuv_web/live/admin/job_live.ex:186
 #: lib/vutuv_web/views/admin/newsletter_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Draft"
@@ -6855,7 +6856,7 @@ msgstr ""
 msgid "Kind"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:181
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:184
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Manage audiences"
@@ -6878,7 +6879,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_live.ex:176
 #: lib/vutuv_web/live/admin/user_live.ex:177
 #: lib/vutuv_web/live/admin/user_live.ex:184
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:88
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:89
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:45
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:90
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:9
@@ -6910,7 +6911,7 @@ msgstr ""
 msgid "New newsletter"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:168
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:171
 #: lib/vutuv_web/templates/settings/notifications.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "Newsletter"
@@ -6918,7 +6919,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:33
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:568
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:178
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Newsletter audiences"
 msgstr ""
@@ -6979,7 +6980,7 @@ msgstr ""
 msgid "Off: take the oldest members first (by join date)."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:171
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Open newsletters"
 msgstr ""
@@ -7104,7 +7105,7 @@ msgid "Suppressed (bounced address)"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
-#: lib/vutuv_web/live/job_board_live.ex:204
+#: lib/vutuv_web/live/job_board_live.ex:205
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Tag"
@@ -7534,49 +7535,49 @@ msgstr ""
 msgid "Moderation & queues"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:165
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "Communication"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:189
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Content & taxonomy"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:245
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:249
 #, elixir-autogen, elixir-format
 msgid "System & insights"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:196
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Manage tags"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:198
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Create, rename and remove the tags members can add to their profile."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:216
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:219
 #: lib/vutuv_web/templates/admin/username/index.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Usernames"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:219
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:222
 #: lib/vutuv_web/templates/admin/username/index.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Disable a username"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:221
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:224
 #, elixir-autogen, elixir-format
 msgid "Take an unwanted username away from a member by force-renaming the account."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:183
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Build fixed recipient groups from filters (language, country, age, tag) to target a newsletter."
 msgstr ""
@@ -7612,7 +7613,7 @@ msgstr ""
 msgid "Everything that keeps vutuv running, in one place. Cards with open work glow in coral."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:95
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Search, filter and sort every account, and verify a member's identity."
 msgstr ""
@@ -7891,7 +7892,7 @@ msgid "Awaiting verification"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:196
-#: lib/vutuv_web/live/job_board_live.ex:191
+#: lib/vutuv_web/live/job_board_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -7917,18 +7918,18 @@ msgstr ""
 msgid "Find a member by name, @handle or email, then delete the account. Deletion is permanent: it removes the account and everything it owns (posts, phone numbers, email addresses, tags and more). The member is not emailed; a record is sent to the operator."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:105
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "Find an account by name, @handle or email and delete it, with everything it owns, behind a confirmation."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:169
-#: lib/vutuv_web/live/admin/job_live.ex:178
-#: lib/vutuv_web/live/admin/job_live.ex:212
+#: lib/vutuv_web/live/admin/job_live.ex:162
+#: lib/vutuv_web/live/admin/job_live.ex:171
+#: lib/vutuv_web/live/admin/job_live.ex:205
 #: lib/vutuv_web/live/admin/member_badges.ex:21
-#: lib/vutuv_web/live/admin/organization_live.ex:173
-#: lib/vutuv_web/live/admin/organization_live.ex:178
-#: lib/vutuv_web/live/admin/organization_live.ex:202
+#: lib/vutuv_web/live/admin/organization_live.ex:166
+#: lib/vutuv_web/live/admin/organization_live.ex:171
+#: lib/vutuv_web/live/admin/organization_live.ex:195
 #: lib/vutuv_web/live/admin/user_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Frozen"
@@ -7944,6 +7945,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
+#: lib/vutuv/accounts.ex:886
+#: lib/vutuv/accounts.ex:935
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -7976,11 +7979,12 @@ msgstr ""
 msgid "Not confirmed"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:93
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "Open the member browser"
 msgstr ""
 
+#: lib/vutuv/accounts.ex:903
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8001,7 +8005,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:103
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:104
 #, elixir-autogen, elixir-format
 msgid "Search and delete"
 msgstr ""
@@ -8299,7 +8303,7 @@ msgstr ""
 msgid "A photo and a short tagline make your profile complete."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:968
+#: lib/vutuv_web/live/user_profile_live.ex:969
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
@@ -8324,8 +8328,8 @@ msgstr[1] ""
 msgid "Loading posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:103
-#: lib/vutuv_web/templates/user/show.html.heex:1022
+#: lib/vutuv_web/templates/settings/privacy.html.heex:92
+#: lib/vutuv_web/templates/user/show.html.heex:1023
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8445,17 +8449,17 @@ msgstr ""
 msgid "Suggested posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:105
+#: lib/vutuv_web/templates/settings/privacy.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:117
+#: lib/vutuv_web/templates/settings/privacy.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Show my latest social media posts on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:119
+#: lib/vutuv_web/templates/settings/privacy.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
@@ -8555,7 +8559,7 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:288
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:292
 #, elixir-autogen, elixir-format
 msgid "Edit the legal pages"
 msgstr ""
@@ -8570,7 +8574,7 @@ msgstr ""
 msgid "Impressum"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:290
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "Impressum, Datenschutzerklärung and Nutzungsbedingungen: every installation publishes its own operator identity here."
 msgstr ""
@@ -8581,7 +8585,7 @@ msgid "Last edited"
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/legal_page_controller.ex:22
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:285
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:289
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:2
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:3
@@ -8610,7 +8614,7 @@ msgstr ""
 msgid "Publish page"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:390
+#: lib/vutuv_web/live/admin/job_live.ex:383
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Published"
@@ -8638,7 +8642,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2867
 #: lib/vutuv_web/controllers/settings_controller.ex:186
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:261
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:265
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:8
 #, elixir-autogen, elixir-format
@@ -8701,6 +8705,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
+#: lib/vutuv/accounts.ex:898
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8753,7 +8758,7 @@ msgstr ""
 msgid "Volunteering & hobbies"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:253
+#: lib/vutuv_web/live/search_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr ""
@@ -9274,7 +9279,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
-#: lib/vutuv_web/cv/html.ex:189
+#: lib/vutuv_web/cv/html.ex:188
 #: lib/vutuv_web/cv/latex.ex:149
 #: lib/vutuv_web/cv/odt.ex:163
 #: lib/vutuv_web/live/cv_live.ex:346
@@ -9471,6 +9476,7 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:609
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9481,6 +9487,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:606
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9502,7 +9509,7 @@ msgstr ""
 msgid "Enter a single word with no spaces."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:203
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:206
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:2
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -9519,7 +9526,7 @@ msgstr ""
 msgid "Honor tags ›"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:207
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Manage honor tags"
 msgstr ""
@@ -9539,7 +9546,7 @@ msgstr ""
 msgid "No honor tags yet. Create one above."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:209
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "Official badges you grant, like vutuv_developer for the core team. See who holds each and add or remove members."
 msgstr ""
@@ -9600,7 +9607,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/qualification_controller.ex:49
 #: lib/vutuv_web/controllers/qualification_controller.ex:88
 #: lib/vutuv_web/cv/docx.ex:183
-#: lib/vutuv_web/cv/html.ex:173
+#: lib/vutuv_web/cv/html.ex:172
 #: lib/vutuv_web/cv/latex.ex:140
 #: lib/vutuv_web/cv/odt.ex:154
 #: lib/vutuv_web/live/cv_live.ex:321
@@ -9636,8 +9643,8 @@ msgstr ""
 msgid "Does not expire"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:171
-#: lib/vutuv_web/live/admin/job_live.ex:187
+#: lib/vutuv_web/live/admin/job_live.ex:164
+#: lib/vutuv_web/live/admin/job_live.ex:180
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
 #: lib/vutuv_web/views/qualification_html.ex:133
 #, elixir-autogen, elixir-format
@@ -9958,22 +9965,22 @@ msgstr ""
 msgid "Pick a section from the menu on the left to view or change it."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:277
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:281
 #, elixir-autogen, elixir-format
 msgid "%{followers} remote followers, %{queue} queued for delivery."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:269
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Attention:"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:275
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:279
 #, elixir-autogen, elixir-format
 msgid "Outbound federation is healthy."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:266
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:270
 #, elixir-autogen, elixir-format
 msgid "See the daily trend"
 msgstr ""
@@ -9983,7 +9990,7 @@ msgstr ""
 msgid "Showing the most recent %{shown} of %{total}."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:269
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "stuck outbound delivery."
 msgid_plural "stuck outbound deliveries."
@@ -10417,17 +10424,17 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:56
 #: lib/vutuv_web/agent_docs/text.ex:55
-#: lib/vutuv_web/templates/user/show.html.heex:996
+#: lib/vutuv_web/templates/user/show.html.heex:997
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:135
+#: lib/vutuv_web/templates/settings/privacy.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:137
+#: lib/vutuv_web/templates/settings/privacy.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
@@ -10437,12 +10444,12 @@ msgstr ""
 msgid "Last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:149
+#: lib/vutuv_web/templates/settings/privacy.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Show code statistics on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:151
+#: lib/vutuv_web/templates/settings/privacy.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
@@ -10740,7 +10747,7 @@ msgstr[1] ""
 msgid "Changed for this installation."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:301
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:305
 #, elixir-autogen, elixir-format
 msgid "Edit the defaults"
 msgstr ""
@@ -10750,14 +10757,14 @@ msgstr ""
 msgid "Follows the installation default."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:308
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:312
 #, elixir-autogen, elixir-format
 msgid "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} default differs from the shipped value."
 msgid_plural "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} defaults differ from the shipped values."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:304
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:308
 #, elixir-autogen, elixir-format
 msgid "How posts and maps behave for everyone who has not chosen for themselves. This installation runs on the shipped defaults."
 msgstr ""
@@ -10788,7 +10795,7 @@ msgid "Post display settings reset to the site defaults."
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:55
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:297
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:301
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:6
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:7
 #, elixir-autogen, elixir-format
@@ -10875,7 +10882,7 @@ msgstr ""
 msgid "These are the member's own settings: change them here only for support. A field on \"installation default\" follows whatever the defaults page says, now and in the future; a set value stays until the member (or an admin) changes it again."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:159
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Auto-generated screenshots for single-link posts: watch the capture queue and browse the gallery of finished shots, each linked to its post."
 msgstr ""
@@ -10918,7 +10925,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/screenshot_live.ex:33
 #: lib/vutuv_web/live/admin/screenshot_live.ex:51
 #: lib/vutuv_web/live/admin/screenshot_live.ex:52
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:154
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Link screenshots"
 msgstr ""
@@ -10928,14 +10935,14 @@ msgstr ""
 msgid "No screenshots captured yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:157
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "Open the screenshot queue"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:172
-#: lib/vutuv_web/live/admin/organization_live.ex:186
-#: lib/vutuv_web/live/admin/organization_live.ex:201
+#: lib/vutuv_web/live/admin/organization_live.ex:165
+#: lib/vutuv_web/live/admin/organization_live.ex:179
+#: lib/vutuv_web/live/admin/organization_live.ex:194
 #: lib/vutuv_web/live/admin/screenshot_live.ex:196
 #: lib/vutuv_web/live/organization_live/domains.ex:181
 #, elixir-autogen, elixir-format
@@ -10978,16 +10985,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:621
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:626
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:624
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
@@ -11224,7 +11234,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:137
+#: lib/vutuv_web/controllers/organization_controller.ex:144
 #: lib/vutuv_web/live/job_posting_live/exclusions.ex:31
 #, elixir-autogen, elixir-format
 msgid "Please log in first."
@@ -11419,18 +11429,18 @@ msgstr ""
 msgid "Alternative name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:399
+#: lib/vutuv_web/live/admin/organization_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "Archive"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:396
+#: lib/vutuv_web/live/admin/organization_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Archive this page?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:174
-#: lib/vutuv_web/live/admin/organization_live.ex:189
+#: lib/vutuv_web/live/admin/organization_live.ex:167
+#: lib/vutuv_web/live/admin/organization_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "Archived"
 msgstr ""
@@ -11441,7 +11451,7 @@ msgstr ""
 msgid "Brand"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:335
+#: lib/vutuv_web/live/admin/organization_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "Claimed by"
 msgstr ""
@@ -11451,7 +11461,7 @@ msgstr ""
 msgid "Current team"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:405
+#: lib/vutuv_web/live/admin/organization_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Delete this page and everything it owns? This cannot be undone."
 msgstr ""
@@ -11472,7 +11482,7 @@ msgid "Domain verified."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:211
-#: lib/vutuv_web/live/admin/organization_live.ex:312
+#: lib/vutuv_web/live/admin/organization_live.ex:305
 #: lib/vutuv_web/live/organization_live/domains.ex:161
 #: lib/vutuv_web/live/organization_live/show.ex:277
 #, elixir-autogen, elixir-format
@@ -11489,13 +11499,13 @@ msgstr ""
 msgid "Former name"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:472
-#: lib/vutuv_web/live/admin/organization_live.ex:380
+#: lib/vutuv_web/live/admin/job_live.ex:465
+#: lib/vutuv_web/live/admin/organization_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Freeze"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:377
+#: lib/vutuv_web/live/admin/organization_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
@@ -11516,12 +11526,12 @@ msgstr ""
 msgid "Leave"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:167
-#: lib/vutuv_web/live/admin/job_live.ex:183
-#: lib/vutuv_web/live/admin/job_live.ex:210
-#: lib/vutuv_web/live/admin/organization_live.ex:171
-#: lib/vutuv_web/live/admin/organization_live.ex:182
-#: lib/vutuv_web/live/admin/organization_live.ex:200
+#: lib/vutuv_web/live/admin/job_live.ex:160
+#: lib/vutuv_web/live/admin/job_live.ex:176
+#: lib/vutuv_web/live/admin/job_live.ex:203
+#: lib/vutuv_web/live/admin/organization_live.ex:164
+#: lib/vutuv_web/live/admin/organization_live.ex:175
+#: lib/vutuv_web/live/admin/organization_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr ""
@@ -11541,7 +11551,7 @@ msgstr ""
 msgid "Method"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:341
+#: lib/vutuv_web/live/admin/organization_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Names & aliases"
 msgstr ""
@@ -11591,13 +11601,13 @@ msgstr ""
 msgid "Role updated."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:240
+#: lib/vutuv_web/live/admin/organization_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Search name, alias or domain"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:208
-#: lib/vutuv_web/live/admin/organization_live.ex:328
+#: lib/vutuv_web/live/admin/organization_live.ex:321
 #: lib/vutuv_web/live/organization_live/roles.ex:153
 #: lib/vutuv_web/live/organization_live/show.ex:270
 #, elixir-autogen, elixir-format
@@ -11624,25 +11634,25 @@ msgstr ""
 msgid "That member could not be added."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:481
-#: lib/vutuv_web/live/admin/organization_live.ex:389
+#: lib/vutuv_web/live/admin/job_live.ex:474
+#: lib/vutuv_web/live/admin/organization_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Unfreeze"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:318
+#: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "pending"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:316
+#: lib/vutuv_web/live/admin/organization_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "primary"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:315
 #: lib/vutuv_web/agent_docs/text.ex:349
-#: lib/vutuv_web/live/admin/organization_live.ex:318
+#: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
 msgstr ""
@@ -11817,14 +11827,14 @@ msgstr ""
 msgid "former"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:236
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:239
 #, elixir-autogen, elixir-format
 msgid "%{formatted} alias matches another verified organization and is flagged for review."
 msgid_plural "%{formatted} aliases match another verified organization and are flagged for review."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:206
+#: lib/vutuv_web/live/admin/organization_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "%{count} alias matches another verified organization and is flagged for review. Open an organization below to see it."
 msgid_plural "%{count} aliases match another verified organization and are flagged for review. Open an organization below to see them."
@@ -11921,12 +11931,12 @@ msgstr ""
 msgid "Leave this organization team?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:355
+#: lib/vutuv_web/live/admin/organization_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Matches another verified organization"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:245
+#: lib/vutuv_web/live/admin/organization_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "No organization pages match."
 msgstr ""
@@ -11956,7 +11966,7 @@ msgstr ""
 msgid "Nothing here yet. Organizations you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:231
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "Open organization oversight"
 msgstr ""
@@ -11988,9 +11998,9 @@ msgid "Organization page"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:25
-#: lib/vutuv_web/live/admin/organization_live.ex:195
-#: lib/vutuv_web/live/admin/organization_live.ex:196
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:226
+#: lib/vutuv_web/live/admin/organization_live.ex:188
+#: lib/vutuv_web/live/admin/organization_live.ex:189
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "Organization pages"
 msgstr ""
@@ -12023,12 +12033,12 @@ msgstr ""
 msgid "Please choose"
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:104
+#: lib/vutuv_web/controllers/organization_controller.ex:111
 #, elixir-autogen, elixir-format
 msgid "Please confirm your email address before claiming an organization page."
 msgstr ""
 
-#: lib/vutuv_web/controllers/organization_controller.ex:110
+#: lib/vutuv_web/controllers/organization_controller.ex:117
 #, elixir-autogen, elixir-format
 msgid "Please log in to claim an organization page."
 msgstr ""
@@ -12073,7 +12083,7 @@ msgstr ""
 msgid "Verified organization pages on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:234
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:237
 #, elixir-autogen, elixir-format
 msgid "Verified organization pages: domains, team roles, aliases and rename history. Freeze, archive or delete a page."
 msgstr ""
@@ -12158,7 +12168,7 @@ msgstr ""
 msgid "Public authority"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:382
+#: lib/vutuv_web/live/admin/job_live.ex:375
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:138
 #, elixir-autogen, elixir-format
 msgid "%{views} views · %{clicks} apply clicks"
@@ -12204,7 +12214,7 @@ msgstr ""
 msgid "Application e-mail"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:110
+#: lib/vutuv_web/controllers/job_posting_controller.ex:106
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Application: %{title}"
 msgstr ""
@@ -12214,12 +12224,12 @@ msgstr ""
 msgid "Applications go to"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:270
+#: lib/vutuv_web/live/job_posting_live/show.ex:271
 #, elixir-autogen, elixir-format
 msgid "Apply by e-mail"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:269
+#: lib/vutuv_web/live/job_posting_live/show.ex:270
 #, elixir-autogen, elixir-format
 msgid "Apply on website"
 msgstr ""
@@ -12229,8 +12239,8 @@ msgstr ""
 msgid "Apprenticeship"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:170
-#: lib/vutuv_web/live/admin/job_live.ex:190
+#: lib/vutuv_web/live/admin/job_live.ex:163
+#: lib/vutuv_web/live/admin/job_live.ex:183
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:184
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Closed"
@@ -12260,7 +12270,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:339
 #: lib/vutuv_web/agent_docs/text.ex:206
 #: lib/vutuv_web/agent_docs/text.ex:373
-#: lib/vutuv_web/live/admin/job_live.ex:351
+#: lib/vutuv_web/live/admin/job_live.ex:344
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employer"
 msgstr ""
@@ -12274,7 +12284,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:340
 #: lib/vutuv_web/agent_docs/text.ex:207
 #: lib/vutuv_web/agent_docs/text.ex:374
-#: lib/vutuv_web/live/job_board_live.ex:280
+#: lib/vutuv_web/live/job_board_live.ex:281
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employment type"
@@ -12295,7 +12305,7 @@ msgstr ""
 msgid "Full-time"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:158
+#: lib/vutuv_web/live/job_posting_live/show.ex:159
 #, elixir-autogen, elixir-format
 msgid "Highlighted tags match your profile."
 msgstr ""
@@ -12315,7 +12325,7 @@ msgstr ""
 msgid "Hybrid"
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:124
+#: lib/vutuv_web/controllers/job_posting_controller.ex:120
 #, elixir-autogen, elixir-format
 msgid "I'm interested in your posting: %{url}"
 msgstr ""
@@ -12332,8 +12342,8 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/job_board_doc.ex:19
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:40
-#: lib/vutuv_web/live/job_board_live.ex:145
+#: lib/vutuv_web/live/job_board_live.ex:41
+#: lib/vutuv_web/live/job_board_live.ex:146
 #: lib/vutuv_web/live/post_live/saved.ex:458
 #: lib/vutuv_web/live/shell_live.ex:339
 #: lib/vutuv_web/templates/layout/app.html.heex:77
@@ -12367,7 +12377,7 @@ msgstr ""
 msgid "Mark this posting as filled and close it?"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:271
+#: lib/vutuv_web/live/job_posting_live/show.ex:272
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Message the poster"
 msgstr ""
@@ -12384,7 +12394,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:25
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:101
-#: lib/vutuv_web/live/job_posting_live/show.ex:180
+#: lib/vutuv_web/live/job_posting_live/show.ex:181
 #, elixir-autogen, elixir-format, fuzzy
 msgid "My postings"
 msgstr ""
@@ -12403,7 +12413,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:222
 #: lib/vutuv_web/agent_docs/text.ex:217
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
-#: lib/vutuv_web/live/job_posting_live/show.ex:153
+#: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
 msgid "Nice to have"
 msgstr ""
@@ -12433,7 +12443,7 @@ msgstr ""
 msgid "On-site"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:87
+#: lib/vutuv_web/live/job_posting_live/show.ex:88
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this posting while a report about it is handled."
 msgstr ""
@@ -12458,7 +12468,7 @@ msgstr ""
 msgid "Please confirm your email address before posting a job."
 msgstr ""
 
-#: lib/vutuv_web/controllers/job_posting_controller.ex:116
+#: lib/vutuv_web/controllers/job_posting_controller.ex:112
 #, elixir-autogen, elixir-format
 msgid "Please log in to message the poster."
 msgstr ""
@@ -12487,7 +12497,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:344
 #: lib/vutuv_web/agent_docs/text.ex:211
 #: lib/vutuv_web/agent_docs/text.ex:378
-#: lib/vutuv_web/live/job_posting_live/show.ex:132
+#: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posted"
 msgstr ""
@@ -12520,7 +12530,7 @@ msgstr ""
 msgid "Remote"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:168
+#: lib/vutuv_web/live/job_posting_live/show.ex:169
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this posting"
 msgstr ""
@@ -12528,7 +12538,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:221
 #: lib/vutuv_web/agent_docs/text.ex:216
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
-#: lib/vutuv_web/live/job_posting_live/show.ex:148
+#: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
@@ -12591,7 +12601,7 @@ msgstr ""
 msgid "This organization has reached its published-postings limit."
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:94
+#: lib/vutuv_web/live/job_posting_live/show.ex:95
 #, elixir-autogen, elixir-format
 msgid "This position is no longer available."
 msgstr ""
@@ -12602,7 +12612,7 @@ msgid "Tip: adding a gender marker like (m/w/d) helps your posting comply with t
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:108
-#: lib/vutuv_web/live/job_posting_live/show.ex:208
+#: lib/vutuv_web/live/job_posting_live/show.ex:209
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verified organization"
 msgstr ""
@@ -12647,7 +12657,7 @@ msgstr ""
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
-#: lib/vutuv_web/live/job_posting_live/show.ex:175
+#: lib/vutuv_web/live/job_posting_live/show.ex:176
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your posting"
 msgstr ""
@@ -12794,12 +12804,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/job_board_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:274
+#: lib/vutuv_web/live/job_board_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr ""
@@ -12815,32 +12825,32 @@ msgstr ""
 msgid "All jobs with this tag: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:281
+#: lib/vutuv_web/live/job_board_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:263
+#: lib/vutuv_web/live/job_board_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/job_board_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:183
+#: lib/vutuv_web/live/job_board_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:175
+#: lib/vutuv_web/live/job_board_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:337
+#: lib/vutuv_web/live/job_board_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr ""
@@ -12850,7 +12860,7 @@ msgstr ""
 msgid "Minimum yearly salary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:238
+#: lib/vutuv_web/live/job_board_live.ex:239
 #: lib/vutuv_web/live/organization_live/show.ex:342
 #, elixir-autogen, elixir-format
 msgid "More jobs"
@@ -12866,12 +12876,12 @@ msgstr ""
 msgid "Next page: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:328
+#: lib/vutuv_web/live/job_board_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:326
+#: lib/vutuv_web/live/job_board_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
@@ -12887,92 +12897,92 @@ msgid "Open positions"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/job_board_doc.ex:20
-#: lib/vutuv_web/live/job_board_live.ex:147
+#: lib/vutuv_web/live/job_board_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:155
+#: lib/vutuv_web/live/job_board_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:220
+#: lib/vutuv_web/live/job_board_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:267
+#: lib/vutuv_web/live/job_board_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:255
+#: lib/vutuv_web/live/job_board_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:144
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "%{formatted} job posting has an open moderation case."
 msgid_plural "%{formatted} job postings have an open moderation case."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:447
+#: lib/vutuv_web/live/admin/job_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "%{count} report"
 msgid_plural "%{count} reports"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:366
+#: lib/vutuv_web/live/admin/job_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "(free text, unverified)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:199
+#: lib/vutuv_web/live/admin/job_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "(no employer)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:488
+#: lib/vutuv_web/live/admin/job_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Close this posting? It ends the listing (a regular ending, not a deletion)."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:425
+#: lib/vutuv_web/live/admin/job_live.ex:418
 #: lib/vutuv_web/live/admin/user_detail_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cold outreach"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:380
+#: lib/vutuv_web/live/admin/job_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Counters"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:497
+#: lib/vutuv_web/live/admin/job_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "Delete this posting and everything it owns? This cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:142
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Every job posting: search, freeze/unfreeze, close or delete, with the poster's report history and cold-outreach counter."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:168
+#: lib/vutuv_web/live/admin/job_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Expiring"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:211
+#: lib/vutuv_web/live/admin/job_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Expiring (7 days)"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:469
+#: lib/vutuv_web/live/admin/job_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Freeze this posting? It disappears from the public board and its indexing but stays visible to its poster."
 msgstr ""
@@ -12983,42 +12993,42 @@ msgid "Job posting"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:30
-#: lib/vutuv_web/live/admin/job_live.ex:205
-#: lib/vutuv_web/live/admin/job_live.ex:206
+#: lib/vutuv_web/live/admin/job_live.ex:198
+#: lib/vutuv_web/live/admin/job_live.ex:199
 #: lib/vutuv_web/live/admin/user_detail_live.ex:175
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:134
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Job postings"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:413
+#: lib/vutuv_web/live/admin/job_live.ex:406
 #: lib/vutuv_web/live/admin/user_detail_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Live postings"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:265
+#: lib/vutuv_web/live/admin/job_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "No job postings match."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:457
+#: lib/vutuv_web/live/admin/job_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "Open case"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:421
+#: lib/vutuv_web/live/admin/job_live.ex:414
 #: lib/vutuv_web/live/admin/user_detail_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "Open job cases"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:139
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Open job oversight"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:249
+#: lib/vutuv_web/live/admin/job_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Open reports"
 msgstr ""
@@ -13028,13 +13038,13 @@ msgstr ""
 msgid "Open the job posting"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:272
-#: lib/vutuv_web/live/admin/job_live.ex:338
+#: lib/vutuv_web/live/admin/job_live.ex:265
+#: lib/vutuv_web/live/admin/job_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Poster"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:410
+#: lib/vutuv_web/live/admin/job_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Poster footprint"
 msgstr ""
@@ -13059,38 +13069,38 @@ msgstr ""
 msgid "Posting unfrozen."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:438
+#: lib/vutuv_web/live/admin/job_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Report history"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:260
+#: lib/vutuv_web/live/admin/job_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Search title, poster or organization"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:271
+#: lib/vutuv_web/live/admin/job_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:417
+#: lib/vutuv_web/live/admin/job_live.ex:410
 #: lib/vutuv_web/live/admin/user_detail_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Total postings"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:395
+#: lib/vutuv_web/live/admin/job_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "never"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:361
+#: lib/vutuv_web/live/admin/job_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "verified organization page"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/job_live.ex:402
+#: lib/vutuv_web/live/admin/job_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "—"
 msgstr ""
@@ -13245,7 +13255,7 @@ msgstr ""
 msgid "job search"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:301
+#: lib/vutuv_web/live/search_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "only people open to offers (status:open) or looking (status:looking)"
 msgstr ""
@@ -13414,7 +13424,7 @@ msgstr ""
 msgid "Alias flag cleared."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/organization_live.ex:361
+#: lib/vutuv_web/live/admin/organization_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "Reviewed, all fine: clear the flag"
 msgstr ""
@@ -13434,7 +13444,7 @@ msgstr ""
 msgid "This member no longer exists."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:78
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr ""
@@ -13458,12 +13468,12 @@ msgid "Image is being reviewed"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:303
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:67
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:73
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
 msgstr ""
@@ -13503,6 +13513,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:639
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13513,16 +13524,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:642
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:645
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:636
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13550,7 +13564,7 @@ msgstr ""
 msgid "Handle change"
 msgstr ""
 
-#: lib/vutuv_web/controllers/username_controller.ex:42
+#: lib/vutuv_web/controllers/username_controller.ex:44
 #, elixir-autogen, elixir-format
 msgid "We updated %{formatted} post that mentioned your old handle and notified its author."
 msgid_plural "We updated %{formatted} posts that mentioned your old handle and notified their authors."
@@ -13604,12 +13618,12 @@ msgstr ""
 msgid "Posts with this tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:270
+#: lib/vutuv_web/live/search_live.ex:268
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:297
+#: lib/vutuv_web/live/search_live.ex:295
 #, elixir-autogen, elixir-format, fuzzy
 msgid "people and posts with this tag, combinable: miller tag:php"
 msgstr ""
@@ -13661,4 +13675,34 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:666
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:324
+#, elixir-autogen, elixir-format
+msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:320
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Search tips"
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:378
+#, elixir-autogen, elixir-format
+msgid "any of these titles"
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:380
+#, elixir-autogen, elixir-format
+msgid "exact wording"
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:381
+#, elixir-autogen, elixir-format
+msgid "without internships"
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:379
+#, elixir-autogen, elixir-format
+msgid "word start: also finds Entwickler, Entwicklung"
 msgstr ""

--- a/test/vutuv/jobs/search_query_test.exs
+++ b/test/vutuv/jobs/search_query_test.exs
@@ -1,0 +1,126 @@
+defmodule Vutuv.Jobs.SearchQueryTest do
+  @moduledoc """
+  The `/jobs` board search-box grammar (issue #952): comma/`or` → OR between
+  titles, `*` prefix wildcard, `"…"` phrase, `-` exclusion, and the safety
+  guarantee that no visitor input can produce a `to_tsquery` string that raises.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Vutuv.Jobs.SearchQuery
+
+  describe "single term" do
+    test "one word is a plain lexeme" do
+      assert SearchQuery.to_tsquery("Elixir") == "elixir"
+    end
+
+    test "several words are AND-ed" do
+      assert SearchQuery.to_tsquery("Senior Elixir Engineer") ==
+               "(senior & elixir & engineer)"
+    end
+
+    test "a hyphenated word splits into AND-ed lexemes" do
+      assert SearchQuery.to_tsquery("PHP-Entwickler") == "(php & entwickler)"
+    end
+  end
+
+  describe "comma / or → OR between titles" do
+    test "comma separates OR-groups" do
+      assert SearchQuery.to_tsquery("Webentwickler, PHP-Entwickler") ==
+               "(webentwickler | (php & entwickler))"
+    end
+
+    test "the word 'or' separates OR-groups" do
+      assert SearchQuery.to_tsquery("web developer or php developer") ==
+               "((web & developer) | (php & developer))"
+    end
+
+    test "the German 'oder' separates OR-groups" do
+      assert SearchQuery.to_tsquery("Entwickler oder Ingenieur") ==
+               "(entwickler | ingenieur)"
+    end
+
+    test "a pipe separates OR-groups" do
+      assert SearchQuery.to_tsquery("java|kotlin") == "(java | kotlin)"
+    end
+
+    test "'or' inside a word is not a separator" do
+      assert SearchQuery.to_tsquery("editor") == "editor"
+      assert SearchQuery.to_tsquery("corridor") == "corridor"
+    end
+
+    test "newlines separate OR-groups (a pasted list)" do
+      assert SearchQuery.to_tsquery("Webentwickler\nPHP Developer") ==
+               "(webentwickler | (php & developer))"
+    end
+  end
+
+  describe "prefix wildcard" do
+    test "a trailing * becomes a prefix match" do
+      assert SearchQuery.to_tsquery("entwickl*") == "entwickl:*"
+    end
+
+    test "the wildcard applies to the last lexeme of a word" do
+      assert SearchQuery.to_tsquery("full-stack*") == "(full & stack:*)"
+    end
+
+    test "wildcards combine with OR" do
+      assert SearchQuery.to_tsquery("entwickl*, develop*") ==
+               "(entwickl:* | develop:*)"
+    end
+  end
+
+  describe "quoted phrase" do
+    test "quoted words become an adjacent phrase" do
+      assert SearchQuery.to_tsquery(~s("Full Stack Developer")) ==
+               "(full <-> stack <-> developer)"
+    end
+
+    test "a comma inside a phrase does not split it" do
+      assert SearchQuery.to_tsquery(~s("Berlin, Germany")) ==
+               "(berlin <-> germany)"
+    end
+
+    test "a phrase OR-ed with a plain title" do
+      assert SearchQuery.to_tsquery(~s(Elixir, "Ruby on Rails")) ==
+               "(elixir | (ruby <-> on <-> rails))"
+    end
+  end
+
+  describe "exclusion" do
+    test "a leading - excludes the word from the whole search" do
+      assert SearchQuery.to_tsquery("entwickler -praktikum") ==
+               "entwickler & !(praktikum)"
+    end
+
+    test "exclusion applies across OR-groups globally" do
+      assert SearchQuery.to_tsquery("entwickler, developer -senior") ==
+               "(entwickler | developer) & !(senior)"
+    end
+
+    test "an excluded prefix wildcard" do
+      assert SearchQuery.to_tsquery("developer -intern*") ==
+               "developer & !(intern:*)"
+    end
+  end
+
+  describe "empty / junk input never raises and yields nil" do
+    test "blank and non-binary" do
+      assert SearchQuery.to_tsquery("") == nil
+      assert SearchQuery.to_tsquery("   ") == nil
+      assert SearchQuery.to_tsquery(nil) == nil
+    end
+
+    test "punctuation-only input collapses to nil" do
+      assert SearchQuery.to_tsquery(",,,") == nil
+      assert SearchQuery.to_tsquery("* - ! |") == nil
+      assert SearchQuery.to_tsquery(~s("")) == nil
+    end
+
+    test "tsquery operator characters are neutralised, not passed through" do
+      # Would be a syntax error if handed raw to to_tsquery/2.
+      assert SearchQuery.to_tsquery("(a & b) : c") == "(a & b & c)"
+      assert SearchQuery.to_tsquery("c++") == "c"
+    end
+  end
+end

--- a/test/vutuv/jobs_board_test.exs
+++ b/test/vutuv/jobs_board_test.exs
@@ -85,6 +85,32 @@ defmodule Vutuv.JobsBoardTest do
       assert ids(Jobs.board_page(nil, %{q: "Elixir"})) == [elixir.id]
     end
 
+    test "comma is an OR between titles (issue #952)", %{elixir: elixir, java: java} do
+      both = Jobs.board_page(nil, %{q: "Elixir, Java"}) |> ids() |> Enum.sort()
+      assert both == Enum.sort([elixir.id, java.id])
+    end
+
+    test "the word 'or' also ORs titles", %{elixir: elixir, java: java} do
+      both = Jobs.board_page(nil, %{q: "elixir or java"}) |> ids() |> Enum.sort()
+      assert both == Enum.sort([elixir.id, java.id])
+    end
+
+    test "a trailing * prefix-matches word variants", %{elixir: elixir} do
+      # "Engineer" in the Elixir posting's title; "Engine*" must reach it.
+      assert ids(Jobs.board_page(nil, %{q: "Engine*"})) == [elixir.id]
+    end
+
+    test "a leading - excludes a word", %{elixir: elixir, java: java} do
+      # Both are "…eer"/"Developer"; exclude Java to keep only Elixir.
+      assert ids(Jobs.board_page(nil, %{q: "developer or engineer -java"})) == [elixir.id]
+      assert java.id not in ids(Jobs.board_page(nil, %{q: "developer or engineer -java"}))
+    end
+
+    test "operator-only junk is a no-op, not a crash", %{elixir: elixir, java: java} do
+      all = Jobs.board_page(nil, %{q: "*** ,,, |"}) |> ids() |> Enum.sort()
+      assert all == Enum.sort([elixir.id, java.id])
+    end
+
     test "tag filters to postings carrying the slug", %{elixir: elixir} do
       assert ids(Jobs.board_page(nil, %{tag: "phoenix"})) == [elixir.id]
     end

--- a/test/vutuv_web/live/job_board_live_test.exs
+++ b/test/vutuv_web/live/job_board_live_test.exs
@@ -34,6 +34,33 @@ defmodule VutuvWeb.JobBoardLiveTest do
     refute html =~ "Java Developer"
   end
 
+  test "a comma OR search matches either title (issue #952)", %{conn: conn} do
+    poster = poster_fixture()
+    publish_job!(poster, %{"title" => "Elixir Engineer"})
+    publish_job!(poster, %{"title" => "Java Developer"})
+
+    {:ok, _view, html} = live(conn, ~p"/jobs?#{[q: "Elixir, Java"]}")
+
+    assert html =~ "Elixir Engineer"
+    assert html =~ "Java Developer"
+  end
+
+  test "a prefix wildcard search reaches word variants", %{conn: conn} do
+    poster = poster_fixture()
+    publish_job!(poster, %{"title" => "Elixir Engineer"})
+
+    {:ok, _view, html} = live(conn, ~p"/jobs?#{[q: "Engine*"]}")
+
+    assert html =~ "Elixir Engineer"
+  end
+
+  test "the search-tips help is on the board", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/jobs")
+
+    assert has_element?(view, "details summary", "Search tips")
+    assert render(view) =~ "Webentwickler, PHP-Entwickler"
+  end
+
   test "shows an empty state with no postings", %{conn: conn} do
     {:ok, _view, html} = live(conn, ~p"/jobs")
     assert html =~ "No job postings yet"


### PR DESCRIPTION
Closes #952.

## What

A role often has no single canonical title (Webentwickler / Full-Stack Developer / PHP Developer / …), so searching the `/jobs` board one title at a time, or saving a separate search per permutation, is not workable. This lets one search cover several titles at once, plus prefix wildcards.

New grammar in the board search box:

| Input | Meaning |
|---|---|
| `Webentwickler, PHP-Entwickler, Full-Stack Developer` | any of these titles (comma = OR) |
| `Entwickler oder Ingenieur` | OR via the German word (also `or`, `\|`, newlines) |
| `entwickl*` | prefix wildcard: Entwickler, Entwicklung, … |
| `"Full Stack Developer"` | exact phrase |
| `Entwickler -Praktikum` | exclude a word |

## How

Replaces the board's `websearch_to_tsquery` (whose only OR operator is the English `or` keyword, useless to a German visitor typing `oder`) with a dedicated parser, `Vutuv.Jobs.SearchQuery.to_tsquery/1`, that turns the human box into a sanitised `to_tsquery('simple', …)` string. Every token is reduced to lexeme-safe characters and the query assembled from well-formed pieces only, so no visitor input can make Postgres raise; a query with no searchable token is a no-op. Because the live board and the saved-search alert sweeper share `apply_board_filters/3`, a saved OR/wildcard search alerts on the same grammar.

Documented on the board itself via a collapsible **"Suchtipps"** disclosure with worked examples (German + English), and in `docs/architecture/jobs.md`.

## Tests

- 21 pure parser cases (incl. junk-never-crashes / operator-neutralisation)
- board-query cases: comma-OR, `or`/`oder`, wildcard, exclusion, junk-is-a-no-op
- LiveView cases: rendered comma & wildcard search, the help block

Full `mix precommit` green (4098 tests). Version bumped 7.118.0 → 7.119.0 (minor).