### PR TITLE
Fix the async-suite 40P01 deadlock at its root: unique test tag names (v7.119.1)

### DIFF
--- a/.claude/rules/elixir.md
+++ b/.claude/rules/elixir.md
@@ -50,6 +50,7 @@ paths:
 
 ## Test guidelines
 
+- **An async test module must never insert a unique-key value (tag name/slug, email, username/handle, org slug) that another async test file also inserts.** The SQL sandbox wraps each test in one never-committing transaction, so an inserted unique-index key stays exclusively locked until the test ends; two async files minting the same literal (`insert(:tag, slug: "elixir")`, a shared `"tag_list"`, `username: "alice"`) convoy on that lock, and two such keys acquired in opposite orders deadlock — the long-standing intermittent `40P01 deadlock_detected` in `register_user` at the pre-push gate (root-caused and fixed 2026-07-21). `ON CONFLICT` get-or-create does **not** help in tests: nothing commits, so every test really inserts. Use the factory sequences (`insert(:tag)` with no name), `Vutuv.Factory.unique_tag_name/1` bound to a variable, or the per-module `@registration_tags`; a hardcoded literal is acceptable only in a sync (`async: false`) module or when provably no other async file mints the same value.
 - **Always use `start_supervised!/1`** to start processes in tests as it guarantees cleanup between tests
 - **Avoid** `Process.sleep/1` and `Process.alive?/1` in tests
   - Instead of sleeping to wait for a process to finish, **always** use `Process.monitor/1` and assert on the DOWN message:

