### PR TITLE
Show job usage on each qualification (issue #1005)

### DIFF
--- a/docs/architecture/profiles.md
+++ b/docs/architecture/profiles.md
@@ -428,6 +428,24 @@ JSON Resume, which has no native job↔credential field — carries it in the wo
 summary. The GDPR export names the cited credential per job. LinkedIn's
 `Positions.csv` has no such link, so imported jobs arrive uncited.
 
+**The reverse direction — usage badges on the credential (issue #1005).** Every
+qualification list row (profile card, `/:slug/qualifications`, the
+`/settings/qualifications` editor, all via the shared
+`QualificationHTML.qualification_row/1`) shows how the member's jobs use the
+credential: a brand-tint "Used for N jobs" pill plus either an emerald
+"Currently in use" (some citing job is ongoing — no end year, the same
+convention `CvSection.order_by_date/1` sorts by) or a slate "Last used: M/YYYY"
+(the newest citing job's end). An uncited credential shows nothing — absence is
+the "not used at all" signal, keeping rows calm. The policy lives in
+`Qualification.job_usage/1`, reading the `work_experiences` preload spliced in
+via `Qualification.citing_jobs_preload/0`; like `cited_qualification/1` it
+falls through to nil on an unloaded association. The entry show page renders
+the same facts as one "Jobs" line (`QualificationHTML.usage_line/1`), and the
+agent formats carry a `jobs: {count, in_use, last_used}` map per entry
+(`SectionDocs.qualification_entry/1`; md/txt append "used for N jobs ·
+currently in use" to the facts line), kept honest by the drift test; `/api/2.0`
+qualification entries include the same map.
+
 ## Online messengers profile section
 
 Members list the online messengers they can be reached on (`Vutuv.Profiles.Messenger`,

--- a/lib/vutuv/profiles/qualification.ex
+++ b/lib/vutuv/profiles/qualification.ex
@@ -16,6 +16,7 @@ defmodule Vutuv.Profiles.Qualification do
 
   alias Vutuv.BerlinTime
   alias Vutuv.Profiles.CvSection
+  alias Vutuv.Profiles.WorkExperience
 
   # The two kinds a member picks between. A LinkedIn import lands everything as
   # a certification (LinkedIn has no signal separating a licence from a cert).
@@ -39,6 +40,9 @@ defmodule Vutuv.Profiles.Qualification do
     belongs_to(:user, Vutuv.Accounts.User)
     # Reserved for issue #857; always nil now, so it is not cast.
     belongs_to(:education, Vutuv.Profiles.Education)
+    # The jobs earned with this credential (issue #858's `qualification_id`,
+    # read back here for the usage badges of issue #1005).
+    has_many(:work_experiences, WorkExperience)
 
     timestamps()
   end
@@ -171,6 +175,46 @@ defmodule Vutuv.Profiles.Qualification do
           (q.expires_year == ^year and
              (is_nil(q.expires_month) or q.expires_month >= ^month))
     )
+  end
+
+  @doc """
+  The preload that lets `job_usage/1` see the jobs citing each credential
+  (issue #1005), in the standard CV order (ongoing roles first). Splice it
+  into any `Repo.preload` whose rendering shows the usage badges:
+  `qualifications: {query, Qualification.citing_jobs_preload()}`.
+  """
+  def citing_jobs_preload do
+    [work_experiences: WorkExperience.order_by_date(WorkExperience)]
+  end
+
+  @doc """
+  How the member's jobs use this credential (issue #1005), read from the
+  preloaded `work_experiences` (see `citing_jobs_preload/0`): `%{count:,
+  current?:, last_end:}`. `current?` is true while any citing job is ongoing —
+  no end year, the same "no end date = ongoing" convention
+  `CvSection.order_by_date/1` sorts by — and `last_end` is the newest citing
+  job's `{year, month | nil}` end (a year-only end counts as the whole year).
+
+  Returns nil when nothing cites the credential and, like
+  `WorkExperience.cited_qualification/1`, when the association was not
+  preloaded — a surface that doesn't load the jobs quietly shows no usage
+  instead of crashing.
+  """
+  def job_usage(%__MODULE__{work_experiences: [_ | _] = jobs}) do
+    %{
+      count: length(jobs),
+      current?: Enum.any?(jobs, &is_nil(&1.end_year)),
+      last_end: last_end(jobs)
+    }
+  end
+
+  def job_usage(_qualification), do: nil
+
+  defp last_end(jobs) do
+    jobs
+    |> Enum.reject(&is_nil(&1.end_year))
+    |> Enum.map(&{&1.end_year, &1.end_month})
+    |> Enum.max_by(fn {year, month} -> {year, month || 13} end, fn -> nil end)
   end
 
   # Imported and hand-entered entries alike are addressed by their UUID: unlike

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -645,15 +645,32 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   # awarded and "valid until" dates and the credential id.
   @doc false
   def qualification_facts(qualification) do
-    [
-      qualification_kind_label(qualification.kind),
-      qualification.issuer,
-      qualification.awarded && gettext("awarded %{date}", date: qualification.awarded),
-      qualification.expires && gettext("valid until %{date}", date: qualification.expires),
-      qualification.credential_id && gettext("ID: %{id}", id: qualification.credential_id)
-    ]
+    ([
+       qualification_kind_label(qualification.kind),
+       qualification.issuer,
+       qualification.awarded && gettext("awarded %{date}", date: qualification.awarded),
+       qualification.expires && gettext("valid until %{date}", date: qualification.expires),
+       qualification.credential_id && gettext("ID: %{id}", id: qualification.credential_id)
+     ] ++ qualification_usage_facts(Map.get(qualification, :jobs)))
     |> Enum.filter(& &1)
     |> Enum.join(" · ")
+  end
+
+  # The usage facts (issue #1005) from the entry's `jobs` map, mirroring the
+  # HTML badges: how many jobs the credential earned, and whether it is in
+  # current use or when it was last used.
+  defp qualification_usage_facts(nil), do: []
+
+  defp qualification_usage_facts(jobs) do
+    [
+      ngettext("used for %{count} job", "used for %{count} jobs", jobs.count),
+      jobs.in_use && gettext("currently in use"),
+      # pgettext: the bare "last used %{date}" msgid already belongs to the
+      # access-token list ("zuletzt benutzt am …"), whose grammar doesn't fit
+      # a year-month value — a distinct context keeps the two independent.
+      !jobs.in_use && jobs.last_used &&
+        pgettext("qualification job usage", "last used %{date}", date: jobs.last_used)
+    ]
   end
 
   @doc false

--- a/lib/vutuv_web/agent_docs/profile_doc.ex
+++ b/lib/vutuv_web/agent_docs/profile_doc.ex
@@ -179,8 +179,11 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
       work_experiences:
         {WorkExperience.order_by_date(WorkExperience), WorkExperience.display_preloads()},
       educations: Education.order_by_date(Education),
-      # The anonymous public view hides expired credentials (issue #859).
-      qualifications: Qualification.visible_to(false) |> Qualification.ordered(),
+      # The anonymous public view hides expired credentials (issue #859); the
+      # citing jobs ride along for the usage facts (issue #1005).
+      qualifications:
+        {Qualification.visible_to(false) |> Qualification.ordered(),
+         Qualification.citing_jobs_preload()},
       languages: Language.ordered(),
       # The owner's chosen order (see Vutuv.Ordering), so the profile's agent
       # documents list these contact sections the same way the HTML pages do.

--- a/lib/vutuv_web/agent_docs/section_docs.ex
+++ b/lib/vutuv_web/agent_docs/section_docs.ex
@@ -24,6 +24,7 @@ defmodule VutuvWeb.AgentDocs.SectionDocs do
   alias Vutuv.Organizations.Organization
   alias Vutuv.Phone
   alias Vutuv.Profiles.Messenger
+  alias Vutuv.Profiles.Qualification
   alias Vutuv.Profiles.SocialMediaAccount
   alias Vutuv.Profiles.WorkExperience
   alias Vutuv.Tags.UserTag
@@ -234,9 +235,30 @@ defmodule VutuvWeb.AgentDocs.SectionDocs do
       credential_id: qualification.credential_id,
       url: qualification.url,
       awarded: CV.year_month(qualification.awarded_year, qualification.awarded_month),
-      expires: CV.year_month(qualification.expires_year, qualification.expires_month)
+      expires: CV.year_month(qualification.expires_year, qualification.expires_month),
+      # The jobs earned with this credential (issue #1005), mirroring the HTML
+      # usage badges. nil when no job cites it — and, like qualification_ref/1
+      # on the work entry, when the citing jobs were not preloaded.
+      jobs: job_usage_ref(qualification)
     }
   end
+
+  defp job_usage_ref(qualification) do
+    case Qualification.job_usage(qualification) do
+      nil ->
+        nil
+
+      usage ->
+        %{
+          count: usage.count,
+          in_use: usage.current?,
+          last_used: last_used(usage.last_end)
+        }
+    end
+  end
+
+  defp last_used(nil), do: nil
+  defp last_used({year, month}), do: CV.year_month(year, month)
 
   @doc """
   A member's language entries, mapped to doc maps and — once there is a choice

--- a/lib/vutuv_web/controllers/api_v2/section_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/section_controller.ex
@@ -124,6 +124,16 @@ defmodule VutuvWeb.ApiV2.SectionController do
     user |> assoc(:work_experiences) |> Repo.all() |> preload_for_doc(:work_experiences)
   end
 
+  # The citing jobs ride along so the API entries carry the same usage facts
+  # (issue #1005) as the public .json sibling.
+  defp entries(user, :qualifications, _viewer) do
+    user
+    |> assoc(:qualifications)
+    |> Qualification.ordered()
+    |> Repo.all()
+    |> preload_for_doc(:qualifications)
+  end
+
   # The position-ordered sections (links, social, addresses, phone numbers)
   # follow the owner's chosen order, matching the HTML pages.
   defp entries(user, section, _viewer) do
@@ -142,6 +152,9 @@ defmodule VutuvWeb.ApiV2.SectionController do
   # the fact from the API response).
   defp preload_for_doc(record_or_records, :work_experiences),
     do: Repo.preload(record_or_records, WorkExperience.display_preloads())
+
+  defp preload_for_doc(record_or_records, :qualifications),
+    do: Repo.preload(record_or_records, Qualification.citing_jobs_preload())
 
   defp preload_for_doc(record_or_records, _section), do: record_or_records
 end

--- a/lib/vutuv_web/controllers/qualification_controller.ex
+++ b/lib/vutuv_web/controllers/qualification_controller.ex
@@ -20,9 +20,13 @@ defmodule VutuvWeb.QualificationController do
   # sync, see agent_docs_drift_test.exs). Both show the anonymous public view,
   # which hides expired credentials (issue #859).
   def index(conn, _params) do
+    # citing_jobs_preload: the jobs earned with each credential ride along for
+    # the usage badges (issue #1005).
     user =
       Repo.preload(conn.assigns[:user],
-        qualifications: Qualification.visible_to(false) |> Qualification.ordered()
+        qualifications:
+          {Qualification.visible_to(false) |> Qualification.ordered(),
+           Qualification.citing_jobs_preload()}
       )
 
     AgentDocs.respond(conn,
@@ -42,7 +46,10 @@ defmodule VutuvWeb.QualificationController do
   # The owner's editor (GET /settings/qualifications) — shows everything the
   # member holds, expired entries included, since this is where they manage them.
   def manage(conn, _params) do
-    user = Repo.preload(conn.assigns[:user], qualifications: Qualification.ordered())
+    user =
+      Repo.preload(conn.assigns[:user],
+        qualifications: {Qualification.ordered(), Qualification.citing_jobs_preload()}
+      )
 
     render(conn, "manage.html",
       user: user,
@@ -83,15 +90,19 @@ defmodule VutuvWeb.QualificationController do
   end
 
   def show(conn, _params) do
-    # resolve_qualification scoped :qualification to conn.assigns[:user].
+    # resolve_qualification scoped :qualification to conn.assigns[:user]; the
+    # citing jobs ride along for the usage line (issue #1005).
+    qualification =
+      Repo.preload(conn.assigns[:qualification], Qualification.citing_jobs_preload())
+
     AgentDocs.respond(conn,
       html:
         &render(&1, "show.html",
-          qualification: conn.assigns[:qualification],
-          page_title: entry_page_title(conn.assigns[:user], conn.assigns[:qualification])
+          qualification: qualification,
+          page_title: entry_page_title(conn.assigns[:user], qualification)
         ),
       doc: fn ->
-        SectionDocs.build_show(conn.assigns[:user], :qualifications, conn.assigns[:qualification])
+        SectionDocs.build_show(conn.assigns[:user], :qualifications, qualification)
       end
     )
   end

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -881,7 +881,11 @@ defmodule VutuvWeb.UserProfileLive do
       # visible_to(owner?) hides expired credentials from visitors in SQL (the
       # same scope the section page, CV and agent docs use), so the card renders
       # what is loaded — no in-memory filter, and limit-after-filter is correct.
-      qualifications: Qualification.visible_to(owner?) |> Qualification.ordered() |> limit(8),
+      # citing_jobs_preload: the jobs earned with each credential ride along
+      # for the usage badges (issue #1005).
+      qualifications:
+        {Qualification.visible_to(owner?) |> Qualification.ordered() |> limit(8),
+         Qualification.citing_jobs_preload()},
       phone_numbers: PhoneNumber.ordered() |> limit(3),
       urls: Url.ordered() |> limit(3),
       addresses: Address.ordered() |> limit(3),

--- a/lib/vutuv_web/templates/qualification/show.html.heex
+++ b/lib/vutuv_web/templates/qualification/show.html.heex
@@ -34,6 +34,11 @@
     <p><%= Enum.reject([@qualification.expires_month, @qualification.expires_year], &is_nil/1) |> Enum.join("/") %></p>
   <% end %>
 
+  <%= if usage = usage_line(@qualification) do %>
+    <h2 class="card__label"><%= gettext("Jobs") %></h2>
+    <p data-qualification-usage><%= usage %></p>
+  <% end %>
+
   <%= if @qualification.credential_id do %>
     <h2 class="card__label"><%= gettext("Credential ID") %></h2>
     <p><%= @qualification.credential_id %></p>

--- a/lib/vutuv_web/views/qualification_html.ex
+++ b/lib/vutuv_web/views/qualification_html.ex
@@ -121,6 +121,41 @@ defmodule VutuvWeb.QualificationHTML do
   defdelegate expired?(qualification), to: Qualification
 
   @doc """
+  The usage facts of a credential as one " · "-joined sentence (issue #1005),
+  for the entry show page: "Used for 2 jobs · Currently in use". nil when no
+  job cites it (or the citing jobs were not preloaded), so the caller can drop
+  the whole block.
+  """
+  def usage_line(qualification) do
+    case Qualification.job_usage(qualification) do
+      nil ->
+        nil
+
+      usage ->
+        [usage_count_text(usage), usage_status_text(usage)]
+        |> Enum.reject(&is_nil/1)
+        |> Enum.join(" · ")
+    end
+  end
+
+  defp usage_count_text(usage) do
+    ngettext("Used for %{formatted} job", "Used for %{formatted} jobs", usage.count,
+      formatted: compact_count(usage.count)
+    )
+  end
+
+  defp usage_status_text(%{current?: true}), do: gettext("Currently in use")
+
+  defp usage_status_text(%{last_end: {_year, _month} = last_end}),
+    do: gettext("Last used: %{date}", date: end_text(last_end))
+
+  defp usage_status_text(_usage), do: nil
+
+  # The badge's month/year form, matching the meta line's "3/2026" style.
+  defp end_text({year, nil}), do: Integer.to_string(year)
+  defp end_text({year, month}), do: "#{month}/#{year}"
+
+  @doc """
   One credential's row body (glyph + name link + owner "Expired" badge + the
   issuer/date meta line + the verification "Proof" link), shared by the profile
   card and the section `card_list` so both read the same. The caller supplies
@@ -131,7 +166,10 @@ defmodule VutuvWeb.QualificationHTML do
   attr(:as_owner?, :boolean, default: false)
 
   def qualification_row(assigns) do
-    assigns = assign(assigns, :meta, meta_line(assigns.qualification))
+    assigns =
+      assigns
+      |> assign(:meta, meta_line(assigns.qualification))
+      |> assign(:usage, Qualification.job_usage(assigns.qualification))
 
     ~H"""
     <.qualification_glyph class="mt-0.5 h-5 w-5 shrink-0 text-slate-400 dark:text-slate-500" />
@@ -149,6 +187,32 @@ defmodule VutuvWeb.QualificationHTML do
         {gettext("Expired")}
       </span>
       <p :if={@meta != ""} class="text-sm text-slate-600 dark:text-slate-400">{@meta}</p>
+      <p
+        :if={@usage}
+        class="mt-1 flex flex-wrap items-center gap-1.5"
+        data-qualification-usage
+      >
+        <span
+          class="inline-flex items-center rounded-lg bg-brand-50 px-2 py-0.5 text-xs font-medium text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
+          data-usage-jobs
+        >
+          {usage_count_text(@usage)}
+        </span>
+        <span
+          :if={@usage.current?}
+          class="inline-flex items-center rounded-lg bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+          data-usage-current
+        >
+          {gettext("Currently in use")}
+        </span>
+        <span
+          :if={not @usage.current? and @usage.last_end != nil}
+          class="inline-flex items-center rounded-lg bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-400"
+          data-usage-last
+        >
+          {gettext("Last used: %{date}", date: end_text(@usage.last_end))}
+        </span>
+      </p>
       <a
         :if={@qualification.url}
         href={@qualification.url}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.128.0",
+      version: "7.129.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: de\n"
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:2751
-#: lib/vutuv_web/components/ui.ex:2756
+#: lib/vutuv_web/components/ui.ex:2877
+#: lib/vutuv_web/components/ui.ex:2882
 #: lib/vutuv_web/live/organization_live/domains.ex:235
 #: lib/vutuv_web/live/organization_live/edit.ex:382
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -25,7 +25,7 @@ msgid "Add"
 msgstr "Eintrag hinzufügen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:201
-#: lib/vutuv_web/agent_docs/section_docs.ex:119
+#: lib/vutuv_web/agent_docs/section_docs.ex:120
 #: lib/vutuv_web/agent_docs/text.ex:196
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
@@ -34,7 +34,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1150
+#: lib/vutuv_web/templates/user/show.html.heex:1154
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -58,7 +58,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:2896
+#: lib/vutuv_web/components/ui.ex:3022
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -76,8 +76,8 @@ msgstr "Adressen"
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:2556
-#: lib/vutuv_web/components/ui.ex:2650
+#: lib/vutuv_web/components/ui.ex:2682
+#: lib/vutuv_web/components/ui.ex:2776
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #, elixir-autogen
 msgid "Are you sure?"
@@ -97,13 +97,13 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/agent_docs/markdown.ex:423
 #: lib/vutuv_web/agent_docs/text.ex:425
 #: lib/vutuv_web/agent_docs/text.ex:426
-#: lib/vutuv_web/templates/user/show.html.heex:815
+#: lib/vutuv_web/templates/user/show.html.heex:819
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:2549
+#: lib/vutuv_web/components/ui.ex:2675
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -141,7 +141,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:13
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:853
+#: lib/vutuv_web/templates/user/show.html.heex:857
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -151,7 +151,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr "Konnte nicht zu %{name} zurückfolgen."
 
 #: lib/vutuv_web/components/post_components.ex:816
-#: lib/vutuv_web/components/ui.ex:2653
+#: lib/vutuv_web/components/ui.ex:2779
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -196,7 +196,7 @@ msgid "Download"
 msgstr "Download"
 
 #: lib/vutuv_web/components/post_components.ex:809
-#: lib/vutuv_web/components/ui.ex:2644
+#: lib/vutuv_web/components/ui.ex:2770
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -218,7 +218,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/url/edit.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:838
+#: lib/vutuv_web/templates/user/show.html.heex:842
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #, elixir-autogen
 msgid "Edit"
@@ -295,11 +295,11 @@ msgstr "Nachname eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:2887
+#: lib/vutuv_web/components/ui.ex:3013
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:485
+#: lib/vutuv_web/templates/user/show.html.heex:489
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:3
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -331,16 +331,16 @@ msgstr "Follower"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:435
 #: lib/vutuv_web/agent_docs/text.ex:438
-#: lib/vutuv_web/components/ui.ex:1287
-#: lib/vutuv_web/components/ui.ex:1312
-#: lib/vutuv_web/components/ui.ex:1315
-#: lib/vutuv_web/components/ui.ex:1322
-#: lib/vutuv_web/components/ui.ex:1325
-#: lib/vutuv_web/components/ui.ex:1383
+#: lib/vutuv_web/components/ui.ex:1413
+#: lib/vutuv_web/components/ui.ex:1438
+#: lib/vutuv_web/components/ui.ex:1441
+#: lib/vutuv_web/components/ui.ex:1448
+#: lib/vutuv_web/components/ui.ex:1451
+#: lib/vutuv_web/components/ui.ex:1509
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:763
+#: lib/vutuv_web/templates/user/show.html.heex:767
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
@@ -355,7 +355,7 @@ msgstr "Folge ich"
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:62
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:810
+#: lib/vutuv_web/templates/user/show.html.heex:814
 #, elixir-autogen
 msgid "Gender"
 msgstr "Geschlecht"
@@ -416,7 +416,7 @@ msgstr "Link wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:52
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:2891
+#: lib/vutuv_web/components/ui.ex:3017
 #: lib/vutuv_web/controllers/url_controller.ex:23
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
@@ -453,8 +453,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:482
-#: lib/vutuv_web/live/shell_live.ex:519
+#: lib/vutuv_web/live/shell_live.ex:556
+#: lib/vutuv_web/live/shell_live.ex:593
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -466,7 +466,7 @@ msgstr "Einloggen"
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
-#: lib/vutuv_web/components/ui.ex:2907
+#: lib/vutuv_web/components/ui.ex:3033
 #: lib/vutuv_web/live/notification_live/index.ex:558
 #, elixir-autogen
 msgid "More"
@@ -662,8 +662,8 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/job_board_live.ex:314
 #: lib/vutuv_web/live/search_live.ex:35
 #: lib/vutuv_web/live/search_live.ex:229
-#: lib/vutuv_web/live/shell_live.ex:346
-#: lib/vutuv_web/live/shell_live.ex:502
+#: lib/vutuv_web/live/shell_live.ex:420
+#: lib/vutuv_web/live/shell_live.ex:576
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
 #: lib/vutuv_web/templates/layout/app.html.heex:120
 #, elixir-autogen
@@ -692,7 +692,7 @@ msgstr "Slug"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:55
 #: lib/vutuv_web/agent_docs/text.ex:52
-#: lib/vutuv_web/components/ui.ex:2892
+#: lib/vutuv_web/components/ui.ex:3018
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
@@ -705,18 +705,18 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:964
+#: lib/vutuv_web/templates/user/show.html.heex:968
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:966
+#: lib/vutuv_web/templates/user/show.html.heex:970
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:98
+#: lib/vutuv_web/agent_docs/section_docs.ex:99
 #, elixir-autogen, elixir-format
 msgid "Profiles of %{name}"
 msgstr "Profile von %{name}"
@@ -761,7 +761,7 @@ msgstr "Code & Repositorys"
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
 
-#: lib/vutuv_web/components/ui.ex:2550
+#: lib/vutuv_web/components/ui.ex:2676
 #, elixir-autogen
 msgid "Submit"
 msgstr "Absenden"
@@ -849,7 +849,7 @@ msgstr "Benutzername"
 #: lib/vutuv_web/templates/url/index.html.heex:8
 #: lib/vutuv_web/templates/url/show.html.heex:4
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:2
-#: lib/vutuv_web/templates/user_tag/index.html.heex:8
+#: lib/vutuv_web/templates/user_tag/index.html.heex:15
 #: lib/vutuv_web/templates/user_tag/show.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:8
 #: lib/vutuv_web/templates/work_experience/show.html.heex:4
@@ -863,9 +863,9 @@ msgstr "Benutzer"
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:2714
-#: lib/vutuv_web/templates/user/show.html.heex:757
-#: lib/vutuv_web/templates/user/show.html.heex:777
+#: lib/vutuv_web/components/ui.ex:2840
+#: lib/vutuv_web/templates/user/show.html.heex:761
+#: lib/vutuv_web/templates/user/show.html.heex:781
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
@@ -1131,7 +1131,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:799
+#: lib/vutuv_web/templates/user/show.html.heex:803
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1276,7 +1276,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:177
-#: lib/vutuv_web/live/shell_live.ex:454
+#: lib/vutuv_web/live/shell_live.ex:528
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
 #: lib/vutuv_web/templates/admin/ad/show.html.heex:4
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:1
@@ -1315,6 +1315,7 @@ msgstr "Alle Tag-URLs"
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
+#: lib/vutuv_web/templates/user/show.html.heex:483
 #, elixir-autogen
 msgid "All tags"
 msgstr "Alle Tags"
@@ -1486,13 +1487,13 @@ msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
 #: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:785
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:393
-#: lib/vutuv_web/agent_docs/text.ex:556
-#: lib/vutuv_web/components/ui.ex:2897
-#: lib/vutuv_web/controllers/user_tag_controller.ex:37
-#: lib/vutuv_web/controllers/user_tag_controller.ex:54
+#: lib/vutuv_web/agent_docs/text.ex:565
+#: lib/vutuv_web/components/ui.ex:3023
+#: lib/vutuv_web/controllers/user_tag_controller.ex:38
+#: lib/vutuv_web/controllers/user_tag_controller.ex:55
 #: lib/vutuv_web/cv/docx.ex:174
 #: lib/vutuv_web/cv/html.ex:159
 #: lib/vutuv_web/cv/latex.ex:131
@@ -1517,7 +1518,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/tag/show.html.heex:25
 #: lib/vutuv_web/templates/user/show.html.heex:453
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
-#: lib/vutuv_web/templates/user_tag/index.html.heex:10
+#: lib/vutuv_web/templates/user_tag/index.html.heex:17
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
 #, elixir-autogen
@@ -1627,7 +1628,6 @@ msgid "Tag closures"
 msgstr "Tag-Beziehungen"
 
 #: lib/vutuv_web/templates/tag/card_list.html.heex:5
-#: lib/vutuv_web/templates/user_tag/index.html.heex:19
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:10
 #, elixir-autogen
 msgid "Tag name"
@@ -1648,7 +1648,7 @@ msgstr "Empfehlung zurückgenommen."
 msgid "User tag created successfully."
 msgstr "Tag erfolgreich hinzugefügt."
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:126
+#: lib/vutuv_web/controllers/user_tag_controller.ex:134
 #, elixir-autogen
 msgid "User tag deleted successfully."
 msgstr "Ein Tag wurde gelöscht."
@@ -1706,7 +1706,7 @@ msgstr "Vorgeschlagen"
 msgid "Admin Area"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:101
+#: lib/vutuv_web/agent_docs/section_docs.ex:102
 #: lib/vutuv_web/templates/address/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Addresses of %{name}"
@@ -1717,7 +1717,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:505
+#: lib/vutuv_web/live/shell_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1786,21 +1786,21 @@ msgstr "Profil bearbeiten"
 
 #: lib/vutuv_web/components/ui.ex:950
 #: lib/vutuv_web/components/ui.ex:959
-#: lib/vutuv_web/components/ui.ex:1134
+#: lib/vutuv_web/components/ui.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Empfehlen"
 
-#: lib/vutuv_web/components/ui.ex:1252
-#: lib/vutuv_web/components/ui.ex:1252
-#: lib/vutuv_web/components/ui.ex:1269
-#: lib/vutuv_web/components/ui.ex:1278
-#: lib/vutuv_web/components/ui.ex:1294
-#: lib/vutuv_web/components/ui.ex:1331
-#: lib/vutuv_web/components/ui.ex:1334
-#: lib/vutuv_web/components/ui.ex:1341
-#: lib/vutuv_web/components/ui.ex:1344
-#: lib/vutuv_web/components/ui.ex:1417
+#: lib/vutuv_web/components/ui.ex:1378
+#: lib/vutuv_web/components/ui.ex:1378
+#: lib/vutuv_web/components/ui.ex:1395
+#: lib/vutuv_web/components/ui.ex:1404
+#: lib/vutuv_web/components/ui.ex:1420
+#: lib/vutuv_web/components/ui.ex:1457
+#: lib/vutuv_web/components/ui.ex:1460
+#: lib/vutuv_web/components/ui.ex:1467
+#: lib/vutuv_web/components/ui.ex:1470
+#: lib/vutuv_web/components/ui.ex:1543
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1818,7 +1818,7 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:473
+#: lib/vutuv_web/live/shell_live.ex:547
 #: lib/vutuv_web/views/settings_html.ex:218
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1842,20 +1842,20 @@ msgstr "Nachricht"
 
 #: lib/vutuv_web/live/message_live/index.ex:45
 #: lib/vutuv_web/live/message_live/index.ex:496
-#: lib/vutuv_web/live/shell_live.ex:362
-#: lib/vutuv_web/live/shell_live.ex:504
+#: lib/vutuv_web/live/shell_live.ex:436
+#: lib/vutuv_web/live/shell_live.ex:578
 #: lib/vutuv_web/templates/layout/app.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/vutuv_web/live/shell_live.ex:332
+#: lib/vutuv_web/live/shell_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:285
-#: lib/vutuv_web/components/ui.ex:2753
+#: lib/vutuv_web/components/ui.ex:2879
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -1867,10 +1867,10 @@ msgstr "Hier gibt es noch nichts."
 msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
-#: lib/vutuv_web/components/ui.ex:2911
+#: lib/vutuv_web/components/ui.ex:3037
 #: lib/vutuv_web/live/notification_live/index.ex:81
 #: lib/vutuv_web/live/notification_live/index.ex:245
-#: lib/vutuv_web/live/shell_live.ex:373
+#: lib/vutuv_web/live/shell_live.ex:447
 #: lib/vutuv_web/templates/layout/app.html.heex:118
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1912,8 +1912,8 @@ msgstr "Quellcode"
 msgid "Submit a bug report or feature request"
 msgstr "Fehler melden oder Feature vorschlagen"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:104
-#: lib/vutuv_web/templates/user_tag/index.html.heex:5
+#: lib/vutuv_web/agent_docs/section_docs.ex:105
+#: lib/vutuv_web/templates/user_tag/index.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Tags of %{name}"
 msgstr "Tags von %{name}"
@@ -1963,7 +1963,7 @@ msgstr ""
 "unten ein, um die Adresse zu bestätigen."
 
 #: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1234
+#: lib/vutuv_web/templates/user/show.html.heex:1238
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
@@ -2014,8 +2014,8 @@ msgstr "ist jetzt mit Ihnen vernetzt."
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:2145
-#: lib/vutuv_web/components/ui.ex:2290
+#: lib/vutuv_web/components/ui.ex:2271
+#: lib/vutuv_web/components/ui.ex:2416
 #: lib/vutuv_web/live/organization_live/index.ex:130
 #, elixir-autogen, elixir-format
 msgid "Pagination"
@@ -2026,7 +2026,7 @@ msgstr "Seitennavigation"
 msgid "Load %{count} of %{remaining} more"
 msgstr "%{count} von %{remaining} mehr laden"
 
-#: lib/vutuv_web/components/ui.ex:2778
+#: lib/vutuv_web/components/ui.ex:2904
 #: lib/vutuv_web/live/notification_live/index.ex:624
 #, elixir-autogen, elixir-format
 msgid "Load more"
@@ -2039,7 +2039,7 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:2559
+#: lib/vutuv_web/components/ui.ex:2685
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
@@ -2084,12 +2084,12 @@ msgstr "Titelbild hinzufügen"
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:1908
+#: lib/vutuv_web/components/ui.ex:2034
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
-#: lib/vutuv_web/components/ui.ex:1912
+#: lib/vutuv_web/components/ui.ex:2038
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
@@ -2114,37 +2114,37 @@ msgstr "Titelbild"
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:1916
+#: lib/vutuv_web/components/ui.ex:2042
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
-#: lib/vutuv_web/components/ui.ex:1906
+#: lib/vutuv_web/components/ui.ex:2032
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
-#: lib/vutuv_web/components/ui.ex:1905
+#: lib/vutuv_web/components/ui.ex:2031
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
-#: lib/vutuv_web/components/ui.ex:1911
+#: lib/vutuv_web/components/ui.ex:2037
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
-#: lib/vutuv_web/components/ui.ex:1910
+#: lib/vutuv_web/components/ui.ex:2036
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
-#: lib/vutuv_web/components/ui.ex:1907
+#: lib/vutuv_web/components/ui.ex:2033
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
-#: lib/vutuv_web/components/ui.ex:1909
+#: lib/vutuv_web/components/ui.ex:2035
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
@@ -2159,17 +2159,17 @@ msgstr "Mitglied seit %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
-#: lib/vutuv_web/components/ui.ex:1915
+#: lib/vutuv_web/components/ui.ex:2041
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
-#: lib/vutuv_web/components/ui.ex:1914
+#: lib/vutuv_web/components/ui.ex:2040
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
-#: lib/vutuv_web/components/ui.ex:1913
+#: lib/vutuv_web/components/ui.ex:2039
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "September"
@@ -2229,8 +2229,8 @@ msgstr "Beitrag bearbeiten"
 
 #: lib/vutuv_web/live/post_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:552
-#: lib/vutuv_web/live/shell_live.ex:312
-#: lib/vutuv_web/live/shell_live.ex:500
+#: lib/vutuv_web/live/shell_live.ex:369
+#: lib/vutuv_web/live/shell_live.ex:574
 #: lib/vutuv_web/templates/layout/app.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2403,8 +2403,8 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:3084
-#: lib/vutuv_web/live/shell_live.ex:416
+#: lib/vutuv_web/components/ui.ex:3210
+#: lib/vutuv_web/live/shell_live.ex:490
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:165
@@ -2427,22 +2427,22 @@ msgstr "Was gibt's Neues? Markdown wird unterstützt."
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:1842
+#: lib/vutuv_web/components/post_components.ex:1839
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:1846
+#: lib/vutuv_web/components/post_components.ex:1843
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:1844
+#: lib/vutuv_web/components/post_components.ex:1841
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:1845
+#: lib/vutuv_web/components/post_components.ex:1842
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2483,40 +2483,40 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1914
-#: lib/vutuv_web/components/ui.ex:1612
-#: lib/vutuv_web/components/ui.ex:1612
-#: lib/vutuv_web/components/ui.ex:2220
+#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/ui.ex:1738
+#: lib/vutuv_web/components/ui.ex:1738
+#: lib/vutuv_web/components/ui.ex:2346
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:790
+#: lib/vutuv_web/agent_docs/markdown.ex:817
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
-#: lib/vutuv_web/live/shell_live.ex:355
-#: lib/vutuv_web/live/shell_live.ex:421
+#: lib/vutuv_web/live/shell_live.ex:429
+#: lib/vutuv_web/live/shell_live.ex:495
 #: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1881
-#: lib/vutuv_web/components/ui.ex:1641
-#: lib/vutuv_web/components/ui.ex:1641
-#: lib/vutuv_web/components/ui.ex:2206
+#: lib/vutuv_web/components/post_components.ex:1878
+#: lib/vutuv_web/components/ui.ex:1767
+#: lib/vutuv_web/components/ui.ex:1767
+#: lib/vutuv_web/components/ui.ex:2332
 #: lib/vutuv_web/live/notification_live/index.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:789
+#: lib/vutuv_web/agent_docs/markdown.ex:816
 #: lib/vutuv_web/live/notification_live/index.ex:648
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
-#: lib/vutuv_web/live/shell_live.ex:424
+#: lib/vutuv_web/live/shell_live.ex:498
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Likes"
@@ -2532,48 +2532,48 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:1903
+#: lib/vutuv_web/components/post_components.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1914
-#: lib/vutuv_web/components/ui.ex:1602
-#: lib/vutuv_web/components/ui.ex:1602
+#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/ui.ex:1728
+#: lib/vutuv_web/components/ui.ex:1728
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1900
+#: lib/vutuv_web/components/post_components.ex:1897
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1341
+#: lib/vutuv_web/components/post_components.ex:1324
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1900
+#: lib/vutuv_web/components/post_components.ex:1897
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:1881
-#: lib/vutuv_web/components/ui.ex:1631
-#: lib/vutuv_web/components/ui.ex:1631
+#: lib/vutuv_web/components/post_components.ex:1878
+#: lib/vutuv_web/components/ui.ex:1757
+#: lib/vutuv_web/components/ui.ex:1757
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
-#: lib/vutuv_web/components/ui.ex:1247
-#: lib/vutuv_web/components/ui.ex:1247
-#: lib/vutuv_web/components/ui.ex:1384
+#: lib/vutuv_web/components/ui.ex:1373
+#: lib/vutuv_web/components/ui.ex:1373
+#: lib/vutuv_web/components/ui.ex:1510
 #: lib/vutuv_web/live/post_live/feed.ex:665
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
 #, elixir-autogen, elixir-format
@@ -2585,7 +2585,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:1954
+#: lib/vutuv_web/components/post_components.ex:1951
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2599,8 +2599,8 @@ msgstr "Nur öffentliche Beiträge können beantwortet werden."
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1937
-#: lib/vutuv_web/components/post_components.ex:1938
+#: lib/vutuv_web/components/post_components.ex:1934
+#: lib/vutuv_web/components/post_components.ex:1935
 #: lib/vutuv_web/live/notification_live/index.ex:693
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
@@ -2703,7 +2703,7 @@ msgstr "Mitglied nicht gefunden."
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
-#: lib/vutuv_web/components/ui.ex:1784
+#: lib/vutuv_web/components/ui.ex:1910
 #: lib/vutuv_web/live/message_live/index.ex:596
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2816,54 +2816,55 @@ msgid "Use a different email address"
 msgstr "Andere E-Mail-Adresse verwenden"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:689
+#: lib/vutuv_web/templates/user/show.html.heex:693
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:927
+#: lib/vutuv_web/templates/user/show.html.heex:931
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1152
+#: lib/vutuv_web/templates/user/show.html.heex:1156
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:855
+#: lib/vutuv_web/templates/user/show.html.heex:859
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:801
+#: lib/vutuv_web/templates/user/show.html.heex:805
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/templates/user/show.html.heex:492
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
-#: lib/vutuv_web/live/user_profile_live.ex:961
+#: lib/vutuv_web/live/user_profile_live.ex:965
 #: lib/vutuv_web/templates/user/show.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:2351
-#: lib/vutuv_web/components/ui.ex:2716
+#: lib/vutuv_web/components/ui.ex:2477
+#: lib/vutuv_web/components/ui.ex:2842
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
 #: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
+#: lib/vutuv_web/templates/user/show.html.heex:483
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Verwalten"
@@ -2949,7 +2950,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:1843
+#: lib/vutuv_web/components/post_components.ex:1840
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -2975,7 +2976,7 @@ msgid "Endorsement"
 msgstr "Empfehlung"
 
 #: lib/vutuv_web/live/notification_live/index.ex:691
-#: lib/vutuv_web/templates/user/show.html.heex:744
+#: lib/vutuv_web/templates/user/show.html.heex:748
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3222,8 +3223,8 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:895
-#: lib/vutuv_web/templates/user/show.html.heex:896
+#: lib/vutuv_web/templates/user/show.html.heex:899
+#: lib/vutuv_web/templates/user/show.html.heex:900
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
@@ -3283,9 +3284,9 @@ msgstr ""
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/components/ui.ex:2884
-#: lib/vutuv_web/live/shell_live.ex:325
-#: lib/vutuv_web/live/shell_live.ex:509
+#: lib/vutuv_web/components/ui.ex:3010
+#: lib/vutuv_web/live/shell_live.ex:382
+#: lib/vutuv_web/live/shell_live.ex:583
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3395,7 +3396,7 @@ msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:2120
+#: lib/vutuv_web/components/ui.ex:2246
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
@@ -4019,12 +4020,12 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:524
+#: lib/vutuv_web/agent_docs/markdown.ex:526
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:834
+#: lib/vutuv_web/agent_docs/markdown.ex:861
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -4038,11 +4039,11 @@ msgstr "%{count} Beiträge von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:144
 #: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:785
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:139
 #: lib/vutuv_web/agent_docs/text.ex:152
-#: lib/vutuv_web/agent_docs/text.ex:556
+#: lib/vutuv_web/agent_docs/text.ex:565
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
@@ -4059,20 +4060,20 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:776
-#: lib/vutuv_web/agent_docs/text.ex:567
+#: lib/vutuv_web/agent_docs/markdown.ex:803
+#: lib/vutuv_web/agent_docs/text.ex:576
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:773
-#: lib/vutuv_web/agent_docs/text.ex:564
+#: lib/vutuv_web/agent_docs/markdown.ex:800
+#: lib/vutuv_web/agent_docs/text.ex:573
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:780
-#: lib/vutuv_web/agent_docs/text.ex:570
+#: lib/vutuv_web/agent_docs/markdown.ex:807
+#: lib/vutuv_web/agent_docs/text.ex:579
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
@@ -4124,17 +4125,17 @@ msgstr "Beiträge (insgesamt %{count})"
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:727
+#: lib/vutuv_web/agent_docs/markdown.ex:754
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:657
+#: lib/vutuv_web/agent_docs/markdown.ex:684
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:658
+#: lib/vutuv_web/agent_docs/markdown.ex:685
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4149,22 +4150,22 @@ msgstr "Diese Seite auf %{language}: %{url}"
 msgid "Connections of %{name}"
 msgstr "Vernetzungen von %{name}"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:103
+#: lib/vutuv_web/agent_docs/section_docs.ex:104
 #, elixir-autogen, elixir-format
 msgid "Email addresses of %{name}"
 msgstr "E-Mail-Adressen von %{name}"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:95
+#: lib/vutuv_web/agent_docs/section_docs.ex:96
 #, elixir-autogen, elixir-format
 msgid "Links of %{name}"
 msgstr "Links von %{name}"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:102
+#: lib/vutuv_web/agent_docs/section_docs.ex:103
 #, elixir-autogen, elixir-format
 msgid "Phone numbers of %{name}"
 msgstr "Telefonnummern von %{name}"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:88
+#: lib/vutuv_web/agent_docs/section_docs.ex:89
 #, elixir-autogen, elixir-format
 msgid "Work experience of %{name}"
 msgstr "Lebenslauf von %{name}"
@@ -4760,7 +4761,7 @@ msgstr "Mitglieder finden"
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:763
+#: lib/vutuv_web/templates/user/show.html.heex:767
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4876,7 +4877,7 @@ msgstr "müller"
 msgid "searches first names only (last: for last names)"
 msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
-#: lib/vutuv_web/live/user_profile_live.ex:949
+#: lib/vutuv_web/live/user_profile_live.ex:953
 #: lib/vutuv_web/templates/user/show.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -5509,7 +5510,7 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:2917
+#: lib/vutuv_web/components/ui.ex:3043
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5560,7 +5561,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:403
+#: lib/vutuv_web/live/shell_live.ex:477
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5581,7 +5582,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:464
+#: lib/vutuv_web/live/shell_live.ex:538
 #: lib/vutuv_web/templates/layout/app.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5592,11 +5593,11 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:3003
-#: lib/vutuv_web/components/ui.ex:3008
-#: lib/vutuv_web/components/ui.ex:3076
+#: lib/vutuv_web/components/ui.ex:3129
+#: lib/vutuv_web/components/ui.ex:3134
+#: lib/vutuv_web/components/ui.ex:3202
 #: lib/vutuv_web/controllers/settings_controller.ex:51
-#: lib/vutuv_web/live/shell_live.ex:444
+#: lib/vutuv_web/live/shell_live.ex:518
 #: lib/vutuv_web/live/tag_new_live.ex:44
 #: lib/vutuv_web/templates/address/edit.html.heex:2
 #: lib/vutuv_web/templates/address/new.html.heex:2
@@ -5660,7 +5661,7 @@ msgstr "Profil vervollständigen"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/live/user_profile_live.ex:951
+#: lib/vutuv_web/live/user_profile_live.ex:955
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -5675,8 +5676,8 @@ msgstr "Nächster Beitrag im Feed"
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
-#: lib/vutuv_web/live/shell_live.ex:305
-#: lib/vutuv_web/live/shell_live.ex:493
+#: lib/vutuv_web/live/shell_live.ex:362
+#: lib/vutuv_web/live/shell_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -5742,7 +5743,7 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:2899
+#: lib/vutuv_web/components/ui.ex:3025
 #: lib/vutuv_web/live/admin/user_live.ex:266
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:13
 #, elixir-autogen, elixir-format
@@ -5766,7 +5767,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:2894
+#: lib/vutuv_web/components/ui.ex:3020
 #: lib/vutuv_web/controllers/email_controller.ex:30
 #: lib/vutuv_web/controllers/email_controller.ex:49
 #: lib/vutuv_web/controllers/email_controller.ex:191
@@ -5797,7 +5798,7 @@ msgstr "Persönliche Tokens für die vutuv-API."
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:2909
+#: lib/vutuv_web/components/ui.ex:3035
 #: lib/vutuv_web/templates/settings/privacy.html.heex:9
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5912,7 +5913,7 @@ msgstr "@%{slug} hat Sie auf vutuv empfohlen"
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 
-#: lib/vutuv_web/components/ui.ex:2916
+#: lib/vutuv_web/components/ui.ex:3042
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -5923,7 +5924,7 @@ msgstr "Apps"
 msgid "Apps & API"
 msgstr "Apps & API-Zugang"
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:103
+#: lib/vutuv_web/controllers/user_tag_controller.ex:104
 #: lib/vutuv_web/live/notification_live/index.ex:650
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
@@ -6350,7 +6351,7 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/live/user_profile_live.ex:955
+#: lib/vutuv_web/live/user_profile_live.ex:959
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
@@ -6364,7 +6365,7 @@ msgstr "Kurzbeschreibung"
 #: lib/vutuv_web/components/ui.ex:174
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:687
+#: lib/vutuv_web/templates/user/show.html.heex:691
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6385,7 +6386,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1199
+#: lib/vutuv_web/templates/user/show.html.heex:1203
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6430,8 +6431,8 @@ msgstr "Foto verwenden"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:821
-#: lib/vutuv_web/templates/user/show.html.heex:831
+#: lib/vutuv_web/templates/user/show.html.heex:825
+#: lib/vutuv_web/templates/user/show.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6473,12 +6474,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:942
+#: lib/vutuv_web/templates/user/show.html.heex:946
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:953
+#: lib/vutuv_web/templates/user/show.html.heex:957
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6513,14 +6514,14 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:789
+#: lib/vutuv_web/agent_docs/markdown.ex:816
 #: lib/vutuv_web/components/post_components.ex:273
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:951
+#: lib/vutuv_web/templates/user/show.html.heex:955
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6549,7 +6550,7 @@ msgstr "Nach oben"
 
 #: lib/vutuv_web/components/ui.ex:950
 #: lib/vutuv_web/components/ui.ex:959
-#: lib/vutuv_web/components/ui.ex:1135
+#: lib/vutuv_web/components/ui.ex:1261
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Empfehlung zurücknehmen"
@@ -6576,9 +6577,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1185
-#: lib/vutuv_web/templates/user/show.html.heex:1193
-#: lib/vutuv_web/templates/user/show.html.heex:1205
+#: lib/vutuv_web/templates/user/show.html.heex:1189
+#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:1209
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6614,7 +6615,7 @@ msgstr "Mitglieder, die %{name} für %{tag} empfohlen haben"
 msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
-#: lib/vutuv_web/components/ui.ex:1088
+#: lib/vutuv_web/components/ui.ex:1214
 #: lib/vutuv_web/live/notification_live/index.ex:413
 #: lib/vutuv_web/live/notification_live/index.ex:428
 #: lib/vutuv_web/live/notification_live/index.ex:514
@@ -6623,7 +6624,7 @@ msgstr "Noch keine Empfehlungen."
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:798
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -6925,7 +6926,7 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/ui.ex:1572
+#: lib/vutuv_web/components/ui.ex:1698
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Mute"
@@ -6947,7 +6948,7 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/ui.ex:1571
+#: lib/vutuv_web/components/ui.ex:1697
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Unmute"
@@ -6986,33 +6987,33 @@ msgstr "Beruflich"
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
 
-#: lib/vutuv_web/components/ui.ex:1542
+#: lib/vutuv_web/components/ui.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr "Folgt dir nicht"
 
-#: lib/vutuv_web/components/ui.ex:1536
+#: lib/vutuv_web/components/ui.ex:1662
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr "Folgt dir"
 
-#: lib/vutuv_web/components/ui.ex:1526
+#: lib/vutuv_web/components/ui.ex:1652
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr "Dieses Mitglied folgt dir nicht"
 
-#: lib/vutuv_web/components/ui.ex:1477
-#: lib/vutuv_web/components/ui.ex:1526
+#: lib/vutuv_web/components/ui.ex:1603
+#: lib/vutuv_web/components/ui.ex:1652
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr "Dieses Mitglied folgt dir"
 
-#: lib/vutuv_web/components/ui.ex:1475
+#: lib/vutuv_web/components/ui.ex:1601
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr "Ihr folgt euch"
 
-#: lib/vutuv_web/components/ui.ex:1476
+#: lib/vutuv_web/components/ui.ex:1602
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr "Du folgst diesem Mitglied"
@@ -7596,13 +7597,13 @@ msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:2158
+#: lib/vutuv_web/components/ui.ex:2284
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:2174
+#: lib/vutuv_web/components/ui.ex:2300
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7871,17 +7872,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:839
+#: lib/vutuv_web/agent_docs/markdown.ex:866
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Dein Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:842
+#: lib/vutuv_web/agent_docs/markdown.ex:869
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:849
+#: lib/vutuv_web/agent_docs/markdown.ex:876
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -8407,7 +8408,7 @@ msgstr "PIN abgelaufen"
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:2161
+#: lib/vutuv_web/components/ui.ex:2287
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
@@ -8540,7 +8541,7 @@ msgstr[0] "%{count} Berufserfahrung"
 msgstr[1] "%{count} Berufserfahrungen"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:540
+#: lib/vutuv_web/templates/user/show.html.heex:544
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Ausbildung hinzufügen"
@@ -8552,7 +8553,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:2888
+#: lib/vutuv_web/components/ui.ex:3014
 #: lib/vutuv_web/controllers/education_controller.ex:38
 #: lib/vutuv_web/controllers/education_controller.ex:53
 #: lib/vutuv_web/controllers/education_controller.ex:103
@@ -8565,7 +8566,7 @@ msgstr "Abschluss"
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:537
+#: lib/vutuv_web/templates/user/show.html.heex:541
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr "Ausbildung"
@@ -8580,7 +8581,7 @@ msgstr "Ausbildung erfolgreich erstellt."
 msgid "Education deleted successfully."
 msgstr "Ausbildung erfolgreich gelöscht."
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:89
+#: lib/vutuv_web/agent_docs/section_docs.ex:90
 #, elixir-autogen, elixir-format
 msgid "Education of %{name}"
 msgstr "Ausbildung von %{name}"
@@ -8611,7 +8612,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:2904
+#: lib/vutuv_web/components/ui.ex:3030
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8640,7 +8641,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:2895
+#: lib/vutuv_web/components/ui.ex:3021
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8737,12 +8738,12 @@ msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 msgid "A photo and a short tagline make your profile complete."
 msgstr "Ein Foto und eine Kurzbeschreibung machen Ihr Profil komplett."
 
-#: lib/vutuv_web/live/user_profile_live.ex:974
+#: lib/vutuv_web/live/user_profile_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr "Zum Beispiel ein Gedanke zu %{tag}."
 
-#: lib/vutuv_web/components/ui.ex:2397
+#: lib/vutuv_web/components/ui.ex:2523
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:36
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:42
@@ -8767,7 +8768,7 @@ msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:94
-#: lib/vutuv_web/templates/user/show.html.heex:1056
+#: lib/vutuv_web/templates/user/show.html.heex:1060
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8846,13 +8847,13 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:2886
+#: lib/vutuv_web/components/ui.ex:3012
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:2903
+#: lib/vutuv_web/components/ui.ex:3029
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8864,7 +8865,7 @@ msgstr "Sprache & Anzeige"
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:2901
+#: lib/vutuv_web/components/ui.ex:3027
 #: lib/vutuv_web/controllers/settings_controller.ex:89
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:5
@@ -8873,7 +8874,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:2905
+#: lib/vutuv_web/components/ui.ex:3031
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -9126,7 +9127,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 msgid "Allow followers from the Fediverse"
 msgstr "Follower aus dem Fediverse erlauben"
 
-#: lib/vutuv_web/components/ui.ex:2910
+#: lib/vutuv_web/components/ui.ex:3036
 #: lib/vutuv_web/controllers/settings_controller.ex:186
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:265
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
@@ -9237,7 +9238,7 @@ msgid "Employment"
 msgstr "Anstellung"
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:576
+#: lib/vutuv_web/agent_docs/markdown.ex:586
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -9260,7 +9261,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr "Berufserfahrung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:577
+#: lib/vutuv_web/agent_docs/markdown.ex:587
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -9291,13 +9292,13 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:624
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:613
+#: lib/vutuv_web/agent_docs/markdown.ex:623
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9326,14 +9327,14 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:1344
+#: lib/vutuv_web/components/post_components.ex:1327
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:730
+#: lib/vutuv_web/agent_docs/markdown.ex:757
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9426,14 +9427,14 @@ msgstr ""
 "Der Lebenslauf von %{name} auf vutuv: Berufserfahrung, Ausbildung und "
 "Kenntnisse zum Ansehen und Herunterladen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:575
+#: lib/vutuv_web/agent_docs/markdown.ex:585
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr "Freiberuflich / Selbstständig"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:588
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9562,7 +9563,7 @@ msgstr "Dieses Mitglied aus dem Tag entfernen?"
 msgid "Removed @%{handle} from this tag."
 msgstr "@%{handle} aus diesem Tag entfernt."
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:131
+#: lib/vutuv_web/controllers/user_tag_controller.ex:139
 #, elixir-autogen, elixir-format
 msgid "This tag can only be removed by a site admin."
 msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
@@ -9572,8 +9573,8 @@ msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
 msgid "Yes"
 msgstr "Ja"
 
-#: lib/vutuv_web/components/ui.ex:992
-#: lib/vutuv_web/components/ui.ex:993
+#: lib/vutuv_web/components/ui.ex:994
+#: lib/vutuv_web/components/ui.ex:995
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:64
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9602,7 +9603,7 @@ msgid "A2 (Elementary)"
 msgstr "A2 (Grundkenntnisse)"
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:602
+#: lib/vutuv_web/templates/user/show.html.heex:606
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Sprache hinzufügen"
@@ -9814,7 +9815,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:49
 #: lib/vutuv_web/agent_docs/text.ex:46
-#: lib/vutuv_web/components/ui.ex:2890
+#: lib/vutuv_web/components/ui.ex:3016
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
@@ -9827,12 +9828,12 @@ msgstr "Sprache erfolgreich aktualisiert."
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:3
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:599
+#: lib/vutuv_web/templates/user/show.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Sprachen"
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:94
+#: lib/vutuv_web/agent_docs/section_docs.ex:95
 #, elixir-autogen, elixir-format
 msgid "Languages of %{name}"
 msgstr "Sprachen von %{name}"
@@ -10119,28 +10120,28 @@ msgstr[0] "%{count} Zertifikat oder Lizenz"
 msgstr[1] "%{count} Zertifikate oder Lizenzen"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:642
+#: lib/vutuv_web/templates/user/show.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:651
+#: lib/vutuv_web/agent_docs/markdown.ex:678
 #: lib/vutuv_web/views/qualification_html.ex:10
 #, elixir-autogen, elixir-format
 msgid "Certificate"
 msgstr "Zertifikat"
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:78
+#: lib/vutuv_web/controllers/qualification_controller.ex:85
 #, elixir-autogen, elixir-format
 msgid "Certificate or license added successfully."
 msgstr "Zertifikat oder Lizenz erfolgreich hinzugefügt."
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:128
+#: lib/vutuv_web/controllers/qualification_controller.ex:139
 #, elixir-autogen, elixir-format
 msgid "Certificate or license deleted successfully."
 msgstr "Zertifikat oder Lizenz erfolgreich gelöscht."
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:119
+#: lib/vutuv_web/controllers/qualification_controller.ex:130
 #, elixir-autogen, elixir-format
 msgid "Certificate or license updated successfully."
 msgstr "Zertifikat oder Lizenz erfolgreich aktualisiert."
@@ -10152,10 +10153,10 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:2889
-#: lib/vutuv_web/controllers/qualification_controller.ex:35
-#: lib/vutuv_web/controllers/qualification_controller.ex:51
-#: lib/vutuv_web/controllers/qualification_controller.ex:102
+#: lib/vutuv_web/components/ui.ex:3015
+#: lib/vutuv_web/controllers/qualification_controller.ex:39
+#: lib/vutuv_web/controllers/qualification_controller.ex:58
+#: lib/vutuv_web/controllers/qualification_controller.ex:113
 #: lib/vutuv_web/cv/docx.ex:183
 #: lib/vutuv_web/cv/html.ex:172
 #: lib/vutuv_web/cv/latex.ex:140
@@ -10167,7 +10168,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:3
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:639
+#: lib/vutuv_web/templates/user/show.html.heex:643
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr "Zertifikate & Lizenzen"
@@ -10177,13 +10178,13 @@ msgstr "Zertifikate & Lizenzen"
 msgid "Certificates & licenses of "
 msgstr "Zertifikate & Lizenzen von "
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:92
+#: lib/vutuv_web/agent_docs/section_docs.ex:93
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses of %{name}"
 msgstr "Zertifikate & Lizenzen von %{name}"
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:49
-#: lib/vutuv_web/templates/qualification/show.html.heex:38
+#: lib/vutuv_web/templates/qualification/show.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Credential ID"
 msgstr "Ausweisnummer"
@@ -10196,7 +10197,7 @@ msgstr "Läuft nicht ab"
 #: lib/vutuv_web/live/admin/job_live.ex:164
 #: lib/vutuv_web/live/admin/job_live.ex:180
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
-#: lib/vutuv_web/views/qualification_html.ex:149
+#: lib/vutuv_web/views/qualification_html.ex:187
 #, elixir-autogen, elixir-format
 msgid "Expired"
 msgstr "Abgelaufen"
@@ -10211,7 +10212,7 @@ msgstr "Ablaufmonat"
 msgid "Expiry year"
 msgstr "Ablaufjahr"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:643
+#: lib/vutuv_web/agent_docs/markdown.ex:653
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10237,7 +10238,7 @@ msgstr "Ausstellungsjahr"
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:650
+#: lib/vutuv_web/agent_docs/markdown.ex:677
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10256,18 +10257,18 @@ msgstr ""
 "Deshalb importieren wir alle als Zertifikate. Bitte prüfen Sie den Bereich "
 "anschließend und ändern Sie alle Einträge, die Lizenzen sind."
 
-#: lib/vutuv_web/views/qualification_html.ex:159
+#: lib/vutuv_web/views/qualification_html.ex:223
 #, elixir-autogen, elixir-format
 msgid "Proof"
 msgstr "Nachweis"
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:55
-#: lib/vutuv_web/templates/qualification/show.html.heex:43
+#: lib/vutuv_web/templates/qualification/show.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:641
+#: lib/vutuv_web/agent_docs/markdown.ex:651
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10282,7 +10283,7 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:642
+#: lib/vutuv_web/agent_docs/markdown.ex:652
 #: lib/vutuv_web/views/qualification_html.ex:76
 #: lib/vutuv_web/views/qualification_html.ex:79
 #, elixir-autogen, elixir-format
@@ -10301,15 +10302,15 @@ msgstr ""
 msgid "Preferred"
 msgstr "Bevorzugt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:533
+#: lib/vutuv_web/agent_docs/markdown.ex:543
 #: lib/vutuv_web/live/section_reorder_live.ex:269
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:917
-#: lib/vutuv_web/templates/user/show.html.heex:918
+#: lib/vutuv_web/templates/user/show.html.heex:921
+#: lib/vutuv_web/templates/user/show.html.heex:922
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10381,7 +10382,7 @@ msgid "First name"
 msgstr "Vorname"
 
 #: lib/vutuv_web/controllers/invitation_controller.ex:54
-#: lib/vutuv_web/live/shell_live.ex:435
+#: lib/vutuv_web/live/shell_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "Invite a friend"
 msgstr "Freunde einladen"
@@ -11004,21 +11005,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr "auf diesem Gerät einrichten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:503
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} Follower"
 msgstr[1] "%{count} Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:499
+#: lib/vutuv_web/agent_docs/markdown.ex:501
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} Repository"
 msgstr[1] "%{count} Repositories"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:497
+#: lib/vutuv_web/agent_docs/markdown.ex:499
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -11041,7 +11042,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1030
+#: lib/vutuv_web/templates/user/show.html.heex:1034
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -11076,12 +11077,12 @@ msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten nur als einfache "
 "Links."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:515
+#: lib/vutuv_web/agent_docs/markdown.ex:517
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:502
+#: lib/vutuv_web/agent_docs/markdown.ex:504
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "seit %{date}"
@@ -12527,8 +12528,8 @@ msgstr ""
 "Wir konnten den Nachweis noch nicht finden. Die Verbreitung kann etwas "
 "dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:671
-#: lib/vutuv_web/agent_docs/text.ex:537
+#: lib/vutuv_web/agent_docs/markdown.ex:698
+#: lib/vutuv_web/agent_docs/text.ex:539
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -12779,12 +12780,12 @@ msgid "Organization unfrozen."
 msgstr "Organisation"
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:2902
+#: lib/vutuv_web/components/ui.ex:3028
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
 #: lib/vutuv_web/live/post_live/saved.ex:455
-#: lib/vutuv_web/live/shell_live.ex:431
+#: lib/vutuv_web/live/shell_live.ex:505
 #: lib/vutuv_web/templates/layout/app.html.heex:79
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
@@ -13121,8 +13122,9 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:41
 #: lib/vutuv_web/live/job_board_live.ex:146
 #: lib/vutuv_web/live/post_live/saved.ex:458
-#: lib/vutuv_web/live/shell_live.ex:339
+#: lib/vutuv_web/live/shell_live.ex:396
 #: lib/vutuv_web/templates/layout/app.html.heex:77
+#: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr "Jobs"
@@ -13967,7 +13969,7 @@ msgstr "Suche speichern"
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:2940
+#: lib/vutuv_web/components/ui.ex:3066
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -14444,7 +14446,7 @@ msgstr "Eigene Beiträge"
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr "Beiträge mit einem Tag, dem du folgst, landen in deinem Feed, und passende Personen tauchen in deinen Vorschlägen auf. Einem Tag folgst du auf seiner Seite."
 
-#: lib/vutuv_web/components/ui.ex:2929
+#: lib/vutuv_web/components/ui.ex:3055
 #: lib/vutuv_web/controllers/settings_controller.ex:259
 #: lib/vutuv_web/live/post_live/feed.ex:651
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14494,7 +14496,7 @@ msgid "Signal and WhatsApp accept a phone number or a username; the other messen
 msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzernamen; die anderen Messenger nutzen ihre eigene ID oder ihren Handle (z. B. eine 8-stellige Threema-ID oder eine Matrix-Adresse @du:matrix.org)."
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:996
+#: lib/vutuv_web/templates/user/show.html.heex:1000
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14523,7 +14525,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:2893
+#: lib/vutuv_web/components/ui.ex:3019
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:3
@@ -14531,7 +14533,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:3
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:994
+#: lib/vutuv_web/templates/user/show.html.heex:998
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14541,7 +14543,7 @@ msgstr "Messenger"
 msgid "Messengers of "
 msgstr "Messenger von "
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:100
+#: lib/vutuv_web/agent_docs/section_docs.ex:101
 #, elixir-autogen, elixir-format
 msgid "Messengers of %{name}"
 msgstr "Messenger von %{name}"
@@ -14551,14 +14553,14 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:2483
+#: lib/vutuv_web/components/ui.ex:2609
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:2493
+#: lib/vutuv_web/components/ui.ex:2619
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
@@ -14608,7 +14610,7 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:1705
+#: lib/vutuv_web/components/post_components.ex:1702
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
@@ -14623,19 +14625,19 @@ msgstr "Autor/in"
 msgid "Book"
 msgstr "Buch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:801
-#: lib/vutuv_web/components/post_components.ex:1662
+#: lib/vutuv_web/agent_docs/markdown.ex:828
+#: lib/vutuv_web/components/post_components.ex:1659
 #: lib/vutuv_web/live/post_live/composer.ex:659
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:1706
+#: lib/vutuv_web/components/post_components.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:1708
+#: lib/vutuv_web/components/post_components.ex:1705
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
@@ -14645,7 +14647,7 @@ msgstr "DVD/Blu-ray"
 msgid "Director"
 msgstr "Regie"
 
-#: lib/vutuv_web/components/post_components.ex:1704
+#: lib/vutuv_web/components/post_components.ex:1701
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
@@ -14655,8 +14657,8 @@ msgstr "E-Book"
 msgid "Film"
 msgstr "Film"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:801
-#: lib/vutuv_web/components/post_components.ex:1661
+#: lib/vutuv_web/agent_docs/markdown.ex:828
+#: lib/vutuv_web/components/post_components.ex:1658
 #: lib/vutuv_web/live/post_live/composer.ex:658
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -14687,7 +14689,7 @@ msgstr "Schlage nach …"
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr "Zu dieser ISBN wurde nichts gefunden. Bitte füllen Sie die Felder selbst aus."
 
-#: lib/vutuv_web/components/post_components.ex:1703
+#: lib/vutuv_web/components/post_components.ex:1700
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
@@ -14714,7 +14716,7 @@ msgstr "Ein Buch besprechen"
 msgid "Review a film"
 msgstr "Einen Film besprechen"
 
-#: lib/vutuv_web/components/post_components.ex:1707
+#: lib/vutuv_web/components/post_components.ex:1704
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14734,34 +14736,34 @@ msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:1744
+#: lib/vutuv_web/components/post_components.ex:1741
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:1774
+#: lib/vutuv_web/components/post_components.ex:1771
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:1775
+#: lib/vutuv_web/components/post_components.ex:1772
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:1773
+#: lib/vutuv_web/components/post_components.ex:1770
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:1733
+#: lib/vutuv_web/components/post_components.ex:1730
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:1780
+#: lib/vutuv_web/components/post_components.ex:1777
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14786,12 +14788,12 @@ msgstr "Qualifikation"
 msgid "With qualification:"
 msgstr "Mit Qualifikation:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:562
+#: lib/vutuv_web/agent_docs/markdown.ex:572
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1556
+#: lib/vutuv_web/components/post_components.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14839,17 +14841,17 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:1552
+#: lib/vutuv_web/components/post_components.ex:1535
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
 
-#: lib/vutuv_web/components/ui.ex:1055
+#: lib/vutuv_web/components/ui.ex:1065
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Empfohlen von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:1057
+#: lib/vutuv_web/components/ui.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14862,3 +14864,40 @@ msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
 msgstr[0] "%{formatted} neues Mitglied heute"
 msgstr[1] "%{formatted} neue Mitglieder heute"
+
+#: lib/vutuv_web/views/qualification_html.ex:147
+#: lib/vutuv_web/views/qualification_html.ex:206
+#, elixir-autogen, elixir-format
+msgid "Currently in use"
+msgstr "Aktuell genutzt"
+
+#: lib/vutuv_web/views/qualification_html.ex:150
+#: lib/vutuv_web/views/qualification_html.ex:213
+#, elixir-autogen, elixir-format
+msgid "Last used: %{date}"
+msgstr "Zuletzt genutzt: %{date}"
+
+#: lib/vutuv_web/views/qualification_html.ex:142
+#, elixir-autogen, elixir-format
+msgid "Used for %{formatted} job"
+msgid_plural "Used for %{formatted} jobs"
+msgstr[0] "Für %{formatted} Job genutzt"
+msgstr[1] "Für %{formatted} Jobs genutzt"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:667
+#, elixir-autogen, elixir-format
+msgid "currently in use"
+msgstr "aktuell genutzt"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:666
+#, elixir-autogen, elixir-format
+msgid "used for %{count} job"
+msgid_plural "used for %{count} jobs"
+msgstr[0] "für %{count} Job genutzt"
+msgstr[1] "für %{count} Jobs genutzt"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:672
+#, elixir-autogen, elixir-format
+msgctxt "qualification job usage"
+msgid "last used %{date}"
+msgstr "zuletzt genutzt %{date}"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -17,8 +17,8 @@ msgstr ""
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2751
-#: lib/vutuv_web/components/ui.ex:2756
+#: lib/vutuv_web/components/ui.ex:2877
+#: lib/vutuv_web/components/ui.ex:2882
 #: lib/vutuv_web/live/organization_live/domains.ex:235
 #: lib/vutuv_web/live/organization_live/edit.ex:382
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -27,7 +27,7 @@ msgid "Add"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:201
-#: lib/vutuv_web/agent_docs/section_docs.ex:119
+#: lib/vutuv_web/agent_docs/section_docs.ex:120
 #: lib/vutuv_web/agent_docs/text.ex:196
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
@@ -36,7 +36,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1150
+#: lib/vutuv_web/templates/user/show.html.heex:1154
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -60,7 +60,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:2896
+#: lib/vutuv_web/components/ui.ex:3022
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -78,8 +78,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2556
-#: lib/vutuv_web/components/ui.ex:2650
+#: lib/vutuv_web/components/ui.ex:2682
+#: lib/vutuv_web/components/ui.ex:2776
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #, elixir-autogen
 msgid "Are you sure?"
@@ -99,13 +99,13 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:423
 #: lib/vutuv_web/agent_docs/text.ex:425
 #: lib/vutuv_web/agent_docs/text.ex:426
-#: lib/vutuv_web/templates/user/show.html.heex:815
+#: lib/vutuv_web/templates/user/show.html.heex:819
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:2549
+#: lib/vutuv_web/components/ui.ex:2675
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -141,7 +141,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:13
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:853
+#: lib/vutuv_web/templates/user/show.html.heex:857
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -151,7 +151,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:816
-#: lib/vutuv_web/components/ui.ex:2653
+#: lib/vutuv_web/components/ui.ex:2779
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -196,7 +196,7 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:809
-#: lib/vutuv_web/components/ui.ex:2644
+#: lib/vutuv_web/components/ui.ex:2770
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -218,7 +218,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/url/edit.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:838
+#: lib/vutuv_web/templates/user/show.html.heex:842
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #, elixir-autogen
 msgid "Edit"
@@ -295,11 +295,11 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:2887
+#: lib/vutuv_web/components/ui.ex:3013
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:485
+#: lib/vutuv_web/templates/user/show.html.heex:489
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:3
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -331,16 +331,16 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:435
 #: lib/vutuv_web/agent_docs/text.ex:438
-#: lib/vutuv_web/components/ui.ex:1287
-#: lib/vutuv_web/components/ui.ex:1312
-#: lib/vutuv_web/components/ui.ex:1315
-#: lib/vutuv_web/components/ui.ex:1322
-#: lib/vutuv_web/components/ui.ex:1325
-#: lib/vutuv_web/components/ui.ex:1383
+#: lib/vutuv_web/components/ui.ex:1413
+#: lib/vutuv_web/components/ui.ex:1438
+#: lib/vutuv_web/components/ui.ex:1441
+#: lib/vutuv_web/components/ui.ex:1448
+#: lib/vutuv_web/components/ui.ex:1451
+#: lib/vutuv_web/components/ui.ex:1509
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:763
+#: lib/vutuv_web/templates/user/show.html.heex:767
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -355,7 +355,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:62
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:810
+#: lib/vutuv_web/templates/user/show.html.heex:814
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -416,7 +416,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:52
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:2891
+#: lib/vutuv_web/components/ui.ex:3017
 #: lib/vutuv_web/controllers/url_controller.ex:23
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
@@ -453,8 +453,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:482
-#: lib/vutuv_web/live/shell_live.ex:519
+#: lib/vutuv_web/live/shell_live.ex:556
+#: lib/vutuv_web/live/shell_live.ex:593
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -466,7 +466,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2907
+#: lib/vutuv_web/components/ui.ex:3033
 #: lib/vutuv_web/live/notification_live/index.ex:558
 #, elixir-autogen
 msgid "More"
@@ -662,8 +662,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:314
 #: lib/vutuv_web/live/search_live.ex:35
 #: lib/vutuv_web/live/search_live.ex:229
-#: lib/vutuv_web/live/shell_live.ex:346
-#: lib/vutuv_web/live/shell_live.ex:502
+#: lib/vutuv_web/live/shell_live.ex:420
+#: lib/vutuv_web/live/shell_live.ex:576
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
 #: lib/vutuv_web/templates/layout/app.html.heex:120
 #, elixir-autogen
@@ -692,7 +692,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:55
 #: lib/vutuv_web/agent_docs/text.ex:52
-#: lib/vutuv_web/components/ui.ex:2892
+#: lib/vutuv_web/components/ui.ex:3018
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
@@ -705,18 +705,18 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:964
+#: lib/vutuv_web/templates/user/show.html.heex:968
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:966
+#: lib/vutuv_web/templates/user/show.html.heex:970
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:98
+#: lib/vutuv_web/agent_docs/section_docs.ex:99
 #, elixir-autogen, elixir-format
 msgid "Profiles of %{name}"
 msgstr ""
@@ -759,7 +759,7 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2550
+#: lib/vutuv_web/components/ui.ex:2676
 #, elixir-autogen
 msgid "Submit"
 msgstr ""
@@ -846,7 +846,7 @@ msgstr ""
 #: lib/vutuv_web/templates/url/index.html.heex:8
 #: lib/vutuv_web/templates/url/show.html.heex:4
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:2
-#: lib/vutuv_web/templates/user_tag/index.html.heex:8
+#: lib/vutuv_web/templates/user_tag/index.html.heex:15
 #: lib/vutuv_web/templates/user_tag/show.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:8
 #: lib/vutuv_web/templates/work_experience/show.html.heex:4
@@ -860,9 +860,9 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2714
-#: lib/vutuv_web/templates/user/show.html.heex:757
-#: lib/vutuv_web/templates/user/show.html.heex:777
+#: lib/vutuv_web/components/ui.ex:2840
+#: lib/vutuv_web/templates/user/show.html.heex:761
+#: lib/vutuv_web/templates/user/show.html.heex:781
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -1109,7 +1109,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:799
+#: lib/vutuv_web/templates/user/show.html.heex:803
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1251,7 +1251,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:177
-#: lib/vutuv_web/live/shell_live.ex:454
+#: lib/vutuv_web/live/shell_live.ex:528
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
 #: lib/vutuv_web/templates/admin/ad/show.html.heex:4
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:1
@@ -1290,6 +1290,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
+#: lib/vutuv_web/templates/user/show.html.heex:483
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1458,13 +1459,13 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
 #: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:785
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:393
-#: lib/vutuv_web/agent_docs/text.ex:556
-#: lib/vutuv_web/components/ui.ex:2897
-#: lib/vutuv_web/controllers/user_tag_controller.ex:37
-#: lib/vutuv_web/controllers/user_tag_controller.ex:54
+#: lib/vutuv_web/agent_docs/text.ex:565
+#: lib/vutuv_web/components/ui.ex:3023
+#: lib/vutuv_web/controllers/user_tag_controller.ex:38
+#: lib/vutuv_web/controllers/user_tag_controller.ex:55
 #: lib/vutuv_web/cv/docx.ex:174
 #: lib/vutuv_web/cv/html.ex:159
 #: lib/vutuv_web/cv/latex.ex:131
@@ -1489,7 +1490,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/show.html.heex:25
 #: lib/vutuv_web/templates/user/show.html.heex:453
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
-#: lib/vutuv_web/templates/user_tag/index.html.heex:10
+#: lib/vutuv_web/templates/user_tag/index.html.heex:17
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
 #, elixir-autogen
@@ -1596,7 +1597,6 @@ msgid "Tag closures"
 msgstr ""
 
 #: lib/vutuv_web/templates/tag/card_list.html.heex:5
-#: lib/vutuv_web/templates/user_tag/index.html.heex:19
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:10
 #, elixir-autogen
 msgid "Tag name"
@@ -1617,7 +1617,7 @@ msgstr ""
 msgid "User tag created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:126
+#: lib/vutuv_web/controllers/user_tag_controller.ex:134
 #, elixir-autogen
 msgid "User tag deleted successfully."
 msgstr ""
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Admin Area"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:101
+#: lib/vutuv_web/agent_docs/section_docs.ex:102
 #: lib/vutuv_web/templates/address/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Addresses of %{name}"
@@ -1684,7 +1684,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:505
+#: lib/vutuv_web/live/shell_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1753,21 +1753,21 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:950
 #: lib/vutuv_web/components/ui.ex:959
-#: lib/vutuv_web/components/ui.ex:1134
+#: lib/vutuv_web/components/ui.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1252
-#: lib/vutuv_web/components/ui.ex:1252
-#: lib/vutuv_web/components/ui.ex:1269
-#: lib/vutuv_web/components/ui.ex:1278
-#: lib/vutuv_web/components/ui.ex:1294
-#: lib/vutuv_web/components/ui.ex:1331
-#: lib/vutuv_web/components/ui.ex:1334
-#: lib/vutuv_web/components/ui.ex:1341
-#: lib/vutuv_web/components/ui.ex:1344
-#: lib/vutuv_web/components/ui.ex:1417
+#: lib/vutuv_web/components/ui.ex:1378
+#: lib/vutuv_web/components/ui.ex:1378
+#: lib/vutuv_web/components/ui.ex:1395
+#: lib/vutuv_web/components/ui.ex:1404
+#: lib/vutuv_web/components/ui.ex:1420
+#: lib/vutuv_web/components/ui.ex:1457
+#: lib/vutuv_web/components/ui.ex:1460
+#: lib/vutuv_web/components/ui.ex:1467
+#: lib/vutuv_web/components/ui.ex:1470
+#: lib/vutuv_web/components/ui.ex:1543
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1782,7 +1782,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:473
+#: lib/vutuv_web/live/shell_live.ex:547
 #: lib/vutuv_web/views/settings_html.ex:218
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1806,20 +1806,20 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:45
 #: lib/vutuv_web/live/message_live/index.ex:496
-#: lib/vutuv_web/live/shell_live.ex:362
-#: lib/vutuv_web/live/shell_live.ex:504
+#: lib/vutuv_web/live/shell_live.ex:436
+#: lib/vutuv_web/live/shell_live.ex:578
 #: lib/vutuv_web/templates/layout/app.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:332
+#: lib/vutuv_web/live/shell_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:285
-#: lib/vutuv_web/components/ui.ex:2753
+#: lib/vutuv_web/components/ui.ex:2879
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -1831,10 +1831,10 @@ msgstr ""
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2911
+#: lib/vutuv_web/components/ui.ex:3037
 #: lib/vutuv_web/live/notification_live/index.ex:81
 #: lib/vutuv_web/live/notification_live/index.ex:245
-#: lib/vutuv_web/live/shell_live.ex:373
+#: lib/vutuv_web/live/shell_live.ex:447
 #: lib/vutuv_web/templates/layout/app.html.heex:118
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1876,8 +1876,8 @@ msgstr ""
 msgid "Submit a bug report or feature request"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:104
-#: lib/vutuv_web/templates/user_tag/index.html.heex:5
+#: lib/vutuv_web/agent_docs/section_docs.ex:105
+#: lib/vutuv_web/templates/user_tag/index.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Tags of %{name}"
 msgstr ""
@@ -1921,7 +1921,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1234
+#: lib/vutuv_web/templates/user/show.html.heex:1238
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1972,8 +1972,8 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2145
-#: lib/vutuv_web/components/ui.ex:2290
+#: lib/vutuv_web/components/ui.ex:2271
+#: lib/vutuv_web/components/ui.ex:2416
 #: lib/vutuv_web/live/organization_live/index.ex:130
 #, elixir-autogen, elixir-format
 msgid "Pagination"
@@ -1984,7 +1984,7 @@ msgstr ""
 msgid "Load %{count} of %{remaining} more"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2778
+#: lib/vutuv_web/components/ui.ex:2904
 #: lib/vutuv_web/live/notification_live/index.ex:624
 #, elixir-autogen, elixir-format
 msgid "Load more"
@@ -1995,7 +1995,7 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2559
+#: lib/vutuv_web/components/ui.ex:2685
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -2040,12 +2040,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1908
+#: lib/vutuv_web/components/ui.ex:2034
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1912
+#: lib/vutuv_web/components/ui.ex:2038
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2070,37 +2070,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1916
+#: lib/vutuv_web/components/ui.ex:2042
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1906
+#: lib/vutuv_web/components/ui.ex:2032
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1905
+#: lib/vutuv_web/components/ui.ex:2031
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1911
+#: lib/vutuv_web/components/ui.ex:2037
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1910
+#: lib/vutuv_web/components/ui.ex:2036
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1907
+#: lib/vutuv_web/components/ui.ex:2033
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1909
+#: lib/vutuv_web/components/ui.ex:2035
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2115,17 +2115,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1915
+#: lib/vutuv_web/components/ui.ex:2041
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1914
+#: lib/vutuv_web/components/ui.ex:2040
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1913
+#: lib/vutuv_web/components/ui.ex:2039
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2183,8 +2183,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:552
-#: lib/vutuv_web/live/shell_live.ex:312
-#: lib/vutuv_web/live/shell_live.ex:500
+#: lib/vutuv_web/live/shell_live.ex:369
+#: lib/vutuv_web/live/shell_live.ex:574
 #: lib/vutuv_web/templates/layout/app.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2353,8 +2353,8 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3084
-#: lib/vutuv_web/live/shell_live.ex:416
+#: lib/vutuv_web/components/ui.ex:3210
+#: lib/vutuv_web/live/shell_live.ex:490
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:165
@@ -2377,22 +2377,22 @@ msgstr ""
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1842
+#: lib/vutuv_web/components/post_components.ex:1839
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1846
+#: lib/vutuv_web/components/post_components.ex:1843
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1844
+#: lib/vutuv_web/components/post_components.ex:1841
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1845
+#: lib/vutuv_web/components/post_components.ex:1842
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2433,40 +2433,40 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1914
-#: lib/vutuv_web/components/ui.ex:1612
-#: lib/vutuv_web/components/ui.ex:1612
-#: lib/vutuv_web/components/ui.ex:2220
+#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/ui.ex:1738
+#: lib/vutuv_web/components/ui.ex:1738
+#: lib/vutuv_web/components/ui.ex:2346
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:790
+#: lib/vutuv_web/agent_docs/markdown.ex:817
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
-#: lib/vutuv_web/live/shell_live.ex:355
-#: lib/vutuv_web/live/shell_live.ex:421
+#: lib/vutuv_web/live/shell_live.ex:429
+#: lib/vutuv_web/live/shell_live.ex:495
 #: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1881
-#: lib/vutuv_web/components/ui.ex:1641
-#: lib/vutuv_web/components/ui.ex:1641
-#: lib/vutuv_web/components/ui.ex:2206
+#: lib/vutuv_web/components/post_components.ex:1878
+#: lib/vutuv_web/components/ui.ex:1767
+#: lib/vutuv_web/components/ui.ex:1767
+#: lib/vutuv_web/components/ui.ex:2332
 #: lib/vutuv_web/live/notification_live/index.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:789
+#: lib/vutuv_web/agent_docs/markdown.ex:816
 #: lib/vutuv_web/live/notification_live/index.ex:648
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
-#: lib/vutuv_web/live/shell_live.ex:424
+#: lib/vutuv_web/live/shell_live.ex:498
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Likes"
@@ -2482,48 +2482,48 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1903
+#: lib/vutuv_web/components/post_components.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1914
-#: lib/vutuv_web/components/ui.ex:1602
-#: lib/vutuv_web/components/ui.ex:1602
+#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/ui.ex:1728
+#: lib/vutuv_web/components/ui.ex:1728
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1900
+#: lib/vutuv_web/components/post_components.ex:1897
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1341
+#: lib/vutuv_web/components/post_components.ex:1324
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1900
+#: lib/vutuv_web/components/post_components.ex:1897
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1881
-#: lib/vutuv_web/components/ui.ex:1631
-#: lib/vutuv_web/components/ui.ex:1631
+#: lib/vutuv_web/components/post_components.ex:1878
+#: lib/vutuv_web/components/ui.ex:1757
+#: lib/vutuv_web/components/ui.ex:1757
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1247
-#: lib/vutuv_web/components/ui.ex:1247
-#: lib/vutuv_web/components/ui.ex:1384
+#: lib/vutuv_web/components/ui.ex:1373
+#: lib/vutuv_web/components/ui.ex:1373
+#: lib/vutuv_web/components/ui.ex:1510
 #: lib/vutuv_web/live/post_live/feed.ex:665
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
 #, elixir-autogen, elixir-format
@@ -2535,7 +2535,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1954
+#: lib/vutuv_web/components/post_components.ex:1951
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2549,8 +2549,8 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1937
-#: lib/vutuv_web/components/post_components.ex:1938
+#: lib/vutuv_web/components/post_components.ex:1934
+#: lib/vutuv_web/components/post_components.ex:1935
 #: lib/vutuv_web/live/notification_live/index.ex:693
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
@@ -2649,7 +2649,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1784
+#: lib/vutuv_web/components/ui.ex:1910
 #: lib/vutuv_web/live/message_live/index.ex:596
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2758,54 +2758,55 @@ msgid "Use a different email address"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:689
+#: lib/vutuv_web/templates/user/show.html.heex:693
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:927
+#: lib/vutuv_web/templates/user/show.html.heex:931
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1152
+#: lib/vutuv_web/templates/user/show.html.heex:1156
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:855
+#: lib/vutuv_web/templates/user/show.html.heex:859
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:801
+#: lib/vutuv_web/templates/user/show.html.heex:805
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/templates/user/show.html.heex:492
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:961
+#: lib/vutuv_web/live/user_profile_live.ex:965
 #: lib/vutuv_web/templates/user/show.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2351
-#: lib/vutuv_web/components/ui.ex:2716
+#: lib/vutuv_web/components/ui.ex:2477
+#: lib/vutuv_web/components/ui.ex:2842
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
 #: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
+#: lib/vutuv_web/templates/user/show.html.heex:483
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
@@ -2889,7 +2890,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1843
+#: lib/vutuv_web/components/post_components.ex:1840
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2915,7 +2916,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:691
-#: lib/vutuv_web/templates/user/show.html.heex:744
+#: lib/vutuv_web/templates/user/show.html.heex:748
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3144,8 +3145,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:895
-#: lib/vutuv_web/templates/user/show.html.heex:896
+#: lib/vutuv_web/templates/user/show.html.heex:899
+#: lib/vutuv_web/templates/user/show.html.heex:900
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -3199,9 +3200,9 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2884
-#: lib/vutuv_web/live/shell_live.ex:325
-#: lib/vutuv_web/live/shell_live.ex:509
+#: lib/vutuv_web/components/ui.ex:3010
+#: lib/vutuv_web/live/shell_live.ex:382
+#: lib/vutuv_web/live/shell_live.ex:583
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3308,7 +3309,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2120
+#: lib/vutuv_web/components/ui.ex:2246
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3878,12 +3879,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:524
+#: lib/vutuv_web/agent_docs/markdown.ex:526
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:834
+#: lib/vutuv_web/agent_docs/markdown.ex:861
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3897,11 +3898,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:144
 #: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:785
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:139
 #: lib/vutuv_web/agent_docs/text.ex:152
-#: lib/vutuv_web/agent_docs/text.ex:556
+#: lib/vutuv_web/agent_docs/text.ex:565
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3918,20 +3919,20 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:776
-#: lib/vutuv_web/agent_docs/text.ex:567
+#: lib/vutuv_web/agent_docs/markdown.ex:803
+#: lib/vutuv_web/agent_docs/text.ex:576
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:773
-#: lib/vutuv_web/agent_docs/text.ex:564
+#: lib/vutuv_web/agent_docs/markdown.ex:800
+#: lib/vutuv_web/agent_docs/text.ex:573
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:780
-#: lib/vutuv_web/agent_docs/text.ex:570
+#: lib/vutuv_web/agent_docs/markdown.ex:807
+#: lib/vutuv_web/agent_docs/text.ex:579
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
@@ -3983,17 +3984,17 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:727
+#: lib/vutuv_web/agent_docs/markdown.ex:754
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:657
+#: lib/vutuv_web/agent_docs/markdown.ex:684
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:658
+#: lib/vutuv_web/agent_docs/markdown.ex:685
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4008,22 +4009,22 @@ msgstr ""
 msgid "Connections of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:103
+#: lib/vutuv_web/agent_docs/section_docs.ex:104
 #, elixir-autogen, elixir-format
 msgid "Email addresses of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:95
+#: lib/vutuv_web/agent_docs/section_docs.ex:96
 #, elixir-autogen, elixir-format
 msgid "Links of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:102
+#: lib/vutuv_web/agent_docs/section_docs.ex:103
 #, elixir-autogen, elixir-format
 msgid "Phone numbers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:88
+#: lib/vutuv_web/agent_docs/section_docs.ex:89
 #, elixir-autogen, elixir-format
 msgid "Work experience of %{name}"
 msgstr ""
@@ -4576,7 +4577,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:763
+#: lib/vutuv_web/templates/user/show.html.heex:767
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4688,7 +4689,7 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:949
+#: lib/vutuv_web/live/user_profile_live.ex:953
 #: lib/vutuv_web/templates/user/show.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -5276,7 +5277,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2917
+#: lib/vutuv_web/components/ui.ex:3043
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5322,7 +5323,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:403
+#: lib/vutuv_web/live/shell_live.ex:477
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5343,7 +5344,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:464
+#: lib/vutuv_web/live/shell_live.ex:538
 #: lib/vutuv_web/templates/layout/app.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5354,11 +5355,11 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3003
-#: lib/vutuv_web/components/ui.ex:3008
-#: lib/vutuv_web/components/ui.ex:3076
+#: lib/vutuv_web/components/ui.ex:3129
+#: lib/vutuv_web/components/ui.ex:3134
+#: lib/vutuv_web/components/ui.ex:3202
 #: lib/vutuv_web/controllers/settings_controller.ex:51
-#: lib/vutuv_web/live/shell_live.ex:444
+#: lib/vutuv_web/live/shell_live.ex:518
 #: lib/vutuv_web/live/tag_new_live.ex:44
 #: lib/vutuv_web/templates/address/edit.html.heex:2
 #: lib/vutuv_web/templates/address/new.html.heex:2
@@ -5420,7 +5421,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:951
+#: lib/vutuv_web/live/user_profile_live.ex:955
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5435,8 +5436,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:305
-#: lib/vutuv_web/live/shell_live.ex:493
+#: lib/vutuv_web/live/shell_live.ex:362
+#: lib/vutuv_web/live/shell_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5502,7 +5503,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2899
+#: lib/vutuv_web/components/ui.ex:3025
 #: lib/vutuv_web/live/admin/user_live.ex:266
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:13
 #, elixir-autogen, elixir-format
@@ -5525,7 +5526,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2894
+#: lib/vutuv_web/components/ui.ex:3020
 #: lib/vutuv_web/controllers/email_controller.ex:30
 #: lib/vutuv_web/controllers/email_controller.ex:49
 #: lib/vutuv_web/controllers/email_controller.ex:191
@@ -5556,7 +5557,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2909
+#: lib/vutuv_web/components/ui.ex:3035
 #: lib/vutuv_web/templates/settings/privacy.html.heex:9
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5669,7 +5670,7 @@ msgstr ""
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2916
+#: lib/vutuv_web/components/ui.ex:3042
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -5680,7 +5681,7 @@ msgstr ""
 msgid "Apps & API"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:103
+#: lib/vutuv_web/controllers/user_tag_controller.ex:104
 #: lib/vutuv_web/live/notification_live/index.ex:650
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
@@ -6091,7 +6092,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:955
+#: lib/vutuv_web/live/user_profile_live.ex:959
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6105,7 +6106,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:174
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:687
+#: lib/vutuv_web/templates/user/show.html.heex:691
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6126,7 +6127,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1199
+#: lib/vutuv_web/templates/user/show.html.heex:1203
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6169,8 +6170,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:821
-#: lib/vutuv_web/templates/user/show.html.heex:831
+#: lib/vutuv_web/templates/user/show.html.heex:825
+#: lib/vutuv_web/templates/user/show.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6210,12 +6211,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:942
+#: lib/vutuv_web/templates/user/show.html.heex:946
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:953
+#: lib/vutuv_web/templates/user/show.html.heex:957
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6250,14 +6251,14 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:789
+#: lib/vutuv_web/agent_docs/markdown.ex:816
 #: lib/vutuv_web/components/post_components.ex:273
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:951
+#: lib/vutuv_web/templates/user/show.html.heex:955
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6284,7 +6285,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:950
 #: lib/vutuv_web/components/ui.ex:959
-#: lib/vutuv_web/components/ui.ex:1135
+#: lib/vutuv_web/components/ui.ex:1261
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6311,9 +6312,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1185
-#: lib/vutuv_web/templates/user/show.html.heex:1193
-#: lib/vutuv_web/templates/user/show.html.heex:1205
+#: lib/vutuv_web/templates/user/show.html.heex:1189
+#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:1209
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6345,7 +6346,7 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1088
+#: lib/vutuv_web/components/ui.ex:1214
 #: lib/vutuv_web/live/notification_live/index.ex:413
 #: lib/vutuv_web/live/notification_live/index.ex:428
 #: lib/vutuv_web/live/notification_live/index.ex:514
@@ -6354,7 +6355,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:798
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6628,7 +6629,7 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1572
+#: lib/vutuv_web/components/ui.ex:1698
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Mute"
@@ -6650,7 +6651,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1571
+#: lib/vutuv_web/components/ui.ex:1697
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Unmute"
@@ -6687,33 +6688,33 @@ msgstr ""
 msgid "Unmute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1542
+#: lib/vutuv_web/components/ui.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1536
+#: lib/vutuv_web/components/ui.ex:1662
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1526
+#: lib/vutuv_web/components/ui.ex:1652
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1477
-#: lib/vutuv_web/components/ui.ex:1526
+#: lib/vutuv_web/components/ui.ex:1603
+#: lib/vutuv_web/components/ui.ex:1652
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1475
+#: lib/vutuv_web/components/ui.ex:1601
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1476
+#: lib/vutuv_web/components/ui.ex:1602
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -7275,13 +7276,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2158
+#: lib/vutuv_web/components/ui.ex:2284
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2174
+#: lib/vutuv_web/components/ui.ex:2300
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7534,17 +7535,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:839
+#: lib/vutuv_web/agent_docs/markdown.ex:866
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:842
+#: lib/vutuv_web/agent_docs/markdown.ex:869
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:849
+#: lib/vutuv_web/agent_docs/markdown.ex:876
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8026,7 +8027,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2161
+#: lib/vutuv_web/components/ui.ex:2287
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8145,7 +8146,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:540
+#: lib/vutuv_web/templates/user/show.html.heex:544
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8157,7 +8158,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:2888
+#: lib/vutuv_web/components/ui.ex:3014
 #: lib/vutuv_web/controllers/education_controller.ex:38
 #: lib/vutuv_web/controllers/education_controller.ex:53
 #: lib/vutuv_web/controllers/education_controller.ex:103
@@ -8170,7 +8171,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:537
+#: lib/vutuv_web/templates/user/show.html.heex:541
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -8185,7 +8186,7 @@ msgstr ""
 msgid "Education deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:89
+#: lib/vutuv_web/agent_docs/section_docs.ex:90
 #, elixir-autogen, elixir-format
 msgid "Education of %{name}"
 msgstr ""
@@ -8211,7 +8212,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2904
+#: lib/vutuv_web/components/ui.ex:3030
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8240,7 +8241,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2895
+#: lib/vutuv_web/components/ui.ex:3021
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8334,12 +8335,12 @@ msgstr ""
 msgid "A photo and a short tagline make your profile complete."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:974
+#: lib/vutuv_web/live/user_profile_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2397
+#: lib/vutuv_web/components/ui.ex:2523
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:36
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:42
@@ -8360,7 +8361,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:94
-#: lib/vutuv_web/templates/user/show.html.heex:1056
+#: lib/vutuv_web/templates/user/show.html.heex:1060
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8420,13 +8421,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2886
+#: lib/vutuv_web/components/ui.ex:3012
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2903
+#: lib/vutuv_web/components/ui.ex:3029
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8438,7 +8439,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2901
+#: lib/vutuv_web/components/ui.ex:3027
 #: lib/vutuv_web/controllers/settings_controller.ex:89
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:5
@@ -8447,7 +8448,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2905
+#: lib/vutuv_web/components/ui.ex:3031
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8671,7 +8672,7 @@ msgstr ""
 msgid "Allow followers from the Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2910
+#: lib/vutuv_web/components/ui.ex:3036
 #: lib/vutuv_web/controllers/settings_controller.ex:186
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:265
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
@@ -8761,7 +8762,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:576
+#: lib/vutuv_web/agent_docs/markdown.ex:586
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8782,7 +8783,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:577
+#: lib/vutuv_web/agent_docs/markdown.ex:587
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8813,13 +8814,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:624
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:613
+#: lib/vutuv_web/agent_docs/markdown.ex:623
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8845,14 +8846,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1344
+#: lib/vutuv_web/components/post_components.ex:1327
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:730
+#: lib/vutuv_web/agent_docs/markdown.ex:757
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8930,14 +8931,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:575
+#: lib/vutuv_web/agent_docs/markdown.ex:585
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:588
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9054,7 +9055,7 @@ msgstr ""
 msgid "Removed @%{handle} from this tag."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:131
+#: lib/vutuv_web/controllers/user_tag_controller.ex:139
 #, elixir-autogen, elixir-format
 msgid "This tag can only be removed by a site admin."
 msgstr ""
@@ -9064,8 +9065,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:992
-#: lib/vutuv_web/components/ui.ex:993
+#: lib/vutuv_web/components/ui.ex:994
+#: lib/vutuv_web/components/ui.ex:995
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:64
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9094,7 +9095,7 @@ msgid "A2 (Elementary)"
 msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:602
+#: lib/vutuv_web/templates/user/show.html.heex:606
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9306,7 +9307,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:49
 #: lib/vutuv_web/agent_docs/text.ex:46
-#: lib/vutuv_web/components/ui.ex:2890
+#: lib/vutuv_web/components/ui.ex:3016
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
@@ -9319,12 +9320,12 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:3
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:599
+#: lib/vutuv_web/templates/user/show.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:94
+#: lib/vutuv_web/agent_docs/section_docs.ex:95
 #, elixir-autogen, elixir-format
 msgid "Languages of %{name}"
 msgstr ""
@@ -9600,28 +9601,28 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:642
+#: lib/vutuv_web/templates/user/show.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:651
+#: lib/vutuv_web/agent_docs/markdown.ex:678
 #: lib/vutuv_web/views/qualification_html.ex:10
 #, elixir-autogen, elixir-format
 msgid "Certificate"
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:78
+#: lib/vutuv_web/controllers/qualification_controller.ex:85
 #, elixir-autogen, elixir-format
 msgid "Certificate or license added successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:128
+#: lib/vutuv_web/controllers/qualification_controller.ex:139
 #, elixir-autogen, elixir-format
 msgid "Certificate or license deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:119
+#: lib/vutuv_web/controllers/qualification_controller.ex:130
 #, elixir-autogen, elixir-format
 msgid "Certificate or license updated successfully."
 msgstr ""
@@ -9633,10 +9634,10 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:2889
-#: lib/vutuv_web/controllers/qualification_controller.ex:35
-#: lib/vutuv_web/controllers/qualification_controller.ex:51
-#: lib/vutuv_web/controllers/qualification_controller.ex:102
+#: lib/vutuv_web/components/ui.ex:3015
+#: lib/vutuv_web/controllers/qualification_controller.ex:39
+#: lib/vutuv_web/controllers/qualification_controller.ex:58
+#: lib/vutuv_web/controllers/qualification_controller.ex:113
 #: lib/vutuv_web/cv/docx.ex:183
 #: lib/vutuv_web/cv/html.ex:172
 #: lib/vutuv_web/cv/latex.ex:140
@@ -9648,7 +9649,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:3
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:639
+#: lib/vutuv_web/templates/user/show.html.heex:643
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr ""
@@ -9658,13 +9659,13 @@ msgstr ""
 msgid "Certificates & licenses of "
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:92
+#: lib/vutuv_web/agent_docs/section_docs.ex:93
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:49
-#: lib/vutuv_web/templates/qualification/show.html.heex:38
+#: lib/vutuv_web/templates/qualification/show.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Credential ID"
 msgstr ""
@@ -9677,7 +9678,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:164
 #: lib/vutuv_web/live/admin/job_live.ex:180
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
-#: lib/vutuv_web/views/qualification_html.ex:149
+#: lib/vutuv_web/views/qualification_html.ex:187
 #, elixir-autogen, elixir-format
 msgid "Expired"
 msgstr ""
@@ -9692,7 +9693,7 @@ msgstr ""
 msgid "Expiry year"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:643
+#: lib/vutuv_web/agent_docs/markdown.ex:653
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9718,7 +9719,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:650
+#: lib/vutuv_web/agent_docs/markdown.ex:677
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9734,18 +9735,18 @@ msgstr ""
 msgid "LinkedIn does not say whether an entry is a certificate or a license, so we import all of them as certificates. Please review the section afterwards and switch any that are licenses."
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:159
+#: lib/vutuv_web/views/qualification_html.ex:223
 #, elixir-autogen, elixir-format
 msgid "Proof"
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:55
-#: lib/vutuv_web/templates/qualification/show.html.heex:43
+#: lib/vutuv_web/templates/qualification/show.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:641
+#: lib/vutuv_web/agent_docs/markdown.ex:651
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9760,7 +9761,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:642
+#: lib/vutuv_web/agent_docs/markdown.ex:652
 #: lib/vutuv_web/views/qualification_html.ex:76
 #: lib/vutuv_web/views/qualification_html.ex:79
 #, elixir-autogen, elixir-format
@@ -9777,15 +9778,15 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:533
+#: lib/vutuv_web/agent_docs/markdown.ex:543
 #: lib/vutuv_web/live/section_reorder_live.ex:269
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:917
-#: lib/vutuv_web/templates/user/show.html.heex:918
+#: lib/vutuv_web/templates/user/show.html.heex:921
+#: lib/vutuv_web/templates/user/show.html.heex:922
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9852,7 +9853,7 @@ msgid "First name"
 msgstr ""
 
 #: lib/vutuv_web/controllers/invitation_controller.ex:54
-#: lib/vutuv_web/live/shell_live.ex:435
+#: lib/vutuv_web/live/shell_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "Invite a friend"
 msgstr ""
@@ -10418,21 +10419,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:503
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:499
+#: lib/vutuv_web/agent_docs/markdown.ex:501
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:497
+#: lib/vutuv_web/agent_docs/markdown.ex:499
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10455,7 +10456,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1030
+#: lib/vutuv_web/templates/user/show.html.heex:1034
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10485,12 +10486,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:515
+#: lib/vutuv_web/agent_docs/markdown.ex:517
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:502
+#: lib/vutuv_web/agent_docs/markdown.ex:504
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -11835,8 +11836,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:671
-#: lib/vutuv_web/agent_docs/text.ex:537
+#: lib/vutuv_web/agent_docs/markdown.ex:698
+#: lib/vutuv_web/agent_docs/text.ex:539
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -12067,12 +12068,12 @@ msgid "Organization unfrozen."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:2902
+#: lib/vutuv_web/components/ui.ex:3028
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
 #: lib/vutuv_web/live/post_live/saved.ex:455
-#: lib/vutuv_web/live/shell_live.ex:431
+#: lib/vutuv_web/live/shell_live.ex:505
 #: lib/vutuv_web/templates/layout/app.html.heex:79
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
@@ -12396,8 +12397,9 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:41
 #: lib/vutuv_web/live/job_board_live.ex:146
 #: lib/vutuv_web/live/post_live/saved.ex:458
-#: lib/vutuv_web/live/shell_live.ex:339
+#: lib/vutuv_web/live/shell_live.ex:396
 #: lib/vutuv_web/templates/layout/app.html.heex:77
+#: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr ""
@@ -13240,7 +13242,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2940
+#: lib/vutuv_web/components/ui.ex:3066
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13715,7 +13717,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2929
+#: lib/vutuv_web/components/ui.ex:3055
 #: lib/vutuv_web/controllers/settings_controller.ex:259
 #: lib/vutuv_web/live/post_live/feed.ex:651
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13765,7 +13767,7 @@ msgid "Signal and WhatsApp accept a phone number or a username; the other messen
 msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:996
+#: lib/vutuv_web/templates/user/show.html.heex:1000
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13794,7 +13796,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:2893
+#: lib/vutuv_web/components/ui.ex:3019
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:3
@@ -13802,7 +13804,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:3
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:994
+#: lib/vutuv_web/templates/user/show.html.heex:998
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13812,7 +13814,7 @@ msgstr ""
 msgid "Messengers of "
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:100
+#: lib/vutuv_web/agent_docs/section_docs.ex:101
 #, elixir-autogen, elixir-format
 msgid "Messengers of %{name}"
 msgstr ""
@@ -13822,14 +13824,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2483
+#: lib/vutuv_web/components/ui.ex:2609
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:2493
+#: lib/vutuv_web/components/ui.ex:2619
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13879,7 +13881,7 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1705
+#: lib/vutuv_web/components/post_components.ex:1702
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
@@ -13894,19 +13896,19 @@ msgstr ""
 msgid "Book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:801
-#: lib/vutuv_web/components/post_components.ex:1662
+#: lib/vutuv_web/agent_docs/markdown.ex:828
+#: lib/vutuv_web/components/post_components.ex:1659
 #: lib/vutuv_web/live/post_live/composer.ex:659
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1706
+#: lib/vutuv_web/components/post_components.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1708
+#: lib/vutuv_web/components/post_components.ex:1705
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
@@ -13916,7 +13918,7 @@ msgstr ""
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1704
+#: lib/vutuv_web/components/post_components.ex:1701
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
@@ -13926,8 +13928,8 @@ msgstr ""
 msgid "Film"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:801
-#: lib/vutuv_web/components/post_components.ex:1661
+#: lib/vutuv_web/agent_docs/markdown.ex:828
+#: lib/vutuv_web/components/post_components.ex:1658
 #: lib/vutuv_web/live/post_live/composer.ex:658
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13958,7 +13960,7 @@ msgstr ""
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1703
+#: lib/vutuv_web/components/post_components.ex:1700
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
@@ -13985,7 +13987,7 @@ msgstr ""
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1707
+#: lib/vutuv_web/components/post_components.ex:1704
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -14005,34 +14007,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1744
+#: lib/vutuv_web/components/post_components.ex:1741
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1774
+#: lib/vutuv_web/components/post_components.ex:1771
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1775
+#: lib/vutuv_web/components/post_components.ex:1772
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1773
+#: lib/vutuv_web/components/post_components.ex:1770
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1733
+#: lib/vutuv_web/components/post_components.ex:1730
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1780
+#: lib/vutuv_web/components/post_components.ex:1777
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14057,12 +14059,12 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:562
+#: lib/vutuv_web/agent_docs/markdown.ex:572
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1556
+#: lib/vutuv_web/components/post_components.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14110,17 +14112,17 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1552
+#: lib/vutuv_web/components/post_components.ex:1535
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1055
+#: lib/vutuv_web/components/ui.ex:1065
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1057
+#: lib/vutuv_web/components/ui.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14133,3 +14135,40 @@ msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/vutuv_web/views/qualification_html.ex:147
+#: lib/vutuv_web/views/qualification_html.ex:206
+#, elixir-autogen, elixir-format
+msgid "Currently in use"
+msgstr ""
+
+#: lib/vutuv_web/views/qualification_html.ex:150
+#: lib/vutuv_web/views/qualification_html.ex:213
+#, elixir-autogen, elixir-format
+msgid "Last used: %{date}"
+msgstr ""
+
+#: lib/vutuv_web/views/qualification_html.ex:142
+#, elixir-autogen, elixir-format
+msgid "Used for %{formatted} job"
+msgid_plural "Used for %{formatted} jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:667
+#, elixir-autogen, elixir-format
+msgid "currently in use"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:666
+#, elixir-autogen, elixir-format
+msgid "used for %{count} job"
+msgid_plural "used for %{count} jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:672
+#, elixir-autogen, elixir-format
+msgctxt "qualification job usage"
+msgid "last used %{date}"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -15,8 +15,8 @@ msgstr "Language: en\n"
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2751
-#: lib/vutuv_web/components/ui.ex:2756
+#: lib/vutuv_web/components/ui.ex:2877
+#: lib/vutuv_web/components/ui.ex:2882
 #: lib/vutuv_web/live/organization_live/domains.ex:235
 #: lib/vutuv_web/live/organization_live/edit.ex:382
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -25,7 +25,7 @@ msgid "Add"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:201
-#: lib/vutuv_web/agent_docs/section_docs.ex:119
+#: lib/vutuv_web/agent_docs/section_docs.ex:120
 #: lib/vutuv_web/agent_docs/text.ex:196
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
@@ -34,7 +34,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1150
+#: lib/vutuv_web/templates/user/show.html.heex:1154
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -58,7 +58,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:2896
+#: lib/vutuv_web/components/ui.ex:3022
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -76,8 +76,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2556
-#: lib/vutuv_web/components/ui.ex:2650
+#: lib/vutuv_web/components/ui.ex:2682
+#: lib/vutuv_web/components/ui.ex:2776
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #, elixir-autogen
 msgid "Are you sure?"
@@ -97,13 +97,13 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:423
 #: lib/vutuv_web/agent_docs/text.ex:425
 #: lib/vutuv_web/agent_docs/text.ex:426
-#: lib/vutuv_web/templates/user/show.html.heex:815
+#: lib/vutuv_web/templates/user/show.html.heex:819
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:2549
+#: lib/vutuv_web/components/ui.ex:2675
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -139,7 +139,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:13
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:853
+#: lib/vutuv_web/templates/user/show.html.heex:857
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -149,7 +149,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:816
-#: lib/vutuv_web/components/ui.ex:2653
+#: lib/vutuv_web/components/ui.ex:2779
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -194,7 +194,7 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:809
-#: lib/vutuv_web/components/ui.ex:2644
+#: lib/vutuv_web/components/ui.ex:2770
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -216,7 +216,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/url/edit.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:838
+#: lib/vutuv_web/templates/user/show.html.heex:842
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #, elixir-autogen
 msgid "Edit"
@@ -293,11 +293,11 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:2887
+#: lib/vutuv_web/components/ui.ex:3013
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:485
+#: lib/vutuv_web/templates/user/show.html.heex:489
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:3
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -329,16 +329,16 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:435
 #: lib/vutuv_web/agent_docs/text.ex:438
-#: lib/vutuv_web/components/ui.ex:1287
-#: lib/vutuv_web/components/ui.ex:1312
-#: lib/vutuv_web/components/ui.ex:1315
-#: lib/vutuv_web/components/ui.ex:1322
-#: lib/vutuv_web/components/ui.ex:1325
-#: lib/vutuv_web/components/ui.ex:1383
+#: lib/vutuv_web/components/ui.ex:1413
+#: lib/vutuv_web/components/ui.ex:1438
+#: lib/vutuv_web/components/ui.ex:1441
+#: lib/vutuv_web/components/ui.ex:1448
+#: lib/vutuv_web/components/ui.ex:1451
+#: lib/vutuv_web/components/ui.ex:1509
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:763
+#: lib/vutuv_web/templates/user/show.html.heex:767
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -353,7 +353,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:62
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:810
+#: lib/vutuv_web/templates/user/show.html.heex:814
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -414,7 +414,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:52
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:2891
+#: lib/vutuv_web/components/ui.ex:3017
 #: lib/vutuv_web/controllers/url_controller.ex:23
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
@@ -451,8 +451,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:482
-#: lib/vutuv_web/live/shell_live.ex:519
+#: lib/vutuv_web/live/shell_live.ex:556
+#: lib/vutuv_web/live/shell_live.ex:593
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -464,7 +464,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2907
+#: lib/vutuv_web/components/ui.ex:3033
 #: lib/vutuv_web/live/notification_live/index.ex:558
 #, elixir-autogen
 msgid "More"
@@ -660,8 +660,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:314
 #: lib/vutuv_web/live/search_live.ex:35
 #: lib/vutuv_web/live/search_live.ex:229
-#: lib/vutuv_web/live/shell_live.ex:346
-#: lib/vutuv_web/live/shell_live.ex:502
+#: lib/vutuv_web/live/shell_live.ex:420
+#: lib/vutuv_web/live/shell_live.ex:576
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
 #: lib/vutuv_web/templates/layout/app.html.heex:120
 #, elixir-autogen
@@ -690,7 +690,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:55
 #: lib/vutuv_web/agent_docs/text.ex:52
-#: lib/vutuv_web/components/ui.ex:2892
+#: lib/vutuv_web/components/ui.ex:3018
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
@@ -703,18 +703,18 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:964
+#: lib/vutuv_web/templates/user/show.html.heex:968
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:966
+#: lib/vutuv_web/templates/user/show.html.heex:970
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:98
+#: lib/vutuv_web/agent_docs/section_docs.ex:99
 #, elixir-autogen, elixir-format
 msgid "Profiles of %{name}"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2550
+#: lib/vutuv_web/components/ui.ex:2676
 #, elixir-autogen
 msgid "Submit"
 msgstr ""
@@ -844,7 +844,7 @@ msgstr ""
 #: lib/vutuv_web/templates/url/index.html.heex:8
 #: lib/vutuv_web/templates/url/show.html.heex:4
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:2
-#: lib/vutuv_web/templates/user_tag/index.html.heex:8
+#: lib/vutuv_web/templates/user_tag/index.html.heex:15
 #: lib/vutuv_web/templates/user_tag/show.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:8
 #: lib/vutuv_web/templates/work_experience/show.html.heex:4
@@ -858,9 +858,9 @@ msgstr ""
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2714
-#: lib/vutuv_web/templates/user/show.html.heex:757
-#: lib/vutuv_web/templates/user/show.html.heex:777
+#: lib/vutuv_web/components/ui.ex:2840
+#: lib/vutuv_web/templates/user/show.html.heex:761
+#: lib/vutuv_web/templates/user/show.html.heex:781
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -1107,7 +1107,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:799
+#: lib/vutuv_web/templates/user/show.html.heex:803
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1249,7 +1249,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:177
-#: lib/vutuv_web/live/shell_live.ex:454
+#: lib/vutuv_web/live/shell_live.ex:528
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
 #: lib/vutuv_web/templates/admin/ad/show.html.heex:4
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:1
@@ -1288,6 +1288,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
+#: lib/vutuv_web/templates/user/show.html.heex:483
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1456,13 +1457,13 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
 #: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:785
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:393
-#: lib/vutuv_web/agent_docs/text.ex:556
-#: lib/vutuv_web/components/ui.ex:2897
-#: lib/vutuv_web/controllers/user_tag_controller.ex:37
-#: lib/vutuv_web/controllers/user_tag_controller.ex:54
+#: lib/vutuv_web/agent_docs/text.ex:565
+#: lib/vutuv_web/components/ui.ex:3023
+#: lib/vutuv_web/controllers/user_tag_controller.ex:38
+#: lib/vutuv_web/controllers/user_tag_controller.ex:55
 #: lib/vutuv_web/cv/docx.ex:174
 #: lib/vutuv_web/cv/html.ex:159
 #: lib/vutuv_web/cv/latex.ex:131
@@ -1487,7 +1488,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/show.html.heex:25
 #: lib/vutuv_web/templates/user/show.html.heex:453
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
-#: lib/vutuv_web/templates/user_tag/index.html.heex:10
+#: lib/vutuv_web/templates/user_tag/index.html.heex:17
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
 #, elixir-autogen
@@ -1594,7 +1595,6 @@ msgid "Tag closures"
 msgstr ""
 
 #: lib/vutuv_web/templates/tag/card_list.html.heex:5
-#: lib/vutuv_web/templates/user_tag/index.html.heex:19
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:10
 #, elixir-autogen
 msgid "Tag name"
@@ -1615,7 +1615,7 @@ msgstr ""
 msgid "User tag created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:126
+#: lib/vutuv_web/controllers/user_tag_controller.ex:134
 #, elixir-autogen
 msgid "User tag deleted successfully."
 msgstr ""
@@ -1671,7 +1671,7 @@ msgstr ""
 msgid "Admin Area"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:101
+#: lib/vutuv_web/agent_docs/section_docs.ex:102
 #: lib/vutuv_web/templates/address/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Addresses of %{name}"
@@ -1682,7 +1682,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:505
+#: lib/vutuv_web/live/shell_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1751,21 +1751,21 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:950
 #: lib/vutuv_web/components/ui.ex:959
-#: lib/vutuv_web/components/ui.ex:1134
+#: lib/vutuv_web/components/ui.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1252
-#: lib/vutuv_web/components/ui.ex:1252
-#: lib/vutuv_web/components/ui.ex:1269
-#: lib/vutuv_web/components/ui.ex:1278
-#: lib/vutuv_web/components/ui.ex:1294
-#: lib/vutuv_web/components/ui.ex:1331
-#: lib/vutuv_web/components/ui.ex:1334
-#: lib/vutuv_web/components/ui.ex:1341
-#: lib/vutuv_web/components/ui.ex:1344
-#: lib/vutuv_web/components/ui.ex:1417
+#: lib/vutuv_web/components/ui.ex:1378
+#: lib/vutuv_web/components/ui.ex:1378
+#: lib/vutuv_web/components/ui.ex:1395
+#: lib/vutuv_web/components/ui.ex:1404
+#: lib/vutuv_web/components/ui.ex:1420
+#: lib/vutuv_web/components/ui.ex:1457
+#: lib/vutuv_web/components/ui.ex:1460
+#: lib/vutuv_web/components/ui.ex:1467
+#: lib/vutuv_web/components/ui.ex:1470
+#: lib/vutuv_web/components/ui.ex:1543
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1780,7 +1780,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:473
+#: lib/vutuv_web/live/shell_live.ex:547
 #: lib/vutuv_web/views/settings_html.ex:218
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1804,20 +1804,20 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:45
 #: lib/vutuv_web/live/message_live/index.ex:496
-#: lib/vutuv_web/live/shell_live.ex:362
-#: lib/vutuv_web/live/shell_live.ex:504
+#: lib/vutuv_web/live/shell_live.ex:436
+#: lib/vutuv_web/live/shell_live.ex:578
 #: lib/vutuv_web/templates/layout/app.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:332
+#: lib/vutuv_web/live/shell_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:285
-#: lib/vutuv_web/components/ui.ex:2753
+#: lib/vutuv_web/components/ui.ex:2879
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -1829,10 +1829,10 @@ msgstr ""
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2911
+#: lib/vutuv_web/components/ui.ex:3037
 #: lib/vutuv_web/live/notification_live/index.ex:81
 #: lib/vutuv_web/live/notification_live/index.ex:245
-#: lib/vutuv_web/live/shell_live.ex:373
+#: lib/vutuv_web/live/shell_live.ex:447
 #: lib/vutuv_web/templates/layout/app.html.heex:118
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -1874,8 +1874,8 @@ msgstr ""
 msgid "Submit a bug report or feature request"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:104
-#: lib/vutuv_web/templates/user_tag/index.html.heex:5
+#: lib/vutuv_web/agent_docs/section_docs.ex:105
+#: lib/vutuv_web/templates/user_tag/index.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Tags of %{name}"
 msgstr ""
@@ -1919,7 +1919,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1234
+#: lib/vutuv_web/templates/user/show.html.heex:1238
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1970,8 +1970,8 @@ msgstr ""
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2145
-#: lib/vutuv_web/components/ui.ex:2290
+#: lib/vutuv_web/components/ui.ex:2271
+#: lib/vutuv_web/components/ui.ex:2416
 #: lib/vutuv_web/live/organization_live/index.ex:130
 #, elixir-autogen, elixir-format
 msgid "Pagination"
@@ -1982,7 +1982,7 @@ msgstr ""
 msgid "Load %{count} of %{remaining} more"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2778
+#: lib/vutuv_web/components/ui.ex:2904
 #: lib/vutuv_web/live/notification_live/index.ex:624
 #, elixir-autogen, elixir-format
 msgid "Load more"
@@ -1993,7 +1993,7 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2559
+#: lib/vutuv_web/components/ui.ex:2685
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -2038,12 +2038,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1908
+#: lib/vutuv_web/components/ui.ex:2034
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1912
+#: lib/vutuv_web/components/ui.ex:2038
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2068,37 +2068,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1916
+#: lib/vutuv_web/components/ui.ex:2042
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1906
+#: lib/vutuv_web/components/ui.ex:2032
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1905
+#: lib/vutuv_web/components/ui.ex:2031
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1911
+#: lib/vutuv_web/components/ui.ex:2037
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1910
+#: lib/vutuv_web/components/ui.ex:2036
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1907
+#: lib/vutuv_web/components/ui.ex:2033
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1909
+#: lib/vutuv_web/components/ui.ex:2035
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2113,17 +2113,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1915
+#: lib/vutuv_web/components/ui.ex:2041
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1914
+#: lib/vutuv_web/components/ui.ex:2040
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1913
+#: lib/vutuv_web/components/ui.ex:2039
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2181,8 +2181,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:79
 #: lib/vutuv_web/live/post_live/feed.ex:552
-#: lib/vutuv_web/live/shell_live.ex:312
-#: lib/vutuv_web/live/shell_live.ex:500
+#: lib/vutuv_web/live/shell_live.ex:369
+#: lib/vutuv_web/live/shell_live.ex:574
 #: lib/vutuv_web/templates/layout/app.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2351,8 +2351,8 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3084
-#: lib/vutuv_web/live/shell_live.ex:416
+#: lib/vutuv_web/components/ui.ex:3210
+#: lib/vutuv_web/live/shell_live.ex:490
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:165
@@ -2375,22 +2375,22 @@ msgstr ""
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1842
+#: lib/vutuv_web/components/post_components.ex:1839
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1846
+#: lib/vutuv_web/components/post_components.ex:1843
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1844
+#: lib/vutuv_web/components/post_components.ex:1841
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1845
+#: lib/vutuv_web/components/post_components.ex:1842
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2431,40 +2431,40 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1914
-#: lib/vutuv_web/components/ui.ex:1612
-#: lib/vutuv_web/components/ui.ex:1612
-#: lib/vutuv_web/components/ui.ex:2220
+#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/ui.ex:1738
+#: lib/vutuv_web/components/ui.ex:1738
+#: lib/vutuv_web/components/ui.ex:2346
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:790
+#: lib/vutuv_web/agent_docs/markdown.ex:817
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
-#: lib/vutuv_web/live/shell_live.ex:355
-#: lib/vutuv_web/live/shell_live.ex:421
+#: lib/vutuv_web/live/shell_live.ex:429
+#: lib/vutuv_web/live/shell_live.ex:495
 #: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1881
-#: lib/vutuv_web/components/ui.ex:1641
-#: lib/vutuv_web/components/ui.ex:1641
-#: lib/vutuv_web/components/ui.ex:2206
+#: lib/vutuv_web/components/post_components.ex:1878
+#: lib/vutuv_web/components/ui.ex:1767
+#: lib/vutuv_web/components/ui.ex:1767
+#: lib/vutuv_web/components/ui.ex:2332
 #: lib/vutuv_web/live/notification_live/index.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:789
+#: lib/vutuv_web/agent_docs/markdown.ex:816
 #: lib/vutuv_web/live/notification_live/index.ex:648
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
-#: lib/vutuv_web/live/shell_live.ex:424
+#: lib/vutuv_web/live/shell_live.ex:498
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Likes"
@@ -2480,48 +2480,48 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1903
+#: lib/vutuv_web/components/post_components.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1914
-#: lib/vutuv_web/components/ui.ex:1602
-#: lib/vutuv_web/components/ui.ex:1602
+#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/ui.ex:1728
+#: lib/vutuv_web/components/ui.ex:1728
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1900
+#: lib/vutuv_web/components/post_components.ex:1897
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1341
+#: lib/vutuv_web/components/post_components.ex:1324
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1900
+#: lib/vutuv_web/components/post_components.ex:1897
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1881
-#: lib/vutuv_web/components/ui.ex:1631
-#: lib/vutuv_web/components/ui.ex:1631
+#: lib/vutuv_web/components/post_components.ex:1878
+#: lib/vutuv_web/components/ui.ex:1757
+#: lib/vutuv_web/components/ui.ex:1757
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1247
-#: lib/vutuv_web/components/ui.ex:1247
-#: lib/vutuv_web/components/ui.ex:1384
+#: lib/vutuv_web/components/ui.ex:1373
+#: lib/vutuv_web/components/ui.ex:1373
+#: lib/vutuv_web/components/ui.ex:1510
 #: lib/vutuv_web/live/post_live/feed.ex:665
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
 #, elixir-autogen, elixir-format
@@ -2533,7 +2533,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1954
+#: lib/vutuv_web/components/post_components.ex:1951
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2547,8 +2547,8 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1937
-#: lib/vutuv_web/components/post_components.ex:1938
+#: lib/vutuv_web/components/post_components.ex:1934
+#: lib/vutuv_web/components/post_components.ex:1935
 #: lib/vutuv_web/live/notification_live/index.ex:693
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
@@ -2647,7 +2647,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1784
+#: lib/vutuv_web/components/ui.ex:1910
 #: lib/vutuv_web/live/message_live/index.ex:596
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2756,54 +2756,55 @@ msgid "Use a different email address"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:689
+#: lib/vutuv_web/templates/user/show.html.heex:693
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:927
+#: lib/vutuv_web/templates/user/show.html.heex:931
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1152
+#: lib/vutuv_web/templates/user/show.html.heex:1156
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:855
+#: lib/vutuv_web/templates/user/show.html.heex:859
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:801
+#: lib/vutuv_web/templates/user/show.html.heex:805
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/templates/user/show.html.heex:492
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:961
+#: lib/vutuv_web/live/user_profile_live.ex:965
 #: lib/vutuv_web/templates/user/show.html.heex:395
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2351
-#: lib/vutuv_web/components/ui.ex:2716
+#: lib/vutuv_web/components/ui.ex:2477
+#: lib/vutuv_web/components/ui.ex:2842
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
 #: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
+#: lib/vutuv_web/templates/user/show.html.heex:483
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
@@ -2887,7 +2888,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1843
+#: lib/vutuv_web/components/post_components.ex:1840
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2913,7 +2914,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:691
-#: lib/vutuv_web/templates/user/show.html.heex:744
+#: lib/vutuv_web/templates/user/show.html.heex:748
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3142,8 +3143,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:895
-#: lib/vutuv_web/templates/user/show.html.heex:896
+#: lib/vutuv_web/templates/user/show.html.heex:899
+#: lib/vutuv_web/templates/user/show.html.heex:900
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -3197,9 +3198,9 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2884
-#: lib/vutuv_web/live/shell_live.ex:325
-#: lib/vutuv_web/live/shell_live.ex:509
+#: lib/vutuv_web/components/ui.ex:3010
+#: lib/vutuv_web/live/shell_live.ex:382
+#: lib/vutuv_web/live/shell_live.ex:583
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3306,7 +3307,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2120
+#: lib/vutuv_web/components/ui.ex:2246
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3876,12 +3877,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:524
+#: lib/vutuv_web/agent_docs/markdown.ex:526
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:834
+#: lib/vutuv_web/agent_docs/markdown.ex:861
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3895,11 +3896,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:144
 #: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:785
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:139
 #: lib/vutuv_web/agent_docs/text.ex:152
-#: lib/vutuv_web/agent_docs/text.ex:556
+#: lib/vutuv_web/agent_docs/text.ex:565
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3916,20 +3917,20 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:776
-#: lib/vutuv_web/agent_docs/text.ex:567
+#: lib/vutuv_web/agent_docs/markdown.ex:803
+#: lib/vutuv_web/agent_docs/text.ex:576
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:773
-#: lib/vutuv_web/agent_docs/text.ex:564
+#: lib/vutuv_web/agent_docs/markdown.ex:800
+#: lib/vutuv_web/agent_docs/text.ex:573
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:780
-#: lib/vutuv_web/agent_docs/text.ex:570
+#: lib/vutuv_web/agent_docs/markdown.ex:807
+#: lib/vutuv_web/agent_docs/text.ex:579
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
@@ -3981,17 +3982,17 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:727
+#: lib/vutuv_web/agent_docs/markdown.ex:754
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:657
+#: lib/vutuv_web/agent_docs/markdown.ex:684
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:658
+#: lib/vutuv_web/agent_docs/markdown.ex:685
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4006,22 +4007,22 @@ msgstr ""
 msgid "Connections of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:103
+#: lib/vutuv_web/agent_docs/section_docs.ex:104
 #, elixir-autogen, elixir-format
 msgid "Email addresses of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:95
+#: lib/vutuv_web/agent_docs/section_docs.ex:96
 #, elixir-autogen, elixir-format
 msgid "Links of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:102
+#: lib/vutuv_web/agent_docs/section_docs.ex:103
 #, elixir-autogen, elixir-format
 msgid "Phone numbers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:88
+#: lib/vutuv_web/agent_docs/section_docs.ex:89
 #, elixir-autogen, elixir-format
 msgid "Work experience of %{name}"
 msgstr ""
@@ -4574,7 +4575,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:763
+#: lib/vutuv_web/templates/user/show.html.heex:767
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4686,7 +4687,7 @@ msgstr ""
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:949
+#: lib/vutuv_web/live/user_profile_live.ex:953
 #: lib/vutuv_web/templates/user/show.html.heex:456
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -5274,7 +5275,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2917
+#: lib/vutuv_web/components/ui.ex:3043
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5320,7 +5321,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:403
+#: lib/vutuv_web/live/shell_live.ex:477
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5341,7 +5342,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:464
+#: lib/vutuv_web/live/shell_live.ex:538
 #: lib/vutuv_web/templates/layout/app.html.heex:147
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5352,11 +5353,11 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3003
-#: lib/vutuv_web/components/ui.ex:3008
-#: lib/vutuv_web/components/ui.ex:3076
+#: lib/vutuv_web/components/ui.ex:3129
+#: lib/vutuv_web/components/ui.ex:3134
+#: lib/vutuv_web/components/ui.ex:3202
 #: lib/vutuv_web/controllers/settings_controller.ex:51
-#: lib/vutuv_web/live/shell_live.ex:444
+#: lib/vutuv_web/live/shell_live.ex:518
 #: lib/vutuv_web/live/tag_new_live.ex:44
 #: lib/vutuv_web/templates/address/edit.html.heex:2
 #: lib/vutuv_web/templates/address/new.html.heex:2
@@ -5418,7 +5419,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:951
+#: lib/vutuv_web/live/user_profile_live.ex:955
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5433,8 +5434,8 @@ msgstr ""
 msgid "Previous post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:305
-#: lib/vutuv_web/live/shell_live.ex:493
+#: lib/vutuv_web/live/shell_live.ex:362
+#: lib/vutuv_web/live/shell_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5500,7 +5501,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2899
+#: lib/vutuv_web/components/ui.ex:3025
 #: lib/vutuv_web/live/admin/user_live.ex:266
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:13
 #, elixir-autogen, elixir-format
@@ -5523,7 +5524,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2894
+#: lib/vutuv_web/components/ui.ex:3020
 #: lib/vutuv_web/controllers/email_controller.ex:30
 #: lib/vutuv_web/controllers/email_controller.ex:49
 #: lib/vutuv_web/controllers/email_controller.ex:191
@@ -5554,7 +5555,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2909
+#: lib/vutuv_web/components/ui.ex:3035
 #: lib/vutuv_web/templates/settings/privacy.html.heex:9
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5667,7 +5668,7 @@ msgstr ""
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2916
+#: lib/vutuv_web/components/ui.ex:3042
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -5678,7 +5679,7 @@ msgstr ""
 msgid "Apps & API"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:103
+#: lib/vutuv_web/controllers/user_tag_controller.ex:104
 #: lib/vutuv_web/live/notification_live/index.ex:650
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
@@ -6089,7 +6090,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:955
+#: lib/vutuv_web/live/user_profile_live.ex:959
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6103,7 +6104,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:174
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:687
+#: lib/vutuv_web/templates/user/show.html.heex:691
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6124,7 +6125,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1199
+#: lib/vutuv_web/templates/user/show.html.heex:1203
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6167,8 +6168,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:821
-#: lib/vutuv_web/templates/user/show.html.heex:831
+#: lib/vutuv_web/templates/user/show.html.heex:825
+#: lib/vutuv_web/templates/user/show.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6208,12 +6209,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:942
+#: lib/vutuv_web/templates/user/show.html.heex:946
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:953
+#: lib/vutuv_web/templates/user/show.html.heex:957
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6248,14 +6249,14 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:789
+#: lib/vutuv_web/agent_docs/markdown.ex:816
 #: lib/vutuv_web/components/post_components.ex:273
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:951
+#: lib/vutuv_web/templates/user/show.html.heex:955
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6282,7 +6283,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:950
 #: lib/vutuv_web/components/ui.ex:959
-#: lib/vutuv_web/components/ui.ex:1135
+#: lib/vutuv_web/components/ui.ex:1261
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6309,9 +6310,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1185
-#: lib/vutuv_web/templates/user/show.html.heex:1193
-#: lib/vutuv_web/templates/user/show.html.heex:1205
+#: lib/vutuv_web/templates/user/show.html.heex:1189
+#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:1209
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6343,7 +6344,7 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1088
+#: lib/vutuv_web/components/ui.ex:1214
 #: lib/vutuv_web/live/notification_live/index.ex:413
 #: lib/vutuv_web/live/notification_live/index.ex:428
 #: lib/vutuv_web/live/notification_live/index.ex:514
@@ -6352,7 +6353,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:798
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6626,7 +6627,7 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1572
+#: lib/vutuv_web/components/ui.ex:1698
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Mute"
@@ -6648,7 +6649,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1571
+#: lib/vutuv_web/components/ui.ex:1697
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Unmute"
@@ -6685,33 +6686,33 @@ msgstr ""
 msgid "Unmute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1542
+#: lib/vutuv_web/components/ui.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1536
+#: lib/vutuv_web/components/ui.ex:1662
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1526
+#: lib/vutuv_web/components/ui.ex:1652
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1477
-#: lib/vutuv_web/components/ui.ex:1526
+#: lib/vutuv_web/components/ui.ex:1603
+#: lib/vutuv_web/components/ui.ex:1652
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1475
+#: lib/vutuv_web/components/ui.ex:1601
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1476
+#: lib/vutuv_web/components/ui.ex:1602
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -7273,13 +7274,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2158
+#: lib/vutuv_web/components/ui.ex:2284
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2174
+#: lib/vutuv_web/components/ui.ex:2300
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7532,17 +7533,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:839
+#: lib/vutuv_web/agent_docs/markdown.ex:866
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:842
+#: lib/vutuv_web/agent_docs/markdown.ex:869
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:849
+#: lib/vutuv_web/agent_docs/markdown.ex:876
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8024,7 +8025,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2161
+#: lib/vutuv_web/components/ui.ex:2287
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8143,7 +8144,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:540
+#: lib/vutuv_web/templates/user/show.html.heex:544
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8155,7 +8156,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:2888
+#: lib/vutuv_web/components/ui.ex:3014
 #: lib/vutuv_web/controllers/education_controller.ex:38
 #: lib/vutuv_web/controllers/education_controller.ex:53
 #: lib/vutuv_web/controllers/education_controller.ex:103
@@ -8168,7 +8169,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:537
+#: lib/vutuv_web/templates/user/show.html.heex:541
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -8183,7 +8184,7 @@ msgstr ""
 msgid "Education deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:89
+#: lib/vutuv_web/agent_docs/section_docs.ex:90
 #, elixir-autogen, elixir-format
 msgid "Education of %{name}"
 msgstr ""
@@ -8209,7 +8210,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2904
+#: lib/vutuv_web/components/ui.ex:3030
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8238,7 +8239,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2895
+#: lib/vutuv_web/components/ui.ex:3021
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8332,12 +8333,12 @@ msgstr ""
 msgid "A photo and a short tagline make your profile complete."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:974
+#: lib/vutuv_web/live/user_profile_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2397
+#: lib/vutuv_web/components/ui.ex:2523
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:36
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:42
@@ -8358,7 +8359,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:94
-#: lib/vutuv_web/templates/user/show.html.heex:1056
+#: lib/vutuv_web/templates/user/show.html.heex:1060
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8418,13 +8419,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2886
+#: lib/vutuv_web/components/ui.ex:3012
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2903
+#: lib/vutuv_web/components/ui.ex:3029
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8436,7 +8437,7 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2901
+#: lib/vutuv_web/components/ui.ex:3027
 #: lib/vutuv_web/controllers/settings_controller.ex:89
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:5
@@ -8445,7 +8446,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2905
+#: lib/vutuv_web/components/ui.ex:3031
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8669,7 +8670,7 @@ msgstr ""
 msgid "Allow followers from the Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2910
+#: lib/vutuv_web/components/ui.ex:3036
 #: lib/vutuv_web/controllers/settings_controller.ex:186
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:265
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
@@ -8759,7 +8760,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:576
+#: lib/vutuv_web/agent_docs/markdown.ex:586
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8780,7 +8781,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:577
+#: lib/vutuv_web/agent_docs/markdown.ex:587
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8811,13 +8812,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:614
+#: lib/vutuv_web/agent_docs/markdown.ex:624
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:613
+#: lib/vutuv_web/agent_docs/markdown.ex:623
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8843,14 +8844,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1344
+#: lib/vutuv_web/components/post_components.ex:1327
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:730
+#: lib/vutuv_web/agent_docs/markdown.ex:757
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8928,14 +8929,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:575
+#: lib/vutuv_web/agent_docs/markdown.ex:585
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:588
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9052,7 +9053,7 @@ msgstr ""
 msgid "Removed @%{handle} from this tag."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:131
+#: lib/vutuv_web/controllers/user_tag_controller.ex:139
 #, elixir-autogen, elixir-format
 msgid "This tag can only be removed by a site admin."
 msgstr ""
@@ -9062,8 +9063,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:992
-#: lib/vutuv_web/components/ui.ex:993
+#: lib/vutuv_web/components/ui.ex:994
+#: lib/vutuv_web/components/ui.ex:995
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:64
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9092,7 +9093,7 @@ msgid "A2 (Elementary)"
 msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:602
+#: lib/vutuv_web/templates/user/show.html.heex:606
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9304,7 +9305,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:49
 #: lib/vutuv_web/agent_docs/text.ex:46
-#: lib/vutuv_web/components/ui.ex:2890
+#: lib/vutuv_web/components/ui.ex:3016
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
@@ -9317,12 +9318,12 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:3
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:599
+#: lib/vutuv_web/templates/user/show.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:94
+#: lib/vutuv_web/agent_docs/section_docs.ex:95
 #, elixir-autogen, elixir-format
 msgid "Languages of %{name}"
 msgstr ""
@@ -9598,28 +9599,28 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:642
+#: lib/vutuv_web/templates/user/show.html.heex:646
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:651
+#: lib/vutuv_web/agent_docs/markdown.ex:678
 #: lib/vutuv_web/views/qualification_html.ex:10
 #, elixir-autogen, elixir-format
 msgid "Certificate"
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:78
+#: lib/vutuv_web/controllers/qualification_controller.ex:85
 #, elixir-autogen, elixir-format
 msgid "Certificate or license added successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:128
+#: lib/vutuv_web/controllers/qualification_controller.ex:139
 #, elixir-autogen, elixir-format
 msgid "Certificate or license deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/qualification_controller.ex:119
+#: lib/vutuv_web/controllers/qualification_controller.ex:130
 #, elixir-autogen, elixir-format
 msgid "Certificate or license updated successfully."
 msgstr ""
@@ -9631,10 +9632,10 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:2889
-#: lib/vutuv_web/controllers/qualification_controller.ex:35
-#: lib/vutuv_web/controllers/qualification_controller.ex:51
-#: lib/vutuv_web/controllers/qualification_controller.ex:102
+#: lib/vutuv_web/components/ui.ex:3015
+#: lib/vutuv_web/controllers/qualification_controller.ex:39
+#: lib/vutuv_web/controllers/qualification_controller.ex:58
+#: lib/vutuv_web/controllers/qualification_controller.ex:113
 #: lib/vutuv_web/cv/docx.ex:183
 #: lib/vutuv_web/cv/html.ex:172
 #: lib/vutuv_web/cv/latex.ex:140
@@ -9646,7 +9647,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:3
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:639
+#: lib/vutuv_web/templates/user/show.html.heex:643
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr ""
@@ -9656,13 +9657,13 @@ msgstr ""
 msgid "Certificates & licenses of "
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:92
+#: lib/vutuv_web/agent_docs/section_docs.ex:93
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:49
-#: lib/vutuv_web/templates/qualification/show.html.heex:38
+#: lib/vutuv_web/templates/qualification/show.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Credential ID"
 msgstr ""
@@ -9675,7 +9676,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:164
 #: lib/vutuv_web/live/admin/job_live.ex:180
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:183
-#: lib/vutuv_web/views/qualification_html.ex:149
+#: lib/vutuv_web/views/qualification_html.ex:187
 #, elixir-autogen, elixir-format
 msgid "Expired"
 msgstr ""
@@ -9690,7 +9691,7 @@ msgstr ""
 msgid "Expiry year"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:643
+#: lib/vutuv_web/agent_docs/markdown.ex:653
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9716,7 +9717,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:650
+#: lib/vutuv_web/agent_docs/markdown.ex:677
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9732,18 +9733,18 @@ msgstr ""
 msgid "LinkedIn does not say whether an entry is a certificate or a license, so we import all of them as certificates. Please review the section afterwards and switch any that are licenses."
 msgstr ""
 
-#: lib/vutuv_web/views/qualification_html.ex:159
+#: lib/vutuv_web/views/qualification_html.ex:223
 #, elixir-autogen, elixir-format
 msgid "Proof"
 msgstr ""
 
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:55
-#: lib/vutuv_web/templates/qualification/show.html.heex:43
+#: lib/vutuv_web/templates/qualification/show.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:641
+#: lib/vutuv_web/agent_docs/markdown.ex:651
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9758,7 +9759,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:642
+#: lib/vutuv_web/agent_docs/markdown.ex:652
 #: lib/vutuv_web/views/qualification_html.ex:76
 #: lib/vutuv_web/views/qualification_html.ex:79
 #, elixir-autogen, elixir-format
@@ -9775,15 +9776,15 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:533
+#: lib/vutuv_web/agent_docs/markdown.ex:543
 #: lib/vutuv_web/live/section_reorder_live.ex:269
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:917
-#: lib/vutuv_web/templates/user/show.html.heex:918
+#: lib/vutuv_web/templates/user/show.html.heex:921
+#: lib/vutuv_web/templates/user/show.html.heex:922
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9850,7 +9851,7 @@ msgid "First name"
 msgstr ""
 
 #: lib/vutuv_web/controllers/invitation_controller.ex:54
-#: lib/vutuv_web/live/shell_live.ex:435
+#: lib/vutuv_web/live/shell_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "Invite a friend"
 msgstr ""
@@ -10416,21 +10417,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:503
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:499
+#: lib/vutuv_web/agent_docs/markdown.ex:501
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:497
+#: lib/vutuv_web/agent_docs/markdown.ex:499
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10453,7 +10454,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1030
+#: lib/vutuv_web/templates/user/show.html.heex:1034
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10483,12 +10484,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:515
+#: lib/vutuv_web/agent_docs/markdown.ex:517
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:502
+#: lib/vutuv_web/agent_docs/markdown.ex:504
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -11833,8 +11834,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:671
-#: lib/vutuv_web/agent_docs/text.ex:537
+#: lib/vutuv_web/agent_docs/markdown.ex:698
+#: lib/vutuv_web/agent_docs/text.ex:539
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -12065,12 +12066,12 @@ msgid "Organization unfrozen."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:2902
+#: lib/vutuv_web/components/ui.ex:3028
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
 #: lib/vutuv_web/live/post_live/saved.ex:455
-#: lib/vutuv_web/live/shell_live.ex:431
+#: lib/vutuv_web/live/shell_live.ex:505
 #: lib/vutuv_web/templates/layout/app.html.heex:79
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
@@ -12394,8 +12395,9 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:41
 #: lib/vutuv_web/live/job_board_live.ex:146
 #: lib/vutuv_web/live/post_live/saved.ex:458
-#: lib/vutuv_web/live/shell_live.ex:339
+#: lib/vutuv_web/live/shell_live.ex:396
 #: lib/vutuv_web/templates/layout/app.html.heex:77
+#: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr ""
@@ -13238,7 +13240,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2940
+#: lib/vutuv_web/components/ui.ex:3066
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13713,7 +13715,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2929
+#: lib/vutuv_web/components/ui.ex:3055
 #: lib/vutuv_web/controllers/settings_controller.ex:259
 #: lib/vutuv_web/live/post_live/feed.ex:651
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13763,7 +13765,7 @@ msgid "Signal and WhatsApp accept a phone number or a username; the other messen
 msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:996
+#: lib/vutuv_web/templates/user/show.html.heex:1000
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13792,7 +13794,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:2893
+#: lib/vutuv_web/components/ui.ex:3019
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:3
@@ -13800,7 +13802,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:3
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:994
+#: lib/vutuv_web/templates/user/show.html.heex:998
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13810,7 +13812,7 @@ msgstr ""
 msgid "Messengers of "
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/section_docs.ex:100
+#: lib/vutuv_web/agent_docs/section_docs.ex:101
 #, elixir-autogen, elixir-format
 msgid "Messengers of %{name}"
 msgstr ""
@@ -13820,14 +13822,14 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2483
+#: lib/vutuv_web/components/ui.ex:2609
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:2493
+#: lib/vutuv_web/components/ui.ex:2619
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
@@ -13877,7 +13879,7 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1705
+#: lib/vutuv_web/components/post_components.ex:1702
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
@@ -13892,19 +13894,19 @@ msgstr ""
 msgid "Book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:801
-#: lib/vutuv_web/components/post_components.ex:1662
+#: lib/vutuv_web/agent_docs/markdown.ex:828
+#: lib/vutuv_web/components/post_components.ex:1659
 #: lib/vutuv_web/live/post_live/composer.ex:659
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1706
+#: lib/vutuv_web/components/post_components.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1708
+#: lib/vutuv_web/components/post_components.ex:1705
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
@@ -13914,7 +13916,7 @@ msgstr ""
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1704
+#: lib/vutuv_web/components/post_components.ex:1701
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
@@ -13924,8 +13926,8 @@ msgstr ""
 msgid "Film"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:801
-#: lib/vutuv_web/components/post_components.ex:1661
+#: lib/vutuv_web/agent_docs/markdown.ex:828
+#: lib/vutuv_web/components/post_components.ex:1658
 #: lib/vutuv_web/live/post_live/composer.ex:658
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13956,7 +13958,7 @@ msgstr ""
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1703
+#: lib/vutuv_web/components/post_components.ex:1700
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
@@ -13983,7 +13985,7 @@ msgstr ""
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1707
+#: lib/vutuv_web/components/post_components.ex:1704
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -14003,34 +14005,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1744
+#: lib/vutuv_web/components/post_components.ex:1741
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1774
+#: lib/vutuv_web/components/post_components.ex:1771
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1775
+#: lib/vutuv_web/components/post_components.ex:1772
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1773
+#: lib/vutuv_web/components/post_components.ex:1770
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1733
+#: lib/vutuv_web/components/post_components.ex:1730
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1780
+#: lib/vutuv_web/components/post_components.ex:1777
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14055,12 +14057,12 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:562
+#: lib/vutuv_web/agent_docs/markdown.ex:572
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1556
+#: lib/vutuv_web/components/post_components.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14108,13 +14110,17 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
+#: lib/vutuv_web/components/post_components.ex:1535
+#, elixir-autogen, elixir-format
+msgid "by:"
+msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1055
+#: lib/vutuv_web/components/ui.ex:1065
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1057
+#: lib/vutuv_web/components/ui.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14127,3 +14133,40 @@ msgid "%{formatted} new member today"
 msgid_plural "%{formatted} new members today"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/vutuv_web/views/qualification_html.ex:147
+#: lib/vutuv_web/views/qualification_html.ex:206
+#, elixir-autogen, elixir-format
+msgid "Currently in use"
+msgstr ""
+
+#: lib/vutuv_web/views/qualification_html.ex:150
+#: lib/vutuv_web/views/qualification_html.ex:213
+#, elixir-autogen, elixir-format
+msgid "Last used: %{date}"
+msgstr ""
+
+#: lib/vutuv_web/views/qualification_html.ex:142
+#, elixir-autogen, elixir-format
+msgid "Used for %{formatted} job"
+msgid_plural "Used for %{formatted} jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:667
+#, elixir-autogen, elixir-format
+msgid "currently in use"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:666
+#, elixir-autogen, elixir-format
+msgid "used for %{count} job"
+msgid_plural "used for %{count} jobs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:672
+#, elixir-autogen, elixir-format
+msgctxt "qualification job usage"
+msgid "last used %{date}"
+msgstr ""

--- a/test/vutuv/profiles/qualification_test.exs
+++ b/test/vutuv/profiles/qualification_test.exs
@@ -148,6 +148,57 @@ defmodule Vutuv.Profiles.QualificationTest do
     end
   end
 
+  describe "job_usage/1 (issue #1005)" do
+    alias Vutuv.Profiles.WorkExperience
+
+    test "nil when the citing jobs were not preloaded" do
+      assert Qualification.job_usage(%Qualification{}) == nil
+    end
+
+    test "nil when no job cites the credential" do
+      assert Qualification.job_usage(%Qualification{work_experiences: []}) == nil
+    end
+
+    test "counts the citing jobs and marks an ongoing one as current" do
+      qual = %Qualification{
+        work_experiences: [
+          %WorkExperience{end_year: nil},
+          %WorkExperience{end_year: 2019, end_month: 9}
+        ]
+      }
+
+      assert %{count: 2, current?: true} = Qualification.job_usage(qual)
+    end
+
+    test "a credential only past jobs cite reports the newest end date" do
+      qual = %Qualification{
+        work_experiences: [
+          %WorkExperience{end_year: 2016, end_month: 12},
+          %WorkExperience{end_year: 2019, end_month: 9}
+        ]
+      }
+
+      assert %{count: 2, current?: false, last_end: {2019, 9}} = Qualification.job_usage(qual)
+    end
+
+    test "a year-only end date counts as the whole year (beats earlier months)" do
+      qual = %Qualification{
+        work_experiences: [
+          %WorkExperience{end_year: 2019, end_month: 3},
+          %WorkExperience{end_year: 2019, end_month: nil}
+        ]
+      }
+
+      assert %{last_end: {2019, nil}} = Qualification.job_usage(qual)
+    end
+
+    test "a job with no dates at all reads as ongoing (no known end)" do
+      qual = %Qualification{work_experiences: [%WorkExperience{}]}
+
+      assert %{count: 1, current?: true} = Qualification.job_usage(qual)
+    end
+  end
+
   describe "ordered/1" do
     test "sorts most recently awarded first, undated last, then by name" do
       user = insert(:user)

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -220,6 +220,24 @@ defmodule VutuvWeb.AgentDocsDriftTest do
 
     assert rendered.xml =~ "<qualification>"
 
+    # The reverse direction (issue #1005): the credential's list rows show how
+    # many jobs it earned and that it is in current use (the Bridge Engineer
+    # role is ongoing). HTML shows the badges, md/txt the facts, JSON/XML the
+    # structured jobs map.
+    assert rendered.html =~ "Used for 1 job"
+    assert rendered.html =~ "Currently in use"
+    assert rendered.md =~ "used for 1 job"
+    assert rendered.md =~ "currently in use"
+    assert rendered.txt =~ "used for 1 job"
+
+    qualification_json =
+      Jason.decode!(rendered.json)["qualifications"]
+      |> Enum.find(&(&1["name"] == "Chartered Structural Engineer"))
+
+    assert qualification_json["jobs"]["count"] == 1
+    assert qualification_json["jobs"]["in_use"] == true
+    assert rendered.xml =~ "<in_use>true</in_use>"
+
     # The employment status (issue #870): the HTML badge and the md/txt fact
     # line show the human label, JSON/XML carry the raw machine value.
     assert rendered.html =~ "Looking for a job"

--- a/test/vutuv_web/controllers/qualification_controller_test.exs
+++ b/test/vutuv_web/controllers/qualification_controller_test.exs
@@ -111,6 +111,125 @@ defmodule VutuvWeb.QualificationControllerTest do
     end
   end
 
+  describe "job usage badges (issue #1005)" do
+    setup %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      %{conn: conn, owner: owner}
+    end
+
+    test "a credential a current job cites shows the count and the in-use badge",
+         %{owner: owner} do
+      qualification = insert(:qualification, user: owner, name: "Meisterbrief")
+      insert(:work_experience, user: owner, qualification: qualification, end_year: nil)
+
+      html = build_conn() |> get(~p"/#{owner}/qualifications") |> html_response(200)
+
+      assert html =~ "data-qualification-usage"
+      assert html =~ "data-usage-jobs"
+      assert html =~ "Used for 1 job"
+      assert html =~ "data-usage-current"
+      assert html =~ "Currently in use"
+      refute html =~ "data-usage-last"
+    end
+
+    test "a credential only past jobs cite shows the newest end date instead",
+         %{owner: owner} do
+      qualification = insert(:qualification, user: owner, name: "Meisterbrief")
+
+      insert(:work_experience,
+        user: owner,
+        qualification: qualification,
+        start_year: 2015,
+        end_year: 2017,
+        end_month: 3
+      )
+
+      insert(:work_experience,
+        user: owner,
+        qualification: qualification,
+        start_year: 2018,
+        end_year: 2019,
+        end_month: 9
+      )
+
+      html = build_conn() |> get(~p"/#{owner}/qualifications") |> html_response(200)
+
+      assert html =~ "Used for 2 jobs"
+      assert html =~ "data-usage-last"
+      assert html =~ "Last used: 9/2019"
+      refute html =~ "data-usage-current"
+    end
+
+    test "an uncited credential shows no usage badges", %{owner: owner} do
+      insert(:qualification, user: owner, name: "Unused cert")
+
+      html = build_conn() |> get(~p"/#{owner}/qualifications") |> html_response(200)
+
+      refute html =~ "data-qualification-usage"
+    end
+
+    test "the owner's /settings editor shows the badges too", %{conn: conn, owner: owner} do
+      qualification = insert(:qualification, user: owner, name: "Meisterbrief")
+      insert(:work_experience, user: owner, qualification: qualification, end_year: nil)
+
+      html = conn |> get(~p"/settings/qualifications") |> html_response(200)
+
+      assert html =~ "Used for 1 job"
+      assert html =~ "Currently in use"
+    end
+
+    test "the entry page shows the usage line and its doc siblings carry it",
+         %{owner: owner} do
+      qualification = insert(:qualification, user: owner, name: "Meisterbrief")
+      insert(:work_experience, user: owner, qualification: qualification, end_year: nil)
+
+      html =
+        build_conn()
+        |> get(~p"/#{owner}/qualifications/#{qualification}")
+        |> html_response(200)
+
+      assert html =~ "data-qualification-usage"
+      assert html =~ "Used for 1 job"
+      assert html =~ "Currently in use"
+
+      json =
+        build_conn()
+        |> get("/#{owner.username}/qualifications/#{qualification.id}.json")
+        |> Map.get(:resp_body)
+        |> Jason.decode!()
+
+      assert json["entry"]["jobs"]["count"] == 1
+      assert json["entry"]["jobs"]["in_use"] == true
+    end
+
+    test "the index doc siblings carry the usage facts", %{owner: owner} do
+      qualification = insert(:qualification, user: owner, name: "Meisterbrief")
+
+      insert(:work_experience,
+        user: owner,
+        qualification: qualification,
+        start_year: 2018,
+        end_year: 2019,
+        end_month: 9
+      )
+
+      json =
+        build_conn()
+        |> get("/#{owner.username}/qualifications.json")
+        |> Map.get(:resp_body)
+        |> Jason.decode!()
+
+      entry = Enum.find(json["entries"], &(&1["name"] == "Meisterbrief"))
+      assert entry["jobs"]["count"] == 1
+      assert entry["jobs"]["in_use"] == false
+      assert entry["jobs"]["last_used"] == "2019-09"
+
+      md = build_conn() |> get("/#{owner.username}/qualifications.md") |> Map.get(:resp_body)
+      assert md =~ "used for 1 job"
+      assert md =~ "last used 2019-09"
+    end
+  end
+
   describe "public page vs /settings editor" do
     setup %{conn: conn} do
       {conn, owner} = create_and_login_user(conn)


### PR DESCRIPTION
Closes #1005.

**What**: Every qualification list row (profile card, `/:slug/qualifications`, `/settings/qualifications` editor) now shows how the member's jobs use the credential, per the issue's mockup:

- a brand-tint **"Used for N jobs"** pill (count of work experiences citing it via #858's `qualification_id`),
- an emerald **"Currently in use"** pill when a citing job is ongoing (no end date), or
- a slate **"Last used: M/YYYY"** pill from the newest citing job's end date.

An uncited credential shows nothing, so a calm row itself answers "used at all?". The entry show page gets the same facts as one "Jobs" line, and the agent-format siblings (md/txt/json/xml, profile doc, /api/2.0) carry a structured `jobs: {count, in_use, last_used}` map, guarded by the drift test. German: "Für N Jobs genutzt" / "Aktuell genutzt" / "Zuletzt genutzt: 9/2019".

**How**: policy home `Qualification.job_usage/1` over a `work_experiences` preload (`citing_jobs_preload/0`), nil-safe on unloaded associations like `WorkExperience.cited_qualification/1`. Rendering lives once in the shared `qualification_row/1`.

**Tested**: unit tests for `job_usage/1`, controller tests for all three surfaces + doc siblings, drift-test assertions across all five formats; `mix precommit` green (4373 tests). Browser-smoke-tested against the dev server in German and English (section page, profile card, entry page) with a throwaway QA member (`selma_probst`).

*Written with this GitHub account, but not necessarily by the human behind it — this may just be a note-taking issue that gets deleted later without ever being tackled.*