### PR TITLE
Book and film reviews on posts (v7.122.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ erl_crash.dump
 /avatars
 /covers
 /post_images
+/review_covers
 /screenshots
 /originals
 /moderation_evidence

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ We use the [MIT License](LICENSE).
   Members can also **follow a tag** to pull its posts into their feed and get
   matching people suggested. Adding a new CV entry (job, education,
   certificate) can optionally notify your followers — your call per entry,
-  in-app only, and switchable off by whoever receives it. Developer profiles can show cached public stats of
+  in-app only, and switchable off by whoever receives it. A post can be a
+  **book or film review**: attach an ISBN (or IMDb link) plus title, author or
+  director, year and how you consumed it (print / e-book / audiobook, cinema /
+  streaming / disc), and the post shows a review card with the fetched book
+  cover and a shop or IMDb link. Developer profiles can show cached public stats of
   their GitHub, GitLab and Codeberg accounts (stars, repositories, languages,
   activity).
 - Verified organization pages at `/organizations` (a company, a Verein, a public

--- a/config/config.exs
+++ b/config/config.exs
@@ -147,6 +147,23 @@ config :vutuv, :newsletter_send_timeout_ms, :timer.seconds(60)
 # 5,000/hour; see docs/ADMINS.md.
 config :vutuv, :fetch_code_stats, true
 
+# Book metadata for post reviews (Vutuv.BookMetadata: the composer's ISBN →
+# title/author/year prefill; Vutuv.Posts.ReviewCovers: the cover image on the
+# review card). Both come keyless from Open Library. Off = nothing is ever
+# fetched — the switch for installations that must not call out (intranets);
+# the review card then renders without a cover and the fields are typed by
+# hand. Runtime override: FETCH_BOOK_METADATA=false (config/runtime.exs).
+# Tests keep it off and stub HTTP via :book_metadata_req_options /
+# :book_covers_req_options.
+config :vutuv, :fetch_book_metadata, true
+
+# The shop link on a book review card: https://<domain>/dp/<isbn10> (search
+# fallback for 979 ISBNs), with an optional Amazon affiliate tag appended as
+# ?tag=. An empty AMAZON_DOMAIN removes the link entirely (config/runtime.exs
+# overrides both), so every installation chooses its own store — or none.
+config :vutuv, :amazon_domain, "www.amazon.de"
+config :vutuv, :amazon_affiliate_tag, nil
+
 # Post images: larger than avatars (6 MB), capped per post. Derived versions
 # are WebP; originals stay private on disk (see Vutuv.PostImageStore).
 config :vutuv, :post_images, max_filesize: 6_000_000, max_per_post: 10

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -136,6 +136,24 @@ if config_env() == :prod do
     config :vutuv, :fediverse_enabled, false
   end
 
+  # Book metadata + covers for post reviews come keyless from Open Library.
+  # FETCH_BOOK_METADATA=false turns every such fetch off (intranets); the
+  # review panel then has no lookup button and covers stay empty.
+  if System.get_env("FETCH_BOOK_METADATA") == "false" do
+    config :vutuv, :fetch_book_metadata, false
+  end
+
+  # The shop link on book review cards. AMAZON_DOMAIN picks the store
+  # ("www.amazon.com", …); an explicitly empty AMAZON_DOMAIN="" removes the
+  # link. AMAZON_AFFILIATE_TAG rides along as ?tag= when set.
+  if amazon_domain = System.get_env("AMAZON_DOMAIN") do
+    config :vutuv, :amazon_domain, amazon_domain
+  end
+
+  if amazon_tag = System.get_env("AMAZON_AFFILIATE_TAG") do
+    config :vutuv, :amazon_affiliate_tag, amazon_tag
+  end
+
   # AI image moderation via an Ollama vision model. Fail-closed while
   # enabled: with Ollama unreachable, new images wait in owner-only limbo and
   # are scanned automatically once it is back. IMAGE_MODERATION_ENABLED=false

--- a/config/test.exs
+++ b/config/test.exs
@@ -73,6 +73,10 @@ config :vutuv, :refresh_popular_users, false
 config :vutuv, :fetch_mastodon_posts, false
 config :vutuv, :fetch_bluesky_posts, false
 config :vutuv, :fetch_code_stats, false
+# Book review metadata/covers (Open Library): off, so a create_post with a
+# review never fetches; the review tests call the fetchers directly with
+# stubbed HTTP (:book_metadata_req_options / :book_covers_req_options).
+config :vutuv, :fetch_book_metadata, false
 # Organization domain re-check GenServer would touch the sandbox from outside; tests
 # call Vutuv.Organizations.recheck_domain/1 directly. DNS / well-known verification
 # is off too, so the suite never hits real DNS / HTTP; the domain tests flip

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -109,6 +109,9 @@ Everything else has a default (the vutuv.de production value):
 | `BOUNCE_WEBHOOK_TOKEN` | – | Bearer token for `POST /webhooks/bounces`; unset = bounce handling off |
 | `MAIL_LOG_PATH` | `/var/log/mail.log` | Postfix log the bounce watcher tails; `""` = watcher off |
 | `FEDIVERSE_ENABLED` | `true` | `false` turns follow-only ActivityPub federation off entirely (endpoints 404, nothing is delivered) — set it on intranet installations |
+| `FETCH_BOOK_METADATA` | `true` | `false` turns the Open Library lookups behind post **book reviews** off (the composer's ISBN → title/author/year prefill and the automatic cover image on the review card). The review feature itself keeps working — members type the fields by hand and the card renders without a cover. Set it on installations that must not call out (intranets) |
+| `AMAZON_DOMAIN` | `www.amazon.de` | The store a book review card's shop link points at (`https://<domain>/dp/<isbn10>`). Set your regional store (`www.amazon.com`, …) — or an **empty** value (`AMAZON_DOMAIN=`) to remove the shop link entirely |
+| `AMAZON_AFFILIATE_TAG` | – | Optional Amazon affiliate tag appended to book review shop links as `?tag=` |
 | `VERIFY_ORGANIZATION_DOMAINS` | `true` | `false` disables the verified-organization-page domain proof (the DNS TXT and well-known-file checks and their periodic re-check) — no new organization page can be verified, existing ones keep working. Set it on installations that must not make outbound DNS/HTTP calls. A newly verified organization sends an operator notice to `OPERATOR_EMAIL` |
 | `VERIFY_USER_LINKS` | `true` | `false` disables verified personal-webpage links (a member proving a profile link is their own page via a rel=me back-link, or the same DNS TXT / well-known-file domain proof, plus their periodic re-check) — no new link can be verified, existing marks keep working. Set it on installations that must not make outbound DNS/HTTP calls |
 | `GITHUB_API_TOKEN` | – | Optional token for the profile code-stats fetches (GitHub allows 60 unauthenticated requests/hour per IP; a token raises that to 5,000). A [fine-grained PAT](https://github.com/settings/personal-access-tokens) with **no** scopes/permissions is enough — the fetches read public data only. Can be added (or rotated) at any time; without it everything still works, the 7-day snapshot cache is sized for the unauthenticated limit |
@@ -272,6 +275,9 @@ vutuv runs fine without internet access:
   `:generate_screenshots` (profile link-preview screenshots **and** the
   auto-screenshot for single-link posts — these fetch the linked page and run
   headless Chromium).
+- Set `FETCH_BOOK_METADATA=false`: the book-review ISBN lookup and cover
+  fetch call Open Library. Book and film reviews keep working — the fields
+  are typed by hand and the card renders without a cover.
 - AI image moderation works **fully offline** — Ollama is local inference, no
   cloud involved. Install Ollama on the server, pull the vision model once
   while you still have internet access (`ollama pull qwen3-vl:8b`), and keep

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -64,8 +64,10 @@ window frame (`Vutuv.BrowserFrame`); see `Vutuv.PageScreenshot`. Needs a
 
 **Every** image that could become visible to anyone but its owner passes
 through one gate before release: member uploads (avatar, cover, post /
-job-posting / organization images) **and** the machine-generated link
-screenshots (a screenshot of an NSFW page must not bypass the upload gate).
+job-posting / organization images) **and** the machine-fetched ones — link
+screenshots (a screenshot of an NSFW page must not bypass the upload gate)
+and the book covers on post reviews (`review_cover`, fetched from Open
+Library by ISBN).
 The moderation-evidence screenshots are deliberately exempt — they are
 admin-only records of reported content and never public.
 

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -329,3 +329,41 @@ skips it, and `reconcile/1` leaves it in place for the same URL, so a plain
 re-save never re-captures it (changing the URL still re-captures; dropping the
 link cancels the row). It broadcasts `{:post_screenshot_removed, …}` so open
 feeds/profiles drop the card live, and is excluded from the admin queue/gallery.
+
+## Book and film reviews
+
+A post can carry a structured **review sidecar** (`Vutuv.Posts.PostReview`,
+table `post_reviews`, one per post): `kind` (`book`/`movie` — open for future
+kinds), an `identifier` (a checksum-validated ISBN-13 via `Vutuv.Isbn`, or an
+IMDb `tt…` id extracted from a pasted URL), cached display metadata (`title`,
+`creator`, `year`) and an optional `medium` (book: print/ebook/audiobook,
+movie: cinema/streaming/disc — "I listened to the audiobook"). The body stays
+plain Markdown; *"this post is a book review"* is simply *"the post has a
+review row"*, never body parsing. The composer's 📖/🎬 triggers open the panel;
+the hidden `kind` field always submits, so closing the panel deletes a stored
+review on save, while attrs without a `:review` key (the API's partial PATCH)
+leave it untouched.
+
+Every surface that renders the post adds the **review card** below the prose
+(`VutuvWeb.PostComponents.review_card/1`): cover (or a kind-glyph tile), kind
+label, title, creator · year · medium, and an outbound link — Amazon for books
+(built offline from the ISBN: ISBN-10 `/dp/` link, search fallback for 979
+ISBNs; domain + optional affiliate tag are config, an empty `AMAZON_DOMAIN`
+removes the link), IMDb for films. The permalink's JSON-LD becomes
+`["BlogPosting", "Review"]` with `itemReviewed` (Book/Movie), and the agent
+formats carry a `review` entry / fact line (drift-tested).
+
+**Book covers** are fetched from Open Library by ISBN
+(`Vutuv.Posts.ReviewCovers`), off the request path, gated by
+`:fetch_book_metadata` (also the flag for the composer's ISBN → title/author/
+year prefill, `Vutuv.BookMetadata`). Not a durable queue on purpose: a cover
+is decorative, `cover_status` (`none`/`pending`/`ready`/`failed`) tracks the
+fetch, a changed ISBN resets it to `pending` and re-fetches, and a lost fetch
+is simply retried on the next edit. The fetched cover is an external image
+shown publicly, so it enters the AI-moderation gate like any upload
+(`review_cover` kind in `Vutuv.Moderation.ImageSubjects`) and is served
+through the authorizing proxy `VutuvWeb.ReviewCoverController`
+(`/review_covers/:id/cover-<hash>.avif` — post audience + moderation verdict
+checked per request, content-fingerprinted filename, so an outdated cover URL
+stops resolving). Files live under `review_covers/<review.id>/` with a private
+original (`Vutuv.ReviewCover`); post deletion and account deletion purge them.

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -612,6 +612,19 @@ defmodule Vutuv.Accounts do
         )
       )
 
+    # The user's review covers (book/film review sidecars): the post_reviews
+    # rows cascade with the posts, but their fetched cover files (keyed by the
+    # review id) would be orphaned otherwise.
+    review_ids =
+      Repo.all(
+        from(r in Vutuv.Posts.PostReview,
+          join: p in Vutuv.Posts.Post,
+          on: p.id == r.post_id,
+          where: p.user_id == ^user.id,
+          select: %{id: r.id}
+        )
+      )
+
     # Captured before the delete: once the account is gone so are its follow
     # edges, so the recipients of the "post gone" broadcasts can't be looked up
     # afterwards. See Vutuv.Posts.deletion_targets_for_user/1.
@@ -642,6 +655,7 @@ defmodule Vutuv.Accounts do
     Enum.each(job_image_tokens, &Vutuv.JobPostingImageStore.delete/1)
     Enum.each(url_ids, &Vutuv.Screenshot.delete/1)
     Enum.each(screenshot_ids, &Vutuv.Screenshot.delete/1)
+    Enum.each(review_ids, &Vutuv.ReviewCover.delete_files/1)
     Moderation.EvidenceScreenshot.delete_for_cases(evidence_case_ids)
     Vutuv.Avatar.delete(user)
     Vutuv.Cover.delete(user)

--- a/lib/vutuv/accounts/reserved_slugs.ex
+++ b/lib/vutuv/accounts/reserved_slugs.ex
@@ -30,7 +30,7 @@ defmodule Vutuv.Accounts.ReservedSlugs do
     edit emails favicon.ico feed follow_back
     follows fonts groups health help images impressum jobs js legal likes listings live
     llms.txt login logout mail maps memberships messages moderation new new_registration news
-    notifications nutzungsbedingungen oauth phoenix post_images job_posting_images posts press privacy reports robots.txt
+    notifications nutzungsbedingungen oauth phoenix post_images job_posting_images posts press privacy reports review_covers robots.txt
     screenshots search search_queries security.txt sent_emails sessions settings
     sitemap.xml sitemaps socket status support system tag_follows tags team terms tidewave unsubscribe
     user_bookmarks user_likes username users webhooks www

--- a/lib/vutuv/book_metadata.ex
+++ b/lib/vutuv/book_metadata.ex
@@ -1,0 +1,73 @@
+defmodule Vutuv.BookMetadata do
+  @moduledoc """
+  ISBN → title/author/year lookup for the post composer's review panel, via
+  Open Library's keyless books API (one request, no auth, no account). The
+  result only **prefills** the form — the author can overwrite everything,
+  and an installation with `:fetch_book_metadata` off (air-gapped intranets)
+  simply types the fields by hand; the lookup button then never renders.
+
+  Tests stub HTTP via `:book_metadata_req_options` (a `plug:` seam, like the
+  social-feed clients).
+  """
+
+  @req_options_key :book_metadata_req_options
+
+  @doc "Whether this installation looks up book metadata at all."
+  def enabled?, do: Application.get_env(:vutuv, :fetch_book_metadata, true)
+
+  @doc """
+  Looks the normalized ISBN-13 up on Open Library. Returns
+  `{:ok, %{title: …, creator: …, year: …}}` (each value may be nil except
+  the title) or `:error` (unknown ISBN, network trouble, flag off).
+  """
+  def lookup(isbn) when is_binary(isbn) do
+    if enabled?(), do: request(isbn), else: :error
+  end
+
+  defp request(isbn) do
+    [
+      url: "https://openlibrary.org/api/books",
+      params: [bibkeys: "ISBN:#{isbn}", format: "json", jscmd: "data"],
+      receive_timeout: 5_000,
+      retry: false
+    ]
+    |> Keyword.merge(Application.get_env(:vutuv, @req_options_key, []))
+    |> Req.get()
+    |> case do
+      {:ok, %Req.Response{status: 200, body: %{} = body}} -> parse(body["ISBN:#{isbn}"])
+      _other -> :error
+    end
+  end
+
+  defp parse(%{"title" => title} = data) when is_binary(title) and title != "" do
+    {:ok,
+     %{
+       title: title,
+       creator: authors(data["authors"]),
+       year: year(data["publish_date"])
+     }}
+  end
+
+  defp parse(_missing), do: :error
+
+  defp authors(authors) when is_list(authors) do
+    case authors |> Enum.map(& &1["name"]) |> Enum.reject(&(&1 in [nil, ""])) do
+      [] -> nil
+      names -> Enum.join(names, ", ")
+    end
+  end
+
+  defp authors(_other), do: nil
+
+  # publish_date is free text ("March 2009", "1998"): the year is enough.
+  defp year(date) when is_binary(date) do
+    with [year] <- Regex.run(~r/\b(1\d{3}|2\d{3})\b/, date, capture: :first),
+         {int, ""} <- Integer.parse(year) do
+      int
+    else
+      _ -> nil
+    end
+  end
+
+  defp year(_other), do: nil
+end

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -235,7 +235,7 @@ defmodule Vutuv.Fediverse do
          true <- federated?(user),
          false <- Vutuv.Posts.restricted?(post),
          [_ | _] = inboxes <- delivery_inboxes(user) do
-      post = Repo.preload(post, [:images, reply_ref: [:parent_author]])
+      post = Repo.preload(post, [:images, :review, reply_ref: [:parent_author]])
       enqueue(user, inboxes, builder.(post, user))
     else
       _ -> :skip

--- a/lib/vutuv/isbn.ex
+++ b/lib/vutuv/isbn.ex
@@ -1,0 +1,111 @@
+defmodule Vutuv.Isbn do
+  @moduledoc """
+  ISBN parsing for the post review card (`Vutuv.Posts.PostReview`).
+
+  `normalize/1` accepts what people actually paste — ISBN-10 or ISBN-13, with
+  hyphens, spaces or a leading "ISBN" label — validates the check digit and
+  returns the canonical bare ISBN-13, the one form stored and used for the
+  Open Library cover/metadata lookups. `isbn10/1` derives the ISBN-10 twin of
+  a 978-prefixed ISBN-13 (the identifier Amazon's `/dp/` URLs take); 979
+  ISBNs have no ISBN-10 form by definition.
+  """
+
+  @doc """
+  Canonicalizes `input` into a bare, checksum-valid ISBN-13 string —
+  `{:ok, "9783161484100"}` — or `:error`. An ISBN-10 is converted to its
+  978-prefixed ISBN-13 equivalent.
+  """
+  def normalize(input) when is_binary(input) do
+    case strip(input) do
+      <<_::binary-size(13)>> = digits -> normalize13(digits)
+      <<_::binary-size(10)>> = digits -> normalize10(digits)
+      _other -> :error
+    end
+  end
+
+  def normalize(_input), do: :error
+
+  @doc """
+  The ISBN-10 form of a normalized ISBN-13, for building an Amazon `/dp/`
+  link — `{:ok, "316148410X"}` — or `:error` (979 ISBNs, invalid input).
+  """
+  def isbn10(<<"978", body::binary-size(9), _check::binary-size(1)>> = isbn13) do
+    with {:ok, ^isbn13} <- normalize13(isbn13) do
+      {:ok, body <> check10(body)}
+    end
+  end
+
+  def isbn10(_other), do: :error
+
+  # Uppercases (the ISBN-10 X), drops separators and an optional leading
+  # "ISBN"/"ISBN:" label.
+  defp strip(input) do
+    input
+    |> String.trim()
+    |> String.upcase()
+    |> String.replace_prefix("ISBN", "")
+    |> String.replace(~r/[\s:-]/, "")
+  end
+
+  defp normalize13(digits) do
+    if digits =~ ~r/^\d{13}$/ and valid13?(digits), do: {:ok, digits}, else: :error
+  end
+
+  defp normalize10(digits) do
+    if digits =~ ~r/^\d{9}[\dX]$/ and valid10?(digits) do
+      body = "978" <> binary_part(digits, 0, 9)
+      {:ok, body <> check13(body)}
+    else
+      :error
+    end
+  end
+
+  # ISBN-13: digits weighted 1,3,1,3,… must sum to a multiple of 10.
+  defp valid13?(digits) do
+    digits
+    |> digit_values()
+    |> Enum.with_index()
+    |> Enum.reduce(0, fn {value, index}, sum ->
+      sum + value * if(rem(index, 2) == 0, do: 1, else: 3)
+    end)
+    |> rem(10) == 0
+  end
+
+  # ISBN-10: digits weighted 10..1 (X = 10) must sum to a multiple of 11.
+  defp valid10?(digits) do
+    digits
+    |> digit_values()
+    |> Enum.with_index()
+    |> Enum.reduce(0, fn {value, index}, sum -> sum + value * (10 - index) end)
+    |> rem(11) == 0
+  end
+
+  defp check13(body) do
+    sum =
+      body
+      |> digit_values()
+      |> Enum.with_index()
+      |> Enum.reduce(0, fn {value, index}, sum ->
+        sum + value * if(rem(index, 2) == 0, do: 1, else: 3)
+      end)
+
+    Integer.to_string(rem(10 - rem(sum, 10), 10))
+  end
+
+  defp check10(body) do
+    sum =
+      body
+      |> digit_values()
+      |> Enum.with_index()
+      |> Enum.reduce(0, fn {value, index}, sum -> sum + value * (10 - index) end)
+
+    case rem(11 - rem(sum, 11), 11) do
+      10 -> "X"
+      digit -> Integer.to_string(digit)
+    end
+  end
+
+  defp digit_values(digits) do
+    for <<char <- digits>>, do: if(char == ?X, do: 10, else: char - ?0)
+  end
+end

--- a/lib/vutuv/moderation/image_scan.ex
+++ b/lib/vutuv/moderation/image_scan.ex
@@ -22,7 +22,7 @@ defmodule Vutuv.Moderation.ImageScan do
   use VutuvWeb, :model
 
   @kinds ~w(avatar cover post_image job_posting_image organization_image
-            url_screenshot post_screenshot)
+            url_screenshot post_screenshot review_cover)
   @statuses ~w(pending scanning approved rejected canceled)
   @open_statuses ~w(pending scanning)
 

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -21,6 +21,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
   alias Vutuv.Organizations.Organization
   alias Vutuv.Organizations.OrganizationImage
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.PostReview
   alias Vutuv.Posts.PostScreenshot
   alias Vutuv.Profiles.Url
   alias Vutuv.Repo
@@ -106,6 +107,18 @@ defmodule Vutuv.Moderation.ImageSubjects do
     with %Url{} = url <- Repo.get(Url, scan.subject_id),
          true <- url.screenshot != nil and url.screenshot == scan.fingerprint do
       screenshot_source(url.id)
+    else
+      _ -> :gone
+    end
+  end
+
+  def source(%ImageScan{kind: "review_cover"} = scan) do
+    with %PostReview{} = review <- Repo.get(PostReview, scan.subject_id),
+         true <- review.cover != nil and review.cover == scan.fingerprint do
+      first_existing([
+        Originals.path("review_covers/#{review.id}"),
+        largest_served_file("review_covers/#{review.id}")
+      ])
     else
       _ -> :gone
     end
@@ -256,6 +269,29 @@ defmodule Vutuv.Moderation.ImageSubjects do
     end
   end
 
+  def apply_approved(%ImageScan{kind: "review_cover"} = scan) do
+    flipped =
+      from(r in PostReview,
+        where:
+          r.id == ^scan.subject_id and r.cover == ^scan.fingerprint and
+            r.cover_moderation == "pending"
+      )
+      |> Repo.update_all(set: [cover_moderation: "approved"])
+
+    case flipped do
+      {1, _} ->
+        review = Repo.get!(PostReview, scan.subject_id)
+        # The card upgrade was held back at fetch time; the cover is only
+        # announced once it is released (no quarantine move — covers are
+        # served through the authorizing proxy, which checks this state).
+        Vutuv.Posts.broadcast_review_cover_ready(review.post_id)
+        :ok
+
+      _ ->
+        :stale
+    end
+  end
+
   @doc """
   Deletes the rejected image on the spot: files (served, quarantined and the
   private original — nothing unsafe stays at rest) and the asset's
@@ -336,6 +372,21 @@ defmodule Vutuv.Moderation.ImageSubjects do
     end
   end
 
+  def apply_rejected(%ImageScan{kind: "review_cover"} = scan) do
+    cleared =
+      from(r in PostReview, where: r.id == ^scan.subject_id and r.cover == ^scan.fingerprint)
+      |> Repo.update_all(set: [cover: nil, cover_status: "failed", cover_moderation: nil])
+
+    case cleared do
+      {1, _} ->
+        Vutuv.ReviewCover.delete_files(%PostReview{id: scan.subject_id})
+        :ok
+
+      _ ->
+        :stale
+    end
+  end
+
   # An organization's `logo` column points at its image token; a rejected logo
   # must not leave a dangling pointer behind.
   defp clear_gallery_references("organization_image", image) do
@@ -393,7 +444,8 @@ defmodule Vutuv.Moderation.ImageSubjects do
       gallery_stranded("job_posting_image") ++
       gallery_stranded("organization_image") ++
       url_screenshot_stranded() ++
-      post_screenshot_stranded()
+      post_screenshot_stranded() ++
+      review_cover_stranded()
   end
 
   defp open_scan_exists(kind) do
@@ -454,6 +506,20 @@ defmodule Vutuv.Moderation.ImageSubjects do
     |> Repo.all()
     |> Enum.map(fn {id, owner_id, fingerprint} ->
       {"post_screenshot", id, owner_id, fingerprint}
+    end)
+  end
+
+  defp review_cover_stranded do
+    from(r in PostReview,
+      as: :subject,
+      join: p in assoc(r, :post),
+      where: r.cover_moderation == "pending",
+      where: not exists(open_scan_exists("review_cover")),
+      select: {r.id, p.user_id, r.cover}
+    )
+    |> Repo.all()
+    |> Enum.map(fn {id, owner_id, fingerprint} ->
+      {"review_cover", id, owner_id, fingerprint}
     end)
   end
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -55,8 +55,10 @@ defmodule Vutuv.Posts do
   alias Vutuv.Posts.PostLike
   alias Vutuv.Posts.PostReply
   alias Vutuv.Posts.PostRepost
+  alias Vutuv.Posts.PostReview
   alias Vutuv.Posts.PostScreenshot
   alias Vutuv.Posts.PostTag
+  alias Vutuv.Posts.ReviewCovers
   alias Vutuv.Posts.Screenshots
   alias Vutuv.Posts.ScreenshotWorker
   alias Vutuv.Repo
@@ -114,6 +116,9 @@ defmodule Vutuv.Posts do
           # A single-URL, image-less post gets a link screenshot, captured off
           # the request path via the durable queue.
           reconcile_screenshot(post)
+          # A book review with an ISBN gets its cover fetched off the request
+          # path (no-op for every other post).
+          ReviewCovers.reconcile(post)
           {:ok, post}
 
         {:error, _} = error ->
@@ -154,6 +159,7 @@ defmodule Vutuv.Posts do
           broadcast_reply(parent, post)
           Vutuv.Fediverse.federate_new_post(post)
           reconcile_screenshot(post)
+          ReviewCovers.reconcile(post)
           {:ok, post}
 
         {:error, _} = error ->
@@ -188,7 +194,7 @@ defmodule Vutuv.Posts do
   never changes.
   """
   def update_post(%Post{} = post, attrs) do
-    post = Repo.preload(post, [:denials, :post_tags, :images])
+    post = Repo.preload(post, [:denials, :post_tags, :images, :review])
     image_ids = parse_ids(fetch(attrs, :image_ids) || [])
 
     with {:ok, denials} <- normalize_denials(post.user_id, fetch(attrs, :denials) || []),
@@ -215,6 +221,8 @@ defmodule Vutuv.Posts do
         # An edit can add/remove the qualifying URL or an image: enqueue, refresh
         # or drop the link screenshot to match.
         reconcile_screenshot(updated)
+        # …and change the reviewed ISBN, which re-fetches the cover.
+        ReviewCovers.reconcile(updated)
         {:ok, updated}
 
       {:error, _} = error ->
@@ -244,7 +252,7 @@ defmodule Vutuv.Posts do
   parent's fresh reply count is re-broadcast.
   """
   def delete_post(%Post{} = post) do
-    post = Repo.preload(post, [:images, :screenshot])
+    post = Repo.preload(post, [:images, :screenshot, :review])
     parent_id = reply_parent_id(post.id)
 
     case Repo.delete(post) do
@@ -253,6 +261,8 @@ defmodule Vutuv.Posts do
         # The post_screenshots row cascades with the post; its stored files do
         # not, so purge them explicitly (a no-op when there was no screenshot).
         if post.screenshot, do: Screenshots.delete(post.screenshot)
+        # Same for a book review's fetched cover files.
+        if post.review, do: ReviewCovers.delete_files(post.review)
         broadcast_post_deleted(post.id, post.user_id)
         if parent_id, do: broadcast_reply_count(parent_id)
         # Deleting reported content settles its moderation case.
@@ -266,8 +276,8 @@ defmodule Vutuv.Posts do
     end
   end
 
-  # Body + denials + tags in one changeset; images attach separately (they
-  # are pre-existing rows, not nested params).
+  # Body + denials + tags + review in one changeset; images attach separately
+  # (they are pre-existing rows, not nested params).
   defp build_changeset(post_or_struct, attrs, denials, image_ids) do
     tag_ids = attrs |> fetch(:tags) |> parse_tag_values() |> tag_ids_for()
 
@@ -276,10 +286,37 @@ defmodule Vutuv.Posts do
       |> Post.changeset(%{body: to_string(fetch(attrs, :body) || "")})
       |> Ecto.Changeset.put_assoc(:denials, Enum.map(denials, &struct(PostDenial, &1)))
       |> Ecto.Changeset.put_assoc(:post_tags, Enum.map(tag_ids, &%PostTag{tag_id: &1}))
+      |> put_review(post_or_struct, fetch(attrs, :review))
       |> require_content(image_ids)
 
     if changeset.valid?, do: {:ok, changeset}, else: {:error, changeset}
   end
+
+  # The optional review sidecar (Vutuv.Posts.PostReview). Attrs without a
+  # :review key leave an existing review untouched (the API's partial PATCH);
+  # a blank kind removes it (the composer always submits the kind, so closing
+  # the review panel deletes on save); anything else casts onto the existing
+  # review (update — preloaded by update_post) or a fresh one (create).
+  defp put_review(changeset, _post, nil), do: changeset
+
+  defp put_review(changeset, post, review_attrs) when is_map(review_attrs) do
+    case fetch(review_attrs, :kind) do
+      blank when blank in [nil, ""] ->
+        Ecto.Changeset.put_assoc(changeset, :review, nil)
+
+      _kind ->
+        existing =
+          case post do
+            %Post{review: %PostReview{} = review} -> review
+            _post -> %PostReview{}
+          end
+
+        Ecto.Changeset.put_assoc(changeset, :review, PostReview.changeset(existing, review_attrs))
+    end
+  end
+
+  defp put_review(changeset, _post, _other),
+    do: Ecto.Changeset.add_error(changeset, :review, "is invalid")
 
   defp require_content(changeset, image_ids) do
     body = Ecto.Changeset.get_field(changeset, :body) || ""
@@ -1709,6 +1746,16 @@ defmodule Vutuv.Posts do
   defp order_engaged(query, _recent),
     do: order_by(query, [engagement: e], desc: e.inserted_at, desc: e.id)
 
+  @doc """
+  A review by id with its post (+ author) preloaded, or `nil` — the cover
+  proxy's lookup (`VutuvWeb.ReviewCoverController`).
+  """
+  def get_review(id) do
+    UUIDv7.with_cast(id, fn uuid ->
+      PostReview |> Repo.get(uuid) |> Repo.preload(post: [:user])
+    end)
+  end
+
   @doc "The permalink lookup: `author`'s preloaded post by id, or `nil`."
   def get_post(%User{id: author_id}, id) do
     UUIDv7.with_cast(id, fn id ->
@@ -1783,11 +1830,20 @@ defmodule Vutuv.Posts do
       # The auto link screenshot rendered beside a single-URL post (nil for
       # every other post); the card shows it only once `status: "ready"`.
       :screenshot,
+      # The book/film review sidecar (nil for ordinary posts) — the card
+      # renders it wherever the post renders, so it always travels along.
+      :review,
       denials: [:denied_user],
       tags: from(t in Tag, order_by: t.name),
       reply_ref: [
         :parent_author,
-        parent_post: [:user, :images, :screenshot, tags: from(t in Tag, order_by: t.name)]
+        parent_post: [
+          :user,
+          :images,
+          :screenshot,
+          :review,
+          tags: from(t in Tag, order_by: t.name)
+        ]
       ]
     ]
   end
@@ -2053,6 +2109,16 @@ defmodule Vutuv.Posts do
   """
   def broadcast_screenshot_removed(post_id) when is_binary(post_id) do
     broadcast_post_followers_event(post_id, :post_screenshot_removed)
+  end
+
+  @doc """
+  A book review's cover finished fetching (and cleared moderation) — open
+  feeds/profiles re-render the card. Reuses the screenshot-ready event on
+  purpose: both mean "an auto-fetched attachment of this post became ready,
+  refresh the card", and every LiveView already handles it.
+  """
+  def broadcast_review_cover_ready(post_id) when is_binary(post_id) do
+    broadcast_post_followers_event(post_id, :post_screenshot_ready)
   end
 
   # Fan a `{event_name, %{post_id:, author_id:}}` out to the post author's own

--- a/lib/vutuv/posts/post.ex
+++ b/lib/vutuv/posts/post.ex
@@ -33,6 +33,12 @@ defmodule Vutuv.Posts.Post do
     # URL and no image at save time (see Vutuv.Posts.Screenshots). Rendered
     # beside the body once `status: "ready"`.
     has_one(:screenshot, Vutuv.Posts.PostScreenshot)
+
+    # The structured book/film review riding on this post (see PostReview);
+    # nil for ordinary posts. Replaced wholesale on edit, deleted when the
+    # author clears the review kind.
+    has_one(:review, Vutuv.Posts.PostReview, on_replace: :delete)
+
     has_many(:post_tags, Vutuv.Posts.PostTag, on_replace: :delete)
     has_many(:tags, through: [:post_tags, :tag])
 

--- a/lib/vutuv/posts/post_review.ex
+++ b/lib/vutuv/posts/post_review.ex
@@ -1,0 +1,206 @@
+defmodule Vutuv.Posts.PostReview do
+  @moduledoc """
+  The structured **review sidecar** of a post: a member reviewing a book or a
+  film attaches kind + identifier (ISBN / IMDb id) + display metadata to an
+  ordinary post, and every surface that renders the post adds a review card
+  (cover, title, creator, year, shop/IMDb link) on top of the prose. The body
+  stays plain Markdown — "this post is a book review" is simply "the post has
+  a review row", never body parsing. Future kinds (music, games, hotels…)
+  join by extending `@kinds` and the per-kind identifier normalization.
+
+  The **cover** is fetched from Open Library by ISBN (`Vutuv.Posts.ReviewCovers`,
+  book reviews only) and follows the screenshot lifecycle: `cover_status`
+  `none` → `pending` → `ready`/`failed`, with `cover` holding the
+  content-fingerprinted filename and `cover_moderation` the AI-scan state
+  (`Vutuv.Moderation.ImageScans` — an external image shown publicly is gated
+  like any upload). A changed ISBN resets the cover to `pending`, so an edit
+  re-fetches; the fields are set here in the changeset, never cast from
+  params.
+  """
+
+  use VutuvWeb, :model
+
+  alias Vutuv.Isbn
+  alias Vutuv.Moderation.ImageScans
+
+  @kinds ~w(book movie)
+  @cover_statuses ~w(none pending ready failed)
+
+  # How the reviewer consumed the work — a book review can say "I listened to
+  # the audiobook", a film review "seen in the cinema". Optional, per kind.
+  @media %{
+    "book" => ~w(print ebook audiobook),
+    "movie" => ~w(cinema streaming disc)
+  }
+
+  schema "post_reviews" do
+    belongs_to(:post, Vutuv.Posts.Post)
+
+    field(:kind, :string)
+    field(:identifier, :string)
+    field(:title, :string)
+    field(:creator, :string)
+    field(:year, :integer)
+    field(:medium, :string)
+
+    field(:cover, :string)
+    field(:cover_status, :string, default: "none")
+    field(:cover_moderation, :string)
+
+    timestamps()
+  end
+
+  def kinds, do: @kinds
+  def cover_statuses, do: @cover_statuses
+
+  @doc "The medium choices of a kind (`\"book\"` → print/ebook/audiobook, …)."
+  def media(kind), do: Map.get(@media, kind, [])
+
+  def changeset(post_review, params \\ %{}) do
+    post_review
+    |> cast(params, [:kind, :identifier, :title, :creator, :year, :medium])
+    |> update_change(:title, &String.trim/1)
+    |> update_change(:creator, &String.trim/1)
+    |> validate_required([:kind])
+    # Standalone sentence: the composer surfaces these without field names.
+    |> validate_required([:title], message: "the review is missing the title of the work")
+    |> validate_inclusion(:kind, @kinds)
+    |> validate_length(:title, max: 255)
+    |> validate_length(:creator, max: 255)
+    |> validate_number(:year, greater_than_or_equal_to: 1000, less_than_or_equal_to: 3000)
+    |> normalize_medium()
+    |> normalize_identifier()
+    |> reconcile_cover_state()
+  end
+
+  # Blank medium (the select's "no answer") stores nil; a set one must fit
+  # the review's kind, so a book can never claim "cinema".
+  defp normalize_medium(changeset) do
+    changeset =
+      update_change(changeset, :medium, fn medium ->
+        if medium && String.trim(medium) != "", do: medium
+      end)
+
+    case get_field(changeset, :medium) do
+      nil -> changeset
+      medium -> check_medium(changeset, medium)
+    end
+  end
+
+  defp check_medium(changeset, medium) do
+    if medium in media(get_field(changeset, :kind)) do
+      changeset
+    else
+      add_error(changeset, :medium, "is invalid")
+    end
+  end
+
+  # Canonicalizes what people paste — a hyphenated ISBN-10/13, a full IMDb
+  # URL — into the one stored form per kind. Runs on the *change*, so an
+  # unchanged identifier is never re-normalized (and never resets the cover).
+  defp normalize_identifier(changeset) do
+    case {get_field(changeset, :kind), get_change(changeset, :identifier)} do
+      {_kind, nil} ->
+        changeset
+
+      {kind, value} ->
+        case normalize(kind, String.trim(value)) do
+          {:ok, normalized} -> put_change(changeset, :identifier, normalized)
+          :empty -> put_change(changeset, :identifier, nil)
+          :error -> add_error(changeset, :identifier, identifier_error(kind))
+        end
+    end
+  end
+
+  defp normalize(_kind, ""), do: :empty
+  defp normalize("book", value), do: Isbn.normalize(value)
+  defp normalize("movie", value), do: imdb_id(value)
+  defp normalize(_kind, _value), do: :empty
+
+  defp identifier_error("movie"), do: "is not a valid IMDb link"
+  defp identifier_error(_kind), do: "is not a valid ISBN"
+
+  # A bare IMDb title id, or one inside a pasted imdb.com URL.
+  defp imdb_id(value) do
+    cond do
+      value =~ ~r/^tt\d{6,10}$/ ->
+        {:ok, value}
+
+      match = Regex.run(~r|imdb\.com/(?:[a-z-]+/)?title/(tt\d{6,10})|i, value) ->
+        {:ok, Enum.at(match, 1)}
+
+      true ->
+        :error
+    end
+  end
+
+  # Only a book with an ISBN has a fetchable cover. A new/changed ISBN queues
+  # a (re-)fetch; dropping the ISBN or switching kinds clears the cover.
+  defp reconcile_cover_state(changeset) do
+    identifier_changed? = Map.has_key?(changeset.changes, :identifier)
+    book? = get_field(changeset, :kind) == "book"
+    isbn? = book? and get_field(changeset, :identifier) != nil
+
+    cond do
+      not changeset.valid? ->
+        changeset
+
+      isbn? and (identifier_changed? or get_field(changeset, :cover_status) == "none") ->
+        change(changeset, cover: nil, cover_status: "pending", cover_moderation: nil)
+
+      not isbn? and get_field(changeset, :cover_status) != "none" ->
+        change(changeset, cover: nil, cover_status: "none", cover_moderation: nil)
+
+      true ->
+        changeset
+    end
+  end
+
+  @doc """
+  Whether the fetched cover may render for the general public: fetched *and*
+  released by the AI image scan. The author sees their own pending cover via
+  `visible_cover?/2`'s owner clause instead.
+  """
+  def cover_ready?(%__MODULE__{cover_status: "ready", cover: cover, cover_moderation: moderation})
+      when is_binary(cover),
+      do: ImageScans.released?(moderation)
+
+  def cover_ready?(%__MODULE__{}), do: false
+
+  @doc """
+  The shop link of a book review: the Amazon `/dp/` page of the ISBN-10 form
+  (a 979 ISBN, which has none, gets a search link). `nil` for non-books,
+  ISBN-less reviews, or when the operator blanked `:amazon_domain` — the
+  per-installation off switch (see `config/runtime.exs`). An optional
+  `:amazon_affiliate_tag` rides along as `?tag=`.
+  """
+  def amazon_url(%__MODULE__{kind: "book", identifier: isbn}) when is_binary(isbn) do
+    case Application.get_env(:vutuv, :amazon_domain, "www.amazon.de") do
+      blank when blank in [nil, ""] -> nil
+      domain -> with_affiliate_tag("https://#{domain}" <> amazon_path(isbn))
+    end
+  end
+
+  def amazon_url(%__MODULE__{}), do: nil
+
+  defp amazon_path(isbn) do
+    case Isbn.isbn10(isbn) do
+      {:ok, isbn10} -> "/dp/#{isbn10}"
+      :error -> "/s?k=#{isbn}"
+    end
+  end
+
+  defp with_affiliate_tag(url) do
+    case Application.get_env(:vutuv, :amazon_affiliate_tag) do
+      blank when blank in [nil, ""] -> url
+      tag -> url <> if(String.contains?(url, "?"), do: "&", else: "?") <> "tag=#{tag}"
+    end
+  end
+
+  @doc "The IMDb title page of a film review, `nil` without an id."
+  def imdb_url(%__MODULE__{kind: "movie", identifier: "tt" <> _ = id}) do
+    "https://www.imdb.com/title/#{id}/"
+  end
+
+  def imdb_url(%__MODULE__{}), do: nil
+end

--- a/lib/vutuv/posts/review_covers.ex
+++ b/lib/vutuv/posts/review_covers.ex
@@ -1,0 +1,139 @@
+defmodule Vutuv.Posts.ReviewCovers do
+  @moduledoc """
+  Fetches the **cover of a book review** from Open Library by ISBN, off the
+  request path: `Vutuv.Posts` calls `reconcile/1` after every post
+  create/update, and a review whose `cover_status` is `pending` (a new or
+  changed ISBN — `Vutuv.Posts.PostReview` sets that in its changeset) gets a
+  background fetch under `Vutuv.TaskSupervisor`.
+
+  Gated by the `:fetch_book_metadata` flag (air-gapped installs fetch
+  nothing and the card renders its placeholder tile; tests keep it off and
+  stub HTTP via `:book_covers_req_options`). Not a durable queue on purpose —
+  a cover is decorative, a fetch lost to a restart is simply retried on the
+  next edit, and a `failed` status keeps the card rendering without a cover.
+
+  A fetched cover is an **external image shown publicly**, so it enters the
+  AI-moderation gate like any upload: stored `pending`
+  (`Vutuv.Moderation.ImageScans`), served through the authorizing proxy only
+  once released, deleted on rejection (`Vutuv.Moderation.ImageSubjects`).
+  """
+
+  import Ecto.Query
+
+  alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Posts.Post
+  alias Vutuv.Posts.PostReview
+  alias Vutuv.Repo
+  alias Vutuv.ReviewCover
+
+  require Logger
+
+  @req_options_key :book_covers_req_options
+
+  @doc "Whether this installation fetches book metadata/covers at all."
+  def enabled?, do: Application.get_env(:vutuv, :fetch_book_metadata, true)
+
+  @doc "Removes a review's stored cover files (post deletion, moderation)."
+  defdelegate delete_files(review), to: ReviewCover
+
+  @doc """
+  Starts the background cover fetch for a post whose review is waiting on
+  one; a no-op for every other post (and with `:fetch_book_metadata` off —
+  the review then stays `pending`, harmless and re-checked on the next
+  edit). Expects `post.review` preloaded, as the create/update paths do.
+  """
+  def reconcile(%Post{review: %PostReview{kind: "book", cover_status: "pending"} = review})
+      when is_binary(review.identifier) do
+    if enabled?() do
+      Task.Supervisor.start_child(Vutuv.TaskSupervisor, fn -> fetch(review) end)
+    end
+
+    :ok
+  end
+
+  def reconcile(%Post{}), do: :ok
+
+  @doc """
+  The fetch itself (synchronous — `reconcile/1` wraps it in a task): pulls
+  the ISBN's cover from Open Library, stores it and flips the review to
+  `ready` (entering moderation limbo) or `failed` (no cover known, network
+  trouble). Guarded on the review still carrying the fetched ISBN, so a
+  concurrent edit wins over a slow fetch.
+  """
+  def fetch(%PostReview{kind: "book", identifier: isbn} = review) when is_binary(isbn) do
+    case get_cover(isbn) do
+      {:ok, bytes} -> store(review, bytes)
+      :error -> mark(review, cover_status: "failed")
+    end
+  rescue
+    exception ->
+      Logger.warning(
+        "review cover fetch failed for review #{review.id} (#{isbn}): #{Exception.message(exception)}"
+      )
+
+      mark(review, cover_status: "failed")
+  end
+
+  defp get_cover(isbn) do
+    # default=false turns Open Library's 1x1 placeholder into a plain 404.
+    [
+      url: "https://covers.openlibrary.org/b/isbn/#{isbn}-L.jpg?default=false",
+      receive_timeout: 15_000,
+      retry: false
+    ]
+    |> Keyword.merge(Application.get_env(:vutuv, @req_options_key, []))
+    |> Req.get()
+    |> case do
+      {:ok, %Req.Response{status: 200, body: bytes}} when is_binary(bytes) and bytes != "" ->
+        {:ok, bytes}
+
+      _other ->
+        :error
+    end
+  end
+
+  defp store(review, bytes) do
+    case ReviewCover.store_binary(bytes, review) do
+      {:ok, file} -> announce_stored(review, file)
+      {:error, _reason} -> mark(review, cover_status: "failed")
+    end
+  end
+
+  defp announce_stored(review, file) do
+    moderation = ImageScans.initial_state()
+
+    case mark(review, cover: file, cover_status: "ready", cover_moderation: moderation) do
+      :ok when moderation == "approved" ->
+        # Open feeds/profiles re-render the card with the cover.
+        Vutuv.Posts.broadcast_review_cover_ready(review.post_id)
+        :ok
+
+      :ok ->
+        # Moderation limbo: the scan verdict announces (or deletes) it later.
+        ImageScans.enqueue("review_cover", review.id, owner_id(review), file)
+        :ok
+
+      :stale ->
+        # An edit changed the ISBN while we fetched: its own reconcile
+        # re-fetches; drop what we stored for the outdated ISBN.
+        ReviewCover.delete_files(review)
+        :ok
+    end
+  end
+
+  # Atomically updates the review iff it still carries the fetched ISBN
+  # (identifier is pinned in the WHERE); `:stale` when an edit won the race.
+  defp mark(%PostReview{} = review, set) do
+    now = NaiveDateTime.utc_now(:second)
+
+    {count, _} =
+      from(r in PostReview, where: r.id == ^review.id and r.identifier == ^review.identifier)
+      |> Repo.update_all(set: Keyword.put(set, :updated_at, now))
+
+    if count == 1, do: :ok, else: :stale
+  end
+
+  defp owner_id(%PostReview{post_id: post_id}) do
+    Repo.one(from(p in Post, where: p.id == ^post_id, select: p.user_id))
+  end
+end

--- a/lib/vutuv/uploaders/review_cover.ex
+++ b/lib/vutuv/uploaders/review_cover.ex
@@ -1,0 +1,116 @@
+defmodule Vutuv.ReviewCover do
+  @moduledoc """
+  Book-cover storage for post reviews (`Vutuv.Posts.PostReview`): the cover
+  bytes fetched from Open Library land here as one served AVIF version plus
+  the private original.
+
+      <uploads_dir_prefix>/review_covers/<review.id>/cover-<hash>.avif
+      <uploads_dir_prefix>/originals/review_covers/<review.id>/original.jpg
+
+  Like the screenshots, the served filename is **content-fingerprinted**
+  (`<hash>` = first 12 hex chars of the SHA-256 of the fetched bytes), so the
+  URL changes whenever the bytes do and responses can be cached immutably.
+  The `post_reviews.cover` column stores `<hash><ext>`.
+
+  Unlike the nginx-served screenshots, covers are served through the
+  authorizing proxy (`VutuvWeb.ReviewCoverController` — post visibility and
+  the AI-moderation verdict are checked per request), so there is no
+  quarantine tree here: an unreleased cover simply never leaves the proxy.
+  """
+
+  alias Vutuv.Uploads
+  alias Vutuv.Uploads.Originals
+  alias Vutuv.Uploads.Spec
+
+  @doc """
+  Stores the fetched cover `bytes` for `review`: derives the served AVIF
+  (replacing any prior cover) and keeps the original bytes privately.
+  Returns `{:ok, "<hash><ext>"}` (for the `cover` column) or
+  `{:error, reason}` when the bytes don't decode as an image.
+  """
+  def store_binary(bytes, review, ext \\ ".jpg") when is_binary(bytes) do
+    with {:ok, rotated} <- Spec.open_rotated_binary(bytes) do
+      hash =
+        :sha256 |> :crypto.hash(bytes) |> Base.encode16(case: :lower) |> binary_part(0, 12)
+
+      dir = disk_dir(review)
+      File.mkdir_p!(dir)
+      clear_versions(dir)
+
+      spec = Spec.version(:review_cover, :cover)
+
+      with :ok <- Spec.write_derived(spec, rotated, Path.join(dir, filename(hash))) do
+        store_original(review, bytes, ext)
+        {:ok, "#{hash}#{ext}"}
+      end
+    end
+  end
+
+  @doc """
+  Absolute on-disk path of the served cover version, or `nil` when missing.
+  `version` must match the fingerprinted name the review's `cover` column
+  yields (see `version_name/1`) — anything else never resolves.
+  """
+  def version_path(review, version) do
+    if version == version_name(review) do
+      path = Path.join(disk_dir(review), version <> Spec.served_ext())
+      if File.exists?(path), do: path
+    end
+  end
+
+  @doc """
+  The path nginx would resolve for X-Accel serving. The default install
+  serves covers via `send_file` (`:post_image_serving`), like post images.
+  """
+  def accel_path(review, version) do
+    "/internal_review_covers/#{review.id}/#{version}#{Spec.served_ext()}"
+  end
+
+  @doc """
+  The fingerprinted version segment of a review's stored cover —
+  `"cover-<hash>"` — or `nil` when no cover is stored. Both the URL builder
+  and the proxy's whitelist derive from this, so they cannot drift.
+  """
+  def version_name(%{cover: cover}) when is_binary(cover) do
+    "cover-" <> Path.rootname(cover)
+  end
+
+  def version_name(_review), do: nil
+
+  @doc "Root-relative URL of the served cover, `nil` when none is stored."
+  def url(%{id: id} = review) do
+    if version = version_name(review) do
+      "/review_covers/#{id}/#{version}#{Spec.served_ext()}"
+    end
+  end
+
+  @doc """
+  Removes every stored file of a review's cover (served + original). A no-op
+  when none. The row is the caller's business — post deletion cascades it,
+  a moderation rejection clears its columns.
+  """
+  def delete_files(review) do
+    File.rm_rf(disk_dir(review))
+    Originals.delete(storage_dir(review))
+    :ok
+  end
+
+  defp store_original(review, bytes, ext) do
+    tmp = Path.join(System.tmp_dir!(), "review-cover-#{review.id}")
+    File.write!(tmp, bytes)
+    :ok = Originals.store(storage_dir(review), tmp, ext)
+    File.rm(tmp)
+    :ok
+  end
+
+  defp clear_versions(dir) do
+    for file <- Path.wildcard(Path.join(dir, "cover-*")), do: File.rm(file)
+    :ok
+  end
+
+  defp filename(hash), do: "cover-#{hash}#{Spec.served_ext()}"
+
+  defp storage_dir(%{id: id}), do: "review_covers/#{id}"
+
+  defp disk_dir(review), do: Uploads.disk_dir(storage_dir(review))
+end

--- a/lib/vutuv/uploads/spec.ex
+++ b/lib/vutuv/uploads/spec.ex
@@ -57,6 +57,11 @@ defmodule Vutuv.Uploads.Spec do
       # 2x the 400x264 on-page display size; crop :high keeps the page top.
       %{name: :thumb, fit: {:crop, 800, 528, :high}, quality: 58}
     ],
+    review_cover: [
+      # A book cover fetched by ISBN (Vutuv.ReviewCover): portrait aspect
+      # preserved, ~4x the review card's 80-96px display width for HiDPI.
+      %{name: :cover, fit: {:box_down, 640}, quality: 58}
+    ],
     post_image: [
       # thumb: square feed-grid cell; feed: single-image feed width;
       # large: permalink/lightbox.

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -15,6 +15,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
 
   alias Vutuv.Accounts.User
   alias Vutuv.CodeStats
+  alias VutuvWeb.PostComponents
 
   # The per-user people lists (followers/following/connections) share one
   # clause; the set lives in ListDocs.
@@ -100,6 +101,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       "# #{gettext("Post by %{name}", name: author_link)} · #{doc.published_on}",
       doc.in_reply_to && in_reply_to_line(doc.in_reply_to),
       doc.body_markdown,
+      review_line(doc.review),
       tags_line(doc.tags),
       engagement_line(doc),
       section(gettext("Images"), Enum.map(doc.images, &image_line/1)),
@@ -773,6 +775,33 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   def engagement_line(doc) do
     "#{gettext("Likes")}: #{doc.like_count} · #{gettext("Reposts")}: #{doc.repost_count} · " <>
       "#{gettext("Bookmarks")}: #{doc.bookmark_count}"
+  end
+
+  @doc """
+  The post's review sidecar as one fact line (what the HTML review card
+  shows), nil when the post carries none. Shared with the text renderer.
+  """
+  def review_line(nil), do: nil
+
+  def review_line(review) do
+    label =
+      if review.kind == "movie", do: gettext("Film review"), else: gettext("Book review")
+
+    isbn = if review.kind == "book" and review.identifier, do: "ISBN #{review.identifier}"
+
+    details =
+      [
+        review.title,
+        review.creator,
+        review.year,
+        PostComponents.review_medium_label(review.medium),
+        isbn,
+        review.link
+      ]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(" · ")
+
+    "#{label}: #{details}"
   end
 
   # The pager / feed-summary / cursor hints are shared with the plain-text

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -14,6 +14,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.PostReview
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.UserHelpers
 
@@ -45,6 +46,9 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       author: AgentDocs.person_ref(author),
       published_on: post.published_on,
       body_markdown: post.body,
+      # The structured book/film review riding on the post (nil for ordinary
+      # posts) — what the HTML review card shows.
+      review: review_entry(post.review),
       tags: Enum.map(post.tags, & &1.name),
       # Anonymous public view: images still in (or deleted by) AI moderation
       # never appear here.
@@ -118,6 +122,20 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       body_markdown: reply.body
     }
   end
+
+  defp review_entry(%PostReview{} = review) do
+    %{
+      kind: review.kind,
+      identifier: review.identifier,
+      title: review.title,
+      creator: review.creator,
+      year: review.year,
+      medium: review.medium,
+      link: PostReview.amazon_url(review) || PostReview.imdb_url(review)
+    }
+  end
+
+  defp review_entry(_other), do: nil
 
   defp image_entry(%PostImage{} = image) do
     %{

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -97,6 +97,7 @@ defmodule VutuvWeb.AgentDocs.Text do
       heading("#{gettext("Post by %{name}", name: doc.author.name)} · #{doc.published_on}"),
       doc.in_reply_to && in_reply_to_line(doc.in_reply_to),
       doc.body_markdown,
+      Markdown.review_line(doc.review),
       tags_line(doc.tags),
       Markdown.engagement_line(doc),
       section(gettext("Images"), Enum.map(doc.images, &image_lines/1)),

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -30,7 +30,9 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Posts
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.PostReview
   alias Vutuv.Posts.PostScreenshot
+  alias Vutuv.ReviewCover
 
   # How many reposter faces the "Reposted by" avatar stack shows before the
   # rest collapse into a `+N` chip. Five keeps the strip to one tidy line even
@@ -174,6 +176,9 @@ defmodule VutuvWeb.PostComponents do
       # text (3/4 body, 1/4 screenshot).
       |> assign(:link_screenshot, link_screenshot(post))
       |> assign(:link_screenshot_layout?, link_screenshot_layout?(post, assigns.mode))
+      # The book/film review sidecar; nil for ordinary posts (and for nested
+      # renderings whose preload chain didn't carry it).
+      |> assign(:review, review_of(post))
       |> assign(:actions_id, "post-actions-#{entry_key}")
       # The action bar's acting viewer id (nil = logged-out / public preview).
       # On a LiveView host the inline component is handed this directly; on a
@@ -995,6 +1000,12 @@ defmodule VutuvWeb.PostComponents do
             class="mt-4 block max-w-md"
           />
 
+          <%!-- The book/film review card (the post's structured sidecar,
+          Vutuv.Posts.PostReview): cover or kind glyph, title, creator, year
+          and the shop/IMDb link. Rendered in both modes, outside the clamp,
+          so the reviewed work is always visible under the prose. --%>
+          <.review_card :if={@review} review={@review} author?={@author?} />
+
           <%!-- The remaining layouts put the tags in their own full-width row
           below the body/images: plain (line-clamp) previews — no float there,
           so this row already sits at the end of the text — and the photo-only
@@ -1387,6 +1398,146 @@ defmodule VutuvWeb.PostComponents do
   # shows the screenshot below the body instead.
   defp link_screenshot_layout?(post, :preview), do: link_screenshot(post) != nil
   defp link_screenshot_layout?(_post, _mode), do: false
+
+  # The post's review sidecar, nil when absent — and nil for a nested parent
+  # card whose preload chain didn't carry it (NotLoaded must not crash).
+  defp review_of(%{review: %PostReview{} = review}), do: review
+  defp review_of(_post), do: nil
+
+  # The review card under the prose: cover (or a kind glyph tile), the kind
+  # label, title, creator · year, and the outbound shop/IMDb link. The cover
+  # renders for everyone once released; the author additionally sees their
+  # own cover while it waits in AI-moderation limbo (the proxy enforces the
+  # same rule per request).
+  attr(:review, PostReview, required: true)
+  attr(:author?, :boolean, default: false)
+
+  defp review_card(assigns) do
+    review = assigns.review
+
+    cover_url =
+      if PostReview.cover_ready?(review) or
+           (assigns.author? and review.cover_status == "ready" and is_binary(review.cover)) do
+        ReviewCover.url(review)
+      end
+
+    assigns =
+      assigns
+      |> assign(:cover_url, cover_url)
+      |> assign(:external_url, review_external_url(review))
+
+    ~H"""
+    <div
+      class="mt-3 flex gap-3 rounded-xl bg-slate-50 p-3 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:ring-slate-700"
+      data-review-card
+      data-review-kind={@review.kind}
+    >
+      <img
+        :if={@cover_url}
+        src={@cover_url}
+        alt=""
+        loading="lazy"
+        class="w-16 self-start rounded-lg ring-1 ring-slate-200 dark:ring-slate-700 sm:w-20"
+      />
+      <span
+        :if={!@cover_url}
+        aria-hidden="true"
+        class="flex aspect-[2/3] w-16 shrink-0 items-center justify-center self-start rounded-lg bg-brand-50 text-2xl dark:bg-brand-900/40 sm:w-20"
+      >
+        {if @review.kind == "movie", do: "🎬", else: "📖"}
+      </span>
+
+      <div class="min-w-0">
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">
+          {review_kind_label(@review.kind)}
+        </p>
+        <p class="mt-0.5 font-semibold text-slate-900 dark:text-slate-100">{@review.title}</p>
+        <p
+          :if={@review.creator || @review.year || @review.medium}
+          class="text-sm text-slate-600 dark:text-slate-400"
+        >
+          {[@review.creator, @review.year, review_medium_label(@review.medium)]
+          |> Enum.reject(&is_nil/1)
+          |> Enum.join(" · ")}
+        </p>
+        <p :if={@review.kind == "book" and @review.identifier} class="mt-1 text-xs text-slate-600 dark:text-slate-400">
+          ISBN {@review.identifier}
+        </p>
+        <p :if={@external_url} class="mt-1.5">
+          <a
+            href={@external_url}
+            target="_blank"
+            rel="nofollow noopener noreferrer"
+            class="text-sm font-semibold text-brand-600 hover:text-brand-700"
+          >
+            {review_link_label(@review.kind)} ↗
+          </a>
+        </p>
+      </div>
+    </div>
+    """
+  end
+
+  defp review_external_url(%PostReview{kind: "book"} = review), do: PostReview.amazon_url(review)
+  defp review_external_url(%PostReview{kind: "movie"} = review), do: PostReview.imdb_url(review)
+  defp review_external_url(%PostReview{}), do: nil
+
+  defp review_kind_label("movie"), do: gettext("Film review")
+  defp review_kind_label(_kind), do: gettext("Book review")
+
+  @doc """
+  The post's review sidecar as one compact HTML paragraph (an escaped raw
+  string, `""` when the post carries none) — appended to the rendered body
+  wherever the post leaves the site as plain HTML: the federated
+  ActivityPub Note (`VutuvWeb.Fediverse.Docs`) and the RSS items
+  (`VutuvWeb.Feeds`). Remote software knows nothing of review cards, so the
+  facts ride inside the content itself.
+  """
+  def review_content_html(%{review: %PostReview{} = review}) do
+    {glyph, label} =
+      case review.kind do
+        "movie" -> {"🎬", gettext("Film review")}
+        _book -> {"📖", gettext("Book review")}
+      end
+
+    isbn = if review.kind == "book" and review.identifier, do: "ISBN #{review.identifier}"
+
+    details =
+      [review.creator, review.year, review_medium_label(review.medium), isbn]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map_join("", &" · #{esc(&1)}")
+
+    link = PostReview.amazon_url(review) || PostReview.imdb_url(review)
+
+    title =
+      if link,
+        do: ~s(<a href="#{esc(link)}" rel="nofollow noopener">#{esc(review.title)}</a>),
+        else: esc(review.title)
+
+    "<p>#{glyph} #{esc(label)}: #{title}#{details}</p>"
+  end
+
+  def review_content_html(_post), do: ""
+
+  defp esc(value),
+    do: value |> to_string() |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
+
+  @doc """
+  The display label of a review medium (how the reviewer consumed the work),
+  nil for nil — shared by the review card, the composer's select and the
+  agent docs, so the wording cannot drift.
+  """
+  def review_medium_label(nil), do: nil
+  def review_medium_label("print"), do: gettext("Printed book")
+  def review_medium_label("ebook"), do: gettext("E-book")
+  def review_medium_label("audiobook"), do: gettext("Audiobook")
+  def review_medium_label("cinema"), do: gettext("Cinema")
+  def review_medium_label("streaming"), do: gettext("Streaming")
+  def review_medium_label("disc"), do: gettext("DVD/Blu-ray")
+  def review_medium_label(_other), do: nil
+
+  defp review_link_label("movie"), do: gettext("View on IMDb")
+  defp review_link_label(_kind), do: gettext("View on Amazon")
 
   # The link screenshot image, shared by the preview (1/4 column) and full
   # (below-body) layouts. A decorative duplicate of the body's autolinked URL —

--- a/lib/vutuv_web/controllers/post_controller.ex
+++ b/lib/vutuv_web/controllers/post_controller.ex
@@ -263,7 +263,7 @@ defmodule VutuvWeb.PostController do
 
   # The ActivityPub rendering of a public post (see Vutuv.Fediverse).
   defp send_note(conn, author, post) do
-    post = Repo.preload(post, [:images, reply_ref: [:parent_author]])
+    post = Repo.preload(post, [:images, :review, reply_ref: [:parent_author]])
 
     note =
       post

--- a/lib/vutuv_web/controllers/review_cover_controller.ex
+++ b/lib/vutuv_web/controllers/review_cover_controller.ex
@@ -1,0 +1,44 @@
+defmodule VutuvWeb.ReviewCoverController do
+  @moduledoc """
+  The authorizing **review-cover proxy**: the fetched book cover of a post
+  review is served through here, so the post's audience (deny model,
+  `Vutuv.Posts.visible_to?/2`) also guards its cover, and a cover still in
+  AI-moderation limbo shows to its author alone (`Vutuv.Moderation`). The
+  URL's version segment is the content-fingerprinted filename
+  (`cover-<hash>.avif`), so only the currently stored cover ever resolves;
+  denied and unknown are both 404 (`VutuvWeb.ImageProxy`).
+  """
+
+  use VutuvWeb, :controller
+
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostReview
+  alias Vutuv.ReviewCover
+  alias VutuvWeb.ImageProxy
+
+  def show(conn, %{"id" => id, "version" => version_file}) do
+    viewer = conn.assigns[:current_user]
+
+    with review when not is_nil(review) <- Posts.get_review(id),
+         version when not is_nil(version) <- parse_version(version_file, review),
+         true <- cover_visible?(review, viewer) do
+      ImageProxy.serve(conn, version,
+        accel_path: &ReviewCover.accel_path(review, &1),
+        version_path: &ReviewCover.version_path(review, &1)
+      )
+    else
+      _ -> ImageProxy.not_found(conn)
+    end
+  end
+
+  # The whitelist is exactly the fingerprinted name the stored cover yields —
+  # an ISBN change rotates the URL, an outdated one stops resolving.
+  defp parse_version(version_file, review) do
+    ImageProxy.parse_version(version_file, List.wrap(ReviewCover.version_name(review)))
+  end
+
+  defp cover_visible?(review, viewer) do
+    Posts.visible_to?(review.post, viewer) and
+      (PostReview.cover_ready?(review) or Posts.author?(review.post, viewer))
+  end
+end

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -20,6 +20,9 @@ defmodule VutuvWeb.Fediverse.Docs do
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.PostReview
+  alias Vutuv.ReviewCover
+  alias VutuvWeb.PostComponents
   alias VutuvWeb.UserHelpers
 
   @public "https://www.w3.org/ns/activitystreams#Public"
@@ -129,11 +132,17 @@ defmodule VutuvWeb.Fediverse.Docs do
   end
 
   # The same rendering members see, with every relative link/image made
-  # absolute (remote servers render this HTML on their own domain).
+  # absolute (remote servers render this HTML on their own domain). A review
+  # sidecar is rendered INTO the content: the Note is one more rendering of
+  # the post (like the agent docs), so a Mastodon reader gets the reviewed
+  # work's facts even though remote software knows nothing of review cards.
   defp content_html(post) do
-    post.body
-    |> VutuvWeb.Markdown.render_post(images(post))
-    |> Phoenix.HTML.safe_to_string()
+    body_html =
+      post.body
+      |> VutuvWeb.Markdown.render_post(images(post))
+      |> Phoenix.HTML.safe_to_string()
+
+    (body_html <> PostComponents.review_content_html(post))
     |> absolutize()
   end
 
@@ -175,25 +184,40 @@ defmodule VutuvWeb.Fediverse.Docs do
 
   # Public posts only federate, and a public post's images are publicly
   # servable through the authorizing proxy — so their URLs can ride along.
+  # A released review cover rides along as an attachment too — a public
+  # post's cover is publicly servable through the authorizing proxy.
   defp put_attachments(note, post) do
-    case images(post) do
-      [] ->
-        note
+    attachments =
+      Enum.map(images(post), fn image ->
+        %{
+          "type" => "Document",
+          "mediaType" => "image/avif",
+          "url" => base() <> PostImage.url(image, "large")
+        }
+      end) ++ cover_attachments(post)
 
-      images ->
-        Map.put(
-          note,
-          "attachment",
-          Enum.map(images, fn image ->
-            %{
-              "type" => "Document",
-              "mediaType" => "image/avif",
-              "url" => base() <> PostImage.url(image, "large")
-            }
-          end)
-        )
+    case attachments do
+      [] -> note
+      attachments -> Map.put(note, "attachment", attachments)
     end
   end
+
+  defp cover_attachments(%Post{review: %PostReview{} = review}) do
+    if PostReview.cover_ready?(review) do
+      [
+        %{
+          "type" => "Document",
+          "mediaType" => "image/avif",
+          "name" => review.title,
+          "url" => base() <> ReviewCover.url(review)
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  defp cover_attachments(%Post{}), do: []
 
   defp summary(user) do
     case user.headline do

--- a/lib/vutuv_web/feeds.ex
+++ b/lib/vutuv_web/feeds.ex
@@ -12,6 +12,7 @@ defmodule VutuvWeb.Feeds do
 
   alias Vutuv.Posts
   alias VutuvWeb.AgentDocs
+  alias VutuvWeb.PostComponents
   alias VutuvWeb.UserHelpers
   alias VutuvWeb.Xml
 
@@ -88,11 +89,16 @@ defmodule VutuvWeb.Feeds do
   end
 
   defp rendered_body(post) do
-    post.body
-    # An RSS reader is an anonymous viewer: only AI-released images may
-    # render inline (the unreleased rest simply stays absent).
-    |> VutuvWeb.Markdown.render_post(Posts.released_images(post))
-    |> Phoenix.HTML.safe_to_string()
+    body_html =
+      post.body
+      # An RSS reader is an anonymous viewer: only AI-released images may
+      # render inline (the unreleased rest simply stays absent).
+      |> VutuvWeb.Markdown.render_post(Posts.released_images(post))
+      |> Phoenix.HTML.safe_to_string()
+
+    # A review sidecar rides inside the item content (same as the federated
+    # Note): RSS readers know nothing of review cards.
+    (body_html <> PostComponents.review_content_html(post))
     |> absolutize_urls()
   end
 

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -30,12 +30,26 @@ defmodule VutuvWeb.PostLive.Composer do
 
   use VutuvWeb, :live_component
 
+  alias Vutuv.BookMetadata
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.PostReview
   alias VutuvWeb.ErrorHelpers
+  alias VutuvWeb.PostComponents
 
   @presets ~w(public followers connections only_me custom)
+
+  # The review panel's form values, kept as a plain string-keyed map (the
+  # panel inputs are plain form fields; the changeset runs on save).
+  @empty_review %{
+    "kind" => "",
+    "identifier" => "",
+    "title" => "",
+    "creator" => "",
+    "year" => "",
+    "medium" => ""
+  }
 
   @impl true
   def update(assigns, socket) do
@@ -66,6 +80,8 @@ defmodule VutuvWeb.PostLive.Composer do
       post != nil and (Posts.has_reposts?(post) or Posts.has_replies?(post))
     )
     |> assign(:body, (post && post.body) || "")
+    |> assign(:review, review_values(post))
+    |> assign(:review_lookup_error, nil)
     |> assign(:tags_value, tags_value(post))
     |> assign(:images, (post && post.images) || [])
     |> assign(:alts, %{})
@@ -86,6 +102,21 @@ defmodule VutuvWeb.PostLive.Composer do
 
   defp tags_value(nil), do: ""
   defp tags_value(post), do: Enum.map_join(post.tags, ", ", & &1.name)
+
+  # Edit mode prefills the panel from the stored review; the panel is open
+  # exactly when a kind is set.
+  defp review_values(%Post{review: %PostReview{} = review}) do
+    %{
+      "kind" => review.kind,
+      "identifier" => review.identifier || "",
+      "title" => review.title || "",
+      "creator" => review.creator || "",
+      "year" => if(review.year, do: Integer.to_string(review.year), else: ""),
+      "medium" => review.medium || ""
+    }
+  end
+
+  defp review_values(_post), do: @empty_review
 
   # Edit mode: recognize the quick presets in the stored denials; anything
   # else (including a lone "non_followees", which no longer has its own preset)
@@ -129,6 +160,7 @@ defmodule VutuvWeb.PostLive.Composer do
       |> assign(:body, params["body"] || socket.assigns.body)
       |> assign(:tags_value, params["tags"] || socket.assigns.tags_value)
       |> assign(:alts, params["alts"] || socket.assigns.alts)
+      |> assign(:review, Map.merge(socket.assigns.review, params["review"] || %{}))
       |> assign(:preset, preset)
       |> assign(:error, nil)
       |> sweep_rejected_uploads()
@@ -171,6 +203,52 @@ defmodule VutuvWeb.PostLive.Composer do
   def handle_event("undeny-user", %{"id" => id}, socket) do
     {:noreply,
      assign(socket, :denied_users, Enum.reject(socket.assigns.denied_users, &(&1.id == id)))}
+  end
+
+  # The 📖/🎬 buttons open the review panel with that kind; the panel's ✕
+  # sets it back to "" (which deletes a stored review on save). The other
+  # field values survive a toggle, so an accidental close loses nothing.
+  def handle_event("review-kind", %{"kind" => kind}, socket) do
+    if kind in ["" | PostReview.kinds()] do
+      # The medium is per-kind (audiobook vs. cinema), so it resets on a
+      # switch; every other field survives an accidental toggle.
+      review = %{socket.assigns.review | "kind" => kind, "medium" => ""}
+
+      {:noreply,
+       socket
+       |> assign(:review, review)
+       |> assign(:review_lookup_error, nil)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  # The ISBN lookup (book panel only, rendered only with :fetch_book_metadata
+  # on): prefills title/creator/year from Open Library. Everything stays
+  # editable — the lookup is convenience, not truth.
+  def handle_event("review-lookup", _params, socket) do
+    review = socket.assigns.review
+
+    with {:ok, isbn} <- Vutuv.Isbn.normalize(review["identifier"] || ""),
+         {:ok, data} <- BookMetadata.lookup(isbn) do
+      filled =
+        Map.merge(review, %{
+          "identifier" => isbn,
+          "title" => data.title,
+          "creator" => data.creator || review["creator"],
+          "year" => if(data.year, do: Integer.to_string(data.year), else: review["year"])
+        })
+
+      {:noreply, socket |> assign(:review, filled) |> assign(:review_lookup_error, nil)}
+    else
+      :error ->
+        {:noreply,
+         assign(
+           socket,
+           :review_lookup_error,
+           gettext("Nothing found for this ISBN. Please fill in the fields yourself.")
+         )}
+    end
   end
 
   def handle_event("insert-inline", %{"id" => id}, socket) do
@@ -218,6 +296,9 @@ defmodule VutuvWeb.PostLive.Composer do
     attrs = %{
       body: params["body"] || "",
       tags: params["tags"] || "",
+      # The submitted panel fields are the truth; with the panel closed only
+      # the hidden kind ("") arrives, which removes a stored review on save.
+      review: params["review"] || %{"kind" => ""},
       denials: denials_payload(socket.assigns),
       image_ids: Enum.map(socket.assigns.images, & &1.id)
     }
@@ -249,6 +330,8 @@ defmodule VutuvWeb.PostLive.Composer do
          socket
          |> assign(:body, "")
          |> assign(:tags_value, "")
+         |> assign(:review, @empty_review)
+         |> assign(:review_lookup_error, nil)
          |> assign(:images, [])
          |> assign(:alts, %{})
          |> assign(:error, nil)}
@@ -425,11 +508,20 @@ defmodule VutuvWeb.PostLive.Composer do
   # `%{handles}` becomes the actual handle) rather than dumping the raw msgid
   # prefixed with the field atom ("body mentions a handle …: %{handles}"). Each
   # message is now a self-contained sentence, so the field name is dropped.
+  # traverse_errors walks nested changesets too, so a review-field error (an
+  # invalid ISBN, say) surfaces instead of failing silently.
   defp changeset_message(changeset) do
-    Enum.map_join(changeset.errors, " ", fn {_field, error} ->
-      ErrorHelpers.translate_error(error)
-    end)
+    changeset
+    |> Ecto.Changeset.traverse_errors(&ErrorHelpers.translate_error/1)
+    |> flatten_messages()
+    |> Enum.join(" ")
   end
+
+  defp flatten_messages(map) when is_map(map),
+    do: Enum.flat_map(map, fn {_field, value} -> flatten_messages(value) end)
+
+  defp flatten_messages(list) when is_list(list), do: Enum.flat_map(list, &flatten_messages/1)
+  defp flatten_messages(message) when is_binary(message), do: [message]
 
   defp full_name(user), do: VutuvWeb.UserHelpers.full_name(user)
 
@@ -550,6 +642,110 @@ defmodule VutuvWeb.PostLive.Composer do
             class={[input_class(), "mt-3"]}
           />
 
+          <%!-- The review sidecar (book/film review, Vutuv.Posts.PostReview).
+          The hidden kind always submits — closing the panel deletes a stored
+          review on save; the panel fields join it while open. --%>
+          <input type="hidden" name="post[review][kind]" value={@review["kind"]} />
+
+          <div
+            :if={@review["kind"] != ""}
+            id={"#{@id}-review-panel"}
+            class="mt-4 rounded-xl bg-slate-50 p-4 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:ring-slate-700"
+          >
+            <div class="flex items-center justify-between gap-3">
+              <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">
+                {if @review["kind"] == "movie",
+                  do: "🎬 " <> gettext("Film review"),
+                  else: "📖 " <> gettext("Book review")}
+              </h3>
+              <button
+                type="button"
+                phx-click="review-kind"
+                phx-value-kind=""
+                phx-target={@myself}
+                class="text-sm font-semibold text-slate-500 hover:text-red-600 dark:text-slate-400"
+              >
+                ✕ {gettext("Remove review")}
+              </button>
+            </div>
+
+            <div class="mt-3 flex gap-2">
+              <input
+                type="text"
+                name="post[review][identifier]"
+                value={@review["identifier"]}
+                placeholder={
+                  if @review["kind"] == "movie",
+                    do: gettext("IMDb link or ID"),
+                    else: gettext("ISBN")
+                }
+                class={[input_class(), "flex-1"]}
+              />
+              <button
+                :if={@review["kind"] == "book" and BookMetadata.enabled?()}
+                type="button"
+                id={"#{@id}-review-lookup"}
+                phx-click="review-lookup"
+                phx-target={@myself}
+                phx-disable-with={gettext("Looking up…")}
+                class="shrink-0 rounded-lg bg-slate-100 px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+              >
+                {gettext("Look up")}
+              </button>
+            </div>
+            <p :if={@review_lookup_error} class="mt-1 text-sm text-red-600">
+              {@review_lookup_error}
+            </p>
+
+            <div class="mt-3 grid gap-3 sm:grid-cols-2">
+              <input
+                type="text"
+                name="post[review][title]"
+                value={@review["title"]}
+                placeholder={gettext("Title")}
+                class={input_class()}
+              />
+              <input
+                type="text"
+                name="post[review][creator]"
+                value={@review["creator"]}
+                placeholder={
+                  if @review["kind"] == "movie", do: gettext("Director"), else: gettext("Author(s)")
+                }
+                class={input_class()}
+              />
+            </div>
+
+            <div class="mt-3 grid gap-3 sm:grid-cols-2">
+              <input
+                type="text"
+                name="post[review][year]"
+                value={@review["year"]}
+                inputmode="numeric"
+                placeholder={gettext("Year")}
+                class={input_class()}
+              />
+              <select name="post[review][medium]" class={input_class()}>
+                <option value="">
+                  {if @review["kind"] == "movie",
+                    do: gettext("Watched as… (optional)"),
+                    else: gettext("Read as… (optional)")}
+                </option>
+                <option
+                  :for={medium <- PostReview.media(@review["kind"])}
+                  value={medium}
+                  selected={@review["medium"] == medium}
+                >
+                  {PostComponents.review_medium_label(medium)}
+                </option>
+              </select>
+            </div>
+
+            <p :if={@review["kind"] == "book"} class="mt-2 text-xs text-slate-600 dark:text-slate-400">
+              {gettext("With an ISBN, the post shows the book cover and a shop link automatically.")}
+            </p>
+          </div>
+
           <%!-- Bottom row: the image picker on the left, the (slightly wider)
           submit button on the right. New posts publish public, so there is no
           audience picker here; a post pinned public by reposts/replies still
@@ -563,6 +759,33 @@ defmodule VutuvWeb.PostLive.Composer do
               📷 {gettext("Add images")}
               <.live_file_input upload={@uploads.images} class="sr-only" />
             </label>
+
+            <%!-- Review triggers: open the book/film review panel. Emoji-only
+            on phones (the row is tight there), labeled from sm up. --%>
+            <button
+              :if={@review["kind"] == ""}
+              type="button"
+              phx-click="review-kind"
+              phx-value-kind="book"
+              phx-target={@myself}
+              title={gettext("Review a book")}
+              aria-label={gettext("Review a book")}
+              class="inline-flex h-9 items-center gap-1.5 rounded-lg bg-slate-100 px-3 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+            >
+              📖<span class="hidden sm:inline">{gettext("Book")}</span>
+            </button>
+            <button
+              :if={@review["kind"] == ""}
+              type="button"
+              phx-click="review-kind"
+              phx-value-kind="movie"
+              phx-target={@myself}
+              title={gettext("Review a film")}
+              aria-label={gettext("Review a film")}
+              class="inline-flex h-9 items-center gap-1.5 rounded-lg bg-slate-100 px-3 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+            >
+              🎬<span class="hidden sm:inline">{gettext("Film")}</span>
+            </button>
 
             <div class="ml-auto flex items-center gap-3">
               <span

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -288,6 +288,11 @@ defmodule VutuvWeb.Router do
     # The authorizing job-posting-image proxy, like /post_images.
     get("/job_posting_images/:token/:version", JobPostingImageController, :show)
 
+    # The authorizing review-cover proxy (book covers fetched by ISBN for
+    # post reviews), like /post_images: the post's audience and the AI-scan
+    # verdict guard the cover.
+    get("/review_covers/:id/:version", ReviewCoverController, :show)
+
     # Post deletion (the permalink lives in the profile scope below; "posts"
     # is in ReservedSlugs).
     delete("/posts/:id", PostController, :delete)

--- a/lib/vutuv_web/views/json_ld.ex
+++ b/lib/vutuv_web/views/json_ld.ex
@@ -31,6 +31,7 @@ defmodule VutuvWeb.JsonLd do
   alias Vutuv.Organizations.OrganizationImage
   alias Vutuv.Posts
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.PostReview
   alias Vutuv.Profiles.SocialMediaAccount
   alias Vutuv.Tags.UserTag
   alias VutuvWeb.AgentDocs
@@ -240,7 +241,10 @@ defmodule VutuvWeb.JsonLd do
 
     compact(%{
       "@context" => "https://schema.org",
-      "@type" => "BlogPosting",
+      # A post carrying a review sidecar is also a schema.org Review of the
+      # book/movie it names (rich results pick the Review type up).
+      "@type" => if(review_of(post), do: ["BlogPosting", "Review"], else: "BlogPosting"),
+      "itemReviewed" => item_reviewed(review_of(post)),
       "@id" => permalink,
       "headline" => "#{UserHelpers.full_name(author)} · #{Date.to_iso8601(post.published_on)}",
       "datePublished" => Date.to_iso8601(post.published_on),
@@ -442,4 +446,39 @@ defmodule VutuvWeb.JsonLd do
     |> Enum.reject(fn {_key, value} -> value in [nil, [], ""] end)
     |> Map.new()
   end
+
+  defp review_of(%{review: %PostReview{} = review}), do: review
+  defp review_of(_post), do: nil
+
+  # The reviewed work as a schema.org Book/Movie. The medium maps onto
+  # bookFormat where schema.org has a value for it (print stays unset — we
+  # don't know hardcover vs. paperback).
+  defp item_reviewed(nil), do: nil
+
+  defp item_reviewed(%PostReview{kind: "book"} = review) do
+    compact(%{
+      "@type" => "Book",
+      "name" => review.title,
+      "author" => review.creator,
+      "isbn" => review.identifier,
+      "datePublished" => review.year && Integer.to_string(review.year),
+      "bookFormat" => book_format(review.medium)
+    })
+  end
+
+  defp item_reviewed(%PostReview{kind: "movie"} = review) do
+    compact(%{
+      "@type" => "Movie",
+      "name" => review.title,
+      "director" => review.creator,
+      "sameAs" => PostReview.imdb_url(review),
+      "datePublished" => review.year && Integer.to_string(review.year)
+    })
+  end
+
+  defp item_reviewed(%PostReview{}), do: nil
+
+  defp book_format("ebook"), do: "https://schema.org/EBook"
+  defp book_format("audiobook"), do: "https://schema.org/AudiobookFormat"
+  defp book_format(_other), do: nil
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.121.4",
+      version: "7.122.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: de\n"
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:2709
-#: lib/vutuv_web/components/ui.ex:2714
+#: lib/vutuv_web/components/ui.ex:2751
+#: lib/vutuv_web/components/ui.ex:2756
 #: lib/vutuv_web/live/organization_live/domains.ex:235
 #: lib/vutuv_web/live/organization_live/edit.ex:382
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -24,9 +24,9 @@ msgstr "Impressum"
 msgid "Add"
 msgstr "Eintrag hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:194
-#: lib/vutuv_web/agent_docs/section_docs.ex:114
-#: lib/vutuv_web/agent_docs/text.ex:191
+#: lib/vutuv_web/agent_docs/markdown.ex:200
+#: lib/vutuv_web/agent_docs/section_docs.ex:118
+#: lib/vutuv_web/agent_docs/text.ex:196
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:110
@@ -34,7 +34,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1117
+#: lib/vutuv_web/templates/user/show.html.heex:1150
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -56,9 +56,9 @@ msgstr "Eine Adresse wurde gelöscht."
 msgid "Address updated successfully."
 msgstr "Eine Adresse wurde geändert."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:61
-#: lib/vutuv_web/agent_docs/text.ex:60
-#: lib/vutuv_web/components/ui.ex:2853
+#: lib/vutuv_web/agent_docs/markdown.ex:66
+#: lib/vutuv_web/agent_docs/text.ex:64
+#: lib/vutuv_web/components/ui.ex:2896
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -76,8 +76,8 @@ msgstr "Adressen"
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:2514
-#: lib/vutuv_web/components/ui.ex:2608
+#: lib/vutuv_web/components/ui.ex:2556
+#: lib/vutuv_web/components/ui.ex:2650
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #, elixir-autogen
 msgid "Are you sure?"
@@ -93,17 +93,17 @@ msgstr "Avatar"
 msgid "Birthdate"
 msgstr "Geburtstag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:415
-#: lib/vutuv_web/agent_docs/markdown.ex:416
-#: lib/vutuv_web/agent_docs/text.ex:420
-#: lib/vutuv_web/agent_docs/text.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:422
+#: lib/vutuv_web/agent_docs/text.ex:425
+#: lib/vutuv_web/agent_docs/text.ex:426
 #: lib/vutuv_web/templates/user/show.html.heex:815
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:2507
+#: lib/vutuv_web/components/ui.ex:2549
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -136,8 +136,11 @@ msgstr ""
 msgid "Choose One"
 msgstr "Wählen Sie einen Typ aus"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:51
+#: lib/vutuv_web/agent_docs/markdown.ex:52
 #: lib/vutuv_web/agent_docs/text.ex:50
+#: lib/vutuv_web/templates/messenger/card_list.html.heex:6
+#: lib/vutuv_web/templates/messenger/form_content.html.heex:13
+#: lib/vutuv_web/templates/messenger/show.html.heex:21
 #: lib/vutuv_web/templates/user/show.html.heex:853
 #, elixir-autogen
 msgid "Contact"
@@ -147,8 +150,8 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "Konnte nicht zu %{name} zurückfolgen."
 
-#: lib/vutuv_web/components/post_components.ex:806
-#: lib/vutuv_web/components/ui.ex:2611
+#: lib/vutuv_web/components/post_components.ex:811
+#: lib/vutuv_web/components/ui.ex:2653
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -192,8 +195,8 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:799
-#: lib/vutuv_web/components/ui.ex:2602
+#: lib/vutuv_web/components/post_components.ex:804
+#: lib/vutuv_web/components/ui.ex:2644
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -209,6 +212,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/education/edit.html.heex:4
 #: lib/vutuv_web/templates/email/edit.html.heex:5
 #: lib/vutuv_web/templates/language/edit.html.heex:4
+#: lib/vutuv_web/templates/messenger/edit.html.heex:4
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:4
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
@@ -289,12 +293,12 @@ msgstr "Vorname eingeben"
 msgid "Enter your last name"
 msgstr "Nachname eingeben"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:35
+#: lib/vutuv_web/agent_docs/markdown.ex:36
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:2845
-#: lib/vutuv_web/controllers/work_experience_controller.ex:40
-#: lib/vutuv_web/controllers/work_experience_controller.ex:57
-#: lib/vutuv_web/controllers/work_experience_controller.ex:135
+#: lib/vutuv_web/components/ui.ex:2887
+#: lib/vutuv_web/controllers/work_experience_controller.ex:42
+#: lib/vutuv_web/controllers/work_experience_controller.ex:59
+#: lib/vutuv_web/controllers/work_experience_controller.ex:148
 #: lib/vutuv_web/templates/user/show.html.heex:485
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:3
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
@@ -315,8 +319,8 @@ msgstr "Fax"
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:427
-#: lib/vutuv_web/agent_docs/text.ex:432
+#: lib/vutuv_web/agent_docs/markdown.ex:433
+#: lib/vutuv_web/agent_docs/text.ex:437
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -324,14 +328,14 @@ msgstr "Vorname"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:428
-#: lib/vutuv_web/agent_docs/text.ex:433
-#: lib/vutuv_web/components/ui.ex:1283
-#: lib/vutuv_web/components/ui.ex:1308
-#: lib/vutuv_web/components/ui.ex:1311
-#: lib/vutuv_web/components/ui.ex:1318
-#: lib/vutuv_web/components/ui.ex:1321
-#: lib/vutuv_web/components/ui.ex:1379
+#: lib/vutuv_web/agent_docs/markdown.ex:434
+#: lib/vutuv_web/agent_docs/text.ex:438
+#: lib/vutuv_web/components/ui.ex:1287
+#: lib/vutuv_web/components/ui.ex:1312
+#: lib/vutuv_web/components/ui.ex:1315
+#: lib/vutuv_web/components/ui.ex:1322
+#: lib/vutuv_web/components/ui.ex:1325
+#: lib/vutuv_web/components/ui.ex:1383
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
@@ -340,8 +344,8 @@ msgstr "Follower"
 msgid "Following"
 msgstr "Folge ich"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:414
-#: lib/vutuv_web/agent_docs/text.ex:419
+#: lib/vutuv_web/agent_docs/markdown.ex:420
+#: lib/vutuv_web/agent_docs/text.ex:424
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -409,9 +413,9 @@ msgstr "Link wurde gelöscht."
 msgid "Link updated successfully."
 msgstr "Link wurde geändert."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:50
+#: lib/vutuv_web/agent_docs/markdown.ex:51
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:2849
+#: lib/vutuv_web/components/ui.ex:2891
 #: lib/vutuv_web/controllers/url_controller.ex:23
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
@@ -461,7 +465,7 @@ msgstr "Einloggen"
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
-#: lib/vutuv_web/components/ui.ex:2864
+#: lib/vutuv_web/components/ui.ex:2907
 #, elixir-autogen
 msgid "More"
 msgstr "Mehr"
@@ -488,6 +492,7 @@ msgstr "Name"
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/email/new.html.heex:5
 #: lib/vutuv_web/templates/language/new.html.heex:4
+#: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/phone_number/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
@@ -548,8 +553,8 @@ msgid_plural "Phone Numbers"
 msgstr[0] "Telefonnummer"
 msgstr[1] "Telefonnummern"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:58
-#: lib/vutuv_web/agent_docs/text.ex:57
+#: lib/vutuv_web/agent_docs/markdown.ex:63
+#: lib/vutuv_web/agent_docs/text.ex:61
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:3
 #: lib/vutuv_web/templates/phone_number/index.html.heex:10
 #: lib/vutuv_web/templates/phone_number/new.html.heex:3
@@ -593,7 +598,7 @@ msgstr "Titel"
 msgid "Privacy Policy"
 msgstr "Datenschutzerklärung"
 
-#: lib/vutuv_web/live/section_reorder_live.ex:237
+#: lib/vutuv_web/live/section_reorder_live.ex:248
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -618,8 +623,8 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:574
-#: lib/vutuv_web/live/section_reorder_live.ex:236
+#: lib/vutuv_web/live/post_live/composer.ex:797
+#: lib/vutuv_web/live/section_reorder_live.ex:247
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -633,18 +638,18 @@ msgid "Public (Everyone can view) or Private (Only you can view)"
 msgstr "Öffentlich (für alle sichtbar) oder Privat (nur für Sie sichtbar)"
 
 #: lib/vutuv_web/live/organization_live/edit.ex:327
-#: lib/vutuv_web/live/post_live/composer.ex:583
+#: lib/vutuv_web/live/post_live/composer.ex:806
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:83
-#: lib/vutuv_web/templates/settings/notifications.html.heex:66
+#: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
 #: lib/vutuv_web/templates/settings/preferences.html.heex:180
 #: lib/vutuv_web/templates/settings/privacy.html.heex:64
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:342
-#: lib/vutuv_web/views/settings_html.ex:135
+#: lib/vutuv_web/views/settings_html.ex:131
 #, elixir-autogen
 msgid "Save"
 msgstr "Speichern"
@@ -682,9 +687,9 @@ msgstr "Gratis Account erstellen"
 msgid "Slug"
 msgstr "Slug"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:53
+#: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:52
-#: lib/vutuv_web/components/ui.ex:2850
+#: lib/vutuv_web/components/ui.ex:2892
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
@@ -708,7 +713,7 @@ msgstr "Profile"
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:95
+#: lib/vutuv_web/agent_docs/section_docs.ex:97
 #, elixir-autogen, elixir-format
 msgid "Profiles of %{name}"
 msgstr "Profile von %{name}"
@@ -748,12 +753,12 @@ msgstr "Code & Repositorys"
 #: lib/vutuv_web/controllers/block_controller.ex:31
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:112
+#: lib/vutuv_web/live/user_profile_live.ex:113
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
 
-#: lib/vutuv_web/components/ui.ex:2508
+#: lib/vutuv_web/components/ui.ex:2550
 #, elixir-autogen
 msgid "Submit"
 msgstr "Absenden"
@@ -830,6 +835,8 @@ msgstr "Benutzername"
 #: lib/vutuv_web/templates/follower/index.html.heex:2
 #: lib/vutuv_web/templates/language/index.html.heex:8
 #: lib/vutuv_web/templates/language/show.html.heex:4
+#: lib/vutuv_web/templates/messenger/index.html.heex:8
+#: lib/vutuv_web/templates/messenger/show.html.heex:4
 #: lib/vutuv_web/templates/phone_number/index.html.heex:8
 #: lib/vutuv_web/templates/phone_number/show.html.heex:4
 #: lib/vutuv_web/templates/qualification/index.html.heex:9
@@ -847,13 +854,13 @@ msgstr "Benutzername"
 msgid "Users"
 msgstr "Benutzer"
 
-#: lib/vutuv_web/components/ui.ex:577
+#: lib/vutuv_web/components/ui.ex:581
 #: lib/vutuv_web/templates/user/show.html.heex:279
 #, elixir-autogen
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:2672
+#: lib/vutuv_web/components/ui.ex:2714
 #: lib/vutuv_web/templates/user/show.html.heex:757
 #: lib/vutuv_web/templates/user/show.html.heex:777
 #, elixir-autogen
@@ -897,17 +904,17 @@ msgstr "Arbeit"
 msgid "Work Experiences"
 msgstr "Lebenslauf"
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:110
+#: lib/vutuv_web/controllers/work_experience_controller.ex:122
 #, elixir-autogen
 msgid "Work experience created successfully."
 msgstr "Ein Lebenslaufeintrag wurde erstellt."
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:204
+#: lib/vutuv_web/controllers/work_experience_controller.ex:217
 #, elixir-autogen
 msgid "Work experience deleted successfully."
 msgstr "Ein Lebenlaufseintrag wurde gelöscht"
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:156
+#: lib/vutuv_web/controllers/work_experience_controller.ex:169
 #, elixir-autogen
 msgid "Work experience updated successfully."
 msgstr "Ein Lebenslaufeintrag wurde geändert."
@@ -1047,14 +1054,14 @@ msgstr "Wählen Sie einen Monat"
 msgid "Select a year"
 msgstr "Wählen Sie ein Jahr"
 
-#: lib/vutuv/accounts/user.ex:732
+#: lib/vutuv/accounts/user.ex:740
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr "Frau"
 
-#: lib/vutuv/accounts/user.ex:731
+#: lib/vutuv/accounts/user.ex:739
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1474,13 +1481,13 @@ msgstr "Tag-URL erfolgreich aktualisiert."
 msgid "Tag urls"
 msgstr "Tag-URLs"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:31
-#: lib/vutuv_web/agent_docs/markdown.ex:354
-#: lib/vutuv_web/agent_docs/markdown.ex:729
+#: lib/vutuv_web/agent_docs/markdown.ex:32
+#: lib/vutuv_web/agent_docs/markdown.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:745
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:388
-#: lib/vutuv_web/agent_docs/text.ex:540
-#: lib/vutuv_web/components/ui.ex:2854
+#: lib/vutuv_web/agent_docs/text.ex:393
+#: lib/vutuv_web/agent_docs/text.ex:554
+#: lib/vutuv_web/components/ui.ex:2897
 #: lib/vutuv_web/controllers/user_tag_controller.ex:37
 #: lib/vutuv_web/controllers/user_tag_controller.ex:54
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1696,7 +1703,7 @@ msgstr "Vorgeschlagen"
 msgid "Admin Area"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:97
+#: lib/vutuv_web/agent_docs/section_docs.ex:100
 #: lib/vutuv_web/templates/address/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Addresses of %{name}"
@@ -1727,8 +1734,8 @@ msgstr "Schauen Sie in Ihr Postfach"
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:460
-#: lib/vutuv_web/live/post_live/composer.ex:461
+#: lib/vutuv_web/live/post_live/composer.ex:552
+#: lib/vutuv_web/live/post_live/composer.ex:553
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1774,23 +1781,23 @@ msgstr "Mein Konto löschen"
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
-#: lib/vutuv_web/components/ui.ex:946
-#: lib/vutuv_web/components/ui.ex:955
-#: lib/vutuv_web/components/ui.ex:1130
+#: lib/vutuv_web/components/ui.ex:950
+#: lib/vutuv_web/components/ui.ex:959
+#: lib/vutuv_web/components/ui.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Empfehlen"
 
-#: lib/vutuv_web/components/ui.ex:1248
-#: lib/vutuv_web/components/ui.ex:1248
-#: lib/vutuv_web/components/ui.ex:1265
-#: lib/vutuv_web/components/ui.ex:1274
-#: lib/vutuv_web/components/ui.ex:1290
-#: lib/vutuv_web/components/ui.ex:1327
-#: lib/vutuv_web/components/ui.ex:1330
-#: lib/vutuv_web/components/ui.ex:1337
-#: lib/vutuv_web/components/ui.ex:1340
-#: lib/vutuv_web/components/ui.ex:1413
+#: lib/vutuv_web/components/ui.ex:1252
+#: lib/vutuv_web/components/ui.ex:1252
+#: lib/vutuv_web/components/ui.ex:1269
+#: lib/vutuv_web/components/ui.ex:1278
+#: lib/vutuv_web/components/ui.ex:1294
+#: lib/vutuv_web/components/ui.ex:1331
+#: lib/vutuv_web/components/ui.ex:1334
+#: lib/vutuv_web/components/ui.ex:1341
+#: lib/vutuv_web/components/ui.ex:1344
+#: lib/vutuv_web/components/ui.ex:1417
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1809,7 +1816,7 @@ msgstr ""
 "Folgen!"
 
 #: lib/vutuv_web/live/shell_live.ex:473
-#: lib/vutuv_web/views/settings_html.ex:222
+#: lib/vutuv_web/views/settings_html.ex:218
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr "Ausloggen"
@@ -1844,25 +1851,25 @@ msgstr "Nachrichten"
 msgid "Network"
 msgstr "Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:275
-#: lib/vutuv_web/components/ui.ex:2711
+#: lib/vutuv_web/components/post_components.ex:280
+#: lib/vutuv_web/components/ui.ex:2753
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr "Hier gibt es noch nichts."
 
-#: lib/vutuv_web/live/notification_live/index.ex:237
+#: lib/vutuv_web/live/notification_live/index.ex:265
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
-#: lib/vutuv_web/components/ui.ex:2868
+#: lib/vutuv_web/components/ui.ex:2911
 #: lib/vutuv_web/live/notification_live/index.ex:66
-#: lib/vutuv_web/live/notification_live/index.ex:135
+#: lib/vutuv_web/live/notification_live/index.ex:140
 #: lib/vutuv_web/live/shell_live.ex:373
 #: lib/vutuv_web/templates/layout/app.html.heex:118
-#: lib/vutuv_web/templates/settings/notifications.html.heex:7
+#: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr "Mitteilungen"
@@ -1902,7 +1909,7 @@ msgstr "Quellcode"
 msgid "Submit a bug report or feature request"
 msgstr "Fehler melden oder Feature vorschlagen"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:100
+#: lib/vutuv_web/agent_docs/section_docs.ex:103
 #: lib/vutuv_web/templates/user_tag/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Tags of %{name}"
@@ -1953,7 +1960,7 @@ msgstr ""
 "unten ein, um die Adresse zu bestätigen."
 
 #: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1201
+#: lib/vutuv_web/templates/user/show.html.heex:1234
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
@@ -1989,35 +1996,35 @@ msgstr "folgt"
 msgid "submit a bug report"
 msgstr "einen Fehlerbericht erstellen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:351
+#: lib/vutuv_web/live/notification_live/index.ex:391
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr "hat Sie für %{tag} empfohlen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:353
+#: lib/vutuv_web/live/notification_live/index.ex:393
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr "ist jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:348
+#: lib/vutuv_web/live/notification_live/index.ex:388
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:2141
-#: lib/vutuv_web/components/ui.ex:2286
+#: lib/vutuv_web/components/ui.ex:2145
+#: lib/vutuv_web/components/ui.ex:2290
 #: lib/vutuv_web/live/organization_live/index.ex:130
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Seitennavigation"
 
-#: lib/vutuv_web/live/notification_live/index.ex:255
+#: lib/vutuv_web/live/notification_live/index.ex:283
 #, elixir-autogen, elixir-format
 msgid "Load %{count} of %{remaining} more"
 msgstr "%{count} von %{remaining} mehr laden"
 
-#: lib/vutuv_web/components/ui.ex:2736
-#: lib/vutuv_web/live/notification_live/index.ex:252
+#: lib/vutuv_web/components/ui.ex:2778
+#: lib/vutuv_web/live/notification_live/index.ex:280
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Mehr laden"
@@ -2029,13 +2036,13 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:2517
+#: lib/vutuv_web/components/ui.ex:2559
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
 
-#: lib/vutuv_web/components/ui.ex:699
-#: lib/vutuv_web/components/ui.ex:709
+#: lib/vutuv_web/components/ui.ex:703
+#: lib/vutuv_web/components/ui.ex:713
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Optionen"
@@ -2074,12 +2081,12 @@ msgstr "Titelbild hinzufügen"
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:1904
+#: lib/vutuv_web/components/ui.ex:1908
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
-#: lib/vutuv_web/components/ui.ex:1908
+#: lib/vutuv_web/components/ui.ex:1912
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
@@ -2104,37 +2111,37 @@ msgstr "Titelbild"
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:1912
+#: lib/vutuv_web/components/ui.ex:1916
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
-#: lib/vutuv_web/components/ui.ex:1902
+#: lib/vutuv_web/components/ui.ex:1906
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
-#: lib/vutuv_web/components/ui.ex:1901
+#: lib/vutuv_web/components/ui.ex:1905
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
-#: lib/vutuv_web/components/ui.ex:1907
+#: lib/vutuv_web/components/ui.ex:1911
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
-#: lib/vutuv_web/components/ui.ex:1906
+#: lib/vutuv_web/components/ui.ex:1910
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
-#: lib/vutuv_web/components/ui.ex:1903
+#: lib/vutuv_web/components/ui.ex:1907
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
-#: lib/vutuv_web/components/ui.ex:1905
+#: lib/vutuv_web/components/ui.ex:1909
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
@@ -2149,17 +2156,17 @@ msgstr "Mitglied seit %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
-#: lib/vutuv_web/components/ui.ex:1911
+#: lib/vutuv_web/components/ui.ex:1915
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
-#: lib/vutuv_web/components/ui.ex:1910
+#: lib/vutuv_web/components/ui.ex:1914
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
-#: lib/vutuv_web/components/ui.ex:1909
+#: lib/vutuv_web/components/ui.ex:1913
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "September"
@@ -2172,12 +2179,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:563
+#: lib/vutuv_web/live/post_live/composer.ex:759
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:691
+#: lib/vutuv_web/live/post_live/composer.ex:914
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2190,7 +2197,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:531
+#: lib/vutuv_web/live/post_live/composer.ex:623
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2200,13 +2207,13 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:803
+#: lib/vutuv_web/components/post_components.ex:808
 #: lib/vutuv_web/live/post_live/edit.ex:117
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
 msgstr "Diesen Beitrag endgültig löschen?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:496
+#: lib/vutuv_web/live/post_live/composer.ex:588
 #, elixir-autogen, elixir-format
 msgid "Describe this image (alt text)"
 msgstr "Beschreiben Sie dieses Bild (Alt-Text)"
@@ -2236,29 +2243,29 @@ msgstr "Folgen Sie %{name}, um ihn zu lesen."
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:667
+#: lib/vutuv_web/live/post_live/composer.ex:890
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:595
+#: lib/vutuv_web/live/post_live/composer.ex:818
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:788
-#: lib/vutuv_web/components/post_components.ex:790
+#: lib/vutuv_web/components/post_components.ex:793
+#: lib/vutuv_web/components/post_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:637
+#: lib/vutuv_web/live/post_live/composer.ex:860
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:278
-#: lib/vutuv_web/live/post_live/composer.ex:338
+#: lib/vutuv_web/live/post_live/composer.ex:361
+#: lib/vutuv_web/live/post_live/composer.ex:421
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
@@ -2270,23 +2277,23 @@ msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:272
+#: lib/vutuv_web/live/post_live/composer.ex:355
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:627
+#: lib/vutuv_web/live/post_live/composer.ex:850
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:617
+#: lib/vutuv_web/live/post_live/composer.ex:840
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:121
-#: lib/vutuv_web/live/post_live/composer.ex:583
+#: lib/vutuv_web/live/post_live/composer.ex:806
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2297,7 +2304,7 @@ msgstr "Posten"
 msgid "Post deleted successfully."
 msgstr "Beitrag erfolgreich gelöscht."
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:76
+#: lib/vutuv_web/agent_docs/post_doc.ex:80
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:73
@@ -2312,13 +2319,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1170
-#: lib/vutuv_web/components/post_components.ex:1174
+#: lib/vutuv_web/components/post_components.ex:1181
+#: lib/vutuv_web/components/post_components.ex:1185
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:1171
+#: lib/vutuv_web/components/post_components.ex:1182
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
@@ -2328,16 +2335,16 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/organization_live/domains.ex:209
 #: lib/vutuv_web/live/organization_live/edit.ex:359
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:653
+#: lib/vutuv_web/live/post_live/composer.ex:876
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:268
+#: lib/vutuv_web/views/settings_html.ex:264
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:514
+#: lib/vutuv_web/live/post_live/composer.ex:606
 #, elixir-autogen, elixir-format
 msgid "Remove image"
 msgstr "Bild entfernen"
@@ -2349,7 +2356,7 @@ msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:581
+#: lib/vutuv_web/live/post_live/composer.ex:804
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
@@ -2367,12 +2374,12 @@ msgstr[1] "Zeige %{formatted} neue Beiträge"
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:362
+#: lib/vutuv_web/live/post_live/composer.ex:445
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:266
+#: lib/vutuv_web/live/post_live/composer.ex:349
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
@@ -2382,77 +2389,77 @@ msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:722
+#: lib/vutuv_web/live/post_live/composer.ex:945
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:723
+#: lib/vutuv_web/live/post_live/composer.ex:946
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:3041
+#: lib/vutuv_web/components/ui.ex:3084
 #: lib/vutuv_web/live/shell_live.ex:416
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:169
+#: lib/vutuv_web/views/settings_html.ex:165
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:472
+#: lib/vutuv_web/live/post_live/composer.ex:564
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:473
+#: lib/vutuv_web/live/post_live/composer.ex:565
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:785
+#: lib/vutuv_web/components/post_components.ex:790
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:1426
+#: lib/vutuv_web/components/post_components.ex:1540
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:1430
+#: lib/vutuv_web/components/post_components.ex:1544
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:1428
+#: lib/vutuv_web/components/post_components.ex:1542
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:1429
+#: lib/vutuv_web/components/post_components.ex:1543
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:297
+#: lib/vutuv_web/views/settings_html.ex:293
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:546
+#: lib/vutuv_web/live/post_live/composer.ex:638
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr "Tags, durch Komma oder Leerzeichen getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:713
+#: lib/vutuv_web/live/post_live/composer.ex:936
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:717
+#: lib/vutuv_web/live/post_live/composer.ex:940
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
@@ -2472,16 +2479,16 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1498
-#: lib/vutuv_web/components/ui.ex:1608
-#: lib/vutuv_web/components/ui.ex:1608
-#: lib/vutuv_web/components/ui.ex:2216
+#: lib/vutuv_web/components/post_components.ex:1612
+#: lib/vutuv_web/components/ui.ex:1612
+#: lib/vutuv_web/components/ui.ex:1612
+#: lib/vutuv_web/components/ui.ex:2220
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:761
+#: lib/vutuv_web/agent_docs/markdown.ex:777
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:355
@@ -2491,17 +2498,17 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1465
-#: lib/vutuv_web/components/ui.ex:1637
-#: lib/vutuv_web/components/ui.ex:1637
-#: lib/vutuv_web/components/ui.ex:2202
-#: lib/vutuv_web/live/notification_live/index.ex:300
+#: lib/vutuv_web/components/post_components.ex:1579
+#: lib/vutuv_web/components/ui.ex:1641
+#: lib/vutuv_web/components/ui.ex:1641
+#: lib/vutuv_web/components/ui.ex:2206
+#: lib/vutuv_web/live/notification_live/index.ex:329
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:760
+#: lib/vutuv_web/agent_docs/markdown.ex:776
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:424
@@ -2520,48 +2527,48 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:1487
+#: lib/vutuv_web/components/post_components.ex:1601
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1498
-#: lib/vutuv_web/components/ui.ex:1598
-#: lib/vutuv_web/components/ui.ex:1598
+#: lib/vutuv_web/components/post_components.ex:1612
+#: lib/vutuv_web/components/ui.ex:1602
+#: lib/vutuv_web/components/ui.ex:1602
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1484
+#: lib/vutuv_web/components/post_components.ex:1598
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1305
+#: lib/vutuv_web/components/post_components.ex:1316
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1484
+#: lib/vutuv_web/components/post_components.ex:1598
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:1465
-#: lib/vutuv_web/components/ui.ex:1627
-#: lib/vutuv_web/components/ui.ex:1627
+#: lib/vutuv_web/components/post_components.ex:1579
+#: lib/vutuv_web/components/ui.ex:1631
+#: lib/vutuv_web/components/ui.ex:1631
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
-#: lib/vutuv_web/components/ui.ex:1243
-#: lib/vutuv_web/components/ui.ex:1243
-#: lib/vutuv_web/components/ui.ex:1380
+#: lib/vutuv_web/components/ui.ex:1247
+#: lib/vutuv_web/components/ui.ex:1247
+#: lib/vutuv_web/components/ui.ex:1384
 #: lib/vutuv_web/live/post_live/feed.ex:665
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
 #, elixir-autogen, elixir-format
@@ -2573,49 +2580,49 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:1538
+#: lib/vutuv_web/components/post_components.ex:1652
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:102
-#: lib/vutuv_web/agent_docs/text.ex:100
-#: lib/vutuv_web/components/post_components.ex:264
+#: lib/vutuv_web/agent_docs/markdown.ex:108
+#: lib/vutuv_web/agent_docs/text.ex:105
+#: lib/vutuv_web/components/post_components.ex:269
 #: lib/vutuv_web/templates/post/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1521
-#: lib/vutuv_web/components/post_components.ex:1522
-#: lib/vutuv_web/live/notification_live/index.ex:207
-#: lib/vutuv_web/live/notification_live/index.ex:299
+#: lib/vutuv_web/components/post_components.ex:1635
+#: lib/vutuv_web/components/post_components.ex:1636
+#: lib/vutuv_web/live/notification_live/index.ex:212
+#: lib/vutuv_web/live/notification_live/index.ex:328
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:756
+#: lib/vutuv_web/components/post_components.ex:761
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:269
-#: lib/vutuv_web/live/post_live/composer.ex:571
+#: lib/vutuv_web/live/post_live/composer.ex:352
+#: lib/vutuv_web/live/post_live/composer.ex:794
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 "Die Sichtbarkeit kann nicht eingeschränkt werden, solange Reposts oder "
 "Antworten existieren."
 
-#: lib/vutuv_web/live/post_live/composer.ex:698
+#: lib/vutuv_web/live/post_live/composer.ex:921
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 "Dieser Beitrag wurde repostet oder beantwortet. Er bleibt öffentlich, "
 "solange Reposts oder Antworten existieren; löschen können Sie ihn jederzeit."
 
-#: lib/vutuv_web/live/notification_live/index.ex:355
+#: lib/vutuv_web/live/notification_live/index.ex:395
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
@@ -2625,12 +2632,12 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:751
+#: lib/vutuv_web/components/post_components.ex:756
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:745
+#: lib/vutuv_web/components/post_components.ex:750
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2691,7 +2698,7 @@ msgstr "Mitglied nicht gefunden."
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
-#: lib/vutuv_web/components/ui.ex:1780
+#: lib/vutuv_web/components/ui.ex:1784
 #: lib/vutuv_web/live/message_live/index.ex:596
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2788,7 +2795,7 @@ msgstr "Ein neuer PIN ist unterwegs zu Ihrer E-Mail-Adresse."
 msgid "Okay, let's start over."
 msgstr "Alles klar, fangen wir neu an."
 
-#: lib/vutuv_web/components/ui.ex:413
+#: lib/vutuv_web/components/ui.ex:417
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr "PIN erneut senden"
@@ -2798,7 +2805,7 @@ msgstr "PIN erneut senden"
 msgid "Too many PIN requests. Please try again later."
 msgstr "Zu viele PIN-Anfragen. Bitte versuchen Sie es später erneut."
 
-#: lib/vutuv_web/components/ui.ex:422
+#: lib/vutuv_web/components/ui.ex:426
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr "Andere E-Mail-Adresse verwenden"
@@ -2816,7 +2823,7 @@ msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1119
+#: lib/vutuv_web/templates/user/show.html.heex:1152
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
@@ -2838,18 +2845,18 @@ msgstr "Persönliche Angaben hinzufügen"
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
-#: lib/vutuv_web/live/user_profile_live.ex:956
+#: lib/vutuv_web/live/user_profile_live.ex:960
 #: lib/vutuv_web/templates/user/show.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:2347
-#: lib/vutuv_web/components/ui.ex:2674
+#: lib/vutuv_web/components/ui.ex:2351
+#: lib/vutuv_web/components/ui.ex:2716
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
-#: lib/vutuv_web/templates/settings/privacy.html.heex:130
+#: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
 #, elixir-autogen, elixir-format
@@ -2890,15 +2897,15 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 weiteres Tag"
 msgstr[1] "+%{formatted} weitere Tags"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:429
-#: lib/vutuv_web/agent_docs/text.ex:434
+#: lib/vutuv_web/agent_docs/markdown.ex:435
+#: lib/vutuv_web/agent_docs/text.ex:439
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr "Vernetzungen"
 
-#: lib/vutuv_web/components/ui.ex:568
+#: lib/vutuv_web/components/ui.ex:572
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2908,17 +2915,17 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Noch keine Vernetzungen."
 
-#: lib/vutuv_web/components/ui.ex:583
+#: lib/vutuv_web/components/ui.ex:587
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:607
+#: lib/vutuv_web/live/post_live/composer.ex:830
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
 
-#: lib/vutuv_web/components/ui.ex:569
+#: lib/vutuv_web/components/ui.ex:573
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Nur Text"
@@ -2936,7 +2943,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:1427
+#: lib/vutuv_web/components/post_components.ex:1541
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -2946,22 +2953,22 @@ msgstr "Personen, mit denen Sie nicht vernetzt sind"
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:307
+#: lib/vutuv_web/live/notification_live/index.ex:337
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:301
+#: lib/vutuv_web/live/notification_live/index.ex:330
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:298
+#: lib/vutuv_web/live/notification_live/index.ex:327
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:297
+#: lib/vutuv_web/live/notification_live/index.ex:326
 #: lib/vutuv_web/templates/user/show.html.heex:744
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2974,7 +2981,7 @@ msgstr[1] "Follower"
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Willkommen bei vutuv, %{name}!"
 
-#: lib/vutuv_web/live/notification_live/index.ex:356
+#: lib/vutuv_web/live/notification_live/index.ex:396
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr "gefällt Ihr Beitrag."
@@ -3006,12 +3013,12 @@ msgstr "(gelöschtes Konto)"
 msgid "(no text)"
 msgstr "(kein Text)"
 
-#: lib/vutuv_web/live/notification_live/index.ex:378
+#: lib/vutuv_web/live/notification_live/index.ex:418
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde bestätigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:379
+#: lib/vutuv_web/live/notification_live/index.ex:419
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
@@ -3041,8 +3048,8 @@ msgstr "Gibt es etwas, das unsere Admins wissen sollten? (optional)"
 msgid "Bullying or harassment"
 msgstr "Mobbing oder Belästigung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:273
-#: lib/vutuv_web/agent_docs/text.ex:266
+#: lib/vutuv_web/agent_docs/markdown.ex:279
+#: lib/vutuv_web/agent_docs/text.ex:271
 #: lib/vutuv_web/controllers/page_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3126,7 +3133,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:302
+#: lib/vutuv_web/live/notification_live/index.ex:331
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3215,7 +3222,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:733
+#: lib/vutuv_web/components/post_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3270,7 +3277,7 @@ msgstr ""
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/components/ui.ex:2842
+#: lib/vutuv_web/components/ui.ex:2884
 #: lib/vutuv_web/live/shell_live.ex:325
 #: lib/vutuv_web/live/shell_live.ex:509
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3296,7 +3303,7 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:827
+#: lib/vutuv_web/components/post_components.ex:832
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3382,7 +3389,7 @@ msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:2116
+#: lib/vutuv_web/components/ui.ex:2120
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3583,12 +3590,12 @@ msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
 
-#: lib/vutuv_web/live/notification_live/index.ex:381
+#: lib/vutuv_web/live/notification_live/index.ex:421
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt gelöscht; der Fall ist abgeschlossen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:380
+#: lib/vutuv_web/live/notification_live/index.ex:420
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
@@ -3598,7 +3605,7 @@ msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
 msgid "Your content was reported"
 msgstr "Ihr Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/live/notification_live/index.ex:382
+#: lib/vutuv_web/live/notification_live/index.ex:422
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3800,7 +3807,7 @@ msgstr "Verlauf"
 msgid "Open the profile"
 msgstr "Profil öffnen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:405
+#: lib/vutuv_web/live/notification_live/index.ex:445
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3827,7 +3834,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:304
+#: lib/vutuv_web/live/notification_live/index.ex:333
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -3909,7 +3916,7 @@ msgstr "Bestätigt"
 msgid "Waiting for the owner"
 msgstr "Wartet auf den Besitzer"
 
-#: lib/vutuv_web/live/notification_live/index.ex:410
+#: lib/vutuv_web/live/notification_live/index.ex:450
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4006,30 +4013,30 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:516
+#: lib/vutuv_web/agent_docs/markdown.ex:523
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:773
+#: lib/vutuv_web/agent_docs/markdown.ex:816
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:114
-#: lib/vutuv_web/agent_docs/text.ex:111
+#: lib/vutuv_web/agent_docs/markdown.ex:120
+#: lib/vutuv_web/agent_docs/text.ex:116
 #, elixir-autogen, elixir-format
 msgid "%{count} posts by %{name}"
 msgstr "%{count} Beiträge von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:76
-#: lib/vutuv_web/agent_docs/markdown.ex:137
-#: lib/vutuv_web/agent_docs/markdown.ex:150
-#: lib/vutuv_web/agent_docs/markdown.ex:729
-#: lib/vutuv_web/agent_docs/text.ex:75
-#: lib/vutuv_web/agent_docs/text.ex:134
-#: lib/vutuv_web/agent_docs/text.ex:147
-#: lib/vutuv_web/agent_docs/text.ex:540
+#: lib/vutuv_web/agent_docs/markdown.ex:81
+#: lib/vutuv_web/agent_docs/markdown.ex:143
+#: lib/vutuv_web/agent_docs/markdown.ex:156
+#: lib/vutuv_web/agent_docs/markdown.ex:745
+#: lib/vutuv_web/agent_docs/text.ex:79
+#: lib/vutuv_web/agent_docs/text.ex:139
+#: lib/vutuv_web/agent_docs/text.ex:152
+#: lib/vutuv_web/agent_docs/text.ex:554
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
@@ -4039,39 +4046,39 @@ msgstr "%{count} insgesamt"
 msgid "Followers of %{name}"
 msgstr "Follower von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:101
-#: lib/vutuv_web/agent_docs/text.ex:98
+#: lib/vutuv_web/agent_docs/markdown.ex:107
+#: lib/vutuv_web/agent_docs/text.ex:103
 #: lib/vutuv_web/live/job_posting_live/form.ex:493
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:747
-#: lib/vutuv_web/agent_docs/text.ex:551
+#: lib/vutuv_web/agent_docs/markdown.ex:763
+#: lib/vutuv_web/agent_docs/text.ex:565
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:744
-#: lib/vutuv_web/agent_docs/text.ex:548
+#: lib/vutuv_web/agent_docs/markdown.ex:760
+#: lib/vutuv_web/agent_docs/text.ex:562
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:751
-#: lib/vutuv_web/agent_docs/text.ex:554
+#: lib/vutuv_web/agent_docs/markdown.ex:767
+#: lib/vutuv_web/agent_docs/text.ex:568
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:412
-#: lib/vutuv_web/agent_docs/text.ex:417
+#: lib/vutuv_web/agent_docs/markdown.ex:418
+#: lib/vutuv_web/agent_docs/text.ex:422
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Mitglied seit"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:163
-#: lib/vutuv_web/agent_docs/text.ex:160
+#: lib/vutuv_web/agent_docs/markdown.ex:169
+#: lib/vutuv_web/agent_docs/text.ex:165
 #, elixir-autogen, elixir-format
 msgid "Most endorsed members"
 msgstr "Am häufigsten empfohlene Mitglieder"
@@ -4086,42 +4093,42 @@ msgstr "Mitglieder mit den meisten Followern"
 msgid "People %{name} follows"
 msgstr "Wem %{name} folgt"
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:77
+#: lib/vutuv_web/agent_docs/post_doc.ex:81
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr "Beitragsarchiv von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:96
-#: lib/vutuv_web/agent_docs/text.ex:93
+#: lib/vutuv_web/agent_docs/markdown.ex:101
+#: lib/vutuv_web/agent_docs/text.ex:97
 #: lib/vutuv_web/live/admin/screenshot_live.ex:96
 #: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
 msgstr "Beitrag von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:63
-#: lib/vutuv_web/agent_docs/text.ex:62
+#: lib/vutuv_web/agent_docs/markdown.ex:68
+#: lib/vutuv_web/agent_docs/text.ex:66
 #, elixir-autogen, elixir-format
 msgid "Posts (%{count} total)"
 msgstr "Beiträge (insgesamt %{count})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:408
-#: lib/vutuv_web/agent_docs/text.ex:413
+#: lib/vutuv_web/agent_docs/markdown.ex:414
+#: lib/vutuv_web/agent_docs/text.ex:418
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:698
+#: lib/vutuv_web/agent_docs/markdown.ex:714
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:637
+#: lib/vutuv_web/agent_docs/markdown.ex:644
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:638
+#: lib/vutuv_web/agent_docs/markdown.ex:645
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4136,22 +4143,22 @@ msgstr "Diese Seite auf %{language}: %{url}"
 msgid "Connections of %{name}"
 msgstr "Vernetzungen von %{name}"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:99
+#: lib/vutuv_web/agent_docs/section_docs.ex:102
 #, elixir-autogen, elixir-format
 msgid "Email addresses of %{name}"
 msgstr "E-Mail-Adressen von %{name}"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:92
+#: lib/vutuv_web/agent_docs/section_docs.ex:94
 #, elixir-autogen, elixir-format
 msgid "Links of %{name}"
 msgstr "Links von %{name}"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:98
+#: lib/vutuv_web/agent_docs/section_docs.ex:101
 #, elixir-autogen, elixir-format
 msgid "Phone numbers of %{name}"
 msgstr "Telefonnummern von %{name}"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:85
+#: lib/vutuv_web/agent_docs/section_docs.ex:87
 #, elixir-autogen, elixir-format
 msgid "Work experience of %{name}"
 msgstr "Lebenslauf von %{name}"
@@ -4198,8 +4205,8 @@ msgstr ""
 msgid "Billing name"
 msgstr "Name für die Rechnung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/text.ex:274
+#: lib/vutuv_web/agent_docs/markdown.ex:293
+#: lib/vutuv_web/agent_docs/text.ex:279
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr "Online buchen (Login erforderlich): %{url}"
@@ -4248,8 +4255,8 @@ msgstr "Tag"
 msgid "Markdown is supported. At most %{max} characters."
 msgstr "Markdown wird unterstützt. Höchstens %{max} Zeichen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:277
-#: lib/vutuv_web/agent_docs/text.ex:270
+#: lib/vutuv_web/agent_docs/markdown.ex:283
+#: lib/vutuv_web/agent_docs/text.ex:275
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4265,8 +4272,8 @@ msgstr "Ein Tag. Eine Anzeige. Alle Besucher."
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr "Eine reine Textanzeige pro Kalendertag, gesehen von allen Besuchern."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:274
-#: lib/vutuv_web/agent_docs/text.ex:267
+#: lib/vutuv_web/agent_docs/markdown.ex:280
+#: lib/vutuv_web/agent_docs/text.ex:272
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4500,14 +4507,14 @@ msgstr "gebucht am"
 msgid "deleted account"
 msgstr "gelöschtes Konto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:279
-#: lib/vutuv_web/agent_docs/text.ex:272
+#: lib/vutuv_web/agent_docs/markdown.ex:285
+#: lib/vutuv_web/agent_docs/text.ex:277
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr "Bereits gebucht"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:275
-#: lib/vutuv_web/agent_docs/text.ex:268
+#: lib/vutuv_web/agent_docs/markdown.ex:281
+#: lib/vutuv_web/agent_docs/text.ex:273
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr "Buchungszeitraum"
@@ -4652,7 +4659,7 @@ msgstr "Werbung für heute ausblenden"
 msgid "Login PINs and other essential emails are not affected."
 msgstr "Login-PINs und andere notwendige E-Mails sind davon nicht betroffen."
 
-#: lib/vutuv_web/live/section_reorder_live.ex:231
+#: lib/vutuv_web/live/section_reorder_live.ex:242
 #: lib/vutuv_web/templates/email/card_list.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Mail to this address bounced. Logging in with a PIN sent to it will clear this warning."
@@ -4660,7 +4667,7 @@ msgstr ""
 "E-Mails an diese Adresse kamen als unzustellbar zurück. Ein Login mit einer "
 "an diese Adresse geschickten PIN entfernt diese Warnung."
 
-#: lib/vutuv_web/live/section_reorder_live.ex:232
+#: lib/vutuv_web/live/section_reorder_live.ex:243
 #: lib/vutuv_web/templates/email/card_list.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Undeliverable"
@@ -4690,7 +4697,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:1
 #: lib/vutuv_web/templates/block/index.html.heex:1
-#: lib/vutuv_web/templates/settings/privacy.html.heex:127
+#: lib/vutuv_web/templates/settings/privacy.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Blocked members"
 msgstr "Blockierte Mitglieder"
@@ -4730,7 +4737,7 @@ msgid "You have not blocked anyone."
 msgstr "Sie haben niemanden blockiert."
 
 #: lib/vutuv_web/controllers/block_controller.ex:86
-#: lib/vutuv_web/live/user_profile_live.ex:241
+#: lib/vutuv_web/live/user_profile_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
@@ -4789,8 +4796,8 @@ msgstr "Keine Ergebnisse für \"%{query}\""
 msgid "Not an exact match, but sounds like your search."
 msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:302
-#: lib/vutuv_web/agent_docs/text.ex:336
+#: lib/vutuv_web/agent_docs/markdown.ex:308
+#: lib/vutuv_web/agent_docs/text.ex:341
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
@@ -4812,7 +4819,7 @@ msgstr ""
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
-#: lib/vutuv_web/components/post_components.ex:261
+#: lib/vutuv_web/components/post_components.ex:266
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/search_live.ex:176
@@ -4861,7 +4868,7 @@ msgstr "müller"
 msgid "searches first names only (last: for last names)"
 msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
-#: lib/vutuv_web/live/user_profile_live.ex:944
+#: lib/vutuv_web/live/user_profile_live.ex:948
 #: lib/vutuv_web/templates/user/show.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -4912,8 +4919,8 @@ msgstr "Entwickler"
 msgid "Edit your profile and its sections"
 msgstr "Ihr Profil und seine Bereiche bearbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:216
-#: lib/vutuv_web/agent_docs/text.ex:212
+#: lib/vutuv_web/agent_docs/markdown.ex:222
+#: lib/vutuv_web/agent_docs/text.ex:217
 #: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
@@ -5110,7 +5117,7 @@ msgstr "API-Anwendungen"
 #: lib/vutuv_web/live/admin/api_app_live.ex:94
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:31
-#: lib/vutuv_web/views/settings_html.ex:213
+#: lib/vutuv_web/views/settings_html.ex:209
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
@@ -5494,7 +5501,7 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:2874
+#: lib/vutuv_web/components/ui.ex:2917
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5535,12 +5542,12 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:275
+#: lib/vutuv_web/live/post_live/composer.ex:358
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:133
+#: lib/vutuv_web/templates/settings/privacy.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
@@ -5576,9 +5583,9 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:2960
-#: lib/vutuv_web/components/ui.ex:2965
-#: lib/vutuv_web/components/ui.ex:3033
+#: lib/vutuv_web/components/ui.ex:3003
+#: lib/vutuv_web/components/ui.ex:3008
+#: lib/vutuv_web/components/ui.ex:3076
 #: lib/vutuv_web/controllers/settings_controller.ex:51
 #: lib/vutuv_web/live/shell_live.ex:444
 #: lib/vutuv_web/live/tag_new_live.ex:44
@@ -5593,6 +5600,8 @@ msgstr "Navigation"
 #: lib/vutuv_web/templates/language/edit.html.heex:2
 #: lib/vutuv_web/templates/language/new.html.heex:2
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
+#: lib/vutuv_web/templates/messenger/edit.html.heex:2
+#: lib/vutuv_web/templates/messenger/new.html.heex:2
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:2
 #: lib/vutuv_web/templates/phone_number/new.html.heex:2
 #: lib/vutuv_web/templates/qualification/edit.html.heex:2
@@ -5605,7 +5614,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/templates/username/new.html.heex:4
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:2
 #: lib/vutuv_web/templates/work_experience/new.html.heex:2
-#: lib/vutuv_web/views/settings_html.ex:164
+#: lib/vutuv_web/views/settings_html.ex:160
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -5642,7 +5651,7 @@ msgstr "Profil vervollständigen"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/live/user_profile_live.ex:946
+#: lib/vutuv_web/live/user_profile_live.ex:950
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -5668,9 +5677,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:869
-#: lib/vutuv_web/components/post_components.ex:923
-#: lib/vutuv_web/components/post_components.ex:1232
+#: lib/vutuv_web/components/post_components.ex:874
+#: lib/vutuv_web/components/post_components.ex:928
+#: lib/vutuv_web/components/post_components.ex:1243
 #: lib/vutuv_web/live/post_live/feed.ex:737
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5686,7 +5695,7 @@ msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr "Ihre Tags (z.B. JavaScript, Kochen, Origami, Katze)"
 
-#: lib/vutuv/accounts/user.ex:735
+#: lib/vutuv/accounts/user.ex:743
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5724,7 +5733,7 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:2856
+#: lib/vutuv_web/components/ui.ex:2899
 #: lib/vutuv_web/live/admin/user_live.ex:266
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:13
 #, elixir-autogen, elixir-format
@@ -5748,7 +5757,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:2851
+#: lib/vutuv_web/components/ui.ex:2894
 #: lib/vutuv_web/controllers/email_controller.ex:30
 #: lib/vutuv_web/controllers/email_controller.ex:49
 #: lib/vutuv_web/controllers/email_controller.ex:191
@@ -5764,7 +5773,7 @@ msgstr "E-Mail-Adressen"
 msgid "Notification settings saved."
 msgstr "Benachrichtigungseinstellungen gespeichert."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:128
+#: lib/vutuv_web/templates/settings/privacy.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you."
 msgstr "Personen, die nicht mit Ihnen interagieren können."
@@ -5779,7 +5788,7 @@ msgstr "Persönliche Tokens für die vutuv-API."
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:2866
+#: lib/vutuv_web/components/ui.ex:2909
 #: lib/vutuv_web/templates/settings/privacy.html.heex:9
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5795,7 +5804,7 @@ msgstr "Datenschutzeinstellungen gespeichert."
 msgid "Third-party apps you authorized."
 msgstr "Apps von Drittanbietern, die Sie autorisiert haben."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:136
+#: lib/vutuv_web/templates/settings/privacy.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Ansehen"
@@ -5805,12 +5814,12 @@ msgstr "Ansehen"
 msgid "Your name"
 msgstr "Ihr Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:196
+#: lib/vutuv_web/live/notification_live/index.ex:201
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Ihr Beitrag"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:134
+#: lib/vutuv_web/templates/settings/privacy.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Your posts or profile a moderator is looking at."
 msgstr "Ihre Beiträge oder Ihr Profil, die ein Moderator gerade prüft."
@@ -5825,7 +5834,7 @@ msgstr "Apps & API-Zugang"
 msgid "Download your data"
 msgstr "Ihre Daten herunterladen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:11
+#: lib/vutuv_web/templates/settings/notifications.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Email notifications"
 msgstr "E-Mail-Benachrichtigungen"
@@ -5894,7 +5903,7 @@ msgstr "@%{slug} hat Sie auf vutuv empfohlen"
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 
-#: lib/vutuv_web/components/ui.ex:2873
+#: lib/vutuv_web/components/ui.ex:2916
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -5906,23 +5915,23 @@ msgid "Apps & API"
 msgstr "Apps & API-Zugang"
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:103
-#: lib/vutuv_web/templates/settings/notifications.html.heex:50
+#: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Endorsements"
 msgstr "Empfehlungen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:80
+#: lib/vutuv_web/templates/settings/notifications.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Endorsements and new followers"
 msgstr "Empfehlungen und neue Follower"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:74
+#: lib/vutuv_web/templates/settings/notifications.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "In-app notifications"
 msgstr "Benachrichtigungen in der App"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:55
+#: lib/vutuv_web/templates/settings/notifications.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "New followers"
 msgstr "Neue Follower"
@@ -5932,7 +5941,7 @@ msgstr "Neue Follower"
 msgid "Notification settings"
 msgstr "Benachrichtigungseinstellungen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:88
+#: lib/vutuv_web/templates/settings/notifications.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Open your notifications"
 msgstr "Benachrichtigungen öffnen"
@@ -5942,12 +5951,12 @@ msgstr "Benachrichtigungen öffnen"
 msgid "Privacy settings"
 msgstr "Privatsphäre-Einstellungen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:81
+#: lib/vutuv_web/templates/settings/notifications.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr "Antworten und Likes zu Ihren Beiträgen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:124
+#: lib/vutuv_web/templates/settings/privacy.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr "Sicherheit"
@@ -5957,29 +5966,29 @@ msgstr "Sicherheit"
 msgid "Search engines & AI"
 msgstr "Suchmaschinen & KI"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:76
+#: lib/vutuv_web/templates/settings/notifications.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "These are always on. You see them under the bell at the top of every page, in real time."
 msgstr ""
 "Diese sind immer aktiv. Sie sehen sie in Echtzeit unter der Glocke oben auf "
 "jeder Seite."
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:25
+#: lib/vutuv_web/templates/settings/notifications.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Unread messages"
 msgstr "Ungelesene Nachrichten"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:52
+#: lib/vutuv_web/templates/settings/notifications.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "When someone endorses you for one of your tags."
 msgstr "Wenn jemand Sie für eines Ihrer Tags empfiehlt."
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:27
+#: lib/vutuv_web/templates/settings/notifications.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "When someone messages you and you have not read it yet."
 msgstr "Wenn Ihnen jemand schreibt und Sie es noch nicht gelesen haben."
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:57
+#: lib/vutuv_web/templates/settings/notifications.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "When someone starts following you."
 msgstr "Wenn jemand beginnt, Ihnen zu folgen."
@@ -6032,25 +6041,25 @@ msgid "You cannot block yourself."
 msgstr "Sie können sich nicht selbst blockieren."
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:23
-#: lib/vutuv_web/live/user_profile_live.ex:207
+#: lib/vutuv_web/live/user_profile_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Bookmark removed."
 msgstr "Lesezeichen entfernt."
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:19
-#: lib/vutuv_web/live/user_profile_live.ex:204
+#: lib/vutuv_web/live/user_profile_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Bookmarked."
 msgstr "Lesezeichen gesetzt."
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:31
-#: lib/vutuv_web/live/user_profile_live.ex:213
+#: lib/vutuv_web/live/user_profile_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Like removed."
 msgstr "Gefällt mir entfernt."
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:27
-#: lib/vutuv_web/live/user_profile_live.ex:210
+#: lib/vutuv_web/live/user_profile_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Liked."
 msgstr "Gefällt mir."
@@ -6112,21 +6121,21 @@ msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:174
-#: lib/vutuv_web/views/settings_html.ex:306
+#: lib/vutuv_web/views/settings_html.ex:302
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/views/settings_html.ex:305
+#: lib/vutuv_web/views/settings_html.ex:301
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/views/settings_html.ex:304
+#: lib/vutuv_web/views/settings_html.ex:300
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -6143,7 +6152,7 @@ msgstr "Alle anderen Geräte wurden abgemeldet."
 msgid "Another session was already active on your account."
 msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
 
-#: lib/vutuv_web/views/settings_html.ex:202
+#: lib/vutuv_web/views/settings_html.ex:198
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr "Zuletzt aktiv"
@@ -6158,7 +6167,7 @@ msgstr "Alle anderen Geräte abmelden"
 msgid "Log out of every device except this one?"
 msgstr "Von allen Geräten außer diesem abmelden?"
 
-#: lib/vutuv_web/views/settings_html.ex:219
+#: lib/vutuv_web/views/settings_html.ex:215
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
@@ -6183,7 +6192,7 @@ msgstr "Dieses Gerät wurde abgemeldet."
 msgid "The location looks different from where you usually sign in."
 msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
 
-#: lib/vutuv_web/views/settings_html.ex:203
+#: lib/vutuv_web/views/settings_html.ex:199
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Dieses Gerät"
@@ -6195,29 +6204,29 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/views/settings_html.ex:303
+#: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:78
+#: lib/vutuv_web/templates/settings/privacy.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 "Ein grüner Punkt auf Ihrem Avatar zeigt anderen Mitgliedern, dass Sie gerade"
 " online sind."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:77
+#: lib/vutuv_web/templates/settings/privacy.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr "Online-Status"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:79
+#: lib/vutuv_web/templates/settings/privacy.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Show when I'm online"
 msgstr "Anzeigen, wenn ich online bin"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:80
+#: lib/vutuv_web/templates/settings/privacy.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
@@ -6230,7 +6239,7 @@ msgid "Add a passkey"
 msgstr "Passkey hinzufügen"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/views/settings_html.ex:254
+#: lib/vutuv_web/views/settings_html.ex:250
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Hinzugefügt"
@@ -6241,7 +6250,7 @@ msgid "Could not add the passkey. Please try again."
 msgstr ""
 "Der Passkey konnte nicht hinzugefügt werden. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/views/settings_html.ex:257
+#: lib/vutuv_web/views/settings_html.ex:253
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr "Zuletzt verwendet"
@@ -6251,7 +6260,7 @@ msgstr "Zuletzt verwendet"
 msgid "Name (optional)"
 msgstr "Name (optional)"
 
-#: lib/vutuv_web/views/settings_html.ex:251
+#: lib/vutuv_web/views/settings_html.ex:247
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr "Passkey"
@@ -6271,7 +6280,7 @@ msgstr "Passkey entfernt."
 msgid "Passkeys"
 msgstr "Passkeys"
 
-#: lib/vutuv_web/views/settings_html.ex:265
+#: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr "Diesen Passkey entfernen?"
@@ -6331,7 +6340,7 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/live/user_profile_live.ex:950
+#: lib/vutuv_web/live/user_profile_live.ex:954
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
@@ -6342,7 +6351,7 @@ msgstr "Kurzbeschreibung hinzufügen"
 msgid "Tagline"
 msgstr "Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:170
+#: lib/vutuv_web/components/ui.ex:174
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:687
@@ -6366,7 +6375,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1166
+#: lib/vutuv_web/templates/user/show.html.heex:1199
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6419,8 +6428,8 @@ msgid_plural "%{count} years old"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:417
-#: lib/vutuv_web/agent_docs/text.ex:422
+#: lib/vutuv_web/agent_docs/markdown.ex:423
+#: lib/vutuv_web/agent_docs/text.ex:427
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Alter"
@@ -6494,8 +6503,8 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:760
-#: lib/vutuv_web/components/post_components.ex:263
+#: lib/vutuv_web/agent_docs/markdown.ex:776
+#: lib/vutuv_web/components/post_components.ex:268
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
@@ -6506,31 +6515,31 @@ msgstr "Reposts"
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
 
-#: lib/vutuv_web/live/section_reorder_live.ex:107
+#: lib/vutuv_web/live/section_reorder_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
 msgstr "Zum Sortieren ziehen"
 
-#: lib/vutuv_web/live/section_reorder_live.ex:158
+#: lib/vutuv_web/live/section_reorder_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder, or use the arrows. The order is the one shown on your profile."
 msgstr ""
 "Zum Sortieren ziehen oder die Pfeile verwenden. Diese Reihenfolge wird auf "
 "Ihrem Profil angezeigt."
 
-#: lib/vutuv_web/live/section_reorder_live.ex:135
+#: lib/vutuv_web/live/section_reorder_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Move down"
 msgstr "Nach unten"
 
-#: lib/vutuv_web/live/section_reorder_live.ex:126
+#: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/vutuv_web/components/ui.ex:946
-#: lib/vutuv_web/components/ui.ex:955
-#: lib/vutuv_web/components/ui.ex:1131
+#: lib/vutuv_web/components/ui.ex:950
+#: lib/vutuv_web/components/ui.ex:959
+#: lib/vutuv_web/components/ui.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Empfehlung zurücknehmen"
@@ -6557,9 +6566,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1152
-#: lib/vutuv_web/templates/user/show.html.heex:1160
-#: lib/vutuv_web/templates/user/show.html.heex:1172
+#: lib/vutuv_web/templates/user/show.html.heex:1185
+#: lib/vutuv_web/templates/user/show.html.heex:1193
+#: lib/vutuv_web/templates/user/show.html.heex:1205
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6595,13 +6604,14 @@ msgstr "Mitglieder, die %{name} für %{tag} empfohlen haben"
 msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
-#: lib/vutuv_web/components/ui.ex:1084
-#: lib/vutuv_web/live/notification_live/index.ex:227
+#: lib/vutuv_web/components/ui.ex:1088
+#: lib/vutuv_web/live/notification_live/index.ex:237
+#: lib/vutuv_web/live/notification_live/index.ex:255
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:742
+#: lib/vutuv_web/agent_docs/markdown.ex:758
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -6776,7 +6786,7 @@ msgstr "Keine Bounces erfasst."
 msgid "No deliverability events yet."
 msgstr "Noch keine Zustellbarkeitsereignisse."
 
-#: lib/vutuv_web/components/ui.ex:406
+#: lib/vutuv_web/components/ui.ex:410
 #, elixir-autogen, elixir-format
 msgid "Not getting the PIN? That email address may no longer be working. If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
@@ -6898,19 +6908,19 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/ui.ex:1568
+#: lib/vutuv_web/components/ui.ex:1572
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr "Stummschalten"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:189
+#: lib/vutuv_web/live/user_profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr "Stummgeschaltet. Die Beiträge erscheinen nicht mehr in Ihrem Feed."
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:79
+#: lib/vutuv_web/templates/settings/notifications.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "New messages and new connections"
 msgstr "Neue Nachrichten und neue Vernetzungen"
@@ -6920,14 +6930,14 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/ui.ex:1567
+#: lib/vutuv_web/components/ui.ex:1571
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr "Stummschaltung aufheben"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:191
+#: lib/vutuv_web/live/user_profile_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -6944,7 +6954,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:824
+#: lib/vutuv_web/components/post_components.ex:829
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6954,38 +6964,38 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:823
+#: lib/vutuv_web/components/post_components.ex:828
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
 
-#: lib/vutuv_web/components/ui.ex:1538
+#: lib/vutuv_web/components/ui.ex:1542
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr "Folgt dir nicht"
 
-#: lib/vutuv_web/components/ui.ex:1532
+#: lib/vutuv_web/components/ui.ex:1536
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr "Folgt dir"
 
-#: lib/vutuv_web/components/ui.ex:1522
+#: lib/vutuv_web/components/ui.ex:1526
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr "Dieses Mitglied folgt dir nicht"
 
-#: lib/vutuv_web/components/ui.ex:1473
-#: lib/vutuv_web/components/ui.ex:1522
+#: lib/vutuv_web/components/ui.ex:1477
+#: lib/vutuv_web/components/ui.ex:1526
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr "Dieses Mitglied folgt dir"
 
-#: lib/vutuv_web/components/ui.ex:1471
+#: lib/vutuv_web/components/ui.ex:1475
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr "Ihr folgt euch"
 
-#: lib/vutuv_web/components/ui.ex:1472
+#: lib/vutuv_web/components/ui.ex:1476
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr "Du folgst diesem Mitglied"
@@ -7159,8 +7169,8 @@ msgstr "Filtern"
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:190
-#: lib/vutuv_web/agent_docs/text.ex:187
+#: lib/vutuv_web/agent_docs/markdown.ex:196
+#: lib/vutuv_web/agent_docs/text.ex:192
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -7223,7 +7233,7 @@ msgid "New newsletter"
 msgstr "Neuer Newsletter"
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:171
-#: lib/vutuv_web/templates/settings/notifications.html.heex:60
+#: lib/vutuv_web/templates/settings/notifications.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Newsletter"
 msgstr "Newsletter"
@@ -7281,7 +7291,7 @@ msgstr "Kein Tag mit diesem Namen."
 msgid "Nothing sent yet."
 msgstr "Noch nichts versendet."
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:62
+#: lib/vutuv_web/templates/settings/notifications.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Occasional vutuv news and announcements."
 msgstr "Gelegentliche vutuv-Neuigkeiten und Ankündigungen."
@@ -7301,7 +7311,7 @@ msgstr "Newsletter öffnen"
 msgid "Pick capped members at random"
 msgstr "Begrenzte Mitglieder zufällig auswählen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:13
+#: lib/vutuv_web/templates/settings/notifications.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Pick which emails vutuv may send you. Each email has a one-click unsubscribe."
 msgstr ""
@@ -7569,13 +7579,13 @@ msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:2154
+#: lib/vutuv_web/components/ui.ex:2158
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:2170
+#: lib/vutuv_web/components/ui.ex:2174
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7844,17 +7854,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:778
+#: lib/vutuv_web/agent_docs/markdown.ex:821
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Dein Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:781
+#: lib/vutuv_web/agent_docs/markdown.ex:824
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:788
+#: lib/vutuv_web/agent_docs/markdown.ex:831
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -8155,12 +8165,12 @@ msgstr "Aus der Zielgruppe entfernen"
 msgid "Add to audience"
 msgstr "Hinzufügen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:35
+#: lib/vutuv_web/templates/settings/notifications.html.heex:36
 #, elixir-autogen
 msgid "How often"
 msgstr "Wie oft"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:39
+#: lib/vutuv_web/templates/settings/notifications.html.heex:40
 #, elixir-autogen
 msgid "Send the email"
 msgstr "E-Mail senden"
@@ -8205,7 +8215,7 @@ msgstr "Nur die erste Nachricht"
 msgid "Every message"
 msgstr "Jede Nachricht"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:44
+#: lib/vutuv_web/templates/settings/notifications.html.heex:45
 #, elixir-autogen
 msgid "We wait a little before emailing, so you can read the message yourself first. These two settings apply only while unread-message emails are on."
 msgstr ""
@@ -8213,7 +8223,7 @@ msgstr ""
 "selbst lesen können. Diese beiden Einstellungen gelten nur, solange E-Mails "
 "zu ungelesenen Nachrichten aktiviert sind."
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:76
+#: lib/vutuv_web/controllers/work_experience_controller.ex:78
 #, elixir-autogen
 msgid "That work experience could not be pinned."
 msgstr "Diese Berufserfahrung konnte nicht festgelegt werden."
@@ -8378,7 +8388,7 @@ msgstr "PIN abgelaufen"
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:2157
+#: lib/vutuv_web/components/ui.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
@@ -8521,12 +8531,12 @@ msgstr "Ausbildung hinzufügen"
 msgid "Degree"
 msgstr "Abschluss"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:39
+#: lib/vutuv_web/agent_docs/markdown.ex:40
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:2846
-#: lib/vutuv_web/controllers/education_controller.ex:36
-#: lib/vutuv_web/controllers/education_controller.ex:51
-#: lib/vutuv_web/controllers/education_controller.ex:89
+#: lib/vutuv_web/components/ui.ex:2888
+#: lib/vutuv_web/controllers/education_controller.ex:38
+#: lib/vutuv_web/controllers/education_controller.ex:53
+#: lib/vutuv_web/controllers/education_controller.ex:103
 #: lib/vutuv_web/cv/cv.ex:258
 #: lib/vutuv_web/templates/education/edit.html.heex:3
 #: lib/vutuv_web/templates/education/index.html.heex:5
@@ -8541,22 +8551,22 @@ msgstr "Abschluss"
 msgid "Education"
 msgstr "Ausbildung"
 
-#: lib/vutuv_web/controllers/education_controller.ex:67
+#: lib/vutuv_web/controllers/education_controller.ex:81
 #, elixir-autogen, elixir-format
 msgid "Education created successfully."
 msgstr "Ausbildung erfolgreich erstellt."
 
-#: lib/vutuv_web/controllers/education_controller.ex:120
+#: lib/vutuv_web/controllers/education_controller.ex:134
 #, elixir-autogen, elixir-format
 msgid "Education deleted successfully."
 msgstr "Ausbildung erfolgreich gelöscht."
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:86
+#: lib/vutuv_web/agent_docs/section_docs.ex:88
 #, elixir-autogen, elixir-format
 msgid "Education of %{name}"
 msgstr "Ausbildung von %{name}"
 
-#: lib/vutuv_web/controllers/education_controller.ex:109
+#: lib/vutuv_web/controllers/education_controller.ex:123
 #, elixir-autogen, elixir-format
 msgid "Education updated successfully."
 msgstr "Ausbildung erfolgreich aktualisiert."
@@ -8582,7 +8592,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:2861
+#: lib/vutuv_web/components/ui.ex:2904
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8611,7 +8621,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:2852
+#: lib/vutuv_web/components/ui.ex:2895
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8708,12 +8718,12 @@ msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 msgid "A photo and a short tagline make your profile complete."
 msgstr "Ein Foto und eine Kurzbeschreibung machen Ihr Profil komplett."
 
-#: lib/vutuv_web/live/user_profile_live.ex:969
+#: lib/vutuv_web/live/user_profile_live.ex:973
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr "Zum Beispiel ein Gedanke zu %{tag}."
 
-#: lib/vutuv_web/components/ui.ex:2393
+#: lib/vutuv_web/components/ui.ex:2397
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:36
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:42
@@ -8737,8 +8747,8 @@ msgstr[1] ""
 msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:92
-#: lib/vutuv_web/templates/user/show.html.heex:1023
+#: lib/vutuv_web/templates/settings/privacy.html.heex:94
+#: lib/vutuv_web/templates/user/show.html.heex:1056
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8817,13 +8827,13 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:2844
+#: lib/vutuv_web/components/ui.ex:2886
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:2860
+#: lib/vutuv_web/components/ui.ex:2903
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8835,7 +8845,7 @@ msgstr "Sprache & Anzeige"
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:2858
+#: lib/vutuv_web/components/ui.ex:2901
 #: lib/vutuv_web/controllers/settings_controller.ex:89
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:5
@@ -8844,7 +8854,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:2862
+#: lib/vutuv_web/components/ui.ex:2905
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8882,19 +8892,19 @@ msgstr "Andere Beiträge anzeigen"
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:94
+#: lib/vutuv_web/templates/settings/privacy.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 "Wenn Sie ein Mastodon- oder Bluesky-Konto angeben, kann Ihr Profil Ihre "
 "neuesten öffentlichen Beiträge von dort anzeigen."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:98
+#: lib/vutuv_web/templates/settings/privacy.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Show my latest social media posts on my profile"
 msgstr "Meine neuesten Social-Media-Beiträge auf meinem Profil anzeigen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:99
+#: lib/vutuv_web/templates/settings/privacy.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
@@ -8989,7 +8999,7 @@ msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 "Die Seite %{letter} des Mitgliederverzeichnisses, sortiert nach Nachnamen."
 
-#: lib/vutuv_web/components/ui.ex:585
+#: lib/vutuv_web/components/ui.ex:589
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -9097,7 +9107,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 msgid "Allow followers from the Fediverse"
 msgstr "Follower aus dem Fediverse erlauben"
 
-#: lib/vutuv_web/components/ui.ex:2867
+#: lib/vutuv_web/components/ui.ex:2910
 #: lib/vutuv_web/controllers/settings_controller.ex:186
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:265
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
@@ -9208,7 +9218,7 @@ msgid "Employment"
 msgstr "Anstellung"
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:556
+#: lib/vutuv_web/agent_docs/markdown.ex:563
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -9231,7 +9241,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr "Berufserfahrung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:557
+#: lib/vutuv_web/agent_docs/markdown.ex:564
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -9262,13 +9272,13 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:594
+#: lib/vutuv_web/agent_docs/markdown.ex:601
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:593
+#: lib/vutuv_web/agent_docs/markdown.ex:600
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9292,19 +9302,19 @@ msgstr ""
 "Ihres Browsers (Strg+P oder Cmd+P) und wählen Sie \"Als PDF speichern\", um "
 "eine PDF-Datei zu erhalten."
 
-#: lib/vutuv_web/components/ui.ex:619
+#: lib/vutuv_web/components/ui.ex:623
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:1308
+#: lib/vutuv_web/components/post_components.ex:1319
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:701
+#: lib/vutuv_web/agent_docs/markdown.ex:717
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9331,7 +9341,7 @@ msgstr "Jeder Download enthält genau die ausgewählten Teile."
 msgid "Header"
 msgstr "Kopfzeile"
 
-#: lib/vutuv_web/components/ui.ex:629
+#: lib/vutuv_web/components/ui.ex:633
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -9368,7 +9378,7 @@ msgstr ""
 "Besuchers enthält nur, was er dort ohnehin sehen kann, und private E-Mail-"
 "Adressen erscheinen nur in Ihrem eigenen."
 
-#: lib/vutuv_web/components/ui.ex:621
+#: lib/vutuv_web/components/ui.ex:625
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9397,14 +9407,14 @@ msgstr ""
 "Der Lebenslauf von %{name} auf vutuv: Berufserfahrung, Ausbildung und "
 "Kenntnisse zum Ansehen und Herunterladen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:555
+#: lib/vutuv_web/agent_docs/markdown.ex:562
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr "Freiberuflich / Selbstständig"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:558
+#: lib/vutuv_web/agent_docs/markdown.ex:565
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9445,7 +9455,7 @@ msgstr "Oben im Profil anzeigen"
 msgid "Shown at the top of your profile"
 msgstr "Wird oben in Ihrem Profil angezeigt"
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:88
+#: lib/vutuv_web/controllers/work_experience_controller.ex:90
 #, elixir-autogen, elixir-format
 msgid "The job title at the top of your profile is chosen automatically again."
 msgstr "Der Jobtitel oben in Ihrem Profil wird wieder automatisch gewählt."
@@ -9457,7 +9467,7 @@ msgstr ""
 "Der Jobtitel oben in Ihrem Profil wird automatisch gewählt. Derzeit ist das "
 "%{job}. Wählen Sie unten eine Position, um ihn selbst festzulegen."
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:71
+#: lib/vutuv_web/controllers/work_experience_controller.ex:73
 #, elixir-autogen, elixir-format
 msgid "This job title now shows at the top of your profile."
 msgstr "Dieser Jobtitel wird jetzt oben in Ihrem Profil angezeigt."
@@ -9543,8 +9553,8 @@ msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
 msgid "Yes"
 msgstr "Ja"
 
-#: lib/vutuv_web/components/ui.ex:988
-#: lib/vutuv_web/components/ui.ex:989
+#: lib/vutuv_web/components/ui.ex:992
+#: lib/vutuv_web/components/ui.ex:993
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:64
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9556,8 +9566,8 @@ msgstr "Ehren-Tag"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Ehren-Tag (nur Admins können es vergeben)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:438
-#: lib/vutuv_web/agent_docs/text.ex:441
+#: lib/vutuv_web/agent_docs/markdown.ex:444
+#: lib/vutuv_web/agent_docs/text.ex:446
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "Ehren-Tag"
@@ -9783,9 +9793,9 @@ msgstr "Sprache erfolgreich gelöscht."
 msgid "Language updated successfully."
 msgstr "Sprache erfolgreich aktualisiert."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:47
+#: lib/vutuv_web/agent_docs/markdown.ex:48
 #: lib/vutuv_web/agent_docs/text.ex:46
-#: lib/vutuv_web/components/ui.ex:2848
+#: lib/vutuv_web/components/ui.ex:2890
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
@@ -9803,7 +9813,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 msgid "Languages"
 msgstr "Sprachen"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:91
+#: lib/vutuv_web/agent_docs/section_docs.ex:93
 #, elixir-autogen, elixir-format
 msgid "Languages of %{name}"
 msgstr "Sprachen von %{name}"
@@ -9979,14 +9989,14 @@ msgstr "Walisisch"
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:410
-#: lib/vutuv_web/agent_docs/text.ex:415
+#: lib/vutuv_web/agent_docs/markdown.ex:416
+#: lib/vutuv_web/agent_docs/text.ex:420
 #: lib/vutuv_web/templates/user/edit.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:609
+#: lib/vutuv/accounts/user.ex:617
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9997,7 +10007,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:606
+#: lib/vutuv/accounts/user.ex:614
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10095,23 +10105,23 @@ msgstr[1] "%{count} Zertifikate oder Lizenzen"
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:631
+#: lib/vutuv_web/agent_docs/markdown.ex:638
 #: lib/vutuv_web/views/qualification_html.ex:10
 #, elixir-autogen, elixir-format
 msgid "Certificate"
 msgstr "Zertifikat"
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:65
+#: lib/vutuv_web/controllers/qualification_controller.ex:78
 #, elixir-autogen, elixir-format
 msgid "Certificate or license added successfully."
 msgstr "Zertifikat oder Lizenz erfolgreich hinzugefügt."
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:114
+#: lib/vutuv_web/controllers/qualification_controller.ex:128
 #, elixir-autogen, elixir-format
 msgid "Certificate or license deleted successfully."
 msgstr "Zertifikat oder Lizenz erfolgreich gelöscht."
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:105
+#: lib/vutuv_web/controllers/qualification_controller.ex:119
 #, elixir-autogen, elixir-format
 msgid "Certificate or license updated successfully."
 msgstr "Zertifikat oder Lizenz erfolgreich aktualisiert."
@@ -10121,12 +10131,12 @@ msgstr "Zertifikat oder Lizenz erfolgreich aktualisiert."
 msgid "Certificates"
 msgstr "Zertifikate"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:43
+#: lib/vutuv_web/agent_docs/markdown.ex:44
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:2847
-#: lib/vutuv_web/controllers/qualification_controller.ex:33
-#: lib/vutuv_web/controllers/qualification_controller.ex:49
-#: lib/vutuv_web/controllers/qualification_controller.ex:88
+#: lib/vutuv_web/components/ui.ex:2889
+#: lib/vutuv_web/controllers/qualification_controller.ex:35
+#: lib/vutuv_web/controllers/qualification_controller.ex:51
+#: lib/vutuv_web/controllers/qualification_controller.ex:102
 #: lib/vutuv_web/cv/docx.ex:183
 #: lib/vutuv_web/cv/html.ex:172
 #: lib/vutuv_web/cv/latex.ex:140
@@ -10148,7 +10158,7 @@ msgstr "Zertifikate & Lizenzen"
 msgid "Certificates & licenses of "
 msgstr "Zertifikate & Lizenzen von "
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:89
+#: lib/vutuv_web/agent_docs/section_docs.ex:91
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses of %{name}"
 msgstr "Zertifikate & Lizenzen von %{name}"
@@ -10182,7 +10192,7 @@ msgstr "Ablaufmonat"
 msgid "Expiry year"
 msgstr "Ablaufjahr"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:623
+#: lib/vutuv_web/agent_docs/markdown.ex:630
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10208,7 +10218,7 @@ msgstr "Ausstellungsjahr"
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/markdown.ex:637
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10238,7 +10248,7 @@ msgstr "Nachweis"
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:621
+#: lib/vutuv_web/agent_docs/markdown.ex:628
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10253,14 +10263,14 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:622
+#: lib/vutuv_web/agent_docs/markdown.ex:629
 #: lib/vutuv_web/views/qualification_html.ex:60
 #: lib/vutuv_web/views/qualification_html.ex:63
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
 msgstr "gültig bis %{date}"
 
-#: lib/vutuv_web/live/section_reorder_live.ex:153
+#: lib/vutuv_web/live/section_reorder_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder, or use the arrows. The first language is your preferred contact language."
 msgstr ""
@@ -10272,8 +10282,8 @@ msgstr ""
 msgid "Preferred"
 msgstr "Bevorzugt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:525
-#: lib/vutuv_web/live/section_reorder_live.ex:258
+#: lib/vutuv_web/agent_docs/markdown.ex:532
+#: lib/vutuv_web/live/section_reorder_live.ex:269
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
@@ -10706,12 +10716,12 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr "Authenticator-App ausgeschaltet."
 
-#: lib/vutuv_web/components/ui.ex:158
+#: lib/vutuv_web/components/ui.ex:162
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr "Fett"
 
-#: lib/vutuv_web/components/ui.ex:238
+#: lib/vutuv_web/components/ui.ex:242
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr "Aufzählung"
@@ -10723,7 +10733,7 @@ msgstr ""
 "Sie können den Code nicht scannen? Geben Sie stattdessen diesen Schlüssel in"
 " Ihrer App ein:"
 
-#: lib/vutuv_web/components/ui.ex:230
+#: lib/vutuv_web/components/ui.ex:234
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr "Codeblock"
@@ -10739,17 +10749,17 @@ msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 "Kennwortliste löschen? Alle Codes darauf funktionieren sofort nicht mehr."
 
-#: lib/vutuv_web/components/ui.ex:252
+#: lib/vutuv_web/components/ui.ex:256
 #, elixir-autogen, elixir-format
 msgid "Divider"
 msgstr "Trennlinie"
 
-#: lib/vutuv_web/components/ui.ex:156
+#: lib/vutuv_web/components/ui.ex:160
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr "Formatierung"
 
-#: lib/vutuv_web/components/ui.ex:264
+#: lib/vutuv_web/components/ui.ex:268
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr "Vollbild"
@@ -10764,32 +10774,32 @@ msgstr "Neue Liste erstellen"
 msgid "Generate code list"
 msgstr "Kennwortliste erstellen"
 
-#: lib/vutuv_web/components/ui.ex:218
+#: lib/vutuv_web/components/ui.ex:222
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr "Überschrift 1"
 
-#: lib/vutuv_web/components/ui.ex:221
+#: lib/vutuv_web/components/ui.ex:225
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr "Überschrift 2"
 
-#: lib/vutuv_web/components/ui.ex:224
+#: lib/vutuv_web/components/ui.ex:228
 #, elixir-autogen, elixir-format
 msgid "Heading 3"
 msgstr "Überschrift 3"
 
-#: lib/vutuv_web/components/ui.ex:167
+#: lib/vutuv_web/components/ui.ex:171
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr "Inline-Code"
 
-#: lib/vutuv_web/components/ui.ex:161
+#: lib/vutuv_web/components/ui.ex:165
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr "Kursiv"
 
-#: lib/vutuv_web/components/ui.ex:151
+#: lib/vutuv_web/components/ui.ex:155
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr "Link-URL"
@@ -10799,8 +10809,8 @@ msgstr "Link-URL"
 msgid "Login codes"
 msgstr "Anmelde-Codes"
 
-#: lib/vutuv_web/components/ui.ex:206
-#: lib/vutuv_web/components/ui.ex:207
+#: lib/vutuv_web/components/ui.ex:210
+#: lib/vutuv_web/components/ui.ex:211
 #, elixir-autogen, elixir-format
 msgid "More formatting"
 msgstr "Mehr Formatierung"
@@ -10811,7 +10821,7 @@ msgstr "Mehr Formatierung"
 msgid "Not set up."
 msgstr "Nicht eingerichtet."
 
-#: lib/vutuv_web/components/ui.ex:241
+#: lib/vutuv_web/components/ui.ex:245
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr "Nummerierte Liste"
@@ -10828,7 +10838,7 @@ msgstr ""
 "Drucken Sie diese Seite aus oder schreiben Sie die Codes ab. "
 "Durchgestrichene Codes wurden bereits verwendet."
 
-#: lib/vutuv_web/components/ui.ex:227
+#: lib/vutuv_web/components/ui.ex:231
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr "Zitat"
@@ -10853,12 +10863,12 @@ msgstr ""
 msgid "Set up"
 msgstr "Einrichten"
 
-#: lib/vutuv_web/components/ui.ex:164
+#: lib/vutuv_web/components/ui.ex:168
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr "Durchgestrichen"
 
-#: lib/vutuv_web/components/ui.ex:249
+#: lib/vutuv_web/components/ui.ex:253
 #, elixir-autogen, elixir-format
 msgid "Table"
 msgstr "Tabelle"
@@ -10875,7 +10885,7 @@ msgstr ""
 msgid "To finish, enter the code your app shows now"
 msgstr "Geben Sie zum Abschluss den Code ein, den Ihre App jetzt anzeigt"
 
-#: lib/vutuv_web/components/ui.ex:261
+#: lib/vutuv_web/components/ui.ex:265
 #, elixir-autogen, elixir-format
 msgid "Toggle Markdown source"
 msgstr "Markdown-Quelltext umschalten"
@@ -10975,21 +10985,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr "auf diesem Gerät einrichten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:493
+#: lib/vutuv_web/agent_docs/markdown.ex:500
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} Follower"
 msgstr[1] "%{count} Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:491
+#: lib/vutuv_web/agent_docs/markdown.ex:498
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} Repository"
 msgstr[1] "%{count} Repositories"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:489
+#: lib/vutuv_web/agent_docs/markdown.ex:496
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -11010,19 +11020,19 @@ msgid_plural "%{formatted} stars"
 msgstr[0] "%{formatted} Stern"
 msgstr[1] "%{formatted} Sterne"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:56
-#: lib/vutuv_web/agent_docs/text.ex:55
-#: lib/vutuv_web/templates/user/show.html.heex:997
+#: lib/vutuv_web/agent_docs/markdown.ex:61
+#: lib/vutuv_web/agent_docs/text.ex:59
+#: lib/vutuv_web/templates/user/show.html.heex:1030
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:110
+#: lib/vutuv_web/templates/settings/privacy.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr "Code-Statistiken"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:112
+#: lib/vutuv_web/templates/settings/privacy.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
@@ -11035,24 +11045,24 @@ msgstr ""
 msgid "Last active %{date}"
 msgstr "Zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:116
+#: lib/vutuv_web/templates/settings/privacy.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Show code statistics on my profile"
 msgstr "Code-Statistiken auf meinem Profil anzeigen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:117
+#: lib/vutuv_web/templates/settings/privacy.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten nur als einfache "
 "Links."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:507
+#: lib/vutuv_web/agent_docs/markdown.ex:514
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:494
+#: lib/vutuv_web/agent_docs/markdown.ex:501
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "seit %{date}"
@@ -11211,7 +11221,7 @@ msgstr ""
 "Verwalten Sie Ihr vutuv-Konto: Profil, Privatsphäre, Benachrichtigungen und "
 "Anmeldung."
 
-#: lib/vutuv_web/controllers/tag_controller.ex:72
+#: lib/vutuv_web/controllers/tag_controller.ex:85
 #, elixir-autogen, elixir-format
 msgid "Members on vutuv tagged %{tag}."
 msgstr "Mitglieder auf vutuv mit dem Tag %{tag}."
@@ -11638,19 +11648,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:621
+#: lib/vutuv/accounts/user.ex:629
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:626
+#: lib/vutuv/accounts/user.ex:634
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:624
+#: lib/vutuv/accounts/user.ex:632
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
@@ -11976,8 +11986,8 @@ msgstr "Verifizierungsmethode"
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:191
-#: lib/vutuv_web/agent_docs/text.ex:188
+#: lib/vutuv_web/agent_docs/markdown.ex:197
+#: lib/vutuv_web/agent_docs/text.ex:193
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr "Verifiziert über"
@@ -12006,8 +12016,8 @@ msgstr ""
 "Wir konnten den Eintrag oder die Datei noch nicht finden. Die Verbreitung "
 "kann etwas dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:193
-#: lib/vutuv_web/agent_docs/text.ex:190
+#: lib/vutuv_web/agent_docs/markdown.ex:199
+#: lib/vutuv_web/agent_docs/text.ex:195
 #: lib/vutuv_web/live/organization_live/edit.ex:273
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -12093,8 +12103,8 @@ msgstr "Alias hinzugefügt."
 msgid "Alias removed."
 msgstr "Alias entfernt."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:294
-#: lib/vutuv_web/agent_docs/text.ex:329
+#: lib/vutuv_web/agent_docs/markdown.ex:300
+#: lib/vutuv_web/agent_docs/text.ex:334
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
@@ -12336,8 +12346,8 @@ msgstr "ausstehend"
 msgid "primary"
 msgstr "primär"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:315
-#: lib/vutuv_web/agent_docs/text.ex:349
+#: lib/vutuv_web/agent_docs/markdown.ex:321
+#: lib/vutuv_web/agent_docs/text.ex:354
 #: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -12432,8 +12442,8 @@ msgstr ""
 "Der Linktext ist beliebig. Ein verstecktes <link rel=\"me\"> im Seitenkopf "
 "funktioniert ebenfalls."
 
-#: lib/vutuv_web/components/ui.ex:517
-#: lib/vutuv_web/live/section_reorder_live.ex:182
+#: lib/vutuv_web/components/ui.ex:521
+#: lib/vutuv_web/live/section_reorder_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
 msgstr "Verifizierte Webseite"
@@ -12449,7 +12459,7 @@ msgstr "Verifiziert. Führen Sie eine der Methoden unten erneut aus, um es zu ak
 msgid "Verify link"
 msgstr "Link verifizieren"
 
-#: lib/vutuv_web/live/section_reorder_live.ex:189
+#: lib/vutuv_web/live/section_reorder_live.ex:191
 #: lib/vutuv_web/templates/url/card_list.html.heex:32
 #: lib/vutuv_web/templates/url/show.html.heex:29
 #, elixir-autogen, elixir-format
@@ -12478,8 +12488,8 @@ msgstr ""
 "Wir konnten den Nachweis noch nicht finden. Die Verbreitung kann etwas "
 "dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:651
-#: lib/vutuv_web/agent_docs/text.ex:521
+#: lib/vutuv_web/agent_docs/markdown.ex:658
+#: lib/vutuv_web/agent_docs/text.ex:535
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -12515,8 +12525,8 @@ msgstr "Verknüpft mit {name}"
 msgid "Remove link"
 msgstr "Verknüpfung entfernen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:306
-#: lib/vutuv_web/agent_docs/text.ex:340
+#: lib/vutuv_web/agent_docs/markdown.ex:312
+#: lib/vutuv_web/agent_docs/text.ex:345
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr "ehemalig"
@@ -12719,7 +12729,7 @@ msgstr "Organisation"
 msgid "Organization pages"
 msgstr "Organisation"
 
-#: lib/vutuv_web/live/notification_live/index.ex:305
+#: lib/vutuv_web/live/notification_live/index.ex:334
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisation"
@@ -12730,7 +12740,7 @@ msgid "Organization unfrozen."
 msgstr "Organisation"
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:2859
+#: lib/vutuv_web/components/ui.ex:2902
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
@@ -12830,22 +12840,22 @@ msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
 msgid "Your organization page was updated."
 msgstr "Ihre Organisationsseite wurde aktualisiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:370
+#: lib/vutuv_web/live/notification_live/index.ex:410
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr "hat dir eine Rolle bei %{company} gegeben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:367
+#: lib/vutuv_web/live/notification_live/index.ex:407
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr "hat dich zum Recruiter für %{company} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:364
+#: lib/vutuv_web/live/notification_live/index.ex:404
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr "hat dich zum Administrator von %{company} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:361
+#: lib/vutuv_web/live/notification_live/index.ex:401
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr "hat dich zum Inhaber von %{company} gemacht."
@@ -12993,10 +13003,10 @@ msgstr "Entwürfe"
 msgid "Edit posting"
 msgstr "Anzeige bearbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:210
-#: lib/vutuv_web/agent_docs/markdown.ex:339
-#: lib/vutuv_web/agent_docs/text.ex:206
-#: lib/vutuv_web/agent_docs/text.ex:373
+#: lib/vutuv_web/agent_docs/markdown.ex:216
+#: lib/vutuv_web/agent_docs/markdown.ex:345
+#: lib/vutuv_web/agent_docs/text.ex:211
+#: lib/vutuv_web/agent_docs/text.ex:378
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employer"
@@ -13007,10 +13017,10 @@ msgstr "Arbeitgeber"
 msgid "Employer name (optional)"
 msgstr "Name des Arbeitgebers (optional)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:211
-#: lib/vutuv_web/agent_docs/markdown.ex:340
-#: lib/vutuv_web/agent_docs/text.ex:207
-#: lib/vutuv_web/agent_docs/text.ex:374
+#: lib/vutuv_web/agent_docs/markdown.ex:217
+#: lib/vutuv_web/agent_docs/markdown.ex:346
+#: lib/vutuv_web/agent_docs/text.ex:212
+#: lib/vutuv_web/agent_docs/text.ex:379
 #: lib/vutuv_web/live/job_board_live.ex:281
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format, fuzzy
@@ -13083,12 +13093,12 @@ msgstr "Jobs"
 msgid "Let search engines index this posting."
 msgstr "Suchmaschinen dürfen diese Anzeige indexieren."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:321
-#: lib/vutuv_web/agent_docs/markdown.ex:325
 #: lib/vutuv_web/agent_docs/markdown.ex:327
-#: lib/vutuv_web/agent_docs/text.ex:355
-#: lib/vutuv_web/agent_docs/text.ex:359
-#: lib/vutuv_web/agent_docs/text.ex:361
+#: lib/vutuv_web/agent_docs/markdown.ex:331
+#: lib/vutuv_web/agent_docs/markdown.ex:333
+#: lib/vutuv_web/agent_docs/text.ex:360
+#: lib/vutuv_web/agent_docs/text.ex:364
+#: lib/vutuv_web/agent_docs/text.ex:366
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
@@ -13137,8 +13147,8 @@ msgstr "Neue Konten können nach einigen Tagen veröffentlichen."
 msgid "New posting"
 msgstr "Neue Anzeige"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:222
-#: lib/vutuv_web/agent_docs/text.ex:217
+#: lib/vutuv_web/agent_docs/markdown.ex:228
+#: lib/vutuv_web/agent_docs/text.ex:222
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
@@ -13222,10 +13232,10 @@ msgstr "Veröffentlichen als"
 msgid "Postal code"
 msgstr "Postleitzahl"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:215
-#: lib/vutuv_web/agent_docs/markdown.ex:344
-#: lib/vutuv_web/agent_docs/text.ex:211
-#: lib/vutuv_web/agent_docs/text.ex:378
+#: lib/vutuv_web/agent_docs/markdown.ex:221
+#: lib/vutuv_web/agent_docs/markdown.ex:350
+#: lib/vutuv_web/agent_docs/text.ex:216
+#: lib/vutuv_web/agent_docs/text.ex:383
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posted"
@@ -13249,10 +13259,10 @@ msgstr "Veröffentlichen"
 
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
-#: lib/vutuv_web/agent_docs/markdown.ex:325
-#: lib/vutuv_web/agent_docs/markdown.ex:327
-#: lib/vutuv_web/agent_docs/text.ex:359
-#: lib/vutuv_web/agent_docs/text.ex:361
+#: lib/vutuv_web/agent_docs/markdown.ex:331
+#: lib/vutuv_web/agent_docs/markdown.ex:333
+#: lib/vutuv_web/agent_docs/text.ex:364
+#: lib/vutuv_web/agent_docs/text.ex:366
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format
@@ -13264,18 +13274,18 @@ msgstr "Remote"
 msgid "Report this posting"
 msgstr "Diese Anzeige melden"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:221
-#: lib/vutuv_web/agent_docs/text.ex:216
+#: lib/vutuv_web/agent_docs/markdown.ex:227
+#: lib/vutuv_web/agent_docs/text.ex:221
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Erforderlich"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:214
-#: lib/vutuv_web/agent_docs/markdown.ex:343
-#: lib/vutuv_web/agent_docs/text.ex:210
-#: lib/vutuv_web/agent_docs/text.ex:377
+#: lib/vutuv_web/agent_docs/markdown.ex:220
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/text.ex:215
+#: lib/vutuv_web/agent_docs/text.ex:382
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Salary"
 msgstr "Gehalt"
@@ -13367,10 +13377,10 @@ msgstr "Wer kann sie sehen"
 msgid "Working student"
 msgstr "Werkstudent:in"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:212
-#: lib/vutuv_web/agent_docs/markdown.ex:341
-#: lib/vutuv_web/agent_docs/text.ex:208
-#: lib/vutuv_web/agent_docs/text.ex:375
+#: lib/vutuv_web/agent_docs/markdown.ex:218
+#: lib/vutuv_web/agent_docs/markdown.ex:347
+#: lib/vutuv_web/agent_docs/text.ex:213
+#: lib/vutuv_web/agent_docs/text.ex:380
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Workplace"
@@ -13543,13 +13553,13 @@ msgstr "%{km} km"
 msgid "All countries"
 msgstr "Alle Länder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:362
+#: lib/vutuv_web/agent_docs/markdown.ex:368
 #: lib/vutuv_web/templates/tag/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Alle Stellen mit diesem Tag"
 
-#: lib/vutuv_web/agent_docs/text.ex:395
+#: lib/vutuv_web/agent_docs/text.ex:400
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr "Alle Stellen mit diesem Tag: %{url}"
@@ -13595,12 +13605,12 @@ msgstr "Mindestgehalt pro Jahr"
 msgid "More jobs"
 msgstr "Weitere Stellen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:234
+#: lib/vutuv_web/agent_docs/markdown.ex:240
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr "Nächste Seite"
 
-#: lib/vutuv_web/agent_docs/text.ex:229
+#: lib/vutuv_web/agent_docs/text.ex:234
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr "Nächste Seite: %{url}"
@@ -13615,10 +13625,10 @@ msgstr "Noch keine Stellenanzeigen."
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Keine passenden Stellen. Passe die Filter an."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:360
-#: lib/vutuv_web/agent_docs/markdown.ex:372
-#: lib/vutuv_web/agent_docs/text.ex:393
-#: lib/vutuv_web/agent_docs/text.ex:405
+#: lib/vutuv_web/agent_docs/markdown.ex:366
+#: lib/vutuv_web/agent_docs/markdown.ex:378
+#: lib/vutuv_web/agent_docs/text.ex:398
+#: lib/vutuv_web/agent_docs/text.ex:410
 #: lib/vutuv_web/live/organization_live/show.ex:329
 #: lib/vutuv_web/templates/tag/show.html.heex:57
 #, elixir-autogen, elixir-format
@@ -13809,6 +13819,7 @@ msgid "Search title, poster or organization"
 msgstr "Titel, Ersteller oder Organisation suchen"
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
+#: lib/vutuv_web/live/post_live/composer.ex:705
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
@@ -13917,7 +13928,7 @@ msgstr "Suche speichern"
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:2897
+#: lib/vutuv_web/components/ui.ex:2940
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -14183,7 +14194,7 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "An image was removed from your vutuv account"
 msgstr "Ein Bild wurde aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/components/post_components.ex:987
+#: lib/vutuv_web/components/post_components.ex:992
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -14191,12 +14202,12 @@ msgstr "Ein Bild wurde aus Ihrem vutuv-Konto entfernt"
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:977
+#: lib/vutuv_web/components/post_components.ex:982
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/live/notification_live/index.ex:303
+#: lib/vutuv_web/live/notification_live/index.ex:332
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -14207,7 +14218,7 @@ msgstr "Bildprüfung"
 msgid "No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
 msgstr "Keine Bilder in der KI-Prüfung. %{formatted} in den letzten 7 Tagen abgelehnt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:393
+#: lib/vutuv_web/live/notification_live/index.ex:433
 #, elixir-autogen, elixir-format
 msgid "Our automated image review removed %{what}. Only family-friendly images suitable for a work environment are allowed."
 msgstr "Unsere automatische Bildprüfung hat %{what} entfernt. Erlaubt sind nur familienfreundliche Bilder, die für ein Arbeitsumfeld geeignet sind."
@@ -14242,7 +14253,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:639
+#: lib/vutuv/accounts/user.ex:647
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14253,19 +14264,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:642
+#: lib/vutuv/accounts/user.ex:650
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:645
+#: lib/vutuv/accounts/user.ex:653
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:636
+#: lib/vutuv/accounts/user.ex:644
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14288,7 +14299,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:306
+#: lib/vutuv_web/live/notification_live/index.ex:335
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -14300,48 +14311,48 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] "Wir haben %{formatted} Beitrag aktualisiert, der Ihren alten Handle erwähnt hat, und dessen Verfasser benachrichtigt."
 msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle erwähnt haben, und deren Verfasser benachrichtigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:420
+#: lib/vutuv_web/live/notification_live/index.ex:460
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
 
-#: lib/vutuv_web/components/ui.ex:191
+#: lib/vutuv_web/components/ui.ex:195
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr "Zentriert"
 
-#: lib/vutuv_web/components/ui.ex:188
+#: lib/vutuv_web/components/ui.ex:192
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr "Linksbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:194
+#: lib/vutuv_web/components/ui.ex:198
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr "Rechtsbündig (Text umfließt)"
 
-#: lib/vutuv_web/components/ui.ex:185
+#: lib/vutuv_web/components/ui.ex:189
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr "Volle Breite"
 
-#: lib/vutuv_web/live/post_live/composer.ex:507
+#: lib/vutuv_web/live/post_live/composer.ex:599
 #, elixir-autogen, elixir-format
 msgid "Insert"
 msgstr "Einfügen"
 
-#: lib/vutuv_web/components/ui.ex:173
+#: lib/vutuv_web/components/ui.ex:177
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:504
+#: lib/vutuv_web/live/post_live/composer.ex:596
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:166
-#: lib/vutuv_web/agent_docs/text.ex:163
+#: lib/vutuv_web/agent_docs/markdown.ex:172
+#: lib/vutuv_web/agent_docs/text.ex:168
 #: lib/vutuv_web/templates/tag/show.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
@@ -14369,22 +14380,22 @@ msgstr "Mobil (privat)"
 msgid "Work mobile"
 msgstr "Mobil (Arbeit)"
 
-#: lib/vutuv_web/components/post_components.ex:272
+#: lib/vutuv_web/components/post_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Noch keine Beiträge."
 
-#: lib/vutuv_web/components/post_components.ex:274
+#: lib/vutuv_web/components/post_components.ex:279
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Noch keine Antworten."
 
-#: lib/vutuv_web/components/post_components.ex:273
+#: lib/vutuv_web/components/post_components.ex:278
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Noch keine Reposts."
 
-#: lib/vutuv_web/components/post_components.ex:262
+#: lib/vutuv_web/components/post_components.ex:267
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Eigene Beiträge"
@@ -14394,7 +14405,7 @@ msgstr "Eigene Beiträge"
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr "Beiträge mit einem Tag, dem du folgst, landen in deinem Feed, und passende Personen tauchen in deinen Vorschlägen auf. Einem Tag folgst du auf seiner Seite."
 
-#: lib/vutuv_web/components/ui.ex:2886
+#: lib/vutuv_web/components/ui.ex:2929
 #: lib/vutuv_web/controllers/settings_controller.ex:259
 #: lib/vutuv_web/live/post_live/feed.ex:651
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14443,14 +14454,15 @@ msgstr "Wortanfang: findet auch Entwickler, Entwicklung"
 msgid "Signal and WhatsApp accept a phone number or a username; the other messengers use their own id or handle (e.g. an 8-character Threema ID or a Matrix @you:matrix.org)."
 msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzernamen; die anderen Messenger nutzen ihre eigene ID oder ihren Handle (z. B. eine 8-stellige Threema-ID oder eine Matrix-Adresse @du:matrix.org)."
 
-#: lib/vutuv_web/templates/messenger/manage.html.heex:11
+#: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
 
+#: lib/vutuv_web/templates/messenger/card_list.html.heex:5
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:5
-#: lib/vutuv_web/templates/messenger/show.html.heex:16
+#: lib/vutuv_web/templates/messenger/show.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Messenger"
 msgstr "Messenger"
@@ -14460,30 +14472,37 @@ msgstr "Messenger"
 msgid "Messenger created successfully."
 msgstr "Messenger wurde erstellt."
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:107
+#: lib/vutuv_web/controllers/messenger_controller.ex:102
 #, elixir-autogen, elixir-format
 msgid "Messenger deleted successfully."
 msgstr "Messenger wurde gelöscht."
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:99
+#: lib/vutuv_web/controllers/messenger_controller.ex:91
 #, elixir-autogen, elixir-format
 msgid "Messenger updated successfully."
 msgstr "Messenger wurde geändert."
 
-#: lib/vutuv_web/components/ui.ex:2851
-#: lib/vutuv_web/controllers/messenger_controller.ex:22
-#: lib/vutuv_web/templates/messenger/index.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/agent_docs/markdown.ex:58
+#: lib/vutuv_web/agent_docs/text.ex:56
+#: lib/vutuv_web/components/ui.ex:2893
+#: lib/vutuv_web/controllers/messenger_controller.ex:21
+#: lib/vutuv_web/controllers/messenger_controller.ex:36
+#: lib/vutuv_web/templates/messenger/edit.html.heex:3
+#: lib/vutuv_web/templates/messenger/index.html.heex:10
+#: lib/vutuv_web/templates/messenger/manage.html.heex:4
+#: lib/vutuv_web/templates/messenger/new.html.heex:3
+#: lib/vutuv_web/templates/messenger/show.html.heex:6
+#: lib/vutuv_web/templates/user/show.html.heex:994
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
 
-#: lib/vutuv_web/templates/messenger/index.html.heex:6
+#: lib/vutuv_web/templates/messenger/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Messengers of "
 msgstr "Messenger von "
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:100
+#: lib/vutuv_web/agent_docs/section_docs.ex:99
 #, elixir-autogen, elixir-format
 msgid "Messengers of %{name}"
 msgstr "Messenger von %{name}"
@@ -14493,59 +14512,195 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:2494
+#: lib/vutuv_web/components/ui.ex:2483
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:2503
+#: lib/vutuv_web/components/ui.ex:2493
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:311
+#: lib/vutuv_web/live/notification_live/index.ex:336
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
 
-#: lib/vutuv_web/live/notification_live/index.ex:449
+#: lib/vutuv_web/live/notification_live/index.ex:480
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr "hat eine neue Station im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:443
+#: lib/vutuv_web/live/notification_live/index.ex:472
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr "hat eine neue Ausbildung im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:446
+#: lib/vutuv_web/live/notification_live/index.ex:477
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr "hat ein neues Zertifikat im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:74
+#: lib/vutuv_web/templates/settings/notifications.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "CV updates"
 msgstr "Lebenslauf-Updates"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:77
+#: lib/vutuv_web/templates/settings/notifications.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "When someone you follow adds a new entry to their CV, they can let their followers know. It shows up under the bell, never by email."
 msgstr "Wenn jemand, dem Sie folgen, einen neuen Eintrag im Lebenslauf ergänzt, kann diese Person ihre Follower darüber informieren. Das erscheint unter der Glocke, nie per E-Mail."
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:82
+#: lib/vutuv_web/templates/settings/notifications.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Tell me about new CV entries of people I follow"
 msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folge"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:83
+#: lib/vutuv_web/templates/settings/notifications.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
 
-#: lib/vutuv_web/live/notification_live/index.ex:470
+#: lib/vutuv_web/live/notification_live/index.ex:485
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
+
+#: lib/vutuv_web/components/post_components.ex:1496
+#, elixir-autogen, elixir-format
+msgid "Audiobook"
+msgstr "Hörbuch"
+
+#: lib/vutuv_web/live/post_live/composer.ex:713
+#, elixir-autogen, elixir-format
+msgid "Author(s)"
+msgstr "Autor/in"
+
+#: lib/vutuv_web/live/post_live/composer.ex:775
+#, elixir-autogen, elixir-format
+msgid "Book"
+msgstr "Buch"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:788
+#: lib/vutuv_web/components/post_components.ex:1486
+#: lib/vutuv_web/live/post_live/composer.ex:659
+#, elixir-autogen, elixir-format
+msgid "Book review"
+msgstr "Buchbesprechung"
+
+#: lib/vutuv_web/components/post_components.ex:1497
+#, elixir-autogen, elixir-format
+msgid "Cinema"
+msgstr "Kino"
+
+#: lib/vutuv_web/components/post_components.ex:1499
+#, elixir-autogen, elixir-format
+msgid "DVD/Blu-ray"
+msgstr "DVD/Blu-ray"
+
+#: lib/vutuv_web/live/post_live/composer.ex:713
+#, elixir-autogen, elixir-format
+msgid "Director"
+msgstr "Regie"
+
+#: lib/vutuv_web/components/post_components.ex:1495
+#, elixir-autogen, elixir-format
+msgid "E-book"
+msgstr "E-Book"
+
+#: lib/vutuv_web/live/post_live/composer.ex:787
+#, elixir-autogen, elixir-format
+msgid "Film"
+msgstr "Film"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:788
+#: lib/vutuv_web/components/post_components.ex:1485
+#: lib/vutuv_web/live/post_live/composer.ex:658
+#, elixir-autogen, elixir-format
+msgid "Film review"
+msgstr "Filmbesprechung"
+
+#: lib/vutuv_web/live/post_live/composer.ex:679
+#, elixir-autogen, elixir-format
+msgid "IMDb link or ID"
+msgstr "IMDb-Link oder -ID"
+
+#: lib/vutuv_web/live/post_live/composer.ex:680
+#, elixir-autogen, elixir-format
+msgid "ISBN"
+msgstr "ISBN"
+
+#: lib/vutuv_web/live/post_live/composer.ex:693
+#, elixir-autogen, elixir-format
+msgid "Look up"
+msgstr "Nachschlagen"
+
+#: lib/vutuv_web/live/post_live/composer.ex:690
+#, elixir-autogen, elixir-format
+msgid "Looking up…"
+msgstr "Schlage nach …"
+
+#: lib/vutuv_web/live/post_live/composer.ex:249
+#, elixir-autogen, elixir-format
+msgid "Nothing found for this ISBN. Please fill in the fields yourself."
+msgstr "Zu dieser ISBN wurde nichts gefunden. Bitte füllen Sie die Felder selbst aus."
+
+#: lib/vutuv_web/components/post_components.ex:1494
+#, elixir-autogen, elixir-format
+msgid "Printed book"
+msgstr "Gedrucktes Buch"
+
+#: lib/vutuv_web/live/post_live/composer.ex:732
+#, elixir-autogen, elixir-format
+msgid "Read as… (optional)"
+msgstr "Gelesen als … (optional)"
+
+#: lib/vutuv_web/live/post_live/composer.ex:668
+#, elixir-autogen, elixir-format
+msgid "Remove review"
+msgstr "Besprechung entfernen"
+
+#: lib/vutuv_web/live/post_live/composer.ex:771
+#: lib/vutuv_web/live/post_live/composer.ex:772
+#, elixir-autogen, elixir-format
+msgid "Review a book"
+msgstr "Ein Buch besprechen"
+
+#: lib/vutuv_web/live/post_live/composer.ex:783
+#: lib/vutuv_web/live/post_live/composer.ex:784
+#, elixir-autogen, elixir-format
+msgid "Review a film"
+msgstr "Einen Film besprechen"
+
+#: lib/vutuv_web/components/post_components.ex:1498
+#, elixir-autogen, elixir-format
+msgid "Streaming"
+msgstr "Streaming"
+
+#: lib/vutuv_web/components/post_components.ex:1503
+#, elixir-autogen, elixir-format
+msgid "View on Amazon"
+msgstr "Bei Amazon ansehen"
+
+#: lib/vutuv_web/components/post_components.ex:1502
+#, elixir-autogen, elixir-format
+msgid "View on IMDb"
+msgstr "Bei IMDb ansehen"
+
+#: lib/vutuv_web/live/post_live/composer.ex:731
+#, elixir-autogen, elixir-format
+msgid "Watched as… (optional)"
+msgstr "Wie gesehen? (optional)"
+
+#: lib/vutuv_web/live/post_live/composer.ex:745
+#, elixir-autogen, elixir-format
+msgid "With an ISBN, the post shows the book cover and a shop link automatically."
+msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link."
+
+#: lib/vutuv_web/live/post_live/composer.ex:725
+#, elixir-autogen, elixir-format
+msgid "Year"
+msgstr "Jahr"

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -172,3 +172,12 @@ msgid "The handle %{handles} does not exist. Remove the mention or check the spe
 msgid_plural "The handle %{handles} does not exist. Remove the mention or check the spelling."
 msgstr[0] "Den Handle %{handles} gibt es nicht. Entferne die Erwähnung oder überprüfe die Schreibweise."
 msgstr[1] "Diese Handles gibt es nicht: %{handles}. Entferne die Erwähnungen oder überprüfe die Schreibweise."
+
+msgid "is not a valid ISBN"
+msgstr "ist keine gültige ISBN"
+
+msgid "is not a valid IMDb link"
+msgstr "ist kein gültiger IMDb-Link"
+
+msgid "the review is missing the title of the work"
+msgstr "der Besprechung fehlt der Titel des Werks"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -17,8 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2709
-#: lib/vutuv_web/components/ui.ex:2714
+#: lib/vutuv_web/components/ui.ex:2751
+#: lib/vutuv_web/components/ui.ex:2756
 #: lib/vutuv_web/live/organization_live/domains.ex:235
 #: lib/vutuv_web/live/organization_live/edit.ex:382
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -26,9 +26,9 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:194
-#: lib/vutuv_web/agent_docs/section_docs.ex:114
-#: lib/vutuv_web/agent_docs/text.ex:191
+#: lib/vutuv_web/agent_docs/markdown.ex:200
+#: lib/vutuv_web/agent_docs/section_docs.ex:118
+#: lib/vutuv_web/agent_docs/text.ex:196
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:110
@@ -36,7 +36,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1117
+#: lib/vutuv_web/templates/user/show.html.heex:1150
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -58,9 +58,9 @@ msgstr ""
 msgid "Address updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:61
-#: lib/vutuv_web/agent_docs/text.ex:60
-#: lib/vutuv_web/components/ui.ex:2853
+#: lib/vutuv_web/agent_docs/markdown.ex:66
+#: lib/vutuv_web/agent_docs/text.ex:64
+#: lib/vutuv_web/components/ui.ex:2896
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -78,8 +78,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2514
-#: lib/vutuv_web/components/ui.ex:2608
+#: lib/vutuv_web/components/ui.ex:2556
+#: lib/vutuv_web/components/ui.ex:2650
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #, elixir-autogen
 msgid "Are you sure?"
@@ -95,17 +95,17 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:415
-#: lib/vutuv_web/agent_docs/markdown.ex:416
-#: lib/vutuv_web/agent_docs/text.ex:420
-#: lib/vutuv_web/agent_docs/text.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:422
+#: lib/vutuv_web/agent_docs/text.ex:425
+#: lib/vutuv_web/agent_docs/text.ex:426
 #: lib/vutuv_web/templates/user/show.html.heex:815
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:2507
+#: lib/vutuv_web/components/ui.ex:2549
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -136,8 +136,11 @@ msgstr ""
 msgid "Choose One"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:51
+#: lib/vutuv_web/agent_docs/markdown.ex:52
 #: lib/vutuv_web/agent_docs/text.ex:50
+#: lib/vutuv_web/templates/messenger/card_list.html.heex:6
+#: lib/vutuv_web/templates/messenger/form_content.html.heex:13
+#: lib/vutuv_web/templates/messenger/show.html.heex:21
 #: lib/vutuv_web/templates/user/show.html.heex:853
 #, elixir-autogen
 msgid "Contact"
@@ -147,8 +150,8 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:806
-#: lib/vutuv_web/components/ui.ex:2611
+#: lib/vutuv_web/components/post_components.ex:811
+#: lib/vutuv_web/components/ui.ex:2653
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -192,8 +195,8 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:799
-#: lib/vutuv_web/components/ui.ex:2602
+#: lib/vutuv_web/components/post_components.ex:804
+#: lib/vutuv_web/components/ui.ex:2644
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -209,6 +212,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/edit.html.heex:4
 #: lib/vutuv_web/templates/email/edit.html.heex:5
 #: lib/vutuv_web/templates/language/edit.html.heex:4
+#: lib/vutuv_web/templates/messenger/edit.html.heex:4
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:4
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
@@ -289,12 +293,12 @@ msgstr ""
 msgid "Enter your last name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:35
+#: lib/vutuv_web/agent_docs/markdown.ex:36
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:2845
-#: lib/vutuv_web/controllers/work_experience_controller.ex:40
-#: lib/vutuv_web/controllers/work_experience_controller.ex:57
-#: lib/vutuv_web/controllers/work_experience_controller.ex:135
+#: lib/vutuv_web/components/ui.ex:2887
+#: lib/vutuv_web/controllers/work_experience_controller.ex:42
+#: lib/vutuv_web/controllers/work_experience_controller.ex:59
+#: lib/vutuv_web/controllers/work_experience_controller.ex:148
 #: lib/vutuv_web/templates/user/show.html.heex:485
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:3
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
@@ -315,8 +319,8 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:427
-#: lib/vutuv_web/agent_docs/text.ex:432
+#: lib/vutuv_web/agent_docs/markdown.ex:433
+#: lib/vutuv_web/agent_docs/text.ex:437
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -324,14 +328,14 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:428
-#: lib/vutuv_web/agent_docs/text.ex:433
-#: lib/vutuv_web/components/ui.ex:1283
-#: lib/vutuv_web/components/ui.ex:1308
-#: lib/vutuv_web/components/ui.ex:1311
-#: lib/vutuv_web/components/ui.ex:1318
-#: lib/vutuv_web/components/ui.ex:1321
-#: lib/vutuv_web/components/ui.ex:1379
+#: lib/vutuv_web/agent_docs/markdown.ex:434
+#: lib/vutuv_web/agent_docs/text.ex:438
+#: lib/vutuv_web/components/ui.ex:1287
+#: lib/vutuv_web/components/ui.ex:1312
+#: lib/vutuv_web/components/ui.ex:1315
+#: lib/vutuv_web/components/ui.ex:1322
+#: lib/vutuv_web/components/ui.ex:1325
+#: lib/vutuv_web/components/ui.ex:1383
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
@@ -340,8 +344,8 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:414
-#: lib/vutuv_web/agent_docs/text.ex:419
+#: lib/vutuv_web/agent_docs/markdown.ex:420
+#: lib/vutuv_web/agent_docs/text.ex:424
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -409,9 +413,9 @@ msgstr ""
 msgid "Link updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:50
+#: lib/vutuv_web/agent_docs/markdown.ex:51
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:2849
+#: lib/vutuv_web/components/ui.ex:2891
 #: lib/vutuv_web/controllers/url_controller.ex:23
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
@@ -461,7 +465,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2864
+#: lib/vutuv_web/components/ui.ex:2907
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -488,6 +492,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/email/new.html.heex:5
 #: lib/vutuv_web/templates/language/new.html.heex:4
+#: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/phone_number/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
@@ -548,8 +553,8 @@ msgid_plural "Phone Numbers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:58
-#: lib/vutuv_web/agent_docs/text.ex:57
+#: lib/vutuv_web/agent_docs/markdown.ex:63
+#: lib/vutuv_web/agent_docs/text.ex:61
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:3
 #: lib/vutuv_web/templates/phone_number/index.html.heex:10
 #: lib/vutuv_web/templates/phone_number/new.html.heex:3
@@ -593,7 +598,7 @@ msgstr ""
 msgid "Privacy Policy"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:237
+#: lib/vutuv_web/live/section_reorder_live.ex:248
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -618,8 +623,8 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:574
-#: lib/vutuv_web/live/section_reorder_live.ex:236
+#: lib/vutuv_web/live/post_live/composer.ex:797
+#: lib/vutuv_web/live/section_reorder_live.ex:247
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -633,18 +638,18 @@ msgid "Public (Everyone can view) or Private (Only you can view)"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:327
-#: lib/vutuv_web/live/post_live/composer.ex:583
+#: lib/vutuv_web/live/post_live/composer.ex:806
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:83
-#: lib/vutuv_web/templates/settings/notifications.html.heex:66
+#: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
 #: lib/vutuv_web/templates/settings/preferences.html.heex:180
 #: lib/vutuv_web/templates/settings/privacy.html.heex:64
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:342
-#: lib/vutuv_web/views/settings_html.ex:135
+#: lib/vutuv_web/views/settings_html.ex:131
 #, elixir-autogen
 msgid "Save"
 msgstr ""
@@ -682,9 +687,9 @@ msgstr ""
 msgid "Slug"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:53
+#: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:52
-#: lib/vutuv_web/components/ui.ex:2850
+#: lib/vutuv_web/components/ui.ex:2892
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
@@ -708,7 +713,7 @@ msgstr ""
 msgid "Add a profile"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:95
+#: lib/vutuv_web/agent_docs/section_docs.ex:97
 #, elixir-autogen, elixir-format
 msgid "Profiles of %{name}"
 msgstr ""
@@ -746,12 +751,12 @@ msgstr ""
 #: lib/vutuv_web/controllers/block_controller.ex:31
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:112
+#: lib/vutuv_web/live/user_profile_live.ex:113
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2508
+#: lib/vutuv_web/components/ui.ex:2550
 #, elixir-autogen
 msgid "Submit"
 msgstr ""
@@ -827,6 +832,8 @@ msgstr ""
 #: lib/vutuv_web/templates/follower/index.html.heex:2
 #: lib/vutuv_web/templates/language/index.html.heex:8
 #: lib/vutuv_web/templates/language/show.html.heex:4
+#: lib/vutuv_web/templates/messenger/index.html.heex:8
+#: lib/vutuv_web/templates/messenger/show.html.heex:4
 #: lib/vutuv_web/templates/phone_number/index.html.heex:8
 #: lib/vutuv_web/templates/phone_number/show.html.heex:4
 #: lib/vutuv_web/templates/qualification/index.html.heex:9
@@ -844,13 +851,13 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:577
+#: lib/vutuv_web/components/ui.ex:581
 #: lib/vutuv_web/templates/user/show.html.heex:279
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2672
+#: lib/vutuv_web/components/ui.ex:2714
 #: lib/vutuv_web/templates/user/show.html.heex:757
 #: lib/vutuv_web/templates/user/show.html.heex:777
 #, elixir-autogen
@@ -892,17 +899,17 @@ msgstr ""
 msgid "Work Experiences"
 msgstr ""
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:110
+#: lib/vutuv_web/controllers/work_experience_controller.ex:122
 #, elixir-autogen
 msgid "Work experience created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:204
+#: lib/vutuv_web/controllers/work_experience_controller.ex:217
 #, elixir-autogen
 msgid "Work experience deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:156
+#: lib/vutuv_web/controllers/work_experience_controller.ex:169
 #, elixir-autogen
 msgid "Work experience updated successfully."
 msgstr ""
@@ -1031,14 +1038,14 @@ msgstr ""
 msgid "Select a year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:732
+#: lib/vutuv/accounts/user.ex:740
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:731
+#: lib/vutuv/accounts/user.ex:739
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1446,13 +1453,13 @@ msgstr ""
 msgid "Tag urls"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:31
-#: lib/vutuv_web/agent_docs/markdown.ex:354
-#: lib/vutuv_web/agent_docs/markdown.ex:729
+#: lib/vutuv_web/agent_docs/markdown.ex:32
+#: lib/vutuv_web/agent_docs/markdown.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:745
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:388
-#: lib/vutuv_web/agent_docs/text.ex:540
-#: lib/vutuv_web/components/ui.ex:2854
+#: lib/vutuv_web/agent_docs/text.ex:393
+#: lib/vutuv_web/agent_docs/text.ex:554
+#: lib/vutuv_web/components/ui.ex:2897
 #: lib/vutuv_web/controllers/user_tag_controller.ex:37
 #: lib/vutuv_web/controllers/user_tag_controller.ex:54
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1663,7 +1670,7 @@ msgstr ""
 msgid "Admin Area"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:97
+#: lib/vutuv_web/agent_docs/section_docs.ex:100
 #: lib/vutuv_web/templates/address/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Addresses of %{name}"
@@ -1694,8 +1701,8 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:460
-#: lib/vutuv_web/live/post_live/composer.ex:461
+#: lib/vutuv_web/live/post_live/composer.ex:552
+#: lib/vutuv_web/live/post_live/composer.ex:553
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1741,23 +1748,23 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:946
-#: lib/vutuv_web/components/ui.ex:955
-#: lib/vutuv_web/components/ui.ex:1130
+#: lib/vutuv_web/components/ui.ex:950
+#: lib/vutuv_web/components/ui.ex:959
+#: lib/vutuv_web/components/ui.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1248
-#: lib/vutuv_web/components/ui.ex:1248
-#: lib/vutuv_web/components/ui.ex:1265
-#: lib/vutuv_web/components/ui.ex:1274
-#: lib/vutuv_web/components/ui.ex:1290
-#: lib/vutuv_web/components/ui.ex:1327
-#: lib/vutuv_web/components/ui.ex:1330
-#: lib/vutuv_web/components/ui.ex:1337
-#: lib/vutuv_web/components/ui.ex:1340
-#: lib/vutuv_web/components/ui.ex:1413
+#: lib/vutuv_web/components/ui.ex:1252
+#: lib/vutuv_web/components/ui.ex:1252
+#: lib/vutuv_web/components/ui.ex:1269
+#: lib/vutuv_web/components/ui.ex:1278
+#: lib/vutuv_web/components/ui.ex:1294
+#: lib/vutuv_web/components/ui.ex:1331
+#: lib/vutuv_web/components/ui.ex:1334
+#: lib/vutuv_web/components/ui.ex:1341
+#: lib/vutuv_web/components/ui.ex:1344
+#: lib/vutuv_web/components/ui.ex:1417
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1773,7 +1780,7 @@ msgid "It doesn't look like you're following anyone yet. Open the profile of som
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:473
-#: lib/vutuv_web/views/settings_html.ex:222
+#: lib/vutuv_web/views/settings_html.ex:218
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -1808,25 +1815,25 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:275
-#: lib/vutuv_web/components/ui.ex:2711
+#: lib/vutuv_web/components/post_components.ex:280
+#: lib/vutuv_web/components/ui.ex:2753
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:237
+#: lib/vutuv_web/live/notification_live/index.ex:265
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2868
+#: lib/vutuv_web/components/ui.ex:2911
 #: lib/vutuv_web/live/notification_live/index.ex:66
-#: lib/vutuv_web/live/notification_live/index.ex:135
+#: lib/vutuv_web/live/notification_live/index.ex:140
 #: lib/vutuv_web/live/shell_live.ex:373
 #: lib/vutuv_web/templates/layout/app.html.heex:118
-#: lib/vutuv_web/templates/settings/notifications.html.heex:7
+#: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
@@ -1866,7 +1873,7 @@ msgstr ""
 msgid "Submit a bug report or feature request"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:100
+#: lib/vutuv_web/agent_docs/section_docs.ex:103
 #: lib/vutuv_web/templates/user_tag/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Tags of %{name}"
@@ -1911,7 +1918,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1201
+#: lib/vutuv_web/templates/user/show.html.heex:1234
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1947,35 +1954,35 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:351
+#: lib/vutuv_web/live/notification_live/index.ex:391
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:353
+#: lib/vutuv_web/live/notification_live/index.ex:393
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:348
+#: lib/vutuv_web/live/notification_live/index.ex:388
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2141
-#: lib/vutuv_web/components/ui.ex:2286
+#: lib/vutuv_web/components/ui.ex:2145
+#: lib/vutuv_web/components/ui.ex:2290
 #: lib/vutuv_web/live/organization_live/index.ex:130
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:255
+#: lib/vutuv_web/live/notification_live/index.ex:283
 #, elixir-autogen, elixir-format
 msgid "Load %{count} of %{remaining} more"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2736
-#: lib/vutuv_web/live/notification_live/index.ex:252
+#: lib/vutuv_web/components/ui.ex:2778
+#: lib/vutuv_web/live/notification_live/index.ex:280
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -1985,13 +1992,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2517
+#: lib/vutuv_web/components/ui.ex:2559
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:699
-#: lib/vutuv_web/components/ui.ex:709
+#: lib/vutuv_web/components/ui.ex:703
+#: lib/vutuv_web/components/ui.ex:713
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -2030,12 +2037,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1904
+#: lib/vutuv_web/components/ui.ex:1908
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1908
+#: lib/vutuv_web/components/ui.ex:1912
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2060,37 +2067,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1912
+#: lib/vutuv_web/components/ui.ex:1916
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1902
+#: lib/vutuv_web/components/ui.ex:1906
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1901
+#: lib/vutuv_web/components/ui.ex:1905
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1907
+#: lib/vutuv_web/components/ui.ex:1911
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1906
+#: lib/vutuv_web/components/ui.ex:1910
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1903
+#: lib/vutuv_web/components/ui.ex:1907
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1905
+#: lib/vutuv_web/components/ui.ex:1909
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2105,17 +2112,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1911
+#: lib/vutuv_web/components/ui.ex:1915
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1910
+#: lib/vutuv_web/components/ui.ex:1914
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1909
+#: lib/vutuv_web/components/ui.ex:1913
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2128,12 +2135,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:563
+#: lib/vutuv_web/live/post_live/composer.ex:759
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:691
+#: lib/vutuv_web/live/post_live/composer.ex:914
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2144,7 +2151,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:531
+#: lib/vutuv_web/live/post_live/composer.ex:623
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2154,13 +2161,13 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:803
+#: lib/vutuv_web/components/post_components.ex:808
 #: lib/vutuv_web/live/post_live/edit.ex:117
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:496
+#: lib/vutuv_web/live/post_live/composer.ex:588
 #, elixir-autogen, elixir-format
 msgid "Describe this image (alt text)"
 msgstr ""
@@ -2190,29 +2197,29 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:667
+#: lib/vutuv_web/live/post_live/composer.ex:890
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:595
+#: lib/vutuv_web/live/post_live/composer.ex:818
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:788
-#: lib/vutuv_web/components/post_components.ex:790
+#: lib/vutuv_web/components/post_components.ex:793
+#: lib/vutuv_web/components/post_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:637
+#: lib/vutuv_web/live/post_live/composer.ex:860
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:278
-#: lib/vutuv_web/live/post_live/composer.ex:338
+#: lib/vutuv_web/live/post_live/composer.ex:361
+#: lib/vutuv_web/live/post_live/composer.ex:421
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2222,23 +2229,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:272
+#: lib/vutuv_web/live/post_live/composer.ex:355
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:627
+#: lib/vutuv_web/live/post_live/composer.ex:850
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:617
+#: lib/vutuv_web/live/post_live/composer.ex:840
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:121
-#: lib/vutuv_web/live/post_live/composer.ex:583
+#: lib/vutuv_web/live/post_live/composer.ex:806
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2249,7 +2256,7 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:76
+#: lib/vutuv_web/agent_docs/post_doc.ex:80
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:73
@@ -2264,13 +2271,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1170
-#: lib/vutuv_web/components/post_components.ex:1174
+#: lib/vutuv_web/components/post_components.ex:1181
+#: lib/vutuv_web/components/post_components.ex:1185
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1171
+#: lib/vutuv_web/components/post_components.ex:1182
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2280,16 +2287,16 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:209
 #: lib/vutuv_web/live/organization_live/edit.ex:359
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:653
+#: lib/vutuv_web/live/post_live/composer.ex:876
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:268
+#: lib/vutuv_web/views/settings_html.ex:264
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:514
+#: lib/vutuv_web/live/post_live/composer.ex:606
 #, elixir-autogen, elixir-format
 msgid "Remove image"
 msgstr ""
@@ -2299,7 +2306,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:581
+#: lib/vutuv_web/live/post_live/composer.ex:804
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2317,12 +2324,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:362
+#: lib/vutuv_web/live/post_live/composer.ex:445
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:266
+#: lib/vutuv_web/live/post_live/composer.ex:349
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2332,77 +2339,77 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:722
+#: lib/vutuv_web/live/post_live/composer.ex:945
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:723
+#: lib/vutuv_web/live/post_live/composer.ex:946
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3041
+#: lib/vutuv_web/components/ui.ex:3084
 #: lib/vutuv_web/live/shell_live.ex:416
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:169
+#: lib/vutuv_web/views/settings_html.ex:165
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:472
+#: lib/vutuv_web/live/post_live/composer.ex:564
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:473
+#: lib/vutuv_web/live/post_live/composer.ex:565
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:785
+#: lib/vutuv_web/components/post_components.ex:790
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1426
+#: lib/vutuv_web/components/post_components.ex:1540
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1430
+#: lib/vutuv_web/components/post_components.ex:1544
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1428
+#: lib/vutuv_web/components/post_components.ex:1542
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1429
+#: lib/vutuv_web/components/post_components.ex:1543
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:297
+#: lib/vutuv_web/views/settings_html.ex:293
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:546
+#: lib/vutuv_web/live/post_live/composer.ex:638
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:713
+#: lib/vutuv_web/live/post_live/composer.ex:936
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:717
+#: lib/vutuv_web/live/post_live/composer.ex:940
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2422,16 +2429,16 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1498
-#: lib/vutuv_web/components/ui.ex:1608
-#: lib/vutuv_web/components/ui.ex:1608
-#: lib/vutuv_web/components/ui.ex:2216
+#: lib/vutuv_web/components/post_components.ex:1612
+#: lib/vutuv_web/components/ui.ex:1612
+#: lib/vutuv_web/components/ui.ex:1612
+#: lib/vutuv_web/components/ui.ex:2220
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:761
+#: lib/vutuv_web/agent_docs/markdown.ex:777
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:355
@@ -2441,17 +2448,17 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1465
-#: lib/vutuv_web/components/ui.ex:1637
-#: lib/vutuv_web/components/ui.ex:1637
-#: lib/vutuv_web/components/ui.ex:2202
-#: lib/vutuv_web/live/notification_live/index.ex:300
+#: lib/vutuv_web/components/post_components.ex:1579
+#: lib/vutuv_web/components/ui.ex:1641
+#: lib/vutuv_web/components/ui.ex:1641
+#: lib/vutuv_web/components/ui.ex:2206
+#: lib/vutuv_web/live/notification_live/index.ex:329
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:760
+#: lib/vutuv_web/agent_docs/markdown.ex:776
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:424
@@ -2470,48 +2477,48 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1487
+#: lib/vutuv_web/components/post_components.ex:1601
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1498
-#: lib/vutuv_web/components/ui.ex:1598
-#: lib/vutuv_web/components/ui.ex:1598
+#: lib/vutuv_web/components/post_components.ex:1612
+#: lib/vutuv_web/components/ui.ex:1602
+#: lib/vutuv_web/components/ui.ex:1602
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1484
+#: lib/vutuv_web/components/post_components.ex:1598
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1305
+#: lib/vutuv_web/components/post_components.ex:1316
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1484
+#: lib/vutuv_web/components/post_components.ex:1598
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1465
-#: lib/vutuv_web/components/ui.ex:1627
-#: lib/vutuv_web/components/ui.ex:1627
+#: lib/vutuv_web/components/post_components.ex:1579
+#: lib/vutuv_web/components/ui.ex:1631
+#: lib/vutuv_web/components/ui.ex:1631
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1243
-#: lib/vutuv_web/components/ui.ex:1243
-#: lib/vutuv_web/components/ui.ex:1380
+#: lib/vutuv_web/components/ui.ex:1247
+#: lib/vutuv_web/components/ui.ex:1247
+#: lib/vutuv_web/components/ui.ex:1384
 #: lib/vutuv_web/live/post_live/feed.ex:665
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
 #, elixir-autogen, elixir-format
@@ -2523,45 +2530,45 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1538
+#: lib/vutuv_web/components/post_components.ex:1652
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:102
-#: lib/vutuv_web/agent_docs/text.ex:100
-#: lib/vutuv_web/components/post_components.ex:264
+#: lib/vutuv_web/agent_docs/markdown.ex:108
+#: lib/vutuv_web/agent_docs/text.ex:105
+#: lib/vutuv_web/components/post_components.ex:269
 #: lib/vutuv_web/templates/post/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1521
-#: lib/vutuv_web/components/post_components.ex:1522
-#: lib/vutuv_web/live/notification_live/index.ex:207
-#: lib/vutuv_web/live/notification_live/index.ex:299
+#: lib/vutuv_web/components/post_components.ex:1635
+#: lib/vutuv_web/components/post_components.ex:1636
+#: lib/vutuv_web/live/notification_live/index.ex:212
+#: lib/vutuv_web/live/notification_live/index.ex:328
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:756
+#: lib/vutuv_web/components/post_components.ex:761
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:269
-#: lib/vutuv_web/live/post_live/composer.ex:571
+#: lib/vutuv_web/live/post_live/composer.ex:352
+#: lib/vutuv_web/live/post_live/composer.ex:794
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:698
+#: lib/vutuv_web/live/post_live/composer.ex:921
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:355
+#: lib/vutuv_web/live/notification_live/index.ex:395
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2571,12 +2578,12 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:751
+#: lib/vutuv_web/components/post_components.ex:756
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:745
+#: lib/vutuv_web/components/post_components.ex:750
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2637,7 +2644,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1780
+#: lib/vutuv_web/components/ui.ex:1784
 #: lib/vutuv_web/live/message_live/index.ex:596
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2730,7 +2737,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:413
+#: lib/vutuv_web/components/ui.ex:417
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2740,7 +2747,7 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:422
+#: lib/vutuv_web/components/ui.ex:426
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
@@ -2758,7 +2765,7 @@ msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1119
+#: lib/vutuv_web/templates/user/show.html.heex:1152
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
@@ -2780,18 +2787,18 @@ msgstr ""
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:956
+#: lib/vutuv_web/live/user_profile_live.ex:960
 #: lib/vutuv_web/templates/user/show.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2347
-#: lib/vutuv_web/components/ui.ex:2674
+#: lib/vutuv_web/components/ui.ex:2351
+#: lib/vutuv_web/components/ui.ex:2716
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
-#: lib/vutuv_web/templates/settings/privacy.html.heex:130
+#: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
 #, elixir-autogen, elixir-format
@@ -2830,15 +2837,15 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:429
-#: lib/vutuv_web/agent_docs/text.ex:434
+#: lib/vutuv_web/agent_docs/markdown.ex:435
+#: lib/vutuv_web/agent_docs/text.ex:439
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:568
+#: lib/vutuv_web/components/ui.ex:572
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2848,17 +2855,17 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:583
+#: lib/vutuv_web/components/ui.ex:587
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:607
+#: lib/vutuv_web/live/post_live/composer.ex:830
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:569
+#: lib/vutuv_web/components/ui.ex:573
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2876,7 +2883,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1427
+#: lib/vutuv_web/components/post_components.ex:1541
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2886,22 +2893,22 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:307
+#: lib/vutuv_web/live/notification_live/index.ex:337
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:301
+#: lib/vutuv_web/live/notification_live/index.ex:330
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:298
+#: lib/vutuv_web/live/notification_live/index.ex:327
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:297
+#: lib/vutuv_web/live/notification_live/index.ex:326
 #: lib/vutuv_web/templates/user/show.html.heex:744
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2914,7 +2921,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:356
+#: lib/vutuv_web/live/notification_live/index.ex:396
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2946,12 +2953,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:378
+#: lib/vutuv_web/live/notification_live/index.ex:418
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:379
+#: lib/vutuv_web/live/notification_live/index.ex:419
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -2981,8 +2988,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:273
-#: lib/vutuv_web/agent_docs/text.ex:266
+#: lib/vutuv_web/agent_docs/markdown.ex:279
+#: lib/vutuv_web/agent_docs/text.ex:271
 #: lib/vutuv_web/controllers/page_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3057,7 +3064,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:302
+#: lib/vutuv_web/live/notification_live/index.ex:331
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3137,7 +3144,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:733
+#: lib/vutuv_web/components/post_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3186,7 +3193,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2842
+#: lib/vutuv_web/components/ui.ex:2884
 #: lib/vutuv_web/live/shell_live.ex:325
 #: lib/vutuv_web/live/shell_live.ex:509
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3212,7 +3219,7 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:827
+#: lib/vutuv_web/components/post_components.ex:832
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3295,7 +3302,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2116
+#: lib/vutuv_web/components/ui.ex:2120
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3476,12 +3483,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:381
+#: lib/vutuv_web/live/notification_live/index.ex:421
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:380
+#: lib/vutuv_web/live/notification_live/index.ex:420
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3491,7 +3498,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:382
+#: lib/vutuv_web/live/notification_live/index.ex:422
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3680,7 +3687,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:405
+#: lib/vutuv_web/live/notification_live/index.ex:445
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3705,7 +3712,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:304
+#: lib/vutuv_web/live/notification_live/index.ex:333
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3780,7 +3787,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:410
+#: lib/vutuv_web/live/notification_live/index.ex:450
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -3865,30 +3872,30 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:516
+#: lib/vutuv_web/agent_docs/markdown.ex:523
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:773
+#: lib/vutuv_web/agent_docs/markdown.ex:816
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:114
-#: lib/vutuv_web/agent_docs/text.ex:111
+#: lib/vutuv_web/agent_docs/markdown.ex:120
+#: lib/vutuv_web/agent_docs/text.ex:116
 #, elixir-autogen, elixir-format
 msgid "%{count} posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:76
-#: lib/vutuv_web/agent_docs/markdown.ex:137
-#: lib/vutuv_web/agent_docs/markdown.ex:150
-#: lib/vutuv_web/agent_docs/markdown.ex:729
-#: lib/vutuv_web/agent_docs/text.ex:75
-#: lib/vutuv_web/agent_docs/text.ex:134
-#: lib/vutuv_web/agent_docs/text.ex:147
-#: lib/vutuv_web/agent_docs/text.ex:540
+#: lib/vutuv_web/agent_docs/markdown.ex:81
+#: lib/vutuv_web/agent_docs/markdown.ex:143
+#: lib/vutuv_web/agent_docs/markdown.ex:156
+#: lib/vutuv_web/agent_docs/markdown.ex:745
+#: lib/vutuv_web/agent_docs/text.ex:79
+#: lib/vutuv_web/agent_docs/text.ex:139
+#: lib/vutuv_web/agent_docs/text.ex:152
+#: lib/vutuv_web/agent_docs/text.ex:554
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3898,39 +3905,39 @@ msgstr ""
 msgid "Followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:101
-#: lib/vutuv_web/agent_docs/text.ex:98
+#: lib/vutuv_web/agent_docs/markdown.ex:107
+#: lib/vutuv_web/agent_docs/text.ex:103
 #: lib/vutuv_web/live/job_posting_live/form.ex:493
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:747
-#: lib/vutuv_web/agent_docs/text.ex:551
+#: lib/vutuv_web/agent_docs/markdown.ex:763
+#: lib/vutuv_web/agent_docs/text.ex:565
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:744
-#: lib/vutuv_web/agent_docs/text.ex:548
+#: lib/vutuv_web/agent_docs/markdown.ex:760
+#: lib/vutuv_web/agent_docs/text.ex:562
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:751
-#: lib/vutuv_web/agent_docs/text.ex:554
+#: lib/vutuv_web/agent_docs/markdown.ex:767
+#: lib/vutuv_web/agent_docs/text.ex:568
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:412
-#: lib/vutuv_web/agent_docs/text.ex:417
+#: lib/vutuv_web/agent_docs/markdown.ex:418
+#: lib/vutuv_web/agent_docs/text.ex:422
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:163
-#: lib/vutuv_web/agent_docs/text.ex:160
+#: lib/vutuv_web/agent_docs/markdown.ex:169
+#: lib/vutuv_web/agent_docs/text.ex:165
 #, elixir-autogen, elixir-format
 msgid "Most endorsed members"
 msgstr ""
@@ -3945,42 +3952,42 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:77
+#: lib/vutuv_web/agent_docs/post_doc.ex:81
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:96
-#: lib/vutuv_web/agent_docs/text.ex:93
+#: lib/vutuv_web/agent_docs/markdown.ex:101
+#: lib/vutuv_web/agent_docs/text.ex:97
 #: lib/vutuv_web/live/admin/screenshot_live.ex:96
 #: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:63
-#: lib/vutuv_web/agent_docs/text.ex:62
+#: lib/vutuv_web/agent_docs/markdown.ex:68
+#: lib/vutuv_web/agent_docs/text.ex:66
 #, elixir-autogen, elixir-format
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:408
-#: lib/vutuv_web/agent_docs/text.ex:413
+#: lib/vutuv_web/agent_docs/markdown.ex:414
+#: lib/vutuv_web/agent_docs/text.ex:418
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:698
+#: lib/vutuv_web/agent_docs/markdown.ex:714
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:637
+#: lib/vutuv_web/agent_docs/markdown.ex:644
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:638
+#: lib/vutuv_web/agent_docs/markdown.ex:645
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -3995,22 +4002,22 @@ msgstr ""
 msgid "Connections of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:99
+#: lib/vutuv_web/agent_docs/section_docs.ex:102
 #, elixir-autogen, elixir-format
 msgid "Email addresses of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:92
+#: lib/vutuv_web/agent_docs/section_docs.ex:94
 #, elixir-autogen, elixir-format
 msgid "Links of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:98
+#: lib/vutuv_web/agent_docs/section_docs.ex:101
 #, elixir-autogen, elixir-format
 msgid "Phone numbers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:85
+#: lib/vutuv_web/agent_docs/section_docs.ex:87
 #, elixir-autogen, elixir-format
 msgid "Work experience of %{name}"
 msgstr ""
@@ -4055,8 +4062,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/text.ex:274
+#: lib/vutuv_web/agent_docs/markdown.ex:293
+#: lib/vutuv_web/agent_docs/text.ex:279
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4105,8 +4112,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:277
-#: lib/vutuv_web/agent_docs/text.ex:270
+#: lib/vutuv_web/agent_docs/markdown.ex:283
+#: lib/vutuv_web/agent_docs/text.ex:275
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4122,8 +4129,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:274
-#: lib/vutuv_web/agent_docs/text.ex:267
+#: lib/vutuv_web/agent_docs/markdown.ex:280
+#: lib/vutuv_web/agent_docs/text.ex:272
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4337,14 +4344,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:279
-#: lib/vutuv_web/agent_docs/text.ex:272
+#: lib/vutuv_web/agent_docs/markdown.ex:285
+#: lib/vutuv_web/agent_docs/text.ex:277
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:275
-#: lib/vutuv_web/agent_docs/text.ex:268
+#: lib/vutuv_web/agent_docs/markdown.ex:281
+#: lib/vutuv_web/agent_docs/text.ex:273
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4483,13 +4490,13 @@ msgstr ""
 msgid "Login PINs and other essential emails are not affected."
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:231
+#: lib/vutuv_web/live/section_reorder_live.ex:242
 #: lib/vutuv_web/templates/email/card_list.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Mail to this address bounced. Logging in with a PIN sent to it will clear this warning."
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:232
+#: lib/vutuv_web/live/section_reorder_live.ex:243
 #: lib/vutuv_web/templates/email/card_list.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Undeliverable"
@@ -4513,7 +4520,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:1
 #: lib/vutuv_web/templates/block/index.html.heex:1
-#: lib/vutuv_web/templates/settings/privacy.html.heex:127
+#: lib/vutuv_web/templates/settings/privacy.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Blocked members"
 msgstr ""
@@ -4546,7 +4553,7 @@ msgid "You have not blocked anyone."
 msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:86
-#: lib/vutuv_web/live/user_profile_live.ex:241
+#: lib/vutuv_web/live/user_profile_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr ""
@@ -4603,8 +4610,8 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:302
-#: lib/vutuv_web/agent_docs/text.ex:336
+#: lib/vutuv_web/agent_docs/markdown.ex:308
+#: lib/vutuv_web/agent_docs/text.ex:341
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
@@ -4624,7 +4631,7 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:261
+#: lib/vutuv_web/components/post_components.ex:266
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/search_live.ex:176
@@ -4673,7 +4680,7 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:944
+#: lib/vutuv_web/live/user_profile_live.ex:948
 #: lib/vutuv_web/templates/user/show.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -4722,8 +4729,8 @@ msgstr ""
 msgid "Edit your profile and its sections"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:216
-#: lib/vutuv_web/agent_docs/text.ex:212
+#: lib/vutuv_web/agent_docs/markdown.ex:222
+#: lib/vutuv_web/agent_docs/text.ex:217
 #: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
@@ -4905,7 +4912,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:94
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:31
-#: lib/vutuv_web/views/settings_html.ex:213
+#: lib/vutuv_web/views/settings_html.ex:209
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -5261,7 +5268,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2874
+#: lib/vutuv_web/components/ui.ex:2917
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5297,12 +5304,12 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:275
+#: lib/vutuv_web/live/post_live/composer.ex:358
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:133
+#: lib/vutuv_web/templates/settings/privacy.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Content under review"
 msgstr ""
@@ -5338,9 +5345,9 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2960
-#: lib/vutuv_web/components/ui.ex:2965
-#: lib/vutuv_web/components/ui.ex:3033
+#: lib/vutuv_web/components/ui.ex:3003
+#: lib/vutuv_web/components/ui.ex:3008
+#: lib/vutuv_web/components/ui.ex:3076
 #: lib/vutuv_web/controllers/settings_controller.ex:51
 #: lib/vutuv_web/live/shell_live.ex:444
 #: lib/vutuv_web/live/tag_new_live.ex:44
@@ -5355,6 +5362,8 @@ msgstr ""
 #: lib/vutuv_web/templates/language/edit.html.heex:2
 #: lib/vutuv_web/templates/language/new.html.heex:2
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
+#: lib/vutuv_web/templates/messenger/edit.html.heex:2
+#: lib/vutuv_web/templates/messenger/new.html.heex:2
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:2
 #: lib/vutuv_web/templates/phone_number/new.html.heex:2
 #: lib/vutuv_web/templates/qualification/edit.html.heex:2
@@ -5367,7 +5376,7 @@ msgstr ""
 #: lib/vutuv_web/templates/username/new.html.heex:4
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:2
 #: lib/vutuv_web/templates/work_experience/new.html.heex:2
-#: lib/vutuv_web/views/settings_html.ex:164
+#: lib/vutuv_web/views/settings_html.ex:160
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5402,7 +5411,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:946
+#: lib/vutuv_web/live/user_profile_live.ex:950
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5428,9 +5437,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:869
-#: lib/vutuv_web/components/post_components.ex:923
-#: lib/vutuv_web/components/post_components.ex:1232
+#: lib/vutuv_web/components/post_components.ex:874
+#: lib/vutuv_web/components/post_components.ex:928
+#: lib/vutuv_web/components/post_components.ex:1243
 #: lib/vutuv_web/live/post_live/feed.ex:737
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5446,7 +5455,7 @@ msgstr ""
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:735
+#: lib/vutuv/accounts/user.ex:743
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5484,7 +5493,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2856
+#: lib/vutuv_web/components/ui.ex:2899
 #: lib/vutuv_web/live/admin/user_live.ex:266
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:13
 #, elixir-autogen, elixir-format
@@ -5507,7 +5516,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2851
+#: lib/vutuv_web/components/ui.ex:2894
 #: lib/vutuv_web/controllers/email_controller.ex:30
 #: lib/vutuv_web/controllers/email_controller.ex:49
 #: lib/vutuv_web/controllers/email_controller.ex:191
@@ -5523,7 +5532,7 @@ msgstr ""
 msgid "Notification settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:128
+#: lib/vutuv_web/templates/settings/privacy.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you."
 msgstr ""
@@ -5538,7 +5547,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2866
+#: lib/vutuv_web/components/ui.ex:2909
 #: lib/vutuv_web/templates/settings/privacy.html.heex:9
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5554,7 +5563,7 @@ msgstr ""
 msgid "Third-party apps you authorized."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:136
+#: lib/vutuv_web/templates/settings/privacy.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -5564,12 +5573,12 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:196
+#: lib/vutuv_web/live/notification_live/index.ex:201
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:134
+#: lib/vutuv_web/templates/settings/privacy.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Your posts or profile a moderator is looking at."
 msgstr ""
@@ -5584,7 +5593,7 @@ msgstr ""
 msgid "Download your data"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:11
+#: lib/vutuv_web/templates/settings/notifications.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Email notifications"
 msgstr ""
@@ -5651,7 +5660,7 @@ msgstr ""
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2873
+#: lib/vutuv_web/components/ui.ex:2916
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -5663,23 +5672,23 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:103
-#: lib/vutuv_web/templates/settings/notifications.html.heex:50
+#: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Endorsements"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:80
+#: lib/vutuv_web/templates/settings/notifications.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Endorsements and new followers"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:74
+#: lib/vutuv_web/templates/settings/notifications.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "In-app notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:55
+#: lib/vutuv_web/templates/settings/notifications.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "New followers"
 msgstr ""
@@ -5689,7 +5698,7 @@ msgstr ""
 msgid "Notification settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:88
+#: lib/vutuv_web/templates/settings/notifications.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Open your notifications"
 msgstr ""
@@ -5699,12 +5708,12 @@ msgstr ""
 msgid "Privacy settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:81
+#: lib/vutuv_web/templates/settings/notifications.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:124
+#: lib/vutuv_web/templates/settings/privacy.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr ""
@@ -5714,27 +5723,27 @@ msgstr ""
 msgid "Search engines & AI"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:76
+#: lib/vutuv_web/templates/settings/notifications.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "These are always on. You see them under the bell at the top of every page, in real time."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:25
+#: lib/vutuv_web/templates/settings/notifications.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Unread messages"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:52
+#: lib/vutuv_web/templates/settings/notifications.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "When someone endorses you for one of your tags."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:27
+#: lib/vutuv_web/templates/settings/notifications.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "When someone messages you and you have not read it yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:57
+#: lib/vutuv_web/templates/settings/notifications.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "When someone starts following you."
 msgstr ""
@@ -5785,25 +5794,25 @@ msgid "You cannot block yourself."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:23
-#: lib/vutuv_web/live/user_profile_live.ex:207
+#: lib/vutuv_web/live/user_profile_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Bookmark removed."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:19
-#: lib/vutuv_web/live/user_profile_live.ex:204
+#: lib/vutuv_web/live/user_profile_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Bookmarked."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:31
-#: lib/vutuv_web/live/user_profile_live.ex:213
+#: lib/vutuv_web/live/user_profile_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Like removed."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:27
-#: lib/vutuv_web/live/user_profile_live.ex:210
+#: lib/vutuv_web/live/user_profile_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Liked."
 msgstr ""
@@ -5865,21 +5874,21 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:174
-#: lib/vutuv_web/views/settings_html.ex:306
+#: lib/vutuv_web/views/settings_html.ex:302
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:305
+#: lib/vutuv_web/views/settings_html.ex:301
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:304
+#: lib/vutuv_web/views/settings_html.ex:300
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5896,7 +5905,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:202
+#: lib/vutuv_web/views/settings_html.ex:198
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5911,7 +5920,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:219
+#: lib/vutuv_web/views/settings_html.ex:215
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5936,7 +5945,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:203
+#: lib/vutuv_web/views/settings_html.ex:199
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5946,27 +5955,27 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:303
+#: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:78
+#: lib/vutuv_web/templates/settings/privacy.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:77
+#: lib/vutuv_web/templates/settings/privacy.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:79
+#: lib/vutuv_web/templates/settings/privacy.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Show when I'm online"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:80
+#: lib/vutuv_web/templates/settings/privacy.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
@@ -5977,7 +5986,7 @@ msgid "Add a passkey"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/views/settings_html.ex:254
+#: lib/vutuv_web/views/settings_html.ex:250
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -5987,7 +5996,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:257
+#: lib/vutuv_web/views/settings_html.ex:253
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -5997,7 +6006,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:251
+#: lib/vutuv_web/views/settings_html.ex:247
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -6017,7 +6026,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:265
+#: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6072,7 +6081,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:950
+#: lib/vutuv_web/live/user_profile_live.ex:954
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6083,7 +6092,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:170
+#: lib/vutuv_web/components/ui.ex:174
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:687
@@ -6107,7 +6116,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1166
+#: lib/vutuv_web/templates/user/show.html.heex:1199
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6158,8 +6167,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:417
-#: lib/vutuv_web/agent_docs/text.ex:422
+#: lib/vutuv_web/agent_docs/markdown.ex:423
+#: lib/vutuv_web/agent_docs/text.ex:427
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6231,8 +6240,8 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:760
-#: lib/vutuv_web/components/post_components.ex:263
+#: lib/vutuv_web/agent_docs/markdown.ex:776
+#: lib/vutuv_web/components/post_components.ex:268
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
@@ -6243,29 +6252,29 @@ msgstr ""
 msgid "View all phone numbers"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:107
+#: lib/vutuv_web/live/section_reorder_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:158
+#: lib/vutuv_web/live/section_reorder_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder, or use the arrows. The order is the one shown on your profile."
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:135
+#: lib/vutuv_web/live/section_reorder_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Move down"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:126
+#: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:946
-#: lib/vutuv_web/components/ui.ex:955
-#: lib/vutuv_web/components/ui.ex:1131
+#: lib/vutuv_web/components/ui.ex:950
+#: lib/vutuv_web/components/ui.ex:959
+#: lib/vutuv_web/components/ui.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6292,9 +6301,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1152
-#: lib/vutuv_web/templates/user/show.html.heex:1160
-#: lib/vutuv_web/templates/user/show.html.heex:1172
+#: lib/vutuv_web/templates/user/show.html.heex:1185
+#: lib/vutuv_web/templates/user/show.html.heex:1193
+#: lib/vutuv_web/templates/user/show.html.heex:1205
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6326,13 +6335,14 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1084
-#: lib/vutuv_web/live/notification_live/index.ex:227
+#: lib/vutuv_web/components/ui.ex:1088
+#: lib/vutuv_web/live/notification_live/index.ex:237
+#: lib/vutuv_web/live/notification_live/index.ex:255
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:742
+#: lib/vutuv_web/agent_docs/markdown.ex:758
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6492,7 +6502,7 @@ msgstr ""
 msgid "No deliverability events yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:406
+#: lib/vutuv_web/components/ui.ex:410
 #, elixir-autogen, elixir-format
 msgid "Not getting the PIN? That email address may no longer be working. If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
@@ -6601,19 +6611,19 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1568
+#: lib/vutuv_web/components/ui.ex:1572
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:189
+#: lib/vutuv_web/live/user_profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:79
+#: lib/vutuv_web/templates/settings/notifications.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "New messages and new connections"
 msgstr ""
@@ -6623,14 +6633,14 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1567
+#: lib/vutuv_web/components/ui.ex:1571
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:191
+#: lib/vutuv_web/live/user_profile_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -6645,7 +6655,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:824
+#: lib/vutuv_web/components/post_components.ex:829
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6655,38 +6665,38 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:823
+#: lib/vutuv_web/components/post_components.ex:828
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1538
+#: lib/vutuv_web/components/ui.ex:1542
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1532
+#: lib/vutuv_web/components/ui.ex:1536
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1522
+#: lib/vutuv_web/components/ui.ex:1526
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1473
-#: lib/vutuv_web/components/ui.ex:1522
+#: lib/vutuv_web/components/ui.ex:1477
+#: lib/vutuv_web/components/ui.ex:1526
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1471
+#: lib/vutuv_web/components/ui.ex:1475
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1472
+#: lib/vutuv_web/components/ui.ex:1476
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -6850,8 +6860,8 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:190
-#: lib/vutuv_web/agent_docs/text.ex:187
+#: lib/vutuv_web/agent_docs/markdown.ex:196
+#: lib/vutuv_web/agent_docs/text.ex:192
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -6914,7 +6924,7 @@ msgid "New newsletter"
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:171
-#: lib/vutuv_web/templates/settings/notifications.html.heex:60
+#: lib/vutuv_web/templates/settings/notifications.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Newsletter"
 msgstr ""
@@ -6972,7 +6982,7 @@ msgstr ""
 msgid "Nothing sent yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:62
+#: lib/vutuv_web/templates/settings/notifications.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Occasional vutuv news and announcements."
 msgstr ""
@@ -6992,7 +7002,7 @@ msgstr ""
 msgid "Pick capped members at random"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:13
+#: lib/vutuv_web/templates/settings/notifications.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Pick which emails vutuv may send you. Each email has a one-click unsubscribe."
 msgstr ""
@@ -7248,13 +7258,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2154
+#: lib/vutuv_web/components/ui.ex:2158
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2170
+#: lib/vutuv_web/components/ui.ex:2174
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7507,17 +7517,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:778
+#: lib/vutuv_web/agent_docs/markdown.ex:821
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:781
+#: lib/vutuv_web/agent_docs/markdown.ex:824
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:788
+#: lib/vutuv_web/agent_docs/markdown.ex:831
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -7793,12 +7803,12 @@ msgstr ""
 msgid "Add to audience"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:35
+#: lib/vutuv_web/templates/settings/notifications.html.heex:36
 #, elixir-autogen
 msgid "How often"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:39
+#: lib/vutuv_web/templates/settings/notifications.html.heex:40
 #, elixir-autogen
 msgid "Send the email"
 msgstr ""
@@ -7843,12 +7853,12 @@ msgstr ""
 msgid "Every message"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:44
+#: lib/vutuv_web/templates/settings/notifications.html.heex:45
 #, elixir-autogen
 msgid "We wait a little before emailing, so you can read the message yourself first. These two settings apply only while unread-message emails are on."
 msgstr ""
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:76
+#: lib/vutuv_web/controllers/work_experience_controller.ex:78
 #, elixir-autogen
 msgid "That work experience could not be pinned."
 msgstr ""
@@ -7997,7 +8007,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2157
+#: lib/vutuv_web/components/ui.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8126,12 +8136,12 @@ msgstr ""
 msgid "Degree"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:39
+#: lib/vutuv_web/agent_docs/markdown.ex:40
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:2846
-#: lib/vutuv_web/controllers/education_controller.ex:36
-#: lib/vutuv_web/controllers/education_controller.ex:51
-#: lib/vutuv_web/controllers/education_controller.ex:89
+#: lib/vutuv_web/components/ui.ex:2888
+#: lib/vutuv_web/controllers/education_controller.ex:38
+#: lib/vutuv_web/controllers/education_controller.ex:53
+#: lib/vutuv_web/controllers/education_controller.ex:103
 #: lib/vutuv_web/cv/cv.ex:258
 #: lib/vutuv_web/templates/education/edit.html.heex:3
 #: lib/vutuv_web/templates/education/index.html.heex:5
@@ -8146,22 +8156,22 @@ msgstr ""
 msgid "Education"
 msgstr ""
 
-#: lib/vutuv_web/controllers/education_controller.ex:67
+#: lib/vutuv_web/controllers/education_controller.ex:81
 #, elixir-autogen, elixir-format
 msgid "Education created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/education_controller.ex:120
+#: lib/vutuv_web/controllers/education_controller.ex:134
 #, elixir-autogen, elixir-format
 msgid "Education deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:86
+#: lib/vutuv_web/agent_docs/section_docs.ex:88
 #, elixir-autogen, elixir-format
 msgid "Education of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/education_controller.ex:109
+#: lib/vutuv_web/controllers/education_controller.ex:123
 #, elixir-autogen, elixir-format
 msgid "Education updated successfully."
 msgstr ""
@@ -8182,7 +8192,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2861
+#: lib/vutuv_web/components/ui.ex:2904
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8211,7 +8221,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2852
+#: lib/vutuv_web/components/ui.ex:2895
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8305,12 +8315,12 @@ msgstr ""
 msgid "A photo and a short tagline make your profile complete."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:969
+#: lib/vutuv_web/live/user_profile_live.ex:973
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2393
+#: lib/vutuv_web/components/ui.ex:2397
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:36
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:42
@@ -8330,8 +8340,8 @@ msgstr[1] ""
 msgid "Loading posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:92
-#: lib/vutuv_web/templates/user/show.html.heex:1023
+#: lib/vutuv_web/templates/settings/privacy.html.heex:94
+#: lib/vutuv_web/templates/user/show.html.heex:1056
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8391,13 +8401,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2844
+#: lib/vutuv_web/components/ui.ex:2886
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2860
+#: lib/vutuv_web/components/ui.ex:2903
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8409,7 +8419,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2858
+#: lib/vutuv_web/components/ui.ex:2901
 #: lib/vutuv_web/controllers/settings_controller.ex:89
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:5
@@ -8418,7 +8428,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2862
+#: lib/vutuv_web/components/ui.ex:2905
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8451,17 +8461,17 @@ msgstr ""
 msgid "Suggested posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:94
+#: lib/vutuv_web/templates/settings/privacy.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:98
+#: lib/vutuv_web/templates/settings/privacy.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Show my latest social media posts on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:99
+#: lib/vutuv_web/templates/settings/privacy.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
@@ -8546,7 +8556,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:585
+#: lib/vutuv_web/components/ui.ex:589
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8642,7 +8652,7 @@ msgstr ""
 msgid "Allow followers from the Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2867
+#: lib/vutuv_web/components/ui.ex:2910
 #: lib/vutuv_web/controllers/settings_controller.ex:186
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:265
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
@@ -8732,7 +8742,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:556
+#: lib/vutuv_web/agent_docs/markdown.ex:563
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8753,7 +8763,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:557
+#: lib/vutuv_web/agent_docs/markdown.ex:564
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8784,13 +8794,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:594
+#: lib/vutuv_web/agent_docs/markdown.ex:601
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:593
+#: lib/vutuv_web/agent_docs/markdown.ex:600
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8811,19 +8821,19 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:619
+#: lib/vutuv_web/components/ui.ex:623
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1308
+#: lib/vutuv_web/components/post_components.ex:1319
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:701
+#: lib/vutuv_web/agent_docs/markdown.ex:717
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8850,7 +8860,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:629
+#: lib/vutuv_web/components/ui.ex:633
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8881,7 +8891,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:621
+#: lib/vutuv_web/components/ui.ex:625
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -8901,14 +8911,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:555
+#: lib/vutuv_web/agent_docs/markdown.ex:562
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:558
+#: lib/vutuv_web/agent_docs/markdown.ex:565
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -8945,7 +8955,7 @@ msgstr ""
 msgid "Shown at the top of your profile"
 msgstr ""
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:88
+#: lib/vutuv_web/controllers/work_experience_controller.ex:90
 #, elixir-autogen, elixir-format
 msgid "The job title at the top of your profile is chosen automatically again."
 msgstr ""
@@ -8955,7 +8965,7 @@ msgstr ""
 msgid "The job title at the top of your profile is picked automatically. Right now it's %{job}. Pick a role below to choose it yourself."
 msgstr ""
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:71
+#: lib/vutuv_web/controllers/work_experience_controller.ex:73
 #, elixir-autogen, elixir-format
 msgid "This job title now shows at the top of your profile."
 msgstr ""
@@ -9035,8 +9045,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:988
-#: lib/vutuv_web/components/ui.ex:989
+#: lib/vutuv_web/components/ui.ex:992
+#: lib/vutuv_web/components/ui.ex:993
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:64
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9048,8 +9058,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:438
-#: lib/vutuv_web/agent_docs/text.ex:441
+#: lib/vutuv_web/agent_docs/markdown.ex:444
+#: lib/vutuv_web/agent_docs/text.ex:446
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9275,9 +9285,9 @@ msgstr ""
 msgid "Language updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:47
+#: lib/vutuv_web/agent_docs/markdown.ex:48
 #: lib/vutuv_web/agent_docs/text.ex:46
-#: lib/vutuv_web/components/ui.ex:2848
+#: lib/vutuv_web/components/ui.ex:2890
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
@@ -9295,7 +9305,7 @@ msgstr ""
 msgid "Languages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:91
+#: lib/vutuv_web/agent_docs/section_docs.ex:93
 #, elixir-autogen, elixir-format
 msgid "Languages of %{name}"
 msgstr ""
@@ -9471,14 +9481,14 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:410
-#: lib/vutuv_web/agent_docs/text.ex:415
+#: lib/vutuv_web/agent_docs/markdown.ex:416
+#: lib/vutuv_web/agent_docs/text.ex:420
 #: lib/vutuv_web/templates/user/edit.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:609
+#: lib/vutuv/accounts/user.ex:617
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9489,7 +9499,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:606
+#: lib/vutuv/accounts/user.ex:614
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9576,23 +9586,23 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:631
+#: lib/vutuv_web/agent_docs/markdown.ex:638
 #: lib/vutuv_web/views/qualification_html.ex:10
 #, elixir-autogen, elixir-format
 msgid "Certificate"
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:65
+#: lib/vutuv_web/controllers/qualification_controller.ex:78
 #, elixir-autogen, elixir-format
 msgid "Certificate or license added successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:114
+#: lib/vutuv_web/controllers/qualification_controller.ex:128
 #, elixir-autogen, elixir-format
 msgid "Certificate or license deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:105
+#: lib/vutuv_web/controllers/qualification_controller.ex:119
 #, elixir-autogen, elixir-format
 msgid "Certificate or license updated successfully."
 msgstr ""
@@ -9602,12 +9612,12 @@ msgstr ""
 msgid "Certificates"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:43
+#: lib/vutuv_web/agent_docs/markdown.ex:44
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:2847
-#: lib/vutuv_web/controllers/qualification_controller.ex:33
-#: lib/vutuv_web/controllers/qualification_controller.ex:49
-#: lib/vutuv_web/controllers/qualification_controller.ex:88
+#: lib/vutuv_web/components/ui.ex:2889
+#: lib/vutuv_web/controllers/qualification_controller.ex:35
+#: lib/vutuv_web/controllers/qualification_controller.ex:51
+#: lib/vutuv_web/controllers/qualification_controller.ex:102
 #: lib/vutuv_web/cv/docx.ex:183
 #: lib/vutuv_web/cv/html.ex:172
 #: lib/vutuv_web/cv/latex.ex:140
@@ -9629,7 +9639,7 @@ msgstr ""
 msgid "Certificates & licenses of "
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:89
+#: lib/vutuv_web/agent_docs/section_docs.ex:91
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses of %{name}"
 msgstr ""
@@ -9663,7 +9673,7 @@ msgstr ""
 msgid "Expiry year"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:623
+#: lib/vutuv_web/agent_docs/markdown.ex:630
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9689,7 +9699,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/markdown.ex:637
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9716,7 +9726,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:621
+#: lib/vutuv_web/agent_docs/markdown.ex:628
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9731,14 +9741,14 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:622
+#: lib/vutuv_web/agent_docs/markdown.ex:629
 #: lib/vutuv_web/views/qualification_html.ex:60
 #: lib/vutuv_web/views/qualification_html.ex:63
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:153
+#: lib/vutuv_web/live/section_reorder_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder, or use the arrows. The first language is your preferred contact language."
 msgstr ""
@@ -9748,8 +9758,8 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:525
-#: lib/vutuv_web/live/section_reorder_live.ex:258
+#: lib/vutuv_web/agent_docs/markdown.ex:532
+#: lib/vutuv_web/live/section_reorder_live.ex:269
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
@@ -10145,12 +10155,12 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:158
+#: lib/vutuv_web/components/ui.ex:162
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:238
+#: lib/vutuv_web/components/ui.ex:242
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
@@ -10160,7 +10170,7 @@ msgstr ""
 msgid "Can't scan the code? Enter this key in your app instead:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:230
+#: lib/vutuv_web/components/ui.ex:234
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -10175,17 +10185,17 @@ msgstr ""
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:252
+#: lib/vutuv_web/components/ui.ex:256
 #, elixir-autogen, elixir-format
 msgid "Divider"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:156
+#: lib/vutuv_web/components/ui.ex:160
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:264
+#: lib/vutuv_web/components/ui.ex:268
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -10200,32 +10210,32 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:218
+#: lib/vutuv_web/components/ui.ex:222
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:221
+#: lib/vutuv_web/components/ui.ex:225
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:224
+#: lib/vutuv_web/components/ui.ex:228
 #, elixir-autogen, elixir-format
 msgid "Heading 3"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:167
+#: lib/vutuv_web/components/ui.ex:171
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:161
+#: lib/vutuv_web/components/ui.ex:165
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:151
+#: lib/vutuv_web/components/ui.ex:155
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr ""
@@ -10235,8 +10245,8 @@ msgstr ""
 msgid "Login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:206
-#: lib/vutuv_web/components/ui.ex:207
+#: lib/vutuv_web/components/ui.ex:210
+#: lib/vutuv_web/components/ui.ex:211
 #, elixir-autogen, elixir-format
 msgid "More formatting"
 msgstr ""
@@ -10247,7 +10257,7 @@ msgstr ""
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:241
+#: lib/vutuv_web/components/ui.ex:245
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10262,7 +10272,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:227
+#: lib/vutuv_web/components/ui.ex:231
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10283,12 +10293,12 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:164
+#: lib/vutuv_web/components/ui.ex:168
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:249
+#: lib/vutuv_web/components/ui.ex:253
 #, elixir-autogen, elixir-format
 msgid "Table"
 msgstr ""
@@ -10303,7 +10313,7 @@ msgstr ""
 msgid "To finish, enter the code your app shows now"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:261
+#: lib/vutuv_web/components/ui.ex:265
 #, elixir-autogen, elixir-format
 msgid "Toggle Markdown source"
 msgstr ""
@@ -10389,21 +10399,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:493
+#: lib/vutuv_web/agent_docs/markdown.ex:500
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:491
+#: lib/vutuv_web/agent_docs/markdown.ex:498
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:489
+#: lib/vutuv_web/agent_docs/markdown.ex:496
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10424,19 +10434,19 @@ msgid_plural "%{formatted} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:56
-#: lib/vutuv_web/agent_docs/text.ex:55
-#: lib/vutuv_web/templates/user/show.html.heex:997
+#: lib/vutuv_web/agent_docs/markdown.ex:61
+#: lib/vutuv_web/agent_docs/text.ex:59
+#: lib/vutuv_web/templates/user/show.html.heex:1030
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:110
+#: lib/vutuv_web/templates/settings/privacy.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:112
+#: lib/vutuv_web/templates/settings/privacy.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
@@ -10446,22 +10456,22 @@ msgstr ""
 msgid "Last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:116
+#: lib/vutuv_web/templates/settings/privacy.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Show code statistics on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:117
+#: lib/vutuv_web/templates/settings/privacy.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:507
+#: lib/vutuv_web/agent_docs/markdown.ex:514
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:494
+#: lib/vutuv_web/agent_docs/markdown.ex:501
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10606,7 +10616,7 @@ msgstr ""
 msgid "Manage your vutuv account: profile, privacy, notifications and sign-in."
 msgstr ""
 
-#: lib/vutuv_web/controllers/tag_controller.ex:72
+#: lib/vutuv_web/controllers/tag_controller.ex:85
 #, elixir-autogen, elixir-format
 msgid "Members on vutuv tagged %{tag}."
 msgstr ""
@@ -10987,19 +10997,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:621
+#: lib/vutuv/accounts/user.ex:629
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:626
+#: lib/vutuv/accounts/user.ex:634
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:624
+#: lib/vutuv/accounts/user.ex:632
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
@@ -11305,8 +11315,8 @@ msgstr ""
 msgid "Verified domains"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:191
-#: lib/vutuv_web/agent_docs/text.ex:188
+#: lib/vutuv_web/agent_docs/markdown.ex:197
+#: lib/vutuv_web/agent_docs/text.ex:193
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr ""
@@ -11333,8 +11343,8 @@ msgstr ""
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:193
-#: lib/vutuv_web/agent_docs/text.ex:190
+#: lib/vutuv_web/agent_docs/markdown.ex:199
+#: lib/vutuv_web/agent_docs/text.ex:195
 #: lib/vutuv_web/live/organization_live/edit.ex:273
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -11418,8 +11428,8 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:294
-#: lib/vutuv_web/agent_docs/text.ex:329
+#: lib/vutuv_web/agent_docs/markdown.ex:300
+#: lib/vutuv_web/agent_docs/text.ex:334
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
@@ -11652,8 +11662,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:315
-#: lib/vutuv_web/agent_docs/text.ex:349
+#: lib/vutuv_web/agent_docs/markdown.ex:321
+#: lib/vutuv_web/agent_docs/text.ex:354
 #: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11742,8 +11752,8 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:517
-#: lib/vutuv_web/live/section_reorder_live.ex:182
+#: lib/vutuv_web/components/ui.ex:521
+#: lib/vutuv_web/live/section_reorder_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
 msgstr ""
@@ -11759,7 +11769,7 @@ msgstr ""
 msgid "Verify link"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:189
+#: lib/vutuv_web/live/section_reorder_live.ex:191
 #: lib/vutuv_web/templates/url/card_list.html.heex:32
 #: lib/vutuv_web/templates/url/show.html.heex:29
 #, elixir-autogen, elixir-format
@@ -11786,8 +11796,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:651
-#: lib/vutuv_web/agent_docs/text.ex:521
+#: lib/vutuv_web/agent_docs/markdown.ex:658
+#: lib/vutuv_web/agent_docs/text.ex:535
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11823,8 +11833,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:306
-#: lib/vutuv_web/agent_docs/text.ex:340
+#: lib/vutuv_web/agent_docs/markdown.ex:312
+#: lib/vutuv_web/agent_docs/text.ex:345
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -12007,7 +12017,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:305
+#: lib/vutuv_web/live/notification_live/index.ex:334
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12018,7 +12028,7 @@ msgid "Organization unfrozen."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:2859
+#: lib/vutuv_web/components/ui.ex:2902
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
@@ -12110,22 +12120,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:370
+#: lib/vutuv_web/live/notification_live/index.ex:410
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:367
+#: lib/vutuv_web/live/notification_live/index.ex:407
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:364
+#: lib/vutuv_web/live/notification_live/index.ex:404
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:361
+#: lib/vutuv_web/live/notification_live/index.ex:401
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12268,10 +12278,10 @@ msgstr ""
 msgid "Edit posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:210
-#: lib/vutuv_web/agent_docs/markdown.ex:339
-#: lib/vutuv_web/agent_docs/text.ex:206
-#: lib/vutuv_web/agent_docs/text.ex:373
+#: lib/vutuv_web/agent_docs/markdown.ex:216
+#: lib/vutuv_web/agent_docs/markdown.ex:345
+#: lib/vutuv_web/agent_docs/text.ex:211
+#: lib/vutuv_web/agent_docs/text.ex:378
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Employer"
@@ -12282,10 +12292,10 @@ msgstr ""
 msgid "Employer name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:211
-#: lib/vutuv_web/agent_docs/markdown.ex:340
-#: lib/vutuv_web/agent_docs/text.ex:207
-#: lib/vutuv_web/agent_docs/text.ex:374
+#: lib/vutuv_web/agent_docs/markdown.ex:217
+#: lib/vutuv_web/agent_docs/markdown.ex:346
+#: lib/vutuv_web/agent_docs/text.ex:212
+#: lib/vutuv_web/agent_docs/text.ex:379
 #: lib/vutuv_web/live/job_board_live.ex:281
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
@@ -12358,12 +12368,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:321
-#: lib/vutuv_web/agent_docs/markdown.ex:325
 #: lib/vutuv_web/agent_docs/markdown.ex:327
-#: lib/vutuv_web/agent_docs/text.ex:355
-#: lib/vutuv_web/agent_docs/text.ex:359
-#: lib/vutuv_web/agent_docs/text.ex:361
+#: lib/vutuv_web/agent_docs/markdown.ex:331
+#: lib/vutuv_web/agent_docs/markdown.ex:333
+#: lib/vutuv_web/agent_docs/text.ex:360
+#: lib/vutuv_web/agent_docs/text.ex:364
+#: lib/vutuv_web/agent_docs/text.ex:366
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12412,8 +12422,8 @@ msgstr ""
 msgid "New posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:222
-#: lib/vutuv_web/agent_docs/text.ex:217
+#: lib/vutuv_web/agent_docs/markdown.ex:228
+#: lib/vutuv_web/agent_docs/text.ex:222
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
@@ -12495,10 +12505,10 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:215
-#: lib/vutuv_web/agent_docs/markdown.ex:344
-#: lib/vutuv_web/agent_docs/text.ex:211
-#: lib/vutuv_web/agent_docs/text.ex:378
+#: lib/vutuv_web/agent_docs/markdown.ex:221
+#: lib/vutuv_web/agent_docs/markdown.ex:350
+#: lib/vutuv_web/agent_docs/text.ex:216
+#: lib/vutuv_web/agent_docs/text.ex:383
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12522,10 +12532,10 @@ msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
-#: lib/vutuv_web/agent_docs/markdown.ex:325
-#: lib/vutuv_web/agent_docs/markdown.ex:327
-#: lib/vutuv_web/agent_docs/text.ex:359
-#: lib/vutuv_web/agent_docs/text.ex:361
+#: lib/vutuv_web/agent_docs/markdown.ex:331
+#: lib/vutuv_web/agent_docs/markdown.ex:333
+#: lib/vutuv_web/agent_docs/text.ex:364
+#: lib/vutuv_web/agent_docs/text.ex:366
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format
@@ -12537,18 +12547,18 @@ msgstr ""
 msgid "Report this posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:221
-#: lib/vutuv_web/agent_docs/text.ex:216
+#: lib/vutuv_web/agent_docs/markdown.ex:227
+#: lib/vutuv_web/agent_docs/text.ex:221
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:214
-#: lib/vutuv_web/agent_docs/markdown.ex:343
-#: lib/vutuv_web/agent_docs/text.ex:210
-#: lib/vutuv_web/agent_docs/text.ex:377
+#: lib/vutuv_web/agent_docs/markdown.ex:220
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/text.ex:215
+#: lib/vutuv_web/agent_docs/text.ex:382
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12640,10 +12650,10 @@ msgstr ""
 msgid "Working student"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:212
-#: lib/vutuv_web/agent_docs/markdown.ex:341
-#: lib/vutuv_web/agent_docs/text.ex:208
-#: lib/vutuv_web/agent_docs/text.ex:375
+#: lib/vutuv_web/agent_docs/markdown.ex:218
+#: lib/vutuv_web/agent_docs/markdown.ex:347
+#: lib/vutuv_web/agent_docs/text.ex:213
+#: lib/vutuv_web/agent_docs/text.ex:380
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -12816,13 +12826,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:362
+#: lib/vutuv_web/agent_docs/markdown.ex:368
 #: lib/vutuv_web/templates/tag/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:395
+#: lib/vutuv_web/agent_docs/text.ex:400
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12868,12 +12878,12 @@ msgstr ""
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:234
+#: lib/vutuv_web/agent_docs/markdown.ex:240
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:229
+#: lib/vutuv_web/agent_docs/text.ex:234
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
@@ -12888,10 +12898,10 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:360
-#: lib/vutuv_web/agent_docs/markdown.ex:372
-#: lib/vutuv_web/agent_docs/text.ex:393
-#: lib/vutuv_web/agent_docs/text.ex:405
+#: lib/vutuv_web/agent_docs/markdown.ex:366
+#: lib/vutuv_web/agent_docs/markdown.ex:378
+#: lib/vutuv_web/agent_docs/text.ex:398
+#: lib/vutuv_web/agent_docs/text.ex:410
 #: lib/vutuv_web/live/organization_live/show.ex:329
 #: lib/vutuv_web/templates/tag/show.html.heex:57
 #, elixir-autogen, elixir-format
@@ -13082,6 +13092,7 @@ msgid "Search title, poster or organization"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
+#: lib/vutuv_web/live/post_live/composer.ex:705
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -13190,7 +13201,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2897
+#: lib/vutuv_web/components/ui.ex:2940
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13456,7 +13467,7 @@ msgstr ""
 msgid "An image was removed from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:987
+#: lib/vutuv_web/components/post_components.ex:992
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -13464,12 +13475,12 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:977
+#: lib/vutuv_web/components/post_components.ex:982
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:303
+#: lib/vutuv_web/live/notification_live/index.ex:332
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13480,7 +13491,7 @@ msgstr ""
 msgid "No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:393
+#: lib/vutuv_web/live/notification_live/index.ex:433
 #, elixir-autogen, elixir-format
 msgid "Our automated image review removed %{what}. Only family-friendly images suitable for a work environment are allowed."
 msgstr ""
@@ -13515,7 +13526,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:639
+#: lib/vutuv/accounts/user.ex:647
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13526,19 +13537,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:642
+#: lib/vutuv/accounts/user.ex:650
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:645
+#: lib/vutuv/accounts/user.ex:653
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:636
+#: lib/vutuv/accounts/user.ex:644
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13561,7 +13572,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:306
+#: lib/vutuv_web/live/notification_live/index.ex:335
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13573,48 +13584,48 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:420
+#: lib/vutuv_web/live/notification_live/index.ex:460
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:191
+#: lib/vutuv_web/components/ui.ex:195
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:188
+#: lib/vutuv_web/components/ui.ex:192
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:194
+#: lib/vutuv_web/components/ui.ex:198
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:185
+#: lib/vutuv_web/components/ui.ex:189
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:507
+#: lib/vutuv_web/live/post_live/composer.ex:599
 #, elixir-autogen, elixir-format
 msgid "Insert"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:173
+#: lib/vutuv_web/components/ui.ex:177
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:504
+#: lib/vutuv_web/live/post_live/composer.ex:596
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:166
-#: lib/vutuv_web/agent_docs/text.ex:163
+#: lib/vutuv_web/agent_docs/markdown.ex:172
+#: lib/vutuv_web/agent_docs/text.ex:168
 #: lib/vutuv_web/templates/tag/show.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
@@ -13640,22 +13651,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:272
+#: lib/vutuv_web/components/post_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:274
+#: lib/vutuv_web/components/post_components.ex:279
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:273
+#: lib/vutuv_web/components/post_components.ex:278
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:262
+#: lib/vutuv_web/components/post_components.ex:267
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13665,7 +13676,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2886
+#: lib/vutuv_web/components/ui.ex:2929
 #: lib/vutuv_web/controllers/settings_controller.ex:259
 #: lib/vutuv_web/live/post_live/feed.ex:651
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13714,14 +13725,15 @@ msgstr ""
 msgid "Signal and WhatsApp accept a phone number or a username; the other messengers use their own id or handle (e.g. an 8-character Threema ID or a Matrix @you:matrix.org)."
 msgstr ""
 
-#: lib/vutuv_web/templates/messenger/manage.html.heex:11
+#: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
 
+#: lib/vutuv_web/templates/messenger/card_list.html.heex:5
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:5
-#: lib/vutuv_web/templates/messenger/show.html.heex:16
+#: lib/vutuv_web/templates/messenger/show.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Messenger"
 msgstr ""
@@ -13731,30 +13743,37 @@ msgstr ""
 msgid "Messenger created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:107
+#: lib/vutuv_web/controllers/messenger_controller.ex:102
 #, elixir-autogen, elixir-format
 msgid "Messenger deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:99
+#: lib/vutuv_web/controllers/messenger_controller.ex:91
 #, elixir-autogen, elixir-format
 msgid "Messenger updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2851
-#: lib/vutuv_web/controllers/messenger_controller.ex:22
-#: lib/vutuv_web/templates/messenger/index.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/agent_docs/markdown.ex:58
+#: lib/vutuv_web/agent_docs/text.ex:56
+#: lib/vutuv_web/components/ui.ex:2893
+#: lib/vutuv_web/controllers/messenger_controller.ex:21
+#: lib/vutuv_web/controllers/messenger_controller.ex:36
+#: lib/vutuv_web/templates/messenger/edit.html.heex:3
+#: lib/vutuv_web/templates/messenger/index.html.heex:10
+#: lib/vutuv_web/templates/messenger/manage.html.heex:4
+#: lib/vutuv_web/templates/messenger/new.html.heex:3
+#: lib/vutuv_web/templates/messenger/show.html.heex:6
+#: lib/vutuv_web/templates/user/show.html.heex:994
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
 
-#: lib/vutuv_web/templates/messenger/index.html.heex:6
+#: lib/vutuv_web/templates/messenger/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Messengers of "
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:100
+#: lib/vutuv_web/agent_docs/section_docs.ex:99
 #, elixir-autogen, elixir-format
 msgid "Messengers of %{name}"
 msgstr ""
@@ -13764,59 +13783,195 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2494
+#: lib/vutuv_web/components/ui.ex:2483
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:2503
+#: lib/vutuv_web/components/ui.ex:2493
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:311
+#: lib/vutuv_web/live/notification_live/index.ex:336
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:449
+#: lib/vutuv_web/live/notification_live/index.ex:480
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:443
+#: lib/vutuv_web/live/notification_live/index.ex:472
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:446
+#: lib/vutuv_web/live/notification_live/index.ex:477
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:74
+#: lib/vutuv_web/templates/settings/notifications.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "CV updates"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:77
+#: lib/vutuv_web/templates/settings/notifications.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "When someone you follow adds a new entry to their CV, they can let their followers know. It shows up under the bell, never by email."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:82
+#: lib/vutuv_web/templates/settings/notifications.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Tell me about new CV entries of people I follow"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:83
+#: lib/vutuv_web/templates/settings/notifications.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:470
+#: lib/vutuv_web/live/notification_live/index.ex:485
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1496
+#, elixir-autogen, elixir-format
+msgid "Audiobook"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:713
+#, elixir-autogen, elixir-format
+msgid "Author(s)"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:775
+#, elixir-autogen, elixir-format
+msgid "Book"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:788
+#: lib/vutuv_web/components/post_components.ex:1486
+#: lib/vutuv_web/live/post_live/composer.ex:659
+#, elixir-autogen, elixir-format
+msgid "Book review"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1497
+#, elixir-autogen, elixir-format
+msgid "Cinema"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1499
+#, elixir-autogen, elixir-format
+msgid "DVD/Blu-ray"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:713
+#, elixir-autogen, elixir-format
+msgid "Director"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1495
+#, elixir-autogen, elixir-format
+msgid "E-book"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:787
+#, elixir-autogen, elixir-format
+msgid "Film"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:788
+#: lib/vutuv_web/components/post_components.ex:1485
+#: lib/vutuv_web/live/post_live/composer.ex:658
+#, elixir-autogen, elixir-format
+msgid "Film review"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:679
+#, elixir-autogen, elixir-format
+msgid "IMDb link or ID"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:680
+#, elixir-autogen, elixir-format
+msgid "ISBN"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:693
+#, elixir-autogen, elixir-format
+msgid "Look up"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:690
+#, elixir-autogen, elixir-format
+msgid "Looking up…"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:249
+#, elixir-autogen, elixir-format
+msgid "Nothing found for this ISBN. Please fill in the fields yourself."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1494
+#, elixir-autogen, elixir-format
+msgid "Printed book"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:732
+#, elixir-autogen, elixir-format
+msgid "Read as… (optional)"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:668
+#, elixir-autogen, elixir-format
+msgid "Remove review"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:771
+#: lib/vutuv_web/live/post_live/composer.ex:772
+#, elixir-autogen, elixir-format
+msgid "Review a book"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:783
+#: lib/vutuv_web/live/post_live/composer.ex:784
+#, elixir-autogen, elixir-format
+msgid "Review a film"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1498
+#, elixir-autogen, elixir-format
+msgid "Streaming"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1503
+#, elixir-autogen, elixir-format
+msgid "View on Amazon"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1502
+#, elixir-autogen, elixir-format
+msgid "View on IMDb"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:731
+#, elixir-autogen, elixir-format
+msgid "Watched as… (optional)"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:745
+#, elixir-autogen, elixir-format
+msgid "With an ISBN, the post shows the book cover and a shop link automatically."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:725
+#, elixir-autogen, elixir-format
+msgid "Year"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: en\n"
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2709
-#: lib/vutuv_web/components/ui.ex:2714
+#: lib/vutuv_web/components/ui.ex:2751
+#: lib/vutuv_web/components/ui.ex:2756
 #: lib/vutuv_web/live/organization_live/domains.ex:235
 #: lib/vutuv_web/live/organization_live/edit.ex:382
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -24,9 +24,9 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:194
-#: lib/vutuv_web/agent_docs/section_docs.ex:114
-#: lib/vutuv_web/agent_docs/text.ex:191
+#: lib/vutuv_web/agent_docs/markdown.ex:200
+#: lib/vutuv_web/agent_docs/section_docs.ex:118
+#: lib/vutuv_web/agent_docs/text.ex:196
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:110
@@ -34,7 +34,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1117
+#: lib/vutuv_web/templates/user/show.html.heex:1150
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -56,9 +56,9 @@ msgstr ""
 msgid "Address updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:61
-#: lib/vutuv_web/agent_docs/text.ex:60
-#: lib/vutuv_web/components/ui.ex:2853
+#: lib/vutuv_web/agent_docs/markdown.ex:66
+#: lib/vutuv_web/agent_docs/text.ex:64
+#: lib/vutuv_web/components/ui.ex:2896
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -76,8 +76,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2514
-#: lib/vutuv_web/components/ui.ex:2608
+#: lib/vutuv_web/components/ui.ex:2556
+#: lib/vutuv_web/components/ui.ex:2650
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #, elixir-autogen
 msgid "Are you sure?"
@@ -93,17 +93,17 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:415
-#: lib/vutuv_web/agent_docs/markdown.ex:416
-#: lib/vutuv_web/agent_docs/text.ex:420
-#: lib/vutuv_web/agent_docs/text.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:422
+#: lib/vutuv_web/agent_docs/text.ex:425
+#: lib/vutuv_web/agent_docs/text.ex:426
 #: lib/vutuv_web/templates/user/show.html.heex:815
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:2507
+#: lib/vutuv_web/components/ui.ex:2549
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -134,8 +134,11 @@ msgstr ""
 msgid "Choose One"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:51
+#: lib/vutuv_web/agent_docs/markdown.ex:52
 #: lib/vutuv_web/agent_docs/text.ex:50
+#: lib/vutuv_web/templates/messenger/card_list.html.heex:6
+#: lib/vutuv_web/templates/messenger/form_content.html.heex:13
+#: lib/vutuv_web/templates/messenger/show.html.heex:21
 #: lib/vutuv_web/templates/user/show.html.heex:853
 #, elixir-autogen
 msgid "Contact"
@@ -145,8 +148,8 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:806
-#: lib/vutuv_web/components/ui.ex:2611
+#: lib/vutuv_web/components/post_components.ex:811
+#: lib/vutuv_web/components/ui.ex:2653
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -190,8 +193,8 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:799
-#: lib/vutuv_web/components/ui.ex:2602
+#: lib/vutuv_web/components/post_components.ex:804
+#: lib/vutuv_web/components/ui.ex:2644
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -207,6 +210,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/edit.html.heex:4
 #: lib/vutuv_web/templates/email/edit.html.heex:5
 #: lib/vutuv_web/templates/language/edit.html.heex:4
+#: lib/vutuv_web/templates/messenger/edit.html.heex:4
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:4
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
@@ -287,12 +291,12 @@ msgstr ""
 msgid "Enter your last name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:35
+#: lib/vutuv_web/agent_docs/markdown.ex:36
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:2845
-#: lib/vutuv_web/controllers/work_experience_controller.ex:40
-#: lib/vutuv_web/controllers/work_experience_controller.ex:57
-#: lib/vutuv_web/controllers/work_experience_controller.ex:135
+#: lib/vutuv_web/components/ui.ex:2887
+#: lib/vutuv_web/controllers/work_experience_controller.ex:42
+#: lib/vutuv_web/controllers/work_experience_controller.ex:59
+#: lib/vutuv_web/controllers/work_experience_controller.ex:148
 #: lib/vutuv_web/templates/user/show.html.heex:485
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:3
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
@@ -313,8 +317,8 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:427
-#: lib/vutuv_web/agent_docs/text.ex:432
+#: lib/vutuv_web/agent_docs/markdown.ex:433
+#: lib/vutuv_web/agent_docs/text.ex:437
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -322,14 +326,14 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:428
-#: lib/vutuv_web/agent_docs/text.ex:433
-#: lib/vutuv_web/components/ui.ex:1283
-#: lib/vutuv_web/components/ui.ex:1308
-#: lib/vutuv_web/components/ui.ex:1311
-#: lib/vutuv_web/components/ui.ex:1318
-#: lib/vutuv_web/components/ui.ex:1321
-#: lib/vutuv_web/components/ui.ex:1379
+#: lib/vutuv_web/agent_docs/markdown.ex:434
+#: lib/vutuv_web/agent_docs/text.ex:438
+#: lib/vutuv_web/components/ui.ex:1287
+#: lib/vutuv_web/components/ui.ex:1312
+#: lib/vutuv_web/components/ui.ex:1315
+#: lib/vutuv_web/components/ui.ex:1322
+#: lib/vutuv_web/components/ui.ex:1325
+#: lib/vutuv_web/components/ui.ex:1383
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
@@ -338,8 +342,8 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:414
-#: lib/vutuv_web/agent_docs/text.ex:419
+#: lib/vutuv_web/agent_docs/markdown.ex:420
+#: lib/vutuv_web/agent_docs/text.ex:424
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -407,9 +411,9 @@ msgstr ""
 msgid "Link updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:50
+#: lib/vutuv_web/agent_docs/markdown.ex:51
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:2849
+#: lib/vutuv_web/components/ui.ex:2891
 #: lib/vutuv_web/controllers/url_controller.ex:23
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
@@ -459,7 +463,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2864
+#: lib/vutuv_web/components/ui.ex:2907
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -486,6 +490,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/new.html.heex:4
 #: lib/vutuv_web/templates/email/new.html.heex:5
 #: lib/vutuv_web/templates/language/new.html.heex:4
+#: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/phone_number/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
@@ -546,8 +551,8 @@ msgid_plural "Phone Numbers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:58
-#: lib/vutuv_web/agent_docs/text.ex:57
+#: lib/vutuv_web/agent_docs/markdown.ex:63
+#: lib/vutuv_web/agent_docs/text.ex:61
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:3
 #: lib/vutuv_web/templates/phone_number/index.html.heex:10
 #: lib/vutuv_web/templates/phone_number/new.html.heex:3
@@ -591,7 +596,7 @@ msgstr ""
 msgid "Privacy Policy"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:237
+#: lib/vutuv_web/live/section_reorder_live.ex:248
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -616,8 +621,8 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:574
-#: lib/vutuv_web/live/section_reorder_live.ex:236
+#: lib/vutuv_web/live/post_live/composer.ex:797
+#: lib/vutuv_web/live/section_reorder_live.ex:247
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -631,18 +636,18 @@ msgid "Public (Everyone can view) or Private (Only you can view)"
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:327
-#: lib/vutuv_web/live/post_live/composer.ex:583
+#: lib/vutuv_web/live/post_live/composer.ex:806
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:83
-#: lib/vutuv_web/templates/settings/notifications.html.heex:66
+#: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
 #: lib/vutuv_web/templates/settings/preferences.html.heex:180
 #: lib/vutuv_web/templates/settings/privacy.html.heex:64
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:342
-#: lib/vutuv_web/views/settings_html.ex:135
+#: lib/vutuv_web/views/settings_html.ex:131
 #, elixir-autogen
 msgid "Save"
 msgstr ""
@@ -680,9 +685,9 @@ msgstr ""
 msgid "Slug"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:53
+#: lib/vutuv_web/agent_docs/markdown.ex:54
 #: lib/vutuv_web/agent_docs/text.ex:52
-#: lib/vutuv_web/components/ui.ex:2850
+#: lib/vutuv_web/components/ui.ex:2892
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
@@ -706,7 +711,7 @@ msgstr ""
 msgid "Add a profile"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:95
+#: lib/vutuv_web/agent_docs/section_docs.ex:97
 #, elixir-autogen, elixir-format
 msgid "Profiles of %{name}"
 msgstr ""
@@ -744,12 +749,12 @@ msgstr ""
 #: lib/vutuv_web/controllers/block_controller.ex:31
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:112
+#: lib/vutuv_web/live/user_profile_live.ex:113
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2508
+#: lib/vutuv_web/components/ui.ex:2550
 #, elixir-autogen
 msgid "Submit"
 msgstr ""
@@ -825,6 +830,8 @@ msgstr ""
 #: lib/vutuv_web/templates/follower/index.html.heex:2
 #: lib/vutuv_web/templates/language/index.html.heex:8
 #: lib/vutuv_web/templates/language/show.html.heex:4
+#: lib/vutuv_web/templates/messenger/index.html.heex:8
+#: lib/vutuv_web/templates/messenger/show.html.heex:4
 #: lib/vutuv_web/templates/phone_number/index.html.heex:8
 #: lib/vutuv_web/templates/phone_number/show.html.heex:4
 #: lib/vutuv_web/templates/qualification/index.html.heex:9
@@ -842,13 +849,13 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:577
+#: lib/vutuv_web/components/ui.ex:581
 #: lib/vutuv_web/templates/user/show.html.heex:279
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2672
+#: lib/vutuv_web/components/ui.ex:2714
 #: lib/vutuv_web/templates/user/show.html.heex:757
 #: lib/vutuv_web/templates/user/show.html.heex:777
 #, elixir-autogen
@@ -890,17 +897,17 @@ msgstr ""
 msgid "Work Experiences"
 msgstr ""
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:110
+#: lib/vutuv_web/controllers/work_experience_controller.ex:122
 #, elixir-autogen
 msgid "Work experience created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:204
+#: lib/vutuv_web/controllers/work_experience_controller.ex:217
 #, elixir-autogen
 msgid "Work experience deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:156
+#: lib/vutuv_web/controllers/work_experience_controller.ex:169
 #, elixir-autogen
 msgid "Work experience updated successfully."
 msgstr ""
@@ -1029,14 +1036,14 @@ msgstr ""
 msgid "Select a year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:732
+#: lib/vutuv/accounts/user.ex:740
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:731
+#: lib/vutuv/accounts/user.ex:739
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1444,13 +1451,13 @@ msgstr ""
 msgid "Tag urls"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:31
-#: lib/vutuv_web/agent_docs/markdown.ex:354
-#: lib/vutuv_web/agent_docs/markdown.ex:729
+#: lib/vutuv_web/agent_docs/markdown.ex:32
+#: lib/vutuv_web/agent_docs/markdown.ex:360
+#: lib/vutuv_web/agent_docs/markdown.ex:745
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:388
-#: lib/vutuv_web/agent_docs/text.ex:540
-#: lib/vutuv_web/components/ui.ex:2854
+#: lib/vutuv_web/agent_docs/text.ex:393
+#: lib/vutuv_web/agent_docs/text.ex:554
+#: lib/vutuv_web/components/ui.ex:2897
 #: lib/vutuv_web/controllers/user_tag_controller.ex:37
 #: lib/vutuv_web/controllers/user_tag_controller.ex:54
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1661,7 +1668,7 @@ msgstr ""
 msgid "Admin Area"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:97
+#: lib/vutuv_web/agent_docs/section_docs.ex:100
 #: lib/vutuv_web/templates/address/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Addresses of %{name}"
@@ -1692,8 +1699,8 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:460
-#: lib/vutuv_web/live/post_live/composer.ex:461
+#: lib/vutuv_web/live/post_live/composer.ex:552
+#: lib/vutuv_web/live/post_live/composer.ex:553
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1739,23 +1746,23 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:946
-#: lib/vutuv_web/components/ui.ex:955
-#: lib/vutuv_web/components/ui.ex:1130
+#: lib/vutuv_web/components/ui.ex:950
+#: lib/vutuv_web/components/ui.ex:959
+#: lib/vutuv_web/components/ui.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1248
-#: lib/vutuv_web/components/ui.ex:1248
-#: lib/vutuv_web/components/ui.ex:1265
-#: lib/vutuv_web/components/ui.ex:1274
-#: lib/vutuv_web/components/ui.ex:1290
-#: lib/vutuv_web/components/ui.ex:1327
-#: lib/vutuv_web/components/ui.ex:1330
-#: lib/vutuv_web/components/ui.ex:1337
-#: lib/vutuv_web/components/ui.ex:1340
-#: lib/vutuv_web/components/ui.ex:1413
+#: lib/vutuv_web/components/ui.ex:1252
+#: lib/vutuv_web/components/ui.ex:1252
+#: lib/vutuv_web/components/ui.ex:1269
+#: lib/vutuv_web/components/ui.ex:1278
+#: lib/vutuv_web/components/ui.ex:1294
+#: lib/vutuv_web/components/ui.ex:1331
+#: lib/vutuv_web/components/ui.ex:1334
+#: lib/vutuv_web/components/ui.ex:1341
+#: lib/vutuv_web/components/ui.ex:1344
+#: lib/vutuv_web/components/ui.ex:1417
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1771,7 +1778,7 @@ msgid "It doesn't look like you're following anyone yet. Open the profile of som
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:473
-#: lib/vutuv_web/views/settings_html.ex:222
+#: lib/vutuv_web/views/settings_html.ex:218
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -1806,25 +1813,25 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:275
-#: lib/vutuv_web/components/ui.ex:2711
+#: lib/vutuv_web/components/post_components.ex:280
+#: lib/vutuv_web/components/ui.ex:2753
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:237
+#: lib/vutuv_web/live/notification_live/index.ex:265
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2868
+#: lib/vutuv_web/components/ui.ex:2911
 #: lib/vutuv_web/live/notification_live/index.ex:66
-#: lib/vutuv_web/live/notification_live/index.ex:135
+#: lib/vutuv_web/live/notification_live/index.ex:140
 #: lib/vutuv_web/live/shell_live.ex:373
 #: lib/vutuv_web/templates/layout/app.html.heex:118
-#: lib/vutuv_web/templates/settings/notifications.html.heex:7
+#: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
@@ -1864,7 +1871,7 @@ msgstr ""
 msgid "Submit a bug report or feature request"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:100
+#: lib/vutuv_web/agent_docs/section_docs.ex:103
 #: lib/vutuv_web/templates/user_tag/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Tags of %{name}"
@@ -1909,7 +1916,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1201
+#: lib/vutuv_web/templates/user/show.html.heex:1234
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1945,35 +1952,35 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:351
+#: lib/vutuv_web/live/notification_live/index.ex:391
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:353
+#: lib/vutuv_web/live/notification_live/index.ex:393
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:348
+#: lib/vutuv_web/live/notification_live/index.ex:388
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2141
-#: lib/vutuv_web/components/ui.ex:2286
+#: lib/vutuv_web/components/ui.ex:2145
+#: lib/vutuv_web/components/ui.ex:2290
 #: lib/vutuv_web/live/organization_live/index.ex:130
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:255
+#: lib/vutuv_web/live/notification_live/index.ex:283
 #, elixir-autogen, elixir-format
 msgid "Load %{count} of %{remaining} more"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2736
-#: lib/vutuv_web/live/notification_live/index.ex:252
+#: lib/vutuv_web/components/ui.ex:2778
+#: lib/vutuv_web/live/notification_live/index.ex:280
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -1983,13 +1990,13 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2517
+#: lib/vutuv_web/components/ui.ex:2559
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:699
-#: lib/vutuv_web/components/ui.ex:709
+#: lib/vutuv_web/components/ui.ex:703
+#: lib/vutuv_web/components/ui.ex:713
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
@@ -2028,12 +2035,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1904
+#: lib/vutuv_web/components/ui.ex:1908
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1908
+#: lib/vutuv_web/components/ui.ex:1912
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2058,37 +2065,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1912
+#: lib/vutuv_web/components/ui.ex:1916
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1902
+#: lib/vutuv_web/components/ui.ex:1906
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1901
+#: lib/vutuv_web/components/ui.ex:1905
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1907
+#: lib/vutuv_web/components/ui.ex:1911
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1906
+#: lib/vutuv_web/components/ui.ex:1910
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1903
+#: lib/vutuv_web/components/ui.ex:1907
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1905
+#: lib/vutuv_web/components/ui.ex:1909
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2103,17 +2110,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1911
+#: lib/vutuv_web/components/ui.ex:1915
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1910
+#: lib/vutuv_web/components/ui.ex:1914
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1909
+#: lib/vutuv_web/components/ui.ex:1913
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2126,12 +2133,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:563
+#: lib/vutuv_web/live/post_live/composer.ex:759
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:691
+#: lib/vutuv_web/live/post_live/composer.ex:914
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2142,7 +2149,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:531
+#: lib/vutuv_web/live/post_live/composer.ex:623
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2152,13 +2159,13 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:803
+#: lib/vutuv_web/components/post_components.ex:808
 #: lib/vutuv_web/live/post_live/edit.ex:117
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:496
+#: lib/vutuv_web/live/post_live/composer.ex:588
 #, elixir-autogen, elixir-format
 msgid "Describe this image (alt text)"
 msgstr ""
@@ -2188,29 +2195,29 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:667
+#: lib/vutuv_web/live/post_live/composer.ex:890
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:595
+#: lib/vutuv_web/live/post_live/composer.ex:818
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:788
-#: lib/vutuv_web/components/post_components.ex:790
+#: lib/vutuv_web/components/post_components.ex:793
+#: lib/vutuv_web/components/post_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:637
+#: lib/vutuv_web/live/post_live/composer.ex:860
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:278
-#: lib/vutuv_web/live/post_live/composer.ex:338
+#: lib/vutuv_web/live/post_live/composer.ex:361
+#: lib/vutuv_web/live/post_live/composer.ex:421
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2220,23 +2227,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:272
+#: lib/vutuv_web/live/post_live/composer.ex:355
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:627
+#: lib/vutuv_web/live/post_live/composer.ex:850
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:617
+#: lib/vutuv_web/live/post_live/composer.ex:840
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:121
-#: lib/vutuv_web/live/post_live/composer.ex:583
+#: lib/vutuv_web/live/post_live/composer.ex:806
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2247,7 +2254,7 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:76
+#: lib/vutuv_web/agent_docs/post_doc.ex:80
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:73
@@ -2262,13 +2269,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1170
-#: lib/vutuv_web/components/post_components.ex:1174
+#: lib/vutuv_web/components/post_components.ex:1181
+#: lib/vutuv_web/components/post_components.ex:1185
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1171
+#: lib/vutuv_web/components/post_components.ex:1182
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2278,16 +2285,16 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:209
 #: lib/vutuv_web/live/organization_live/edit.ex:359
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:653
+#: lib/vutuv_web/live/post_live/composer.ex:876
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:268
+#: lib/vutuv_web/views/settings_html.ex:264
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:514
+#: lib/vutuv_web/live/post_live/composer.ex:606
 #, elixir-autogen, elixir-format
 msgid "Remove image"
 msgstr ""
@@ -2297,7 +2304,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:581
+#: lib/vutuv_web/live/post_live/composer.ex:804
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2315,12 +2322,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:362
+#: lib/vutuv_web/live/post_live/composer.ex:445
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:266
+#: lib/vutuv_web/live/post_live/composer.ex:349
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2330,77 +2337,77 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:722
+#: lib/vutuv_web/live/post_live/composer.ex:945
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:723
+#: lib/vutuv_web/live/post_live/composer.ex:946
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3041
+#: lib/vutuv_web/components/ui.ex:3084
 #: lib/vutuv_web/live/shell_live.ex:416
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:169
+#: lib/vutuv_web/views/settings_html.ex:165
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:472
+#: lib/vutuv_web/live/post_live/composer.ex:564
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:473
+#: lib/vutuv_web/live/post_live/composer.ex:565
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:785
+#: lib/vutuv_web/components/post_components.ex:790
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1426
+#: lib/vutuv_web/components/post_components.ex:1540
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1430
+#: lib/vutuv_web/components/post_components.ex:1544
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1428
+#: lib/vutuv_web/components/post_components.ex:1542
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1429
+#: lib/vutuv_web/components/post_components.ex:1543
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:297
+#: lib/vutuv_web/views/settings_html.ex:293
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:546
+#: lib/vutuv_web/live/post_live/composer.ex:638
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:713
+#: lib/vutuv_web/live/post_live/composer.ex:936
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:717
+#: lib/vutuv_web/live/post_live/composer.ex:940
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2420,16 +2427,16 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1498
-#: lib/vutuv_web/components/ui.ex:1608
-#: lib/vutuv_web/components/ui.ex:1608
-#: lib/vutuv_web/components/ui.ex:2216
+#: lib/vutuv_web/components/post_components.ex:1612
+#: lib/vutuv_web/components/ui.ex:1612
+#: lib/vutuv_web/components/ui.ex:1612
+#: lib/vutuv_web/components/ui.ex:2220
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:761
+#: lib/vutuv_web/agent_docs/markdown.ex:777
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:355
@@ -2439,17 +2446,17 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1465
-#: lib/vutuv_web/components/ui.ex:1637
-#: lib/vutuv_web/components/ui.ex:1637
-#: lib/vutuv_web/components/ui.ex:2202
-#: lib/vutuv_web/live/notification_live/index.ex:300
+#: lib/vutuv_web/components/post_components.ex:1579
+#: lib/vutuv_web/components/ui.ex:1641
+#: lib/vutuv_web/components/ui.ex:1641
+#: lib/vutuv_web/components/ui.ex:2206
+#: lib/vutuv_web/live/notification_live/index.ex:329
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:760
+#: lib/vutuv_web/agent_docs/markdown.ex:776
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:424
@@ -2468,48 +2475,48 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1487
+#: lib/vutuv_web/components/post_components.ex:1601
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1498
-#: lib/vutuv_web/components/ui.ex:1598
-#: lib/vutuv_web/components/ui.ex:1598
+#: lib/vutuv_web/components/post_components.ex:1612
+#: lib/vutuv_web/components/ui.ex:1602
+#: lib/vutuv_web/components/ui.ex:1602
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1484
+#: lib/vutuv_web/components/post_components.ex:1598
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1305
+#: lib/vutuv_web/components/post_components.ex:1316
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1484
+#: lib/vutuv_web/components/post_components.ex:1598
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1465
-#: lib/vutuv_web/components/ui.ex:1627
-#: lib/vutuv_web/components/ui.ex:1627
+#: lib/vutuv_web/components/post_components.ex:1579
+#: lib/vutuv_web/components/ui.ex:1631
+#: lib/vutuv_web/components/ui.ex:1631
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1243
-#: lib/vutuv_web/components/ui.ex:1243
-#: lib/vutuv_web/components/ui.ex:1380
+#: lib/vutuv_web/components/ui.ex:1247
+#: lib/vutuv_web/components/ui.ex:1247
+#: lib/vutuv_web/components/ui.ex:1384
 #: lib/vutuv_web/live/post_live/feed.ex:665
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
 #, elixir-autogen, elixir-format
@@ -2521,45 +2528,45 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1538
+#: lib/vutuv_web/components/post_components.ex:1652
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:102
-#: lib/vutuv_web/agent_docs/text.ex:100
-#: lib/vutuv_web/components/post_components.ex:264
+#: lib/vutuv_web/agent_docs/markdown.ex:108
+#: lib/vutuv_web/agent_docs/text.ex:105
+#: lib/vutuv_web/components/post_components.ex:269
 #: lib/vutuv_web/templates/post/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1521
-#: lib/vutuv_web/components/post_components.ex:1522
-#: lib/vutuv_web/live/notification_live/index.ex:207
-#: lib/vutuv_web/live/notification_live/index.ex:299
+#: lib/vutuv_web/components/post_components.ex:1635
+#: lib/vutuv_web/components/post_components.ex:1636
+#: lib/vutuv_web/live/notification_live/index.ex:212
+#: lib/vutuv_web/live/notification_live/index.ex:328
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:756
+#: lib/vutuv_web/components/post_components.ex:761
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:269
-#: lib/vutuv_web/live/post_live/composer.ex:571
+#: lib/vutuv_web/live/post_live/composer.ex:352
+#: lib/vutuv_web/live/post_live/composer.ex:794
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:698
+#: lib/vutuv_web/live/post_live/composer.ex:921
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:355
+#: lib/vutuv_web/live/notification_live/index.ex:395
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2569,12 +2576,12 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:751
+#: lib/vutuv_web/components/post_components.ex:756
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:745
+#: lib/vutuv_web/components/post_components.ex:750
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2635,7 +2642,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1780
+#: lib/vutuv_web/components/ui.ex:1784
 #: lib/vutuv_web/live/message_live/index.ex:596
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2728,7 +2735,7 @@ msgstr ""
 msgid "Okay, let's start over."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:413
+#: lib/vutuv_web/components/ui.ex:417
 #, elixir-autogen, elixir-format
 msgid "Resend PIN"
 msgstr ""
@@ -2738,7 +2745,7 @@ msgstr ""
 msgid "Too many PIN requests. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:422
+#: lib/vutuv_web/components/ui.ex:426
 #, elixir-autogen, elixir-format
 msgid "Use a different email address"
 msgstr ""
@@ -2756,7 +2763,7 @@ msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1119
+#: lib/vutuv_web/templates/user/show.html.heex:1152
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
@@ -2778,18 +2785,18 @@ msgstr ""
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:956
+#: lib/vutuv_web/live/user_profile_live.ex:960
 #: lib/vutuv_web/templates/user/show.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2347
-#: lib/vutuv_web/components/ui.ex:2674
+#: lib/vutuv_web/components/ui.ex:2351
+#: lib/vutuv_web/components/ui.ex:2716
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
-#: lib/vutuv_web/templates/settings/privacy.html.heex:130
+#: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
 #, elixir-autogen, elixir-format
@@ -2828,15 +2835,15 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:429
-#: lib/vutuv_web/agent_docs/text.ex:434
+#: lib/vutuv_web/agent_docs/markdown.ex:435
+#: lib/vutuv_web/agent_docs/text.ex:439
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:568
+#: lib/vutuv_web/components/ui.ex:572
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2846,17 +2853,17 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:583
+#: lib/vutuv_web/components/ui.ex:587
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:607
+#: lib/vutuv_web/live/post_live/composer.ex:830
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:569
+#: lib/vutuv_web/components/ui.ex:573
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2874,7 +2881,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1427
+#: lib/vutuv_web/components/post_components.ex:1541
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2884,22 +2891,22 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:307
+#: lib/vutuv_web/live/notification_live/index.ex:337
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:301
+#: lib/vutuv_web/live/notification_live/index.ex:330
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:298
+#: lib/vutuv_web/live/notification_live/index.ex:327
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:297
+#: lib/vutuv_web/live/notification_live/index.ex:326
 #: lib/vutuv_web/templates/user/show.html.heex:744
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2912,7 +2919,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:356
+#: lib/vutuv_web/live/notification_live/index.ex:396
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2944,12 +2951,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:378
+#: lib/vutuv_web/live/notification_live/index.ex:418
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:379
+#: lib/vutuv_web/live/notification_live/index.ex:419
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -2979,8 +2986,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:273
-#: lib/vutuv_web/agent_docs/text.ex:266
+#: lib/vutuv_web/agent_docs/markdown.ex:279
+#: lib/vutuv_web/agent_docs/text.ex:271
 #: lib/vutuv_web/controllers/page_controller.ex:54
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3055,7 +3062,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:302
+#: lib/vutuv_web/live/notification_live/index.ex:331
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3135,7 +3142,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:733
+#: lib/vutuv_web/components/post_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3184,7 +3191,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2842
+#: lib/vutuv_web/components/ui.ex:2884
 #: lib/vutuv_web/live/shell_live.ex:325
 #: lib/vutuv_web/live/shell_live.ex:509
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3210,7 +3217,7 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:827
+#: lib/vutuv_web/components/post_components.ex:832
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3293,7 +3300,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2116
+#: lib/vutuv_web/components/ui.ex:2120
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3474,12 +3481,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:381
+#: lib/vutuv_web/live/notification_live/index.ex:421
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:380
+#: lib/vutuv_web/live/notification_live/index.ex:420
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3489,7 +3496,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:382
+#: lib/vutuv_web/live/notification_live/index.ex:422
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3678,7 +3685,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:405
+#: lib/vutuv_web/live/notification_live/index.ex:445
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3703,7 +3710,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:304
+#: lib/vutuv_web/live/notification_live/index.ex:333
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3778,7 +3785,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:410
+#: lib/vutuv_web/live/notification_live/index.ex:450
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -3863,30 +3870,30 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:516
+#: lib/vutuv_web/agent_docs/markdown.ex:523
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:773
+#: lib/vutuv_web/agent_docs/markdown.ex:816
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:114
-#: lib/vutuv_web/agent_docs/text.ex:111
+#: lib/vutuv_web/agent_docs/markdown.ex:120
+#: lib/vutuv_web/agent_docs/text.ex:116
 #, elixir-autogen, elixir-format
 msgid "%{count} posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:76
-#: lib/vutuv_web/agent_docs/markdown.ex:137
-#: lib/vutuv_web/agent_docs/markdown.ex:150
-#: lib/vutuv_web/agent_docs/markdown.ex:729
-#: lib/vutuv_web/agent_docs/text.ex:75
-#: lib/vutuv_web/agent_docs/text.ex:134
-#: lib/vutuv_web/agent_docs/text.ex:147
-#: lib/vutuv_web/agent_docs/text.ex:540
+#: lib/vutuv_web/agent_docs/markdown.ex:81
+#: lib/vutuv_web/agent_docs/markdown.ex:143
+#: lib/vutuv_web/agent_docs/markdown.ex:156
+#: lib/vutuv_web/agent_docs/markdown.ex:745
+#: lib/vutuv_web/agent_docs/text.ex:79
+#: lib/vutuv_web/agent_docs/text.ex:139
+#: lib/vutuv_web/agent_docs/text.ex:152
+#: lib/vutuv_web/agent_docs/text.ex:554
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3896,39 +3903,39 @@ msgstr ""
 msgid "Followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:101
-#: lib/vutuv_web/agent_docs/text.ex:98
+#: lib/vutuv_web/agent_docs/markdown.ex:107
+#: lib/vutuv_web/agent_docs/text.ex:103
 #: lib/vutuv_web/live/job_posting_live/form.ex:493
 #, elixir-autogen, elixir-format
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:747
-#: lib/vutuv_web/agent_docs/text.ex:551
+#: lib/vutuv_web/agent_docs/markdown.ex:763
+#: lib/vutuv_web/agent_docs/text.ex:565
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:744
-#: lib/vutuv_web/agent_docs/text.ex:548
+#: lib/vutuv_web/agent_docs/markdown.ex:760
+#: lib/vutuv_web/agent_docs/text.ex:562
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:751
-#: lib/vutuv_web/agent_docs/text.ex:554
+#: lib/vutuv_web/agent_docs/markdown.ex:767
+#: lib/vutuv_web/agent_docs/text.ex:568
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:412
-#: lib/vutuv_web/agent_docs/text.ex:417
+#: lib/vutuv_web/agent_docs/markdown.ex:418
+#: lib/vutuv_web/agent_docs/text.ex:422
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:163
-#: lib/vutuv_web/agent_docs/text.ex:160
+#: lib/vutuv_web/agent_docs/markdown.ex:169
+#: lib/vutuv_web/agent_docs/text.ex:165
 #, elixir-autogen, elixir-format
 msgid "Most endorsed members"
 msgstr ""
@@ -3943,42 +3950,42 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:77
+#: lib/vutuv_web/agent_docs/post_doc.ex:81
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:96
-#: lib/vutuv_web/agent_docs/text.ex:93
+#: lib/vutuv_web/agent_docs/markdown.ex:101
+#: lib/vutuv_web/agent_docs/text.ex:97
 #: lib/vutuv_web/live/admin/screenshot_live.ex:96
 #: lib/vutuv_web/templates/post/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Post by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:63
-#: lib/vutuv_web/agent_docs/text.ex:62
+#: lib/vutuv_web/agent_docs/markdown.ex:68
+#: lib/vutuv_web/agent_docs/text.ex:66
 #, elixir-autogen, elixir-format
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:408
-#: lib/vutuv_web/agent_docs/text.ex:413
+#: lib/vutuv_web/agent_docs/markdown.ex:414
+#: lib/vutuv_web/agent_docs/text.ex:418
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:698
+#: lib/vutuv_web/agent_docs/markdown.ex:714
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:637
+#: lib/vutuv_web/agent_docs/markdown.ex:644
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:638
+#: lib/vutuv_web/agent_docs/markdown.ex:645
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -3993,22 +4000,22 @@ msgstr ""
 msgid "Connections of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:99
+#: lib/vutuv_web/agent_docs/section_docs.ex:102
 #, elixir-autogen, elixir-format
 msgid "Email addresses of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:92
+#: lib/vutuv_web/agent_docs/section_docs.ex:94
 #, elixir-autogen, elixir-format
 msgid "Links of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:98
+#: lib/vutuv_web/agent_docs/section_docs.ex:101
 #, elixir-autogen, elixir-format
 msgid "Phone numbers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:85
+#: lib/vutuv_web/agent_docs/section_docs.ex:87
 #, elixir-autogen, elixir-format
 msgid "Work experience of %{name}"
 msgstr ""
@@ -4053,8 +4060,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/text.ex:274
+#: lib/vutuv_web/agent_docs/markdown.ex:293
+#: lib/vutuv_web/agent_docs/text.ex:279
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4103,8 +4110,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:277
-#: lib/vutuv_web/agent_docs/text.ex:270
+#: lib/vutuv_web/agent_docs/markdown.ex:283
+#: lib/vutuv_web/agent_docs/text.ex:275
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4120,8 +4127,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:274
-#: lib/vutuv_web/agent_docs/text.ex:267
+#: lib/vutuv_web/agent_docs/markdown.ex:280
+#: lib/vutuv_web/agent_docs/text.ex:272
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4335,14 +4342,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:279
-#: lib/vutuv_web/agent_docs/text.ex:272
+#: lib/vutuv_web/agent_docs/markdown.ex:285
+#: lib/vutuv_web/agent_docs/text.ex:277
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:275
-#: lib/vutuv_web/agent_docs/text.ex:268
+#: lib/vutuv_web/agent_docs/markdown.ex:281
+#: lib/vutuv_web/agent_docs/text.ex:273
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4481,13 +4488,13 @@ msgstr ""
 msgid "Login PINs and other essential emails are not affected."
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:231
+#: lib/vutuv_web/live/section_reorder_live.ex:242
 #: lib/vutuv_web/templates/email/card_list.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Mail to this address bounced. Logging in with a PIN sent to it will clear this warning."
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:232
+#: lib/vutuv_web/live/section_reorder_live.ex:243
 #: lib/vutuv_web/templates/email/card_list.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "Undeliverable"
@@ -4511,7 +4518,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/block/index.html.heex:1
 #: lib/vutuv_web/templates/block/index.html.heex:1
-#: lib/vutuv_web/templates/settings/privacy.html.heex:127
+#: lib/vutuv_web/templates/settings/privacy.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Blocked members"
 msgstr ""
@@ -4544,7 +4551,7 @@ msgid "You have not blocked anyone."
 msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:86
-#: lib/vutuv_web/live/user_profile_live.ex:241
+#: lib/vutuv_web/live/user_profile_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr ""
@@ -4601,8 +4608,8 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:302
-#: lib/vutuv_web/agent_docs/text.ex:336
+#: lib/vutuv_web/agent_docs/markdown.ex:308
+#: lib/vutuv_web/agent_docs/text.ex:341
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
@@ -4622,7 +4629,7 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:261
+#: lib/vutuv_web/components/post_components.ex:266
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/search_live.ex:176
@@ -4671,7 +4678,7 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:944
+#: lib/vutuv_web/live/user_profile_live.ex:948
 #: lib/vutuv_web/templates/user/show.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -4720,8 +4727,8 @@ msgstr ""
 msgid "Edit your profile and its sections"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:216
-#: lib/vutuv_web/agent_docs/text.ex:212
+#: lib/vutuv_web/agent_docs/markdown.ex:222
+#: lib/vutuv_web/agent_docs/text.ex:217
 #: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
@@ -4903,7 +4910,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:94
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
 #: lib/vutuv_web/views/settings_html.ex:31
-#: lib/vutuv_web/views/settings_html.ex:213
+#: lib/vutuv_web/views/settings_html.ex:209
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -5259,7 +5266,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2874
+#: lib/vutuv_web/components/ui.ex:2917
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5295,12 +5302,12 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:275
+#: lib/vutuv_web/live/post_live/composer.ex:358
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:133
+#: lib/vutuv_web/templates/settings/privacy.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "Content under review"
 msgstr ""
@@ -5336,9 +5343,9 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2960
-#: lib/vutuv_web/components/ui.ex:2965
-#: lib/vutuv_web/components/ui.ex:3033
+#: lib/vutuv_web/components/ui.ex:3003
+#: lib/vutuv_web/components/ui.ex:3008
+#: lib/vutuv_web/components/ui.ex:3076
 #: lib/vutuv_web/controllers/settings_controller.ex:51
 #: lib/vutuv_web/live/shell_live.ex:444
 #: lib/vutuv_web/live/tag_new_live.ex:44
@@ -5353,6 +5360,8 @@ msgstr ""
 #: lib/vutuv_web/templates/language/edit.html.heex:2
 #: lib/vutuv_web/templates/language/new.html.heex:2
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
+#: lib/vutuv_web/templates/messenger/edit.html.heex:2
+#: lib/vutuv_web/templates/messenger/new.html.heex:2
 #: lib/vutuv_web/templates/phone_number/edit.html.heex:2
 #: lib/vutuv_web/templates/phone_number/new.html.heex:2
 #: lib/vutuv_web/templates/qualification/edit.html.heex:2
@@ -5365,7 +5374,7 @@ msgstr ""
 #: lib/vutuv_web/templates/username/new.html.heex:4
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:2
 #: lib/vutuv_web/templates/work_experience/new.html.heex:2
-#: lib/vutuv_web/views/settings_html.ex:164
+#: lib/vutuv_web/views/settings_html.ex:160
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5400,7 +5409,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:946
+#: lib/vutuv_web/live/user_profile_live.ex:950
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5426,9 +5435,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:869
-#: lib/vutuv_web/components/post_components.ex:923
-#: lib/vutuv_web/components/post_components.ex:1232
+#: lib/vutuv_web/components/post_components.ex:874
+#: lib/vutuv_web/components/post_components.ex:928
+#: lib/vutuv_web/components/post_components.ex:1243
 #: lib/vutuv_web/live/post_live/feed.ex:737
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:735
+#: lib/vutuv/accounts/user.ex:743
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5482,7 +5491,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2856
+#: lib/vutuv_web/components/ui.ex:2899
 #: lib/vutuv_web/live/admin/user_live.ex:266
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:13
 #, elixir-autogen, elixir-format
@@ -5505,7 +5514,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2851
+#: lib/vutuv_web/components/ui.ex:2894
 #: lib/vutuv_web/controllers/email_controller.ex:30
 #: lib/vutuv_web/controllers/email_controller.ex:49
 #: lib/vutuv_web/controllers/email_controller.ex:191
@@ -5521,7 +5530,7 @@ msgstr ""
 msgid "Notification settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:128
+#: lib/vutuv_web/templates/settings/privacy.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you."
 msgstr ""
@@ -5536,7 +5545,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2866
+#: lib/vutuv_web/components/ui.ex:2909
 #: lib/vutuv_web/templates/settings/privacy.html.heex:9
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5552,7 +5561,7 @@ msgstr ""
 msgid "Third-party apps you authorized."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:136
+#: lib/vutuv_web/templates/settings/privacy.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -5562,12 +5571,12 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:196
+#: lib/vutuv_web/live/notification_live/index.ex:201
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:134
+#: lib/vutuv_web/templates/settings/privacy.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Your posts or profile a moderator is looking at."
 msgstr ""
@@ -5582,7 +5591,7 @@ msgstr ""
 msgid "Download your data"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:11
+#: lib/vutuv_web/templates/settings/notifications.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Email notifications"
 msgstr ""
@@ -5649,7 +5658,7 @@ msgstr ""
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2873
+#: lib/vutuv_web/components/ui.ex:2916
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -5661,23 +5670,23 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:103
-#: lib/vutuv_web/templates/settings/notifications.html.heex:50
+#: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Endorsements"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:80
+#: lib/vutuv_web/templates/settings/notifications.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Endorsements and new followers"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:74
+#: lib/vutuv_web/templates/settings/notifications.html.heex:93
 #, elixir-autogen, elixir-format
 msgid "In-app notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:55
+#: lib/vutuv_web/templates/settings/notifications.html.heex:56
 #, elixir-autogen, elixir-format
 msgid "New followers"
 msgstr ""
@@ -5687,7 +5696,7 @@ msgstr ""
 msgid "Notification settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:88
+#: lib/vutuv_web/templates/settings/notifications.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Open your notifications"
 msgstr ""
@@ -5697,12 +5706,12 @@ msgstr ""
 msgid "Privacy settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:81
+#: lib/vutuv_web/templates/settings/notifications.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:124
+#: lib/vutuv_web/templates/settings/privacy.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr ""
@@ -5712,27 +5721,27 @@ msgstr ""
 msgid "Search engines & AI"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:76
+#: lib/vutuv_web/templates/settings/notifications.html.heex:95
 #, elixir-autogen, elixir-format
 msgid "These are always on. You see them under the bell at the top of every page, in real time."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:25
+#: lib/vutuv_web/templates/settings/notifications.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Unread messages"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:52
+#: lib/vutuv_web/templates/settings/notifications.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "When someone endorses you for one of your tags."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:27
+#: lib/vutuv_web/templates/settings/notifications.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "When someone messages you and you have not read it yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:57
+#: lib/vutuv_web/templates/settings/notifications.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "When someone starts following you."
 msgstr ""
@@ -5783,25 +5792,25 @@ msgid "You cannot block yourself."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:23
-#: lib/vutuv_web/live/user_profile_live.ex:207
+#: lib/vutuv_web/live/user_profile_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Bookmark removed."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:19
-#: lib/vutuv_web/live/user_profile_live.ex:204
+#: lib/vutuv_web/live/user_profile_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Bookmarked."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:31
-#: lib/vutuv_web/live/user_profile_live.ex:213
+#: lib/vutuv_web/live/user_profile_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Like removed."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:27
-#: lib/vutuv_web/live/user_profile_live.ex:210
+#: lib/vutuv_web/live/user_profile_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Liked."
 msgstr ""
@@ -5863,21 +5872,21 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:174
-#: lib/vutuv_web/views/settings_html.ex:306
+#: lib/vutuv_web/views/settings_html.ex:302
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:305
+#: lib/vutuv_web/views/settings_html.ex:301
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:304
+#: lib/vutuv_web/views/settings_html.ex:300
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
@@ -5894,7 +5903,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:202
+#: lib/vutuv_web/views/settings_html.ex:198
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5909,7 +5918,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:219
+#: lib/vutuv_web/views/settings_html.ex:215
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5934,7 +5943,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:203
+#: lib/vutuv_web/views/settings_html.ex:199
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5944,27 +5953,27 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:303
+#: lib/vutuv_web/views/settings_html.ex:299
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:78
+#: lib/vutuv_web/templates/settings/privacy.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:77
+#: lib/vutuv_web/templates/settings/privacy.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:79
+#: lib/vutuv_web/templates/settings/privacy.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Show when I'm online"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:80
+#: lib/vutuv_web/templates/settings/privacy.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
@@ -5975,7 +5984,7 @@ msgid "Add a passkey"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/views/settings_html.ex:254
+#: lib/vutuv_web/views/settings_html.ex:250
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -5985,7 +5994,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:257
+#: lib/vutuv_web/views/settings_html.ex:253
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -5995,7 +6004,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:251
+#: lib/vutuv_web/views/settings_html.ex:247
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -6015,7 +6024,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:265
+#: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6070,7 +6079,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:950
+#: lib/vutuv_web/live/user_profile_live.ex:954
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6081,7 +6090,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:170
+#: lib/vutuv_web/components/ui.ex:174
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
 #: lib/vutuv_web/templates/user/show.html.heex:687
@@ -6105,7 +6114,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1166
+#: lib/vutuv_web/templates/user/show.html.heex:1199
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6156,8 +6165,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:417
-#: lib/vutuv_web/agent_docs/text.ex:422
+#: lib/vutuv_web/agent_docs/markdown.ex:423
+#: lib/vutuv_web/agent_docs/text.ex:427
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6229,8 +6238,8 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:760
-#: lib/vutuv_web/components/post_components.ex:263
+#: lib/vutuv_web/agent_docs/markdown.ex:776
+#: lib/vutuv_web/components/post_components.ex:268
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
@@ -6241,29 +6250,29 @@ msgstr ""
 msgid "View all phone numbers"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:107
+#: lib/vutuv_web/live/section_reorder_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:158
+#: lib/vutuv_web/live/section_reorder_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder, or use the arrows. The order is the one shown on your profile."
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:135
+#: lib/vutuv_web/live/section_reorder_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Move down"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:126
+#: lib/vutuv_web/live/section_reorder_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:946
-#: lib/vutuv_web/components/ui.ex:955
-#: lib/vutuv_web/components/ui.ex:1131
+#: lib/vutuv_web/components/ui.ex:950
+#: lib/vutuv_web/components/ui.ex:959
+#: lib/vutuv_web/components/ui.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6290,9 +6299,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1152
-#: lib/vutuv_web/templates/user/show.html.heex:1160
-#: lib/vutuv_web/templates/user/show.html.heex:1172
+#: lib/vutuv_web/templates/user/show.html.heex:1185
+#: lib/vutuv_web/templates/user/show.html.heex:1193
+#: lib/vutuv_web/templates/user/show.html.heex:1205
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6324,13 +6333,14 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1084
-#: lib/vutuv_web/live/notification_live/index.ex:227
+#: lib/vutuv_web/components/ui.ex:1088
+#: lib/vutuv_web/live/notification_live/index.ex:237
+#: lib/vutuv_web/live/notification_live/index.ex:255
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:742
+#: lib/vutuv_web/agent_docs/markdown.ex:758
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6490,7 +6500,7 @@ msgstr ""
 msgid "No deliverability events yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:406
+#: lib/vutuv_web/components/ui.ex:410
 #, elixir-autogen, elixir-format
 msgid "Not getting the PIN? That email address may no longer be working. If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
@@ -6599,19 +6609,19 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1568
+#: lib/vutuv_web/components/ui.ex:1572
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:189
+#: lib/vutuv_web/live/user_profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:79
+#: lib/vutuv_web/templates/settings/notifications.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "New messages and new connections"
 msgstr ""
@@ -6621,14 +6631,14 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1567
+#: lib/vutuv_web/components/ui.ex:1571
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:191
+#: lib/vutuv_web/live/user_profile_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -6643,7 +6653,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:824
+#: lib/vutuv_web/components/post_components.ex:829
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6653,38 +6663,38 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:823
+#: lib/vutuv_web/components/post_components.ex:828
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1538
+#: lib/vutuv_web/components/ui.ex:1542
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1532
+#: lib/vutuv_web/components/ui.ex:1536
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1522
+#: lib/vutuv_web/components/ui.ex:1526
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1473
-#: lib/vutuv_web/components/ui.ex:1522
+#: lib/vutuv_web/components/ui.ex:1477
+#: lib/vutuv_web/components/ui.ex:1526
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1471
+#: lib/vutuv_web/components/ui.ex:1475
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1472
+#: lib/vutuv_web/components/ui.ex:1476
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -6848,8 +6858,8 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:190
-#: lib/vutuv_web/agent_docs/text.ex:187
+#: lib/vutuv_web/agent_docs/markdown.ex:196
+#: lib/vutuv_web/agent_docs/text.ex:192
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -6912,7 +6922,7 @@ msgid "New newsletter"
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:171
-#: lib/vutuv_web/templates/settings/notifications.html.heex:60
+#: lib/vutuv_web/templates/settings/notifications.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Newsletter"
 msgstr ""
@@ -6970,7 +6980,7 @@ msgstr ""
 msgid "Nothing sent yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:62
+#: lib/vutuv_web/templates/settings/notifications.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Occasional vutuv news and announcements."
 msgstr ""
@@ -6990,7 +7000,7 @@ msgstr ""
 msgid "Pick capped members at random"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:13
+#: lib/vutuv_web/templates/settings/notifications.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Pick which emails vutuv may send you. Each email has a one-click unsubscribe."
 msgstr ""
@@ -7246,13 +7256,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2154
+#: lib/vutuv_web/components/ui.ex:2158
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2170
+#: lib/vutuv_web/components/ui.ex:2174
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7505,17 +7515,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:778
+#: lib/vutuv_web/agent_docs/markdown.ex:821
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:781
+#: lib/vutuv_web/agent_docs/markdown.ex:824
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:788
+#: lib/vutuv_web/agent_docs/markdown.ex:831
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -7791,12 +7801,12 @@ msgstr ""
 msgid "Add to audience"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:35
+#: lib/vutuv_web/templates/settings/notifications.html.heex:36
 #, elixir-autogen
 msgid "How often"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:39
+#: lib/vutuv_web/templates/settings/notifications.html.heex:40
 #, elixir-autogen
 msgid "Send the email"
 msgstr ""
@@ -7841,12 +7851,12 @@ msgstr ""
 msgid "Every message"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:44
+#: lib/vutuv_web/templates/settings/notifications.html.heex:45
 #, elixir-autogen
 msgid "We wait a little before emailing, so you can read the message yourself first. These two settings apply only while unread-message emails are on."
 msgstr ""
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:76
+#: lib/vutuv_web/controllers/work_experience_controller.ex:78
 #, elixir-autogen
 msgid "That work experience could not be pinned."
 msgstr ""
@@ -7995,7 +8005,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2157
+#: lib/vutuv_web/components/ui.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8124,12 +8134,12 @@ msgstr ""
 msgid "Degree"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:39
+#: lib/vutuv_web/agent_docs/markdown.ex:40
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:2846
-#: lib/vutuv_web/controllers/education_controller.ex:36
-#: lib/vutuv_web/controllers/education_controller.ex:51
-#: lib/vutuv_web/controllers/education_controller.ex:89
+#: lib/vutuv_web/components/ui.ex:2888
+#: lib/vutuv_web/controllers/education_controller.ex:38
+#: lib/vutuv_web/controllers/education_controller.ex:53
+#: lib/vutuv_web/controllers/education_controller.ex:103
 #: lib/vutuv_web/cv/cv.ex:258
 #: lib/vutuv_web/templates/education/edit.html.heex:3
 #: lib/vutuv_web/templates/education/index.html.heex:5
@@ -8144,22 +8154,22 @@ msgstr ""
 msgid "Education"
 msgstr ""
 
-#: lib/vutuv_web/controllers/education_controller.ex:67
+#: lib/vutuv_web/controllers/education_controller.ex:81
 #, elixir-autogen, elixir-format
 msgid "Education created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/education_controller.ex:120
+#: lib/vutuv_web/controllers/education_controller.ex:134
 #, elixir-autogen, elixir-format
 msgid "Education deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:86
+#: lib/vutuv_web/agent_docs/section_docs.ex:88
 #, elixir-autogen, elixir-format
 msgid "Education of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/education_controller.ex:109
+#: lib/vutuv_web/controllers/education_controller.ex:123
 #, elixir-autogen, elixir-format
 msgid "Education updated successfully."
 msgstr ""
@@ -8180,7 +8190,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2861
+#: lib/vutuv_web/components/ui.ex:2904
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8209,7 +8219,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2852
+#: lib/vutuv_web/components/ui.ex:2895
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8303,12 +8313,12 @@ msgstr ""
 msgid "A photo and a short tagline make your profile complete."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:969
+#: lib/vutuv_web/live/user_profile_live.ex:973
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2393
+#: lib/vutuv_web/components/ui.ex:2397
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:36
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:42
@@ -8328,8 +8338,8 @@ msgstr[1] ""
 msgid "Loading posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:92
-#: lib/vutuv_web/templates/user/show.html.heex:1023
+#: lib/vutuv_web/templates/settings/privacy.html.heex:94
+#: lib/vutuv_web/templates/user/show.html.heex:1056
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8389,13 +8399,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2844
+#: lib/vutuv_web/components/ui.ex:2886
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2860
+#: lib/vutuv_web/components/ui.ex:2903
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8407,7 +8417,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2858
+#: lib/vutuv_web/components/ui.ex:2901
 #: lib/vutuv_web/controllers/settings_controller.ex:89
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:5
@@ -8416,7 +8426,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2862
+#: lib/vutuv_web/components/ui.ex:2905
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8449,17 +8459,17 @@ msgstr ""
 msgid "Suggested posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:94
+#: lib/vutuv_web/templates/settings/privacy.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:98
+#: lib/vutuv_web/templates/settings/privacy.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "Show my latest social media posts on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:99
+#: lib/vutuv_web/templates/settings/privacy.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
@@ -8544,7 +8554,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:585
+#: lib/vutuv_web/components/ui.ex:589
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8640,7 +8650,7 @@ msgstr ""
 msgid "Allow followers from the Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2867
+#: lib/vutuv_web/components/ui.ex:2910
 #: lib/vutuv_web/controllers/settings_controller.ex:186
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:265
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
@@ -8730,7 +8740,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:556
+#: lib/vutuv_web/agent_docs/markdown.ex:563
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8751,7 +8761,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:557
+#: lib/vutuv_web/agent_docs/markdown.ex:564
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8782,13 +8792,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:594
+#: lib/vutuv_web/agent_docs/markdown.ex:601
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:593
+#: lib/vutuv_web/agent_docs/markdown.ex:600
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8809,19 +8819,19 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:619
+#: lib/vutuv_web/components/ui.ex:623
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1308
+#: lib/vutuv_web/components/post_components.ex:1319
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:701
+#: lib/vutuv_web/agent_docs/markdown.ex:717
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8848,7 +8858,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:629
+#: lib/vutuv_web/components/ui.ex:633
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8879,7 +8889,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:621
+#: lib/vutuv_web/components/ui.ex:625
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -8899,14 +8909,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:555
+#: lib/vutuv_web/agent_docs/markdown.ex:562
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:558
+#: lib/vutuv_web/agent_docs/markdown.ex:565
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -8943,7 +8953,7 @@ msgstr ""
 msgid "Shown at the top of your profile"
 msgstr ""
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:88
+#: lib/vutuv_web/controllers/work_experience_controller.ex:90
 #, elixir-autogen, elixir-format
 msgid "The job title at the top of your profile is chosen automatically again."
 msgstr ""
@@ -8953,7 +8963,7 @@ msgstr ""
 msgid "The job title at the top of your profile is picked automatically. Right now it's %{job}. Pick a role below to choose it yourself."
 msgstr ""
 
-#: lib/vutuv_web/controllers/work_experience_controller.ex:71
+#: lib/vutuv_web/controllers/work_experience_controller.ex:73
 #, elixir-autogen, elixir-format
 msgid "This job title now shows at the top of your profile."
 msgstr ""
@@ -9033,8 +9043,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:988
-#: lib/vutuv_web/components/ui.ex:989
+#: lib/vutuv_web/components/ui.ex:992
+#: lib/vutuv_web/components/ui.ex:993
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:64
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9046,8 +9056,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:438
-#: lib/vutuv_web/agent_docs/text.ex:441
+#: lib/vutuv_web/agent_docs/markdown.ex:444
+#: lib/vutuv_web/agent_docs/text.ex:446
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9273,9 +9283,9 @@ msgstr ""
 msgid "Language updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:47
+#: lib/vutuv_web/agent_docs/markdown.ex:48
 #: lib/vutuv_web/agent_docs/text.ex:46
-#: lib/vutuv_web/components/ui.ex:2848
+#: lib/vutuv_web/components/ui.ex:2890
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
@@ -9293,7 +9303,7 @@ msgstr ""
 msgid "Languages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:91
+#: lib/vutuv_web/agent_docs/section_docs.ex:93
 #, elixir-autogen, elixir-format
 msgid "Languages of %{name}"
 msgstr ""
@@ -9469,14 +9479,14 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:410
-#: lib/vutuv_web/agent_docs/text.ex:415
+#: lib/vutuv_web/agent_docs/markdown.ex:416
+#: lib/vutuv_web/agent_docs/text.ex:420
 #: lib/vutuv_web/templates/user/edit.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:609
+#: lib/vutuv/accounts/user.ex:617
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9487,7 +9497,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:606
+#: lib/vutuv/accounts/user.ex:614
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9574,23 +9584,23 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:631
+#: lib/vutuv_web/agent_docs/markdown.ex:638
 #: lib/vutuv_web/views/qualification_html.ex:10
 #, elixir-autogen, elixir-format
 msgid "Certificate"
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:65
+#: lib/vutuv_web/controllers/qualification_controller.ex:78
 #, elixir-autogen, elixir-format
 msgid "Certificate or license added successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:114
+#: lib/vutuv_web/controllers/qualification_controller.ex:128
 #, elixir-autogen, elixir-format
 msgid "Certificate or license deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:105
+#: lib/vutuv_web/controllers/qualification_controller.ex:119
 #, elixir-autogen, elixir-format
 msgid "Certificate or license updated successfully."
 msgstr ""
@@ -9600,12 +9610,12 @@ msgstr ""
 msgid "Certificates"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:43
+#: lib/vutuv_web/agent_docs/markdown.ex:44
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:2847
-#: lib/vutuv_web/controllers/qualification_controller.ex:33
-#: lib/vutuv_web/controllers/qualification_controller.ex:49
-#: lib/vutuv_web/controllers/qualification_controller.ex:88
+#: lib/vutuv_web/components/ui.ex:2889
+#: lib/vutuv_web/controllers/qualification_controller.ex:35
+#: lib/vutuv_web/controllers/qualification_controller.ex:51
+#: lib/vutuv_web/controllers/qualification_controller.ex:102
 #: lib/vutuv_web/cv/docx.ex:183
 #: lib/vutuv_web/cv/html.ex:172
 #: lib/vutuv_web/cv/latex.ex:140
@@ -9627,7 +9637,7 @@ msgstr ""
 msgid "Certificates & licenses of "
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:89
+#: lib/vutuv_web/agent_docs/section_docs.ex:91
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses of %{name}"
 msgstr ""
@@ -9661,7 +9671,7 @@ msgstr ""
 msgid "Expiry year"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:623
+#: lib/vutuv_web/agent_docs/markdown.ex:630
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9687,7 +9697,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:630
+#: lib/vutuv_web/agent_docs/markdown.ex:637
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9714,7 +9724,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:621
+#: lib/vutuv_web/agent_docs/markdown.ex:628
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9729,14 +9739,14 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:622
+#: lib/vutuv_web/agent_docs/markdown.ex:629
 #: lib/vutuv_web/views/qualification_html.ex:60
 #: lib/vutuv_web/views/qualification_html.ex:63
 #, elixir-autogen, elixir-format
 msgid "valid until %{date}"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:153
+#: lib/vutuv_web/live/section_reorder_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder, or use the arrows. The first language is your preferred contact language."
 msgstr ""
@@ -9746,8 +9756,8 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:525
-#: lib/vutuv_web/live/section_reorder_live.ex:258
+#: lib/vutuv_web/agent_docs/markdown.ex:532
+#: lib/vutuv_web/live/section_reorder_live.ex:269
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
@@ -10143,12 +10153,12 @@ msgstr ""
 msgid "Authenticator app turned off."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:158
+#: lib/vutuv_web/components/ui.ex:162
 #, elixir-autogen, elixir-format
 msgid "Bold"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:238
+#: lib/vutuv_web/components/ui.ex:242
 #, elixir-autogen, elixir-format
 msgid "Bullet list"
 msgstr ""
@@ -10158,7 +10168,7 @@ msgstr ""
 msgid "Can't scan the code? Enter this key in your app instead:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:230
+#: lib/vutuv_web/components/ui.ex:234
 #, elixir-autogen, elixir-format
 msgid "Code block"
 msgstr ""
@@ -10173,17 +10183,17 @@ msgstr ""
 msgid "Delete your code list? All its codes stop working immediately."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:252
+#: lib/vutuv_web/components/ui.ex:256
 #, elixir-autogen, elixir-format
 msgid "Divider"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:156
+#: lib/vutuv_web/components/ui.ex:160
 #, elixir-autogen, elixir-format
 msgid "Formatting"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:264
+#: lib/vutuv_web/components/ui.ex:268
 #, elixir-autogen, elixir-format
 msgid "Full screen"
 msgstr ""
@@ -10198,32 +10208,32 @@ msgstr ""
 msgid "Generate code list"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:218
+#: lib/vutuv_web/components/ui.ex:222
 #, elixir-autogen, elixir-format
 msgid "Heading 1"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:221
+#: lib/vutuv_web/components/ui.ex:225
 #, elixir-autogen, elixir-format
 msgid "Heading 2"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:224
+#: lib/vutuv_web/components/ui.ex:228
 #, elixir-autogen, elixir-format
 msgid "Heading 3"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:167
+#: lib/vutuv_web/components/ui.ex:171
 #, elixir-autogen, elixir-format
 msgid "Inline code"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:161
+#: lib/vutuv_web/components/ui.ex:165
 #, elixir-autogen, elixir-format
 msgid "Italic"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:151
+#: lib/vutuv_web/components/ui.ex:155
 #, elixir-autogen, elixir-format
 msgid "Link URL"
 msgstr ""
@@ -10233,8 +10243,8 @@ msgstr ""
 msgid "Login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:206
-#: lib/vutuv_web/components/ui.ex:207
+#: lib/vutuv_web/components/ui.ex:210
+#: lib/vutuv_web/components/ui.ex:211
 #, elixir-autogen, elixir-format
 msgid "More formatting"
 msgstr ""
@@ -10245,7 +10255,7 @@ msgstr ""
 msgid "Not set up."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:241
+#: lib/vutuv_web/components/ui.ex:245
 #, elixir-autogen, elixir-format
 msgid "Numbered list"
 msgstr ""
@@ -10260,7 +10270,7 @@ msgstr ""
 msgid "Print this page or write the codes down. Crossed-out codes have been used."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:227
+#: lib/vutuv_web/components/ui.ex:231
 #, elixir-autogen, elixir-format
 msgid "Quote"
 msgstr ""
@@ -10281,12 +10291,12 @@ msgstr ""
 msgid "Set up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:164
+#: lib/vutuv_web/components/ui.ex:168
 #, elixir-autogen, elixir-format
 msgid "Strikethrough"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:249
+#: lib/vutuv_web/components/ui.ex:253
 #, elixir-autogen, elixir-format
 msgid "Table"
 msgstr ""
@@ -10301,7 +10311,7 @@ msgstr ""
 msgid "To finish, enter the code your app shows now"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:261
+#: lib/vutuv_web/components/ui.ex:265
 #, elixir-autogen, elixir-format
 msgid "Toggle Markdown source"
 msgstr ""
@@ -10387,21 +10397,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:493
+#: lib/vutuv_web/agent_docs/markdown.ex:500
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:491
+#: lib/vutuv_web/agent_docs/markdown.ex:498
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:489
+#: lib/vutuv_web/agent_docs/markdown.ex:496
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10422,19 +10432,19 @@ msgid_plural "%{formatted} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:56
-#: lib/vutuv_web/agent_docs/text.ex:55
-#: lib/vutuv_web/templates/user/show.html.heex:997
+#: lib/vutuv_web/agent_docs/markdown.ex:61
+#: lib/vutuv_web/agent_docs/text.ex:59
+#: lib/vutuv_web/templates/user/show.html.heex:1030
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:110
+#: lib/vutuv_web/templates/settings/privacy.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:112
+#: lib/vutuv_web/templates/settings/privacy.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
@@ -10444,22 +10454,22 @@ msgstr ""
 msgid "Last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:116
+#: lib/vutuv_web/templates/settings/privacy.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Show code statistics on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:117
+#: lib/vutuv_web/templates/settings/privacy.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:507
+#: lib/vutuv_web/agent_docs/markdown.ex:514
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:494
+#: lib/vutuv_web/agent_docs/markdown.ex:501
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10604,7 +10614,7 @@ msgstr ""
 msgid "Manage your vutuv account: profile, privacy, notifications and sign-in."
 msgstr ""
 
-#: lib/vutuv_web/controllers/tag_controller.ex:72
+#: lib/vutuv_web/controllers/tag_controller.ex:85
 #, elixir-autogen, elixir-format
 msgid "Members on vutuv tagged %{tag}."
 msgstr ""
@@ -10985,19 +10995,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:621
+#: lib/vutuv/accounts/user.ex:629
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:626
+#: lib/vutuv/accounts/user.ex:634
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:624
+#: lib/vutuv/accounts/user.ex:632
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
@@ -11303,8 +11313,8 @@ msgstr ""
 msgid "Verified domains"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:191
-#: lib/vutuv_web/agent_docs/text.ex:188
+#: lib/vutuv_web/agent_docs/markdown.ex:197
+#: lib/vutuv_web/agent_docs/text.ex:193
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr ""
@@ -11331,8 +11341,8 @@ msgstr ""
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:193
-#: lib/vutuv_web/agent_docs/text.ex:190
+#: lib/vutuv_web/agent_docs/markdown.ex:199
+#: lib/vutuv_web/agent_docs/text.ex:195
 #: lib/vutuv_web/live/organization_live/edit.ex:273
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -11416,8 +11426,8 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:294
-#: lib/vutuv_web/agent_docs/text.ex:329
+#: lib/vutuv_web/agent_docs/markdown.ex:300
+#: lib/vutuv_web/agent_docs/text.ex:334
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
@@ -11650,8 +11660,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:315
-#: lib/vutuv_web/agent_docs/text.ex:349
+#: lib/vutuv_web/agent_docs/markdown.ex:321
+#: lib/vutuv_web/agent_docs/text.ex:354
 #: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11740,8 +11750,8 @@ msgstr ""
 msgid "The link text can be anything. A hidden <link rel=\"me\"> in the page head works too."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:517
-#: lib/vutuv_web/live/section_reorder_live.ex:182
+#: lib/vutuv_web/components/ui.ex:521
+#: lib/vutuv_web/live/section_reorder_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "Verified webpage"
 msgstr ""
@@ -11757,7 +11767,7 @@ msgstr ""
 msgid "Verify link"
 msgstr ""
 
-#: lib/vutuv_web/live/section_reorder_live.ex:189
+#: lib/vutuv_web/live/section_reorder_live.ex:191
 #: lib/vutuv_web/templates/url/card_list.html.heex:32
 #: lib/vutuv_web/templates/url/show.html.heex:29
 #, elixir-autogen, elixir-format
@@ -11784,8 +11794,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:651
-#: lib/vutuv_web/agent_docs/text.ex:521
+#: lib/vutuv_web/agent_docs/markdown.ex:658
+#: lib/vutuv_web/agent_docs/text.ex:535
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11821,8 +11831,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:306
-#: lib/vutuv_web/agent_docs/text.ex:340
+#: lib/vutuv_web/agent_docs/markdown.ex:312
+#: lib/vutuv_web/agent_docs/text.ex:345
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -12005,7 +12015,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:305
+#: lib/vutuv_web/live/notification_live/index.ex:334
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12016,7 +12026,7 @@ msgid "Organization unfrozen."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:2859
+#: lib/vutuv_web/components/ui.ex:2902
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
@@ -12108,22 +12118,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:370
+#: lib/vutuv_web/live/notification_live/index.ex:410
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:367
+#: lib/vutuv_web/live/notification_live/index.ex:407
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:364
+#: lib/vutuv_web/live/notification_live/index.ex:404
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:361
+#: lib/vutuv_web/live/notification_live/index.ex:401
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12266,10 +12276,10 @@ msgstr ""
 msgid "Edit posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:210
-#: lib/vutuv_web/agent_docs/markdown.ex:339
-#: lib/vutuv_web/agent_docs/text.ex:206
-#: lib/vutuv_web/agent_docs/text.ex:373
+#: lib/vutuv_web/agent_docs/markdown.ex:216
+#: lib/vutuv_web/agent_docs/markdown.ex:345
+#: lib/vutuv_web/agent_docs/text.ex:211
+#: lib/vutuv_web/agent_docs/text.ex:378
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Employer"
@@ -12280,10 +12290,10 @@ msgstr ""
 msgid "Employer name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:211
-#: lib/vutuv_web/agent_docs/markdown.ex:340
-#: lib/vutuv_web/agent_docs/text.ex:207
-#: lib/vutuv_web/agent_docs/text.ex:374
+#: lib/vutuv_web/agent_docs/markdown.ex:217
+#: lib/vutuv_web/agent_docs/markdown.ex:346
+#: lib/vutuv_web/agent_docs/text.ex:212
+#: lib/vutuv_web/agent_docs/text.ex:379
 #: lib/vutuv_web/live/job_board_live.ex:281
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format, fuzzy
@@ -12356,12 +12366,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:321
-#: lib/vutuv_web/agent_docs/markdown.ex:325
 #: lib/vutuv_web/agent_docs/markdown.ex:327
-#: lib/vutuv_web/agent_docs/text.ex:355
-#: lib/vutuv_web/agent_docs/text.ex:359
-#: lib/vutuv_web/agent_docs/text.ex:361
+#: lib/vutuv_web/agent_docs/markdown.ex:331
+#: lib/vutuv_web/agent_docs/markdown.ex:333
+#: lib/vutuv_web/agent_docs/text.ex:360
+#: lib/vutuv_web/agent_docs/text.ex:364
+#: lib/vutuv_web/agent_docs/text.ex:366
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
@@ -12410,8 +12420,8 @@ msgstr ""
 msgid "New posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:222
-#: lib/vutuv_web/agent_docs/text.ex:217
+#: lib/vutuv_web/agent_docs/markdown.ex:228
+#: lib/vutuv_web/agent_docs/text.ex:222
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
@@ -12493,10 +12503,10 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:215
-#: lib/vutuv_web/agent_docs/markdown.ex:344
-#: lib/vutuv_web/agent_docs/text.ex:211
-#: lib/vutuv_web/agent_docs/text.ex:378
+#: lib/vutuv_web/agent_docs/markdown.ex:221
+#: lib/vutuv_web/agent_docs/markdown.ex:350
+#: lib/vutuv_web/agent_docs/text.ex:216
+#: lib/vutuv_web/agent_docs/text.ex:383
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posted"
@@ -12520,10 +12530,10 @@ msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
-#: lib/vutuv_web/agent_docs/markdown.ex:325
-#: lib/vutuv_web/agent_docs/markdown.ex:327
-#: lib/vutuv_web/agent_docs/text.ex:359
-#: lib/vutuv_web/agent_docs/text.ex:361
+#: lib/vutuv_web/agent_docs/markdown.ex:331
+#: lib/vutuv_web/agent_docs/markdown.ex:333
+#: lib/vutuv_web/agent_docs/text.ex:364
+#: lib/vutuv_web/agent_docs/text.ex:366
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format, fuzzy
@@ -12535,18 +12545,18 @@ msgstr ""
 msgid "Report this posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:221
-#: lib/vutuv_web/agent_docs/text.ex:216
+#: lib/vutuv_web/agent_docs/markdown.ex:227
+#: lib/vutuv_web/agent_docs/text.ex:221
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:214
-#: lib/vutuv_web/agent_docs/markdown.ex:343
-#: lib/vutuv_web/agent_docs/text.ex:210
-#: lib/vutuv_web/agent_docs/text.ex:377
+#: lib/vutuv_web/agent_docs/markdown.ex:220
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/text.ex:215
+#: lib/vutuv_web/agent_docs/text.ex:382
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Salary"
 msgstr ""
@@ -12638,10 +12648,10 @@ msgstr ""
 msgid "Working student"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:212
-#: lib/vutuv_web/agent_docs/markdown.ex:341
-#: lib/vutuv_web/agent_docs/text.ex:208
-#: lib/vutuv_web/agent_docs/text.ex:375
+#: lib/vutuv_web/agent_docs/markdown.ex:218
+#: lib/vutuv_web/agent_docs/markdown.ex:347
+#: lib/vutuv_web/agent_docs/text.ex:213
+#: lib/vutuv_web/agent_docs/text.ex:380
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Workplace"
@@ -12814,13 +12824,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:362
+#: lib/vutuv_web/agent_docs/markdown.ex:368
 #: lib/vutuv_web/templates/tag/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:395
+#: lib/vutuv_web/agent_docs/text.ex:400
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12866,12 +12876,12 @@ msgstr ""
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:234
+#: lib/vutuv_web/agent_docs/markdown.ex:240
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:229
+#: lib/vutuv_web/agent_docs/text.ex:234
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
@@ -12886,10 +12896,10 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:360
-#: lib/vutuv_web/agent_docs/markdown.ex:372
-#: lib/vutuv_web/agent_docs/text.ex:393
-#: lib/vutuv_web/agent_docs/text.ex:405
+#: lib/vutuv_web/agent_docs/markdown.ex:366
+#: lib/vutuv_web/agent_docs/markdown.ex:378
+#: lib/vutuv_web/agent_docs/text.ex:398
+#: lib/vutuv_web/agent_docs/text.ex:410
 #: lib/vutuv_web/live/organization_live/show.ex:329
 #: lib/vutuv_web/templates/tag/show.html.heex:57
 #, elixir-autogen, elixir-format
@@ -13080,6 +13090,7 @@ msgid "Search title, poster or organization"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
+#: lib/vutuv_web/live/post_live/composer.ex:705
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -13188,7 +13199,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2897
+#: lib/vutuv_web/components/ui.ex:2940
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13454,7 +13465,7 @@ msgstr ""
 msgid "An image was removed from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:987
+#: lib/vutuv_web/components/post_components.ex:992
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -13462,12 +13473,12 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:977
+#: lib/vutuv_web/components/post_components.ex:982
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:303
+#: lib/vutuv_web/live/notification_live/index.ex:332
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13478,7 +13489,7 @@ msgstr ""
 msgid "No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:393
+#: lib/vutuv_web/live/notification_live/index.ex:433
 #, elixir-autogen, elixir-format
 msgid "Our automated image review removed %{what}. Only family-friendly images suitable for a work environment are allowed."
 msgstr ""
@@ -13513,7 +13524,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:639
+#: lib/vutuv/accounts/user.ex:647
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13524,19 +13535,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:642
+#: lib/vutuv/accounts/user.ex:650
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:645
+#: lib/vutuv/accounts/user.ex:653
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:636
+#: lib/vutuv/accounts/user.ex:644
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13559,7 +13570,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:306
+#: lib/vutuv_web/live/notification_live/index.ex:335
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13571,48 +13582,48 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:420
+#: lib/vutuv_web/live/notification_live/index.ex:460
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:191
+#: lib/vutuv_web/components/ui.ex:195
 #, elixir-autogen, elixir-format
 msgid "Center"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:188
+#: lib/vutuv_web/components/ui.ex:192
 #, elixir-autogen, elixir-format
 msgid "Float left"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:194
+#: lib/vutuv_web/components/ui.ex:198
 #, elixir-autogen, elixir-format
 msgid "Float right"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:185
+#: lib/vutuv_web/components/ui.ex:189
 #, elixir-autogen, elixir-format
 msgid "Full width"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:507
+#: lib/vutuv_web/live/post_live/composer.ex:599
 #, elixir-autogen, elixir-format
 msgid "Insert"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:173
+#: lib/vutuv_web/components/ui.ex:177
 #, elixir-autogen, elixir-format
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:504
+#: lib/vutuv_web/live/post_live/composer.ex:596
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:166
-#: lib/vutuv_web/agent_docs/text.ex:163
+#: lib/vutuv_web/agent_docs/markdown.ex:172
+#: lib/vutuv_web/agent_docs/text.ex:168
 #: lib/vutuv_web/templates/tag/show.html.heex:39
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts with this tag"
@@ -13638,22 +13649,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:272
+#: lib/vutuv_web/components/post_components.ex:277
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:274
+#: lib/vutuv_web/components/post_components.ex:279
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:273
+#: lib/vutuv_web/components/post_components.ex:278
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:262
+#: lib/vutuv_web/components/post_components.ex:267
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13663,7 +13674,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2886
+#: lib/vutuv_web/components/ui.ex:2929
 #: lib/vutuv_web/controllers/settings_controller.ex:259
 #: lib/vutuv_web/live/post_live/feed.ex:651
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13712,14 +13723,15 @@ msgstr ""
 msgid "Signal and WhatsApp accept a phone number or a username; the other messengers use their own id or handle (e.g. an 8-character Threema ID or a Matrix @you:matrix.org)."
 msgstr ""
 
-#: lib/vutuv_web/templates/messenger/manage.html.heex:11
+#: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
 
+#: lib/vutuv_web/templates/messenger/card_list.html.heex:5
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:5
-#: lib/vutuv_web/templates/messenger/show.html.heex:16
+#: lib/vutuv_web/templates/messenger/show.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Messenger"
 msgstr ""
@@ -13729,30 +13741,37 @@ msgstr ""
 msgid "Messenger created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:107
+#: lib/vutuv_web/controllers/messenger_controller.ex:102
 #, elixir-autogen, elixir-format
 msgid "Messenger deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/messenger_controller.ex:99
+#: lib/vutuv_web/controllers/messenger_controller.ex:91
 #, elixir-autogen, elixir-format
 msgid "Messenger updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2851
-#: lib/vutuv_web/controllers/messenger_controller.ex:22
-#: lib/vutuv_web/templates/messenger/index.html.heex:11
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/agent_docs/markdown.ex:58
+#: lib/vutuv_web/agent_docs/text.ex:56
+#: lib/vutuv_web/components/ui.ex:2893
+#: lib/vutuv_web/controllers/messenger_controller.ex:21
+#: lib/vutuv_web/controllers/messenger_controller.ex:36
+#: lib/vutuv_web/templates/messenger/edit.html.heex:3
+#: lib/vutuv_web/templates/messenger/index.html.heex:10
+#: lib/vutuv_web/templates/messenger/manage.html.heex:4
+#: lib/vutuv_web/templates/messenger/new.html.heex:3
+#: lib/vutuv_web/templates/messenger/show.html.heex:6
+#: lib/vutuv_web/templates/user/show.html.heex:994
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
 
-#: lib/vutuv_web/templates/messenger/index.html.heex:6
+#: lib/vutuv_web/templates/messenger/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Messengers of "
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:100
+#: lib/vutuv_web/agent_docs/section_docs.ex:99
 #, elixir-autogen, elixir-format
 msgid "Messengers of %{name}"
 msgstr ""
@@ -13762,59 +13781,195 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2494
+#: lib/vutuv_web/components/ui.ex:2483
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:2503
+#: lib/vutuv_web/components/ui.ex:2493
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:311
+#: lib/vutuv_web/live/notification_live/index.ex:336
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:449
+#: lib/vutuv_web/live/notification_live/index.ex:480
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:443
+#: lib/vutuv_web/live/notification_live/index.ex:472
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:446
+#: lib/vutuv_web/live/notification_live/index.ex:477
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:74
+#: lib/vutuv_web/templates/settings/notifications.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "CV updates"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:77
+#: lib/vutuv_web/templates/settings/notifications.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "When someone you follow adds a new entry to their CV, they can let their followers know. It shows up under the bell, never by email."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:82
+#: lib/vutuv_web/templates/settings/notifications.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "Tell me about new CV entries of people I follow"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:83
+#: lib/vutuv_web/templates/settings/notifications.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:470
+#: lib/vutuv_web/live/notification_live/index.ex:485
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1496
+#, elixir-autogen, elixir-format
+msgid "Audiobook"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:713
+#, elixir-autogen, elixir-format
+msgid "Author(s)"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:775
+#, elixir-autogen, elixir-format
+msgid "Book"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:788
+#: lib/vutuv_web/components/post_components.ex:1486
+#: lib/vutuv_web/live/post_live/composer.ex:659
+#, elixir-autogen, elixir-format
+msgid "Book review"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1497
+#, elixir-autogen, elixir-format
+msgid "Cinema"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1499
+#, elixir-autogen, elixir-format
+msgid "DVD/Blu-ray"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:713
+#, elixir-autogen, elixir-format
+msgid "Director"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1495
+#, elixir-autogen, elixir-format
+msgid "E-book"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:787
+#, elixir-autogen, elixir-format
+msgid "Film"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:788
+#: lib/vutuv_web/components/post_components.ex:1485
+#: lib/vutuv_web/live/post_live/composer.ex:658
+#, elixir-autogen, elixir-format
+msgid "Film review"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:679
+#, elixir-autogen, elixir-format
+msgid "IMDb link or ID"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:680
+#, elixir-autogen, elixir-format
+msgid "ISBN"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:693
+#, elixir-autogen, elixir-format
+msgid "Look up"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:690
+#, elixir-autogen, elixir-format
+msgid "Looking up…"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:249
+#, elixir-autogen, elixir-format
+msgid "Nothing found for this ISBN. Please fill in the fields yourself."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1494
+#, elixir-autogen, elixir-format
+msgid "Printed book"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:732
+#, elixir-autogen, elixir-format
+msgid "Read as… (optional)"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:668
+#, elixir-autogen, elixir-format
+msgid "Remove review"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:771
+#: lib/vutuv_web/live/post_live/composer.ex:772
+#, elixir-autogen, elixir-format
+msgid "Review a book"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:783
+#: lib/vutuv_web/live/post_live/composer.ex:784
+#, elixir-autogen, elixir-format
+msgid "Review a film"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1498
+#, elixir-autogen, elixir-format
+msgid "Streaming"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1503
+#, elixir-autogen, elixir-format
+msgid "View on Amazon"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1502
+#, elixir-autogen, elixir-format
+msgid "View on IMDb"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:731
+#, elixir-autogen, elixir-format
+msgid "Watched as… (optional)"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:745
+#, elixir-autogen, elixir-format
+msgid "With an ISBN, the post shows the book cover and a shop link automatically."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:725
+#, elixir-autogen, elixir-format
+msgid "Year"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -170,3 +170,12 @@ msgid "The handle %{handles} does not exist. Remove the mention or check the spe
 msgid_plural "The handle %{handles} does not exist. Remove the mention or check the spelling."
 msgstr[0] "The handle %{handles} does not exist. Remove the mention or check the spelling."
 msgstr[1] "These handles do not exist: %{handles}. Remove the mentions or check the spelling."
+
+msgid "is not a valid ISBN"
+msgstr ""
+
+msgid "is not a valid IMDb link"
+msgstr ""
+
+msgid "the review is missing the title of the work"
+msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -173,3 +173,12 @@ msgid "The handle %{handles} does not exist. Remove the mention or check the spe
 msgid_plural "The handle %{handles} does not exist. Remove the mention or check the spelling."
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "is not a valid ISBN"
+msgstr ""
+
+msgid "is not a valid IMDb link"
+msgstr ""
+
+msgid "the review is missing the title of the work"
+msgstr ""

--- a/priv/repo/migrations/20260722100228_create_post_reviews.exs
+++ b/priv/repo/migrations/20260722100228_create_post_reviews.exs
@@ -1,0 +1,27 @@
+defmodule Vutuv.Repo.Migrations.CreatePostReviews do
+  use Ecto.Migration
+
+  # The structured review sidecar of a post (book/film reviews): kind +
+  # identifier (ISBN-13 / IMDb id) + cached display metadata + the fetched
+  # cover image state. One review per post; plain addition, N-1 safe.
+  def change do
+    create table(:post_reviews) do
+      add(:post_id, references(:posts, on_delete: :delete_all), null: false)
+      add(:kind, :string, null: false)
+      add(:identifier, :string)
+      add(:title, :string, null: false)
+      add(:creator, :string)
+      add(:year, :integer)
+      # How the reviewer consumed the work (book: print/ebook/audiobook,
+      # movie: cinema/streaming/disc); nil = unspecified.
+      add(:medium, :string)
+      add(:cover, :string)
+      add(:cover_status, :string, null: false, default: "none")
+      add(:cover_moderation, :string)
+
+      timestamps()
+    end
+
+    create(unique_index(:post_reviews, [:post_id]))
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -304,6 +304,18 @@ defmodule Vutuv.Factory do
     }
   end
 
+  def post_review_factory do
+    %Vutuv.Posts.PostReview{
+      post: build(:post),
+      kind: "book",
+      identifier: "9783161484100",
+      title: sequence(:review_title, &"Reviewed Book #{&1}"),
+      creator: "Erika Mustermann",
+      year: 2021,
+      cover_status: "none"
+    }
+  end
+
   def post_image_factory do
     %Vutuv.Posts.PostImage{
       token: PostImage.gen_token(),

--- a/test/vutuv/book_metadata_test.exs
+++ b/test/vutuv/book_metadata_test.exs
@@ -1,0 +1,60 @@
+defmodule Vutuv.BookMetadataTest do
+  use ExUnit.Case, async: false
+
+  alias Vutuv.BookMetadata
+
+  @isbn "9783161484100"
+
+  setup do
+    Application.put_env(:vutuv, :fetch_book_metadata, true)
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, :fetch_book_metadata, false)
+      Application.delete_env(:vutuv, :book_metadata_req_options)
+    end)
+
+    :ok
+  end
+
+  defp stub(body) do
+    Application.put_env(:vutuv, :book_metadata_req_options,
+      plug: fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(body))
+      end
+    )
+  end
+
+  test "parses title, authors and year from the Open Library answer" do
+    stub(%{
+      "ISBN:#{@isbn}" => %{
+        "title" => "Refactoring",
+        "authors" => [%{"name" => "Martin Fowler"}, %{"name" => "Kent Beck"}],
+        "publish_date" => "November 2018"
+      }
+    })
+
+    assert {:ok, %{title: "Refactoring", creator: "Martin Fowler, Kent Beck", year: 2018}} =
+             BookMetadata.lookup(@isbn)
+  end
+
+  test "missing optional fields come back nil" do
+    stub(%{"ISBN:#{@isbn}" => %{"title" => "Nur Titel"}})
+
+    assert {:ok, %{title: "Nur Titel", creator: nil, year: nil}} = BookMetadata.lookup(@isbn)
+  end
+
+  test "an unknown ISBN is :error" do
+    stub(%{})
+
+    assert :error = BookMetadata.lookup(@isbn)
+  end
+
+  test "with the fetch flag off nothing is looked up" do
+    Application.put_env(:vutuv, :fetch_book_metadata, false)
+    stub(%{"ISBN:#{@isbn}" => %{"title" => "Nie geholt"}})
+
+    assert :error = BookMetadata.lookup(@isbn)
+  end
+end

--- a/test/vutuv/isbn_test.exs
+++ b/test/vutuv/isbn_test.exs
@@ -1,0 +1,62 @@
+defmodule Vutuv.IsbnTest do
+  use ExUnit.Case, async: true
+
+  alias Vutuv.Isbn
+
+  describe "normalize/1" do
+    test "accepts a hyphenated ISBN-13" do
+      assert {:ok, "9783161484100"} = Isbn.normalize("978-3-16-148410-0")
+    end
+
+    test "accepts a bare ISBN-13" do
+      assert {:ok, "9780306406157"} = Isbn.normalize("9780306406157")
+    end
+
+    test "accepts a 979-prefixed ISBN-13" do
+      assert {:ok, "9798765432105"} = Isbn.normalize("979-8-7654-3210-5")
+    end
+
+    test "converts an ISBN-10 to its ISBN-13 form" do
+      assert {:ok, "9783161484100"} = Isbn.normalize("3-16-148410-X")
+      assert {:ok, "9780306406157"} = Isbn.normalize("0306406152")
+    end
+
+    test "accepts a lowercase x check digit" do
+      assert {:ok, "9783161484100"} = Isbn.normalize("316148410x")
+    end
+
+    test "tolerates spaces and a leading ISBN label" do
+      assert {:ok, "9783161484100"} = Isbn.normalize("ISBN 978 3 16 148410 0")
+      assert {:ok, "9783161484100"} = Isbn.normalize("isbn: 978-3-16-148410-0")
+    end
+
+    test "rejects a wrong check digit" do
+      assert :error = Isbn.normalize("978-3-16-148410-1")
+      assert :error = Isbn.normalize("3-16-148410-0")
+    end
+
+    test "rejects wrong lengths and junk" do
+      assert :error = Isbn.normalize("12345")
+      assert :error = Isbn.normalize("")
+      assert :error = Isbn.normalize("not-an-isbn")
+      # An X anywhere but the last position of an ISBN-10 is invalid.
+      assert :error = Isbn.normalize("31614841X0")
+    end
+  end
+
+  describe "isbn10/1" do
+    test "derives the ISBN-10 form of a 978 ISBN-13" do
+      assert {:ok, "316148410X"} = Isbn.isbn10("9783161484100")
+      assert {:ok, "0306406152"} = Isbn.isbn10("9780306406157")
+    end
+
+    test "a 979 ISBN-13 has no ISBN-10 form" do
+      assert :error = Isbn.isbn10("9798765432105")
+    end
+
+    test "rejects anything that is not a normalized ISBN-13" do
+      assert :error = Isbn.isbn10("316148410X")
+      assert :error = Isbn.isbn10("junk")
+    end
+  end
+end

--- a/test/vutuv/posts/post_review_test.exs
+++ b/test/vutuv/posts/post_review_test.exs
@@ -1,0 +1,193 @@
+defmodule Vutuv.Posts.PostReviewTest do
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Posts.PostReview
+
+  defp changeset(params), do: PostReview.changeset(%PostReview{}, params)
+
+  describe "changeset/2 — book" do
+    test "normalizes the ISBN and queues the cover fetch" do
+      changeset =
+        changeset(%{
+          "kind" => "book",
+          "identifier" => "978-3-16-148410-0",
+          "title" => "Beispielbuch",
+          "creator" => "Erika Mustermann",
+          "year" => "2021"
+        })
+
+      assert changeset.valid?
+      assert get_change(changeset, :identifier) == "9783161484100"
+      assert get_field(changeset, :cover_status) == "pending"
+      assert get_field(changeset, :year) == 2021
+    end
+
+    test "an ISBN-10 is stored in its ISBN-13 form" do
+      changeset =
+        changeset(%{"kind" => "book", "identifier" => "3-16-148410-X", "title" => "Altes Buch"})
+
+      assert get_change(changeset, :identifier) == "9783161484100"
+    end
+
+    test "a book without ISBN is fine and fetches no cover" do
+      changeset = changeset(%{"kind" => "book", "title" => "Ohne ISBN"})
+
+      assert changeset.valid?
+      assert get_field(changeset, :cover_status) == "none"
+    end
+
+    test "an invalid ISBN is rejected" do
+      changeset = changeset(%{"kind" => "book", "identifier" => "12345", "title" => "Kaputt"})
+
+      refute changeset.valid?
+      assert %{identifier: [_message]} = errors_on(changeset)
+    end
+
+    test "a changed ISBN resets a previously fetched cover" do
+      existing = %PostReview{
+        kind: "book",
+        identifier: "9783161484100",
+        title: "Buch",
+        cover: "abcdef123456.jpg",
+        cover_status: "ready",
+        cover_moderation: "approved"
+      }
+
+      changeset = PostReview.changeset(existing, %{"identifier" => "9780306406157"})
+
+      assert get_field(changeset, :cover) == nil
+      assert get_field(changeset, :cover_status) == "pending"
+      assert get_field(changeset, :cover_moderation) == nil
+    end
+
+    test "an unchanged ISBN leaves the cover state alone" do
+      existing = %PostReview{
+        kind: "book",
+        identifier: "9783161484100",
+        title: "Buch",
+        cover: "abcdef123456.jpg",
+        cover_status: "ready",
+        cover_moderation: "approved"
+      }
+
+      changeset =
+        PostReview.changeset(existing, %{"identifier" => "9783161484100", "year" => "1999"})
+
+      assert changeset.valid?
+      assert get_field(changeset, :cover) == "abcdef123456.jpg"
+      assert get_field(changeset, :cover_status) == "ready"
+    end
+  end
+
+  describe "changeset/2 — movie" do
+    test "accepts a bare IMDb id" do
+      changeset = changeset(%{"kind" => "movie", "identifier" => "tt0111161", "title" => "Film"})
+
+      assert changeset.valid?
+      assert get_change(changeset, :identifier) == "tt0111161"
+      assert get_field(changeset, :cover_status) == "none"
+    end
+
+    test "extracts the id from a pasted IMDb URL" do
+      changeset =
+        changeset(%{
+          "kind" => "movie",
+          "identifier" => "https://www.imdb.com/title/tt0111161/?ref_=nv_sr_srsg_0",
+          "title" => "Film"
+        })
+
+      assert get_change(changeset, :identifier) == "tt0111161"
+    end
+
+    test "rejects junk identifiers" do
+      changeset = changeset(%{"kind" => "movie", "identifier" => "shawshank", "title" => "Film"})
+
+      refute changeset.valid?
+      assert %{identifier: [_message]} = errors_on(changeset)
+    end
+  end
+
+  describe "changeset/2 — shared validations" do
+    test "kind and title are required" do
+      changeset = changeset(%{"kind" => "", "title" => ""})
+
+      assert %{kind: [_], title: [_]} = errors_on(changeset)
+    end
+
+    test "unknown kinds are rejected" do
+      changeset = changeset(%{"kind" => "hotel", "title" => "Grand Budapest"})
+
+      assert %{kind: [_message]} = errors_on(changeset)
+    end
+
+    test "the year must be plausible" do
+      assert %{year: [_]} =
+               errors_on(changeset(%{"kind" => "book", "title" => "B", "year" => "999"}))
+
+      assert %{year: [_]} =
+               errors_on(changeset(%{"kind" => "book", "title" => "B", "year" => "3001"}))
+    end
+
+    test "the medium must fit the kind" do
+      book = %{"kind" => "book", "title" => "B"}
+      movie = %{"kind" => "movie", "title" => "F"}
+
+      assert changeset(Map.put(book, "medium", "audiobook")).valid?
+      assert changeset(Map.put(movie, "medium", "cinema")).valid?
+      assert %{medium: [_]} = errors_on(changeset(Map.put(book, "medium", "cinema")))
+      assert %{medium: [_]} = errors_on(changeset(Map.put(movie, "medium", "audiobook")))
+      # The select's blank option stores nil.
+      assert changeset(Map.put(book, "medium", "")) |> Ecto.Changeset.get_field(:medium) == nil
+    end
+
+    test "title and creator are capped at their column length" do
+      too_long = String.duplicate("x", 256)
+
+      assert %{title: [_], creator: [_]} =
+               errors_on(
+                 changeset(%{"kind" => "book", "title" => too_long, "creator" => too_long})
+               )
+    end
+  end
+
+  describe "link builders" do
+    test "amazon_url/1 uses the ISBN-10 dp link for 978 ISBNs" do
+      review = %PostReview{kind: "book", identifier: "9783161484100"}
+
+      assert PostReview.amazon_url(review) == "https://www.amazon.de/dp/316148410X"
+    end
+
+    test "amazon_url/1 falls back to a search link for 979 ISBNs" do
+      review = %PostReview{kind: "book", identifier: "9798765432105"}
+
+      assert PostReview.amazon_url(review) == "https://www.amazon.de/s?k=9798765432105"
+    end
+
+    test "amazon_url/1 appends the configured affiliate tag" do
+      review = %PostReview{kind: "book", identifier: "9783161484100"}
+
+      Application.put_env(:vutuv, :amazon_affiliate_tag, "vutuv-21")
+      on_exit(fn -> Application.delete_env(:vutuv, :amazon_affiliate_tag) end)
+
+      assert PostReview.amazon_url(review) == "https://www.amazon.de/dp/316148410X?tag=vutuv-21"
+    end
+
+    test "amazon_url/1 is nil without an ISBN or with the shop switched off" do
+      assert PostReview.amazon_url(%PostReview{kind: "book", identifier: nil}) == nil
+      assert PostReview.amazon_url(%PostReview{kind: "movie", identifier: "tt0111161"}) == nil
+
+      Application.put_env(:vutuv, :amazon_domain, "")
+      on_exit(fn -> Application.delete_env(:vutuv, :amazon_domain) end)
+
+      assert PostReview.amazon_url(%PostReview{kind: "book", identifier: "9783161484100"}) == nil
+    end
+
+    test "imdb_url/1 links the movie page" do
+      review = %PostReview{kind: "movie", identifier: "tt0111161"}
+
+      assert PostReview.imdb_url(review) == "https://www.imdb.com/title/tt0111161/"
+      assert PostReview.imdb_url(%PostReview{kind: "movie", identifier: nil}) == nil
+      assert PostReview.imdb_url(%PostReview{kind: "book", identifier: "9783161484100"}) == nil
+    end
+  end
+end

--- a/test/vutuv/posts/post_reviews_test.exs
+++ b/test/vutuv/posts/post_reviews_test.exs
@@ -1,0 +1,198 @@
+defmodule Vutuv.Posts.PostReviewsTest do
+  @moduledoc """
+  The review sidecar through the Posts context: create/update/delete a post
+  with review attrs, the partial-update semantics (no :review key = leave it
+  alone), and the cover fetch pipeline with stubbed HTTP.
+  """
+
+  use Vutuv.DataCase, async: true
+
+  import Vutuv.Factory
+
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostReview
+  alias Vutuv.Posts.ReviewCovers
+  alias Vutuv.Repo
+
+  @book_review %{
+    "kind" => "book",
+    "identifier" => "978-3-16-148410-0",
+    "title" => "Refactoring",
+    "creator" => "Martin Fowler",
+    "year" => "2018"
+  }
+
+  describe "create_post/2 with a review" do
+    test "persists the review beside the post" do
+      author = insert(:user)
+
+      assert {:ok, post} =
+               Posts.create_post(author, %{body: "Lesenswert!", review: @book_review})
+
+      assert %PostReview{} = post.review
+      assert post.review.kind == "book"
+      assert post.review.identifier == "9783161484100"
+      assert post.review.title == "Refactoring"
+      assert post.review.year == 2018
+      assert post.review.cover_status == "pending"
+    end
+
+    test "a movie review stores the IMDb id and fetches no cover" do
+      author = insert(:user)
+
+      assert {:ok, post} =
+               Posts.create_post(author, %{
+                 body: "Starker Film.",
+                 review: %{
+                   "kind" => "movie",
+                   "identifier" => "https://www.imdb.com/title/tt0111161/",
+                   "title" => "Die Verurteilten",
+                   "creator" => "Frank Darabont",
+                   "year" => "1994"
+                 }
+               })
+
+      assert post.review.kind == "movie"
+      assert post.review.identifier == "tt0111161"
+      assert post.review.cover_status == "none"
+    end
+
+    test "a blank kind or a missing review key creates no review" do
+      author = insert(:user)
+
+      assert {:ok, post} = Posts.create_post(author, %{body: "Ohne Review"})
+      assert post.review == nil
+
+      assert {:ok, post} =
+               Posts.create_post(author, %{body: "Auch ohne", review: %{"kind" => ""}})
+
+      assert post.review == nil
+    end
+
+    test "an invalid review rejects the whole post" do
+      author = insert(:user)
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Posts.create_post(author, %{
+                 body: "Kaputt",
+                 review: %{"kind" => "book", "identifier" => "not-an-isbn", "title" => "X"}
+               })
+
+      assert %{review: %{identifier: [_message]}} = errors_on(changeset)
+    end
+  end
+
+  describe "update_post/2 and the review" do
+    test "adds a review to an existing post" do
+      post = insert(:post)
+
+      assert {:ok, updated} = Posts.update_post(post, %{body: post.body, review: @book_review})
+      assert updated.review.title == "Refactoring"
+    end
+
+    test "a blank kind removes the review" do
+      review = insert(:post_review)
+
+      assert {:ok, updated} =
+               Posts.update_post(review.post, %{body: "bleibt", review: %{"kind" => ""}})
+
+      assert updated.review == nil
+      assert Repo.get(PostReview, review.id) == nil
+    end
+
+    test "attrs without a :review key leave the review untouched (partial update)" do
+      review = insert(:post_review)
+
+      assert {:ok, updated} = Posts.update_post(review.post, %{body: "nur der Text"})
+
+      assert updated.review.id == review.id
+      assert updated.review.title == review.title
+    end
+
+    test "a changed ISBN resets the cover to pending" do
+      review =
+        insert(:post_review,
+          cover: "abcdef123456.jpg",
+          cover_status: "ready",
+          cover_moderation: "approved"
+        )
+
+      assert {:ok, updated} =
+               Posts.update_post(review.post, %{
+                 body: "neues Buch",
+                 review: %{"kind" => "book", "identifier" => "9780306406157", "title" => "Anders"}
+               })
+
+      assert updated.review.id == review.id
+      assert updated.review.identifier == "9780306406157"
+      assert updated.review.cover == nil
+      assert updated.review.cover_status == "pending"
+    end
+  end
+
+  test "delete_post/1 removes the review row" do
+    review = insert(:post_review)
+
+    assert {:ok, _} = Posts.delete_post(review.post)
+    assert Repo.get(PostReview, review.id) == nil
+  end
+
+  describe "ReviewCovers.fetch/1" do
+    # Real JPEG bytes (synthesized via libvips), so the decode succeeds.
+    defp jpeg_bytes do
+      path =
+        Path.join(System.tmp_dir!(), "review_cover_src_#{System.unique_integer([:positive])}.jpg")
+
+      {:ok, img} = Image.new(120, 180, color: [10, 120, 200])
+      {:ok, _} = Image.write(img, path)
+      bytes = File.read!(path)
+      File.rm(path)
+      bytes
+    end
+
+    defp fetch_with_status(review, status, body \\ "") do
+      Application.put_env(:vutuv, :book_covers_req_options,
+        plug: fn conn ->
+          conn
+          |> Plug.Conn.put_resp_content_type("image/jpeg")
+          |> Plug.Conn.resp(status, body)
+        end
+      )
+
+      on_exit(fn -> Application.delete_env(:vutuv, :book_covers_req_options) end)
+
+      ReviewCovers.fetch(review)
+    end
+
+    test "stores the cover and marks the review ready" do
+      review = insert(:post_review, cover_status: "pending")
+
+      assert :ok = fetch_with_status(review, 200, jpeg_bytes())
+
+      stored = Repo.get(PostReview, review.id)
+      assert stored.cover_status == "ready"
+      assert is_binary(stored.cover)
+      # :moderate_images is off in tests, so the cover is born released.
+      assert PostReview.cover_ready?(stored)
+
+      assert Vutuv.ReviewCover.version_path(stored, Vutuv.ReviewCover.version_name(stored))
+      Vutuv.ReviewCover.delete_files(stored)
+    end
+
+    test "a 404 (no cover known) marks the fetch failed" do
+      review = insert(:post_review, cover_status: "pending")
+
+      fetch_with_status(review, 404)
+
+      assert Repo.get(PostReview, review.id).cover_status == "failed"
+    end
+
+    test "undecodable bytes mark the fetch failed" do
+      review = insert(:post_review, cover_status: "pending")
+
+      fetch_with_status(review, 200, "definitely not a jpeg")
+
+      assert Repo.get(PostReview, review.id).cover_status == "failed"
+    end
+  end
+end

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -340,6 +340,33 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert rendered.txt =~ "Likes: 1"
   end
 
+  test "post permalink: a book review's facts reach every format", %{user: user} do
+    reviewed =
+      create_post!(user, %{
+        "body" => "A classic worth rereading.",
+        "review" => %{
+          "kind" => "book",
+          "identifier" => "978-3-16-148410-0",
+          "title" => "Refactoring",
+          "creator" => "Martin Fowler",
+          "year" => "2018",
+          "medium" => "audiobook"
+        }
+      })
+
+    rendered = formats_for("/drift_tester/posts/#{reviewed.id}")
+
+    for fact <- ["Refactoring", "Martin Fowler", "9783161484100", "Audiobook"],
+        do: assert_fact_everywhere(rendered, fact)
+
+    doc = Jason.decode!(rendered.json)
+    assert doc["review"]["kind"] == "book"
+    assert doc["review"]["identifier"] == "9783161484100"
+    assert doc["review"]["year"] == 2018
+    assert doc["review"]["medium"] == "audiobook"
+    assert doc["review"]["link"] == "https://www.amazon.de/dp/316148410X"
+  end
+
   test "post archive: entries and total in every format", %{post: post} do
     rendered = formats_for("/drift_tester/posts")
 

--- a/test/vutuv_web/controllers/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/fediverse_controller_test.exs
@@ -373,6 +373,38 @@ defmodule VutuvWeb.FediverseControllerTest do
       assert body["content"] =~ "Hallo Fediverse"
     end
 
+    test "a book review post's Note carries the review facts in its content", %{conn: conn} do
+      user = federated_user()
+
+      post =
+        create_post!(user, %{
+          body: "Sehr lesenswert.",
+          review: %{
+            "kind" => "book",
+            "identifier" => "978-3-16-148410-0",
+            "title" => "Refactoring",
+            "creator" => "Martin Fowler",
+            "year" => "2018",
+            "medium" => "audiobook"
+          }
+        })
+
+      conn =
+        conn
+        |> put_req_header("accept", "application/activity+json")
+        |> get("/#{user.username}/posts/#{post.id}")
+
+      content = Jason.decode!(conn.resp_body)["content"]
+
+      # Remote software knows nothing of review cards, so the reviewed work's
+      # facts ride inside the Note content itself.
+      assert content =~ "Book review"
+      assert content =~ "Refactoring"
+      assert content =~ "Martin Fowler"
+      assert content =~ "ISBN 9783161484100"
+      assert content =~ "https://www.amazon.de/dp/316148410X"
+    end
+
     test "the profile head advertises the actor for opted-in members", %{conn: conn} do
       user = federated_user()
 

--- a/test/vutuv_web/controllers/feed_controller_test.exs
+++ b/test/vutuv_web/controllers/feed_controller_test.exs
@@ -45,6 +45,26 @@ defmodule VutuvWeb.FeedControllerTest do
       assert body =~ "Second paragraph."
     end
 
+    test "a book review's facts ride inside the item content", %{author: author} do
+      create_post!(author, %{
+        "body" => "Sehr lesenswert.",
+        "review" => %{
+          "kind" => "book",
+          "identifier" => "978-3-16-148410-0",
+          "title" => "Refactoring",
+          "creator" => "Martin Fowler",
+          "year" => "2018"
+        }
+      })
+
+      body = build_conn() |> get("/feed_author/posts/feed.xml") |> Map.fetch!(:resp_body)
+
+      assert body =~ "Book review"
+      assert body =~ "Refactoring"
+      assert body =~ "Martin Fowler"
+      assert body =~ "ISBN 9783161484100"
+    end
+
     test "links and guids are absolute permalinks", %{author: author} do
       post = create_post!(author, %{"body" => "Linked"})
 

--- a/test/vutuv_web/controllers/post_controller_test.exs
+++ b/test/vutuv_web/controllers/post_controller_test.exs
@@ -22,6 +22,53 @@ defmodule VutuvWeb.PostControllerTest do
 
   defp pad(int), do: String.pad_leading(Integer.to_string(int), 2, "0")
 
+  describe "the review card on the permalink" do
+    defp reviewed_post!(user) do
+      create_post!(user, %{
+        body: "Sehr lesenswert.",
+        review: %{
+          "kind" => "book",
+          "identifier" => "978-3-16-148410-0",
+          "title" => "Refactoring",
+          "creator" => "Martin Fowler",
+          "year" => "2018",
+          "medium" => "audiobook"
+        }
+      })
+    end
+
+    test "shows card, medium, shop link and Review JSON-LD", %{conn: conn} do
+      user = insert_activated_user()
+      post = reviewed_post!(user)
+
+      html = conn |> get(Posts.path(post)) |> html_response(200)
+
+      assert html =~ "data-review-card"
+      assert html =~ "Book review"
+      assert html =~ "Refactoring"
+      assert html =~ "Martin Fowler"
+      assert html =~ "Audiobook"
+      assert html =~ "https://www.amazon.de/dp/316148410X"
+      # The structured data marks the post as a Review of the Book.
+      assert html =~ "itemReviewed"
+      assert html =~ ~s("isbn": "9783161484100")
+    end
+
+    test "renders in German for German visitors (locale dimension)", %{conn: conn} do
+      user = insert_activated_user()
+      post = reviewed_post!(user)
+
+      html =
+        conn
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(Posts.path(post))
+        |> html_response(200)
+
+      assert html =~ "Buchbesprechung"
+      assert html =~ "Hörbuch"
+    end
+  end
+
   describe "GET the permalink" do
     test "renders a public post to anonymous visitors, indexable", %{conn: conn} do
       user = insert_activated_user()

--- a/test/vutuv_web/controllers/review_cover_controller_test.exs
+++ b/test/vutuv_web/controllers/review_cover_controller_test.exs
@@ -1,0 +1,115 @@
+defmodule VutuvWeb.ReviewCoverControllerTest do
+  @moduledoc """
+  The authorizing review-cover proxy: the post's audience must guard the
+  cover bytes, a cover still in AI-moderation limbo is the author's alone,
+  and only the currently stored fingerprinted filename resolves. Denied and
+  unknown both answer 404.
+  """
+
+  use VutuvWeb.ConnCase
+
+  alias Vutuv.Posts
+  alias Vutuv.Repo
+  alias Vutuv.ReviewCover
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "vutuv_covers_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    prev = Application.get_env(:vutuv, :uploads_dir_prefix)
+    Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
+
+    on_exit(fn ->
+      File.rm_rf(tmp)
+
+      if prev,
+        do: Application.put_env(:vutuv, :uploads_dir_prefix, prev),
+        else: Application.delete_env(:vutuv, :uploads_dir_prefix)
+    end)
+
+    :ok
+  end
+
+  defp jpeg_bytes do
+    path = Path.join(System.tmp_dir!(), "cover_src_#{System.unique_integer([:positive])}.jpg")
+    {:ok, img} = Image.new(120, 180, color: [10, 120, 200])
+    {:ok, _} = Image.write(img, path)
+    bytes = File.read!(path)
+    File.rm(path)
+    bytes
+  end
+
+  defp reviewed_post!(author, post_attrs \\ %{}, review_overrides \\ %{}) do
+    {:ok, post} =
+      Posts.create_post(
+        author,
+        Map.merge(
+          %{
+            body: "Lesenswert",
+            review: %{
+              "kind" => "book",
+              "identifier" => "978-3-16-148410-0",
+              "title" => "Refactoring"
+            }
+          },
+          post_attrs
+        )
+      )
+
+    {:ok, file} = ReviewCover.store_binary(jpeg_bytes(), post.review)
+
+    review =
+      post.review
+      |> Ecto.Changeset.change(
+        Map.merge(
+          %{cover: file, cover_status: "ready", cover_moderation: "approved"},
+          review_overrides
+        )
+      )
+      |> Repo.update!()
+
+    {post, review}
+  end
+
+  defp cover_path(review), do: ReviewCover.url(review)
+
+  test "a public post's cover is served with immutable private caching", %{conn: conn} do
+    author = insert(:user, email_confirmed?: true)
+    {_post, review} = reviewed_post!(author)
+
+    conn = get(conn, cover_path(review))
+
+    assert response(conn, 200)
+    assert get_resp_header(conn, "content-type") |> hd() =~ "image/avif"
+    assert get_resp_header(conn, "cache-control") == ["private, max-age=31536000, immutable"]
+  end
+
+  test "an outdated or foreign filename never resolves", %{conn: conn} do
+    author = insert(:user, email_confirmed?: true)
+    {_post, review} = reviewed_post!(author)
+
+    assert conn |> get("/review_covers/#{review.id}/cover-000000000000.avif") |> response(404)
+    assert conn |> get("/review_covers/#{review.id}/original.jpg") |> response(404)
+
+    assert conn
+           |> get("/review_covers/#{Vutuv.UUIDv7.generate()}/cover-abc.avif")
+           |> response(404)
+  end
+
+  test "a restricted post's cover is denied to strangers but served to the author", %{conn: conn} do
+    {authed_conn, author} = create_and_login_user(conn)
+
+    {_post, review} =
+      reviewed_post!(author, %{denials: [%{"wildcard" => "non_followers"}]})
+
+    assert conn |> get(cover_path(review)) |> response(404)
+    assert authed_conn |> get(cover_path(review)) |> response(200)
+  end
+
+  test "a cover in moderation limbo is the author's alone", %{conn: conn} do
+    {authed_conn, author} = create_and_login_user(conn)
+    {_post, review} = reviewed_post!(author, %{}, %{cover_moderation: "pending"})
+
+    assert conn |> get(cover_path(review)) |> response(404)
+    assert authed_conn |> get(cover_path(review)) |> response(200)
+  end
+end

--- a/test/vutuv_web/live/post_review_composer_test.exs
+++ b/test/vutuv_web/live/post_review_composer_test.exs
@@ -1,0 +1,177 @@
+defmodule VutuvWeb.PostReviewComposerTest do
+  @moduledoc """
+  The composer's review panel (book/film reviews, `Vutuv.Posts.PostReview`):
+  opening it via the 📖/🎬 triggers, the ISBN lookup prefill, the save round
+  trip onto the feed card, and removing a stored review from the edit page.
+  """
+
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Posts
+
+  @review_params %{
+    "kind" => "book",
+    "identifier" => "978-3-16-148410-0",
+    "title" => "Refactoring",
+    "creator" => "Martin Fowler",
+    "year" => "2018",
+    "medium" => "audiobook"
+  }
+
+  describe "the feed composer" do
+    test "opens the panel, saves a book review and renders the card", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      refute has_element?(live, "#composer-review-panel")
+
+      live
+      |> element(~s(button[phx-click="review-kind"][phx-value-kind="book"]))
+      |> render_click()
+
+      assert has_element?(live, "#composer-review-panel")
+
+      live
+      |> form("#composer-form", %{
+        "post" => %{"body" => "Sehr lesenswert.", "review" => @review_params}
+      })
+      |> render_submit()
+
+      feed_html = live |> element("#feed-posts") |> render()
+      assert feed_html =~ "data-review-card"
+      assert feed_html =~ "Refactoring"
+      assert feed_html =~ "Martin Fowler"
+      assert feed_html =~ "ISBN 9783161484100"
+      assert feed_html =~ "https://www.amazon.de/dp/316148410X"
+
+      # The composer reset also closes the panel for the next post.
+      refute has_element?(live, "#composer-review-panel")
+    end
+
+    test "a film review stores the IMDb id and links IMDb", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      live
+      |> element(~s(button[phx-click="review-kind"][phx-value-kind="movie"]))
+      |> render_click()
+
+      live
+      |> form("#composer-form", %{
+        "post" => %{
+          "body" => "Starker Film.",
+          "review" => %{
+            "kind" => "movie",
+            "identifier" => "https://www.imdb.com/title/tt0111161/?ref_=x",
+            "title" => "Die Verurteilten",
+            "creator" => "Frank Darabont",
+            "medium" => "cinema"
+          }
+        }
+      })
+      |> render_submit()
+
+      feed_html = live |> element("#feed-posts") |> render()
+      assert feed_html =~ ~s(data-review-kind="movie")
+      assert feed_html =~ "https://www.imdb.com/title/tt0111161/"
+
+      _ = user
+      review = Vutuv.Repo.one(Vutuv.Posts.PostReview)
+      assert review.identifier == "tt0111161"
+      assert review.medium == "cinema"
+    end
+
+    test "an invalid ISBN surfaces the review error", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      live
+      |> element(~s(button[phx-click="review-kind"][phx-value-kind="book"]))
+      |> render_click()
+
+      html =
+        live
+        |> form("#composer-form", %{
+          "post" => %{
+            "body" => "Kaputt",
+            "review" => %{"kind" => "book", "identifier" => "12345", "title" => "X"}
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "is not a valid ISBN"
+      assert live |> element("#composer-error") |> render() =~ "is not a valid ISBN"
+    end
+
+    test "the ISBN lookup prefills title, creator and year", %{conn: conn} do
+      Application.put_env(:vutuv, :fetch_book_metadata, true)
+
+      Application.put_env(:vutuv, :book_metadata_req_options,
+        plug: fn plug_conn ->
+          body = %{
+            "ISBN:9783161484100" => %{
+              "title" => "Refactoring",
+              "authors" => [%{"name" => "Martin Fowler"}],
+              "publish_date" => "November 2018"
+            }
+          }
+
+          plug_conn
+          |> Plug.Conn.put_resp_content_type("application/json")
+          |> Plug.Conn.resp(200, Jason.encode!(body))
+        end
+      )
+
+      on_exit(fn ->
+        Application.put_env(:vutuv, :fetch_book_metadata, false)
+        Application.delete_env(:vutuv, :book_metadata_req_options)
+      end)
+
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      live
+      |> element(~s(button[phx-click="review-kind"][phx-value-kind="book"]))
+      |> render_click()
+
+      live
+      |> form("#composer-form", %{
+        "post" => %{"review" => %{"kind" => "book", "identifier" => "978-3-16-148410-0"}}
+      })
+      |> render_change()
+
+      html = live |> element("#composer-review-lookup") |> render_click()
+
+      assert html =~ ~s(value="Refactoring")
+      assert html =~ ~s(value="Martin Fowler")
+      assert html =~ ~s(value="2018")
+    end
+  end
+
+  describe "the edit page" do
+    test "prefills the stored review and removes it via the panel's ✕", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      {:ok, post} =
+        Posts.create_post(user, %{body: "Besprochen", review: @review_params})
+
+      {:ok, live, html} = live(conn, ~p"/posts/#{post.id}/edit")
+
+      assert html =~ ~s(id="composer-review-panel")
+      assert html =~ ~s(value="Refactoring")
+
+      live
+      |> element(~s(#composer-review-panel button[phx-click="review-kind"][phx-value-kind=""]))
+      |> render_click()
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "Besprochen"}})
+      |> render_submit()
+
+      updated = Posts.get_post(post.id)
+      assert updated.review == nil
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** Posts can carry a structured book/film review sidecar: ISBN/IMDb id + title/creator/year/medium, rendered as a review card with an Open-Library-fetched cover and an Amazon/IMDb link — on the site, in JSON-LD, in the agent docs, in RSS and in the federated AP Note.

**Where:** `Vutuv.Posts.PostReview` (+ `Vutuv.Isbn`, `Vutuv.BookMetadata`, `Vutuv.Posts.ReviewCovers`, `Vutuv.ReviewCover`, `VutuvWeb.ReviewCoverController`), composer panel in `PostLive.Composer`, card in `VutuvWeb.PostComponents`.
**Now:** a post is prose only; a book review is just text.
**Want / done:**
- Composer: 📖/🎬 triggers open a review panel; ISBN lookup prefills title/author/year (Open Library, keyless); per-kind medium select (print/ebook/audiobook, cinema/streaming/disc).
- Review card under the prose on feed/profile/permalink: cover (or glyph tile), kind label, title, creator · year · medium, ISBN, Amazon (ISBN-10 `/dp/` link, config domain + optional affiliate tag, empty domain = no link) or IMDb.
- Covers fetched off the request path, gated by `FETCH_BOOK_METADATA`, AI-moderation-gated (`review_cover` kind) and served via authorizing proxy `/review_covers/:id/cover-<hash>.avif`.
- Structured data: permalink JSON-LD becomes `["BlogPosting","Review"]` with `itemReviewed` (Book/Movie, `bookFormat` for ebook/audiobook); agent docs (.md/.txt/.json/.xml) carry the review (drift-tested).
- Fediverse + RSS: the review facts render into the Note/item content, the cover rides as attachment — storage stays structured, remote software needs nothing new.
- Docs: ADMINS.md env table + intranet section, `docs/architecture/posts-and-feed.md`, README.
- 60+ new tests (ISBN checksums, changeset, context round trips, cover fetch with stubbed HTTP, proxy auth, composer LiveView, drift, German locale). `mix precommit` green; browser-smoke-tested end to end incl. live cover fetch.

Future stages discussed but not in this PR: credits linking reviewed authors/organizations to vutuv profiles, TMDB movie posters, further kinds (hotels etc.).

*Written with this GitHub account, but not necessarily by the human behind it — this may just be a note-taking issue that gets deleted later without ever being tackled.*