### PR TITLE
Group CV update notifications per author per three hours (v7.121.1)

### DIFF
--- a/docs/architecture/profiles.md
+++ b/docs/architecture/profiles.md
@@ -275,7 +275,9 @@ are the only parts of the profile that can announce themselves. Their
 **new-entry** forms carry one checkbox ("Tell my N followers about this",
 ticked by default, hidden while the member has no followers) which sets
 `announce_to_followers?` on the row; the people who already follow them then see
-one in-app notification linking to that entry. Edit forms deliberately do not
+one in-app notification linking to that entry. Adding several entries in one
+sitting stays **one** notification: they are grouped per author per three hours,
+so a CV overhaul never floods anyone's bell. Edit forms deliberately do not
 offer it, and the flag is cast **only on insert**
 (`Vutuv.Profiles.CvSection.cast_announcement/2`), so an edit can never
 re-announce. No email is ever sent, and readers can switch the whole kind off in

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -82,9 +82,20 @@ the people who follow them, with one checkbox on the new-entry form (ticked by
 default, hidden while they have no followers). Only those three sections
 announce; the rest of the profile stays quiet.
 
+**One notification per author per three hours, not one per entry.** Somebody
+filling in five roles in one sitting is one piece of news, so the feed folds an
+author's announced entries into fixed three-hour buckets
+(`CvUpdates.bucket_seconds/0`) and renders one row that names them ("added 5 new
+entries to their CV", each entry listed and linked, capped at five plus "and N
+more"). The grouping is a plain `GROUP BY (author, bucket)` on the derived rows,
+so the unread badge counts groups too and a burst can never inflate it. The
+bucket window is baked into the SQL as a literal, not a query parameter: Postgres
+compares a GROUP BY expression with the SELECT list syntactically, and two
+placeholders are not the same expression.
+
 It is derived like every other kind, from the CV rows themselves
 (`Vutuv.Profiles.CvUpdates.feed_query/1` is the single rule behind the items,
-the count and the read marker): so deleting the entry removes the notification,
+the count and the read marker): so deleting the entry removes it from its group,
 renaming the job renames it, and nothing is duplicated into a notifications
 table. Who is told: everyone who followed the author **before** the entry
 appeared (no backfill for a new follower), minus muted follows, minus readers
@@ -102,7 +113,10 @@ Two flags carry it, one per side:
 
 It never sends email. `CvUpdates.announce/2` (called from the three create
 actions and the API create) only adds the live push to the same set of
-followers, so an open session's bell lights up at save time.
+followers, so an open session's bell lights up at save time. The push carries
+the **whole group under its derived id** (the one exception to the "live-"
+id namespace in `NotificationLive`), so a second entry within the window
+updates that row in place instead of stacking another one.
 
 ## Live member counter
 

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -240,10 +240,12 @@ defmodule Vutuv.Activity do
 
   @doc """
   Live push for a new CV entry one of the recipient's followees just added and
-  chose to announce (issue #980). `payload` is `Vutuv.Profiles.CvUpdates.payload/1`
-  — the section, the entry's route param and the two lines that name it, exactly
-  the columns the derived feed selects, so the pushed row and the reloaded page
-  render the same. In-app only: this kind never mails.
+  chose to announce (issue #980). `payload` is
+  `Vutuv.Profiles.CvUpdates.group_payload/2` — the author's whole current
+  three-hour group, under that group's own id, exactly what the derived feed
+  renders. Because the id is the derived one, a second entry within the window
+  **updates** the row an open page already shows instead of stacking another.
+  In-app only: this kind never mails.
   """
   def notify_cv_update(recipient_id, %User{} = author, %{} = payload) do
     notify(recipient_id, Map.merge(actor_fields(author), Map.put(payload, :kind, "cv_update")))
@@ -728,36 +730,20 @@ defmodule Vutuv.Activity do
   end
 
   # "Added a new position to their CV" entries (issue #980): the announced CV
-  # rows of the people this member follows. Derived straight from the CV
-  # tables through the one rule in `Vutuv.Profiles.CvUpdates.feed_query/1`, so
-  # deleting the entry removes the notification and renaming the job renames
-  # it. The actor is the author, and the entry's own page (under their
-  # profile) is what the row links to.
+  # rows of the people this member follows, **grouped per author per three
+  # hours** — somebody filling in five roles in one sitting is one piece of
+  # news, not five. Derived straight from the CV tables through the one rule in
+  # `Vutuv.Profiles.CvUpdates`, so deleting an entry drops it from its group
+  # and renaming the job renames it. The actor is the author; a single-entry
+  # group links to that entry's page, a bigger one to the profile.
   defp cv_update_items(user_id, limit, cursor) do
     user_id
