### PR TITLE
Honour a remote actor's Update and Delete on the Fediverse inbox (v7.121.4)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -3,8 +3,9 @@
 People on Mastodon and other ActivityPub servers can follow an opted-in
 member and receive their **public** posts. Federation is outbound-only by
 design: no remote posts, likes or replies are stored — the inbox only
-processes `Follow` and `Undo(Follow)`; everything else is acknowledged (202)
-and dropped. Everything lives in `Vutuv.Fediverse`.
+processes `Follow`, `Undo(Follow)` and the remote actor's own lifecycle
+(`Update` / `Delete`); everything else is acknowledged (202) and dropped.
+Everything lives in `Vutuv.Fediverse`.
 
 ## Consent first
 
@@ -40,6 +41,18 @@ every endpoint 404s and nothing is delivered.
   (anti-spoofing). A valid `Follow` stores the follower
   (`Vutuv.Fediverse.Follower`: actor URI + inbox + sharedInbox) and answers
   with a delivered `Accept`; `Undo` removes it. Per-IP rate limited.
+- **Remote actor lifecycle**: an `Update` of the actor itself re-syncs the
+  stored row from the freshly fetched document (a renamed remote must not stay
+  listed under the old handle, a moved inbox must not keep receiving posts) and
+  a `Delete` of the actor itself removes it, so a gone account stops counting
+  as a follower. Both are scoped to the actor: `Update`/`Delete` of a remote
+  *note* still falls through and is dropped, and an `Update` from someone who
+  follows nobody here never mints a row. The `Delete` half is best effort by
+  protocol — a server that already purged the account answers our actor fetch
+  with 410, so the signature cannot be verified and the activity is rejected;
+  it lands during the window where the account is suspended but still served.
+  Deliveries to a gone inbox are dropped by the queue on 404/410 but do not
+  yet prune the follower row (see the v1 limits).
 - **Deliveries** (`Vutuv.Fediverse.Delivery` + `Deliverer`): the same
   DB-backed queue shape as webhooks — rows per activity × distinct inbox
   (sharedInbox dedupes per server), drained every 15s or on nudge, POSTs
@@ -78,4 +91,7 @@ every endpoint 404s and nothing is delivered.
 No inbound content (likes/replies/boosts are dropped), no `Announce` for
 reposts, no `Move`/account migration, and account deletion sends no actor
 `Delete` broadcast (rows cascade; remote copies age out). The followers
-collection is count-only (privacy).
+collection is count-only (privacy). A follower row whose inbox answers 404/410
+is not pruned either: deliveries go to the sharedInbox where the remote
+declares one, so a per-actor gone signal rarely reaches us and pruning on a
+shared inbox would drop every follower on that server.

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -11,7 +11,8 @@ defmodule Vutuv.Fediverse do
     * actors — the member's RSA keypair (`Vutuv.Fediverse.Actor`), created
       lazily on opt-in; `VutuvWeb.Fediverse.Docs` renders the documents.
     * followers — remote actors following a member
-      (`Vutuv.Fediverse.Follower`), written by the inbox on Follow/Undo.
+      (`Vutuv.Fediverse.Follower`), written by the inbox on Follow/Undo and
+      kept in step with the remote's own Update/Delete.
     * deliveries — a DB-backed outbound queue (`Vutuv.Fediverse.Delivery`)
       drained by `Vutuv.Fediverse.Deliverer` with signed POSTs
       (`Vutuv.Fediverse.HttpSignature`), mirroring the webhooks queue.
@@ -83,14 +84,33 @@ defmodule Vutuv.Fediverse do
 
   ## Remote followers
 
-  @doc "Records a remote follower (idempotent per remote actor)."
+  @doc """
+  Records a remote follower (idempotent per remote actor). A repeat Follow
+  re-syncs every cached field from the actor document, the display ones
+  included — a remote who renamed must not stay listed under the old handle.
+  """
   def add_follower(%User{} = user, attrs) do
     %Follower{user_id: user.id}
     |> Follower.changeset(attrs)
     |> Repo.insert(
-      on_conflict: {:replace, [:inbox_uri, :shared_inbox_uri, :updated_at]},
+      on_conflict: {:replace, [:inbox_uri, :shared_inbox_uri, :handle, :name, :updated_at]},
       conflict_target: [:user_id, :actor_uri]
     )
+  end
+
+  @doc """
+  Re-syncs an existing follower row from the remote actor document (the
+  inbox's `Update` handler). A no-op when that actor follows nobody here: an
+  `Update` is a broadcast, not a follow request, so it must never mint a row.
+  Like `add_follower/2` it swallows a rejected changeset — a hostile actor
+  document must not crash the inbox.
+  """
+  def refresh_follower(%User{id: user_id}, %{actor_uri: actor_uri} = attrs) do
+    if follower = Repo.get_by(Follower, user_id: user_id, actor_uri: actor_uri) do
+      follower |> Follower.changeset(attrs) |> Repo.update()
+    end
+
+    :ok
   end
 
   def remove_follower(%User{id: user_id}, actor_uri) do

