### PR TITLE
Give the background book lookups a patient budget and one retry

### DIFF
--- a/lib/vutuv/audiobook_length.ex
+++ b/lib/vutuv/audiobook_length.ex
@@ -65,8 +65,11 @@ defmodule Vutuv.AudiobookLength do
         recordSchema: "MARC21-xml",
         maximumRecords: 1
       ],
-      receive_timeout: 8_000,
-      retry: false
+      # Patient and retried once, like the other background lookups: a
+      # catalogue that answers slowly should cost a second, not the fact.
+      receive_timeout: 15_000,
+      retry: :transient,
+      max_retries: 1
     ]
     |> Keyword.merge(Application.get_env(:vutuv, @req_options_key, []))
     |> Req.get()

--- a/lib/vutuv/book_metadata.ex
+++ b/lib/vutuv/book_metadata.ex
@@ -125,8 +125,13 @@ defmodule Vutuv.BookMetadata do
     Enum.at(sorted, div(length(sorted) - 1, 2))
   end
 
+  # The background pass can afford to wait (and to try again): it runs off the
+  # request path, and a lookup lost to one slow answer leaves the card
+  # silently without its facts until somebody edits the post. The composer's
+  # `lookup/1` above keeps its short, no-retry budget — a member is watching
+  # that one.
   defp get_json(url) do
-    [url: url, receive_timeout: 5_000, retry: false]
+    [url: url, receive_timeout: 15_000, retry: :transient, max_retries: 1]
     |> Keyword.merge(Application.get_env(:vutuv, @req_options_key, []))
     |> Req.get()
     |> case do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.123.1",
+      version: "7.123.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Fallout from the first production backfill of the new review fields (#995): it came back empty. The Open Library **edition** lookup was running on the composer's budget — 5s, no retry — and one slow answer left the card silently without its facts, because the pass is best-effort by design and production's logger drops the warning. A second run filled it in (the live card now reads *Goldmann · 190 Seiten (Druckausgabe)*).

Off the request path there is no reason to be that impatient: the cover fetch beside it already waits 15s. Both background lookups — edition details and the audiobook running time — now get the same 15s and retry once on a transient failure. The composer's own ISBN lookup keeps the short, no-retry budget, since a member is watching that one.

No behaviour change beyond that; `mix precommit` green (4291 tests).

https://claude.ai/code/session_01GYn4Bf5vEMej1aBjvZa4Kq