-    |> CvUpdates.feed_query()
-    |> order_by([e], desc: e.inserted_at, desc: e.id)
-    |> limit(^limit)
-    |> at_or_before(cursor)
-    |> select([e, _follow, author], %{
-      id: e.id,
-      at: e.inserted_at,
-      author: struct(author, ^User.listing_fields()),
-      section: e.section,
-      title: e.title,
-      subtitle: e.subtitle,
-      param: e.param
-    })
-    |> Repo.all()
-    |> Enum.map(fn row ->
-      "cv-update-#{row.id}"
-      |> actor_item("cv_update", row.at, row.author)
-      |> Map.merge(%{
-        section: row.section,
-        entry_param: row.param,
-        entry_title: row.title,
-        entry_subtitle: row.subtitle
-      })
+    |> CvUpdates.page(limit, cursor)
+    |> Enum.map(fn %{author: author} = group ->
+      group
+      |> Map.delete(:author)
+      |> Map.merge(actor_fields(author))
+      |> Map.put(:kind, "cv_update")
     end)
   end
 
@@ -860,11 +846,12 @@ defmodule Vutuv.Activity do
     |> since(read_at)
   end
 
+  # Counts CV update **groups**, not rows: the badge must match what the page
+  # renders, so a five-entry burst inside one three-hour bucket is one unread
+  # item. The read-marker filter lives inside the grouped query (a HAVING on
+  # the group's newest entry), hence no `since/2` here.
   defp count_cv_updates(user_id, read_at) do
-    user_id
-    |> CvUpdates.feed_query()
-    |> select([e], %{count: count()})
-    |> since(read_at)
+    from(group in subquery(CvUpdates.count_query(user_id, read_at)), select: %{count: count()})
   end
 
   defp count_moderation(user_id, read_at) do

--- a/lib/vutuv/profiles/cv_updates.ex
+++ b/lib/vutuv/profiles/cv_updates.ex
@@ -16,11 +16,18 @@ defmodule Vutuv.Profiles.CvUpdates do
     * **In-app only.** No email, ever. The reader's single opt-out is
       `users.cv_update_notifications?` on the notification settings page.
 
+  **One notification per author per three hours, not one per entry.** Somebody
+  filling in five roles in one sitting is one piece of news, so the feed groups
+  an author's announced entries into three-hour buckets (`bucket_seconds/0`) and
+  shows a single row that names them ("added 5 new entries to their CV"). The
+  grouping is what the unread badge counts too, so a burst can never inflate it.
+
   Like every other kind in `Vutuv.Activity`, the feed is **derived at read
   time** — from the CV rows themselves, so nothing is duplicated: deleting the
-  entry removes the notification, and renaming the job renames it. `announce/2`
-  only adds the live push that lights up an open session's bell at the moment
-  the entry is saved.
+  entry removes it from its group, and renaming the job renames it. `announce/2`
+  only adds the live push that lights up an open session's bell; it carries the
+  **whole group** under the group's own id, so a second entry updates that one
+  row in place instead of stacking a new one.
 
   Who is told: everyone who followed the author **before** the entry appeared
   (a later follower is not backfilled with old news), minus muted follows and
@@ -41,15 +48,47 @@ defmodule Vutuv.Profiles.CvUpdates do
   alias Vutuv.Repo
   alias Vutuv.Social.Follow
 
+  # How long one "batch of CV news" lasts. Entries an author announces inside
+  # the same three-hour wall-clock bucket share a single notification row.
+  # Fixed buckets, not a sliding window: a bucket is a plain GROUP BY key, so
+  # the items, the unread count and the read marker all derive from the same
+  # cheap expression instead of needing per-reader state.
+  @bucket_seconds 3 * 60 * 60
+
+  # How many of a group's entries the notification names before it says
+  # "and N more".
+  @preview_entries 5
+
+  @doc "The grouping window in seconds (three hours)."
+  def bucket_seconds, do: @bucket_seconds
+
+  # The bucket a timestamp falls into, as SQL. The window is baked into the
+  # fragment **as a literal** rather than a query parameter on purpose:
+  # Postgres matches a GROUP BY expression against the SELECT list
+  # syntactically, and two placeholders ($1 here, $7 there) are not the same
+  # expression — grouping by it then fails with "must appear in the GROUP BY
+  # clause". A macro keeps the constant single-sourced anyway.
+  defmacrop bucket_of_sql(field) do
+    quote do
+      fragment(
+        unquote("floor(extract(epoch from ?) / #{@bucket_seconds})::bigint"),
+        unquote(field)
+      )
+    end
+  end
+
   @doc """
   Pushes the live "new CV entry" notification to the author's eligible
   followers. A no-op for an entry whose author did not tick the box, so the
   create actions can call it unconditionally.
 
-  Runs inline: it is one indexed query plus a local PubSub broadcast per
-  follower, on a page a member visits a handful of times in their life. The
-  durable side needs nothing — the feed derives the same entry from the row
-  that was just inserted.
+  The payload is the author's **whole current bucket**, under that group's
+  stable id, so a second entry within three hours updates the row an open
+  session already shows rather than adding another one — the same row the feed
+  would render on a reload.
+
+  Runs inline: it is two indexed queries plus a local PubSub broadcast per
+  follower, on a form a member submits a handful of times in their life.
   """
   def announce(author, entry)
 
@@ -57,7 +96,7 @@ defmodule Vutuv.Profiles.CvUpdates do
     if Moderation.account_hidden?(author) do
       :ok
     else
-      payload = payload(entry)
+      payload = group_payload(author.id, entry)
 
       author.id
       |> recipient_ids()
@@ -84,40 +123,132 @@ defmodule Vutuv.Profiles.CvUpdates do
   end
 
   @doc """
-  The notification payload for one CV entry: which section it belongs to, the
-  route param its own page is reachable under, and the two lines that name it
-  (`entry_title` leads, `entry_subtitle` qualifies — "Head of Bridges" at "Span
-  AG"). The derived feed selects exactly these columns, so a pushed event and a
-  reloaded page render identically.
+  One notification group as the feed renders it: the group id, its newest
+  timestamp, how many entries it holds and the newest few, named.
+
+  Built for the live push (`announce/2`), where the just-saved `entry` fixes
+  which bucket we are in; the reader-side twin is `page/3`, and both go through
+  `group_item/4` so a pushed row and a reloaded page are the same row.
   """
-  def payload(%WorkExperience{} = entry) do
+  def group_payload(author_id, entry) do
+    bucket = bucket_of(entry.inserted_at)
+
+    rows =
+      Repo.all(
+        from(e in subquery(announced_entries()),
+          where: e.user_id == ^author_id,
+          where: bucket_of_sql(e.inserted_at) == ^bucket,
+          order_by: [desc: e.inserted_at, desc: e.id],
+          select: %{
+            at: e.inserted_at,
+            section: e.section,
+            title: e.title,
+            subtitle: e.subtitle,
+            param: e.param
+          }
+        )
+      )
+
+    entries = Enum.map(rows, &Map.delete(&1, :at))
+    group_item(author_id, bucket, latest_at(rows, entry.inserted_at), entries)
+  end
+
+  defp latest_at([%{at: at} | _], _fallback), do: at
+  defp latest_at([], fallback), do: fallback
+
+  @doc """
+  One page of `recipient_id`'s CV update groups, newest first — the feed source
+  `Vutuv.Activity` plugs into its cursor pagination.
+
+  One query: the announced entries this reader may see, folded into
+  `(author, three-hour bucket)` groups, each carrying its size and its entries'
+  names as parallel arrays (same ORDER BY, so they zip). `cursor` filters on the
+  group's newest entry, which is also what the row is timestamped and sorted by.
+  """
+  def page(recipient_id, limit, cursor) do
+    recipient_id
+    |> grouped_query(nil)
+    |> select([e, _follow, author], %{
+      user_id: e.user_id,
+      bucket: bucket_of_sql(e.inserted_at),
+      at: max(e.inserted_at),
+      count: count(),
+      author: struct(author, ^User.listing_fields()),
+      sections: fragment("array_agg(? ORDER BY ? DESC, ? DESC)", e.section, e.inserted_at, e.id),
+      titles: fragment("array_agg(? ORDER BY ? DESC, ? DESC)", e.title, e.inserted_at, e.id),
+      subtitles:
+        fragment("array_agg(? ORDER BY ? DESC, ? DESC)", e.subtitle, e.inserted_at, e.id),
+      params: fragment("array_agg(? ORDER BY ? DESC, ? DESC)", e.param, e.inserted_at, e.id)
+    })
+    # The tiebreaker is the grouped author id (not an aggregate over the entry
+    # ids): `max()` is not defined for uuid on every Postgres we support.
+    |> order_by([e], desc: max(e.inserted_at), desc: e.user_id)
+    |> limit(^limit)
+    |> before_cursor(cursor)
+    |> Repo.all()
+    |> Enum.map(fn row ->
+      entries =
+        [row.sections, row.titles, row.subtitles, row.params]
+        |> Enum.zip_with(fn [section, title, subtitle, param] ->
+          %{section: section, title: title, subtitle: subtitle, param: param}
+        end)
+
+      row.user_id
+      |> group_item(row.bucket, row.at, entries, row.count)
+      |> Map.put(:author, row.author)
+    end)
+  end
+
+  @doc """
+  The reader's CV update **groups**, as a query `Vutuv.Activity` can count.
+  `read_at` (nil = everything) keeps a group out unless its newest entry is
+  newer than the read marker, so a burst counts as the single unread item it
+  renders as.
+  """
+  def count_query(recipient_id, read_at) do
+    recipient_id
+    |> grouped_query(read_at)
+    |> select([e], %{entries: count()})
+  end
+
+  # The shared grouped shape: the visible entries (feed_query/1), folded into
+  # (author, bucket) groups. `read_at` filters on the group's newest entry —
+  # a HAVING, not a WHERE, so an older entry never drags a fresh group out of
+  # the unread count.
+  defp grouped_query(recipient_id, read_at) do
+    query =
+      recipient_id
+      |> feed_query()
+      |> group_by([e, _follow, author], [
+        e.user_id,
+        author.id,
+        bucket_of_sql(e.inserted_at)
+      ])
+
+    if read_at, do: having(query, [e], max(e.inserted_at) > ^read_at), else: query
+  end
+
+  defp before_cursor(query, nil), do: query
+  defp before_cursor(query, %{at: at}), do: having(query, [e], max(e.inserted_at) <= ^at)
+
+  # The one shape a CV update row has, wherever it comes from: a stable id
+  # (author + bucket, so the live push updates the row the feed derives rather
+  # than doubling it), the group's newest timestamp, the entries it names and
+  # how many there are in total.
+  defp group_item(author_id, bucket, at, entries, count \\ nil) do
     %{
-      section: "work_experiences",
-      entry_param: Phoenix.Param.to_param(entry),
-      entry_title: entry.title,
-      entry_subtitle: entry.organization,
-      at: entry.inserted_at
+      id: "cv-update-#{author_id}-#{bucket}",
+      at: at,
+      entry_count: count || length(entries),
+      entries: Enum.take(entries, @preview_entries)
     }
   end
 
-  def payload(%Education{} = entry) do
-    %{
-      section: "educations",
-      entry_param: Phoenix.Param.to_param(entry),
-      entry_title: entry.degree,
-      entry_subtitle: entry.school,
-      at: entry.inserted_at
-    }
-  end
-
-  def payload(%Qualification{} = entry) do
-    %{
-      section: "qualifications",
-      entry_param: Phoenix.Param.to_param(entry),
-      entry_title: entry.name,
-      entry_subtitle: entry.issuer,
-      at: entry.inserted_at
-    }
+  defp bucket_of(%NaiveDateTime{} = at) do
+    at
+    |> DateTime.from_naive!("Etc/UTC")
+    |> DateTime.to_unix()
+    |> div(@bucket_seconds)
   end
 
   @doc """

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -100,8 +100,11 @@ defmodule VutuvWeb.NotificationLive.Index do
       |> Map.put_new(:kind, "activity")
       # Pushed events carry no row id, so mint one. The "live-" prefix keeps
       # them out of the derived "<kind>-<row id>" namespace - a pushed event
-      # must prepend, never update a derived row in place.
-      |> Map.put(:id, "live-#{System.unique_integer([:positive, :monotonic])}")
+      # must prepend, never update a derived row in place. The one exception
+      # brings its own id: a CV update (issue #980) is pushed under its derived
+      # group id, so a second entry within the grouping window updates that one
+      # row instead of stacking another.
+      |> Map.put_new(:id, "live-#{System.unique_integer([:positive, :monotonic])}")
       # A pushed reply/like carries the post ids but no bodies; quote them like
       # the derived rows do.
       |> List.wrap()
@@ -115,7 +118,9 @@ defmodule VutuvWeb.NotificationLive.Index do
     {:noreply,
      socket
      |> assign(:empty?, false)
-     |> update(:items, &[item | &1])
+     # A re-pushed row (a CV update whose group grew) replaces the copy it
+     # updates, so the midnight restream doesn't render it twice.
+     |> update(:items, fn items -> [item | Enum.reject(items, &(&1.id == item.id))] end)
      |> stream_insert(:notifications, item, at: 0)}
   end
 
@@ -209,6 +214,29 @@ defmodule VutuvWeb.NotificationLive.Index do
               class="mt-2"
               data-reply-preview="true"
             />
+            <%!-- A CV update that covers several entries (issue #980: one
+            notification per author per three hours) names them below the line,
+            each linking to its own page, plus a count of any beyond the shown
+            few. A single-entry group says it in the line itself. --%>
+            <div
+              :if={n.kind == "cv_update" and n[:entry_count] > 1}
+              class="mt-2"
+              data-cv-entries="true"
+            >
+              <ul class="space-y-1">
+                <li :for={entry <- n[:entries] || []} class="text-sm">
+                  <.link
+                    href={cv_entry_path(n, entry)}
+                    class="text-slate-600 hover:text-brand-700 dark:text-slate-400 dark:hover:text-brand-300"
+                  >
+                    {cv_entry_label(entry)}
+                  </.link>
+                </li>
+              </ul>
+              <p :if={cv_entries_more(n) > 0} class="mt-1 text-xs text-slate-600 dark:text-slate-400">
+                {gettext("and %{count} more", count: compact_count(cv_entries_more(n)))}
+              </p>
+            </div>
             <%!-- A handle change lists the recipient's own rewritten posts: the
             newest few as excerpt previews, plus a count of any remaining ones. --%>
             <div :if={n.kind == "handle_change"} class="mt-2 space-y-2" data-change-posts="true">
@@ -328,20 +356,13 @@ defmodule VutuvWeb.NotificationLive.Index do
     if n[:image_kind] in ["avatar", "cover"] and viewer != nil, do: ~p"/settings/profile"
   end
 
-  # A new CV entry (issue #980) opens that entry's own page on the author's
-  # profile; the actor line beside it links to the profile itself. A payload
-  # missing either half falls through to the profile link.
+  # A CV update (issue #980) opens the entry itself when the group holds
+  # exactly one; a bigger group leads to the author's profile, where all of
+  # them sit (the entries are listed and individually linked under the line).
   defp notification_target(%{kind: "cv_update"} = n, _viewer) do
-    with slug when is_binary(slug) <- n[:actor_param],
-         param when is_binary(param) <- n[:entry_param] do
-      case n[:section] do
-        "work_experiences" -> ~p"/#{slug}/work_experiences/#{param}"
-        "educations" -> ~p"/#{slug}/educations/#{param}"
-        "qualifications" -> ~p"/#{slug}/qualifications/#{param}"
-        _ -> ~p"/#{slug}"
-      end
-    else
-      _ -> nil
+    case n[:entries] do
+      [entry] -> cv_entry_path(n, entry)
+      _ -> actor_target(n)
     end
   end
 
@@ -442,19 +463,28 @@ defmodule VutuvWeb.NotificationLive.Index do
     )
   end
 
-  # A new CV entry the author chose to announce (issue #980). The wording names
-  # the section, so a reader can tell a job from a degree without opening it.
-  defp notification_text(%{kind: "cv_update"} = n) do
-    case n[:section] do
+  # New CV entries the author chose to announce (issue #980). A lone entry gets
+  # the section-specific wording, so a reader can tell a job from a degree
+  # without opening it; a group of them is counted and listed below the line.
+  defp notification_text(%{kind: "cv_update", entries: [entry]}) do
+    case entry.section do
       "educations" ->
-        gettext("added a new education entry to their CV: %{entry}", entry: cv_entry_label(n))
+        gettext("added a new education entry to their CV: %{entry}",
+          entry: cv_entry_label(entry)
+        )
 
       "qualifications" ->
-        gettext("added a new certificate to their CV: %{entry}", entry: cv_entry_label(n))
+        gettext("added a new certificate to their CV: %{entry}", entry: cv_entry_label(entry))
 
       _ ->
-        gettext("added a new position to their CV: %{entry}", entry: cv_entry_label(n))
+        gettext("added a new position to their CV: %{entry}", entry: cv_entry_label(entry))
     end
+  end
+
+  defp notification_text(%{kind: "cv_update"} = n) do
+    gettext("added %{count} new entries to their CV:",
+      count: compact_count(n[:entry_count] || 0)
+    )
   end
 
   defp notification_text(n), do: n[:text]
@@ -462,11 +492,29 @@ defmodule VutuvWeb.NotificationLive.Index do
   # "Head of Bridges · Span AG": what the entry is, then where. Either half can
   # be missing (an education entry with no degree, a certificate with no
   # issuer), so the separator only appears when both are there.
-  defp cv_entry_label(n) do
-    [n[:entry_title], n[:entry_subtitle]]
+  defp cv_entry_label(entry) do
+    [entry.title, entry.subtitle]
     |> Enum.reject(&(&1 in [nil, ""]))
     |> Enum.join(" · ")
   end
+
+  # One entry's own page under the author's profile.
+  defp cv_entry_path(n, entry) do
+    with slug when is_binary(slug) <- n[:actor_param],
+         param when is_binary(param) <- entry.param do
+      case entry.section do
+        "work_experiences" -> ~p"/#{slug}/work_experiences/#{param}"
+        "educations" -> ~p"/#{slug}/educations/#{param}"
+        "qualifications" -> ~p"/#{slug}/qualifications/#{param}"
+        _ -> ~p"/#{slug}"
+      end
+    else
+      _ -> nil
+    end
+  end
+
+  # How many of a group's entries are not in the shown list.
+  defp cv_entries_more(n), do: (n[:entry_count] || 0) - length(n[:entries] || [])
 
   # Reply and like notifications carry post ids the row can quote: a like the
   # liked post (`:post_id`), a reply both the recipient's own post that was

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.121.0",
+      version: "7.121.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -14544,3 +14544,8 @@ msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folg
 #, elixir-autogen, elixir-format
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
+
+#: lib/vutuv_web/live/notification_live/index.ex:470
+#, elixir-autogen, elixir-format
+msgid "added %{count} new entries to their CV:"
+msgstr "hat %{count} neue Einträge im Lebenslauf:"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -13815,3 +13815,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:470
+#, elixir-autogen, elixir-format
+msgid "added %{count} new entries to their CV:"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -13813,3 +13813,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:470
+#, elixir-autogen, elixir-format
+msgid "added %{count} new entries to their CV:"
+msgstr ""

--- a/test/vutuv/profiles/cv_updates_test.exs
+++ b/test/vutuv/profiles/cv_updates_test.exs
@@ -6,12 +6,15 @@ defmodule Vutuv.Profiles.CvUpdatesTest do
   """
   use Vutuv.DataCase, async: true
 
+  import Ecto.Query
+
   alias Vutuv.Activity
   alias Vutuv.Profiles.CvUpdates
   alias Vutuv.Profiles.Education
   alias Vutuv.Profiles.Qualification
   alias Vutuv.Profiles.WorkExperience
   alias Vutuv.Repo
+  alias Vutuv.Social.Follow
 
   defp announce_work_experience(author, attrs \\ []) do
     attrs = Keyword.merge([title: "Head of Bridges", organization: "Span AG"], attrs)
@@ -30,12 +33,14 @@ defmodule Vutuv.Profiles.CvUpdatesTest do
 
       announce_work_experience(author)
 
-      assert [entry] = Activity.notifications_page(follower.id).entries
-      assert entry.kind == "cv_update"
+      assert [item] = Activity.notifications_page(follower.id).entries
+      assert item.kind == "cv_update"
+      assert item.entry_count == 1
+      assert [entry] = item.entries
       assert entry.section == "work_experiences"
-      assert entry.entry_title == "Head of Bridges"
-      assert entry.entry_subtitle == "Span AG"
-      assert entry.actor_param == author.username
+      assert entry.title == "Head of Bridges"
+      assert entry.subtitle == "Span AG"
+      assert item.actor_param == author.username
       assert Activity.unread_notification_count(follower.id) == 1
     end
 
@@ -75,16 +80,20 @@ defmodule Vutuv.Profiles.CvUpdatesTest do
 
       CvUpdates.announce(author, qualification)
 
-      entries = Activity.notifications_page(follower.id).entries
-      assert Enum.map(entries, & &1.section) |> Enum.sort() == ["educations", "qualifications"]
+      # Same author, same three-hour window: one grouped notification naming both.
+      assert [item] = Activity.notifications_page(follower.id).entries
+      assert item.entry_count == 2
 
-      education_entry = Enum.find(entries, &(&1.section == "educations"))
-      assert education_entry.entry_title == "MSc Structures"
-      assert education_entry.entry_subtitle == "Bridge University"
+      assert item.entries |> Enum.map(& &1.section) |> Enum.sort() ==
+               ["educations", "qualifications"]
 
-      qualification_entry = Enum.find(entries, &(&1.section == "qualifications"))
-      assert qualification_entry.entry_title == "Bridge Inspector"
-      assert qualification_entry.entry_param == qualification.id
+      education_entry = Enum.find(item.entries, &(&1.section == "educations"))
+      assert education_entry.title == "MSc Structures"
+      assert education_entry.subtitle == "Bridge University"
+
+      qualification_entry = Enum.find(item.entries, &(&1.section == "qualifications"))
+      assert qualification_entry.title == "Bridge Inspector"
+      assert qualification_entry.param == qualification.id
     end
 
     test "only people who follow the author are told" do
@@ -162,6 +171,92 @@ defmodule Vutuv.Profiles.CvUpdatesTest do
     end
   end
 
+  describe "grouping (one notification per author per three hours)" do
+    test "a burst of entries is one notification, not one each" do
+      author = insert_activated_user()
+      follower = insert_activated_user()
+      follow!(follower, author)
+
+      for title <- ["Head of Bridges", "Site Manager", "Junior Engineer"] do
+        announce_work_experience(author, title: title)
+      end
+
+      assert [item] = Activity.notifications_page(follower.id).entries
+      assert item.entry_count == 3
+
+      assert Enum.map(item.entries, & &1.title) == [
+               "Junior Engineer",
+               "Site Manager",
+               "Head of Bridges"
+             ]
+
+      # The badge counts what the page renders: one item, not three.
+      assert Activity.unread_notification_count(follower.id) == 1
+      assert Activity.notifications_count(follower.id) == 1
+    end
+
+    test "entries in different windows stay separate notifications" do
+      author = insert_activated_user()
+      follower = insert_activated_user()
+      follow!(follower, author)
+
+      now = NaiveDateTime.utc_now(:second)
+      long_ago = NaiveDateTime.add(now, -2 * CvUpdates.bucket_seconds(), :second)
+      # The follow predates both entries — a notification is only for entries
+      # added after you followed.
+      Repo.update_all(from(f in Follow, where: f.follower_id == ^follower.id),
+        set: [inserted_at: NaiveDateTime.add(long_ago, -60, :second)]
+      )
+
+      insert(:work_experience,
+        user: author,
+        title: "Yesterday's job",
+        announce_to_followers?: true,
+        inserted_at: long_ago
+      )
+
+      announce_work_experience(author, title: "Today's job")
+
+      items = Activity.notifications_page(follower.id).entries
+      assert length(items) == 2
+      assert Enum.all?(items, &(&1.entry_count == 1))
+      assert Activity.unread_notification_count(follower.id) == 2
+    end
+
+    test "a group beyond the preview cap counts everything but names a few" do
+      author = insert_activated_user()
+      follower = insert_activated_user()
+      follow!(follower, author)
+
+      for i <- 1..7, do: announce_work_experience(author, title: "Role #{i}")
+
+      assert [item] = Activity.notifications_page(follower.id).entries
+      assert item.entry_count == 7
+      assert length(item.entries) == 5
+    end
+
+    test "reading a group and then adding to it makes it unread again" do
+      author = insert_activated_user()
+      follower = insert_activated_user()
+      follow!(follower, author)
+
+      announce_work_experience(author, title: "First")
+      Activity.mark_notifications_read(follower.id)
+      assert Activity.unread_notification_count(follower.id) == 0
+
+      # A minute later, still inside the same three-hour window. (The timestamp
+      # is explicit because the read marker has second precision, so two rows
+      # written in the same test second would tie.)
+      announce_work_experience(author,
+        title: "Second",
+        inserted_at: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 60, :second)
+      )
+
+      assert Activity.unread_notification_count(follower.id) == 1
+      assert [%{entry_count: 2}] = Activity.notifications_page(follower.id).entries
+    end
+  end
+
   describe "the live push" do
     test "an eligible follower is pushed the same payload the feed shows" do
       author = insert_activated_user(first_name: "Greta", last_name: "Gradient")