--- a/lib/vutuv/fediverse/follower.ex
+++ b/lib/vutuv/fediverse/follower.ex
@@ -3,7 +3,10 @@ defmodule Vutuv.Fediverse.Follower do
   A remote (Fediverse) follower of a member: the remote actor's id URI and
   where to deliver (its inbox, plus the server-wide sharedInbox when the
   remote declares one, so a server with many followers gets each post once).
-  Rows are written by the inbox on `Follow` and removed on `Undo`.
+  Rows are written by the inbox on `Follow` and removed on `Undo`; the remote
+  actor's own `Update` re-syncs them and its `Delete` removes them, so a
+  renamed remote stops showing under its old handle and a deleted one stops
+  counting as a follower.
   """
 
   use VutuvWeb, :model

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -6,8 +6,10 @@ defmodule VutuvWeb.FediverseController do
       `@handle@host` into an actor URL,
     * `GET /:slug/actor` (+ `/followers`, `/outbox`) — the member's
       machine-readable identity,
-    * `POST /:slug/actor/inbox` — receives signed `Follow`/`Undo` activities;
-      everything else is acknowledged and dropped (outbound-only by design).
+    * `POST /:slug/actor/inbox` — receives signed `Follow`/`Undo` activities
+      plus the remote actor's own lifecycle (`Update` re-syncs the stored
+      follower, `Delete` of the actor removes it); everything else is
+      acknowledged and dropped (outbound-only by design).
 
   Deliberately outside the `:browser` pipeline: no session, no CSRF — remote
   servers authenticate with HTTP signatures instead, verified against the
@@ -118,13 +120,7 @@ defmodule VutuvWeb.FediverseController do
     if activity["object"] == Docs.actor_url(user) do
       # A remote actor doc with an over-long / malformed inbox or id yields an
       # invalid changeset; accept only a successful insert, never crash the inbox.
-      case Fediverse.add_follower(user, %{
-             actor_uri: remote.id,
-             inbox_uri: remote.inbox,
-             shared_inbox_uri: remote.shared_inbox,
-             handle: remote.preferred_username,
-             name: remote.name
-           }) do
+      case Fediverse.add_follower(user, follower_attrs(remote)) do
         {:ok, _} -> Fediverse.accept_follow(user, activity, remote.inbox)
         {:error, _} -> :ok
       end
@@ -138,9 +134,54 @@ defmodule VutuvWeb.FediverseController do
     send_resp(conn, 202, "")
   end
 
+  # A remote actor that renamed or moved its inbox broadcasts an `Update` of
+  # itself to everyone following it. Re-sync from the actor document we just
+  # fetched: the row is both a delivery target and what the member sees on
+  # their Fediverse settings page, so a stale copy shows the wrong handle and
+  # can deliver to the wrong inbox. An `Update` of anything else (a remote
+  # note) falls through to the catch-all.
+  defp perform(conn, user, %{"type" => "Update"} = activity, remote) do
+    if object_id(activity["object"]) == remote.id do
+      Fediverse.refresh_follower(user, follower_attrs(remote))
+    end
+
+    send_resp(conn, 202, "")
+  end
+
+  # A remote account deleting itself tells every server that follows it, so
+  # drop the row instead of keeping a gone account as a follower (and as a
+  # delivery target). Only a `Delete` of the *actor* counts — deleting one of
+  # its notes must leave the follow intact. Best effort by construction: a
+  # server that already purged the account answers our actor fetch with 410,
+  # so the signature can no longer be verified and `verify_and_perform/2`
+  # rejects it; this catches the window where the account is suspended but
+  # still served, which is when most servers send the Delete.
+  defp perform(conn, user, %{"type" => "Delete"} = activity, remote) do
+    if object_id(activity["object"]) == remote.id do
+      Fediverse.remove_follower(user, remote.id)
+    end
+
+    send_resp(conn, 202, "")
+  end
+
   # Outbound-only federation: likes, replies, announces etc. are acknowledged
   # (so well-behaved servers stop retrying) and dropped.
   defp perform(conn, _user, _activity, _remote), do: send_resp(conn, 202, "")
+
+  defp follower_attrs(remote) do
+    %{
+      actor_uri: remote.id,
+      inbox_uri: remote.inbox,
+      shared_inbox_uri: remote.shared_inbox,
+      handle: remote.preferred_username,
+      name: remote.name
+    }
+  end
+
+  # An activity's object is either an embedded document or a bare id URI.
+  defp object_id(%{"id" => id}) when is_binary(id), do: id
+  defp object_id(id) when is_binary(id), do: id
+  defp object_id(_), do: nil
 
   defp signature_key_id(conn) do
     conn |> get_req_header("signature") |> List.first() |> HttpSignature.key_id()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.121.3",
+      version: "7.121.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_test.exs
+++ b/test/vutuv/fediverse_test.exs
@@ -97,6 +97,64 @@ defmodule Vutuv.FediverseTest do
                "https://social.example/inbox"
              ]
     end
+
+    test "a repeat Follow re-syncs the cached handle and display name" do
+      user = federated_user()
+
+      for handle <- ~w(alice alice_renamed) do
+        {:ok, _} =
+          Fediverse.add_follower(user, %{
+            actor_uri: "https://social.example/users/alice",
+            inbox_uri: "https://social.example/users/alice/inbox",
+            handle: handle,
+            name: "Alice #{handle}"
+          })
+      end
+
+      # Read back from the database: the insert's own return value carries the
+      # attrs we sent whether or not the upsert stored them.
+      assert [follower] = Fediverse.list_followers(user)
+      assert follower.handle == "alice_renamed"
+      assert follower.name == "Alice alice_renamed"
+    end
+
+    test "refresh_follower/2 re-syncs an existing row and never creates one" do
+      user = federated_user()
+      alice = "https://social.example/users/alice"
+
+      {:ok, _} =
+        Fediverse.add_follower(user, %{
+          actor_uri: alice,
+          inbox_uri: "https://social.example/users/alice/inbox",
+          handle: "alice",
+          name: "Alice Example"
+        })
+
+      :ok =
+        Fediverse.refresh_follower(user, %{
+          actor_uri: alice,
+          inbox_uri: "https://social.example/users/alice/inbox2",
+          shared_inbox_uri: "https://social.example/inbox",
+          handle: "alice_renamed",
+          name: "Alice Renamed"
+        })
+
+      assert [follower] = Fediverse.list_followers(user)
+      assert follower.handle == "alice_renamed"
+      assert follower.name == "Alice Renamed"
+      assert follower.inbox_uri == "https://social.example/users/alice/inbox2"
+      assert follower.shared_inbox_uri == "https://social.example/inbox"
+
+      # An Update is a broadcast, not a follow request: a stranger's must not
+      # turn into a follower row.
+      :ok =
+        Fediverse.refresh_follower(user, %{
+          actor_uri: "https://social.example/users/mallory",
+          inbox_uri: "https://social.example/users/mallory/inbox"
+        })
+
+      assert Fediverse.follower_count(user) == 1
+    end
   end
 
   describe "federate_new_post/1" do

--- a/test/vutuv_web/controllers/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/fediverse_controller_test.exs
@@ -25,15 +25,20 @@ defmodule VutuvWeb.FediverseControllerTest do
 
   defp host, do: VutuvWeb.Endpoint.host()
 
-  defp stub_remote_actor(pub_pem) do
+  defp stub_remote_actor(pub_pem, extra \\ %{}) do
     doc =
-      Jason.encode!(%{
-        "id" => @remote_actor,
-        "type" => "Person",
-        "inbox" => @remote_inbox,
-        "endpoints" => %{"sharedInbox" => @remote_shared},
-        "publicKey" => %{"id" => @remote_key_id, "publicKeyPem" => pub_pem}
-      })
+      Jason.encode!(
+        Map.merge(
+          %{
+            "id" => @remote_actor,
+            "type" => "Person",
+            "inbox" => @remote_inbox,
+            "endpoints" => %{"sharedInbox" => @remote_shared},
+            "publicKey" => %{"id" => @remote_key_id, "publicKeyPem" => pub_pem}
+          },
+          extra
+        )
+      )
 
     Application.put_env(:vutuv, :fediverse_req_options,
       plug: fn conn ->
@@ -78,6 +83,29 @@ defmodule VutuvWeb.FediverseControllerTest do
       "actor" => @remote_actor,
       "object" => Docs.actor_url(user)
     }
+  end
+
+  # An Update / Delete the remote actor broadcasts about itself.
+  defp lifecycle_activity(type, object) do
+    %{
+      "@context" => "https://www.w3.org/ns/activitystreams",
+      "id" => "https://social.example/activities/#{type}",
+      "type" => type,
+      "actor" => @remote_actor,
+      "object" => object
+    }
+  end
+
+  defp existing_follower(user) do
+    {:ok, _} =
+      Fediverse.add_follower(user, %{
+        actor_uri: @remote_actor,
+        inbox_uri: @remote_inbox,
+        handle: "alice",
+        name: "Alice Example"
+      })
+
+    :ok
   end
 
   describe "GET /.well-known/webfinger" do
@@ -259,6 +287,62 @@ defmodule VutuvWeb.FediverseControllerTest do
 
       assert conn.status == 202
       assert Repo.aggregate(Delivery, :count) == 0
+    end
+  end
+
+  describe "POST /:slug/actor/inbox — remote actor lifecycle" do
+    test "Update of the actor re-syncs the stored handle, name and inboxes", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub, %{"preferredUsername" => "alice_renamed", "name" => "Alice Renamed"})
+      user = federated_user()
+      :ok = existing_follower(user)
+
+      activity = lifecycle_activity("Update", %{"id" => @remote_actor, "type" => "Person"})
+      conn = signed_post(conn, user, activity, priv)
+
+      assert conn.status == 202
+      assert [follower] = Fediverse.list_followers(user)
+      assert follower.handle == "alice_renamed"
+      assert follower.name == "Alice Renamed"
+      assert follower.shared_inbox_uri == @remote_shared
+    end
+
+    test "an Update from an actor following nobody here creates no follower", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub, %{"preferredUsername" => "alice"})
+      user = federated_user()
+
+      activity = lifecycle_activity("Update", %{"id" => @remote_actor, "type" => "Person"})
+      conn = signed_post(conn, user, activity, priv)
+
+      assert conn.status == 202
+      assert Fediverse.follower_count(user) == 0
+    end
+
+    test "Delete of the actor itself removes the follower", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = federated_user()
+      :ok = existing_follower(user)
+
+      # Mastodon sends the bare actor URI as the object of an account Delete.
+      conn = signed_post(conn, user, lifecycle_activity("Delete", @remote_actor), priv)
+
+      assert conn.status == 202
+      assert Fediverse.follower_count(user) == 0
+    end
+
+    test "Delete of one of the actor's notes leaves the follow intact", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = federated_user()
+      :ok = existing_follower(user)
+
+      tombstone = %{"id" => @remote_actor <> "/statuses/1", "type" => "Tombstone"}
+      conn = signed_post(conn, user, lifecycle_activity("Delete", tombstone), priv)
+
+      assert conn.status == 202
+      assert Fediverse.follower_count(user) == 1
     end
   end
 


### PR DESCRIPTION
The inbox dropped everything except `Follow`/`Undo(Follow)`, and `add_follower/2`'s `ON CONFLICT` replaced only the inbox URIs. Together that meant a remote follower's cached `handle` and `name` were written once and never again:

- someone who **renamed** on their home server stayed listed under their old handle forever on the member's `/settings/fediverse` page (the list we started showing in v7.70.0), and
- a remote account that **deleted itself** kept its handle and name in `fediverse_followers` indefinitely, still counting as a follower and still a delivery target, even though its server had told us it was gone.

## What changed

The inbox now also processes the remote actor's own lifecycle:

| Activity | Effect |
| --- | --- |
| `Update` (object = the actor) | re-syncs handle, name, inbox, sharedInbox from the actor document already fetched for the signature check |
| `Delete` (object = the actor) | removes the follower row |
| `Update`/`Delete` of a remote note | unchanged: falls through to the catch-all and is dropped |

Both are scoped to the actor itself via the activity's object id, so deleting a post can never drop a follow. An `Update` never mints a row either (it is a broadcast to followers, not a follow request), so `refresh_follower/2` is a no-op for an actor that follows nobody here. The `ON CONFLICT` list gains `:handle` and `:name` so a repeat `Follow` re-syncs them too.

## Known limits, documented rather than papered over

The `Delete` half is best effort by protocol: a server that has already purged the account answers our actor fetch with 410, so the signature cannot be verified and the activity is rejected upstream. It lands during the window where the account is suspended but still served, which is when most servers send it.

Pruning on a failed *delivery* would catch the rest, but deliveries go to the sharedInbox wherever the remote declares one, so a 404/410 there would drop every follower on that server. Noted in the architecture doc's v1 limits rather than done.

## Tests

Four new tests, each confirmed red before the fix: `Update` re-syncs the row; an `Update` from a non-follower creates nothing; `Delete` of the actor removes the follower; `Delete` of one of its notes leaves the follow intact. Plus two context tests for the repeat-`Follow` re-sync and `refresh_follower/2`. The repeat-`Follow` one reads back from the database on purpose, since the insert's own return value carries the attrs we sent whether or not the upsert stored them.

`mix precommit` green (4166 passed).

Found while auditing what is left of #784. Two other gaps from that audit are filed as #985 (broadcast an actor `Delete` when a *vutuv* member deletes their account, the mirror of this) and #986 (`alsoKnownAs` + `Move`).