### PR TITLE
Vet generic 5.0.0 bounces by reply text; thaw the wrongly frozen accounts

### DIFF
--- a/docs/production-email-and-bounces.md
+++ b/docs/production-email-and-bounces.md
@@ -199,14 +199,23 @@ Anything else (animina, mehr-schulferien, system cron mail) is ignored.
 
 | dsn / status | Example seen in prod | Meaning | Action |
 |---|---|---|---|
-| `5.1.1` `5.1.2` `5.1.3` `5.5.0` `5.0.0` + `bounced` | "No such mailbox", "User unknown", "mailbox unavailable", "not a valid RFC 5321 address" | **Recipient is dead.** | Deactivate the address (§4.1); count toward freeze (§4.2). |
+| `5.1.1` `5.1.2` `5.1.3` `5.5.0` + `bounced` | "No such mailbox", "User unknown", "mailbox unavailable", "not a valid RFC 5321 address" | **Recipient is dead.** | Deactivate the address (§4.1); count toward freeze (§4.2). |
+| `5.0.0` + `bounced`, text confirms a dead recipient | "550 Requested action not taken: mailbox unavailable", "552 … mailbox not found" | **Recipient is dead** (bare 550/552 reply, no enhanced code). | Same as above — but only with confirming text. |
+| `5.0.0` + `bounced`, quota or block text | "552 … exceeded storage allocation … Quota exceeded", "550 … (user@host:blocked)" | **Mailbox is full, or the recipient's filter blocked this message.** The mailbox lives. | **Do NOT deactivate.** Quota → ignore; block → treated like a policy bounce. |
 | `5.7.x` + `bounced` | `5.7.26 … unauthenticated … DMARC` | **Sender/policy problem, not the recipient.** (Our SPF/DKIM, or the remote's policy.) | **Do NOT deactivate.** Alert ops instead — this means *our* sending is broken for a whole class of recipients. |
 | `4.x.x` + `deferred` | `4.0.0 … receiving mail too quickly`, mailbox full | **Transient.** Postfix keeps retrying. | Never deactivate. Only repeated/aging deferrals feed freeze scoring (§4.2). |
 
 Treating `5.7.x` as a dead recipient is the most dangerous false positive: a
 single DKIM misconfiguration would otherwise "kill" every Gmail recipient at
-once. Always gate on the `5.1.x / 5.5.x / 5.0.x` recipient classes for
-deactivation.
+once. Deactivation gates on the `5.1.x / 5.5.x` recipient families — and on
+`5.0.x` **only when the reply text itself confirms a dead recipient**
+(`Vutuv.Deliverability.MailLog`). `5.0.0` is not an enhanced code from the
+remote: Postfix maps any bare `550`/`552` reply to it, so the bucket mixes
+dead mailboxes with full mailboxes and recipient-side spam/IP blocks. The
+July 2026 newsletters proved the hazard: 19 members with full (gmx/web.de
+quota) or filter-blocked mailboxes were deactivated and then frozen; the
+`RepairMisclassifiedBounceFreezes` migration thawed them and the classifier
+has vetted `5.0.x` by text ever since.
 
 ### 3.4 Granting the detector log access (pick one)
 

--- a/lib/vutuv/deliverability.ex
+++ b/lib/vutuv/deliverability.ex
@@ -162,9 +162,16 @@ defmodule Vutuv.Deliverability do
   defp hard_bounces_for(emails) do
     addresses = Enum.map(emails, & &1.value)
 
-    from(b in EmailBounce, where: b.email_value in ^addresses, select: b.status)
+    from(b in EmailBounce, where: b.email_value in ^addresses, select: {b.status, b.raw})
     |> Repo.all()
-    |> Enum.count(&MailLog.recipient_failure?(&1 || ""))
+    |> Enum.count(&confirmed_recipient_failure?/1)
+  end
+
+  # A ledger row proves a dead recipient only under the text-vetted classifier
+  # (a generic 5.0.0 quota/blocked row recorded before the vetting existed must
+  # not count toward a freeze).
+  defp confirmed_recipient_failure?({status, raw}) do
+    MailLog.recipient_failure?(status || "", raw || "")
   end
 
   defp dead_past_grace?(emails) do
@@ -206,6 +213,59 @@ defmodule Vutuv.Deliverability do
     else
       {:ok, :noop}
     end
+  end
+
+  @doc """
+  Data repair (run by the `RepairMisclassifiedBounceFreezes` migration, kept
+  callable for ops): re-evaluates every address currently marked undeliverable
+  against the text-vetted classifier and clears the mark when none of its
+  ledger rows is a confirmed recipient failure - the generic-5.0.0
+  misclassification, where full mailboxes (552 quota) and recipient-side
+  blocks counted as dead recipients. Each owner is then re-assessed, so a
+  freeze that rested only on misclassified bounces lifts, with the audit
+  trail naming the repair. Idempotent. Returns `%{cleared: n, thawed: n}`.
+  """
+  def repair_misclassified_bounces do
+    cleared =
+      Repo.all(from(e in Email, where: not is_nil(e.undeliverable_at)))
+      |> Enum.filter(&only_misclassified_bounces?/1)
+
+    Enum.each(cleared, fn email ->
+      Bounces.clear(email.value)
+
+      log("address_recovered",
+        user_id: email.user_id,
+        email: email.value,
+        detail: %{"reason" => "misclassified_bounce"}
+      )
+    end)
+
+    owners = cleared |> Enum.map(& &1.user_id) |> Enum.reject(&is_nil/1) |> Enum.uniq()
+
+    thawed =
+      Enum.count(owners, fn user_id ->
+        frozen_before? = frozen_now?(user_id)
+        reassess_user(user_id)
+        frozen_before? and not frozen_now?(user_id)
+      end)
+
+    %{cleared: length(cleared), thawed: thawed}
+  end
+
+  # An address qualifies for the repair only when there is ledger evidence and
+  # none of it survives the vetted classifier. No evidence at all means the
+  # mark came from elsewhere - leave it alone.
+  defp only_misclassified_bounces?(%Email{value: value}) do
+    case Repo.all(
+           from(b in EmailBounce, where: b.email_value == ^value, select: {b.status, b.raw})
+         ) do
+      [] -> false
+      rows -> not Enum.any?(rows, &confirmed_recipient_failure?/1)
+    end
+  end
+
+  defp frozen_now?(user_id) do
+    Repo.exists?(from(u in User, where: u.id == ^user_id and not is_nil(u.unreachable_at)))
   end
 
   @doc """

--- a/lib/vutuv/deliverability/mail_log.ex
+++ b/lib/vutuv/deliverability/mail_log.ex
@@ -21,15 +21,24 @@ defmodule Vutuv.Deliverability.MailLog do
   ## Classification (see the DSN-code table in the ops doc)
 
     * `:hard_bounce` - `status=bounced` with a recipient-failure code
-      (`5.0.x` / `5.1.x` / `5.5.x`: no such user, mailbox unavailable, invalid
-      address). The address is dead; deactivate it.
-    * `:policy` - `status=bounced` with `5.7.x` (authentication / DMARC). A
-      sender- or policy-side problem, **not** the recipient. Never deactivate;
-      it means our own sending is broken for a whole class of recipients.
+      (`5.1.x` / `5.5.x`: no such user, mailbox unavailable, invalid address),
+      or generic `5.0.x` whose reply text itself confirms a dead recipient.
+      The address is dead; deactivate it.
+    * `:policy` - `status=bounced` with `5.7.x` (authentication / DMARC), or
+      `5.0.x` whose text names a recipient-side block. A sender- or
+      policy-side problem, **not** the recipient. Never deactivate; it can
+      mean our own sending is broken for a whole class of recipients.
     * `:transient` - `status=deferred`, or any `4.x.x`. Postfix keeps retrying.
     * `:delivered` - `status=sent`.
     * `:other` - any other `5.x.x` bounce (e.g. `5.2.x` full/disabled mailbox,
-      `5.4.x` routing). Left alone, conservatively, to avoid false positives.
+      `5.4.x` routing), a `5.0.x` quota reply, or a `5.0.x` with unrecognized
+      text. Left alone, conservatively, to avoid false positives.
+
+  `5.0.x` needs the text vetting because it is not an enhanced code from the
+  remote server: Postfix maps any bare `550`/`552` reply to it, so the bucket
+  mixes dead mailboxes with full mailboxes (`552 Quota exceeded`) and
+  recipient-side spam/IP blocks. Treating the whole bucket as dead recipients
+  froze 19 live accounts after the July 2026 newsletters.
   """
 
   @max_tracked 2000
@@ -52,6 +61,15 @@ defmodule Vutuv.Deliverability.MailLog do
   @envelope_re ~r/postfix\/[a-z]+\[\d+\]: ([0-9A-Za-z]{6,}): from=<([^>]*)>/
   # `postfix/smtp[948]: 70EE...: to=<x@y>, relay=..., dsn=5.1.2, status=bounced (...)`
   @delivery_re ~r/postfix\/[a-z]+\[\d+\]: ([0-9A-Za-z]{6,}): to=<([^>]*)>.*?dsn=([0-9.]+), status=(\w+)/
+
+  # Reply-text evidence for the generic `5.0.x` bucket (all shapes seen in the
+  # production log). Contra-indications are checked first: they name a working
+  # mailbox that refused this one message (or a problem with *our* sending),
+  # so they must win over a dead-recipient phrase in the same multi-cause
+  # reply ("Recipient address rejected: Access denied").
+  @full_mailbox_text ~r/quota|storage allocation|mailbox (?:is )?full|insufficient storage/i
+  @blocked_text ~r/blocked|blacklist|denylist|spam|banned|denied|reputation|sender (?:address )?(?:rejected|verify failed)/i
+  @dead_recipient_text ~r/user unknown|unknown (?:user|recipient|address)|address unknown|mailbox \S+ unknown|no such (?:user|recipient|mailbox|address)|does not exist|not found|no mailbox|mailbox unavailable|invalid (?:recipient|mailbox)|no longer (?:available|on system)|address rejected|unroutable|unrouteable/i
 
   @doc "A fresh, empty fold state."
   @spec new() :: t()
@@ -77,7 +95,7 @@ defmodule Vutuv.Deliverability.MailLog do
               to: String.downcase(to),
               dsn: dsn,
               status: status,
-              class: classify(status, dsn),
+              class: classify(status, dsn, line),
               ours?: Map.get(state.senders, queue_id) == our_sender(),
               line: line
             }