@@ -173,11 +268,33 @@ defmodule Vutuv.Profiles.CvUpdatesTest do
 
       assert_receive {:new_notification, notification}
       assert notification.kind == "cv_update"
-      assert notification.section == "work_experiences"
-      assert notification.entry_title == "Head of Bridges"
-      assert notification.entry_subtitle == "Span AG"
+      assert notification.entry_count == 1
+      assert [entry] = notification.entries
+      assert entry.section == "work_experiences"
+      assert entry.title == "Head of Bridges"
+      assert entry.subtitle == "Span AG"
       assert notification.actor_name == "Greta Gradient"
       assert notification.actor_param == author.username
+
+      # The pushed row carries the DERIVED group id, so the page updates that
+      # row instead of stacking a second one.
+      assert [%{id: id}] = Activity.notifications_page(follower.id).entries
+      assert notification.id == id
+    end
+
+    test "a second entry in the same window re-pushes the whole group" do
+      author = insert_activated_user()
+      follower = insert_activated_user()
+      follow!(follower, author)
+      Activity.subscribe(follower.id)
+
+      announce_work_experience(author, title: "First")
+      assert_receive {:new_notification, %{entry_count: 1, id: first_id}}
+
+      announce_work_experience(author, title: "Second")
+      assert_receive {:new_notification, %{entry_count: 2, id: ^first_id} = grouped}
+
+      assert Enum.map(grouped.entries, & &1.title) == ["Second", "First"]
     end
 
     test "no push without the flag, for a muted follow or an opted-out reader" do

