### PR TITLE
Make the deliverability ops alarms visible despite prod's quiet logger

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -254,6 +254,11 @@ config :vutuv, :mailer_from, {"vutuv", "no-reply@vutuv.de"}
 # (BOUNCE_ADDRESS)
 config :vutuv, :bounce_address, "bounces@vutuv.de"
 
+# Keep the email-deliverability ops alarms visible even where the global
+# Logger level is quiet (production runs :error): Vutuv.Application raises the
+# watcher/bounce/emailer modules to :info at boot. Off only in tests.
+config :vutuv, :ops_log_visibility, true
+
 # The visible From (no-reply@vutuv.de) is not read, but the strike-3
 # deactivation mail invites the member to appeal by replying. That one mail
 # carries a Reply-To to this monitored contact so an appeal reaches a human

--- a/config/test.exs
+++ b/config/test.exs
@@ -52,6 +52,9 @@ config :vutuv, :saved_search_alerts, false
 # Deliverability context and parser are called directly in their tests.
 config :vutuv, :bounce_watcher, false
 config :vutuv, :sweep_unreachable_accounts, false
+# Keep the per-module :info override off so the suite stays at the quiet
+# :warning level; Vutuv.OpsLogVisibilityTest exercises the override directly.
+config :vutuv, :ops_log_visibility, false
 # The stuck-broadcast sweep would touch the sandbox from outside; tests call
 # Vutuv.Newsletters.BroadcastResumer.sweep/0 directly.
 config :vutuv, :resume_stuck_broadcasts, false

--- a/docs/production-email-and-bounces.md
+++ b/docs/production-email-and-bounces.md
@@ -102,7 +102,7 @@ fault" (§3.3) so a future DKIM gap can never be misread as dead mailboxes.
 `/var/log/mail.log` is `root:adm`, mode `640`, rotated by logrotate
 (`mail.log`, `mail.log.1`, `mail.log.2.gz`, …). The app user **`vutuv3` is not
 in the `adm` group**, so the app cannot read the log as-is. Two ways to grant
-the detector access — see §3.4.
+the detector access — see §3.5.
 
 ---
 
@@ -157,7 +157,7 @@ Why this is the better fit here:
 - **Reuses the existing webhook + token**, so Layer 1 (§4.1) needs no new app
   endpoint.
 
-The only added cost is attribution (§3.2) and log read access (§3.4), both
+The only added cost is attribution (§3.2) and log read access (§3.5), both
 small.
 
 ---
@@ -217,7 +217,24 @@ quota) or filter-blocked mailboxes were deactivated and then frozen; the
 `RepairMisclassifiedBounceFreezes` migration thawed them and the classifier
 has vetted `5.0.x` by text ever since.
 
-### 3.4 Granting the detector log access (pick one)
+### 3.4 Where the alarms land (journal visibility)
+
+Production runs the global Logger at `:error` (`config/prod.exs`) to keep the
+journal quiet — which would swallow every deliverability log line: the
+watcher's policy-bounce warning, its startup line, the webhook's bounce
+lines, the emailer's dropped-mail warnings. Since v7.122.5,
+`Vutuv.Application` raises exactly these modules to `:info` at boot via
+`Logger.put_module_level/2` (flag `:ops_log_visibility`, on by default), so
+they reach the journal while everything else stays at `:error`:
+
+```
+journalctl -u 'vutuv3@blue' -u 'vutuv3@green' | grep -E 'Deliverability|Email bounce|Dropped|Suppressed'
+```
+
+The startup line `Deliverability.Watcher tailing /var/log/mail.log …` doubles
+as the liveness check that the watcher is running in the current release.
+
+### 3.5 Granting the detector log access (pick one)
 
 - **Add `vutuv3` to the `adm` group** (`usermod -aG adm vutuv3`, then restart the
   release) and let the app tail the log directly. Simplest; reversible.
@@ -295,7 +312,7 @@ a much larger project, unrelated to bounce handling.
    (`/var/www/vutuv3/shared/.env`, mode 600, owner `vutuv3`). Without it
    `/webhooks/bounces` 404s and bounce handling is simply off (fail-closed).
 4. **Log access**: give the detector read access to `/var/log/mail.log`
-   (§3.4) — add the app user to `adm`, or install the root-side shipper.
+   (§3.5) — add the app user to `adm`, or install the root-side shipper.
 5. **Verify** end to end (§7): send to a known-bad address, watch the log line,
    confirm `undeliverable_at` gets set, then clear it with a real PIN login.
 