--- a/docs/DEVELOPERS.md
+++ b/docs/DEVELOPERS.md
@@ -90,6 +90,15 @@ stack conventions and the context-module map.
 mix test
 ```
 
+Most of the suite runs `async: true`. One rule keeps that safe: an async
+test module must never insert the same unique-key value (tag name/slug,
+email, username) as another async file. The SQL sandbox holds every
+inserted unique-index key locked until the test's transaction rolls back,
+so shared literals make concurrent tests queue on each other and can
+deadlock (Postgres 40P01). Use the factory sequences (`insert(:tag)`),
+`Vutuv.Factory.unique_tag_name/1`, or the per-module `@registration_tags`
+instead of hardcoded names.
+
 ## How vutuv.de itself is deployed
 
 This section describes the **reference installation** (vutuv.de). For

--- a/lib/vutuv/tags/tag.ex
+++ b/lib/vutuv/tags/tag.ex
@@ -175,6 +175,15 @@ defmodule Vutuv.Tags.Tag do
   # ON CONFLICT the loser no-ops and re-reads the winner's row, and because the
   # tag insert is its own autocommit statement no transaction ever holds two
   # contended tag rows at once, so no cycle can form.
+  #
+  # That autocommit premise holds only in production. Under the test SQL
+  # sandbox nothing commits: each test is one transaction that keeps the
+  # unique-index lock on every slug it inserts until rollback, so two async
+  # test modules minting the SAME tag name still convoy on it — and deadlock
+  # when two contended slugs are acquired in opposite orders (the historical
+  # 40P01 flake in register_user). The test-side rule is therefore that async
+  # test modules never share literal tag names (see test/support/conn_case.ex
+  # and the test guidelines in .claude/rules/elixir.md).
   defp put_created_tag(changeset, params) do
     tag_changeset = __MODULE__.changeset(%__MODULE__{}, params)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.118.0",
+      version: "7.118.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -25,19 +25,32 @@ defmodule VutuvWeb.ConnCase do
 
       # Registration requires at least three distinct tags (the sign-up tag
       # minimum), so every helper-registered account carries this neutral,
-      # test-greppable trio.
-      @registration_tags "alpha-tag beta-tag gamma-tag"
+      # test-greppable trio — suffixed with a stable per-module discriminator.
+      # Async test modules must never insert the same tag name as another
+      # module: the SQL sandbox keeps every test's inserts uncommitted, so a
+      # minted slug holds its unique-index lock until the test transaction
+      # rolls back. Two modules sharing a slug therefore convoy on it, and two
+      # contended slugs acquired in opposite orders deadlock — the long-lived
+      # intermittent `40P01 deadlock_detected` in register_user. The ON
+      # CONFLICT get-or-create in `Tag.put_created_tag/2` does not help here:
+      # its no-lock reasoning assumes the insert autocommits, which is true in
+      # production and false in the sandbox. Within one module tests run
+      # serially, so sharing the trio module-wide is safe — and keeps it
+      # usable in module attributes.
+      registration_tags_mod_id = :erlang.phash2(__MODULE__, 4_294_967_296)
+
+      @registration_tags "alpha-tag-#{registration_tags_mod_id} " <>
+                           "beta-tag-#{registration_tags_mod_id} " <>
+                           "gamma-tag-#{registration_tags_mod_id}"
 
       # Per-call unique sign-up attrs. The email, name and the handle generated
       # from the name are the shared-fixture rows async test modules used to
       # collide on: two modules registering the identical "email@example.com" /
       # "first_name" at once contend on the emails/username/handles unique
-      # indexes *inside one register_user transaction*, which is the other half
-      # of the intermittent 40P01 deadlock (the tag half is fixed in
-      # `Vutuv.Tags.Tag`). Minting a fresh integer per call keeps every
+      # indexes *inside one register_user transaction* — the same 40P01 class
+      # as the tags above. Minting a fresh integer per call keeps every
       # registration's rows disjoint, so ConnCase tests are safe to run
-      # `async: true`. Tags stay shared on purpose — they get-or-create
-      # idempotently now (`Tag.put_created_tag/2`), so they no longer deadlock.
+      # `async: true`.
       defp registration_attrs(prefix) do
         n = System.unique_integer([:positive])
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -248,6 +248,18 @@ defmodule Vutuv.Factory do
     }
   end
 
+  @doc """
+  A per-call unique tag name with a readable base ("Elixir-123").
+
+  Async test modules must never insert the same tag name as another module:
+  under the SQL sandbox every minted slug keeps its unique-index lock until
+  the test transaction rolls back, so shared names convoy and deadlock
+  (the 40P01 register_user flake). Use this wherever a test types a tag
+  value into a flow (add_user_tag, tag forms, post tags) and the exact
+  spelling is not the point — bind it to a variable and assert on that.
+  """
+  def unique_tag_name(base \\ "tag"), do: "#{base}-#{System.unique_integer([:positive])}"
+
   def user_tag_factory do
     %Vutuv.Tags.UserTag{}
   end

--- a/test/vutuv/accounts/username_test.exs
+++ b/test/vutuv/accounts/username_test.exs
@@ -141,12 +141,13 @@ defmodule Vutuv.Accounts.SlugTest do
       # register_user/2 generates the handle from the name; "Tags" slugifies to
       # the reserved word "tags" and must come out suffixed, not rejected.
       conn = %Plug.Conn{assigns: %{locale: "en"}}
+      n = System.unique_integer([:positive])
 
       {:ok, user} =
         Vutuv.Accounts.register_user(conn, %{
           "first_name" => "Tags",
           "emails" => %{"0" => %{"value" => "tags@example.com"}},
-          "tag_list" => "Elixir Cooking Origami"
+          "tag_list" => "Elixir#{n} Cooking#{n} Origami#{n}"
         })
 
       assert user.username =~ ~r/^tags_[0-9a-f]{8}$/

--- a/test/vutuv/handles_test.exs
+++ b/test/vutuv/handles_test.exs
@@ -52,12 +52,14 @@ defmodule Vutuv.HandlesTest do
 
   describe "registry sync (the chokepoints keep handles in lock-step)" do
     test "register_user writes a matching handle row" do
+      n = System.unique_integer([:positive])
+
       {:ok, user} =
         Accounts.register_user(build_conn(), %{
           "emails" => %{"0" => %{"value" => "reg@example.com"}},
           "first_name" => "Reg",
           "last_name" => "Ister",
-          "tag_list" => "Elixir Cooking Origami"
+          "tag_list" => "Elixir#{n} Cooking#{n} Origami#{n}"
         })
 
       handle = Repo.get_by(Handle, user_id: user.id)

--- a/test/vutuv/mention_existence_test.exs
+++ b/test/vutuv/mention_existence_test.exs
@@ -7,13 +7,15 @@ defmodule Vutuv.MentionExistenceTest do
 
   describe "Post.changeset mention-existence validation" do
     test "accepts a mention of an existing member" do
-      insert(:user, username: "alice")
-      assert Post.changeset(%Post{}, %{body: "hi @alice"}).valid?
+      handle = "alice#{System.unique_integer([:positive])}"
+      insert(:user, username: handle)
+      assert Post.changeset(%Post{}, %{body: "hi @#{handle}"}).valid?
     end
 
     test "accepts a mention of an organization handle (shared namespace)" do
-      insert(:organization, username: "acme")
-      assert Post.changeset(%Post{}, %{body: "join @acme"}).valid?
+      handle = "acme#{System.unique_integer([:positive])}"
+      insert(:organization, username: handle)
+      assert Post.changeset(%Post{}, %{body: "join @#{handle}"}).valid?
     end
 
     test "rejects a mention of a handle nobody holds" do
@@ -59,8 +61,9 @@ defmodule Vutuv.MentionExistenceTest do
     end
 
     test "accepts a DM mentioning an existing member" do
-      insert(:user, username: "alice")
-      assert Message.changeset(%Message{}, %{body: "psst @alice"}).valid?
+      handle = "alice#{System.unique_integer([:positive])}"
+      insert(:user, username: handle)
+      assert Message.changeset(%Message{}, %{body: "psst @#{handle}"}).valid?
     end
   end
 

--- a/test/vutuv/newsletter_groups_test.exs
+++ b/test/vutuv/newsletter_groups_test.exs
@@ -54,10 +54,11 @@ defmodule Vutuv.NewsletterGroupsTest do
     end
 
     test "filters by username with wildcards and contains-match" do
-      member("a@x.com", username: "stefan.wintermeyer")
+      n = System.unique_integer([:positive])
+      member("a@x.com", username: "s#{n}.wintermeyer")
       member("b@x.com", username: "erika.musterfrau")
 
-      assert Newsletters.audience_count(%{username: "stefan*"}) == 1
+      assert Newsletters.audience_count(%{username: "s#{n}*"}) == 1
       assert Newsletters.audience_count(%{username: "*meyer"}) == 1
       assert Newsletters.audience_count(%{username: "wintermeyer"}) == 1
       assert Newsletters.audience_count(%{username: "*.muster*"}) == 1

--- a/test/vutuv/organizations_linking_test.exs
+++ b/test/vutuv/organizations_linking_test.exs
@@ -19,8 +19,9 @@ defmodule Vutuv.OrganizationsLinkingTest do
     end
 
     test "an organization with a root handle is canonical at /:handle" do
-      organization = insert(:organization, slug: "acme-gmbh", username: "acme")
-      assert Organizations.canonical_path(organization) == "/acme"
+      handle = "acme#{System.unique_integer([:positive])}"
+      organization = insert(:organization, slug: "acme-gmbh", username: handle)
+      assert Organizations.canonical_path(organization) == "/#{handle}"
     end
   end
 

--- a/test/vutuv/posts/list_tag_posts_test.exs
+++ b/test/vutuv/posts/list_tag_posts_test.exs
@@ -11,27 +11,33 @@ defmodule Vutuv.Posts.ListTagPostsTest do
   alias Vutuv.Posts
   alias Vutuv.Tags.Tag
 
+  # Per-module unique tag names so async files never share a tags.slug lock
+  # (see the test guidelines in .claude/rules/elixir.md).
+  ltp_mod_id = :erlang.phash2(__MODULE__, 4_294_967_296)
+  @elixir_tag "elixir-#{ltp_mod_id}"
+  @ruby_tag "ruby-#{ltp_mod_id}"
+
   defp author(attrs \\ []), do: insert(:activated_user, attrs)
 
   defp tag_by_name(name), do: Repo.get_by!(Tag, name: name)
 
   test "lists public posts carrying the exact tag, newest first" do
     a = author()
-    older = create_post!(a, %{body: "First", tags: "elixir"})
-    newer = create_post!(a, %{body: "Second", tags: "elixir"})
-    _other = create_post!(a, %{body: "Ruby", tags: "ruby"})
+    older = create_post!(a, %{body: "First", tags: @elixir_tag})
+    newer = create_post!(a, %{body: "Second", tags: @elixir_tag})
+    _other = create_post!(a, %{body: "Ruby", tags: @ruby_tag})
 
-    ids = tag_by_name("elixir") |> Posts.list_tag_posts() |> Enum.map(& &1.id)
+    ids = tag_by_name(@elixir_tag) |> Posts.list_tag_posts() |> Enum.map(& &1.id)
     assert ids == [newer.id, older.id]
   end
 
   test "author and tags are preloaded for rendering" do
     a = author()
-    create_post!(a, %{body: "Hello", tags: "elixir"})
+    create_post!(a, %{body: "Hello", tags: @elixir_tag})
 
-    assert [post] = Posts.list_tag_posts(tag_by_name("elixir"))
+    assert [post] = Posts.list_tag_posts(tag_by_name(@elixir_tag))
     assert post.user.id == a.id
-    assert Enum.map(post.tags, & &1.name) == ["elixir"]
+    assert Enum.map(post.tags, & &1.name) == [@elixir_tag]
   end
 
   test "hides denied, frozen, unactivated and moderation-hidden posts" do
@@ -39,20 +45,20 @@ defmodule Vutuv.Posts.ListTagPostsTest do
 
     create_post!(a, %{
       body: "followers only",
-      tags: "elixir",
+      tags: @elixir_tag,
       denials: [%{"wildcard" => "non_followers"}]
     })
 
-    frozen = create_post!(a, %{body: "frozen", tags: "elixir"})
+    frozen = create_post!(a, %{body: "frozen", tags: @elixir_tag})
 
     Repo.update_all(from(p in Posts.Post, where: p.id == ^frozen.id),
       set: [frozen_at: NaiveDateTime.utc_now(:second)]
     )
 
     unconfirmed = insert(:user, email_confirmed?: false)
-    create_post!(unconfirmed, %{body: "spam", tags: "elixir"})
+    create_post!(unconfirmed, %{body: "spam", tags: @elixir_tag})
 
-    assert Posts.list_tag_posts(tag_by_name("elixir")) == []
+    assert Posts.list_tag_posts(tag_by_name(@elixir_tag)) == []
   end
 
   test "a tag used only in posts (no endorsed members) still returns its posts" do
@@ -65,23 +71,23 @@ defmodule Vutuv.Posts.ListTagPostsTest do
 
   test "count_tag_posts counts only the visible posts" do
     a = author()
-    for i <- 1..3, do: create_post!(a, %{body: "post #{i}", tags: "elixir"})
+    for i <- 1..3, do: create_post!(a, %{body: "post #{i}", tags: @elixir_tag})
 
     create_post!(a, %{
       body: "hidden from strangers",
-      tags: "elixir",
+      tags: @elixir_tag,
       denials: [%{"wildcard" => "everyone"}]
     })
 
-    assert Posts.count_tag_posts(tag_by_name("elixir")) == 3
+    assert Posts.count_tag_posts(tag_by_name(@elixir_tag)) == 3
   end
 
   test "offset-paginates from the ?page param, newest first" do
     a = author()
     # Oldest -> newest; UUID v7 ids sort by creation, so p5 is newest.
-    posts = for i <- 1..5, do: create_post!(a, %{body: "post #{i}", tags: "elixir"})
+    posts = for i <- 1..5, do: create_post!(a, %{body: "post #{i}", tags: @elixir_tag})
     [_p1, p2, p3, p4, p5] = posts
-    tag = tag_by_name("elixir")
+    tag = tag_by_name(@elixir_tag)
 
     page1 = Posts.list_tag_posts(tag, %{"page" => "1"}, per_page: 2)
     page2 = Posts.list_tag_posts(tag, %{"page" => "2"}, per_page: 2)
@@ -93,7 +99,7 @@ defmodule Vutuv.Posts.ListTagPostsTest do
   end
 
   test "an empty tag returns no posts and a zero count" do
-    tag = insert(:tag, name: "lonely", slug: "lonely")
+    tag = insert(:tag)
     assert Posts.list_tag_posts(tag) == []
     assert Posts.count_tag_posts(tag) == 0
   end

--- a/test/vutuv/posts/post_search_test.exs
+++ b/test/vutuv/posts/post_search_test.exs
@@ -11,6 +11,12 @@ defmodule Vutuv.Posts.PostSearchTest do
 
   alias Vutuv.Posts
 
+  # Per-module unique tag names so async files never share a tags.slug lock
+  # (see the test guidelines in .claude/rules/elixir.md).
+  ps_mod_id = :erlang.phash2(__MODULE__, 4_294_967_296)
+  @elixir_tag "elixir-#{ps_mod_id}"
+  @ruby_tag "ruby-#{ps_mod_id}"
+
   defp author(attrs \\ []), do: insert(:activated_user, attrs)
 
   test "finds public posts by body words, any order, author preloaded" do
@@ -85,22 +91,22 @@ defmodule Vutuv.Posts.PostSearchTest do
   describe "tag: filter (issue #946)" do
     test "a bare tag filter lists posts carrying that tag, newest first" do
       a = author()
-      older = create_post!(a, %{body: "First elixir note", tags: "elixir"})
-      newer = create_post!(a, %{body: "Second elixir note", tags: "elixir"})
-      _other = create_post!(a, %{body: "A ruby note", tags: "ruby"})
+      older = create_post!(a, %{body: "First elixir note", tags: @elixir_tag})
+      newer = create_post!(a, %{body: "Second elixir note", tags: @elixir_tag})
+      _other = create_post!(a, %{body: "A ruby note", tags: @ruby_tag})
 
       # Empty body + a tag: filter is a pure tag listing.
-      ids = Posts.search_public("", tag: "elixir") |> Enum.map(& &1.id)
+      ids = Posts.search_public("", tag: @elixir_tag) |> Enum.map(& &1.id)
       assert ids == [newer.id, older.id]
     end
 
     test "combines with body words (AND)" do
       a = author()
-      match = create_post!(a, %{body: "Koblenz elixir meetup", tags: "elixir"})
-      _wrong_body = create_post!(a, %{body: "Berlin elixir meetup", tags: "elixir"})
-      _wrong_tag = create_post!(a, %{body: "Koblenz ruby meetup", tags: "ruby"})
+      match = create_post!(a, %{body: "Koblenz elixir meetup", tags: @elixir_tag})
+      _wrong_body = create_post!(a, %{body: "Berlin elixir meetup", tags: @elixir_tag})
+      _wrong_tag = create_post!(a, %{body: "Koblenz ruby meetup", tags: @ruby_tag})
 
-      assert [found] = Posts.search_public("koblenz", tag: "elixir")
+      assert [found] = Posts.search_public("koblenz", tag: @elixir_tag)
       assert found.id == match.id
     end
 
@@ -120,11 +126,11 @@ defmodule Vutuv.Posts.PostSearchTest do
 
       create_post!(a, %{
         body: "elixir for followers",
-        tags: "elixir",
+        tags: @elixir_tag,
         denials: [%{"wildcard" => "non_followers"}]
       })
 
-      assert Posts.search_public("", tag: "elixir") == []
+      assert Posts.search_public("", tag: @elixir_tag) == []
     end
   end
 end

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -147,33 +147,37 @@ defmodule Vutuv.PostsTest do
     end
 
     test "creates tags from a comma- or space-separated list, reusing tags case-insensitively" do
-      existing = insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      slug = String.downcase(name)
+      existing = insert(:tag, name: name, slug: slug)
 
       # An unquoted comma and space both still split, so "Phoenix Ecto" is two
       # tags; a quoted phrase stays one multi-word tag.
-      post = create_post!(user(), %{body: "tagged", tags: "elixir, Phoenix Ecto"})
+      post = create_post!(user(), %{body: "tagged", tags: "#{slug}, Phoenix Ecto"})
 
       tag_names = post.tags |> Enum.map(& &1.name) |> Enum.sort()
-      assert tag_names == ["Ecto", "Elixir", "Phoenix"]
+      assert tag_names == Enum.sort(["Ecto", name, "Phoenix"])
       assert Enum.any?(post.tags, &(&1.id == existing.id))
     end
 
     test "keeps a quoted phrase as one multi-word post tag" do
-      post = create_post!(user(), %{body: "tagged", tags: ~s(Elixir, "Ruby on Rails")})
+      name = unique_tag_name("Elixir")
+      post = create_post!(user(), %{body: "tagged", tags: ~s(#{name}, "Ruby on Rails")})
 
       tag_names = post.tags |> Enum.map(& &1.name) |> Enum.sort()
-      assert tag_names == ["Elixir", "Ruby on Rails"]
+      assert tag_names == Enum.sort([name, "Ruby on Rails"])
     end
 
     test "strips a leading # from post tags and reuses the bare tag" do
-      existing = insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      existing = insert(:tag, name: name, slug: String.downcase(name))
 
       # A member types the hashtag form in the composer; it stores the bare tags
       # and links #Elixir to the existing Elixir tag rather than a # duplicate.
-      post = create_post!(user(), %{body: "tagged", tags: "#Elixir #phoenix"})
+      post = create_post!(user(), %{body: "tagged", tags: "##{name} #phoenix"})
 
       tag_names = post.tags |> Enum.map(& &1.name) |> Enum.sort()
-      assert tag_names == ["Elixir", "phoenix"]
+      assert tag_names == Enum.sort([name, "phoenix"])
       assert Enum.any?(post.tags, &(&1.id == existing.id))
     end
 
@@ -814,10 +818,11 @@ defmodule Vutuv.PostsTest do
     test "surfaces a followed tag's posts from authors the viewer doesn't follow (#872)" do
       viewer = user()
       stranger = user()
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
       Vutuv.Tags.follow_tag(viewer, tag)
 
-      tagged = create_post!(stranger, %{body: "elixir news", tags: "elixir"})
+      tagged = create_post!(stranger, %{body: "elixir news", tags: String.downcase(name)})
       create_post!(stranger, %{body: "no tag here"})
 
       ids = Posts.feed_page(viewer).entries |> Enum.map(& &1.post.id)
@@ -828,10 +833,11 @@ defmodule Vutuv.PostsTest do
       viewer = user()
       friend = user()
       follow!(viewer, friend)
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
       Vutuv.Tags.follow_tag(viewer, tag)
 
-      post = create_post!(friend, %{body: "elixir by a friend", tags: "elixir"})
+      post = create_post!(friend, %{body: "elixir by a friend", tags: String.downcase(name)})
 
       entries = Posts.feed_page(viewer).entries
       assert Enum.count(entries, &(&1.post.id == post.id)) == 1
@@ -841,33 +847,36 @@ defmodule Vutuv.PostsTest do
       viewer = user()
       noisy = user()
       follow!(viewer, noisy)
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
       Vutuv.Tags.follow_tag(viewer, tag)
 
       fid = Vutuv.Social.follow_id(viewer.id, noisy.id)
       Vutuv.Social.toggle_follow_mute!(viewer.id, fid)
 
-      post = create_post!(noisy, %{body: "muted elixir", tags: "elixir"})
+      post = create_post!(noisy, %{body: "muted elixir", tags: String.downcase(name)})
       refute post.id in (Posts.feed_page(viewer).entries |> Enum.map(& &1.post.id))
     end
 
     test "a blocked author's tagged post never enters the feed via a followed tag (#872)" do
       viewer = user()
       blocked = user()
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
       Vutuv.Tags.follow_tag(viewer, tag)
       {:ok, _} = Vutuv.Social.block_user(viewer, blocked)
 
-      post = create_post!(blocked, %{body: "blocked elixir", tags: "elixir"})
+      post = create_post!(blocked, %{body: "blocked elixir", tags: String.downcase(name)})
       refute post.id in (Posts.feed_page(viewer).entries |> Enum.map(& &1.post.id))
     end
 
     test "an unfollowed tag's posts do not appear (#872)" do
       viewer = user()
       stranger = user()
-      insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      insert(:tag, name: name, slug: String.downcase(name))
 
-      tagged = create_post!(stranger, %{body: "elixir news", tags: "elixir"})
+      tagged = create_post!(stranger, %{body: "elixir news", tags: String.downcase(name)})
 
       refute tagged.id in (Posts.feed_page(viewer).entries |> Enum.map(& &1.post.id))
     end
@@ -1153,7 +1162,7 @@ defmodule Vutuv.PostsTest do
       post =
         create_post!(author, %{
           body: "v1",
-          tags: "elixir",
+          tags: unique_tag_name("elixir"),
           denials: [%{"wildcard" => "everyone"}]
         })
 
@@ -1207,7 +1216,7 @@ defmodule Vutuv.PostsTest do
       post =
         create_post!(author, %{
           body: "bye",
-          tags: "elixir",
+          tags: unique_tag_name("elixir"),
           image_ids: [image.id],
           denials: [%{"wildcard" => "everyone"}]
         })

--- a/test/vutuv/search_test.exs
+++ b/test/vutuv/search_test.exs
@@ -117,14 +117,16 @@ defmodule Vutuv.SearchTest do
     end
 
     test "tags match by name or slug prefix, case-insensitively" do
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
-      insert(:tag, name: "Cooking", slug: "cooking")
+      name = unique_tag_name("Elixir")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
+      insert(:tag)
 
       assert Enum.map(Search.instant("eLi").tags, & &1.id) == [tag.id]
     end
 
     test "the tag member count excludes unactivated and moderation-hidden members" do
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
 
       visible = searchable_user("Vera", "Visible")
       unactivated = insert(:user, email_confirmed?: false)
@@ -260,7 +262,8 @@ defmodule Vutuv.SearchTest do
     end
 
     test "status combines with a tag filter", ctx do
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
       insert(:user_tag, tag: tag, user: ctx.looking)
       # A looking member without the tag must not match.
       insert(:activated_user,
@@ -268,7 +271,7 @@ defmodule Vutuv.SearchTest do
         employment_status_visibility: "members"
       )
 
-      results = Search.instant("status:looking tag:elixir", viewer: ctx.viewer)
+      results = Search.instant("status:looking tag:#{tag.slug}", viewer: ctx.viewer)
       assert Enum.map(results.exact_people, & &1.id) == [ctx.looking.id]
     end
   end
@@ -301,7 +304,7 @@ defmodule Vutuv.SearchTest do
     end
 
     test "@handle searches the username" do
-      user = insert(:activated_user, username: "stefan.wintermeyer")
+      user = insert(:activated_user, username: "stefan.w#{System.unique_integer([:positive])}")
       insert(:activated_user, username: "unrelated")
 
       results = Search.instant("@stefan")
@@ -310,14 +313,15 @@ defmodule Vutuv.SearchTest do
     end
 
     test "tag: lists people with that tag, not the tag itself" do
-      tag = insert(:tag, name: "PHP", slug: "php")
+      name = unique_tag_name("PHP")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
       with_tag = insert(:activated_user, first_name: "Paula", last_name: "Programmer")
       insert(:user_tag, tag: tag, user: with_tag)
       insert(:activated_user, first_name: "Norbert", last_name: "NoTag")
       author = insert(:activated_user)
-      Vutuv.PostsHelpers.create_post!(author, %{body: "All about php"})
+      Vutuv.PostsHelpers.create_post!(author, %{body: "All about #{tag.slug}"})
 
-      results = Search.instant("tag:php")
+      results = Search.instant("tag:#{tag.slug}")
 
       assert Enum.map(results.exact_people, & &1.id) == [with_tag.id]
       assert results.tags == []
@@ -325,26 +329,30 @@ defmodule Vutuv.SearchTest do
     end
 
     test "a name combines with the tag filter" do
-      php_tag = insert(:tag, name: "PHP", slug: "php")
+      name = unique_tag_name("PHP")
+      php_tag = insert(:tag, name: name, slug: String.downcase(name))
       php_mueller = searchable_user("Hans", "Müller")
       insert(:user_tag, tag: php_tag, user: php_mueller)
       searchable_user("Heike", "Müller")
 
-      results = Search.instant("müller tag:php")
+      results = Search.instant("müller tag:#{php_tag.slug}")
 
       assert Enum.map(results.exact_people, & &1.id) == [php_mueller.id]
     end
 
     test "tag: also finds posts carrying that tag, matching the tag not the body (issue #946)" do
-      tag = insert(:tag, name: "PHP", slug: "php")
+      name = unique_tag_name("PHP")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
       with_tag = insert(:activated_user)
       insert(:user_tag, tag: tag, user: with_tag)
 
       author = insert(:activated_user)
-      tagged = Vutuv.PostsHelpers.create_post!(author, %{body: "My write-up", tags: "php"})
-      _untagged = Vutuv.PostsHelpers.create_post!(author, %{body: "php but not tagged"})
+      tagged = Vutuv.PostsHelpers.create_post!(author, %{body: "My write-up", tags: tag.slug})
 
-      results = Search.instant("tag:php")
+      _untagged =
+        Vutuv.PostsHelpers.create_post!(author, %{body: "#{tag.slug} but not tagged"})
+
+      results = Search.instant("tag:#{tag.slug}")
 
       # People AND posts both respond to the tag filter now; the untagged post
       # that merely mentions "php" in its body stays out.
@@ -353,14 +361,15 @@ defmodule Vutuv.SearchTest do
     end
 
     test "the Posts scope with a tag: filter returns only posts" do
-      tag = insert(:tag, name: "PHP", slug: "php")
+      name = unique_tag_name("PHP")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
       with_tag = insert(:activated_user)
       insert(:user_tag, tag: tag, user: with_tag)
 
       tagged =
-        Vutuv.PostsHelpers.create_post!(insert(:activated_user), %{body: "hi", tags: "php"})
+        Vutuv.PostsHelpers.create_post!(insert(:activated_user), %{body: "hi", tags: tag.slug})
 
-      results = Search.instant("tag:php", scope: :posts)
+      results = Search.instant("tag:#{tag.slug}", scope: :posts)
 
       assert results.exact_people == []
       assert Enum.map(results.posts, & &1.id) == [tagged.id]
@@ -398,18 +407,20 @@ defmodule Vutuv.SearchTest do
     end
 
     test "tags carry their member counts" do
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
       insert(:user_tag, tag: tag, user: insert(:activated_user))
       insert(:user_tag, tag: tag, user: insert(:activated_user))
 
-      results = Search.instant("elixir")
+      results = Search.instant(tag.slug)
 
       assert results.tag_member_counts[tag.id] == 2
     end
 
     test "the scope filter limits what is searched" do
       searchable_user("Elia", "Tester")
-      insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      insert(:tag, name: name, slug: String.downcase(name))
       author = insert(:activated_user)
       Vutuv.PostsHelpers.create_post!(author, %{body: "All about elixir and more"})
 

--- a/test/vutuv/tags/user_tag_test.exs
+++ b/test/vutuv/tags/user_tag_test.exs
@@ -14,7 +14,7 @@ defmodule Vutuv.Tags.UserTagTest do
 
   setup do
     user = insert(:user)
-    tag = insert(:tag, name: "Elixir", slug: "elixir")
+    tag = insert(:tag)
     user_tag = insert(:user_tag, user: user, tag: tag)
     # Reload bare (tag not loaded) to model the unconverted callers.
     unloaded = Repo.get!(UserTag, user_tag.id)
@@ -23,25 +23,29 @@ defmodule Vutuv.Tags.UserTagTest do
 
   describe "name/1" do
     test "reads the tag name from an unloaded struct (preloads as a fallback)", %{
+      tag: tag,
       unloaded: unloaded
     } do
       assert match?(%Ecto.Association.NotLoaded{}, unloaded.tag)
-      assert UserTag.name(unloaded) == "Elixir"
+      assert UserTag.name(unloaded) == tag.name
     end
 
-    test "reads the tag name from a preloaded struct without a query", %{unloaded: unloaded} do
+    test "reads the tag name from a preloaded struct without a query", %{
+      tag: tag,
+      unloaded: unloaded
+    } do
       preloaded = Repo.preload(unloaded, :tag)
 
       {result, count} = count_queries(fn -> UserTag.name(preloaded) end)
-      assert result == "Elixir"
+      assert result == tag.name
       assert count == 0
     end
   end
 
   describe "truncated_name/1" do
-    test "works on a preloaded struct", %{unloaded: unloaded} do
+    test "works on a preloaded struct", %{tag: tag, unloaded: unloaded} do
       preloaded = Repo.preload(unloaded, :tag)
-      assert UserTag.truncated_name(preloaded) == "Elixir"
+      assert UserTag.truncated_name(preloaded) == tag.name
     end
 
     test "truncates long names", %{tag: tag} do
@@ -57,15 +61,18 @@ defmodule Vutuv.Tags.UserTagTest do
   end
 
   describe "Phoenix.Param.to_param/1" do
-    test "returns the tag slug for an unloaded struct", %{unloaded: unloaded} do
-      assert Phoenix.Param.to_param(unloaded) == "elixir"
+    test "returns the tag slug for an unloaded struct", %{tag: tag, unloaded: unloaded} do
+      assert Phoenix.Param.to_param(unloaded) == tag.slug
     end
 
-    test "returns the tag slug for a preloaded struct without a query", %{unloaded: unloaded} do
+    test "returns the tag slug for a preloaded struct without a query", %{
+      tag: tag,
+      unloaded: unloaded
+    } do
       preloaded = Repo.preload(unloaded, :tag)
 
       {result, count} = count_queries(fn -> Phoenix.Param.to_param(preloaded) end)
-      assert result == "elixir"
+      assert result == tag.slug
       assert count == 0
     end
   end

--- a/test/vutuv/tags_test.exs
+++ b/test/vutuv/tags_test.exs
@@ -16,8 +16,9 @@ defmodule Vutuv.TagsTest do
     end
 
     test "links to an existing tag whose name matches case-insensitively" do
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
-      changeset = link("elixir")
+      name = unique_tag_name("Elixir")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
+      changeset = link(String.downcase(name))
       assert get_change(changeset, :tag_id) == tag.id
     end
 
@@ -41,8 +42,9 @@ defmodule Vutuv.TagsTest do
     end
 
     test "resolving the same new value twice is idempotent (one row, no unique-violation race)" do
-      first = get_change(link("Elixir"), :tag_id)
-      second = get_change(link("elixir"), :tag_id)
+      name = unique_tag_name("Elixir")
+      first = get_change(link(name), :tag_id)
+      second = get_change(link(String.downcase(name)), :tag_id)
 
       assert first == second
       assert Repo.aggregate(Tag, :count) == 1
@@ -64,20 +66,23 @@ defmodule Vutuv.TagsTest do
       # Multi-word tags are first-class again: a spaced value attaches the
       # existing spaced tag (matched case-insensitively by name), it does not
       # mint a duplicate.
-      tag = insert(:tag, name: "Ruby on Rails", slug: "ruby-on-rails")
+      name = unique_tag_name("Ruby on Rails")
+      slug = name |> String.downcase() |> String.replace(" ", "-")
+      tag = insert(:tag, name: name, slug: slug)
 
-      changeset = link("ruby on rails")
+      changeset = link(String.downcase(name))
       assert get_change(changeset, :tag_id) == tag.id
     end
 
     test "a multi-word value with no match creates one spaced tag and links it" do
-      changeset = link("Ruby on Rails")
+      name = unique_tag_name("Ruby on Rails")
+      changeset = link(name)
 
       tag_id = get_change(changeset, :tag_id)
       assert tag_id
 
       tag = Repo.get!(Tag, tag_id)
-      assert tag.name == "Ruby on Rails"
+      assert tag.name == name
       assert tag.slug =~ "ruby"
     end
   end
@@ -123,10 +128,12 @@ defmodule Vutuv.TagsTest do
     end
 
     test "the admin edit form can recapitalize a legacy lowercase name" do
-      tag = insert(:tag, name: "elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      legacy = String.downcase(name)
+      tag = insert(:tag, name: legacy, slug: legacy)
 
-      assert {:ok, updated} = tag |> Tag.edit_changeset(%{"name" => "Elixir"}) |> Repo.update()
-      assert updated.name == "Elixir"
+      assert {:ok, updated} = tag |> Tag.edit_changeset(%{"name" => name}) |> Repo.update()
+      assert updated.name == name
     end
   end
 
@@ -250,21 +257,23 @@ defmodule Vutuv.TagsTest do
     end
 
     test "create_or_link_tag links #Elixir to the existing Elixir tag" do
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
 
       changeset =
-        %UserTag{} |> change(%{}) |> Tag.create_or_link_tag(%{"value" => "#Elixir"})
+        %UserTag{} |> change(%{}) |> Tag.create_or_link_tag(%{"value" => "#" <> name})
 
       assert get_change(changeset, :tag_id) == tag.id
     end
 
     test "add_user_tag stores #elixir as the tag elixir" do
       user = insert(:user)
+      name = unique_tag_name("elixir")
 
-      assert {:ok, user_tag} = Tags.add_user_tag(user, "#elixir")
+      assert {:ok, user_tag} = Tags.add_user_tag(user, "#" <> name)
       tag = Repo.preload(user_tag, :tag).tag
-      assert tag.name == "elixir"
-      assert tag.slug == "elixir"
+      assert tag.name == name
+      assert tag.slug == name
     end
 
     test "add_user_tag keeps a trailing # (C# stays C#)" do
@@ -311,46 +320,50 @@ defmodule Vutuv.TagsTest do
   describe "add_user_tag/2 stores multi-word tags" do
     test "a multi-word name is stored as one spaced tag" do
       user = insert(:user)
+      name = unique_tag_name("Ruby on Rails")
 
-      assert {:ok, user_tag} = Tags.add_user_tag(user, "Ruby on Rails")
+      assert {:ok, user_tag} = Tags.add_user_tag(user, name)
       tag = Repo.preload(user_tag, :tag).tag
-      assert tag.name == "Ruby on Rails"
+      assert tag.name == name
       assert tag.slug =~ "ruby"
     end
 
     test "a later member linking a spaced tag keeps the first spelling" do
       first = insert(:user)
       later = insert(:user)
+      name = unique_tag_name("Ruby on Rails")
 
-      assert {:ok, ut1} = Tags.add_user_tag(first, "Ruby on Rails")
+      assert {:ok, ut1} = Tags.add_user_tag(first, name)
       tag = Repo.preload(ut1, :tag).tag
 
-      assert {:ok, ut2} = Tags.add_user_tag(later, "ruby on rails")
+      assert {:ok, ut2} = Tags.add_user_tag(later, String.downcase(name))
       assert Repo.preload(ut2, :tag).tag.id == tag.id
       assert Repo.aggregate(Tag, :count) == 1
     end
 
     test "a single-word name is stored" do
       user = insert(:user)
+      name = unique_tag_name("Elixir")
 
-      assert {:ok, user_tag} = Tags.add_user_tag(user, "Elixir")
-      assert Repo.preload(user_tag, :tag).tag.name == "Elixir"
+      assert {:ok, user_tag} = Tags.add_user_tag(user, name)
+      assert Repo.preload(user_tag, :tag).tag.name == name
     end
 
     test "collapses stray whitespace runs into single spaces" do
       user = insert(:user)
+      suffix = System.unique_integer([:positive])
 
-      assert {:ok, user_tag} = Tags.add_user_tag(user, "Ruby\non   Rails")
-      assert Repo.preload(user_tag, :tag).tag.name == "Ruby on Rails"
+      assert {:ok, user_tag} = Tags.add_user_tag(user, "Ruby\non   Rails-#{suffix}")
+      assert Repo.preload(user_tag, :tag).tag.name == "Ruby on Rails-#{suffix}"
     end
   end
 
   describe "user_tags" do
     test "UserTag.name/1 returns the tag's name" do
       user = insert(:user)
-      tag = insert(:tag, name: "Elixir")
+      tag = insert(:tag)
       user_tag = insert(:user_tag, user: user, tag: tag)
-      assert UserTag.name(user_tag) == "Elixir"
+      assert UserTag.name(user_tag) == tag.name
     end
   end
 
@@ -484,9 +497,10 @@ defmodule Vutuv.TagsTest do
 
     test "add_user_tag/2 refuses a reserved (honor) tag" do
       user = insert(:user)
-      insert(:tag, name: "vutuv_developer", slug: "vutuv_developer", honor?: true)
+      name = unique_tag_name("vutuv_developer")
+      insert(:tag, name: name, slug: name, honor?: true)
 
-      assert {:error, changeset} = Tags.add_user_tag(user, "vutuv_developer")
+      assert {:error, changeset} = Tags.add_user_tag(user, name)
       assert %{tag_id: [_ | _]} = errors_on(changeset)
       # Nothing was inserted for this member.
       refute Repo.exists?(from(ut in UserTag, where: ut.user_id == ^user.id))
@@ -494,17 +508,19 @@ defmodule Vutuv.TagsTest do
 
     test "add_user_tag/2 refuses a reserved tag matched case-insensitively" do
       user = insert(:user)
-      insert(:tag, name: "vutuv_developer", slug: "vutuv_developer", honor?: true)
+      name = unique_tag_name("vutuv_developer")
+      insert(:tag, name: name, slug: name, honor?: true)
 
-      assert {:error, _changeset} = Tags.add_user_tag(user, "Vutuv_Developer")
+      assert {:error, _changeset} = Tags.add_user_tag(user, String.upcase(name))
       refute Repo.exists?(from(ut in UserTag, where: ut.user_id == ^user.id))
     end
 
     test "add_user_tag/2 still links a normal (not honor) existing tag" do
       user = insert(:user)
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
 
-      assert {:ok, user_tag} = Tags.add_user_tag(user, "elixir")
+      assert {:ok, user_tag} = Tags.add_user_tag(user, String.downcase(name))
       assert user_tag.tag_id == tag.id
     end
 
@@ -583,25 +599,28 @@ defmodule Vutuv.TagsTest do
     end
 
     test "declare_honor_tag/1 flips an existing holder-less tag" do
-      existing = insert(:tag, name: "mentor", slug: "mentor")
+      name = unique_tag_name("mentor")
+      existing = insert(:tag, name: name, slug: name)
 
-      assert {:ok, tag} = Tags.declare_honor_tag("Mentor")
+      assert {:ok, tag} = Tags.declare_honor_tag(String.capitalize(name))
       assert tag.id == existing.id
       assert tag.honor?
     end
 
     test "declare_honor_tag/1 is idempotent on an existing honor tag" do
-      existing = insert(:tag, name: "mentor", slug: "mentor", honor?: true)
+      name = unique_tag_name("mentor")
+      existing = insert(:tag, name: name, slug: name, honor?: true)
 
-      assert {:ok, tag} = Tags.declare_honor_tag("mentor")
+      assert {:ok, tag} = Tags.declare_honor_tag(name)
       assert tag.id == existing.id
     end
 
     test "declare_honor_tag/1 refuses to silently flip a tag members already hold" do
-      existing = insert(:tag, name: "elixir", slug: "elixir")
+      name = unique_tag_name("elixir")
+      existing = insert(:tag, name: name, slug: name)
       insert(:user_tag, user: insert(:user), tag: existing)
 
-      assert {:error, :has_holders, tag} = Tags.declare_honor_tag("elixir")
+      assert {:error, :has_holders, tag} = Tags.declare_honor_tag(name)
       assert tag.id == existing.id
       refute Repo.reload(existing).honor?
     end
@@ -629,7 +648,7 @@ defmodule Vutuv.TagsTest do
       owner = insert(:user, email_confirmed?: true)
 
       # A self-assigned tag with several visible endorsements.
-      popular = insert(:user_tag, user: owner, tag: insert(:tag, name: "Elixir", slug: "elixir"))
+      popular = insert(:user_tag, user: owner, tag: insert(:tag))
 
       for _ <- 1..3 do
         insert(:user_tag_endorsement,
@@ -642,7 +661,7 @@ defmodule Vutuv.TagsTest do
       honor =
         insert(:user_tag,
           user: owner,
-          tag: insert(:tag, name: "Vutuv Developer", slug: "vutuv_developer", honor?: true)
+          tag: insert(:tag, honor?: true)
         )
 
       ordered =
@@ -772,10 +791,11 @@ defmodule Vutuv.TagsTest do
     end
 
     test "leaves a clean multi-word name untouched and is idempotent" do
-      tag = insert(:tag, name: "Ruby on Rails", slug: "ruby_on_rails")
+      name = unique_tag_name("Ruby on Rails")
+      tag = insert(:tag, name: name, slug: name |> String.downcase() |> String.replace(" ", "_"))
 
       assert {0, 0} = Tags.normalize_legacy_tag_whitespace()
-      assert Repo.get(Tag, tag.id).name == "Ruby on Rails"
+      assert Repo.get(Tag, tag.id).name == name
 
       # A second pass finds nothing to do.
       assert {0, 0} = Tags.normalize_legacy_tag_whitespace()

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -101,7 +101,8 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     insert(:address, user: user, description: "Office", city: "Berlin", zip_code: "10115")
     insert(:social_media_account, user: user, provider: "GitHub", value: "gretagradient")
 
-    tag = insert(:tag, name: "Bridgebuilding", slug: "bridgebuilding")
+    tag_name = unique_tag_name("Bridgebuilding")
+    tag = insert(:tag, name: tag_name, slug: String.downcase(tag_name))
     insert(:user_tag, user: user, tag: tag)
 
     follower = insert_activated_user(first_name: "Fanny", last_name: "Follower")
@@ -130,7 +131,8 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     end
   end
 
-  test "profile: every public fact appears in HTML, Markdown, text and JSON", %{user: user} do
+  test "profile: every public fact appears in HTML, Markdown, text and JSON",
+       %{user: user, tag: tag} do
     rendered = formats_for("/drift_tester")
 
     facts = [
@@ -155,7 +157,7 @@ defmodule VutuvWeb.AgentDocsDriftTest do
       "Handwerkskammer Brückenstadt",
       "Gesellenbrief",
       # tags
-      "Bridgebuilding",
+      tag.name,
       # languages (issue #865): the localized name and the proficiency both
       # appear in every format (HTML badge "Native", md/txt "French: Native",
       # JSON/XML the raw "native" proficiency)
@@ -422,17 +424,17 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     # tag must surface in the HTML page and every agent format.
     Vutuv.JobsHelpers.publish_job!(nil, %{
       "title" => "Bridge Architect (m/w/d)",
-      "required_tags" => "Bridgebuilding"
+      "required_tags" => tag.name
     })
 
     # "Posts with this tag" (#946): a public post carrying the tag surfaces on
     # the HTML page and in every agent format.
-    create_post!(user, %{body: "Spanning the great divide today", tags: "Bridgebuilding"})
+    create_post!(user, %{body: "Spanning the great divide today", tags: tag.name})
 
-    rendered = formats_for("/tags/bridgebuilding")
+    rendered = formats_for("/tags/#{tag.slug}")
 
     for fact <- [
-          "Bridgebuilding",
+          tag.name,
           "connecting shores",
           "Greta Gradient",
           "Bridge Architect",
@@ -441,11 +443,11 @@ defmodule VutuvWeb.AgentDocsDriftTest do
         do: assert_fact_everywhere(rendered, fact)
   end
 
-  test "most followed listing in every format" do
+  test "most followed listing in every format", %{tag: tag} do
     rendered = formats_for("/listings/most_followed_users")
     assert_fact_everywhere(rendered, "Greta Gradient")
     # Each listed member's tags ride along in every format, like their name.
-    assert_fact_everywhere(rendered, "Bridgebuilding")
+    assert_fact_everywhere(rendered, tag.name)
     assert Jason.decode!(rendered.json)["type"] == "listing"
   end
 
@@ -459,16 +461,16 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert Jason.decode!(rendered.json)["type"] == "directory"
   end
 
-  test "member directory letter page in every format" do
+  test "member directory letter page in every format", %{tag: tag} do
     rendered = formats_for("/system/members/g")
 
     assert_fact_everywhere(rendered, "Greta Gradient")
     # Each listed member's tags ride along in every format, like their name.
-    assert_fact_everywhere(rendered, "Bridgebuilding")
+    assert_fact_everywhere(rendered, tag.name)
     assert Jason.decode!(rendered.json)["type"] == "listing"
   end
 
-  test "every profile section page serves its facts in all formats" do
+  test "every profile section page serves its facts in all formats", %{tag: tag} do
     facts = %{
       work_experiences: ["Bridge Engineer", "Span AG", "Building things"],
       educations: [
@@ -484,7 +486,7 @@ defmodule VutuvWeb.AgentDocsDriftTest do
       addresses: ["Berlin", "10115"],
       phone_numbers: ["+49 30 5550100"],
       emails: ["greta.public@example.com"],
-      tags: ["Bridgebuilding"]
+      tags: [tag.name]
     }
 
     # The loop runs over the SectionDocs registry itself, so a new section
@@ -510,7 +512,7 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert get_resp_header(conn, "x-robots-tag") == ["noindex, noai, noimageai"]
   end
 
-  test "a single section entry page serves all formats", %{user: user} do
+  test "a single section entry page serves all formats", %{user: user, tag: tag} do
     work =
       Repo.one!(
         from(w in Ecto.assoc(user, :work_experiences), where: w.title == "Bridge Engineer")
@@ -544,8 +546,8 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     rendered = formats_for("/drift_tester/links/#{url.id}")
     assert_fact_everywhere(rendered, "bridges.example.org")
 
-    rendered = formats_for("/drift_tester/tags/bridgebuilding")
-    assert_fact_everywhere(rendered, "Bridgebuilding")
+    rendered = formats_for("/drift_tester/tags/#{tag.slug}")
+    assert_fact_everywhere(rendered, tag.name)
     assert Jason.decode!(rendered.json)["type"] == "user_tag"
   end
 
@@ -594,7 +596,7 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert doc["type"] == "tag_endorsers"
     assert doc["total"] == 1
     # The list names the tag it belongs to.
-    assert_fact_everywhere(rendered, "Bridgebuilding")
+    assert_fact_everywhere(rendered, tag.name)
 
     # Each row carries when the endorsement was cast. The date (YYYY-MM-DD)
     # appears in every format: the HTML <time> fallback, the md/txt "(endorsed
@@ -656,18 +658,28 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     user = insert_activated_user(username: "sorted_skills")
     endorser = insert_activated_user()
 
-    for {name, slug} <- [{"Beta", "beta"}, {"Alpha", "alpha"}, {"Gamma", "gamma"}] do
-      insert(:user_tag, user: user, tag: insert(:tag, name: name, slug: slug))
+    # Unique suffixes keep the alphabetical tie order (Alpha-* < Beta-*).
+    beta = unique_tag_name("Beta")
+    alpha = unique_tag_name("Alpha")
+    gamma = unique_tag_name("Gamma")
+
+    for name <- [beta, alpha, gamma] do
+      insert(:user_tag, user: user, tag: insert(:tag, name: name, slug: String.downcase(name)))
     end
 
-    [gamma] =
-      Repo.all(from(u in Vutuv.Tags.UserTag, join: t in assoc(u, :tag), where: t.slug == "gamma"))
+    [gamma_ut] =
+      Repo.all(
+        from(u in Vutuv.Tags.UserTag,
+          join: t in assoc(u, :tag),
+          where: t.slug == ^String.downcase(gamma)
+        )
+      )
 
-    insert(:user_tag_endorsement, user_tag: gamma, user: endorser)
+    insert(:user_tag_endorsement, user_tag: gamma_ut, user: endorser)
 
     doc = Jason.decode!(get(build_conn(), "/sorted_skills.json").resp_body)
 
-    assert Enum.map(doc["tags"], & &1["name"]) == ["Gamma", "Alpha", "Beta"]
+    assert Enum.map(doc["tags"], & &1["name"]) == [gamma, alpha, beta]
   end
 
   test "?lang=de translates the labels, English stays the default" do
@@ -737,22 +749,26 @@ defmodule VutuvWeb.AgentDocsDriftTest do
   end
 
   test "a job posting appears in every format" do
+    # publish_job! creates real tag rows from required_tags, so the names must
+    # be unique across async files (markdown_hashtags_test.exs mints "Elixir").
+    phoenix = unique_tag_name("Phoenix")
+
     posting =
       Vutuv.JobsHelpers.publish_job!(nil, %{
         "title" => "Elixir Engineer (m/w/d)",
-        "required_tags" => "Elixir, Phoenix"
+        "required_tags" => "#{unique_tag_name("Elixir")}, #{phoenix}"
       })
 
     rendered = formats_for("/jobs/#{posting.slug}")
     assert_fact_everywhere(rendered, "Elixir Engineer")
     assert_fact_everywhere(rendered, "Köln")
-    assert_fact_everywhere(rendered, "Phoenix")
+    assert_fact_everywhere(rendered, phoenix)
   end
 
   test "the job board appears in every format" do
     Vutuv.JobsHelpers.publish_job!(nil, %{
       "title" => "Board Tester Role",
-      "required_tags" => "Elixir"
+      "required_tags" => unique_tag_name("Elixir")
     })
 
     rendered = formats_for("/jobs")

--- a/test/vutuv_web/agent_docs/agent_format_test.exs
+++ b/test/vutuv_web/agent_docs/agent_format_test.exs
@@ -111,10 +111,13 @@ defmodule VutuvWeb.AgentFormatTest do
     end
 
     test "slugs containing dots keep working, with and without extension" do
-      insert_activated_user(username: "stefan.wintermeyer", first_name: "Stefan")
+      # The dot in the handle is the point of this test: it must survive the
+      # extension stripping, so the unique handle keeps one.
+      handle = "stefan.w#{System.unique_integer([:positive])}"
+      insert_activated_user(username: handle, first_name: "Stefan")
 
-      assert get(build_conn(), "/stefan.wintermeyer") |> html_response(200) =~ "Stefan"
-      conn = get(build_conn(), "/stefan.wintermeyer.md")
+      assert get(build_conn(), "/#{handle}") |> html_response(200) =~ "Stefan"
+      conn = get(build_conn(), "/#{handle}.md")
       assert conn.status == 200
       assert conn.resp_body =~ "# Stefan Test"
     end
@@ -218,9 +221,9 @@ defmodule VutuvWeb.AgentFormatTest do
     end
 
     test "YAML frontmatter keeps interpolation-looking text literal", %{user: _user} do
-      insert(:tag, name: "Sharp", slug: "sharp", description: ~S(Costs #{n} euros))
+      tag = insert(:tag, description: ~S(Costs #{n} euros))
 
-      body = get(build_conn(), "/tags/sharp.md").resp_body
+      body = get(build_conn(), "/tags/#{tag.slug}.md").resp_body
 
       assert body =~ ~S(description: "Costs #{n} euros")
       # inspect/1 would have produced an invalid YAML escape here.
@@ -292,8 +295,8 @@ defmodule VutuvWeb.AgentFormatTest do
     end
 
     test "an extension the page does not support 404s (no .vcf for tags)" do
-      insert(:tag, name: "Elixir", slug: "elixir")
-      assert get(build_conn(), "/tags/elixir.vcf").status == 404
+      tag = insert(:tag)
+      assert get(build_conn(), "/tags/#{tag.slug}.vcf").status == 404
     end
 
     test "robots.txt and llms.txt are not mistaken for agent formats" do

--- a/test/vutuv_web/agent_docs/markdown_format_test.exs
+++ b/test/vutuv_web/agent_docs/markdown_format_test.exs
@@ -42,7 +42,7 @@ defmodule VutuvWeb.AgentDocs.MarkdownFormatTest do
     test "a noindexed profile emits the real key, still no bare false" do
       # Only noindex?: setting both flags blocks the agent docs entirely
       # (AgentExportOptOut), so a rendered profile doc never carries both.
-      user = insert_activated_user(username: "opted_out", noindex?: true, noai?: false)
+      user = insert_activated_user(noindex?: true, noai?: false)
       yaml = frontmatter(get(build_conn(), "/#{user.username}.md").resp_body)
 
       assert yaml =~ "noindex: true"
@@ -133,14 +133,18 @@ defmodule VutuvWeb.AgentDocs.MarkdownFormatTest do
 
   describe "list items are blank-line separated (#925)" do
     test "consecutive profile tags are separated by a blank line", %{user: user} do
-      for {name, slug} <- [{"alpha", "alpha"}, {"beta", "beta"}] do
-        insert(:user_tag, user: user, tag: insert(:tag, name: name, slug: slug))
+      # Unique suffixes keep the alphabetical order (alpha-* < beta-*).
+      alpha = unique_tag_name("alpha")
+      beta = unique_tag_name("beta")
+
+      for name <- [alpha, beta] do
+        insert(:user_tag, user: user, tag: insert(:tag, name: name, slug: name))
       end
 
       body = get(build_conn(), "/#{user.username}.md").resp_body
 
       # Two adjacent `- [tag]` items with a blank line between them.
-      assert body =~ ~r/^- \[alpha\].*\n\n- \[beta\]/m
+      assert body =~ ~r/^- \[#{alpha}\].*\n\n- \[#{beta}\]/m
     end
 
     test "a section index page separates its entries with a blank line", %{user: user} do

--- a/test/vutuv_web/controllers/admin/honor_tag_controller_test.exs
+++ b/test/vutuv_web/controllers/admin/honor_tag_controller_test.exs
@@ -17,13 +17,13 @@ defmodule VutuvWeb.Admin.HonorTagControllerTest do
     test "index lists honor tags and links to the create form", %{conn: conn} do
       # A distinct name, not the "vutuv_developer" the intro/placeholder mention.
       insert(:tag, name: "vutuv_council", slug: "vutuv-council", honor?: true)
-      insert(:tag, name: "elixir", slug: "elixir")
+      normal_tag = insert(:tag)
 
       html = conn |> get(~p"/admin/honor_tags") |> html_response(200)
 
       assert html =~ "vutuv_council"
       # A normal tag does not show here.
-      refute html =~ ">elixir<"
+      refute html =~ ">#{normal_tag.name}<"
       # The one-step create form posts to this page.
       assert html =~ ~s(action="/admin/honor_tags")
     end
@@ -37,22 +37,24 @@ defmodule VutuvWeb.Admin.HonorTagControllerTest do
     end
 
     test "creating flips an existing holder-less tag", %{conn: conn} do
-      tag = insert(:tag, name: "mentor", slug: "mentor")
+      name = unique_tag_name("mentor")
+      tag = insert(:tag, name: name, slug: name)
 
-      conn = post(conn, ~p"/admin/honor_tags", honor_tag: %{name: "mentor"})
+      conn = post(conn, ~p"/admin/honor_tags", honor_tag: %{name: name})
 
-      assert redirected_to(conn) == ~p"/admin/tags/mentor"
+      assert redirected_to(conn) == ~p"/admin/tags/#{name}"
       assert Repo.reload(tag).honor?
     end
 
     test "creating a name members already hold routes to the edit warning, not a silent flip",
          %{conn: conn} do
-      tag = insert(:tag, name: "elixir", slug: "elixir")
+      name = unique_tag_name("elixir")
+      tag = insert(:tag, name: name, slug: name)
       insert(:user_tag, user: insert(:user), tag: tag)
 
-      conn = post(conn, ~p"/admin/honor_tags", honor_tag: %{name: "elixir"})
+      conn = post(conn, ~p"/admin/honor_tags", honor_tag: %{name: name})
 
-      assert redirected_to(conn) == ~p"/admin/tags/elixir/edit"
+      assert redirected_to(conn) == ~p"/admin/tags/#{name}/edit"
       refute Repo.reload(tag).honor?
     end
 

--- a/test/vutuv_web/controllers/admin/tag_controller_test.exs
+++ b/test/vutuv_web/controllers/admin/tag_controller_test.exs
@@ -14,7 +14,7 @@ defmodule VutuvWeb.Admin.TagControllerTest do
 
   describe "index (no slug param)" do
     test "renders the admin tag listing", %{conn: conn} do
-      insert(:tag, name: "Elixir", slug: "elixir")
+      insert(:tag)
       conn = get(conn, ~p"/admin/tags")
       assert conn.status == 200
     end
@@ -35,12 +35,14 @@ defmodule VutuvWeb.Admin.TagControllerTest do
 
   describe "search" do
     test "filters the listing by name (case-insensitive substring)", %{conn: conn} do
-      insert(:tag, name: "Elixir", slug: "elixir")
-      insert(:tag, name: "Ruby", slug: "ruby")
+      elixir_name = unique_tag_name("Elixir")
+      ruby_name = unique_tag_name("Ruby")
+      insert(:tag, name: elixir_name, slug: String.downcase(elixir_name))
+      insert(:tag, name: ruby_name, slug: String.downcase(ruby_name))
 
       html = conn |> get(~p"/admin/tags?q=eli") |> html_response(200)
-      assert html =~ "Elixir"
-      refute html =~ "Ruby"
+      assert html =~ elixir_name
+      refute html =~ ruby_name
     end
 
     test "filters the listing by slug", %{conn: conn} do
@@ -53,37 +55,37 @@ defmodule VutuvWeb.Admin.TagControllerTest do
     end
 
     test "an empty query lists every tag", %{conn: conn} do
-      insert(:tag, name: "Elixir", slug: "elixir")
-      insert(:tag, name: "Ruby", slug: "ruby")
+      tag1 = insert(:tag)
+      tag2 = insert(:tag)
 
       html = conn |> get(~p"/admin/tags?q=") |> html_response(200)
-      assert html =~ "Elixir"
-      assert html =~ "Ruby"
+      assert html =~ tag1.name
+      assert html =~ tag2.name
     end
 
     test "shows a no-results notice when nothing matches", %{conn: conn} do
-      insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
 
       html = conn |> get(~p"/admin/tags?q=zzznope") |> html_response(200)
-      refute html =~ "Elixir"
+      refute html =~ tag.name
       assert html =~ "No tags match"
     end
 
     test "a LIKE metacharacter in the query is treated literally", %{conn: conn} do
-      insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
 
       # An unescaped "%" would match everything; escaped it matches nothing here.
       html = conn |> get(~p"/admin/tags?q=%25") |> html_response(200)
-      refute html =~ "Elixir"
+      refute html =~ tag.name
       assert html =~ "No tags match"
     end
 
     test "a crafted non-string query does not 500", %{conn: conn} do
-      insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
 
       # `?q[x]=1` parses into a map; it must be ignored, not crash to_string/1.
       html = conn |> get("/admin/tags?q[x]=1") |> html_response(200)
-      assert html =~ "Elixir"
+      assert html =~ tag.name
     end
 
     test "pagination keeps the search filter", %{conn: conn} do
@@ -102,7 +104,7 @@ defmodule VutuvWeb.Admin.TagControllerTest do
 
   describe "show" do
     test "renders an existing tag", %{conn: conn} do
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
       conn = get(conn, ~p"/admin/tags/#{tag}")
       assert conn.status == 200
     end
@@ -122,7 +124,7 @@ defmodule VutuvWeb.Admin.TagControllerTest do
     end
 
     test "the edit form offers the honor checkbox", %{conn: conn} do
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
       html = conn |> get(~p"/admin/tags/#{tag}/edit") |> html_response(200)
       assert html =~ ~s(name="tag[honor?]")
     end
@@ -130,7 +132,7 @@ defmodule VutuvWeb.Admin.TagControllerTest do
 
   describe "the honor flag" do
     test "the edit form persists it both on and off", %{conn: conn} do
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
 
       conn = put(conn, ~p"/admin/tags/#{tag}", tag: %{"honor?" => "true"})
       assert redirected_to(conn) == ~p"/admin/tags/#{tag}"

--- a/test/vutuv_web/controllers/admin/tag_member_controller_test.exs
+++ b/test/vutuv_web/controllers/admin/tag_member_controller_test.exs
@@ -15,7 +15,8 @@ defmodule VutuvWeb.Admin.TagMemberControllerTest do
   describe "as an admin" do
     setup %{conn: conn} do
       {conn, admin} = create_and_login_admin(conn)
-      tag = insert(:tag, name: "vutuv_developer", slug: "vutuv_developer", honor?: true)
+      name = unique_tag_name("vutuv_developer")
+      tag = insert(:tag, name: name, slug: name, honor?: true)
       {:ok, conn: conn, admin: admin, tag: tag}
     end
 

--- a/test/vutuv_web/controllers/controller_helpers_test.exs
+++ b/test/vutuv_web/controllers/controller_helpers_test.exs
@@ -7,7 +7,7 @@ defmodule VutuvWeb.ControllerHelpersTest do
   describe "safe_return_to/1" do
     test "keeps a same-origin absolute path" do
       assert ControllerHelpers.safe_return_to("/feed") == "/feed"
-      assert ControllerHelpers.safe_return_to("/alice/posts") == "/alice/posts"
+      assert ControllerHelpers.safe_return_to("/ch_alice/posts") == "/ch_alice/posts"
     end
 
     test "keeps the bare root path without raising" do
@@ -37,8 +37,8 @@ defmodule VutuvWeb.ControllerHelpersTest do
 
     test "falls back to the user's profile without a referer" do
       conn = build_conn()
-      user = %User{username: "alice"}
-      assert ControllerHelpers.referrer_or_profile(conn, user) == "/alice"
+      user = %User{username: "ch_alice"}
+      assert ControllerHelpers.referrer_or_profile(conn, user) == "/ch_alice"
     end
 
     test "falls back to the landing page when logged out and refererless" do

--- a/test/vutuv_web/controllers/cv_controller_test.exs
+++ b/test/vutuv_web/controllers/cv_controller_test.exs
@@ -313,7 +313,8 @@ defmodule VutuvWeb.CVControllerTest do
 
       assert [%{"organization" => "SV Musterstadt"}] = resume["volunteer"]
       assert [%{"institution" => "Universität Bremen"}] = resume["education"]
-      assert Enum.any?(resume["skills"], &(&1["name"] == "alpha-tag"))
+      [first_tag | _] = String.split(@registration_tags)
+      assert Enum.any?(resume["skills"], &(&1["name"] == first_tag))
 
       # The address becomes basics.location, the links become basics.profiles.
       assert resume["basics"]["location"]["address"] =~ "Musterstadt"

--- a/test/vutuv_web/controllers/invitation_controller_test.exs
+++ b/test/vutuv_web/controllers/invitation_controller_test.exs
@@ -157,7 +157,7 @@ defmodule VutuvWeb.InvitationControllerTest do
       params = %{
         "emails" => %{"0" => %{"value" => "invitee@example.com"}},
         "first_name" => "Invited",
-        "tag_list" => "alpha-tag beta-tag gamma-tag"
+        "tag_list" => @registration_tags
       }
 
       conn = post(conn, ~p"/new_registration", user: params)

--- a/test/vutuv_web/controllers/listing_batching_test.exs
+++ b/test/vutuv_web/controllers/listing_batching_test.exs
@@ -61,7 +61,7 @@ defmodule VutuvWeb.ListingBatchingTest do
       # have at least one visible follower).
       insert(:follow, follower: fan, followee: star)
 
-      popular = insert(:tag, name: "Bridgebuilding", slug: "bridgebuilding")
+      popular = insert(:tag)
       popular_ut = insert(:user_tag, user: star, tag: popular)
       # Endorse the popular tag so it ranks first among the member's tags.
       insert(:user_tag_endorsement, user_tag: popular_ut, user: fan)
@@ -74,7 +74,7 @@ defmodule VutuvWeb.ListingBatchingTest do
       body = conn |> get(~p"/listings/most_followed_users") |> html_response(200)
 
       # The most endorsed tag is shown and links to its public tag page.
-      assert body =~ ~r{<a[^>]+href="/tags/bridgebuilding"[^>]*>[^<]*Bridgebuilding}
+      assert body =~ ~r{<a[^>]+href="/tags/#{popular.slug}"[^>]*>[^<]*#{popular.name}}
       # Six tags total, only four shown, so two overflow into the "+N more" count.
       assert body =~ "+2 more tags"
     end
@@ -159,7 +159,7 @@ defmodule VutuvWeb.ListingBatchingTest do
       follower = insert_activated_user(first_name: "Fan")
       insert(:follow, follower: follower, followee: owner)
 
-      popular = insert(:tag, name: "Bridgebuilding", slug: "bridgebuilding")
+      popular = insert(:tag)
       popular_ut = insert(:user_tag, user: follower, tag: popular)
       # Endorse the popular tag so it ranks first among the follower's tags.
       insert(:user_tag_endorsement, user_tag: popular_ut, user: owner)
@@ -175,7 +175,7 @@ defmodule VutuvWeb.ListingBatchingTest do
       body = conn |> get(~p"/#{owner}/followers") |> html_response(200)
 
       # The most endorsed tag is shown and links to its public tag page.
-      assert body =~ ~r{<a[^>]+href="/tags/bridgebuilding"[^>]*>[^<]*Bridgebuilding}
+      assert body =~ ~r{<a[^>]+href="/tags/#{popular.slug}"[^>]*>[^<]*#{popular.name}}
       # Six tags total, only four shown, so two overflow into the "+N more" count.
       assert body =~ "+2 more tags"
     end

--- a/test/vutuv_web/controllers/page_controller_test.exs
+++ b/test/vutuv_web/controllers/page_controller_test.exs
@@ -213,11 +213,12 @@ defmodule VutuvWeb.PageControllerTest do
       assert body =~ ~s(href="https://vutuv.de/wintermeyer")
     end
 
-    test "renders the placeholder page even when a member exists at the example slug",
+    test "renders the placeholder page even when members are registered",
          %{conn: conn} do
-      # The example handle being registered must not change what /username shows:
-      # the route wins over the /:slug catch-all by definition order.
-      insert(:activated_user, username: "wintermeyer")
+      # A registered member must not change what /username shows: the route
+      # wins over the /:slug catch-all by definition order, and the page is a
+      # static template that never consults the database.
+      insert(:activated_user)
 
       body = conn |> get(~p"/username") |> html_response(404)
 
@@ -326,17 +327,11 @@ defmodule VutuvWeb.PageControllerTest do
   end
 
   describe "POST /new_registration" do
-    @valid_attrs %{
-      "emails" => %{"0" => %{"value" => "newcomer@example.com"}},
-      "first_name" => "Newcomer",
-      "tag_list" => "Elixir Cooking Origami"
-    }
-
     # Checking the (inverted) indexing box submits "false", which must land as a
     # search-indexable profile.
     test "checking the indexing box stores an indexable profile", %{conn: conn} do
       attrs =
-        Map.merge(@valid_attrs, %{
+        Map.merge(valid_attrs(), %{
           "emails" => %{"0" => %{"value" => "indexed@example.com"}},
           "noindex?" => "false"
         })
@@ -350,7 +345,7 @@ defmodule VutuvWeb.PageControllerTest do
     # not-indexable. This proves the box drives `noindex?` the inverted way.
     test "unchecking the indexing box stores a non-indexable profile", %{conn: conn} do
       attrs =
-        Map.merge(@valid_attrs, %{
+        Map.merge(valid_attrs(), %{
           "emails" => %{"0" => %{"value" => "hidden@example.com"}},
           "noindex?" => "true"
         })
@@ -365,7 +360,7 @@ defmodule VutuvWeb.PageControllerTest do
     # both land exactly as submitted.
     test "the AI box stores the member's choice independently of indexing", %{conn: conn} do
       attrs =
-        Map.merge(@valid_attrs, %{
+        Map.merge(valid_attrs(), %{
           "emails" => %{"0" => %{"value" => "search_only@example.com"}},
           "noindex?" => "false",
           "noai?" => "true"
@@ -378,7 +373,7 @@ defmodule VutuvWeb.PageControllerTest do
       assert user.noai? == true
 
       attrs =
-        Map.merge(@valid_attrs, %{
+        Map.merge(valid_attrs(), %{
           "emails" => %{"0" => %{"value" => "ai_only@example.com"}},
           "noindex?" => "true",
           "noai?" => "false"
@@ -395,7 +390,7 @@ defmodule VutuvWeb.PageControllerTest do
     # private address; ticking it is the explicit opt-in to a public one.
     test "the email address stays private unless the box is ticked", %{conn: conn} do
       attrs =
-        Map.merge(@valid_attrs, %{
+        Map.merge(valid_attrs(), %{
           "emails" => %{"0" => %{"value" => "private@example.com", "public?" => "false"}}
         })
 
@@ -407,7 +402,7 @@ defmodule VutuvWeb.PageControllerTest do
 
     test "ticking the email box stores a public address", %{conn: conn} do
       attrs =
-        Map.merge(@valid_attrs, %{
+        Map.merge(valid_attrs(), %{
           "emails" => %{"0" => %{"value" => "open@example.com", "public?" => "true"}}
         })
 
@@ -421,7 +416,7 @@ defmodule VutuvWeb.PageControllerTest do
     # %{"0" => %{"value" => …}} map the form builds) must re-render the form,
     # not 500 on chained Access indexing.
     test "a malformed emails param re-renders the form instead of crashing", %{conn: conn} do
-      attrs = %{"emails" => "x", "first_name" => "Foo", "tag_list" => "Elixir Cooking Origami"}
+      attrs = %{"emails" => "x", "first_name" => "Foo", "tag_list" => registration_tags()}
 
       conn = post(conn, ~p"/new_registration", user: attrs)
 
@@ -431,19 +426,24 @@ defmodule VutuvWeb.PageControllerTest do
     # The sign-up form's "Your tags" field must actually land as user tags;
     # it used to be cast into the virtual `tag_list` and silently dropped.
     test "creates user tags from the comma-separated tag list", %{conn: conn} do
+      elixir = unique_tag_name("Elixir")
+      cooking = unique_tag_name("Cooking")
+      origami = unique_tag_name("Origami")
+
       attrs =
-        Map.merge(@valid_attrs, %{
+        Map.merge(valid_attrs(), %{
           "emails" => %{"0" => %{"value" => "tagged@example.com"}},
-          "tag_list" => " Elixir,  Cooking , Origami, "
+          "tag_list" => " #{elixir},  #{cooking} , #{origami}, "
         })
 
       post(conn, ~p"/new_registration", user: attrs)
 
       user = user_by_email("tagged@example.com") |> Vutuv.Repo.preload(user_tags: :tag)
+      expected = Enum.sort(Enum.map([elixir, cooking, origami], &String.downcase/1))
 
       assert user.user_tags
              |> Enum.map(&String.downcase(&1.tag.name))
-             |> Enum.sort() == ["cooking", "elixir", "origami"]
+             |> Enum.sort() == expected
     end
 
     # Tags are a cornerstone of the system, so a sign-up needs at least three
@@ -451,7 +451,7 @@ defmodule VutuvWeb.PageControllerTest do
     # error instead of creating the account.
     test "a blank tag list is rejected", %{conn: conn} do
       attrs =
-        Map.merge(@valid_attrs, %{
+        Map.merge(valid_attrs(), %{
           "emails" => %{"0" => %{"value" => "untagged@example.com"}},
           "tag_list" => "   "
         })
@@ -469,9 +469,9 @@ defmodule VutuvWeb.PageControllerTest do
     # about a "validation error".
     test "a rejected sign-up marks the tag field itself", %{conn: conn} do
       attrs =
-        Map.merge(@valid_attrs, %{
+        Map.merge(valid_attrs(), %{
           "emails" => %{"0" => %{"value" => "marked@example.com"}},
-          "tag_list" => "Elixir"
+          "tag_list" => unique_tag_name("Elixir")
         })
 
       body = conn |> post(~p"/new_registration", user: attrs) |> html_response(422)
@@ -494,10 +494,13 @@ defmodule VutuvWeb.PageControllerTest do
     end
 
     test "fewer than three distinct tags is rejected, counting duplicates once", %{conn: conn} do
+      name = unique_tag_name("Elixir")
+      other = unique_tag_name("Cooking")
+
       attrs =
-        Map.merge(@valid_attrs, %{
+        Map.merge(valid_attrs(), %{
           "emails" => %{"0" => %{"value" => "duplicated@example.com"}},
-          "tag_list" => "Elixir, elixir, ELIXIR, Cooking"
+          "tag_list" => "#{name}, #{String.downcase(name)}, #{String.upcase(name)}, #{other}"
         })
 
       conn = post(conn, ~p"/new_registration", user: attrs)
@@ -510,10 +513,14 @@ defmodule VutuvWeb.PageControllerTest do
     # comma-separated segment) becomes its own tag. A quoted phrase is kept
     # whole (see the next test and Vutuv.Tags.parse_tag_names/1).
     test "splits a space-separated tag list into one tag per word", %{conn: conn} do
+      javascript = unique_tag_name("JavaScript")
+      go = unique_tag_name("Go")
+      hunde = unique_tag_name("Hunde")
+
       attrs =
-        Map.merge(@valid_attrs, %{
+        Map.merge(valid_attrs(), %{
           "emails" => %{"0" => %{"value" => "spaced@example.com"}},
-          "tag_list" => "JavaScript Go Hunde"
+          "tag_list" => "#{javascript} #{go} #{hunde}"
         })
 
       post(conn, ~p"/new_registration", user: attrs)
@@ -522,14 +529,19 @@ defmodule VutuvWeb.PageControllerTest do
 
       assert user.user_tags
              |> Enum.map(& &1.tag.name)
-             |> Enum.sort() == ["Go", "Hunde", "JavaScript"]
+             |> Enum.sort() == Enum.sort([javascript, go, hunde])
     end
 
     test "keeps a quoted multi-word tag whole at sign-up", %{conn: conn} do
+      n = System.unique_integer([:positive])
+      rails = "Ruby on Rails #{n}"
+      elixir = "Elixir#{n}"
+      go = "Go#{n}"
+
       attrs =
-        Map.merge(@valid_attrs, %{
+        Map.merge(valid_attrs(), %{
           "emails" => %{"0" => %{"value" => "quoted@example.com"}},
-          "tag_list" => ~s("Ruby on Rails", Elixir, Go)
+          "tag_list" => ~s("#{rails}", #{elixir}, #{go})
         })
 
       post(conn, ~p"/new_registration", user: attrs)
@@ -538,14 +550,14 @@ defmodule VutuvWeb.PageControllerTest do
 
       assert user.user_tags
              |> Enum.map(& &1.tag.name)
-             |> Enum.sort() == ["Elixir", "Go", "Ruby on Rails"]
+             |> Enum.sort() == Enum.sort([rails, elixir, go])
     end
 
     # The PIN-entry confirmation page shown right after sign-up used to point at
     # the dead @vutuv Twitter account. The whole "Updates about vutuv" line is
     # gone; the PIN form and its instructions must stay untouched.
     test "the PIN confirmation page no longer links to Twitter", %{conn: conn} do
-      conn = post(conn, ~p"/new_registration", user: @valid_attrs)
+      conn = post(conn, ~p"/new_registration", user: valid_attrs())
       body = html_response(conn, 200)
 
       # The confirmation page is the one we are looking at.
@@ -561,7 +573,7 @@ defmodule VutuvWeb.PageControllerTest do
     # "Welcome back!" that the plain login flow uses. The confirmation page
     # marks its PIN form with a registration context for this.
     test "the first PIN login after sign-up greets the newcomer", %{conn: conn} do
-      conn = post(conn, ~p"/new_registration", user: @valid_attrs)
+      conn = post(conn, ~p"/new_registration", user: valid_attrs())
       body = html_response(conn, 200)
       assert body =~ ~s(name="session[context]")
       pin = sent_pin()
@@ -595,7 +607,7 @@ defmodule VutuvWeb.PageControllerTest do
         Vutuv.Accounts.register_user(conn, %{
           "emails" => %{"0" => %{"value" => "taken@example.com"}},
           "first_name" => "Owner",
-          "tag_list" => "Elixir Cooking Origami"
+          "tag_list" => registration_tags()
         })
 
       %{owner: owner}
@@ -673,6 +685,22 @@ defmodule VutuvWeb.PageControllerTest do
       [tag] -> tag =~ "checked"
       _ -> false
     end
+  end
+
+  # Fresh, per-call-unique tag names: an async test file must never insert a
+  # tag name/slug another async file also mints — the sandboxed unique-index
+  # locks would convoy and deadlock (Postgres 40P01).
+  defp registration_tags do
+    n = System.unique_integer([:positive])
+    "Elixir#{n} Cooking#{n} Origami#{n}"
+  end
+
+  defp valid_attrs do
+    %{
+      "emails" => %{"0" => %{"value" => "newcomer@example.com"}},
+      "first_name" => "Newcomer",
+      "tag_list" => registration_tags()
+    }
   end
 
   defp user_by_email(value) do

--- a/test/vutuv_web/controllers/profile_edit_affordances_test.exs
+++ b/test/vutuv_web/controllers/profile_edit_affordances_test.exs
@@ -152,8 +152,10 @@ defmodule VutuvWeb.ProfileEditAffordancesTest do
 
       html = conn |> get(~p"/#{user}") |> html_response(200)
 
-      # @default_login_attrs registers alpha-tag/beta-tag/gamma-tag.
-      assert completion_text(html) =~ "For example, a thought on #alpha-tag."
+      # The registration fixture's alphabetically first tag (the hint picks
+      # the most-endorsed tag, slug as tiebreaker — so alpha-tag-… wins).
+      [first_tag | _] = String.split(@registration_tags)
+      assert completion_text(html) =~ "For example, a thought on ##{first_tag}."
     end
 
     test "the checklist disappears once every step is done", %{conn: conn} do

--- a/test/vutuv_web/controllers/settings_followed_tags_test.exs
+++ b/test/vutuv_web/controllers/settings_followed_tags_test.exs
@@ -9,11 +9,11 @@ defmodule VutuvWeb.SettingsFollowedTagsTest do
 
   test "lists the member's followed tags with an unfollow control", %{conn: conn} do
     {conn, user} = create_and_login_user(conn)
-    tag = insert(:tag, name: "Elixir", slug: "elixir")
+    tag = insert(:tag)
     Tags.follow_tag(user, tag)
 
     html = conn |> get(~p"/settings/followed_tags") |> html_response(200)
-    assert html =~ "Elixir"
+    assert html =~ tag.name
     assert html =~ ~s(href="/tag_follows/#{tag.id}")
   end
 
@@ -23,7 +23,7 @@ defmodule VutuvWeb.SettingsFollowedTagsTest do
     html = conn |> get(~p"/settings") |> html_response(200)
     refute html =~ "Tags you follow"
 
-    tag = insert(:tag, name: "Elixir", slug: "elixir")
+    tag = insert(:tag)
     Tags.follow_tag(user, tag)
 
     html = conn |> recycle() |> get(~p"/settings") |> html_response(200)

--- a/test/vutuv_web/controllers/sitemap_controller_test.exs
+++ b/test/vutuv_web/controllers/sitemap_controller_test.exs
@@ -50,7 +50,7 @@ defmodule VutuvWeb.SitemapControllerTest do
 
     test "excludes unactivated, noindexed and moderation-hidden members" do
       insert(:user, username: "never_activated")
-      insert_activated_user(username: "opted_out", noindex?: true)
+      opted_out = insert_activated_user(noindex?: true)
 
       insert_activated_user(
         username: "frozen_member",
@@ -63,7 +63,7 @@ defmodule VutuvWeb.SitemapControllerTest do
 
       assert conn.resp_body =~ "/visible_member<"
       refute conn.resp_body =~ "never_activated"
-      refute conn.resp_body =~ "opted_out"
+      refute conn.resp_body =~ opted_out.username
       refute conn.resp_body =~ "frozen_member"
     end
   end

--- a/test/vutuv_web/controllers/tag_controller_test.exs
+++ b/test/vutuv_web/controllers/tag_controller_test.exs
@@ -9,7 +9,7 @@ defmodule VutuvWeb.TagControllerTest do
 
   describe "index (no slug param)" do
     test "renders the tag listing", %{conn: conn} do
-      insert(:tag, name: "Elixir", slug: "elixir")
+      insert(:tag)
       conn = get(conn, ~p"/tags")
       assert conn.status == 200
     end
@@ -17,7 +17,7 @@ defmodule VutuvWeb.TagControllerTest do
 
   describe "show" do
     test "renders an existing tag", %{conn: conn} do
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
       conn = get(conn, ~p"/tags/#{tag}")
       assert conn.status == 200
     end
@@ -35,10 +35,12 @@ defmodule VutuvWeb.TagControllerTest do
     test "a tag used only in posts still shows those posts", %{conn: conn} do
       author = insert(:activated_user)
 
-      post =
-        Vutuv.PostsHelpers.create_post!(author, %{body: "Elixir meetup notes", tags: "elixir"})
+      tag_name = unique_tag_name("Elixir")
 
-      html = conn |> get(~p"/tags/elixir") |> html_response(200)
+      post =
+        Vutuv.PostsHelpers.create_post!(author, %{body: "Elixir meetup notes", tags: tag_name})
+
+      html = conn |> get(~p"/tags/#{String.downcase(tag_name)}") |> html_response(200)
 
       assert html =~ "tag-posts"
       assert html =~ "Elixir meetup notes"
@@ -102,9 +104,9 @@ defmodule VutuvWeb.TagControllerTest do
   describe "the tag page carries no profile-mutation control (issue #877)" do
     test "a logged-in visitor without the tag sees no \"Add this tag\" button", %{conn: conn} do
       {conn, _user} = create_and_login_user(conn)
-      insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
 
-      html = conn |> get(~p"/tags/elixir") |> html_response(200)
+      html = conn |> get(~p"/tags/#{tag}") |> html_response(200)
 
       refute html =~ "Add this tag"
       refute html =~ ~s(data-to="/settings/tags?tag_param)

--- a/test/vutuv_web/controllers/tag_follow_controller_test.exs
+++ b/test/vutuv_web/controllers/tag_follow_controller_test.exs
@@ -13,7 +13,7 @@ defmodule VutuvWeb.TagFollowControllerTest do
   describe "create / delete" do
     test "POST follows the tag and DELETE unfollows it", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
 
       conn = post(conn, ~p"/tag_follows", tag_follow: %{tag_id: tag.id})
       assert redirected_to(conn)
@@ -26,7 +26,7 @@ defmodule VutuvWeb.TagFollowControllerTest do
 
     test "a double follow is idempotent, not a 500", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
 
       conn = post(conn, ~p"/tag_follows", tag_follow: %{tag_id: tag.id})
       conn = post(recycle(conn), ~p"/tag_follows", tag_follow: %{tag_id: tag.id})
@@ -44,7 +44,7 @@ defmodule VutuvWeb.TagFollowControllerTest do
   describe "the tag page's follow control (issue #872)" do
     test "renders a pill whose CSRF button targets the real /tag_follows route", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
 
       html = conn |> get(~p"/tags/#{tag}") |> html_response(200)
       assert html =~ ~s(data-to="/tag_follows?tag_follow[tag_id]=#{tag.id}")
@@ -59,7 +59,7 @@ defmodule VutuvWeb.TagFollowControllerTest do
 
     test "shows the aggregate follower count", %{conn: conn} do
       {conn, _user} = create_and_login_user(conn)
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
       for _ <- 1..3, do: Tags.follow_tag(insert(:activated_user), tag)
 
       html = conn |> get(~p"/tags/#{tag}") |> html_response(200)
@@ -67,7 +67,7 @@ defmodule VutuvWeb.TagFollowControllerTest do
     end
 
     test "a logged-out visitor sees no follow control but the page still renders", %{conn: conn} do
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
       html = conn |> get(~p"/tags/#{tag}") |> html_response(200)
       refute html =~ ~s(data-to="/tag_follows)
     end

--- a/test/vutuv_web/controllers/user_tag_controller_test.exs
+++ b/test/vutuv_web/controllers/user_tag_controller_test.exs
@@ -12,7 +12,7 @@ defmodule VutuvWeb.UserTagControllerTest do
     end
 
     test "a member cannot remove an honor tag from themselves", %{conn: conn, user: user} do
-      tag = insert(:tag, name: "vutuv_developer", slug: "vutuv_developer", honor?: true)
+      tag = insert(:tag, honor?: true)
       {:ok, _} = Vutuv.Tags.admin_assign_tag(tag, user)
 
       conn = delete(conn, ~p"/settings/tags/#{tag.slug}")
@@ -26,10 +26,11 @@ defmodule VutuvWeb.UserTagControllerTest do
     end
 
     test "a member can still remove a normal tag", %{conn: conn, user: user} do
-      {:ok, user_tag} = Vutuv.Tags.add_user_tag(user, "Elixir")
+      name = unique_tag_name("Elixir")
+      {:ok, user_tag} = Vutuv.Tags.add_user_tag(user, name)
       tag_id = user_tag.tag_id
 
-      conn = delete(conn, ~p"/settings/tags/elixir")
+      conn = delete(conn, ~p"/settings/tags/#{String.downcase(name)}")
 
       assert redirected_to(conn) == ~p"/settings/tags"
 
@@ -79,7 +80,7 @@ defmodule VutuvWeb.UserTagControllerTest do
   describe "endorsers" do
     setup do
       owner = insert_activated_user(username: "tag_owner")
-      tag = insert(:tag, name: "Ruby", slug: "ruby")
+      tag = insert(:tag)
       user_tag = insert(:user_tag, user: owner, tag: tag)
       {:ok, owner: owner, tag: tag, user_tag: user_tag}
     end
@@ -87,20 +88,22 @@ defmodule VutuvWeb.UserTagControllerTest do
     test "lists the visible endorsers (no login required)", %{
       conn: conn,
       owner: owner,
+      tag: tag,
       user_tag: user_tag
     } do
       endorser = insert_activated_user(first_name: "Rick", last_name: "Sanchez")
       insert(:user_tag_endorsement, user_tag: user_tag, user: endorser)
 
-      html = conn |> get(~p"/#{owner}/tags/ruby/endorsers") |> html_response(200)
+      html = conn |> get(~p"/#{owner}/tags/#{tag.slug}/endorsers") |> html_response(200)
 
       assert html =~ "Rick Sanchez"
-      assert html =~ "Ruby"
+      assert html =~ tag.name
     end
 
     test "the per-row follow icon names itself (title + aria-label)", %{
       conn: conn,
       owner: owner,
+      tag: tag,
       user_tag: user_tag
     } do
       # This table keeps the compact icon-only follow control, so it must carry
@@ -110,7 +113,7 @@ defmodule VutuvWeb.UserTagControllerTest do
       endorser = insert_activated_user(first_name: "Rick", last_name: "Sanchez")
       insert(:user_tag_endorsement, user_tag: user_tag, user: endorser)
 
-      html = conn |> get(~p"/#{owner}/tags/ruby/endorsers") |> html_response(200)
+      html = conn |> get(~p"/#{owner}/tags/#{tag.slug}/endorsers") |> html_response(200)
 
       # The viewer does not follow the endorser, so the row offers "Follow".
       assert html =~ ~s(title="Follow")
@@ -120,12 +123,13 @@ defmodule VutuvWeb.UserTagControllerTest do
     test "shows when each endorsement was cast", %{
       conn: conn,
       owner: owner,
+      tag: tag,
       user_tag: user_tag
     } do
       endorser = insert_activated_user(first_name: "Rick", last_name: "Sanchez")
       endorsement = insert(:user_tag_endorsement, user_tag: user_tag, user: endorser)
 
-      html = conn |> get(~p"/#{owner}/tags/ruby/endorsers") |> html_response(200)
+      html = conn |> get(~p"/#{owner}/tags/#{tag.slug}/endorsers") |> html_response(200)
 
       # The label plus a client-localized <time> (the server text is the no-JS
       # fallback; app.js rewrites it to the viewer's locale).
@@ -137,6 +141,7 @@ defmodule VutuvWeb.UserTagControllerTest do
     test "drops hidden / unconfirmed endorsers from the list (issue #783)", %{
       conn: conn,
       owner: owner,
+      tag: tag,
       user_tag: user_tag
     } do
       visible = insert_activated_user(first_name: "Vee", last_name: "Visible")
@@ -147,7 +152,7 @@ defmodule VutuvWeb.UserTagControllerTest do
       hidden = insert(:user, first_name: "Han", last_name: "Hidden")
       insert(:user_tag_endorsement, user_tag: user_tag, user: hidden)
 
-      html = conn |> get(~p"/#{owner}/tags/ruby/endorsers") |> html_response(200)
+      html = conn |> get(~p"/#{owner}/tags/#{tag.slug}/endorsers") |> html_response(200)
 
       assert html =~ "Vee Visible"
       refute html =~ "Han Hidden"
@@ -160,7 +165,12 @@ defmodule VutuvWeb.UserTagControllerTest do
       assert conn.halted
     end
 
-    test "is sortable by name, username and date", %{conn: conn, owner: owner, user_tag: user_tag} do
+    test "is sortable by name, username and date", %{
+      conn: conn,
+      owner: owner,
+      tag: tag,
+      user_tag: user_tag
+    } do
       zoe = insert_activated_user(first_name: "Zoe", last_name: "Adams", username: "zoe.adams")
       amy = insert_activated_user(first_name: "Amy", last_name: "Baker", username: "amy.baker")
 
@@ -170,7 +180,7 @@ defmodule VutuvWeb.UserTagControllerTest do
 
       # The .json sibling lists people in the same order the HTML table renders.
       names = fn query ->
-        "/#{owner.username}/tags/ruby/endorsers.json?#{URI.encode_query(query)}"
+        "/#{owner.username}/tags/#{tag.slug}/endorsers.json?#{URI.encode_query(query)}"
         |> then(&get(conn, &1).resp_body)
         |> Jason.decode!()
         |> Map.fetch!("people")
@@ -192,6 +202,7 @@ defmodule VutuvWeb.UserTagControllerTest do
     test "paginates the HTML list and keeps the sort across pages", %{
       conn: conn,
       owner: owner,
+      tag: tag,
       user_tag: user_tag
     } do
       for _ <- 1..(Vutuv.Tags.endorsers_per_page() + 1) do
@@ -199,7 +210,9 @@ defmodule VutuvWeb.UserTagControllerTest do
       end
 
       html =
-        conn |> get(~p"/#{owner}/tags/ruby/endorsers?sort=name&dir=asc") |> html_response(200)
+        conn
+        |> get(~p"/#{owner}/tags/#{tag.slug}/endorsers?sort=name&dir=asc")
+        |> html_response(200)
 
       # A second page exists and its link carries the active sort.
       assert html =~ "page=2"

--- a/test/vutuv_web/controllers/user_tag_endorsement_controller_test.exs
+++ b/test/vutuv_web/controllers/user_tag_endorsement_controller_test.exs
@@ -30,7 +30,7 @@ defmodule VutuvWeb.UserTagEndorsementControllerTest do
     test "a tag belonging to another user does not resolve under this user", %{conn: conn} do
       user = insert_activated_user()
       other = insert_activated_user()
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
       insert(:user_tag, user: other, tag: tag)
 
       conn =
@@ -45,7 +45,7 @@ defmodule VutuvWeb.UserTagEndorsementControllerTest do
   describe "require_user_logged_in" do
     test "create on a resolvable tag 404s when logged out (does not redirect)", %{conn: conn} do
       user = insert_activated_user()
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
       insert(:user_tag, user: user, tag: tag)
 
       conn =
@@ -66,7 +66,7 @@ defmodule VutuvWeb.UserTagEndorsementControllerTest do
     setup %{conn: conn} do
       {conn, endorser} = create_and_login_user(conn)
       owner = insert_activated_user()
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
       user_tag = insert(:user_tag, user: owner, tag: tag)
       %{conn: conn, endorser: endorser, owner: owner, tag: tag, user_tag: user_tag}
     end

--- a/test/vutuv_web/live/post_live/feed_followed_tags_test.exs
+++ b/test/vutuv_web/live/post_live/feed_followed_tags_test.exs
@@ -12,7 +12,7 @@ defmodule VutuvWeb.PostLive.FeedFollowedTagsTest do
   describe "Tags you follow rail" do
     test "renders the followed-tag chips and unfollows one with no reload", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
       Tags.follow_tag(user, tag)
 
       {:ok, view, html} = live(conn, ~p"/feed")
@@ -37,7 +37,7 @@ defmodule VutuvWeb.PostLive.FeedFollowedTagsTest do
   describe "Who to follow leads with people from followed tags" do
     test "a member endorsed for a followed tag appears in the who-to-follow rail", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      tag = insert(:tag)
       Tags.follow_tag(user, tag)
 
       candidate = insert(:activated_user, first_name: "Tagged", last_name: "Person")

--- a/test/vutuv_web/live/search_live_test.exs
+++ b/test/vutuv_web/live/search_live_test.exs
@@ -108,11 +108,12 @@ defmodule VutuvWeb.SearchLiveTest do
     end
 
     test "matching tags show as chips linking to the tag page", %{conn: conn} do
-      insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      insert(:tag, name: name, slug: String.downcase(name))
 
       {:ok, view, _html} = live(conn, ~p"/search?q=eli")
 
-      assert has_element?(view, ~s(#search-tags a[href="/tags/elixir"]), "Elixir")
+      assert has_element?(view, ~s(#search-tags a[href="/tags/#{String.downcase(name)}"]), name)
     end
 
     test "matching public posts show with author and permalink", %{conn: conn} do
@@ -194,7 +195,8 @@ defmodule VutuvWeb.SearchLiveTest do
     end
 
     test "tag and post matches are marked too", %{conn: conn} do
-      insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      insert(:tag, name: name, slug: String.downcase(name))
       author = insert(:activated_user)
       create_post!(author, %{body: "Quantum gardening tips for beginners"})
 
@@ -219,7 +221,8 @@ defmodule VutuvWeb.SearchLiveTest do
 
     test "the scope chips narrow the search and the URL carries the filter", %{conn: conn} do
       searchable_user("Elia", "Tester")
-      insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      insert(:tag, name: name, slug: String.downcase(name))
 
       {:ok, view, _html} = live(conn, ~p"/search?q=eli")
       assert has_element?(view, "#search-people")
@@ -274,7 +277,7 @@ defmodule VutuvWeb.SearchLiveTest do
       insert(:activated_user,
         first_name: "Stefan",
         last_name: "Wintermeyer",
-        username: "stefan.wintermeyer"
+        username: "stefan.w#{System.unique_integer([:positive])}"
       )
 
       {:ok, view, _html} = live(conn, ~p"/search?q=@stefan")
@@ -283,13 +286,16 @@ defmodule VutuvWeb.SearchLiveTest do
     end
 
     test "tag chips carry member counts", %{conn: conn} do
-      tag = insert(:tag, name: "Elixir", slug: "elixir")
+      name = unique_tag_name("Elixir")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
       insert(:user_tag, tag: tag, user: insert(:activated_user))
 
       {:ok, view, _html} = live(conn, ~p"/search?q=elixir")
 
-      assert has_element?(view, "#search-tags", "Elixir")
-      assert has_element?(view, "#search-tags", "1")
+      assert has_element?(view, "#search-tags", name)
+      # The member count ("· 1"): the unique name carries digits, so a bare
+      # "1" would match the name itself and prove nothing.
+      assert has_element?(view, "#search-tags", "· 1")
     end
 
     # Issue #846: with a people-only operator in the query the parser pins the
@@ -327,12 +333,13 @@ defmodule VutuvWeb.SearchLiveTest do
     end
 
     test "tag: lists the people with that tag, not the tag itself", %{conn: conn} do
-      tag = insert(:tag, name: "PHP", slug: "php")
+      name = unique_tag_name("PHP")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
       tagged = insert(:activated_user, first_name: "Paula", last_name: "Programmer")
       insert(:user_tag, tag: tag, user: tagged)
       insert(:activated_user, first_name: "Norbert", last_name: "NoTag")
 
-      {:ok, view, _html} = live(conn, ~p"/search?q=tag:php")
+      {:ok, view, _html} = live(conn, ~p"/search?q=tag:#{String.downcase(name)}")
 
       assert has_element?(view, "#search-people-exact", "Paula Programmer")
       refute has_element?(view, "#search-people-exact", "Norbert NoTag")
@@ -341,13 +348,14 @@ defmodule VutuvWeb.SearchLiveTest do
 
     test "tag: also lists posts carrying that tag, and keeps the chips enabled (issue #946)",
          %{conn: conn} do
-      tag = insert(:tag, name: "PHP", slug: "php")
+      name = unique_tag_name("PHP")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
       tagged = insert(:activated_user, first_name: "Paula", last_name: "Programmer")
       insert(:user_tag, tag: tag, user: tagged)
       author = insert(:activated_user)
-      create_post!(author, %{body: "My php write-up today", tags: "php"})
+      create_post!(author, %{body: "My php write-up today", tags: String.downcase(name)})
 
-      {:ok, view, _html} = live(conn, ~p"/search?q=tag:php")
+      {:ok, view, _html} = live(conn, ~p"/search?q=tag:#{String.downcase(name)}")
 
       # Both the person and the post carrying the tag show.
       assert has_element?(view, "#search-people-exact", "Paula Programmer")
@@ -358,14 +366,15 @@ defmodule VutuvWeb.SearchLiveTest do
     end
 
     test "a name combines with tag and city filters", %{conn: conn} do
-      tag = insert(:tag, name: "PHP", slug: "php")
+      name = unique_tag_name("PHP")
+      tag = insert(:tag, name: name, slug: String.downcase(name))
       php_mueller = searchable_user("Hans", "Müller")
       insert(:user_tag, tag: tag, user: php_mueller)
       koblenz_mueller = searchable_user("Klara", "Müller")
       insert(:address, user: koblenz_mueller, city: "Koblenz")
       searchable_user("Heike", "Müller")
 
-      {:ok, view, _html} = live(conn, ~p"/search?q=müller tag:php")
+      {:ok, view, _html} = live(conn, ~p"/search?q=müller tag:#{String.downcase(name)}")
       assert has_element?(view, "#search-people-exact", "Hans Müller")
       refute has_element?(view, "#search-people-exact", "Heike Müller")
 

--- a/test/vutuv_web/live/user_profile_job_exclusion_test.exs
+++ b/test/vutuv_web/live/user_profile_job_exclusion_test.exs
@@ -47,7 +47,7 @@ defmodule VutuvWeb.UserProfileJobExclusionTest do
     attrs = %{
       "emails" => %{"0" => %{"value" => "me@acme.example"}},
       "first_name" => "Colleague",
-      "tag_list" => "alpha-tag beta-tag gamma-tag"
+      "tag_list" => @registration_tags
     }
 
     {conn, _viewer} = create_and_login_user(conn, attrs)
@@ -80,7 +80,7 @@ defmodule VutuvWeb.UserProfileJobExclusionTest do
     attrs = %{
       "emails" => %{"0" => %{"value" => "recruiter@eu.mail.acme.example"}},
       "first_name" => "Sub",
-      "tag_list" => "alpha-tag beta-tag gamma-tag"
+      "tag_list" => @registration_tags
     }
 
     {conn, _viewer} = create_and_login_user(conn, attrs)

--- a/test/vutuv_web/markdown_hashtags_test.exs
+++ b/test/vutuv_web/markdown_hashtags_test.exs
@@ -12,6 +12,13 @@ defmodule VutuvWeb.MarkdownHashtagsTest do
   alias Vutuv.Tags
   alias VutuvWeb.Markdown
 
+  # Per-module unique tag name so async files never share a tags.slug lock
+  # (see the test guidelines in .claude/rules/elixir.md). Dashless on purpose:
+  # the hashtag grammar is `#([A-Za-z0-9_]+)`, a dash would end the match.
+  hashtag_mod_id = :erlang.phash2(__MODULE__, 4_294_967_296)
+  @elixir_tag "Elixir#{hashtag_mod_id}"
+  @elixir_tag_down String.downcase(@elixir_tag)
+
   defp render(text), do: text |> Markdown.render() |> Phoenix.HTML.safe_to_string()
 
   defp render_post(text), do: text |> Markdown.render_post([]) |> Phoenix.HTML.safe_to_string()