--- a/test/vutuv_web/controllers/cv_update_notification_test.exs
+++ b/test/vutuv_web/controllers/cv_update_notification_test.exs
@@ -81,6 +81,32 @@ defmodule VutuvWeb.CvUpdateNotificationTest do
       assert body =~ ~s(href="/#{author.username}")
     end
 
+    test "a second entry joins the first row instead of adding one", %{conn: conn} do
+      {follower_conn, follower} = login_follower()
+      {conn, author} = create_and_login_user(conn)
+      follow!(follower, author)
+
+      for title <- ["Head of Bridges", "Site Manager"] do
+        post(conn, ~p"/settings/work_experiences", %{
+          "work_experience" => %{
+            "title" => title,
+            "organization" => "Span AG",
+            "kind" => "employment",
+            "announce_to_followers?" => "true"
+          }
+        })
+      end
+
+      body = html_response(get(follower_conn, ~p"/notifications"), 200)
+
+      # One row, counting both, with each entry named and linked.
+      assert body =~ "added 2 new entries to their CV"
+      refute body =~ "added a new position to their CV"
+      assert body =~ "Head of Bridges · Span AG"
+      assert body =~ "Site Manager · Span AG"
+      assert [_] = Regex.scan(~r/CV update/, body)
+    end
+
     test "an unticked box tells nobody", %{conn: conn} do
       {follower_conn, follower} = login_follower()
       {conn, author} = create_and_login_user(conn)