--- a/lib/vutuv/application.ex
+++ b/lib/vutuv/application.ex
@@ -3,8 +3,28 @@ defmodule Vutuv.Application do
 
   use Application
 
+  # The email-deliverability subsystem carries deliberate ops alarms that
+  # production's quiet global Logger level (:error, config/prod.exs) would
+  # swallow entirely: the watcher's policy-bounce warning (it fires when *our*
+  # SPF/DKIM sending is broken for a whole class of recipients), its startup
+  # line (the only liveness signal), the DSN webhook's bounce lines, the
+  # sweeper's counts and the emailer's dropped-mail warnings. Nobody could
+  # have seen any of them until v7.122.5. Raise exactly these modules to
+  # :info at boot; everything else stays at the global level. Off in tests
+  # (config/test.exs), which want the quiet :warning default.
+  @ops_log_modules [
+    Vutuv.Deliverability.Watcher,
+    Vutuv.Deliverability.Sweeper,
+    Vutuv.Notifications.Bounces,
+    Vutuv.Notifications.Emailer
+  ]
+
+  @doc "Per-module log-level override making the deliverability ops alarms visible."
+  def ensure_ops_logs_visible, do: Logger.put_module_level(@ops_log_modules, :info)
+
   @impl true
   def start(_type, _args) do
+    if Application.get_env(:vutuv, :ops_log_visibility, true), do: ensure_ops_logs_visible()
     # The optional children below are gated per config flag (off in tests, see
     # config/test.exs): mostly periodic jobs, plus the Vutuv.Prefs.Cache,
     # whose DB reloads would likewise touch the SQL sandbox from outside.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.122.5",
+      version: "7.122.6",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/ops_log_visibility_test.exs
+++ b/test/vutuv/ops_log_visibility_test.exs
@@ -1,0 +1,41 @@
+defmodule Vutuv.OpsLogVisibilityTest do
+  @moduledoc """
+  Production runs the global Logger at :error (config/prod.exs) to keep the
+  journal quiet - which used to swallow the email-deliverability ops alarms
+  entirely: the watcher's policy-bounce warning (our SPF/DKIM may be broken),
+  its startup line (the only liveness signal), the DSN webhook's bounce lines
+  and the emailer's dropped-mail warnings. `Vutuv.Application` raises exactly
+  those modules to :info via per-module log levels at boot; this covers the
+  override so the alarms can never go silent again.
+  """
+  use ExUnit.Case, async: false
+
+  @modules [
+    Vutuv.Deliverability.Watcher,
+    Vutuv.Deliverability.Sweeper,
+    Vutuv.Notifications.Bounces,
+    Vutuv.Notifications.Emailer
+  ]
+
+  test "ensure_ops_logs_visible/0 raises the deliverability modules to :info" do
+    # The flag is off in test config (the suite wants the quiet :warning
+    # default), so app start has not applied the override - apply and clean
+    # up here.
+    refute Application.get_env(:vutuv, :ops_log_visibility)
+    on_exit(fn -> Logger.delete_module_level(@modules) end)
+
+    assert :ok = Vutuv.Application.ensure_ops_logs_visible()
+
+    for mod <- @modules do
+      assert :logger.get_module_level(mod) == [{mod, :info}]
+    end
+  end
+
+  test "the override is config-gated so tests keep the global level" do
+    # Guards that nobody flips the test flag on by accident: with it off, no
+    # module carries an override after boot.
+    for mod <- @modules do
+      assert :logger.get_module_level(mod) == []
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** Prod's global `Logger` level `:error` silenced every deliverability log line, including the watcher's SPF/DKIM policy alarm; the four deliverability modules are now raised to `:info` at boot via `Logger.put_module_level/2`.

**Where:** `Vutuv.Application` (per-module override + `:ops_log_visibility` flag), `config/config.exs` / `config/test.exs`, ops doc §3.4
**Now:** `config :logger, level: :error` (config/prod.exs) swallows the watcher's policy-bounce warning, its startup/liveness line, the DSN webhook's bounce lines and the emailer's dropped-mail warnings - none of them findable in the journal during the July bounce investigation (#992).
**Want:** exactly those modules log at `:info` into the journal while everything else keeps the quiet global level; flag on by default, off in tests. The watcher's startup line doubles as its liveness check (`journalctl -u 'vutuv3@blue' | grep Deliverability`).

Follow-up to #992. Full `mix precommit` green (4265 tests).

*Written with this GitHub account, but not necessarily by the human behind it - this may just be a note-taking issue that gets deleted later without ever being tackled.*