@@ -24,14 +31,14 @@ defmodule VutuvWeb.MarkdownHashtagsTest do
   end
 
   test "a #hashtag of a non-empty tag links to the tag page" do
-    populated_tag("Elixir")
-    html = render("I love #Elixir and #elixir")
+    populated_tag(@elixir_tag)
+    html = render("I love ##{@elixir_tag} and ##{@elixir_tag_down}")
 
-    assert html =~ ~s(href="/tags/elixir")
+    assert html =~ ~s(href="/tags/#{@elixir_tag_down}")
     assert html =~ ~s(class="hashtag")
     # the typed casing is preserved in the visible text
-    assert html =~ ">#Elixir</a>"
-    assert html =~ ">#elixir</a>"
+    assert html =~ ">##{@elixir_tag}</a>"
+    assert html =~ ">##{@elixir_tag_down}</a>"
   end
 
   test "a #hashtag with no matching tag stays plain text" do
@@ -42,11 +49,15 @@ defmodule VutuvWeb.MarkdownHashtagsTest do
   end
 
   test "a #hashtag for a tag that exists but has NO members stays plain text" do
-    insert(:tag, name: "Lonely", slug: "lonely")
-    html = render("nobody uses #lonely")
+    # Dashless unique name: a dash would end the hashtag match (see the grammar
+    # in Vutuv.Mentions), so unique_tag_name/1 is not usable inside a hashtag.
+    name = "Lonely#{System.unique_integer([:positive])}"
+    slug = String.downcase(name)
+    insert(:tag, name: name, slug: slug)
+    html = render("nobody uses ##{slug}")
 