### PR DESCRIPTION
Follow-up to #981 (issue #980).

**TL;DR** A member who adds eight CV entries in one sitting now produces **one** notification, not eight. Announced CV entries are grouped per author per three hours, in the derived feed and in the unread badge alike.

**Now:** one row per entry. A CV overhaul floods every follower's bell — exactly the noise that makes people switch a kind off.
**Want:** one row per author per three-hour window, naming what was added.

### What it looks like

> **Greta Gradient** hat 2 neue Einträge im Lebenslauf:
> Statikerin · Brücken GmbH
> Leiterin Brückenbau · Span AG
> LEBENSLAUF-UPDATE · 22.07.26, 09:20

Each entry links to its own page; the actor line links to the profile. Beyond five entries the row says "und N weitere". A group of exactly one keeps the previous single-line wording ("hat eine neue Station im Lebenslauf: …"), so the common case reads unchanged.

### How

The feed is derived, so this is a plain `GROUP BY (author, three-hour bucket)` over the same rows — **no new column, no migration**, and it applies retroactively to everything announced since yesterday.

- It is the same query the unread count reads, so the badge can never disagree with the page: a burst is one unread item, and adding to a group you already read makes that one item unread again (a `HAVING` on the group's newest entry, not a `WHERE`, so an old entry can't drag a fresh group out of the count).
- The bucket expression is baked into the SQL as a **literal**, not a query parameter: Postgres compares a GROUP BY expression with the SELECT list syntactically, and `$1` vs `$7` are not the same expression (that version failed with *"must appear in the GROUP BY clause"*). A private macro keeps the window single-sourced.
- The live push carries the whole group under its **derived id** — the one exception to `NotificationLive`'s `"live-"` id namespace — so a second entry within the window updates the row an open page already shows instead of stacking another. The shell recomputes its badge from the database on every push, so it stays on the grouped number.

### Tests

`cv_updates_test.exs` grows a grouping block: a burst is one item, different windows stay separate, a group past the preview cap counts all and names five, and reading a group then adding to it makes it unread again. Plus a web test asserting one row names both entries. 4158 tests green (`mix precommit`).

### Browser smoke test (German UI)

Two work experiences added back to back → exactly one row, "hat 2 neue Einträge im Lebenslauf:", both entries listed and linked to `/greta_gradient/work_experiences/…`, headline to `/greta_gradient`.

https://claude.ai/code/session_01UDHS3sZsVbVgoKpJajTFfp