@@ -112,27 +130,76 @@ defmodule Vutuv.Deliverability.MailLog do
     end
   end
 
-  @doc "Classifies a delivery result. See the moduledoc."
-  @spec classify(String.t(), String.t()) :: atom()
-  def classify("sent", _dsn), do: :delivered
-  def classify("deferred", _dsn), do: :transient
-  def classify("bounced", dsn), do: bounce_class(dsn)
-  def classify(_status, _dsn), do: :other
+  @doc """
+  Classifies a delivery result. `text` is the raw reply/log text, consulted
+  only for the generic `5.0.x` bucket (see the moduledoc); without it a
+  `5.0.x` bounce conservatively classifies as `:other`.
+  """
+  @spec classify(String.t(), String.t(), String.t()) :: atom()
+  def classify(status, dsn, text \\ "")
+  def classify("sent", _dsn, _text), do: :delivered
+  def classify("deferred", _dsn, _text), do: :transient
+  def classify("bounced", dsn, text), do: bounce_class(dsn, text)
+  def classify(_status, _dsn, _text), do: :other
 
   @doc """
-  Whether a DSN code names a dead recipient (vs a policy or transient problem).
-  Recipient-failure families only: `5.0.x` (generic permanent), `5.1.x`
-  (addressing / no such user), `5.5.x` (mailbox unavailable).
+  Whether a bounce is a confirmed dead recipient (vs a policy, mailbox-state
+  or transient problem). The enhanced-code families `5.1.x` (addressing / no
+  such user) and `5.5.x` (mailbox unavailable) count on their own; the generic
+  `5.0.x` bucket counts only when `text` (the raw reply) itself confirms a
+  dead recipient - it also carries full-mailbox and recipient-side-block
+  replies, which are not.
   """