-    refute html =~ ~s(href="/tags/lonely")
-    assert html =~ "#lonely"
+    refute html =~ ~s(href="/tags/#{slug}")
+    assert html =~ "##{slug}"
   end
 
   test "a #hashtag whose only member is unconfirmed stays plain text" do
@@ -73,18 +84,18 @@ defmodule VutuvWeb.MarkdownHashtagsTest do
   end
 
   test "a hashtag inside inline code is left untouched" do
-    populated_tag("Elixir")
-    html = render("type `#elixir` to tag")
+    populated_tag(@elixir_tag)
+    html = render("type `##{@elixir_tag_down}` to tag")
 
-    refute html =~ ~s(href="/tags/elixir")
-    assert html =~ "#elixir"
+    refute html =~ ~s(href="/tags/#{@elixir_tag_down}")
+    assert html =~ "##{@elixir_tag_down}"
   end
 
   test "a hashtag inside a fenced code block is left untouched" do
-    populated_tag("Elixir")
-    html = render("```\n#elixir\n```")
+    populated_tag(@elixir_tag)
+    html = render("```\n##{@elixir_tag_down}\n```")
 
-    refute html =~ ~s(href="/tags/elixir")
+    refute html =~ ~s(href="/tags/#{@elixir_tag_down}")
   end
 
   test "a markdown heading is not turned into a hashtag link" do
