### PR TITLE
Pin "CV updates are on by default" with a test (v7.121.3)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.121.2",
+      version: "7.121.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/cv_update_notification_test.exs
+++ b/test/vutuv_web/controllers/cv_update_notification_test.exs
@@ -129,6 +129,27 @@ defmodule VutuvWeb.CvUpdateNotificationTest do
   end
 
   describe "the reader's switch" do
+    test "a brand-new member gets CV updates without touching a setting", %{conn: conn} do
+      # The kind is opt-OUT: on for everyone, from the moment they sign up. The
+      # migration's `NOT NULL DEFAULT true` says the same for every member who
+      # existed before the feature, and only this switch can turn it off.
+      author = insert_activated_user()
+      {conn, follower} = create_and_login_user(conn)
+
+      assert Repo.get!(User, follower.id).cv_update_notifications?
+
+      follow!(follower, author)
+
+      entry =
+        insert(:work_experience,
+          user: author,
+          title: "Head of Bridges",
+          announce_to_followers?: true
+        )
+
+      assert html_response(get(conn, ~p"/notifications"), 200) =~ entry.title
+    end
+
     test "the notification settings page saves it", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 


### PR DESCRIPTION
**TL;DR** CV update notifications are opt-OUT for everyone, old members and new. That was already true; this pins it with a test.

**Where:** `users.cv_update_notifications?`

- The migration added the column as `NOT NULL DEFAULT true`, so **every member who existed when v7.121.0 deployed was backfilled with `true`**.
- `Vutuv.Accounts.User` carries the same schema default, so every registration since starts with it on.
- The only way to `false` is the member's own switch on `/settings/notifications`.

The existing tests all asserted the *off* direction (flip the switch, things disappear). Since "on by default" is a product decision rather than an implementation detail, the new test states it directly: a brand-new member who has touched no setting sees a followee's announced CV entry. A future default flip now breaks a test that explains why it exists.

No behaviour change.

https://claude.ai/code/session_01UDHS3sZsVbVgoKpJajTFfp