-  @spec recipient_failure?(String.t()) :: boolean()
-  def recipient_failure?(dsn), do: Regex.match?(~r/^5\.(0|1|5)\./, dsn)
+  @spec recipient_failure?(String.t(), String.t()) :: boolean()
+  def recipient_failure?(dsn, text \\ "") do
+    cond do
+      Regex.match?(~r/^5\.(1|5)\./, dsn) -> true
+      String.starts_with?(dsn, "5.0.") -> generic_bounce_class(text) == :hard_bounce
+      true -> false
+    end
+  end
 
-  defp bounce_class(dsn) do
+  defp bounce_class(dsn, text) do
     cond do
       String.starts_with?(dsn, "4.") -> :transient
+      String.starts_with?(dsn, "5.0.") -> generic_bounce_class(text)
       recipient_failure?(dsn) -> :hard_bounce
       String.starts_with?(dsn, "5.7.") -> :policy
       true -> :other
+    end
+  end
+
+  # A `5.0.x` code carries no evidence of its own, so the reply text decides:
+  # contra-indications first (full mailbox -> :other, recipient-side block ->
+  # :policy), then a confirming dead-recipient phrase (-> :hard_bounce),
+  # otherwise leave it alone.
+  defp generic_bounce_class(text) do
+    text = reply_text(text)
+
+    cond do
+      Regex.match?(@full_mailbox_text, text) -> :other
+      Regex.match?(@blocked_text, text) -> :policy
+      Regex.match?(@dead_recipient_text, text) -> :hard_bounce
+      true -> :other
+    end
+  end
+
+  # The evidence is the remote server's own words. A full log line also
+  # carries relay hostnames (a real trap: relay=mx10.mailspamprotection.com
+  # made a dead-recipient reply match the "spam" contra-indication), so cut
+  # down to the reply: the part after `said: `, else after `status=xxx (`
+  # (replies with no `said:`, e.g. local errors), else the text as given
+  # (webhook Diagnostic-Code lines).
+  defp reply_text(text) do
+    case Regex.run(~r/said: (.*)/s, text, capture: :all_but_first) do
+      [reply] ->
+        reply
+
+      nil ->
+        case Regex.run(~r/status=\w+ \((.*)/s, text, capture: :all_but_first) do
+          [reply] -> reply
+          nil -> text
+        end
     end
   end
 

--- a/lib/vutuv/notifications/bounces.ex
+++ b/lib/vutuv/notifications/bounces.ex
@@ -9,13 +9,15 @@ defmodule Vutuv.Notifications.Bounces do
   lands here.
 
   A failure DSN (`Action: failed`) records an `EmailBounce`, but only a
-  **recipient-failure** status code (`5.0.x` / `5.1.x` / `5.5.x`: no such
-  user, mailbox unavailable, bad address — `Vutuv.Deliverability.MailLog.recipient_failure?/1`)
-  marks the address undeliverable (`emails.undeliverable_at`). A policy
-  failure (`5.7.x`, e.g. a DMARC/authentication rejection, often the sender's
-  own transient config problem) or a transient one (`4.x`) is logged and left
-  alone, so the webhook agrees with the production log watcher's single
-  classification rather than deactivating a live address on every DSN.
+  **confirmed recipient failure** (`Vutuv.Deliverability.MailLog.recipient_failure?/2`:
+  the `5.1.x` / `5.5.x` families, or generic `5.0.x` whose `Diagnostic-Code:`
+  text itself confirms a dead recipient) marks the address undeliverable
+  (`emails.undeliverable_at`). A policy failure (`5.7.x`, e.g. a
+  DMARC/authentication rejection, often the sender's own transient config
+  problem), a transient one (`4.x`), or an unvetted generic `5.0.x` (full
+  mailbox, recipient-side block) is logged and left alone, so the webhook
+  agrees with the production log watcher's single classification rather than
+  deactivating a live address on every DSN.
   `Emailer.deliver/1` drops *automatic* mail to a suppressed address. User-
   initiated PIN mail keeps sending — one full mailbox must never lock its
   owner out for good — and a successful login PIN through the address proves
@@ -43,7 +45,7 @@ defmodule Vutuv.Notifications.Bounces do
   def record(raw) when is_binary(raw) do
     case parse(raw) do
       {recipients, "failed", status} when is_binary(status) ->
-        if MailLog.recipient_failure?(status) do
+        if MailLog.recipient_failure?(status, diagnostic_text(raw)) do
           record_hard_bounces(recipients, status, raw)
           {:ok, :failed}
         else
@@ -106,6 +108,17 @@ defmodule Vutuv.Notifications.Bounces do
 
     if count > 0, do: Logger.info("Email bounce: cleared undeliverable mark for #{address}")
     :ok
+  end
+
+  # The `Diagnostic-Code:` field carries the remote server's own reply text -
+  # the evidence `recipient_failure?/2` vets a generic 5.0.x status against.
+  # Absent (or unreadable), the empty string keeps 5.0.x conservatively
+  # unconfirmed.
+  defp diagnostic_text(raw) do
+    case Regex.run(~r/^Diagnostic-Code:\s*(.+)$/im, raw, capture: :all_but_first) do
+      [text] -> text
+      nil -> ""
+    end
   end
 
   # Pulls the per-recipient report fields out of the message/delivery-status

--- a/lib/vutuv_web/live/admin/deliverability_live.ex
+++ b/lib/vutuv_web/live/admin/deliverability_live.ex
@@ -289,6 +289,10 @@ defmodule VutuvWeb.Admin.DeliverabilityLive do
   defp reason_label(%{"reason" => "grace_period"}), do: gettext("dead past the grace period")
   defp reason_label(%{"reason" => "address_recovered"}), do: gettext("an address works again")
   defp reason_label(%{"reason" => "admin"}), do: gettext("admin action")
+
+  defp reason_label(%{"reason" => "misclassified_bounce"}),
+    do: gettext("bounce was misclassified (quota/blocked, not a dead mailbox)")
+
   defp reason_label(%{"dsn" => dsn}) when is_binary(dsn), do: dsn
   defp reason_label(_detail), do: nil
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.122.4",
+      version: "7.122.5",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -6853,6 +6853,11 @@ msgstr "Admin-Aktion"
 msgid "an address works again"
 msgstr "eine Adresse funktioniert wieder"
 
+#: lib/vutuv_web/live/admin/deliverability_live.ex:294
+#, elixir-autogen, elixir-format
+msgid "bounce was misclassified (quota/blocked, not a dead mailbox)"
+msgstr "Bounce war fehlklassifiziert (Quota/Block, kein totes Postfach)"
+
 #: lib/vutuv_web/live/admin/deliverability_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "dead past the grace period"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -6566,6 +6566,11 @@ msgstr ""
 msgid "an address works again"
 msgstr ""
 
+#: lib/vutuv_web/live/admin/deliverability_live.ex:294
+#, elixir-autogen, elixir-format
+msgid "bounce was misclassified (quota/blocked, not a dead mailbox)"
+msgstr ""
+
 #: lib/vutuv_web/live/admin/deliverability_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "dead past the grace period"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -6564,6 +6564,11 @@ msgstr ""
 msgid "an address works again"
 msgstr ""
 
+#: lib/vutuv_web/live/admin/deliverability_live.ex:294
+#, elixir-autogen, elixir-format
+msgid "bounce was misclassified (quota/blocked, not a dead mailbox)"
+msgstr ""
+
 #: lib/vutuv_web/live/admin/deliverability_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "dead past the grace period"

--- a/priv/repo/migrations/20260722130655_repair_misclassified_bounce_freezes.exs
+++ b/priv/repo/migrations/20260722130655_repair_misclassified_bounce_freezes.exs
@@ -1,0 +1,30 @@
+defmodule Vutuv.Repo.Migrations.RepairMisclassifiedBounceFreezes do
+  use Ecto.Migration
+
+  # One-off repair for the accounts frozen over misclassified bounces. The
+  # July 2026 newsletters surfaced ~340 hard bounces at once; the log watcher
+  # treated every generic dsn=5.0.0 as a dead recipient, but that bucket (a
+  # bare 550/552 reply without an enhanced code) also carries full mailboxes
+  # ("552 Quota exceeded") and recipient-side spam/IP blocks - live mailboxes
+  # whose owners were then frozen (hidden site-wide) by the grace-period sweep.
+  #
+  # The classifier now vets 5.0.x by reply text (same release). This re-runs
+  # that verdict over the stored evidence: every undeliverable address none of
+  # whose ledger rows survives as a confirmed recipient failure is cleared,
+  # and its owner re-assessed, which lifts a freeze resting only on
+  # misclassified rows. Audit events are written ("misclassified_bounce").
+  #
+  # Data-only, idempotent, N-1 safe (no schema change). It deliberately calls
+  # the repair function shipped in this same release so the migration and the
+  # classifier can never disagree; on a fresh database it is a no-op.
+  def up do
+    %{cleared: cleared, thawed: thawed} = Vutuv.Deliverability.repair_misclassified_bounces()
+
+    IO.puts(
+      "repair_misclassified_bounces: cleared #{cleared} addresses, thawed #{thawed} accounts"
+    )
+  end
+
+  # Not reversible: we deliberately do not re-freeze anyone.
+  def down, do: :ok
+end

--- a/test/vutuv/deliverability/mail_log_test.exs
+++ b/test/vutuv/deliverability/mail_log_test.exs
@@ -92,8 +92,8 @@ defmodule Vutuv.Deliverability.MailLogTest do
       assert MailLog.classify("bounced", "4.4.1") == :transient
     end
 
-    test "hard recipient failures" do
-      for dsn <- ~w(5.0.0 5.1.1 5.1.2 5.1.3 5.5.0) do
+    test "hard recipient failures (enhanced-code families)" do
+      for dsn <- ~w(5.1.1 5.1.2 5.1.3 5.5.0) do
         assert MailLog.classify("bounced", dsn) == :hard_bounce, "#{dsn} should be hard"
       end
     end
@@ -109,14 +109,130 @@ defmodule Vutuv.Deliverability.MailLogTest do
     end
   end
 
-  describe "recipient_failure?/1" do
+  # `5.0.0` is not an enhanced code from the remote: it is Postfix's mapping
+  # for a bare 550/552 reply, so it also carries full mailboxes and
+  # recipient-side blocks. Only the reply text can tell them apart. All sample
+  # texts below are real shapes from the production mail.log (issue: 19
+  # members were frozen over quota/blocked replies miscounted as dead).
+  describe "classify/3 vets the generic 5.0.x bucket by reply text" do
+    test "a full mailbox (552 quota without an enhanced code) is left alone" do
+      text =
+        "host mx01.emig.gmx.net[212.227.17.5] said: 552-Requested mail action aborted: " <>
+          "exceeded storage allocation 552-Quota exceeded"
+
+      assert MailLog.classify("bounced", "5.0.0", text) == :other
+    end
+
+    test "a recipient-side block is a policy problem, not a dead recipient" do
+      barracuda =
+        "host eu.bar.example said: 550 permanent failure for one or more recipients " <>
+          "(dhanneke@example.com:blocked) (in reply to end of DATA command)"
+
+      fakemail =
+        "host mx.example said: 550 Your IP or Email address blocked by the FakeMail User."
+
+      multi_cause =
+        "host mx.example said: 550-The mail server could not deliver mail to x@y. " <>
+          "550-The account or domain may not 550 exist, they may be blacklisted, or missing."
+
+      for text <- [barracuda, fakemail, multi_cause] do
+        assert MailLog.classify("bounced", "5.0.0", text) == :policy
+      end
+    end
+
+    test "reply text confirming a dead recipient stays a hard bounce" do
+      confirmations = [
+        "host mx00.ionos.de[212.227.15.41] said: 550-Requested action not taken: mailbox unavailable",
+        "host mta6.am0.yahoodns.net said: 552 1 Requested mail action aborted, mailbox not found",
+        "host mx.example said: 550 No mailbox by that name is currently available",
+        "host eu-smtp-inbound-1.mimecast.com said: 550 Invalid Recipient - https://example.com",
+        "host smtp.secureserver.net said: 550 5.1.0 <x@y> Recipient not found.",
+        "host mx.example said: 550 User unknown",
+        "host mailin.ng.telekom.net[3.71.246.67] said: 550 #5.1.0 Address rejected.",
+        "host mx.example said: 550 Unroutable address",
+        "host mx.example said: 550 unrouteable address",
+        "host mx.example said: 550 Address unknown",
+        "host mx.example said: 550 MXIN501 mailbox marco.abderhalden@example.ch unknown ;id=x"
+      ]
+
+      for text <- confirmations do
+        assert MailLog.classify("bounced", "5.0.0", text) == :hard_bounce, text
+      end
+    end
+
+    test "only the remote's reply is vetted, never relay hostnames on the log line" do
+      # Real trap from prod: the relay is mx10.mailspamprotection.com - "spam"
+      # in the hostname must not turn a dead-recipient reply into :policy.
+      line =
+        "2026-07-01T13:02:01 bremen2 postfix/smtp[2817771]: 5DF1E3A80864: " <>
+          "to=<miriam@example.com>, relay=mx10.mailspamprotection.com[34.149.79.66]:25, " <>
+          "dsn=5.0.0, status=bounced (host mx10.mailspamprotection.com[34.149.79.66] said: " <>
+          "550 No mailbox by that name is currently available (in reply to RCPT TO command))"
+
+      assert MailLog.classify("bounced", "5.0.0", line) == :hard_bounce
+      assert MailLog.recipient_failure?("5.0.0", line)
+    end
+
+    test "a sender-verification rejection is never a dead recipient" do
+      assert MailLog.classify(
+               "bounced",
+               "5.0.0",
+               "host mx.example said: 550 Sender address rejected: domain not found"
+             ) == :policy
+    end
+
+    test "an unrecognized 5.0.x reply text is conservatively left alone" do
+      assert MailLog.classify("bounced", "5.0.0", "550 something entirely novel") == :other
+      assert MailLog.classify("bounced", "5.0.0") == :other
+    end
+
+    test "an enhanced recipient-failure code stays authoritative over its text" do
+      assert MailLog.classify("bounced", "5.1.1", "552 Quota exceeded") == :hard_bounce
+    end
+
+    test "the vetted class flows through reduce/2, so the watcher never acts on quota" do
+      quota_lines = [
+        "postfix/qmgr[1]: DD445566: from=<bounces@vutuv.de>, size=1",
+        "postfix/smtp[1]: DD445566: to=<full@gmx.de>, relay=mx.gmx.net[1.2.3.4]:25, dsn=5.0.0, " <>
+          "status=bounced (host mx.gmx.net said: 552-Quota exceeded)"
+      ]
+
+      {[event], _state} = MailLog.reduce(quota_lines, MailLog.new())
+      assert event.ours?
+      assert event.class == :other
+
+      dead_lines = [
+        "postfix/qmgr[1]: EE556677: from=<bounces@vutuv.de>, size=1",
+        "postfix/smtp[1]: EE556677: to=<gone@ionos.de>, relay=mx00.ionos.de[1.2.3.4]:25, dsn=5.0.0, " <>
+          "status=bounced (host mx00.ionos.de said: 550-Requested action not taken: mailbox unavailable)"
+      ]
+
+      {[event], _state} = MailLog.reduce(dead_lines, MailLog.new())
+      assert event.ours?
+      assert event.class == :hard_bounce
+    end
+  end
+
+  describe "recipient_failure?/2" do
     test "true only for the recipient-failure families" do
       assert MailLog.recipient_failure?("5.1.1")
       assert MailLog.recipient_failure?("5.5.0")
-      assert MailLog.recipient_failure?("5.0.0")
       refute MailLog.recipient_failure?("5.7.26")
       refute MailLog.recipient_failure?("5.2.2")
       refute MailLog.recipient_failure?("4.0.0")
+    end
+
+    test "5.0.x counts only with reply text confirming a dead recipient" do
+      refute MailLog.recipient_failure?("5.0.0")
+      refute MailLog.recipient_failure?("5.0.0", "552-Quota exceeded")
+      refute MailLog.recipient_failure?("5.0.0", "550 permanent failure (x@y:blocked)")
+
+      assert MailLog.recipient_failure?(
+               "5.0.0",
+               "550 Requested action not taken: mailbox unavailable"
+             )
+
+      assert MailLog.recipient_failure?("5.0.0", "550 User unknown")
     end
   end
 end

--- a/test/vutuv/deliverability_test.exs
+++ b/test/vutuv/deliverability_test.exs
@@ -36,6 +36,23 @@ defmodule Vutuv.DeliverabilityTest do
     Deliverability.events_for_user(id) |> Enum.map(& &1.action)
   end
 
+  # Real reply-text shapes from the production mail.log (all arrive as the
+  # generic dsn=5.0.0, so only the text tells them apart).
+  @quota_raw "host mx.gmx.net said: 552-Requested mail action aborted: exceeded storage allocation 552-Quota exceeded"
+  @blocked_raw "host bar.example said: 550 permanent failure for one or more recipients (x@y:blocked)"
+  @dead_raw "host mx.ionos.de said: 550-Requested action not taken: mailbox unavailable"
+
+  # Reproduces the misclassification's end state: the address was marked
+  # undeliverable (as the old classifier did), and the grace-period sweep froze
+  # the owner.
+  defp frozen_user_with_bounce(address, raw) do
+    user = confirmed_user_with_emails([address])
+    mark_dead(address, Deliverability.grace_days() + 1)
+    insert(:email_bounce, email_value: address, status: "5.0.0", raw: raw)
+    Deliverability.reassess_user(user)
+    user
+  end
+
   describe "record_hard_bounce/3" do
     test "marks the address undeliverable, ledgers the bounce, logs deactivation" do
       user = confirmed_user_with_emails(["dead@example.com"])
@@ -116,6 +133,34 @@ defmodule Vutuv.DeliverabilityTest do
       Deliverability.reassess_user(user)
       refute reload(user).unreachable_at
     end
+
+    test "generic 5.0.0 ledger rows count only when their text confirms a dead recipient" do
+      quota_raw = "host mx.gmx.net said: 552-Quota exceeded 552 storage allocation"
+      user = confirmed_user_with_emails(["full@example.com"])
+      mark_dead("full@example.com")
+
+      for _ <- 1..2,
+          do:
+            insert(:email_bounce,
+              email_value: "full@example.com",
+              status: "5.0.0",
+              raw: quota_raw
+            )
+
+      Deliverability.reassess_user(user)
+      refute reload(user).unreachable_at
+
+      dead_raw = "host mx00.ionos.de said: 550-Requested action not taken: mailbox unavailable"
+      other = confirmed_user_with_emails(["gone@example.com"])
+      mark_dead("gone@example.com")
+
+      for _ <- 1..2,
+          do:
+            insert(:email_bounce, email_value: "gone@example.com", status: "5.0.0", raw: dead_raw)
+
+      Deliverability.reassess_user(other)
+      assert reload(other).unreachable_at
+    end
   end
 
   describe "thawing" do
@@ -181,6 +226,70 @@ defmodule Vutuv.DeliverabilityTest do
 
       assert reload(stale).unreachable_at
       refute reload(recent).unreachable_at
+    end
+  end
+
+  describe "repair_misclassified_bounces/0" do
+    test "clears quota/blocked-only addresses and thaws their owners" do
+      quota_user = frozen_user_with_bounce("full@example.com", @quota_raw)
+      blocked_user = frozen_user_with_bounce("filterblocked@example.com", @blocked_raw)
+      assert reload(quota_user).unreachable_at
+      assert reload(blocked_user).unreachable_at
+
+      assert %{cleared: 2, thawed: 2} = Deliverability.repair_misclassified_bounces()
+
+      refute reload_email("full@example.com").undeliverable_at
+      refute reload(quota_user).unreachable_at
+      refute reload_email("filterblocked@example.com").undeliverable_at
+      refute reload(blocked_user).unreachable_at
+
+      # The audit trail names the repair on the recovery, and the thaw follows.
+      assert [%Event{detail: %{"reason" => "misclassified_bounce"}} | _] =
+               Deliverability.events_for_user(quota_user.id)
+               |> Enum.filter(&(&1.action == "address_recovered"))
+
+      assert "account_thawed" in actions_for(quota_user)
+    end
+
+    test "a genuinely dead address and its frozen owner are untouched" do
+      dead_user = frozen_user_with_bounce("gone@example.com", @dead_raw)
+
+      assert %{cleared: 0, thawed: 0} = Deliverability.repair_misclassified_bounces()
+
+      assert reload_email("gone@example.com").undeliverable_at
+      assert reload(dead_user).unreachable_at
+    end
+
+    test "an address with any confirmed hard bounce is untouched, even beside a quota row" do
+      user = confirmed_user_with_emails(["mixed@example.com"])
+      mark_dead("mixed@example.com", Deliverability.grace_days() + 1)
+      insert(:email_bounce, email_value: "mixed@example.com", status: "5.0.0", raw: @quota_raw)
+
+      insert(:email_bounce,
+        email_value: "mixed@example.com",
+        status: "5.1.1",
+        raw: "550 5.1.1 User unknown"
+      )
+
+      Deliverability.reassess_user(user)
+
+      assert %{cleared: 0, thawed: 0} = Deliverability.repair_misclassified_bounces()
+      assert reload(user).unreachable_at
+    end
+
+    test "an undeliverable address without ledger evidence is untouched" do
+      confirmed_user_with_emails(["noledger@example.com"])
+      mark_dead("noledger@example.com")
+
+      assert %{cleared: 0, thawed: 0} = Deliverability.repair_misclassified_bounces()
+      assert reload_email("noledger@example.com").undeliverable_at
+    end
+
+    test "running the repair twice is a no-op the second time" do
+      frozen_user_with_bounce("full2@example.com", @quota_raw)
+
+      assert %{cleared: 1, thawed: 1} = Deliverability.repair_misclassified_bounces()
+      assert %{cleared: 0, thawed: 0} = Deliverability.repair_misclassified_bounces()
     end
   end
 

--- a/test/vutuv/notifications/bounces_test.exs
+++ b/test/vutuv/notifications/bounces_test.exs
@@ -90,6 +90,40 @@ defmodule Vutuv.Notifications.BouncesTest do
   --X--
   """
 
+  # Generic 5.0.0 (bare 552 reply, no enhanced code) whose diagnostic text is a
+  # full mailbox: the recipient lives, so this must NOT deactivate.
+  @quota_failed_dsn """
+  From: MAILER-DAEMON@mail.example.com (Mail Delivery System)
+  Content-Type: multipart/report; report-type=delivery-status; boundary="ABC"
+
+  --ABC
+  Content-Type: message/delivery-status
+
+  Final-Recipient: rfc822; dead@example.com
+  Action: failed
+  Status: 5.0.0
+  Diagnostic-Code: smtp; 552-Requested mail action aborted: exceeded storage allocation 552-Quota exceeded
+
+  --ABC--
+  """
+
+  # Generic 5.0.0 whose diagnostic text does confirm a dead recipient: this
+  # one deactivates, same verdict as the log watcher.
+  @generic_dead_dsn """
+  From: MAILER-DAEMON@mail.example.com (Mail Delivery System)
+  Content-Type: multipart/report; report-type=delivery-status; boundary="ABC"
+
+  --ABC
+  Content-Type: message/delivery-status
+
+  Final-Recipient: rfc822; dead@example.com
+  Action: failed
+  Status: 5.0.0
+  Diagnostic-Code: smtp; 550-Requested action not taken: mailbox unavailable
+
+  --ABC--
+  """
+
   setup do
     Vutuv.RateLimiter.reset()
     :ok
@@ -132,6 +166,25 @@ defmodule Vutuv.Notifications.BouncesTest do
       # address stays deliverable, matching the log watcher's classification.
       assert reload(email).undeliverable_at == nil
       assert Repo.all(EmailBounce) == []
+    end
+
+    test "a generic 5.0.0 with quota text is ignored, not deactivated" do
+      {_user, email} = user_with_email("dead@example.com")
+
+      assert {:ok, :ignored} = Bounces.record(@quota_failed_dsn)
+
+      # A full mailbox is not a dead mailbox: the address stays deliverable.
+      assert reload(email).undeliverable_at == nil
+      assert Repo.all(EmailBounce) == []
+    end
+
+    test "a generic 5.0.0 whose text confirms a dead recipient deactivates" do
+      {_user, email} = user_with_email("dead@example.com")
+
+      assert {:ok, :failed} = Bounces.record(@generic_dead_dsn)
+
+      assert reload(email).undeliverable_at
+      assert [%EmailBounce{status: "5.0.0"}] = Repo.all(EmailBounce)
     end
 
     test "a transient failure (4.x) is ignored, not deactivated" do


### PR DESCRIPTION
**TL;DR** The bounce classifier counted every generic `dsn=5.0.0` as a dead recipient, which froze ~40 members with live mailboxes (full mailbox / spam-filter block) after the July newsletters; 5.0.x is now vetted by the remote's reply text and a data migration thaws the affected accounts.

**Where:** `Vutuv.Deliverability.MailLog` (classifier), `Vutuv.Deliverability` (freeze counting + repair), `Vutuv.Notifications.Bounces` (DSN webhook), `/admin/deliverability` (new audit label)
**Now:** `5.0.0` (Postfix's bucket for a bare 550/552 reply without an enhanced code) was treated like `5.1.x`: address deactivated, account frozen after the 7-day grace period. That bucket also carries "552 Quota exceeded", "(user@host:blocked)" and relay/callout failures - live mailboxes.
**Want:** `5.0.x` deactivates only when the reply text itself confirms a dead recipient; quota → ignored, blocked → policy; contra-indications win; only the reply after `said:` is vetted (relay hostnames like `mx10.mailspamprotection.com` must never match "spam"). `5.1.x`/`5.5.x` stay authoritative.
**Repair:** `RepairMisclassifiedBounceFreezes` re-runs the vetted verdict over the stored ledger; against a fresh prod copy it clears 40 addresses / thaws 40 accounts (10 quota, 10 blocked, 13 yahoo/aol "mailbox is disabled", 7 relay/verification). Audit events say "misclassified_bounce"; idempotent, data-only, N-1 safe.

Verified: full `mix precommit` green (4263 tests), migration dry-run against the prod copy in dev, still-frozen remainder (292) spot-checked - all carry genuine dead-recipient replies.

*Written with this GitHub account, but not necessarily by the human behind it - this may just be a note-taking issue that gets deleted later without ever being tackled.*