@@ -96,28 +107,31 @@ defmodule VutuvWeb.MarkdownHashtagsTest do
   end
 
   test "mentions and hashtags both resolve in the same body" do
-    insert(:user, username: "ada", first_name: "Ada", last_name: "Lovelace")
-    populated_tag("Elixir")
-    html = render("@ada writes #elixir")
+    handle = "ada#{System.unique_integer([:positive])}"
+    insert(:user, username: handle, first_name: "Ada", last_name: "Lovelace")
+    populated_tag(@elixir_tag)
+    html = render("@#{handle} writes ##{@elixir_tag_down}")
 
-    assert html =~ ~s(href="/ada")
-    assert html =~ ~s(href="/tags/elixir")
+    assert html =~ ~s(href="/#{handle}")
+    assert html =~ ~s(href="/tags/#{@elixir_tag_down}")
   end
 
   test "the internal hashtag link stays in the same tab" do
-    populated_tag("Elixir")
-    html = render("#elixir and https://example.com/x")
+    populated_tag(@elixir_tag)
+    html = render("##{@elixir_tag_down} and https://example.com/x")
 
-    assert html =~ ~r{<a href="/tags/elixir"[^>]*class="hashtag"[^>]*>#elixir</a>}
-    refute html =~ ~r{<a href="/tags/elixir"[^>]*target="_blank"}
+    assert html =~
+             ~r{<a href="/tags/#{@elixir_tag_down}"[^>]*class="hashtag"[^>]*>##{@elixir_tag_down}</a>}
+
+    refute html =~ ~r{<a href="/tags/#{@elixir_tag_down}"[^>]*target="_blank"}
     # the external URL still opens in a new tab
     assert html =~ ~s(target="_blank")
   end
 
   test "hashtags also resolve in post bodies" do
-    populated_tag("Elixir")
-    html = render_post("Shipped with #elixir!")
+    populated_tag(@elixir_tag)
+    html = render_post("Shipped with ##{@elixir_tag_down}!")
 
-    assert html =~ ~s(href="/tags/elixir")
+    assert html =~ ~s(href="/tags/#{@elixir_tag_down}")
   end
 end

--- a/test/vutuv_web/markdown_mentions_test.exs
+++ b/test/vutuv_web/markdown_mentions_test.exs
@@ -15,18 +15,22 @@ defmodule VutuvWeb.MarkdownMentionsTest do
 
   defp render_post(text), do: text |> Markdown.render_post([]) |> Phoenix.HTML.safe_to_string()
 
+  # Ada with a per-test-unique handle (dot/dash-free: the mention grammar in
+  # Vutuv.Mentions stops at them). Returns the handle for interpolation.
   defp ada do
-    insert(:user, username: "ada", first_name: "Ada", last_name: "Lovelace")
+    handle = "ada#{System.unique_integer([:positive])}"
+    insert(:user, username: handle, first_name: "Ada", last_name: "Lovelace")
+    handle
   end
 
   test "an @handle of an existing member links to their profile with a name tooltip" do
-    ada()
-    html = render("Thanks @ada for the help!")
+    handle = ada()
+    html = render("Thanks @#{handle} for the help!")
 
-    assert html =~ ~s(href="/ada")
+    assert html =~ ~s(href="/#{handle}")
     assert html =~ ~s(title="Ada Lovelace")
     assert html =~ ~s(class="mention")
-    assert html =~ ">@ada</a>"
+    assert html =~ ">@#{handle}</a>"
   end
 
   test "an @handle that is not a member stays plain text" do
@@ -37,81 +41,82 @@ defmodule VutuvWeb.MarkdownMentionsTest do
   end
 
   test "a bare username without @ is never linked" do
-    ada()
-    html = render("ada is great")
+    handle = ada()
+    html = render("#{handle} is great")
 
     refute html =~ "<a"
-    assert html =~ "ada is great"
+    assert html =~ "#{handle} is great"
   end
 
   test "matching is case-insensitive but the typed text and canonical slug are preserved" do
-    ada()
-    html = render("ping @Ada now")
+    handle = ada()
+    typed = String.capitalize(handle)
+    html = render("ping @#{typed} now")
 
-    assert html =~ ~s(href="/ada")
-    assert html =~ ">@Ada</a>"
+    assert html =~ ~s(href="/#{handle}")
+    assert html =~ ">@#{typed}</a>"
   end
 
   test "an email address is not mistaken for a mention" do
-    ada()
-    html = render("write to me at info@ada.example")
+    handle = ada()
+    html = render("write to me at info@#{handle}.example")
 
-    refute html =~ ~s(href="/ada")
-    assert html =~ "info@ada.example"
+    refute html =~ ~s(href="/#{handle}")
+    assert html =~ "info@#{handle}.example"
   end
 
   test "a mention inside inline code is left untouched" do
-    ada()
-    html = render("type `@ada` to mention them")
+    handle = ada()
+    html = render("type `@#{handle}` to mention them")
 
-    refute html =~ ~s(href="/ada")
-    assert html =~ "@ada"
+    refute html =~ ~s(href="/#{handle}")
+    assert html =~ "@#{handle}"
   end
 
   test "a mention inside a fenced code block is left untouched" do
-    ada()
-    html = render("```\n@ada\n```")
+    handle = ada()
+    html = render("```\n@#{handle}\n```")
 
-    refute html =~ ~s(href="/ada")
-    assert html =~ "@ada"
+    refute html =~ ~s(href="/#{handle}")
+    assert html =~ "@#{handle}"
   end
 
   test "a mention inside bold text still links" do
-    ada()
-    html = render("**hi @ada**")
+    handle = ada()
+    html = render("**hi @#{handle}**")
 
     assert html =~ "<strong>"
-    assert html =~ ~s(href="/ada")
+    assert html =~ ~s(href="/#{handle}")
   end
 
   test "several mentions in one text all resolve" do
-    ada()
+    handle = ada()
     insert(:user, username: "grace", first_name: "Grace", last_name: "Hopper")
 
-    html = render("cc @ada and @grace")
+    html = render("cc @#{handle} and @grace")
 
-    assert html =~ ~s(href="/ada")
+    assert html =~ ~s(href="/#{handle}")
     assert html =~ ~s(href="/grace")
     assert html =~ ~s(title="Grace Hopper")
   end
 
   test "the internal mention link stays in the same tab while external URLs open a new tab" do
-    ada()
-    html = render("see @ada and https://example.com/page")
+    handle = ada()
+    html = render("see @#{handle} and https://example.com/page")
 
     # the mention is an internal link: no target/rel
-    assert html =~ ~r{<a href="/ada"[^>]*class="mention"[^>]*>@ada</a>}
-    refute html =~ ~r{<a href="/ada"[^>]*target="_blank"}
+    assert html =~ ~r{<a href="/#{handle}"[^>]*class="mention"[^>]*>@#{handle}</a>}
+    refute html =~ ~r{<a href="/#{handle}"[^>]*target="_blank"}
     # the external URL still opens in a new tab
     assert html =~ ~s(href="https://example.com/page")
     assert html =~ ~s(target="_blank")
   end
 
   test "mentions also resolve in post bodies" do
-    ada()
-    html = render_post("Welcome @ada!")
+    handle = ada()
+    html = render_post("Welcome @#{handle}!")
 
-    assert html =~ ~s(href="/ada")
+    assert html =~ ~s(href="/#{handle}")
     assert html =~ ~s(title="Ada Lovelace")
   end
 

--- a/test/vutuv_web/seo_test.exs
+++ b/test/vutuv_web/seo_test.exs
@@ -32,7 +32,7 @@ defmodule VutuvWeb.SeoTest do
     end
 
     test "tag page (with a description and subsections)", %{conn: conn} do
-      tag = insert(:tag, name: "Elixir", slug: "elixir", description: "The BEAM language.")
+      tag = insert(:tag, description: "The BEAM language.")
       body = conn |> get(~p"/tags/#{tag}") |> html_response(200)
       assert h1_count(body) == 1
     end


### PR DESCRIPTION
**TL;DR** The daily "retry, don't chase" 40P01 deadlock at the pre-push gate was real lock contention: async test files inserted the same tag slugs, which the SQL sandbox holds locked until each test ends. Fixed by making every async-minted unique-key value per-module/per-test unique.

**Where:** `test/support/conn_case.ex` (`@registration_tags`), ~35 test files, comment corrections in `lib/vutuv/tags/tag.ex`.
**Now:** every registration fixture minted `alpha-tag beta-tag gamma-tag` and 18 async files minted the `elixir` slug; under the sandbox nothing commits, so those inserts hold the `tags_slug` unique-index lock until test end — files convoy, and opposite acquisition orders deadlock (reproduced: `admin/tag_controller_test` holds the trio and wants `ruby`; `user_tag_controller_test` holds `ruby` and registers, wanting `alpha-tag`). The v7.106.4 `ON CONFLICT` fix only helps in production, where the tag insert autocommits.
**Want (this PR):** `@registration_tags` embeds a stable per-module discriminator; all cross-file tag/username literals replaced with factory sequences, `Vutuv.Factory.unique_tag_name/1`, or per-module names; misleading comments corrected; rule documented in `docs/DEVELOPERS.md` and `.claude/rules/elixir.md`.
**Verification:** a stress loop over the ten contending files (`--max-cases 24`, random seeds) deadlocked on iteration 6 before the fix and ran 8/8 clean after; `mix precommit` green (4069 tests). Side effect: registering async tests no longer serialize behind the first `alpha-tag` holder.

*Written with this GitHub account, but not necessarily by the human behind it — this may just be a note-taking issue that gets deleted later without ever being tackled.*