### PR TITLE
Notify thread participants about new replies

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -178,7 +178,12 @@ above), so a widely-reposted post is one entry, not one card per reposter.
 
 A reply is a **normal post** (own permalink, audience, images, tags,
 likes/reposts/bookmarks, shows up in the replier's feed and profile) plus a
-`post_replies` row naming the parent (`Vutuv.Posts.create_reply/3`).
+`post_replies` row naming the parent (`Vutuv.Posts.create_reply/3`) **and the
+thread root** (`root_post_id`, denormalized at creation — threading is
+otherwise only a parent-pointer chain — so "all replies of this thread" is one
+indexed lookup; it feeds the thread-participation notifications, see
+[realtime.md](realtime.md)). The root reference nilifies when the root post is
+deleted.
 
 Replying works on **public** parents only (the reply button on restricted posts
 is disabled, like repost) and pins the parent's audience open like reposts do.

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -94,6 +94,20 @@ They sit *inside* the row's own link, so they cannot carry links of their own �
 `VutuvWeb.Markdown.to_plain_text/1` flattens their Markdown to plain text
 instead, so no `**marker**` shows there either.
 
+**Thread participation** is its own kind (`"thread"`): once a member writes in
+a thread (they rooted it or replied in it), every later reply **anywhere** in
+that thread notifies them too — not only direct answers to their own posts,
+which stay the `"reply"` kind (an event is always exactly one of the two).
+Answers from before the member joined the thread don't surface (they were on
+screen when the member replied), own replies and blocked members never do.
+The set "all replies of this thread" comes from `post_replies.root_post_id`,
+the thread root denormalized onto every reply at creation (threading is
+otherwise only a parent-pointer chain); a reply whose root was deleted carries
+NULL there and stays out of thread events. Rows link to the new reply's
+permalink and quote it; same-day events of one thread merge into one grouped
+row. The write side (`Vutuv.Posts.create_reply/3` via `broadcast_reply/2`)
+pushes the same event live to every participant's badge.
+
 The only stored state is the `users.notifications_read_at` read marker behind
 the unread badge.
 
@@ -104,10 +118,12 @@ under Berlin-day sections** (`VutuvWeb.NotificationLive.Groups`, a pure
 function over the item list). What reads as one piece of news merges into one
 row, keyed within a Berlin calendar day: same-day likes of one post, the day's
 new followers ("Anna, Ben and 111 more are now following you.", the overflow
-linking to the member's followers list), the day's new connections, and one
-endorser's endorsements ("endorsed you for Elixir and Phoenix."). Replies and
-the rarer kinds (moderation, CV updates, handle changes, ...) stay one row per
-event. Because grouping is pure, every change — a page, a live push, the
+linking to the member's followers list), the day's new connections, one
+endorser's endorsements ("endorsed you for Elixir and Phoenix."), and same-day
+thread events of one thread ("Anna and Ben replied in a thread you posted
+in."). Direct replies and the rarer kinds (moderation, CV updates, handle
+changes, ...) stay one row per event. Because grouping is pure, every change —
+a page, a live push, the
 DayClock midnight rollover — recomputes the sections wholesale; there is no
 LiveView stream to patch, and a live-pushed like merges into the derived row
 for its post/day.

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -11,9 +11,10 @@ defmodule Vutuv.Activity do
 
   The feed is **derived at read time** from the event tables that already exist
   (`follows` — a one-way follow is a "follower" event, a mutual follow a
-  "connection"/vernetzt one —, `user_tag_endorsements`, `post_replies`,
-  `post_likes`, and the announced CV rows behind
-  `Vutuv.Profiles.CvUpdates`) instead of being
+  "connection"/vernetzt one —, `user_tag_endorsements`, `post_replies` — a
+  reply answering the user's post is a "reply" event, a reply elsewhere in a
+  thread the user writes in a "thread" one —, `post_likes`, and the announced
+  CV rows behind `Vutuv.Profiles.CvUpdates`) instead of being
   persisted per notification — which makes it automatically retroactive. The only stored
   state is `users.notifications_read_at`, the read marker behind the unread
   badge; `mark_notifications_read/1` bumps it and broadcasts. Older events are
@@ -29,6 +30,7 @@ defmodule Vutuv.Activity do
   alias Vutuv.Notifications.Emailer
   alias Vutuv.Organizations.Organization
   alias Vutuv.Organizations.OrganizationRole
+  alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostLike
   alias Vutuv.Posts.PostReply
   alias Vutuv.Profiles.CvUpdates
@@ -106,6 +108,8 @@ defmodule Vutuv.Activity do
         select: %{ts: max(r.inserted_at)}
       )
 
+    thread_max = select(thread_replies(user_id), [thread_ref: r], %{ts: max(r.inserted_at)})
+
     like_max =
       from(l in PostLike,
         join: p in assoc(l, :post),
@@ -160,6 +164,7 @@ defmodule Vutuv.Activity do
       |> union_all(^endorsement_max)
       |> union_all(^connection_max)
       |> union_all(^reply_max)
+      |> union_all(^thread_max)
       |> union_all(^like_max)
       |> union_all(^moderation_max)
       |> union_all(^image_rejected_max)
@@ -309,6 +314,26 @@ defmodule Vutuv.Activity do
     )
   end
 
+  @doc ~S"""
+  Convenience: a "replied in a thread you posted in" notification for another
+  participant of a thread — the root author or an earlier replier. The
+  directly answered author gets `notify_reply/4` instead, never both.
+  `reply_post_id` is the new reply, so the row can quote and link it;
+  `root_post_id` keys the notification page's per-thread grouping.
+  """
+  def notify_thread_reply(user_id, replier, root_post_id, reply_post_id) do
+    notify(
+      user_id,
+      Map.merge(actor_fields(replier), %{
+        kind: "thread",
+        text: "replied in a thread you posted in.",
+        root_post_id: root_post_id,
+        reply_post_id: reply_post_id,
+        at: DateTime.utc_now()
+      })
+    )
+  end
+
   @doc ~S(Convenience: a "liked your post" notification for the post's author.)
   def notify_like(author_id, liker, post_id) do
     Vutuv.Webhooks.emit(author_id, "post.liked", %{
@@ -414,8 +439,9 @@ defmodule Vutuv.Activity do
   The feed is derived straight from its source tables — followers
   (`follows`), endorsements (`user_tag_endorsements`, with the tag's name),
   connections (accepted `connections` rows, timestamped at acceptance) and
-  replies (`post_replies`, minus self-replies) — so it includes events from
-  before this feature existed.
+  replies (`post_replies`, minus self-replies; answers elsewhere in a thread
+  the user writes in surface as the separate "thread" kind) — so it includes
+  events from before this feature existed.
   Items mirror the live `notify_*` payload shape; ids are
   `"<kind>-<row id>"` strings, which keeps them out of the `"live-"` id
   namespace the LiveView uses for pushed events.
@@ -455,6 +481,7 @@ defmodule Vutuv.Activity do
       {"endorsement", &endorsement_items(user_id, &1, &2)},
       {"connection", &connection_items(user_id, &1, &2)},
       {"reply", &reply_items(user_id, &1, &2)},
+      {"thread", &thread_items(user_id, &1, &2)},
       {"like", &like_items(user_id, &1, &2)},
       {"organization_role", &organization_role_items(user_id, &1, &2)},
       {"moderation", &moderation_items(user_id, &1, &2)},
@@ -550,6 +577,7 @@ defmodule Vutuv.Activity do
       {"endorsement", count_endorsements(user_id, read_at)},
       {"connection", count_connections(user_id, read_at)},
       {"reply", count_replies(user_id, read_at)},
+      {"thread", count_thread_replies(user_id, read_at)},
       {"like", count_likes(user_id, read_at)},
       {"organization_role", count_organization_roles(user_id, read_at)},
       {"cv_update", count_cv_updates(user_id, read_at)},
@@ -663,6 +691,90 @@ defmodule Vutuv.Activity do
       |> Map.put(:post_id, parent_post_id)
       |> Map.put(:reply_post_id, reply_post_id)
     end)
+  end
+
+  # New replies elsewhere in threads the user writes in: every reply in a
+  # thread they rooted or answered in earlier — except their own replies and
+  # replies answering them directly (those are "reply" events, never both).
+  defp thread_items(user_id, limit, cursor) do
+    thread_replies(user_id)
+    |> join(:inner, [reply_post: reply], replier in User,
+      on: replier.id == reply.user_id,
+      as: :replier
+    )
+    |> order_by([thread_ref: r], desc: r.inserted_at, desc: r.id)
+    |> limit(^limit)
+    |> select(
+      [thread_ref: r, replier: replier],
+      {r.id, r.inserted_at, struct(replier, ^User.listing_fields()), r.root_post_id, r.post_id}
+    )
+    |> at_or_before(cursor)
+    |> Repo.all()
+    |> Enum.map(fn {id, at, replier, root_post_id, reply_post_id} ->
+      "thread-#{id}"
+      |> actor_item("thread", at, replier)
+      # The thread (grouping key) and the reply itself (the quote + link).
+      |> Map.put(:root_post_id, root_post_id)
+      |> Map.put(:reply_post_id, reply_post_id)
+    end)
+  end
+
+  # The base scope behind the "thread" kind, shared by items / count / read
+  # marker. A qualifying reply: sits in a thread (root known), is not the
+  # user's own, does not answer the user directly, its author has no block
+  # either way with the user, and the user had already written in the thread
+  # when it landed — they authored the root, or an earlier reply (replies from
+  # before they joined were on screen when they replied; not news).
+  defp thread_replies(user_id) do
+    from(r in PostReply,
+      as: :thread_ref,
+      join: reply in Post,
+      on: reply.id == r.post_id,
+      as: :reply_post,
+      where: not is_nil(r.root_post_id),
+      where: reply.user_id != ^user_id,
+      where: is_nil(r.parent_author_id) or r.parent_author_id != ^user_id,
+      where:
+        exists(
+          from(root in Post,
+            where: root.id == parent_as(:thread_ref).root_post_id and root.user_id == ^user_id,
+            select: 1
+          )
+        ) or
+          exists(
+            from(mine in PostReply,
+              join: mp in Post,
+              on: mp.id == mine.post_id,
+              where:
+                mine.root_post_id == parent_as(:thread_ref).root_post_id and
+                  mp.user_id == ^user_id and
+                  mine.inserted_at <= parent_as(:thread_ref).inserted_at,
+              select: 1
+            )
+          ),
+      where: reply.user_id not in subquery(blocked_either_way(user_id))
+    )
+  end
+
+  # Everyone with a block either way to `user_id`. Thread events are the one
+  # feed source whose actor needs no prior relation to the user (they answered
+  # a *third* participant), so a blocked member could otherwise surface here —
+  # the same exclusion the post feed applies. The "either direction" filter is
+  # owned by Vutuv.Social; this only adds the select returning the other
+  # party's id for the `NOT IN` subquery.
+  defp blocked_either_way(user_id) do
+    user_id
+    |> Vutuv.Social.blocks_involving()
+    |> select(
+      [b],
+      fragment(
+        "CASE WHEN ? = ? THEN ? ELSE ? END",
+        b.blocker_id,
+        type(^user_id, Vutuv.UUIDv7),
+        b.blocked_id,
+        b.blocker_id
+      )
+    )
   end
 
   # Likes on this user's posts, minus self-likes. Carries the liked post's id
@@ -940,6 +1052,12 @@ defmodule Vutuv.Activity do
       where: r.parent_author_id == ^user_id and reply.user_id != ^user_id,
       select: %{count: count()}
     )
+    |> since(read_at)
+  end
+
+  defp count_thread_replies(user_id, read_at) do
+    thread_replies(user_id)
+    |> select([thread_ref: r], %{count: count()})
     |> since(read_at)
   end
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -356,8 +356,18 @@ defmodule Vutuv.Posts do
     Repo.insert!(%PostReply{
       post_id: post.id,
       parent_post_id: parent.id,
-      parent_author_id: parent.user_id
+      parent_author_id: parent.user_id,
+      root_post_id: thread_root_id(parent)
     })
+  end
+
+  # The thread a reply lands in is its parent's thread; answering a top-level
+  # post starts the thread at that post. A degraded parent (a reply whose own
+  # root was deleted, root_post_id NULL) re-anchors the thread at the parent —
+  # the chain above it is gone anyway.
+  defp thread_root_id(%Post{} = parent) do
+    Repo.one(from(r in PostReply, where: r.post_id == ^parent.id, select: r.root_post_id)) ||
+      parent.id
   end
 
   # Claims each image row for the post (ownership and pending state are
@@ -2285,14 +2295,51 @@ defmodule Vutuv.Posts do
     broadcast_to_followers(repost.user_id, event)
   end
 
-  # A new reply ticks the parent's open action bars and notifies its author
-  # (self-replies are not news).
+  # A new reply ticks the parent's open action bars, notifies its author
+  # (self-replies are not news) and tells the thread's other participants.
   defp broadcast_reply(%Post{} = parent, %Post{} = reply) do
     broadcast_reply_count(parent.id)
 
     if parent.user_id != reply.user_id do
       Vutuv.Activity.notify_reply(parent.user_id, reply.user, parent.id, reply.id)
     end
+
+    notify_thread_participants(parent, reply)
+  end
+
+  # Everyone else who wrote in the thread gets the quieter "replied in a
+  # thread you posted in" push (the feed's "thread" kind): the root author
+  # and every earlier replier — minus the replier themselves, the directly
+  # answered author (notified above) and anyone with a block either way to
+  # the replier. Without this, an answer to a *third* participant was
+  # invisible to the rest of the thread (no badge, no feed entry).
+  defp notify_thread_participants(%Post{} = parent, %Post{} = reply) do
+    root_id = reply.reply_ref && reply.reply_ref.root_post_id
+
+    if root_id do
+      replier_ids =
+        Repo.all(
+          from(r in PostReply,
+            join: p in Post,
+            on: p.id == r.post_id,
+            where: r.root_post_id == ^root_id,
+            distinct: true,
+            select: p.user_id
+          )
+        )
+
+      root_author_id = Repo.one(from(p in Post, where: p.id == ^root_id, select: p.user_id))
+
+      [root_author_id | replier_ids]
+      |> Enum.uniq()
+      |> Enum.reject(
+        &(is_nil(&1) or &1 == reply.user_id or &1 == parent.user_id or
+            Vutuv.Social.blocked_between?(&1, reply.user_id))
+      )
+      |> Enum.each(&Vutuv.Activity.notify_thread_reply(&1, reply.user, root_id, reply.id))
+    end
+
+    :ok
   end
 
   @doc """

--- a/lib/vutuv/posts/post_reply.ex
+++ b/lib/vutuv/posts/post_reply.ex
@@ -11,6 +11,11 @@ defmodule Vutuv.Posts.PostReply do
     # banner-state encoding).
     belongs_to(:parent_post, Vutuv.Posts.Post)
     belongs_to(:parent_author, Vutuv.Accounts.User)
+    # The thread's top post, denormalized at creation (threading is otherwise
+    # only a parent-pointer chain) so "all replies in this thread" is one
+    # indexed lookup — the seam behind the thread-participation notifications.
+    # Nilifies with the root; NULL keeps the reply out of thread events.
+    belongs_to(:root_post, Vutuv.Posts.Post)
 
     timestamps()
   end

--- a/lib/vutuv_web/controllers/api_v2/notification_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/notification_controller.ex
@@ -3,8 +3,8 @@ defmodule VutuvWeb.ApiV2.NotificationController do
   The member's notification feed (`GET /api/2.0/notifications`, cursor-
   paginated, with the unread count) and the read marker (`POST
   /api/2.0/notifications/read`). The feed is `Vutuv.Activity`'s derived
-  feed: followers, endorsements, connections, replies, likes, moderation
-  notices — each entry names its kind and actor.
+  feed: followers, endorsements, connections, replies, thread answers, likes,
+  moderation notices — each entry names its kind and actor.
 
   Notifications span the social areas, so they ride on the social scopes:
   `social:read` to read, `social:write` to mark read.

--- a/lib/vutuv_web/live/notification_live/groups.ex
+++ b/lib/vutuv_web/live/notification_live/groups.ex
@@ -12,9 +12,11 @@ defmodule VutuvWeb.NotificationLive.Groups do
     * new **followers** - "Anna, Ben and 111 more are now following you."
     * new **connections** (mutual follows) - same day-bucket rule
     * one endorser's **endorsements** - "endorsed you for Elixir and Phoenix."
+    * **thread** events of the same thread - "Anna and Ben replied in a
+      thread you posted in."
 
-  Replies and every rarer kind (moderation, CV updates, handle changes, ...)
-  stay one row per event - each carries its own content.
+  Direct replies and every rarer kind (moderation, CV updates, handle
+  changes, ...) stay one row per event - each carries its own content.
 
   Everything here is a pure function over the item list, so the LiveView
   recomputes sections wholesale on every change (load more, live push,
@@ -88,6 +90,9 @@ defmodule VutuvWeb.NotificationLive.Groups do
   defp group_key(%{kind: "like", post_id: post_id}) when is_binary(post_id),
     do: {:like, post_id}
 
+  defp group_key(%{kind: "thread", root_post_id: root_id}) when is_binary(root_id),
+    do: {:thread, root_id}
+
   defp group_key(%{kind: "follower"}), do: :follower
   defp group_key(%{kind: "connection"}), do: :connection
   defp group_key(%{kind: "endorsement"} = item), do: {:endorsement, actor_key(item)}
@@ -112,6 +117,7 @@ defmodule VutuvWeb.NotificationLive.Groups do
 
   defp group_id({:single, id}, _day, _newest), do: id
   defp group_id({:like, post_id}, day, _newest), do: "like-#{post_id}-#{day_key(day)}"
+  defp group_id({:thread, root_id}, day, _newest), do: "thread-#{root_id}-#{day_key(day)}"
   defp group_id(:follower, day, _newest), do: "follower-#{day_key(day)}"
   defp group_id(:connection, day, _newest), do: "connection-#{day_key(day)}"
 

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -74,7 +74,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   # `kinds:` option keeps. "all" passes nil (every source).
   @filters %{
     "all" => nil,
-    "posts" => ~w(reply like),
+    "posts" => ~w(reply thread like),
     "people" => ~w(follower connection endorsement),
     "other" =>
       ~w(organization_role moderation image_rejected report_protection handle_change cv_update
@@ -419,9 +419,10 @@ defmodule VutuvWeb.NotificationLive.Index do
         />
 
         <%!-- A reply quotes the reply itself, under a one-line breadcrumb naming
-        the recipient's own post it answers. --%>
+        the recipient's own post it answers. A thread event carries no post of
+        the recipient's, so there only the reply quotes. --%>
         <div
-          :if={@group.kind == "reply" and (@n[:post_preview] || @n[:reply_preview])}
+          :if={@group.kind in ["reply", "thread"] and (@n[:post_preview] || @n[:reply_preview])}
           class="mt-1.5 space-y-1"
         >
           <.link
@@ -766,7 +767,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   # Event kinds that share the brand badge colour, so the class string lives
   # in one place.
   @brand_kind_classes "bg-brand-50 text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
-  @brand_kinds ~w(follower reply connection report_protection organization_role handle_change cv_update)
+  @brand_kinds ~w(follower reply thread connection report_protection organization_role handle_change cv_update)
 
   defp kind_classes("endorsement"),
     do: "bg-emerald-50 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-300"
@@ -787,6 +788,8 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp kind_glyph("follower"), do: "+"
   defp kind_glyph("endorsement"), do: "★"
   defp kind_glyph("reply"), do: "↩"
+  # A reply elsewhere in a thread the recipient writes in.
+  defp kind_glyph("thread"), do: "⤷"
   defp kind_glyph("like"), do: "♥"
   # "connection" is the vernetzt (mutual-follow) event; the handshake glyph.
   defp kind_glyph("connection"), do: "🤝"
@@ -805,6 +808,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp kind_label("follower"), do: gettext("Follower")
   defp kind_label("endorsement"), do: gettext("Endorsement")
   defp kind_label("reply"), do: gettext("Reply")
+  defp kind_label("thread"), do: gettext("Thread reply")
   defp kind_label("like"), do: gettext("Like")
   defp kind_label("connection"), do: gettext("Connection")
   defp kind_label("moderation"), do: gettext("Moderation")
@@ -839,7 +843,20 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp group_text(%{kind: "endorsement", tags: [_ | _] = tags}),
     do: gettext("endorsed you for %{tags}.", tags: join_names(tags))
 
+  defp group_text(%{kind: "thread", actor_count: count}), do: thread_text(count)
+
   defp group_text(%{item: item}), do: notification_text(item)
+
+  # The English tail is number-blind ("A and B replied in..."), but German
+  # conjugates the verb (hat/haben), so the actor count goes through ngettext
+  # even though both English forms read the same.
+  defp thread_text(count) do
+    ngettext(
+      "replied in a thread you posted in.",
+      "replied in a thread you posted in.",
+      count
+    )
+  end
 
   # "Elixir, Phoenix and Rails" - all but the last joined by commas, the last
   # by the localized joining word.
@@ -889,6 +906,16 @@ defmodule VutuvWeb.NotificationLive.Index do
     end
   end
 
+  # A thread event opens the new reply itself (on the replier's profile) —
+  # the thing the recipient has not read yet.
+  defp notification_target(%{kind: "thread"} = n, _viewer) do
+    if is_binary(n[:reply_post_id]) and is_binary(n[:actor_param]) do
+      ~p"/#{n.actor_param}/posts/#{n.reply_post_id}"
+    else
+      actor_target(n)
+    end
+  end
+
   defp notification_target(n, viewer) do
     primary_target(n, viewer) || actor_target(n)
   end
@@ -910,6 +937,9 @@ defmodule VutuvWeb.NotificationLive.Index do
   # stored) so it translates with the viewer's locale. Unknown kinds fall
   # back to the pushed text.
   defp notification_text(%{kind: "reply"}), do: gettext("replied to your post.")
+
+  # Live-pushed thread events land here (no group context yet): one actor.
+  defp notification_text(%{kind: "thread"}), do: thread_text(1)
 
   defp notification_text(%{kind: "organization_role"} = n) do
     case n[:role] do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.136.0",
+      version: "7.137.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -9,14 +9,14 @@
 msgid ""
 msgstr "Language: de\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:71
+#: lib/vutuv_web/controllers/page_controller.ex:72
 #: lib/vutuv_web/templates/layout/app.html.heex:93
 #, elixir-autogen
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:2877
-#: lib/vutuv_web/components/ui.ex:2882
+#: lib/vutuv_web/components/ui.ex:3024
+#: lib/vutuv_web/components/ui.ex:3029
 #: lib/vutuv_web/live/organization_live/domains.ex:235
 #: lib/vutuv_web/live/organization_live/edit.ex:382
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -32,9 +32,10 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/live/cv_live.ex:110
 #: lib/vutuv_web/live/organization_live/show.ex:350
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
+#: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1154
+#: lib/vutuv_web/templates/user/show.html.heex:1159
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -58,7 +59,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3022
+#: lib/vutuv_web/components/ui.ex:3169
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -71,13 +72,13 @@ msgstr "Eine Adresse wurde geändert."
 msgid "Addresses"
 msgstr "Adressen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:171
+#: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:2682
-#: lib/vutuv_web/components/ui.ex:2776
+#: lib/vutuv_web/components/ui.ex:2829
+#: lib/vutuv_web/components/ui.ex:2923
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #, elixir-autogen
 msgid "Are you sure?"
@@ -88,22 +89,22 @@ msgstr "Sind Sie sicher?"
 msgid "Avatar"
 msgstr "Avatar"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:292
+#: lib/vutuv_web/templates/user/edit.html.heex:333
 #, elixir-autogen
 msgid "Birthdate"
 msgstr "Geburtstag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:422
-#: lib/vutuv_web/agent_docs/markdown.ex:423
-#: lib/vutuv_web/agent_docs/text.ex:425
-#: lib/vutuv_web/agent_docs/text.ex:426
-#: lib/vutuv_web/templates/user/show.html.heex:819
+#: lib/vutuv_web/agent_docs/markdown.ex:424
+#: lib/vutuv_web/agent_docs/markdown.ex:425
+#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/agent_docs/text.ex:428
+#: lib/vutuv_web/templates/user/show.html.heex:824
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:2675
+#: lib/vutuv_web/components/ui.ex:2822
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -118,8 +119,8 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:25
 #: lib/vutuv_web/templates/user/edit.html.heex:50
 #: lib/vutuv_web/templates/user/edit.html.heex:103
-#: lib/vutuv_web/templates/user/edit.html.heex:347
-#: lib/vutuv_web/templates/user/edit.html.heex:382
+#: lib/vutuv_web/templates/user/edit.html.heex:388
+#: lib/vutuv_web/templates/user/edit.html.heex:423
 #, elixir-autogen
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -141,7 +142,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:13
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:857
+#: lib/vutuv_web/templates/user/show.html.heex:862
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -151,7 +152,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr "Konnte nicht zu %{name} zurückfolgen."
 
 #: lib/vutuv_web/components/post_components.ex:816
-#: lib/vutuv_web/components/ui.ex:2779
+#: lib/vutuv_web/components/ui.ex:2926
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -190,14 +191,14 @@ msgstr "Inaktivieren"
 
 #: lib/vutuv_web/live/cv_live.ex:398
 #: lib/vutuv_web/templates/export/index.html.heex:41
-#: lib/vutuv_web/templates/user/show.html.heex:273
+#: lib/vutuv_web/templates/user/show.html.heex:278
 #: lib/vutuv_web/views/qualification_html.ex:237
 #, elixir-autogen
 msgid "Download"
 msgstr "Download"
 
 #: lib/vutuv_web/components/post_components.ex:809
-#: lib/vutuv_web/components/ui.ex:2770
+#: lib/vutuv_web/components/ui.ex:2917
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -219,7 +220,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/url/edit.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:842
+#: lib/vutuv_web/templates/user/show.html.heex:847
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #, elixir-autogen
 msgid "Edit"
@@ -278,29 +279,29 @@ msgstr "Empfehlung eingetragen."
 msgid "English"
 msgstr "Englisch"
 
-#: lib/vutuv_web/templates/page/index.html.heex:114
+#: lib/vutuv_web/templates/page/index.html.heex:117
 #: lib/vutuv_web/templates/session/new.html.heex:37
 #, elixir-autogen
 msgid "Enter your email address"
 msgstr "E-Mail-Adresse eingeben"
 
-#: lib/vutuv_web/templates/page/index.html.heex:75
+#: lib/vutuv_web/templates/page/index.html.heex:78
 #, elixir-autogen
 msgid "Enter your first name"
 msgstr "Vorname eingeben"
 
-#: lib/vutuv_web/templates/page/index.html.heex:79
+#: lib/vutuv_web/templates/page/index.html.heex:82
 #, elixir-autogen
 msgid "Enter your last name"
 msgstr "Nachname eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3013
+#: lib/vutuv_web/components/ui.ex:3160
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:489
+#: lib/vutuv_web/templates/user/show.html.heex:494
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:3
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -320,43 +321,43 @@ msgstr "Fax"
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:434
-#: lib/vutuv_web/agent_docs/text.ex:437
+#: lib/vutuv_web/agent_docs/markdown.ex:436
+#: lib/vutuv_web/agent_docs/text.ex:439
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/notification_live/index.ex:646
+#: lib/vutuv_web/live/notification_live/index.ex:759
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
 #, elixir-autogen
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:435
-#: lib/vutuv_web/agent_docs/text.ex:438
-#: lib/vutuv_web/components/ui.ex:1413
-#: lib/vutuv_web/components/ui.ex:1438
-#: lib/vutuv_web/components/ui.ex:1441
-#: lib/vutuv_web/components/ui.ex:1448
-#: lib/vutuv_web/components/ui.ex:1451
-#: lib/vutuv_web/components/ui.ex:1509
+#: lib/vutuv_web/agent_docs/markdown.ex:437
+#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/components/ui.ex:1551
+#: lib/vutuv_web/components/ui.ex:1576
+#: lib/vutuv_web/components/ui.ex:1579
+#: lib/vutuv_web/components/ui.ex:1586
+#: lib/vutuv_web/components/ui.ex:1589
+#: lib/vutuv_web/components/ui.ex:1647
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:767
+#: lib/vutuv_web/templates/user/show.html.heex:772
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:421
-#: lib/vutuv_web/agent_docs/text.ex:424
+#: lib/vutuv_web/agent_docs/markdown.ex:423
+#: lib/vutuv_web/agent_docs/text.ex:426
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
 #: lib/vutuv_web/cv/odt.ex:109
 #: lib/vutuv_web/live/cv_live.ex:113
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
-#: lib/vutuv_web/templates/page/index.html.heex:62
+#: lib/vutuv_web/templates/page/index.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:814
+#: lib/vutuv_web/templates/user/show.html.heex:819
 #, elixir-autogen
 msgid "Gender"
 msgstr "Geschlecht"
@@ -417,7 +418,7 @@ msgstr "Link wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:52
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:3017
+#: lib/vutuv_web/components/ui.ex:3164
 #: lib/vutuv_web/controllers/url_controller.ex:23
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
@@ -467,8 +468,8 @@ msgstr "Einloggen"
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
-#: lib/vutuv_web/components/ui.ex:3033
-#: lib/vutuv_web/live/notification_live/index.ex:558
+#: lib/vutuv_web/components/ui.ex:3180
+#: lib/vutuv_web/live/notification_live/index.ex:683
 #, elixir-autogen
 msgid "More"
 msgstr "Mehr"
@@ -485,7 +486,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:435
+#: lib/vutuv_web/live/notification_live/index.ex:486
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/templates/access_token/new.html.heex:1
 #: lib/vutuv_web/templates/ad/new.html.heex:3
@@ -607,6 +608,7 @@ msgstr "Datenschutzerklärung"
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
 #: lib/vutuv_web/views/phone_number_html.ex:15
+#: lib/vutuv_web/views/welcome_html.ex:37
 #, elixir-autogen
 msgid "Private"
 msgstr "Privat"
@@ -649,10 +651,10 @@ msgstr "Öffentlich (für alle sichtbar) oder Privat (nur für Sie sichtbar)"
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
-#: lib/vutuv_web/templates/settings/preferences.html.heex:180
+#: lib/vutuv_web/templates/settings/preferences.html.heex:205
 #: lib/vutuv_web/templates/settings/privacy.html.heex:64
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
-#: lib/vutuv_web/templates/user/edit.html.heex:342
+#: lib/vutuv_web/templates/user/edit.html.heex:383
 #: lib/vutuv_web/views/settings_html.ex:131
 #, elixir-autogen
 msgid "Save"
@@ -680,7 +682,7 @@ msgstr "Suche"
 msgid "Show"
 msgstr "Anzeigen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:150
+#: lib/vutuv_web/templates/page/index.html.heex:153
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr "Gratis Account erstellen"
@@ -693,7 +695,7 @@ msgstr "Slug"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:55
 #: lib/vutuv_web/agent_docs/text.ex:52
-#: lib/vutuv_web/components/ui.ex:3018
+#: lib/vutuv_web/components/ui.ex:3165
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
@@ -706,13 +708,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:968
+#: lib/vutuv_web/templates/user/show.html.heex:973
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:970
+#: lib/vutuv_web/templates/user/show.html.heex:975
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -762,7 +764,7 @@ msgstr "Code & Repositorys"
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
 
-#: lib/vutuv_web/components/ui.ex:2676
+#: lib/vutuv_web/components/ui.ex:2823
 #, elixir-autogen
 msgid "Submit"
 msgstr "Absenden"
@@ -817,6 +819,7 @@ msgstr "User wurde verifiziert."
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
+#: lib/vutuv_web/live/notification_live/index.ex:820
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
 #: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:5
@@ -850,7 +853,7 @@ msgstr "Benutzername"
 #: lib/vutuv_web/templates/url/index.html.heex:8
 #: lib/vutuv_web/templates/url/show.html.heex:4
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:2
-#: lib/vutuv_web/templates/user_tag/index.html.heex:15
+#: lib/vutuv_web/templates/user_tag/index.html.heex:24
 #: lib/vutuv_web/templates/user_tag/show.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:8
 #: lib/vutuv_web/templates/work_experience/show.html.heex:4
@@ -859,14 +862,14 @@ msgid "Users"
 msgstr "Benutzer"
 
 #: lib/vutuv_web/components/ui.ex:581
-#: lib/vutuv_web/templates/user/show.html.heex:279
+#: lib/vutuv_web/templates/user/show.html.heex:284
 #, elixir-autogen
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:2840
-#: lib/vutuv_web/templates/user/show.html.heex:761
-#: lib/vutuv_web/templates/user/show.html.heex:781
+#: lib/vutuv_web/components/ui.ex:2987
+#: lib/vutuv_web/templates/user/show.html.heex:766
+#: lib/vutuv_web/templates/user/show.html.heex:786
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
@@ -883,22 +886,22 @@ msgstr "Sichtbarkeit"
 msgid "We can't find em' cap'n!"
 msgstr "Nichts zu finden, Käpt'n!"
 
-#: lib/vutuv_web/templates/page/index.html.heex:174
+#: lib/vutuv_web/templates/page/index.html.heex:177
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
 "Wir behalten uns das Recht vor, Accounts ohne Warnung zu löschen oder den "
 "Dienst einzustellen."
 
-#: lib/vutuv_web/controllers/session_controller.ex:436
+#: lib/vutuv_web/controllers/session_controller.ex:459
 #, elixir-autogen
 msgid "Welcome back!"
 msgstr "Willkommen zurück!"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/email_html.ex:11
 #: lib/vutuv_web/views/phone_number_html.ex:17
+#: lib/vutuv_web/views/welcome_html.ex:37
 #, elixir-autogen
 msgid "Work"
 msgstr "Arbeit"
@@ -964,12 +967,12 @@ msgstr "unserem Blog"
 msgid "An email has been sent to your email address with instructions on how to delete your account."
 msgstr "Eine E-Mail mit einem Löschlink wurde gerade an Sie verschickt."
 
-#: lib/vutuv_web/templates/page/index.html.heex:122
+#: lib/vutuv_web/templates/page/index.html.heex:125
 #, elixir-autogen
 msgid "Allow others to view your email address"
 msgstr "Diese E-Mail-Adresse soll auf meinem Profil öffentlich sichtbar sein."
 
-#: lib/vutuv_web/templates/page/index.html.heex:160
+#: lib/vutuv_web/templates/page/index.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1058,14 +1061,14 @@ msgstr "Wählen Sie einen Monat"
 msgid "Select a year"
 msgstr "Wählen Sie ein Jahr"
 
-#: lib/vutuv/accounts/user.ex:740
+#: lib/vutuv/accounts/user.ex:884
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr "Frau"
 
-#: lib/vutuv/accounts/user.ex:739
+#: lib/vutuv/accounts/user.ex:883
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1132,7 +1135,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:803
+#: lib/vutuv_web/templates/user/show.html.heex:808
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1172,7 +1175,7 @@ msgstr "vutuv Login-PIN"
 msgid "Listings"
 msgstr "Listen"
 
-#: lib/vutuv_web/controllers/page_controller.ex:182
+#: lib/vutuv_web/controllers/page_controller.ex:183
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1316,7 +1319,7 @@ msgstr "Alle Tag-URLs"
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:483
+#: lib/vutuv_web/templates/user/show.html.heex:488
 #, elixir-autogen
 msgid "All tags"
 msgstr "Alle Tags"
@@ -1488,13 +1491,13 @@ msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
 #: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/agent_docs/markdown.ex:793
+#: lib/vutuv_web/agent_docs/markdown.ex:795
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:393
-#: lib/vutuv_web/agent_docs/text.ex:568
-#: lib/vutuv_web/components/ui.ex:3023
-#: lib/vutuv_web/controllers/user_tag_controller.ex:38
-#: lib/vutuv_web/controllers/user_tag_controller.ex:55
+#: lib/vutuv_web/agent_docs/text.ex:570
+#: lib/vutuv_web/components/ui.ex:3170
+#: lib/vutuv_web/controllers/user_tag_controller.ex:39
+#: lib/vutuv_web/controllers/user_tag_controller.ex:56
 #: lib/vutuv_web/cv/docx.ex:174
 #: lib/vutuv_web/cv/html.ex:159
 #: lib/vutuv_web/cv/latex.ex:131
@@ -1517,9 +1520,9 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:453
+#: lib/vutuv_web/templates/user/show.html.heex:458
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
-#: lib/vutuv_web/templates/user_tag/index.html.heex:17
+#: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
 #, elixir-autogen
@@ -1527,7 +1530,7 @@ msgid "Tags"
 msgstr "Tags"
 
 #: lib/vutuv_web/controllers/email_controller.ex:156
-#: lib/vutuv_web/controllers/session_controller.ex:395
+#: lib/vutuv_web/controllers/session_controller.ex:433
 #: lib/vutuv_web/controllers/user_controller.ex:311
 #, elixir-autogen
 msgid "Too many incorrect attempts."
@@ -1649,7 +1652,7 @@ msgstr "Empfehlung zurückgenommen."
 msgid "User tag created successfully."
 msgstr "Tag erfolgreich hinzugefügt."
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:134
+#: lib/vutuv_web/controllers/user_tag_controller.ex:144
 #, elixir-autogen
 msgid "User tag deleted successfully."
 msgstr "Ein Tag wurde gelöscht."
@@ -1685,11 +1688,13 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/new.ex:127
 #: lib/vutuv_web/templates/ad/new.html.heex:111
 #: lib/vutuv_web/templates/address/country_input.html.heex:2
+#: lib/vutuv_web/templates/welcome/show.html.heex:81
 #, elixir-autogen
 msgid "Country"
 msgstr "Land"
 
-#: lib/vutuv_web/templates/address/country_input.html.heex:5
+#: lib/vutuv_web/templates/address/country_input.html.heex:6
+#: lib/vutuv_web/templates/welcome/show.html.heex:83
 #, elixir-autogen
 msgid "Select a Country"
 msgstr "Land auswählen"
@@ -1757,17 +1762,17 @@ msgstr "Bestätigen"
 msgid "Confirm account deletion"
 msgstr "Kontolöschung bestätigen"
 
-#: lib/vutuv_web/controllers/page_controller.ex:75
+#: lib/vutuv_web/controllers/page_controller.ex:76
 #: lib/vutuv_web/templates/layout/app.html.heex:89
-#: lib/vutuv_web/templates/page/index.html.heex:167
+#: lib/vutuv_web/templates/page/index.html.heex:170
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr "Datenschutzerklärung"
 
-#: lib/vutuv_web/controllers/page_controller.ex:81
+#: lib/vutuv_web/controllers/page_controller.ex:82
 #: lib/vutuv_web/templates/layout/app.html.heex:91
-#: lib/vutuv_web/templates/page/index.html.heex:167
+#: lib/vutuv_web/templates/page/index.html.heex:170
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1785,23 +1790,23 @@ msgstr "Mein Konto löschen"
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
-#: lib/vutuv_web/components/ui.ex:950
-#: lib/vutuv_web/components/ui.ex:959
-#: lib/vutuv_web/components/ui.ex:1260
+#: lib/vutuv_web/components/ui.ex:976
+#: lib/vutuv_web/components/ui.ex:985
+#: lib/vutuv_web/components/ui.ex:1378
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Empfehlen"
 
-#: lib/vutuv_web/components/ui.ex:1378
-#: lib/vutuv_web/components/ui.ex:1378
-#: lib/vutuv_web/components/ui.ex:1395
-#: lib/vutuv_web/components/ui.ex:1404
-#: lib/vutuv_web/components/ui.ex:1420
-#: lib/vutuv_web/components/ui.ex:1457
-#: lib/vutuv_web/components/ui.ex:1460
-#: lib/vutuv_web/components/ui.ex:1467
-#: lib/vutuv_web/components/ui.ex:1470
-#: lib/vutuv_web/components/ui.ex:1543
+#: lib/vutuv_web/components/ui.ex:1516
+#: lib/vutuv_web/components/ui.ex:1516
+#: lib/vutuv_web/components/ui.ex:1533
+#: lib/vutuv_web/components/ui.ex:1542
+#: lib/vutuv_web/components/ui.ex:1558
+#: lib/vutuv_web/components/ui.ex:1595
+#: lib/vutuv_web/components/ui.ex:1598
+#: lib/vutuv_web/components/ui.ex:1605
+#: lib/vutuv_web/components/ui.ex:1608
+#: lib/vutuv_web/components/ui.ex:1681
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1856,21 +1861,21 @@ msgid "Network"
 msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:285
-#: lib/vutuv_web/components/ui.ex:2879
+#: lib/vutuv_web/components/ui.ex:3026
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr "Hier gibt es noch nichts."
 
-#: lib/vutuv_web/live/notification_live/index.ex:277
+#: lib/vutuv_web/live/notification_live/index.ex:305
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
-#: lib/vutuv_web/components/ui.ex:3037
-#: lib/vutuv_web/live/notification_live/index.ex:81
-#: lib/vutuv_web/live/notification_live/index.ex:245
+#: lib/vutuv_web/components/ui.ex:3184
+#: lib/vutuv_web/live/notification_live/index.ex:103
+#: lib/vutuv_web/live/notification_live/index.ex:268
 #: lib/vutuv_web/live/shell_live.ex:447
 #: lib/vutuv_web/templates/layout/app.html.heex:118
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -1914,7 +1919,7 @@ msgid "Submit a bug report or feature request"
 msgstr "Fehler melden oder Feature vorschlagen"
 
 #: lib/vutuv_web/agent_docs/section_docs.ex:106
-#: lib/vutuv_web/templates/user_tag/index.html.heex:12
+#: lib/vutuv_web/templates/user_tag/index.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Tags of %{name}"
 msgstr "Tags von %{name}"
@@ -1964,7 +1969,7 @@ msgstr ""
 "unten ein, um die Adresse zu bestätigen."
 
 #: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1238
+#: lib/vutuv_web/templates/user/show.html.heex:1247
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
@@ -1983,14 +1988,14 @@ msgstr "Ihre Anmeldung ist abgelaufen. Bitte versuchen Sie es erneut."
 
 #: lib/vutuv_web/open_graph.ex:256
 #: lib/vutuv_web/templates/tag/show.html.heex:13
-#: lib/vutuv_web/templates/user/show.html.heex:248
+#: lib/vutuv_web/templates/user/show.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] "Follower"
 msgstr[1] "Follower"
 
-#: lib/vutuv_web/templates/user/show.html.heex:252
+#: lib/vutuv_web/templates/user/show.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr "folgt"
@@ -2000,35 +2005,29 @@ msgstr "folgt"
 msgid "submit a bug report"
 msgstr "einen Fehlerbericht erstellen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:722
+#: lib/vutuv_web/live/notification_live/index.ex:841
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr "hat Sie für %{tag} empfohlen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:717
+#: lib/vutuv_web/live/notification_live/index.ex:836
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr "ist jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:712
+#: lib/vutuv_web/live/notification_live/index.ex:831
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2416
+#: lib/vutuv_web/components/ui.ex:2409
+#: lib/vutuv_web/components/ui.ex:2560
 #: lib/vutuv_web/live/organization_live/index.ex:130
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Seitennavigation"
 
-#: lib/vutuv_web/live/notification_live/index.ex:627
-#, elixir-autogen, elixir-format
-msgid "Load %{count} of %{remaining} more"
-msgstr "%{count} von %{remaining} mehr laden"
-
-#: lib/vutuv_web/components/ui.ex:2904
-#: lib/vutuv_web/live/notification_live/index.ex:624
+#: lib/vutuv_web/components/ui.ex:3051
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Mehr laden"
@@ -2040,7 +2039,7 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:2685
+#: lib/vutuv_web/components/ui.ex:2832
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
@@ -2085,12 +2084,12 @@ msgstr "Titelbild hinzufügen"
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:2034
+#: lib/vutuv_web/components/ui.ex:2172
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
-#: lib/vutuv_web/components/ui.ex:2038
+#: lib/vutuv_web/components/ui.ex:2176
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
@@ -2115,37 +2114,37 @@ msgstr "Titelbild"
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:2042
+#: lib/vutuv_web/components/ui.ex:2180
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
-#: lib/vutuv_web/components/ui.ex:2032
+#: lib/vutuv_web/components/ui.ex:2170
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
-#: lib/vutuv_web/components/ui.ex:2031
+#: lib/vutuv_web/components/ui.ex:2169
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
-#: lib/vutuv_web/components/ui.ex:2037
+#: lib/vutuv_web/components/ui.ex:2175
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
-#: lib/vutuv_web/components/ui.ex:2036
+#: lib/vutuv_web/components/ui.ex:2174
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
-#: lib/vutuv_web/components/ui.ex:2033
+#: lib/vutuv_web/components/ui.ex:2171
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
-#: lib/vutuv_web/components/ui.ex:2035
+#: lib/vutuv_web/components/ui.ex:2173
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
@@ -2160,17 +2159,17 @@ msgstr "Mitglied seit %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
-#: lib/vutuv_web/components/ui.ex:2041
+#: lib/vutuv_web/components/ui.ex:2179
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
-#: lib/vutuv_web/components/ui.ex:2040
+#: lib/vutuv_web/components/ui.ex:2178
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
-#: lib/vutuv_web/components/ui.ex:2039
+#: lib/vutuv_web/components/ui.ex:2177
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "September"
@@ -2312,13 +2311,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:73
-#: lib/vutuv_web/gettext_extraction_anchors.ex:77
+#: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/notification_live/index.ex:556
+#: lib/vutuv_web/live/notification_live/index.ex:681
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:179
 #: lib/vutuv_web/live/search_live.ex:375
-#: lib/vutuv_web/templates/settings/preferences.html.heex:114
+#: lib/vutuv_web/templates/settings/preferences.html.heex:118
 #: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2404,7 +2403,7 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:3210
+#: lib/vutuv_web/components/ui.ex:3357
 #: lib/vutuv_web/live/shell_live.ex:490
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2474,7 +2473,7 @@ msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
 msgid "Posts by %{name}"
 msgstr "Beiträge von %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:443
+#: lib/vutuv_web/templates/user/show.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr "Alle %{count} Beiträge ansehen"
@@ -2485,15 +2484,15 @@ msgid "All posts"
 msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:1911
-#: lib/vutuv_web/components/ui.ex:1738
-#: lib/vutuv_web/components/ui.ex:1738
-#: lib/vutuv_web/components/ui.ex:2346
+#: lib/vutuv_web/components/ui.ex:1876
+#: lib/vutuv_web/components/ui.ex:1876
+#: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:825
+#: lib/vutuv_web/agent_docs/markdown.ex:827
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:429
@@ -2504,17 +2503,17 @@ msgid "Bookmarks"
 msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:1878
-#: lib/vutuv_web/components/ui.ex:1767
-#: lib/vutuv_web/components/ui.ex:1767
-#: lib/vutuv_web/components/ui.ex:2332
-#: lib/vutuv_web/live/notification_live/index.ex:694
+#: lib/vutuv_web/components/ui.ex:1905
+#: lib/vutuv_web/components/ui.ex:1905
+#: lib/vutuv_web/components/ui.ex:2470
+#: lib/vutuv_web/live/notification_live/index.ex:812
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:824
-#: lib/vutuv_web/live/notification_live/index.ex:648
+#: lib/vutuv_web/agent_docs/markdown.ex:826
+#: lib/vutuv_web/live/notification_live/index.ex:761
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:498
@@ -2539,8 +2538,8 @@ msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
 #: lib/vutuv_web/components/post_components.ex:1911
-#: lib/vutuv_web/components/ui.ex:1728
-#: lib/vutuv_web/components/ui.ex:1728
+#: lib/vutuv_web/components/ui.ex:1866
+#: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2564,24 +2563,24 @@ msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
 #: lib/vutuv_web/components/post_components.ex:1878
-#: lib/vutuv_web/components/ui.ex:1757
-#: lib/vutuv_web/components/ui.ex:1757
+#: lib/vutuv_web/components/ui.ex:1895
+#: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
-#: lib/vutuv_web/components/ui.ex:1373
-#: lib/vutuv_web/components/ui.ex:1373
-#: lib/vutuv_web/components/ui.ex:1510
+#: lib/vutuv_web/components/ui.ex:1511
+#: lib/vutuv_web/components/ui.ex:1511
+#: lib/vutuv_web/components/ui.ex:1648
 #: lib/vutuv_web/live/post_live/feed.ex:665
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr "Entfolgen"
 
-#: lib/vutuv_web/controllers/session_controller.ex:416
+#: lib/vutuv_web/views/welcome_html.ex:28
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
@@ -2594,7 +2593,7 @@ msgstr "Nur öffentliche Beiträge können beantwortet werden."
 #: lib/vutuv_web/agent_docs/markdown.ex:109
 #: lib/vutuv_web/agent_docs/text.ex:105
 #: lib/vutuv_web/components/post_components.ex:274
-#: lib/vutuv_web/live/notification_live/index.ex:649
+#: lib/vutuv_web/live/notification_live/index.ex:762
 #: lib/vutuv_web/templates/post/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Replies"
@@ -2602,7 +2601,7 @@ msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:1934
 #: lib/vutuv_web/components/post_components.ex:1935
-#: lib/vutuv_web/live/notification_live/index.ex:693
+#: lib/vutuv_web/live/notification_live/index.ex:810
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2628,7 +2627,7 @@ msgstr ""
 "Dieser Beitrag wurde repostet oder beantwortet. Er bleibt öffentlich, "
 "solange Reposts oder Antworten existieren; löschen können Sie ihn jederzeit."
 
-#: lib/vutuv_web/live/notification_live/index.ex:793
+#: lib/vutuv_web/live/notification_live/index.ex:939
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
@@ -2704,7 +2703,7 @@ msgstr "Mitglied nicht gefunden."
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
-#: lib/vutuv_web/components/ui.ex:1910
+#: lib/vutuv_web/components/ui.ex:2048
 #: lib/vutuv_web/live/message_live/index.ex:596
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2780,13 +2779,13 @@ msgstr ""
 "„Genervt von LinkedIn und Ihre Daten sollen in Deutschland bleiben? Da kann"
 " ich helfen.“"
 
-#: lib/vutuv_web/templates/page/index.html.heex:140
+#: lib/vutuv_web/templates/page/index.html.heex:143
 #: lib/vutuv_web/templates/settings/privacy.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
 msgstr "Suchmaschinen dürfen dieses Profil indizieren"
 
-#: lib/vutuv_web/controllers/session_controller.ex:433
+#: lib/vutuv_web/controllers/session_controller.ex:456
 #, elixir-autogen, elixir-format
 msgid "Welcome back, %{name}!"
 msgstr "Willkommen zurück, %{name}!"
@@ -2817,73 +2816,73 @@ msgid "Use a different email address"
 msgstr "Andere E-Mail-Adresse verwenden"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:693
+#: lib/vutuv_web/templates/user/show.html.heex:698
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:931
+#: lib/vutuv_web/templates/user/show.html.heex:936
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1156
+#: lib/vutuv_web/templates/user/show.html.heex:1161
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:859
+#: lib/vutuv_web/templates/user/show.html.heex:864
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:805
+#: lib/vutuv_web/templates/user/show.html.heex:810
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:492
+#: lib/vutuv_web/templates/user/show.html.heex:497
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
 #: lib/vutuv_web/live/user_profile_live.ex:965
-#: lib/vutuv_web/templates/user/show.html.heex:395
+#: lib/vutuv_web/templates/user/show.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:2477
-#: lib/vutuv_web/components/ui.ex:2842
+#: lib/vutuv_web/components/ui.ex:2624
+#: lib/vutuv_web/components/ui.ex:2989
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
 #: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
-#: lib/vutuv_web/templates/user/show.html.heex:483
+#: lib/vutuv_web/templates/user/show.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Verwalten"
 
 #: lib/vutuv_web/live/post_live/feed.ex:564
-#: lib/vutuv_web/templates/user/show.html.heex:395
+#: lib/vutuv_web/templates/user/show.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr "Beitrag schreiben"
 
-#: lib/vutuv_web/views/user_helpers.ex:103
+#: lib/vutuv_web/views/user_helpers.ex:117
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] "%{count} Tag hinzugefügt."
 msgstr[1] "%{count} Tags hinzugefügt."
 
-#: lib/vutuv_web/views/user_helpers.ex:107
+#: lib/vutuv_web/views/user_helpers.ex:121
 #, elixir-autogen, elixir-format
 msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
 msgstr ""
@@ -2904,10 +2903,10 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 weiteres Tag"
 msgstr[1] "+%{formatted} weitere Tags"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:436
-#: lib/vutuv_web/agent_docs/text.ex:439
+#: lib/vutuv_web/agent_docs/markdown.ex:438
+#: lib/vutuv_web/agent_docs/text.ex:441
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:647
+#: lib/vutuv_web/live/notification_live/index.ex:760
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2943,7 +2942,7 @@ msgstr "Nur Text"
 msgid "This post is for the connections of %{name}"
 msgstr "Dieser Beitrag ist für die Vernetzungen von %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:261
+#: lib/vutuv_web/templates/user/show.html.heex:266
 #: lib/vutuv_web/views/admin/moderation_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "connection"
@@ -2961,35 +2960,35 @@ msgstr "Personen, mit denen Sie nicht vernetzt sind"
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:702
+#: lib/vutuv_web/live/notification_live/index.ex:821
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:695
+#: lib/vutuv_web/live/notification_live/index.ex:813
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:692
+#: lib/vutuv_web/live/notification_live/index.ex:809
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:691
-#: lib/vutuv_web/templates/user/show.html.heex:748
+#: lib/vutuv_web/live/notification_live/index.ex:808
+#: lib/vutuv_web/templates/user/show.html.heex:753
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
 msgstr[0] "Follower"
 msgstr[1] "Follower"
 
-#: lib/vutuv_web/controllers/session_controller.ex:412
+#: lib/vutuv_web/views/welcome_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Willkommen bei vutuv, %{name}!"
 
-#: lib/vutuv_web/live/notification_live/index.ex:719
+#: lib/vutuv_web/live/notification_live/index.ex:838
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr "gefällt Ihr Beitrag."
@@ -3021,12 +3020,12 @@ msgstr "(gelöschtes Konto)"
 msgid "(no text)"
 msgstr "(kein Text)"
 
-#: lib/vutuv_web/live/notification_live/index.ex:815
+#: lib/vutuv_web/live/notification_live/index.ex:964
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde bestätigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:816
+#: lib/vutuv_web/live/notification_live/index.ex:965
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
@@ -3058,7 +3057,7 @@ msgstr "Mobbing oder Belästigung"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:280
 #: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/controllers/page_controller.ex:54
+#: lib/vutuv_web/controllers/page_controller.ex:55
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
@@ -3141,7 +3140,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:696
+#: lib/vutuv_web/live/notification_live/index.ex:814
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3224,8 +3223,8 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:899
-#: lib/vutuv_web/templates/user/show.html.heex:900
+#: lib/vutuv_web/templates/user/show.html.heex:904
+#: lib/vutuv_web/templates/user/show.html.heex:905
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
@@ -3285,7 +3284,7 @@ msgstr ""
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/components/ui.ex:3010
+#: lib/vutuv_web/components/ui.ex:3157
 #: lib/vutuv_web/live/shell_live.ex:382
 #: lib/vutuv_web/live/shell_live.ex:583
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3397,7 +3396,7 @@ msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:2246
+#: lib/vutuv_web/components/ui.ex:2384
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3513,13 +3512,13 @@ msgstr ""
 "erhält einen Verwarnungspunkt (verwarnen, sperren, deaktivieren)."
 
 #: lib/vutuv_web/controllers/session_controller.ex:270
-#: lib/vutuv_web/controllers/session_controller.ex:384
+#: lib/vutuv_web/controllers/session_controller.ex:387
 #, elixir-autogen, elixir-format
 msgid "This account has been deactivated."
 msgstr "Dieses Konto wurde deaktiviert."
 
 #: lib/vutuv_web/controllers/session_controller.ex:261
-#: lib/vutuv_web/controllers/session_controller.ex:375
+#: lib/vutuv_web/controllers/session_controller.ex:378
 #, elixir-autogen, elixir-format
 msgid "This account is suspended until %{date}."
 msgstr "Dieses Konto ist bis zum %{date} gesperrt."
@@ -3598,12 +3597,12 @@ msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
 
-#: lib/vutuv_web/live/notification_live/index.ex:818
+#: lib/vutuv_web/live/notification_live/index.ex:967
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt gelöscht; der Fall ist abgeschlossen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:817
+#: lib/vutuv_web/live/notification_live/index.ex:966
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
@@ -3613,7 +3612,7 @@ msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
 msgid "Your content was reported"
 msgstr "Ihr Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/live/notification_live/index.ex:819
+#: lib/vutuv_web/live/notification_live/index.ex:968
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3651,17 +3650,17 @@ msgstr ""
 msgid "yes"
 msgstr "ja"
 
-#: lib/vutuv/notifications/emailer.ex:826
+#: lib/vutuv/notifications/emailer.ex:832
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr "Eine Verwarnung für Ihr vutuv-Konto"
 
-#: lib/vutuv/notifications/emailer.ex:910
+#: lib/vutuv/notifications/emailer.ex:916
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr "Moderation: %{count} Fälle warten"
 
-#: lib/vutuv/notifications/emailer.ex:888
+#: lib/vutuv/notifications/emailer.ex:894
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr "Moderation: Ein Profil wurde gemeldet"
@@ -3681,12 +3680,12 @@ msgstr "Ihr Inhalt auf vutuv wird geprüft"
 msgid "Your content on vutuv was reported and is hidden"
 msgstr "Ihr Inhalt auf vutuv wurde gemeldet und ist verborgen"
 
-#: lib/vutuv/notifications/emailer.ex:840
+#: lib/vutuv/notifications/emailer.ex:846
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr "Ihr vutuv-Konto wurde deaktiviert"
 
-#: lib/vutuv/notifications/emailer.ex:833
+#: lib/vutuv/notifications/emailer.ex:839
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr "Ihr vutuv-Konto ist gesperrt"
@@ -3815,7 +3814,7 @@ msgstr "Verlauf"
 msgid "Open the profile"
 msgstr "Profil öffnen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:841
+#: lib/vutuv_web/live/notification_live/index.ex:992
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3842,7 +3841,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:698
+#: lib/vutuv_web/live/notification_live/index.ex:816
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -3924,7 +3923,7 @@ msgstr "Bestätigt"
 msgid "Waiting for the owner"
 msgstr "Wartet auf den Besitzer"
 
-#: lib/vutuv_web/live/notification_live/index.ex:846
+#: lib/vutuv_web/live/notification_live/index.ex:997
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4021,12 +4020,12 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:526
+#: lib/vutuv_web/agent_docs/markdown.ex:528
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:869
+#: lib/vutuv_web/agent_docs/markdown.ex:871
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -4040,11 +4039,11 @@ msgstr "%{count} Beiträge von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:144
 #: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:793
+#: lib/vutuv_web/agent_docs/markdown.ex:795
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:139
 #: lib/vutuv_web/agent_docs/text.ex:152
-#: lib/vutuv_web/agent_docs/text.ex:568
+#: lib/vutuv_web/agent_docs/text.ex:570
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
@@ -4061,26 +4060,26 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:811
-#: lib/vutuv_web/agent_docs/text.ex:579
+#: lib/vutuv_web/agent_docs/markdown.ex:813
+#: lib/vutuv_web/agent_docs/text.ex:581
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:808
-#: lib/vutuv_web/agent_docs/text.ex:576
+#: lib/vutuv_web/agent_docs/markdown.ex:810
+#: lib/vutuv_web/agent_docs/text.ex:578
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:815
-#: lib/vutuv_web/agent_docs/text.ex:582
+#: lib/vutuv_web/agent_docs/markdown.ex:817
+#: lib/vutuv_web/agent_docs/text.ex:584
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:419
-#: lib/vutuv_web/agent_docs/text.ex:422
+#: lib/vutuv_web/agent_docs/markdown.ex:421
+#: lib/vutuv_web/agent_docs/text.ex:424
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Mitglied seit"
@@ -4126,17 +4125,17 @@ msgstr "Beiträge (insgesamt %{count})"
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:762
+#: lib/vutuv_web/agent_docs/markdown.ex:764
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/markdown.ex:694
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:693
+#: lib/vutuv_web/agent_docs/markdown.ex:695
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4242,6 +4241,7 @@ msgstr "Für die Buchung ist ein vutuv-Login erforderlich."
 #: lib/vutuv_web/live/organization_live/edit.ex:278
 #: lib/vutuv_web/live/organization_live/new.ex:123
 #: lib/vutuv_web/templates/ad/new.html.heex:105
+#: lib/vutuv_web/templates/welcome/show.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "City"
 msgstr "Stadt"
@@ -4762,7 +4762,7 @@ msgstr "Mitglieder finden"
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:767
+#: lib/vutuv_web/templates/user/show.html.heex:772
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4807,7 +4807,7 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/agent_docs/markdown.ex:309
 #: lib/vutuv_web/agent_docs/text.ex:341
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:557
+#: lib/vutuv_web/live/notification_live/index.ex:682
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:177
@@ -4831,7 +4831,7 @@ msgstr "Ähnliche Namen"
 #: lib/vutuv_web/components/post_components.ex:271
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:555
+#: lib/vutuv_web/live/notification_live/index.ex:680
 #: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -4879,7 +4879,7 @@ msgid "searches first names only (last: for last names)"
 msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
 #: lib/vutuv_web/live/user_profile_live.ex:953
-#: lib/vutuv_web/templates/user/show.html.heex:456
+#: lib/vutuv_web/templates/user/show.html.heex:461
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Tag hinzufügen"
@@ -5495,7 +5495,7 @@ msgstr ""
 "Webhook-Dokumentation). Nur https://; http://localhost ist für die "
 "Entwicklung erlaubt."
 
-#: lib/vutuv_web/templates/page/index.html.heex:145
+#: lib/vutuv_web/templates/page/index.html.heex:148
 #: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
@@ -5511,7 +5511,7 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:3043
+#: lib/vutuv_web/components/ui.ex:3190
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5594,9 +5594,9 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:3129
-#: lib/vutuv_web/components/ui.ex:3134
-#: lib/vutuv_web/components/ui.ex:3202
+#: lib/vutuv_web/components/ui.ex:3276
+#: lib/vutuv_web/components/ui.ex:3281
+#: lib/vutuv_web/components/ui.ex:3349
 #: lib/vutuv_web/controllers/settings_controller.ex:51
 #: lib/vutuv_web/live/shell_live.ex:518
 #: lib/vutuv_web/live/tag_new_live.ex:44
@@ -5652,12 +5652,12 @@ msgstr "Beitrag schreiben"
 msgid "Your profile"
 msgstr "Ihr Profil"
 
-#: lib/vutuv_web/templates/user/show.html.heex:301
+#: lib/vutuv_web/templates/user/show.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr "Profil vervollständigen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:323
+#: lib/vutuv_web/templates/user/show.html.heex:328
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
@@ -5691,6 +5691,7 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:899
 #: lib/vutuv_web/components/post_components.ex:953
 #: lib/vutuv_web/components/post_components.ex:1268
+#: lib/vutuv_web/live/notification_live/index.ex:519
 #: lib/vutuv_web/live/post_live/feed.ex:737
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5701,19 +5702,18 @@ msgstr "Beitrag ansehen"
 msgid "Someone tried to register with your email address"
 msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
 
-#: lib/vutuv_web/templates/page/index.html.heex:84
+#: lib/vutuv_web/templates/page/index.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr "Ihre Tags (z.B. JavaScript, Kochen, Origami, Katze)"
 
-#: lib/vutuv/accounts/user.ex:743
+#: lib/vutuv/accounts/user.ex:887
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "divers"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/directory_html.ex:8
 #: lib/vutuv_web/views/email_html.ex:13
 #: lib/vutuv_web/views/invitation_html.ex:18
@@ -5722,7 +5722,6 @@ msgid "Other"
 msgstr "Andere"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/email_html.ex:12
 #: lib/vutuv_web/views/user_html.ex:516
 #, elixir-autogen, elixir-format
@@ -5734,7 +5733,7 @@ msgstr "Privat"
 msgid "Type of Email"
 msgstr "Art der E-Mail"
 
-#: lib/vutuv_web/templates/page/index.html.heex:102
+#: lib/vutuv_web/templates/page/index.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Type of email address"
 msgstr "Art der E-Mail-Adresse"
@@ -5744,7 +5743,7 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:3025
+#: lib/vutuv_web/components/ui.ex:3172
 #: lib/vutuv_web/live/admin/user_live.ex:266
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:13
 #, elixir-autogen, elixir-format
@@ -5768,7 +5767,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:3020
+#: lib/vutuv_web/components/ui.ex:3167
 #: lib/vutuv_web/controllers/email_controller.ex:30
 #: lib/vutuv_web/controllers/email_controller.ex:49
 #: lib/vutuv_web/controllers/email_controller.ex:191
@@ -5799,7 +5798,7 @@ msgstr "Persönliche Tokens für die vutuv-API."
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:3035
+#: lib/vutuv_web/components/ui.ex:3182
 #: lib/vutuv_web/templates/settings/privacy.html.heex:9
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5825,7 +5824,7 @@ msgstr "Ansehen"
 msgid "Your name"
 msgstr "Ihr Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:382
+#: lib/vutuv_web/live/notification_live/index.ex:434
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Ihr Beitrag"
@@ -5914,7 +5913,7 @@ msgstr "@%{slug} hat Sie auf vutuv empfohlen"
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 
-#: lib/vutuv_web/components/ui.ex:3042
+#: lib/vutuv_web/components/ui.ex:3189
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -5925,8 +5924,8 @@ msgstr "Apps"
 msgid "Apps & API"
 msgstr "Apps & API-Zugang"
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:104
-#: lib/vutuv_web/live/notification_live/index.ex:650
+#: lib/vutuv_web/controllers/user_tag_controller.ex:105
+#: lib/vutuv_web/live/notification_live/index.ex:763
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #, elixir-autogen, elixir-format
@@ -6154,7 +6153,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] "vor %{count} Minute"
 msgstr[1] "vor %{count} Minuten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:402
+#: lib/vutuv_web/controllers/settings_controller.ex:411
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
@@ -6194,7 +6193,7 @@ msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
 msgid "Signed-in devices"
 msgstr "Angemeldete Geräte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:391
+#: lib/vutuv_web/controllers/settings_controller.ex:400
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
@@ -6366,14 +6365,14 @@ msgstr "Kurzbeschreibung"
 #: lib/vutuv_web/components/ui.ex:174
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:691
+#: lib/vutuv_web/templates/user/show.html.heex:696
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] "Link"
 msgstr[1] "Links"
 
-#: lib/vutuv_web/templates/user/show.html.heex:376
+#: lib/vutuv_web/templates/user/show.html.heex:381
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6387,7 +6386,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1203
+#: lib/vutuv_web/templates/user/show.html.heex:1212
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6432,16 +6431,16 @@ msgstr "Foto verwenden"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:825
-#: lib/vutuv_web/templates/user/show.html.heex:835
+#: lib/vutuv_web/templates/user/show.html.heex:830
+#: lib/vutuv_web/templates/user/show.html.heex:840
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:424
-#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/agent_docs/markdown.ex:426
+#: lib/vutuv_web/agent_docs/text.ex:429
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Alter"
@@ -6475,12 +6474,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:946
+#: lib/vutuv_web/templates/user/show.html.heex:951
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:957
+#: lib/vutuv_web/templates/user/show.html.heex:962
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6515,14 +6514,14 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:824
+#: lib/vutuv_web/agent_docs/markdown.ex:826
 #: lib/vutuv_web/components/post_components.ex:273
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:955
+#: lib/vutuv_web/templates/user/show.html.heex:960
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6549,9 +6548,9 @@ msgstr "Nach unten"
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/vutuv_web/components/ui.ex:950
-#: lib/vutuv_web/components/ui.ex:959
-#: lib/vutuv_web/components/ui.ex:1261
+#: lib/vutuv_web/components/ui.ex:976
+#: lib/vutuv_web/components/ui.ex:985
+#: lib/vutuv_web/components/ui.ex:1379
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Empfehlung zurücknehmen"
@@ -6572,20 +6571,20 @@ msgstr "Karteneinstellungen gespeichert."
 msgid "Map services to show"
 msgstr "Anzuzeigende Kartendienste"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:78
+#: lib/vutuv_web/gettext_extraction_anchors.ex:80
 #: lib/vutuv_web/templates/settings/preferences.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1189
-#: lib/vutuv_web/templates/user/show.html.heex:1197
-#: lib/vutuv_web/templates/user/show.html.heex:1209
+#: lib/vutuv_web/templates/user/show.html.heex:1198
+#: lib/vutuv_web/templates/user/show.html.heex:1206
+#: lib/vutuv_web/templates/user/show.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:76
+#: lib/vutuv_web/gettext_extraction_anchors.ex:78
 #: lib/vutuv_web/templates/settings/preferences.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6616,16 +6615,16 @@ msgstr "Mitglieder, die %{name} für %{tag} empfohlen haben"
 msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
-#: lib/vutuv_web/components/ui.ex:1214
-#: lib/vutuv_web/live/notification_live/index.ex:413
-#: lib/vutuv_web/live/notification_live/index.ex:428
-#: lib/vutuv_web/live/notification_live/index.ex:514
-#: lib/vutuv_web/live/notification_live/index.ex:516
+#: lib/vutuv_web/components/ui.ex:1332
+#: lib/vutuv_web/live/notification_live/index.ex:464
+#: lib/vutuv_web/live/notification_live/index.ex:479
+#: lib/vutuv_web/live/notification_live/index.ex:602
+#: lib/vutuv_web/live/notification_live/index.ex:604
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:806
+#: lib/vutuv_web/agent_docs/markdown.ex:808
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -6927,7 +6926,7 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/ui.ex:1698
+#: lib/vutuv_web/components/ui.ex:1836
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Mute"
@@ -6949,7 +6948,7 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/ui.ex:1697
+#: lib/vutuv_web/components/ui.ex:1835
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Unmute"
@@ -6988,33 +6987,33 @@ msgstr "Beruflich"
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
 
-#: lib/vutuv_web/components/ui.ex:1668
+#: lib/vutuv_web/components/ui.ex:1806
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr "Folgt dir nicht"
 
-#: lib/vutuv_web/components/ui.ex:1662
+#: lib/vutuv_web/components/ui.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr "Folgt dir"
 
-#: lib/vutuv_web/components/ui.ex:1652
+#: lib/vutuv_web/components/ui.ex:1790
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr "Dieses Mitglied folgt dir nicht"
 
-#: lib/vutuv_web/components/ui.ex:1603
-#: lib/vutuv_web/components/ui.ex:1652
+#: lib/vutuv_web/components/ui.ex:1741
+#: lib/vutuv_web/components/ui.ex:1790
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr "Dieses Mitglied folgt dir"
 
-#: lib/vutuv_web/components/ui.ex:1601
+#: lib/vutuv_web/components/ui.ex:1739
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr "Ihr folgt euch"
 
-#: lib/vutuv_web/components/ui.ex:1602
+#: lib/vutuv_web/components/ui.ex:1740
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr "Du folgst diesem Mitglied"
@@ -7598,13 +7597,13 @@ msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:2284
+#: lib/vutuv_web/components/ui.ex:2422
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:2300
+#: lib/vutuv_web/components/ui.ex:2438
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7873,17 +7872,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:874
+#: lib/vutuv_web/agent_docs/markdown.ex:876
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Dein Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:877
+#: lib/vutuv_web/agent_docs/markdown.ex:879
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:884
+#: lib/vutuv_web/agent_docs/markdown.ex:886
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -8111,13 +8110,13 @@ msgstr "Neue Mitglieder"
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:584
+#: lib/vutuv_web/live/notification_live/index.ex:709
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Heute"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:587
+#: lib/vutuv_web/live/notification_live/index.ex:712
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Gestern"
@@ -8357,8 +8356,8 @@ msgstr "Identität verifiziert. Das Mitglied wurde per E-Mail benachrichtigt."
 msgid "Identity-verified"
 msgstr "Identität verifiziert"
 
-#: lib/vutuv/accounts.ex:911
-#: lib/vutuv/accounts.ex:960
+#: lib/vutuv/accounts.ex:922
+#: lib/vutuv/accounts.ex:971
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8398,7 +8397,7 @@ msgstr "Nicht bestätigt"
 msgid "Open the member browser"
 msgstr "Mitgliederübersicht öffnen"
 
-#: lib/vutuv/accounts.ex:928
+#: lib/vutuv/accounts.ex:939
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8409,7 +8408,7 @@ msgstr "PIN abgelaufen"
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:2287
+#: lib/vutuv_web/components/ui.ex:2425
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
@@ -8542,7 +8541,7 @@ msgstr[0] "%{count} Berufserfahrung"
 msgstr[1] "%{count} Berufserfahrungen"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:544
+#: lib/vutuv_web/templates/user/show.html.heex:549
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Ausbildung hinzufügen"
@@ -8554,7 +8553,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3014
+#: lib/vutuv_web/components/ui.ex:3161
 #: lib/vutuv_web/controllers/education_controller.ex:38
 #: lib/vutuv_web/controllers/education_controller.ex:53
 #: lib/vutuv_web/controllers/education_controller.ex:103
@@ -8567,7 +8566,7 @@ msgstr "Abschluss"
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:541
+#: lib/vutuv_web/templates/user/show.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr "Ausbildung"
@@ -8613,7 +8612,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:3030
+#: lib/vutuv_web/components/ui.ex:3177
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8622,7 +8621,7 @@ msgstr "Import"
 #: lib/vutuv_web/controllers/import_controller.ex:114
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:364
+#: lib/vutuv_web/templates/user/show.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Import from LinkedIn"
 msgstr "Von LinkedIn importieren"
@@ -8642,7 +8641,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:3021
+#: lib/vutuv_web/components/ui.ex:3168
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8734,17 +8733,12 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/controllers/session_controller.ex:429
-#, elixir-autogen, elixir-format
-msgid "A photo and a short tagline make your profile complete."
-msgstr "Ein Foto und eine Kurzbeschreibung machen Ihr Profil komplett."
-
 #: lib/vutuv_web/live/user_profile_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr "Zum Beispiel ein Gedanke zu %{tag}."
 
-#: lib/vutuv_web/components/ui.ex:2523
+#: lib/vutuv_web/components/ui.ex:2670
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:36
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:42
@@ -8769,7 +8763,7 @@ msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:94
-#: lib/vutuv_web/templates/user/show.html.heex:1060
+#: lib/vutuv_web/templates/user/show.html.heex:1065
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8848,25 +8842,25 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:3012
+#: lib/vutuv_web/components/ui.ex:3159
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:3029
+#: lib/vutuv_web/components/ui.ex:3176
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
 msgstr "Sprache & Anzeige"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:401
+#: lib/vutuv_web/templates/user/edit.html.heex:442
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:3027
+#: lib/vutuv_web/components/ui.ex:3174
 #: lib/vutuv_web/controllers/settings_controller.ex:89
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:5
@@ -8875,7 +8869,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:3031
+#: lib/vutuv_web/components/ui.ex:3178
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -9128,7 +9122,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 msgid "Allow followers from the Fediverse"
 msgstr "Follower aus dem Fediverse erlauben"
 
-#: lib/vutuv_web/components/ui.ex:3036
+#: lib/vutuv_web/components/ui.ex:3183
 #: lib/vutuv_web/controllers/settings_controller.ex:186
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:265
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
@@ -9212,7 +9206,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
 
-#: lib/vutuv/accounts.ex:923
+#: lib/vutuv/accounts.ex:934
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9239,7 +9233,7 @@ msgid "Employment"
 msgstr "Anstellung"
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:586
+#: lib/vutuv_web/agent_docs/markdown.ex:588
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -9262,7 +9256,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr "Berufserfahrung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/markdown.ex:589
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -9293,13 +9287,13 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:624
+#: lib/vutuv_web/agent_docs/markdown.ex:626
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:623
+#: lib/vutuv_web/agent_docs/markdown.ex:625
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9335,7 +9329,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:765
+#: lib/vutuv_web/agent_docs/markdown.ex:767
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9428,14 +9422,14 @@ msgstr ""
 "Der Lebenslauf von %{name} auf vutuv: Berufserfahrung, Ausbildung und "
 "Kenntnisse zum Ansehen und Herunterladen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:585
+#: lib/vutuv_web/agent_docs/markdown.ex:587
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr "Freiberuflich / Selbstständig"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:588
+#: lib/vutuv_web/agent_docs/markdown.ex:590
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9564,7 +9558,7 @@ msgstr "Dieses Mitglied aus dem Tag entfernen?"
 msgid "Removed @%{handle} from this tag."
 msgstr "@%{handle} aus diesem Tag entfernt."
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:139
+#: lib/vutuv_web/controllers/user_tag_controller.ex:149
 #, elixir-autogen, elixir-format
 msgid "This tag can only be removed by a site admin."
 msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
@@ -9574,8 +9568,8 @@ msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
 msgid "Yes"
 msgstr "Ja"
 
-#: lib/vutuv_web/components/ui.ex:994
-#: lib/vutuv_web/components/ui.ex:995
+#: lib/vutuv_web/components/ui.ex:1020
+#: lib/vutuv_web/components/ui.ex:1021
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:64
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9587,8 +9581,8 @@ msgstr "Ehren-Tag"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Ehren-Tag (nur Admins können es vergeben)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:445
-#: lib/vutuv_web/agent_docs/text.ex:446
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/text.ex:448
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "Ehren-Tag"
@@ -9604,7 +9598,7 @@ msgid "A2 (Elementary)"
 msgstr "A2 (Grundkenntnisse)"
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:606
+#: lib/vutuv_web/templates/user/show.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Sprache hinzufügen"
@@ -9816,7 +9810,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:49
 #: lib/vutuv_web/agent_docs/text.ex:46
-#: lib/vutuv_web/components/ui.ex:3016
+#: lib/vutuv_web/components/ui.ex:3163
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
@@ -9829,7 +9823,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:3
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:603
+#: lib/vutuv_web/templates/user/show.html.heex:608
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Sprachen"
@@ -10012,12 +10006,11 @@ msgstr "Yoruba"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:417
 #: lib/vutuv_web/agent_docs/text.ex:420
-#: lib/vutuv_web/templates/user/edit.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:617
+#: lib/vutuv/accounts/user.ex:735
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -10028,13 +10021,13 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:614
+#: lib/vutuv/accounts/user.ex:732
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr "Offen für Angebote"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:206
+#: lib/vutuv_web/templates/user/edit.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -10121,12 +10114,12 @@ msgstr[0] "%{count} Zertifikat oder Lizenz"
 msgstr[1] "%{count} Zertifikate oder Lizenzen"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:646
+#: lib/vutuv_web/templates/user/show.html.heex:651
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:686
+#: lib/vutuv_web/agent_docs/markdown.ex:688
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -10154,7 +10147,7 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3015
+#: lib/vutuv_web/components/ui.ex:3162
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -10169,7 +10162,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:3
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:643
+#: lib/vutuv_web/templates/user/show.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr "Zertifikate & Lizenzen"
@@ -10213,7 +10206,7 @@ msgstr "Ablaufmonat"
 msgid "Expiry year"
 msgstr "Ablaufjahr"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
+#: lib/vutuv_web/agent_docs/markdown.ex:663
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10239,7 +10232,7 @@ msgstr "Ausstellungsjahr"
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:685
+#: lib/vutuv_web/agent_docs/markdown.ex:687
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10269,7 +10262,7 @@ msgstr "Nachweis"
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:659
+#: lib/vutuv_web/agent_docs/markdown.ex:661
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10284,7 +10277,7 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:660
+#: lib/vutuv_web/agent_docs/markdown.ex:662
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -10303,15 +10296,15 @@ msgstr ""
 msgid "Preferred"
 msgstr "Bevorzugt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:543
+#: lib/vutuv_web/agent_docs/markdown.ex:545
 #: lib/vutuv_web/live/section_reorder_live.ex:269
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:921
-#: lib/vutuv_web/templates/user/show.html.heex:922
+#: lib/vutuv_web/templates/user/show.html.heex:926
+#: lib/vutuv_web/templates/user/show.html.heex:927
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10325,18 +10318,18 @@ msgstr "+%{code} ist die Ländervorwahl von %{region}"
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:320
-#: lib/vutuv_web/templates/user/edit.html.heex:389
+#: lib/vutuv_web/templates/user/edit.html.heex:361
+#: lib/vutuv_web/templates/user/edit.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr "Geburtsdatum entfernen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:369
+#: lib/vutuv_web/templates/user/edit.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr "Geburtsdatum entfernen?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:372
+#: lib/vutuv_web/templates/user/edit.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -10497,8 +10490,8 @@ msgstr "Ihre Einladung ist unterwegs"
 msgid "Permanent profile link"
 msgstr "Dauerhafter Profillink"
 
-#: lib/vutuv_web/templates/user/show.html.heex:312
-#: lib/vutuv_web/templates/user/show.html.heex:313
+#: lib/vutuv_web/templates/user/show.html.heex:317
+#: lib/vutuv_web/templates/user/show.html.heex:318
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr "Schließen"
@@ -11006,21 +10999,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr "auf diesem Gerät einrichten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:503
+#: lib/vutuv_web/agent_docs/markdown.ex:505
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} Follower"
 msgstr[1] "%{count} Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:503
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} Repository"
 msgstr[1] "%{count} Repositories"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:499
+#: lib/vutuv_web/agent_docs/markdown.ex:501
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -11043,7 +11036,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1034
+#: lib/vutuv_web/templates/user/show.html.heex:1039
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -11078,12 +11071,12 @@ msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten nur als einfache "
 "Links."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:517
+#: lib/vutuv_web/agent_docs/markdown.ex:519
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:504
+#: lib/vutuv_web/agent_docs/markdown.ex:506
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "seit %{date}"
@@ -11289,7 +11282,7 @@ msgstr ""
 "vutuv ist das offene Business-Netzwerk. Fachleute vernetzen sich, tauschen "
 "sich aus und werden gefunden. Kostenlos dabei."
 
-#: lib/vutuv_web/templates/page/index.html.heex:91
+#: lib/vutuv_web/templates/page/index.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "At least three tags, separated by a comma or a space. Multi-word tags go in quotes: \"Ruby on Rails\"."
 msgstr ""
@@ -11318,21 +11311,21 @@ msgstr "%{n} M."
 msgid "%{n}y"
 msgstr "%{n} J."
 
-#: lib/vutuv_web/controllers/session_controller.ex:448
+#: lib/vutuv_web/controllers/session_controller.ex:471
 #, elixir-autogen, elixir-format
 msgid "You have %{formatted} new message."
 msgid_plural "You have %{formatted} new messages."
 msgstr[0] "Sie haben %{formatted} neue Nachricht."
 msgstr[1] "Sie haben %{formatted} neue Nachrichten."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:164
+#: lib/vutuv_web/templates/settings/preferences.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 "Trennt lange Wörter an Silbengrenzen, damit der Text gleichmäßig umbricht. "
 "Hilfreich in der schmalen Smartphone-Spalte."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:116
+#: lib/vutuv_web/templates/settings/preferences.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
@@ -11340,35 +11333,35 @@ msgstr ""
 "Das sind Ihre eigenen Anzeige-Einstellungen."
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:171
+#: lib/vutuv_web/templates/settings/preferences.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr "Silbentrennung am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:70
-#: lib/vutuv_web/templates/settings/preferences.html.heex:175
+#: lib/vutuv_web/templates/settings/preferences.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr "Silbentrennung auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:161
+#: lib/vutuv_web/templates/settings/preferences.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr "Silbentrennung"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:139
+#: lib/vutuv_web/templates/settings/preferences.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr "Zeilen am Desktop"
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:148
+#: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr "Zeilen auf dem Smartphone"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:134
+#: lib/vutuv_web/templates/settings/preferences.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -11380,7 +11373,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:131
+#: lib/vutuv_web/templates/settings/preferences.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr "Beitrag kürzen nach"
@@ -11434,7 +11427,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr "Standard der Installation (%{value})"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:366
+#: lib/vutuv_web/controllers/settings_controller.ex:375
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr "Karten-Einstellungen auf die Standardwerte zurückgesetzt."
@@ -11453,7 +11446,7 @@ msgstr ""
 "Eigener Wert; leeren Sie das Feld, um zum Standard der Installation "
 "zurückzukehren."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:362
+#: lib/vutuv_web/controllers/settings_controller.ex:371
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -11481,7 +11474,7 @@ msgid "Preferences of %{name}"
 msgstr "Einstellungen von %{name}"
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:102
-#: lib/vutuv_web/templates/settings/preferences.html.heex:195
+#: lib/vutuv_web/templates/settings/preferences.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr "Auf die Standardwerte zurücksetzen"
@@ -11515,17 +11508,17 @@ msgstr ""
 "wählt, und was ausgeloggte Besucher sehen. Änderungen gelten sofort; "
 "Mitglieder mit eigenem Wert sind nicht betroffen."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:75
+#: lib/vutuv_web/gettext_extraction_anchors.ex:76
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr "0 bedeutet: Beiträge werden nie gekürzt."
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:80
+#: lib/vutuv_web/gettext_extraction_anchors.ex:82
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Aus"
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:79
+#: lib/vutuv_web/gettext_extraction_anchors.ex:81
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "An"
@@ -11680,7 +11673,7 @@ msgstr "Versuche"
 msgid "Views"
 msgstr "Ansichten"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:215
+#: lib/vutuv_web/templates/user/edit.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
@@ -11689,42 +11682,45 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:629
+#: lib/vutuv/accounts/user.ex:773
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:634
+#: lib/vutuv/accounts/user.ex:778
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:632
+#: lib/vutuv/accounts/user.ex:776
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr "Nur angemeldete Mitglieder"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:212
+#: lib/vutuv_web/templates/user/edit.html.heex:214
+#: lib/vutuv_web/templates/welcome/show.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr "Wer kann Ihre Verfügbarkeit sehen?"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:237
+#: lib/vutuv_web/templates/user/edit.html.heex:239
+#: lib/vutuv_web/templates/welcome/show.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr "Betrag"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:464
-#: lib/vutuv_web/templates/user/edit.html.heex:245
+#: lib/vutuv_web/templates/user/edit.html.heex:247
+#: lib/vutuv_web/templates/welcome/show.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr "Währung"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:255
+#: lib/vutuv_web/templates/user/edit.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
@@ -11732,12 +11728,13 @@ msgstr ""
 "angemeldete Mitglieder“ ergänzt Ihr Profil um eine dezente Zeile für "
 "Mitglieder; „Alle“ zeigt sie auch nicht angemeldeten Besuchern."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:228
+#: lib/vutuv_web/templates/user/edit.html.heex:230
+#: lib/vutuv_web/templates/welcome/show.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr "Mindest-Gehaltsvorstellung"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:231
+#: lib/vutuv_web/templates/user/edit.html.heex:233
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
@@ -11746,17 +11743,18 @@ msgstr ""
 "Sie den Betrag leer, um die Angabe zu entfernen."
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:471
-#: lib/vutuv_web/templates/user/edit.html.heex:241
+#: lib/vutuv_web/templates/user/edit.html.heex:243
+#: lib/vutuv_web/templates/welcome/show.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr "Pro"
 
-#: lib/vutuv_web/templates/user/show.html.heex:222
+#: lib/vutuv_web/templates/user/show.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr "Gehaltsvorstellung ab %{amount} %{currency} pro %{period}"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:252
+#: lib/vutuv_web/templates/user/edit.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr "Wer kann Ihre Gehaltsvorstellung sehen?"
@@ -11825,7 +11823,7 @@ msgstr "Ein Mitglied ausschließen"
 msgid "Exclude an email domain"
 msgstr "Eine E-Mail-Domain ausschließen"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:269
+#: lib/vutuv_web/templates/user/edit.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr "Vor bestimmten Personen verbergen"
@@ -11836,7 +11834,7 @@ msgstr "Vor bestimmten Personen verbergen"
 msgid "Job-search exclusion list"
 msgstr "Ausschlussliste für die Jobsuche"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:272
+#: lib/vutuv_web/templates/user/edit.html.heex:313
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
@@ -11845,7 +11843,7 @@ msgstr ""
 "Mitglieder oder E-Mail-Domains aus; sie sehen Ihre Verfügbarkeit und Ihre "
 "Gehaltsvorstellung dann nie, auch nicht bei „Alle“."
 
-#: lib/vutuv_web/templates/user/edit.html.heex:280
+#: lib/vutuv_web/templates/user/edit.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -12527,8 +12525,8 @@ msgstr ""
 "Wir konnten den Nachweis noch nicht finden. Die Verbreitung kann etwas "
 "dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:706
-#: lib/vutuv_web/agent_docs/text.ex:542
+#: lib/vutuv_web/agent_docs/markdown.ex:708
+#: lib/vutuv_web/agent_docs/text.ex:544
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -12768,7 +12766,7 @@ msgstr "Organisation"
 msgid "Organization pages"
 msgstr "Organisation"
 
-#: lib/vutuv_web/live/notification_live/index.ex:699
+#: lib/vutuv_web/live/notification_live/index.ex:817
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisation"
@@ -12779,7 +12777,7 @@ msgid "Organization unfrozen."
 msgstr "Organisation"
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:3028
+#: lib/vutuv_web/components/ui.ex:3175
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
@@ -12879,22 +12877,22 @@ msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
 msgid "Your organization page was updated."
 msgstr "Ihre Organisationsseite wurde aktualisiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:807
+#: lib/vutuv_web/live/notification_live/index.ex:956
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr "hat dir eine Rolle bei %{company} gegeben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:804
+#: lib/vutuv_web/live/notification_live/index.ex:953
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr "hat dich zum Recruiter für %{company} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:801
+#: lib/vutuv_web/live/notification_live/index.ex:950
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr "hat dich zum Administrator von %{company} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:798
+#: lib/vutuv_web/live/notification_live/index.ex:947
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr "hat dich zum Inhaber von %{company} gemacht."
@@ -13096,6 +13094,7 @@ msgstr "Halten Sie Strg / Cmd gedrückt, um mehrere auszuwählen."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
+#: lib/vutuv/accounts/user.ex:747
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -13215,6 +13214,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
+#: lib/vutuv/accounts/user.ex:746
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -13266,6 +13266,7 @@ msgid "Post as"
 msgstr "Veröffentlichen als"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:398
+#: lib/vutuv_web/templates/welcome/show.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Postal code"
 msgstr "Postleitzahl"
@@ -13295,6 +13296,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
+#: lib/vutuv/accounts/user.ex:748
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
 #: lib/vutuv_web/agent_docs/markdown.ex:332
@@ -13429,7 +13431,7 @@ msgstr "Arbeitsort"
 msgid "You already have the maximum number of published postings."
 msgstr "Sie haben bereits die maximale Anzahl veröffentlichter Anzeigen."
 
-#: lib/vutuv/notifications/emailer.ex:856
+#: lib/vutuv/notifications/emailer.ex:862
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
@@ -13966,7 +13968,7 @@ msgstr "Suche speichern"
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:3066
+#: lib/vutuv_web/components/ui.ex:3213
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -14227,11 +14229,6 @@ msgstr "Dieses Mitglied existiert nicht mehr."
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 Tagen abgelehnt. Eine wachsende Warteschlange bedeutet meist, dass Ollama nicht erreichbar ist."
 
-#: lib/vutuv/notifications/emailer.ex:818
-#, elixir-autogen, elixir-format
-msgid "An image was removed from your vutuv account"
-msgstr "Ein Bild wurde aus Ihrem vutuv-Konto entfernt"
-
 #: lib/vutuv_web/components/post_components.ex:1030
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
@@ -14245,7 +14242,7 @@ msgstr "Bild wird geprüft, nur für Sie sichtbar"
 msgid "Image is being reviewed"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/live/notification_live/index.ex:697
+#: lib/vutuv_web/live/notification_live/index.ex:815
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -14255,11 +14252,6 @@ msgstr "Bildprüfung"
 #, elixir-autogen, elixir-format
 msgid "No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
 msgstr "Keine Bilder in der KI-Prüfung. %{formatted} in den letzten 7 Tagen abgelehnt."
-
-#: lib/vutuv_web/live/notification_live/index.ex:829
-#, elixir-autogen, elixir-format
-msgid "Our automated image review removed %{what}. Only family-friendly images suitable for a work environment are allowed."
-msgstr "Unsere automatische Bildprüfung hat %{what} entfernt. Erlaubt sind nur familienfreundliche Bilder, die für ein Arbeitsumfeld geeignet sind."
 
 #: lib/vutuv_web/templates/user/show.html.heex:159
 #, elixir-autogen, elixir-format
@@ -14291,36 +14283,36 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:647
+#: lib/vutuv/accounts/user.ex:791
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr "Nur das Alter, ohne das Datum"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:331
+#: lib/vutuv_web/templates/user/edit.html.heex:372
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:650
+#: lib/vutuv/accounts/user.ex:794
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:653
+#: lib/vutuv/accounts/user.ex:797
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:644
+#: lib/vutuv/accounts/user.ex:788
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr "Vollständiges Datum und Alter"
 
-#: lib/vutuv_web/templates/user/edit.html.heex:328
+#: lib/vutuv_web/templates/user/edit.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr "Geburtstag anzeigen als"
@@ -14337,7 +14329,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:700
+#: lib/vutuv_web/live/notification_live/index.ex:818
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -14349,7 +14341,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] "Wir haben %{formatted} Beitrag aktualisiert, der Ihren alten Handle erwähnt hat, und dessen Verfasser benachrichtigt."
 msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle erwähnt haben, und deren Verfasser benachrichtigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:855
+#: lib/vutuv_web/live/notification_live/index.ex:1006
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
@@ -14443,7 +14435,7 @@ msgstr "Eigene Beiträge"
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr "Beiträge mit einem Tag, dem du folgst, landen in deinem Feed, und passende Personen tauchen in deinen Vorschlägen auf. Einem Tag folgst du auf seiner Seite."
 
-#: lib/vutuv_web/components/ui.ex:3055
+#: lib/vutuv_web/components/ui.ex:3202
 #: lib/vutuv_web/controllers/settings_controller.ex:259
 #: lib/vutuv_web/live/post_live/feed.ex:651
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -14493,7 +14485,7 @@ msgid "Signal and WhatsApp accept a phone number or a username; the other messen
 msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzernamen; die anderen Messenger nutzen ihre eigene ID oder ihren Handle (z. B. eine 8-stellige Threema-ID oder eine Matrix-Adresse @du:matrix.org)."
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1000
+#: lib/vutuv_web/templates/user/show.html.heex:1005
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14522,7 +14514,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3019
+#: lib/vutuv_web/components/ui.ex:3166
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:3
@@ -14530,7 +14522,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:3
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:998
+#: lib/vutuv_web/templates/user/show.html.heex:1003
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14550,34 +14542,34 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:2609
+#: lib/vutuv_web/components/ui.ex:2756
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:2619
+#: lib/vutuv_web/components/ui.ex:2766
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:701
+#: lib/vutuv_web/live/notification_live/index.ex:819
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
 
-#: lib/vutuv_web/live/notification_live/index.ex:875
+#: lib/vutuv_web/live/notification_live/index.ex:1026
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr "hat eine neue Station im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:867
+#: lib/vutuv_web/live/notification_live/index.ex:1018
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr "hat eine neue Ausbildung im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:872
+#: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr "hat ein neues Zertifikat im Lebenslauf: %{entry}"
@@ -14602,7 +14594,7 @@ msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folg
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
 
-#: lib/vutuv_web/live/notification_live/index.ex:880
+#: lib/vutuv_web/live/notification_live/index.ex:1031
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
@@ -14622,7 +14614,7 @@ msgstr "Autor/in"
 msgid "Book"
 msgstr "Buch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:836
+#: lib/vutuv_web/agent_docs/markdown.ex:838
 #: lib/vutuv_web/components/post_components.ex:1659
 #: lib/vutuv_web/live/post_live/composer.ex:659
 #, elixir-autogen, elixir-format
@@ -14654,7 +14646,7 @@ msgstr "E-Book"
 msgid "Film"
 msgstr "Film"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:836
+#: lib/vutuv_web/agent_docs/markdown.ex:838
 #: lib/vutuv_web/components/post_components.ex:1658
 #: lib/vutuv_web/live/post_live/composer.ex:658
 #, elixir-autogen, elixir-format
@@ -14785,7 +14777,7 @@ msgstr "Qualifikation"
 msgid "With qualification:"
 msgstr "Mit Qualifikation:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:572
+#: lib/vutuv_web/agent_docs/markdown.ex:574
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
@@ -14795,45 +14787,45 @@ msgstr "Mit Qualifikation: %{name}"
 msgid "Publisher:"
 msgstr "Verlag:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:576
+#: lib/vutuv_web/live/notification_live/index.ex:701
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} neue Mitteilung"
 msgstr[1] "%{formatted} neue Mitteilungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:590
+#: lib/vutuv_web/live/notification_live/index.ex:715
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day}. %{month} %{year}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:285
+#: lib/vutuv_web/live/notification_live/index.ex:321
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr "Zurückfolgen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:300
+#: lib/vutuv_web/live/notification_live/index.ex:336
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr "Letzte 30 Tage"
 
-#: lib/vutuv_web/live/notification_live/index.ex:542
-#: lib/vutuv_web/live/notification_live/index.ex:735
+#: lib/vutuv_web/live/notification_live/index.ex:667
+#: lib/vutuv_web/live/notification_live/index.ex:867
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/vutuv_web/live/notification_live/index.ex:715
+#: lib/vutuv_web/live/notification_live/index.ex:834
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "sind jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:710
+#: lib/vutuv_web/live/notification_live/index.ex:829
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "folgen Ihnen jetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:725
+#: lib/vutuv_web/live/notification_live/index.ex:844
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
@@ -14843,12 +14835,12 @@ msgstr "hat Sie für %{tags} empfohlen."
 msgid "by:"
 msgstr "von:"
 
-#: lib/vutuv_web/components/ui.ex:1065
+#: lib/vutuv_web/components/ui.ex:1154
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Empfohlen von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:1067
+#: lib/vutuv_web/components/ui.ex:1158
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14881,19 +14873,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] "Für %{formatted} Job genutzt"
 msgstr[1] "Für %{formatted} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:675
+#: lib/vutuv_web/agent_docs/markdown.ex:677
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr "aktuell genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:674
+#: lib/vutuv_web/agent_docs/markdown.ex:676
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] "für %{count} Job genutzt"
 msgstr[1] "für %{count} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:680
+#: lib/vutuv_web/agent_docs/markdown.ex:682
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14972,130 +14964,117 @@ msgstr "Hochgeladener Nachweis für %{name}"
 msgid "View the uploaded proof (%{label})"
 msgstr "Hochgeladenen Nachweis ansehen (%{label})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:643
-#: lib/vutuv_web/agent_docs/text.ex:534
+#: lib/vutuv_web/agent_docs/markdown.ex:645
+#: lib/vutuv_web/agent_docs/text.ex:536
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "Nachweis"
 
-#: lib/vutuv/prefs.ex:112
 #: lib/vutuv_web/gettext_extraction_anchors.ex:75
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr "Zeilen in Benachrichtigungen"
 
-#: lib/vutuv/prefs.ex:127
 #: lib/vutuv_web/gettext_extraction_anchors.ex:77
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr "Wie viel von einem Beitrag eine Benachrichtigung zitiert, bevor abgeschnitten wird."
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:166
+#: lib/vutuv_web/templates/settings/preferences.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr "Zitierte Beiträge in Benachrichtigungen"
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:169
+#: lib/vutuv_web/templates/settings/preferences.html.heex:168
 #, elixir-autogen, elixir-format
-msgid ""
-"Your notifications quote the post someone liked or replied to. Leave the "
-"field empty to follow the site default."
+msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
 "Ihre Benachrichtigungen zitieren den Beitrag, der jemandem gefällt oder auf "
 "den geantwortet wurde. Lassen Sie das Feld leer, um die Voreinstellung der "
 "Website zu übernehmen."
 
-#: lib/vutuv_web/controllers/welcome_controller.ex
+#: lib/vutuv_web/controllers/welcome_controller.ex:102
 #, elixir-autogen, elixir-format
 msgid "Welcome"
 msgstr "Willkommen"
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:18
 #, elixir-autogen, elixir-format
-msgid ""
-"Two questions before you start. They decide who finds you and which jobs "
-"we show you. Answer as much or as little as you like."
+msgid "Two questions before you start. They decide who finds you and which jobs we show you. Answer as much or as little as you like."
 msgstr ""
 "Zwei Fragen vor dem Start. Sie entscheiden, wer Sie findet und welche "
 "Stellen wir Ihnen zeigen. Beantworten Sie so viel oder so wenig davon, "
 "wie Sie möchten."
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Where are you?"
 msgstr "Wo sind Sie?"
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:43
 #, elixir-autogen, elixir-format
-msgid ""
-"A city alone is enough. It appears on your profile and lets people search "
-"for members near them."
+msgid "A city alone is enough. It appears on your profile and lets people search for members near them."
 msgstr ""
 "Ein Ort allein genügt. Er erscheint auf Ihrem Profil und macht Sie für "
 "Menschen in Ihrer Nähe auffindbar."
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Type of address"
 msgstr "Art der Adresse"
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "Are you looking for a job?"
 msgstr "Suchen Sie eine Stelle?"
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:118
 #, elixir-autogen, elixir-format
-msgid ""
-"Optional, and nobody else sees it. It filters postings below it out of "
-"your own job search."
+msgid "Optional, and nobody else sees it. It filters postings below it out of your own job search."
 msgstr ""
 "Optional, und niemand sonst sieht es. Die Angabe filtert Stellen darunter "
 "aus Ihrer eigenen Jobsuche."
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/user/edit.html.heex:277
+#: lib/vutuv_web/templates/welcome/show.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr "Wie möchten Sie arbeiten?"
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/user/edit.html.heex:297
+#: lib/vutuv_web/templates/welcome/show.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "Shown next to your availability, and used to match you with postings."
 msgstr ""
 "Wird neben Ihrer Verfügbarkeit angezeigt und für passende Stellenangebote "
 "genutzt."
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Save and continue"
 msgstr "Speichern und weiter"
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Skip for now"
 msgstr "Erstmal überspringen"
 
-#: lib/vutuv_web/views/user_helpers.ex
-#, elixir-autogen, elixir-format
-msgid "No preference"
-msgstr "Egal"
-
-#: lib/vutuv_web/agent_docs/markdown.ex
+#: lib/vutuv_web/agent_docs/markdown.ex:419
+#: lib/vutuv_web/agent_docs/text.ex:422
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr "Bevorzugte Arbeitsform"
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/user/edit.html.heex:205
+#: lib/vutuv_web/templates/welcome/show.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: lib/vutuv_web/live/notification_live/index.ex
+#: lib/vutuv_web/live/notification_live/index.ex:637
 #, elixir-autogen, elixir-format
-msgid ""
-"Your automatically assigned vutuv username is {handle}. You can change it "
-"any time at {url}."
+msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
 "Ihr automatisch zugewiesener vutuv-Username ist {handle}. Sie können ihn "
 "jederzeit unter {url} ändern."
@@ -15105,13 +15084,22 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/live/notification_live/index.ex:901
+#: lib/vutuv_web/live/notification_live/index.ex:980
 #, elixir-autogen, elixir-format
-msgid ""
-"An AI, not a person, removed %{what}: it judged the image not family-"
-"friendly enough for a work environment. It can be wrong, so reply to our "
-"email if you disagree."
+msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 "Eine KI hat %{what} entfernt, kein Mensch: Sie hielt das Bild für nicht "
 "familienfreundlich genug für ein Arbeitsumfeld. Sie kann sich irren, "
 "antworten Sie in dem Fall einfach auf unsere E-Mail."
+
+#: lib/vutuv_web/live/notification_live/index.ex:811
+#, elixir-autogen, elixir-format
+msgid "Thread reply"
+msgstr "Thread-Antwort"
+
+#: lib/vutuv_web/live/notification_live/index.ex:854
+#, elixir-autogen, elixir-format
+msgid "replied in a thread you posted in."
+msgid_plural "replied in a thread you posted in."
+msgstr[0] "hat in einem Thread geantwortet, in dem Sie geschrieben haben."
+msgstr[1] "haben in einem Thread geantwortet, in dem Sie geschrieben haben."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,14 +11,14 @@ msgid ""
 msgstr ""
 "Language: INSERT LANGUAGE HERE\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:71
+#: lib/vutuv_web/controllers/page_controller.ex:72
 #: lib/vutuv_web/templates/layout/app.html.heex:93
 #, elixir-autogen
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2877
-#: lib/vutuv_web/components/ui.ex:2882
+#: lib/vutuv_web/components/ui.ex:3024
+#: lib/vutuv_web/components/ui.ex:3029
 #: lib/vutuv_web/live/organization_live/domains.ex:235
 #: lib/vutuv_web/live/organization_live/edit.ex:382
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -34,9 +34,10 @@ msgstr ""
 #: lib/vutuv_web/live/cv_live.ex:110
 #: lib/vutuv_web/live/organization_live/show.ex:350
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
+#: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1154
+#: lib/vutuv_web/templates/user/show.html.heex:1159
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -60,7 +61,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3022
+#: lib/vutuv_web/components/ui.ex:3169
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -73,13 +74,13 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:171
+#: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2682
-#: lib/vutuv_web/components/ui.ex:2776
+#: lib/vutuv_web/components/ui.ex:2829
+#: lib/vutuv_web/components/ui.ex:2923
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #, elixir-autogen
 msgid "Are you sure?"
@@ -90,22 +91,22 @@ msgstr ""
 msgid "Avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:292
+#: lib/vutuv_web/templates/user/edit.html.heex:333
 #, elixir-autogen
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:422
-#: lib/vutuv_web/agent_docs/markdown.ex:423
-#: lib/vutuv_web/agent_docs/text.ex:425
-#: lib/vutuv_web/agent_docs/text.ex:426
-#: lib/vutuv_web/templates/user/show.html.heex:819
+#: lib/vutuv_web/agent_docs/markdown.ex:424
+#: lib/vutuv_web/agent_docs/markdown.ex:425
+#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/agent_docs/text.ex:428
+#: lib/vutuv_web/templates/user/show.html.heex:824
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:2675
+#: lib/vutuv_web/components/ui.ex:2822
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -120,8 +121,8 @@ msgstr ""
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:25
 #: lib/vutuv_web/templates/user/edit.html.heex:50
 #: lib/vutuv_web/templates/user/edit.html.heex:103
-#: lib/vutuv_web/templates/user/edit.html.heex:347
-#: lib/vutuv_web/templates/user/edit.html.heex:382
+#: lib/vutuv_web/templates/user/edit.html.heex:388
+#: lib/vutuv_web/templates/user/edit.html.heex:423
 #, elixir-autogen
 msgid "Cancel"
 msgstr ""
@@ -141,7 +142,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:13
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:857
+#: lib/vutuv_web/templates/user/show.html.heex:862
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -151,7 +152,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:816
-#: lib/vutuv_web/components/ui.ex:2779
+#: lib/vutuv_web/components/ui.ex:2926
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -190,14 +191,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:398
 #: lib/vutuv_web/templates/export/index.html.heex:41
-#: lib/vutuv_web/templates/user/show.html.heex:273
+#: lib/vutuv_web/templates/user/show.html.heex:278
 #: lib/vutuv_web/views/qualification_html.ex:237
 #, elixir-autogen
 msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:809
-#: lib/vutuv_web/components/ui.ex:2770
+#: lib/vutuv_web/components/ui.ex:2917
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -219,7 +220,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/url/edit.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:842
+#: lib/vutuv_web/templates/user/show.html.heex:847
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #, elixir-autogen
 msgid "Edit"
@@ -278,29 +279,29 @@ msgstr ""
 msgid "English"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:114
+#: lib/vutuv_web/templates/page/index.html.heex:117
 #: lib/vutuv_web/templates/session/new.html.heex:37
 #, elixir-autogen
 msgid "Enter your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:75
+#: lib/vutuv_web/templates/page/index.html.heex:78
 #, elixir-autogen
 msgid "Enter your first name"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:79
+#: lib/vutuv_web/templates/page/index.html.heex:82
 #, elixir-autogen
 msgid "Enter your last name"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3013
+#: lib/vutuv_web/components/ui.ex:3160
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:489
+#: lib/vutuv_web/templates/user/show.html.heex:494
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:3
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -320,43 +321,43 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:434
-#: lib/vutuv_web/agent_docs/text.ex:437
+#: lib/vutuv_web/agent_docs/markdown.ex:436
+#: lib/vutuv_web/agent_docs/text.ex:439
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/notification_live/index.ex:646
+#: lib/vutuv_web/live/notification_live/index.ex:759
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
 #, elixir-autogen
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:435
-#: lib/vutuv_web/agent_docs/text.ex:438
-#: lib/vutuv_web/components/ui.ex:1413
-#: lib/vutuv_web/components/ui.ex:1438
-#: lib/vutuv_web/components/ui.ex:1441
-#: lib/vutuv_web/components/ui.ex:1448
-#: lib/vutuv_web/components/ui.ex:1451
-#: lib/vutuv_web/components/ui.ex:1509
+#: lib/vutuv_web/agent_docs/markdown.ex:437
+#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/components/ui.ex:1551
+#: lib/vutuv_web/components/ui.ex:1576
+#: lib/vutuv_web/components/ui.ex:1579
+#: lib/vutuv_web/components/ui.ex:1586
+#: lib/vutuv_web/components/ui.ex:1589
+#: lib/vutuv_web/components/ui.ex:1647
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:767
+#: lib/vutuv_web/templates/user/show.html.heex:772
 #, elixir-autogen
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:421
-#: lib/vutuv_web/agent_docs/text.ex:424
+#: lib/vutuv_web/agent_docs/markdown.ex:423
+#: lib/vutuv_web/agent_docs/text.ex:426
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
 #: lib/vutuv_web/cv/odt.ex:109
 #: lib/vutuv_web/live/cv_live.ex:113
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
-#: lib/vutuv_web/templates/page/index.html.heex:62
+#: lib/vutuv_web/templates/page/index.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:814
+#: lib/vutuv_web/templates/user/show.html.heex:819
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -417,7 +418,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:52
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:3017
+#: lib/vutuv_web/components/ui.ex:3164
 #: lib/vutuv_web/controllers/url_controller.ex:23
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
@@ -467,8 +468,8 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3033
-#: lib/vutuv_web/live/notification_live/index.ex:558
+#: lib/vutuv_web/components/ui.ex:3180
+#: lib/vutuv_web/live/notification_live/index.ex:683
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -485,7 +486,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:435
+#: lib/vutuv_web/live/notification_live/index.ex:486
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/templates/access_token/new.html.heex:1
 #: lib/vutuv_web/templates/ad/new.html.heex:3
@@ -607,6 +608,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
 #: lib/vutuv_web/views/phone_number_html.ex:15
+#: lib/vutuv_web/views/welcome_html.ex:37
 #, elixir-autogen
 msgid "Private"
 msgstr ""
@@ -649,10 +651,10 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
-#: lib/vutuv_web/templates/settings/preferences.html.heex:180
+#: lib/vutuv_web/templates/settings/preferences.html.heex:205
 #: lib/vutuv_web/templates/settings/privacy.html.heex:64
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
-#: lib/vutuv_web/templates/user/edit.html.heex:342
+#: lib/vutuv_web/templates/user/edit.html.heex:383
 #: lib/vutuv_web/views/settings_html.ex:131
 #, elixir-autogen
 msgid "Save"
@@ -680,7 +682,7 @@ msgstr ""
 msgid "Show"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:150
+#: lib/vutuv_web/templates/page/index.html.heex:153
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr ""
@@ -693,7 +695,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:55
 #: lib/vutuv_web/agent_docs/text.ex:52
-#: lib/vutuv_web/components/ui.ex:3018
+#: lib/vutuv_web/components/ui.ex:3165
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
@@ -706,13 +708,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:968
+#: lib/vutuv_web/templates/user/show.html.heex:973
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:970
+#: lib/vutuv_web/templates/user/show.html.heex:975
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -760,7 +762,7 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2676
+#: lib/vutuv_web/components/ui.ex:2823
 #, elixir-autogen
 msgid "Submit"
 msgstr ""
@@ -814,6 +816,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
+#: lib/vutuv_web/live/notification_live/index.ex:820
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
 #: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:5
@@ -847,7 +850,7 @@ msgstr ""
 #: lib/vutuv_web/templates/url/index.html.heex:8
 #: lib/vutuv_web/templates/url/show.html.heex:4
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:2
-#: lib/vutuv_web/templates/user_tag/index.html.heex:15
+#: lib/vutuv_web/templates/user_tag/index.html.heex:24
 #: lib/vutuv_web/templates/user_tag/show.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:8
 #: lib/vutuv_web/templates/work_experience/show.html.heex:4
@@ -856,14 +859,14 @@ msgid "Users"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:581
-#: lib/vutuv_web/templates/user/show.html.heex:279
+#: lib/vutuv_web/templates/user/show.html.heex:284
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2840
-#: lib/vutuv_web/templates/user/show.html.heex:761
-#: lib/vutuv_web/templates/user/show.html.heex:781
+#: lib/vutuv_web/components/ui.ex:2987
+#: lib/vutuv_web/templates/user/show.html.heex:766
+#: lib/vutuv_web/templates/user/show.html.heex:786
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -880,20 +883,20 @@ msgstr ""
 msgid "We can't find em' cap'n!"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:174
+#: lib/vutuv_web/templates/page/index.html.heex:177
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:436
+#: lib/vutuv_web/controllers/session_controller.ex:459
 #, elixir-autogen
 msgid "Welcome back!"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/email_html.ex:11
 #: lib/vutuv_web/views/phone_number_html.ex:17
+#: lib/vutuv_web/views/welcome_html.ex:37
 #, elixir-autogen
 msgid "Work"
 msgstr ""
@@ -955,12 +958,12 @@ msgstr ""
 msgid "An email has been sent to your email address with instructions on how to delete your account."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:122
+#: lib/vutuv_web/templates/page/index.html.heex:125
 #, elixir-autogen
 msgid "Allow others to view your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:160
+#: lib/vutuv_web/templates/page/index.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1042,14 +1045,14 @@ msgstr ""
 msgid "Select a year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:740
+#: lib/vutuv/accounts/user.ex:884
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:739
+#: lib/vutuv/accounts/user.ex:883
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1110,7 +1113,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:803
+#: lib/vutuv_web/templates/user/show.html.heex:808
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1150,7 +1153,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:182
+#: lib/vutuv_web/controllers/page_controller.ex:183
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1291,7 +1294,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:483
+#: lib/vutuv_web/templates/user/show.html.heex:488
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1460,13 +1463,13 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
 #: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/agent_docs/markdown.ex:793
+#: lib/vutuv_web/agent_docs/markdown.ex:795
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:393
-#: lib/vutuv_web/agent_docs/text.ex:568
-#: lib/vutuv_web/components/ui.ex:3023
-#: lib/vutuv_web/controllers/user_tag_controller.ex:38
-#: lib/vutuv_web/controllers/user_tag_controller.ex:55
+#: lib/vutuv_web/agent_docs/text.ex:570
+#: lib/vutuv_web/components/ui.ex:3170
+#: lib/vutuv_web/controllers/user_tag_controller.ex:39
+#: lib/vutuv_web/controllers/user_tag_controller.ex:56
 #: lib/vutuv_web/cv/docx.ex:174
 #: lib/vutuv_web/cv/html.ex:159
 #: lib/vutuv_web/cv/latex.ex:131
@@ -1489,9 +1492,9 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:453
+#: lib/vutuv_web/templates/user/show.html.heex:458
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
-#: lib/vutuv_web/templates/user_tag/index.html.heex:17
+#: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
 #, elixir-autogen
@@ -1499,7 +1502,7 @@ msgid "Tags"
 msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:156
-#: lib/vutuv_web/controllers/session_controller.ex:395
+#: lib/vutuv_web/controllers/session_controller.ex:433
 #: lib/vutuv_web/controllers/user_controller.ex:311
 #, elixir-autogen
 msgid "Too many incorrect attempts."
@@ -1618,7 +1621,7 @@ msgstr ""
 msgid "User tag created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:134
+#: lib/vutuv_web/controllers/user_tag_controller.ex:144
 #, elixir-autogen
 msgid "User tag deleted successfully."
 msgstr ""
@@ -1652,11 +1655,13 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/new.ex:127
 #: lib/vutuv_web/templates/ad/new.html.heex:111
 #: lib/vutuv_web/templates/address/country_input.html.heex:2
+#: lib/vutuv_web/templates/welcome/show.html.heex:81
 #, elixir-autogen
 msgid "Country"
 msgstr ""
 
-#: lib/vutuv_web/templates/address/country_input.html.heex:5
+#: lib/vutuv_web/templates/address/country_input.html.heex:6
+#: lib/vutuv_web/templates/welcome/show.html.heex:83
 #, elixir-autogen
 msgid "Select a Country"
 msgstr ""
@@ -1724,17 +1729,17 @@ msgstr ""
 msgid "Confirm account deletion"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:75
+#: lib/vutuv_web/controllers/page_controller.ex:76
 #: lib/vutuv_web/templates/layout/app.html.heex:89
-#: lib/vutuv_web/templates/page/index.html.heex:167
+#: lib/vutuv_web/templates/page/index.html.heex:170
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:81
+#: lib/vutuv_web/controllers/page_controller.ex:82
 #: lib/vutuv_web/templates/layout/app.html.heex:91
-#: lib/vutuv_web/templates/page/index.html.heex:167
+#: lib/vutuv_web/templates/page/index.html.heex:170
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1752,23 +1757,23 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:950
-#: lib/vutuv_web/components/ui.ex:959
-#: lib/vutuv_web/components/ui.ex:1260
+#: lib/vutuv_web/components/ui.ex:976
+#: lib/vutuv_web/components/ui.ex:985
+#: lib/vutuv_web/components/ui.ex:1378
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1378
-#: lib/vutuv_web/components/ui.ex:1378
-#: lib/vutuv_web/components/ui.ex:1395
-#: lib/vutuv_web/components/ui.ex:1404
-#: lib/vutuv_web/components/ui.ex:1420
-#: lib/vutuv_web/components/ui.ex:1457
-#: lib/vutuv_web/components/ui.ex:1460
-#: lib/vutuv_web/components/ui.ex:1467
-#: lib/vutuv_web/components/ui.ex:1470
-#: lib/vutuv_web/components/ui.ex:1543
+#: lib/vutuv_web/components/ui.ex:1516
+#: lib/vutuv_web/components/ui.ex:1516
+#: lib/vutuv_web/components/ui.ex:1533
+#: lib/vutuv_web/components/ui.ex:1542
+#: lib/vutuv_web/components/ui.ex:1558
+#: lib/vutuv_web/components/ui.ex:1595
+#: lib/vutuv_web/components/ui.ex:1598
+#: lib/vutuv_web/components/ui.ex:1605
+#: lib/vutuv_web/components/ui.ex:1608
+#: lib/vutuv_web/components/ui.ex:1681
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1820,21 +1825,21 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:285
-#: lib/vutuv_web/components/ui.ex:2879
+#: lib/vutuv_web/components/ui.ex:3026
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:277
+#: lib/vutuv_web/live/notification_live/index.ex:305
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3037
-#: lib/vutuv_web/live/notification_live/index.ex:81
-#: lib/vutuv_web/live/notification_live/index.ex:245
+#: lib/vutuv_web/components/ui.ex:3184
+#: lib/vutuv_web/live/notification_live/index.ex:103
+#: lib/vutuv_web/live/notification_live/index.ex:268
 #: lib/vutuv_web/live/shell_live.ex:447
 #: lib/vutuv_web/templates/layout/app.html.heex:118
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -1878,7 +1883,7 @@ msgid "Submit a bug report or feature request"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/section_docs.ex:106
-#: lib/vutuv_web/templates/user_tag/index.html.heex:12
+#: lib/vutuv_web/templates/user_tag/index.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Tags of %{name}"
 msgstr ""
@@ -1922,7 +1927,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1238
+#: lib/vutuv_web/templates/user/show.html.heex:1247
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1941,14 +1946,14 @@ msgstr ""
 
 #: lib/vutuv_web/open_graph.ex:256
 #: lib/vutuv_web/templates/tag/show.html.heex:13
-#: lib/vutuv_web/templates/user/show.html.heex:248
+#: lib/vutuv_web/templates/user/show.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:252
+#: lib/vutuv_web/templates/user/show.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr ""
@@ -1958,35 +1963,29 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:722
+#: lib/vutuv_web/live/notification_live/index.ex:841
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:717
+#: lib/vutuv_web/live/notification_live/index.ex:836
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:712
+#: lib/vutuv_web/live/notification_live/index.ex:831
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2416
+#: lib/vutuv_web/components/ui.ex:2409
+#: lib/vutuv_web/components/ui.ex:2560
 #: lib/vutuv_web/live/organization_live/index.ex:130
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:627
-#, elixir-autogen, elixir-format
-msgid "Load %{count} of %{remaining} more"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:2904
-#: lib/vutuv_web/live/notification_live/index.ex:624
+#: lib/vutuv_web/components/ui.ex:3051
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -1996,7 +1995,7 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2685
+#: lib/vutuv_web/components/ui.ex:2832
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -2041,12 +2040,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2034
+#: lib/vutuv_web/components/ui.ex:2172
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2038
+#: lib/vutuv_web/components/ui.ex:2176
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2071,37 +2070,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2042
+#: lib/vutuv_web/components/ui.ex:2180
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2032
+#: lib/vutuv_web/components/ui.ex:2170
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2031
+#: lib/vutuv_web/components/ui.ex:2169
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2037
+#: lib/vutuv_web/components/ui.ex:2175
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2036
+#: lib/vutuv_web/components/ui.ex:2174
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2033
+#: lib/vutuv_web/components/ui.ex:2171
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2035
+#: lib/vutuv_web/components/ui.ex:2173
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2116,17 +2115,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2041
+#: lib/vutuv_web/components/ui.ex:2179
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2040
+#: lib/vutuv_web/components/ui.ex:2178
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2039
+#: lib/vutuv_web/components/ui.ex:2177
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2264,13 +2263,13 @@ msgstr ""
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:73
-#: lib/vutuv_web/gettext_extraction_anchors.ex:77
+#: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/notification_live/index.ex:556
+#: lib/vutuv_web/live/notification_live/index.ex:681
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:179
 #: lib/vutuv_web/live/search_live.ex:375
-#: lib/vutuv_web/templates/settings/preferences.html.heex:114
+#: lib/vutuv_web/templates/settings/preferences.html.heex:118
 #: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2354,7 +2353,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3210
+#: lib/vutuv_web/components/ui.ex:3357
 #: lib/vutuv_web/live/shell_live.ex:490
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2424,7 +2423,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:443
+#: lib/vutuv_web/templates/user/show.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2435,15 +2434,15 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1911
-#: lib/vutuv_web/components/ui.ex:1738
-#: lib/vutuv_web/components/ui.ex:1738
-#: lib/vutuv_web/components/ui.ex:2346
+#: lib/vutuv_web/components/ui.ex:1876
+#: lib/vutuv_web/components/ui.ex:1876
+#: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:825
+#: lib/vutuv_web/agent_docs/markdown.ex:827
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:429
@@ -2454,17 +2453,17 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1878
-#: lib/vutuv_web/components/ui.ex:1767
-#: lib/vutuv_web/components/ui.ex:1767
-#: lib/vutuv_web/components/ui.ex:2332
-#: lib/vutuv_web/live/notification_live/index.ex:694
+#: lib/vutuv_web/components/ui.ex:1905
+#: lib/vutuv_web/components/ui.ex:1905
+#: lib/vutuv_web/components/ui.ex:2470
+#: lib/vutuv_web/live/notification_live/index.ex:812
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:824
-#: lib/vutuv_web/live/notification_live/index.ex:648
+#: lib/vutuv_web/agent_docs/markdown.ex:826
+#: lib/vutuv_web/live/notification_live/index.ex:761
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:498
@@ -2489,8 +2488,8 @@ msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1911
-#: lib/vutuv_web/components/ui.ex:1728
-#: lib/vutuv_web/components/ui.ex:1728
+#: lib/vutuv_web/components/ui.ex:1866
+#: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2514,24 +2513,24 @@ msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1878
-#: lib/vutuv_web/components/ui.ex:1757
-#: lib/vutuv_web/components/ui.ex:1757
+#: lib/vutuv_web/components/ui.ex:1895
+#: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1373
-#: lib/vutuv_web/components/ui.ex:1373
-#: lib/vutuv_web/components/ui.ex:1510
+#: lib/vutuv_web/components/ui.ex:1511
+#: lib/vutuv_web/components/ui.ex:1511
+#: lib/vutuv_web/components/ui.ex:1648
 #: lib/vutuv_web/live/post_live/feed.ex:665
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:416
+#: lib/vutuv_web/views/welcome_html.ex:28
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv!"
 msgstr ""
@@ -2544,7 +2543,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:109
 #: lib/vutuv_web/agent_docs/text.ex:105
 #: lib/vutuv_web/components/post_components.ex:274
-#: lib/vutuv_web/live/notification_live/index.ex:649
+#: lib/vutuv_web/live/notification_live/index.ex:762
 #: lib/vutuv_web/templates/post/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Replies"
@@ -2552,7 +2551,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1934
 #: lib/vutuv_web/components/post_components.ex:1935
-#: lib/vutuv_web/live/notification_live/index.ex:693
+#: lib/vutuv_web/live/notification_live/index.ex:810
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2574,7 +2573,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:793
+#: lib/vutuv_web/live/notification_live/index.ex:939
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2650,7 +2649,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1910
+#: lib/vutuv_web/components/ui.ex:2048
 #: lib/vutuv_web/live/message_live/index.ex:596
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2722,13 +2721,13 @@ msgstr ""
 msgid "“Tired of LinkedIn, and want your data to stay in Germany? I can help.”"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:140
+#: lib/vutuv_web/templates/page/index.html.heex:143
 #: lib/vutuv_web/templates/settings/privacy.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:433
+#: lib/vutuv_web/controllers/session_controller.ex:456
 #, elixir-autogen, elixir-format
 msgid "Welcome back, %{name}!"
 msgstr ""
@@ -2759,73 +2758,73 @@ msgid "Use a different email address"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:693
+#: lib/vutuv_web/templates/user/show.html.heex:698
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:931
+#: lib/vutuv_web/templates/user/show.html.heex:936
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1156
+#: lib/vutuv_web/templates/user/show.html.heex:1161
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:859
+#: lib/vutuv_web/templates/user/show.html.heex:864
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:805
+#: lib/vutuv_web/templates/user/show.html.heex:810
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:492
+#: lib/vutuv_web/templates/user/show.html.heex:497
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
 #: lib/vutuv_web/live/user_profile_live.ex:965
-#: lib/vutuv_web/templates/user/show.html.heex:395
+#: lib/vutuv_web/templates/user/show.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2477
-#: lib/vutuv_web/components/ui.ex:2842
+#: lib/vutuv_web/components/ui.ex:2624
+#: lib/vutuv_web/components/ui.ex:2989
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
 #: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
-#: lib/vutuv_web/templates/user/show.html.heex:483
+#: lib/vutuv_web/templates/user/show.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:564
-#: lib/vutuv_web/templates/user/show.html.heex:395
+#: lib/vutuv_web/templates/user/show.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:103
+#: lib/vutuv_web/views/user_helpers.ex:117
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_helpers.ex:107
+#: lib/vutuv_web/views/user_helpers.ex:121
 #, elixir-autogen, elixir-format
 msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
 msgstr ""
@@ -2844,10 +2843,10 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:436
-#: lib/vutuv_web/agent_docs/text.ex:439
+#: lib/vutuv_web/agent_docs/markdown.ex:438
+#: lib/vutuv_web/agent_docs/text.ex:441
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:647
+#: lib/vutuv_web/live/notification_live/index.ex:760
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2883,7 +2882,7 @@ msgstr ""
 msgid "This post is for the connections of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:261
+#: lib/vutuv_web/templates/user/show.html.heex:266
 #: lib/vutuv_web/views/admin/moderation_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "connection"
@@ -2901,35 +2900,35 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:702
+#: lib/vutuv_web/live/notification_live/index.ex:821
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:695
+#: lib/vutuv_web/live/notification_live/index.ex:813
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:692
+#: lib/vutuv_web/live/notification_live/index.ex:809
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:691
-#: lib/vutuv_web/templates/user/show.html.heex:748
+#: lib/vutuv_web/live/notification_live/index.ex:808
+#: lib/vutuv_web/templates/user/show.html.heex:753
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:412
+#: lib/vutuv_web/views/welcome_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:719
+#: lib/vutuv_web/live/notification_live/index.ex:838
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2961,12 +2960,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:815
+#: lib/vutuv_web/live/notification_live/index.ex:964
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:816
+#: lib/vutuv_web/live/notification_live/index.ex:965
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -2998,7 +2997,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:280
 #: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/controllers/page_controller.ex:54
+#: lib/vutuv_web/controllers/page_controller.ex:55
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
@@ -3072,7 +3071,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:696
+#: lib/vutuv_web/live/notification_live/index.ex:814
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3146,8 +3145,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:899
-#: lib/vutuv_web/templates/user/show.html.heex:900
+#: lib/vutuv_web/templates/user/show.html.heex:904
+#: lib/vutuv_web/templates/user/show.html.heex:905
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -3201,7 +3200,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3010
+#: lib/vutuv_web/components/ui.ex:3157
 #: lib/vutuv_web/live/shell_live.ex:382
 #: lib/vutuv_web/live/shell_live.ex:583
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3310,7 +3309,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2246
+#: lib/vutuv_web/components/ui.ex:2384
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3411,13 +3410,13 @@ msgid "The report is justified. The content stays hidden and the owner gets a st
 msgstr ""
 
 #: lib/vutuv_web/controllers/session_controller.ex:270
-#: lib/vutuv_web/controllers/session_controller.ex:384
+#: lib/vutuv_web/controllers/session_controller.ex:387
 #, elixir-autogen, elixir-format
 msgid "This account has been deactivated."
 msgstr ""
 
 #: lib/vutuv_web/controllers/session_controller.ex:261
-#: lib/vutuv_web/controllers/session_controller.ex:375
+#: lib/vutuv_web/controllers/session_controller.ex:378
 #, elixir-autogen, elixir-format
 msgid "This account is suspended until %{date}."
 msgstr ""
@@ -3491,12 +3490,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:818
+#: lib/vutuv_web/live/notification_live/index.ex:967
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:817
+#: lib/vutuv_web/live/notification_live/index.ex:966
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3506,7 +3505,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:819
+#: lib/vutuv_web/live/notification_live/index.ex:968
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3537,17 +3536,17 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:826
+#: lib/vutuv/notifications/emailer.ex:832
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:910
+#: lib/vutuv/notifications/emailer.ex:916
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:888
+#: lib/vutuv/notifications/emailer.ex:894
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
@@ -3567,12 +3566,12 @@ msgstr ""
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:840
+#: lib/vutuv/notifications/emailer.ex:846
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:833
+#: lib/vutuv/notifications/emailer.ex:839
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -3695,7 +3694,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:841
+#: lib/vutuv_web/live/notification_live/index.ex:992
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3720,7 +3719,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:698
+#: lib/vutuv_web/live/notification_live/index.ex:816
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3795,7 +3794,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:846
+#: lib/vutuv_web/live/notification_live/index.ex:997
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -3880,12 +3879,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:526
+#: lib/vutuv_web/agent_docs/markdown.ex:528
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:869
+#: lib/vutuv_web/agent_docs/markdown.ex:871
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3899,11 +3898,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:144
 #: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:793
+#: lib/vutuv_web/agent_docs/markdown.ex:795
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:139
 #: lib/vutuv_web/agent_docs/text.ex:152
-#: lib/vutuv_web/agent_docs/text.ex:568
+#: lib/vutuv_web/agent_docs/text.ex:570
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3920,26 +3919,26 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:811
-#: lib/vutuv_web/agent_docs/text.ex:579
+#: lib/vutuv_web/agent_docs/markdown.ex:813
+#: lib/vutuv_web/agent_docs/text.ex:581
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:808
-#: lib/vutuv_web/agent_docs/text.ex:576
+#: lib/vutuv_web/agent_docs/markdown.ex:810
+#: lib/vutuv_web/agent_docs/text.ex:578
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:815
-#: lib/vutuv_web/agent_docs/text.ex:582
+#: lib/vutuv_web/agent_docs/markdown.ex:817
+#: lib/vutuv_web/agent_docs/text.ex:584
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:419
-#: lib/vutuv_web/agent_docs/text.ex:422
+#: lib/vutuv_web/agent_docs/markdown.ex:421
+#: lib/vutuv_web/agent_docs/text.ex:424
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
@@ -3985,17 +3984,17 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:762
+#: lib/vutuv_web/agent_docs/markdown.ex:764
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/markdown.ex:694
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:693
+#: lib/vutuv_web/agent_docs/markdown.ex:695
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4099,6 +4098,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/edit.ex:278
 #: lib/vutuv_web/live/organization_live/new.ex:123
 #: lib/vutuv_web/templates/ad/new.html.heex:105
+#: lib/vutuv_web/templates/welcome/show.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "City"
 msgstr ""
@@ -4578,7 +4578,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:767
+#: lib/vutuv_web/templates/user/show.html.heex:772
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4621,7 +4621,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:309
 #: lib/vutuv_web/agent_docs/text.ex:341
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:557
+#: lib/vutuv_web/live/notification_live/index.ex:682
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:177
@@ -4643,7 +4643,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:271
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:555
+#: lib/vutuv_web/live/notification_live/index.ex:680
 #: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -4691,7 +4691,7 @@ msgid "searches first names only (last: for last names)"
 msgstr ""
 
 #: lib/vutuv_web/live/user_profile_live.ex:953
-#: lib/vutuv_web/templates/user/show.html.heex:456
+#: lib/vutuv_web/templates/user/show.html.heex:461
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5262,7 +5262,7 @@ msgstr ""
 msgid "vutuv POSTs signed JSON envelopes here (see the webhooks documentation). https:// only; http://localhost is allowed for development."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:145
+#: lib/vutuv_web/templates/page/index.html.heex:148
 #: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
@@ -5278,7 +5278,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3043
+#: lib/vutuv_web/components/ui.ex:3190
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5356,9 +5356,9 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3129
-#: lib/vutuv_web/components/ui.ex:3134
-#: lib/vutuv_web/components/ui.ex:3202
+#: lib/vutuv_web/components/ui.ex:3276
+#: lib/vutuv_web/components/ui.ex:3281
+#: lib/vutuv_web/components/ui.ex:3349
 #: lib/vutuv_web/controllers/settings_controller.ex:51
 #: lib/vutuv_web/live/shell_live.ex:518
 #: lib/vutuv_web/live/tag_new_live.ex:44
@@ -5412,12 +5412,12 @@ msgstr ""
 msgid "Your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:301
+#: lib/vutuv_web/templates/user/show.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:323
+#: lib/vutuv_web/templates/user/show.html.heex:328
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
@@ -5451,6 +5451,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:899
 #: lib/vutuv_web/components/post_components.ex:953
 #: lib/vutuv_web/components/post_components.ex:1268
+#: lib/vutuv_web/live/notification_live/index.ex:519
 #: lib/vutuv_web/live/post_live/feed.ex:737
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5461,19 +5462,18 @@ msgstr ""
 msgid "Someone tried to register with your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:84
+#: lib/vutuv_web/templates/page/index.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:743
+#: lib/vutuv/accounts/user.ex:887
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/directory_html.ex:8
 #: lib/vutuv_web/views/email_html.ex:13
 #: lib/vutuv_web/views/invitation_html.ex:18
@@ -5482,7 +5482,6 @@ msgid "Other"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/email_html.ex:12
 #: lib/vutuv_web/views/user_html.ex:516
 #, elixir-autogen, elixir-format
@@ -5494,7 +5493,7 @@ msgstr ""
 msgid "Type of Email"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:102
+#: lib/vutuv_web/templates/page/index.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Type of email address"
 msgstr ""
@@ -5504,7 +5503,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3025
+#: lib/vutuv_web/components/ui.ex:3172
 #: lib/vutuv_web/live/admin/user_live.ex:266
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:13
 #, elixir-autogen, elixir-format
@@ -5527,7 +5526,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3020
+#: lib/vutuv_web/components/ui.ex:3167
 #: lib/vutuv_web/controllers/email_controller.ex:30
 #: lib/vutuv_web/controllers/email_controller.ex:49
 #: lib/vutuv_web/controllers/email_controller.ex:191
@@ -5558,7 +5557,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3035
+#: lib/vutuv_web/components/ui.ex:3182
 #: lib/vutuv_web/templates/settings/privacy.html.heex:9
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5584,7 +5583,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:382
+#: lib/vutuv_web/live/notification_live/index.ex:434
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5671,7 +5670,7 @@ msgstr ""
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3042
+#: lib/vutuv_web/components/ui.ex:3189
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -5682,8 +5681,8 @@ msgstr ""
 msgid "Apps & API"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:104
-#: lib/vutuv_web/live/notification_live/index.ex:650
+#: lib/vutuv_web/controllers/user_tag_controller.ex:105
+#: lib/vutuv_web/live/notification_live/index.ex:763
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #, elixir-autogen, elixir-format
@@ -5907,7 +5906,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:402
+#: lib/vutuv_web/controllers/settings_controller.ex:411
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5947,7 +5946,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:391
+#: lib/vutuv_web/controllers/settings_controller.ex:400
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -6107,14 +6106,14 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:174
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:691
+#: lib/vutuv_web/templates/user/show.html.heex:696
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:376
+#: lib/vutuv_web/templates/user/show.html.heex:381
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6128,7 +6127,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1203
+#: lib/vutuv_web/templates/user/show.html.heex:1212
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6171,16 +6170,16 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:825
-#: lib/vutuv_web/templates/user/show.html.heex:835
+#: lib/vutuv_web/templates/user/show.html.heex:830
+#: lib/vutuv_web/templates/user/show.html.heex:840
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:424
-#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/agent_docs/markdown.ex:426
+#: lib/vutuv_web/agent_docs/text.ex:429
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6212,12 +6211,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:946
+#: lib/vutuv_web/templates/user/show.html.heex:951
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:957
+#: lib/vutuv_web/templates/user/show.html.heex:962
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6252,14 +6251,14 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:824
+#: lib/vutuv_web/agent_docs/markdown.ex:826
 #: lib/vutuv_web/components/post_components.ex:273
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:955
+#: lib/vutuv_web/templates/user/show.html.heex:960
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6284,9 +6283,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:950
-#: lib/vutuv_web/components/ui.ex:959
-#: lib/vutuv_web/components/ui.ex:1261
+#: lib/vutuv_web/components/ui.ex:976
+#: lib/vutuv_web/components/ui.ex:985
+#: lib/vutuv_web/components/ui.ex:1379
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6307,20 +6306,20 @@ msgstr ""
 msgid "Map services to show"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:78
+#: lib/vutuv_web/gettext_extraction_anchors.ex:80
 #: lib/vutuv_web/templates/settings/preferences.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1189
-#: lib/vutuv_web/templates/user/show.html.heex:1197
-#: lib/vutuv_web/templates/user/show.html.heex:1209
+#: lib/vutuv_web/templates/user/show.html.heex:1198
+#: lib/vutuv_web/templates/user/show.html.heex:1206
+#: lib/vutuv_web/templates/user/show.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:76
+#: lib/vutuv_web/gettext_extraction_anchors.ex:78
 #: lib/vutuv_web/templates/settings/preferences.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6347,16 +6346,16 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1214
-#: lib/vutuv_web/live/notification_live/index.ex:413
-#: lib/vutuv_web/live/notification_live/index.ex:428
-#: lib/vutuv_web/live/notification_live/index.ex:514
-#: lib/vutuv_web/live/notification_live/index.ex:516
+#: lib/vutuv_web/components/ui.ex:1332
+#: lib/vutuv_web/live/notification_live/index.ex:464
+#: lib/vutuv_web/live/notification_live/index.ex:479
+#: lib/vutuv_web/live/notification_live/index.ex:602
+#: lib/vutuv_web/live/notification_live/index.ex:604
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:806
+#: lib/vutuv_web/agent_docs/markdown.ex:808
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6630,7 +6629,7 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1698
+#: lib/vutuv_web/components/ui.ex:1836
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Mute"
@@ -6652,7 +6651,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1697
+#: lib/vutuv_web/components/ui.ex:1835
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Unmute"
@@ -6689,33 +6688,33 @@ msgstr ""
 msgid "Unmute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1668
+#: lib/vutuv_web/components/ui.ex:1806
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1662
+#: lib/vutuv_web/components/ui.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1652
+#: lib/vutuv_web/components/ui.ex:1790
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1603
-#: lib/vutuv_web/components/ui.ex:1652
+#: lib/vutuv_web/components/ui.ex:1741
+#: lib/vutuv_web/components/ui.ex:1790
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1601
+#: lib/vutuv_web/components/ui.ex:1739
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1602
+#: lib/vutuv_web/components/ui.ex:1740
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -7277,13 +7276,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2284
+#: lib/vutuv_web/components/ui.ex:2422
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2300
+#: lib/vutuv_web/components/ui.ex:2438
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7536,17 +7535,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:874
+#: lib/vutuv_web/agent_docs/markdown.ex:876
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:877
+#: lib/vutuv_web/agent_docs/markdown.ex:879
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:884
+#: lib/vutuv_web/agent_docs/markdown.ex:886
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -7753,13 +7752,13 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:584
+#: lib/vutuv_web/live/notification_live/index.ex:709
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:587
+#: lib/vutuv_web/live/notification_live/index.ex:712
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7978,8 +7977,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:911
-#: lib/vutuv/accounts.ex:960
+#: lib/vutuv/accounts.ex:922
+#: lib/vutuv/accounts.ex:971
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8017,7 +8016,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:928
+#: lib/vutuv/accounts.ex:939
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8028,7 +8027,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2287
+#: lib/vutuv_web/components/ui.ex:2425
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8147,7 +8146,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:544
+#: lib/vutuv_web/templates/user/show.html.heex:549
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8159,7 +8158,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3014
+#: lib/vutuv_web/components/ui.ex:3161
 #: lib/vutuv_web/controllers/education_controller.ex:38
 #: lib/vutuv_web/controllers/education_controller.ex:53
 #: lib/vutuv_web/controllers/education_controller.ex:103
@@ -8172,7 +8171,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:541
+#: lib/vutuv_web/templates/user/show.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -8213,7 +8212,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3030
+#: lib/vutuv_web/components/ui.ex:3177
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8222,7 +8221,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/import_controller.ex:114
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:364
+#: lib/vutuv_web/templates/user/show.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Import from LinkedIn"
 msgstr ""
@@ -8242,7 +8241,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3021
+#: lib/vutuv_web/components/ui.ex:3168
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8331,17 +8330,12 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:429
-#, elixir-autogen, elixir-format
-msgid "A photo and a short tagline make your profile complete."
-msgstr ""
-
 #: lib/vutuv_web/live/user_profile_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2523
+#: lib/vutuv_web/components/ui.ex:2670
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:36
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:42
@@ -8362,7 +8356,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:94
-#: lib/vutuv_web/templates/user/show.html.heex:1060
+#: lib/vutuv_web/templates/user/show.html.heex:1065
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8422,25 +8416,25 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3012
+#: lib/vutuv_web/components/ui.ex:3159
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3029
+#: lib/vutuv_web/components/ui.ex:3176
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:401
+#: lib/vutuv_web/templates/user/edit.html.heex:442
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3027
+#: lib/vutuv_web/components/ui.ex:3174
 #: lib/vutuv_web/controllers/settings_controller.ex:89
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:5
@@ -8449,7 +8443,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3031
+#: lib/vutuv_web/components/ui.ex:3178
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8673,7 +8667,7 @@ msgstr ""
 msgid "Allow followers from the Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3036
+#: lib/vutuv_web/components/ui.ex:3183
 #: lib/vutuv_web/controllers/settings_controller.ex:186
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:265
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
@@ -8738,7 +8732,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:923
+#: lib/vutuv/accounts.ex:934
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8763,7 +8757,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:586
+#: lib/vutuv_web/agent_docs/markdown.ex:588
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8784,7 +8778,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/markdown.ex:589
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8815,13 +8809,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:624
+#: lib/vutuv_web/agent_docs/markdown.ex:626
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:623
+#: lib/vutuv_web/agent_docs/markdown.ex:625
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8854,7 +8848,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:765
+#: lib/vutuv_web/agent_docs/markdown.ex:767
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8932,14 +8926,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:585
+#: lib/vutuv_web/agent_docs/markdown.ex:587
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:588
+#: lib/vutuv_web/agent_docs/markdown.ex:590
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9056,7 +9050,7 @@ msgstr ""
 msgid "Removed @%{handle} from this tag."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:139
+#: lib/vutuv_web/controllers/user_tag_controller.ex:149
 #, elixir-autogen, elixir-format
 msgid "This tag can only be removed by a site admin."
 msgstr ""
@@ -9066,8 +9060,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:994
-#: lib/vutuv_web/components/ui.ex:995
+#: lib/vutuv_web/components/ui.ex:1020
+#: lib/vutuv_web/components/ui.ex:1021
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:64
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9079,8 +9073,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:445
-#: lib/vutuv_web/agent_docs/text.ex:446
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/text.ex:448
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9096,7 +9090,7 @@ msgid "A2 (Elementary)"
 msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:606
+#: lib/vutuv_web/templates/user/show.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9308,7 +9302,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:49
 #: lib/vutuv_web/agent_docs/text.ex:46
-#: lib/vutuv_web/components/ui.ex:3016
+#: lib/vutuv_web/components/ui.ex:3163
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
@@ -9321,7 +9315,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:3
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:603
+#: lib/vutuv_web/templates/user/show.html.heex:608
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9504,12 +9498,11 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:417
 #: lib/vutuv_web/agent_docs/text.ex:420
-#: lib/vutuv_web/templates/user/edit.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:617
+#: lib/vutuv/accounts/user.ex:735
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9520,13 +9513,13 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:614
+#: lib/vutuv/accounts/user.ex:732
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:206
+#: lib/vutuv_web/templates/user/edit.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -9602,12 +9595,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:646
+#: lib/vutuv_web/templates/user/show.html.heex:651
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:686
+#: lib/vutuv_web/agent_docs/markdown.ex:688
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9635,7 +9628,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3015
+#: lib/vutuv_web/components/ui.ex:3162
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -9650,7 +9643,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:3
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:643
+#: lib/vutuv_web/templates/user/show.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr ""
@@ -9694,7 +9687,7 @@ msgstr ""
 msgid "Expiry year"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
+#: lib/vutuv_web/agent_docs/markdown.ex:663
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9720,7 +9713,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:685
+#: lib/vutuv_web/agent_docs/markdown.ex:687
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9747,7 +9740,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:659
+#: lib/vutuv_web/agent_docs/markdown.ex:661
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9762,7 +9755,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:660
+#: lib/vutuv_web/agent_docs/markdown.ex:662
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -9779,15 +9772,15 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:543
+#: lib/vutuv_web/agent_docs/markdown.ex:545
 #: lib/vutuv_web/live/section_reorder_live.ex:269
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:921
-#: lib/vutuv_web/templates/user/show.html.heex:922
+#: lib/vutuv_web/templates/user/show.html.heex:926
+#: lib/vutuv_web/templates/user/show.html.heex:927
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9801,18 +9794,18 @@ msgstr ""
 msgid "Date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:320
-#: lib/vutuv_web/templates/user/edit.html.heex:389
+#: lib/vutuv_web/templates/user/edit.html.heex:361
+#: lib/vutuv_web/templates/user/edit.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:369
+#: lib/vutuv_web/templates/user/edit.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:372
+#: lib/vutuv_web/templates/user/edit.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -9960,8 +9953,8 @@ msgstr ""
 msgid "Permanent profile link"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:312
-#: lib/vutuv_web/templates/user/show.html.heex:313
+#: lib/vutuv_web/templates/user/show.html.heex:317
+#: lib/vutuv_web/templates/user/show.html.heex:318
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
@@ -10420,21 +10413,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:503
+#: lib/vutuv_web/agent_docs/markdown.ex:505
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:503
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:499
+#: lib/vutuv_web/agent_docs/markdown.ex:501
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10457,7 +10450,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1034
+#: lib/vutuv_web/templates/user/show.html.heex:1039
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10487,12 +10480,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:517
+#: lib/vutuv_web/agent_docs/markdown.ex:519
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:504
+#: lib/vutuv_web/agent_docs/markdown.ex:506
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10682,7 +10675,7 @@ msgstr ""
 msgid "vutuv is the open business network where professionals connect, share, and get found. Free to join."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:91
+#: lib/vutuv_web/templates/page/index.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "At least three tags, separated by a comma or a space. Multi-word tags go in quotes: \"Ruby on Rails\"."
 msgstr ""
@@ -10707,53 +10700,53 @@ msgstr ""
 msgid "%{n}y"
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:448
+#: lib/vutuv_web/controllers/session_controller.ex:471
 #, elixir-autogen, elixir-format
 msgid "You have %{formatted} new message."
 msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:164
+#: lib/vutuv_web/templates/settings/preferences.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:116
+#: lib/vutuv_web/templates/settings/preferences.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:171
+#: lib/vutuv_web/templates/settings/preferences.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:70
-#: lib/vutuv_web/templates/settings/preferences.html.heex:175
+#: lib/vutuv_web/templates/settings/preferences.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:161
+#: lib/vutuv_web/templates/settings/preferences.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:139
+#: lib/vutuv_web/templates/settings/preferences.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:148
+#: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:134
+#: lib/vutuv_web/templates/settings/preferences.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10763,7 +10756,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:131
+#: lib/vutuv_web/templates/settings/preferences.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10807,7 +10800,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:366
+#: lib/vutuv_web/controllers/settings_controller.ex:375
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10822,7 +10815,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:362
+#: lib/vutuv_web/controllers/settings_controller.ex:371
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -10849,7 +10842,7 @@ msgid "Preferences of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:102
-#: lib/vutuv_web/templates/settings/preferences.html.heex:195
+#: lib/vutuv_web/templates/settings/preferences.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -10880,17 +10873,17 @@ msgstr ""
 msgid "What every member gets until they choose for themselves on their settings pages, and what logged-out visitors see. Changes apply immediately; members who set their own value are not affected."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:75
+#: lib/vutuv_web/gettext_extraction_anchors.ex:76
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:80
+#: lib/vutuv_web/gettext_extraction_anchors.ex:82
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:79
+#: lib/vutuv_web/gettext_extraction_anchors.ex:81
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
@@ -11033,73 +11026,78 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:215
+#: lib/vutuv_web/templates/user/edit.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:629
+#: lib/vutuv/accounts/user.ex:773
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:634
+#: lib/vutuv/accounts/user.ex:778
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:632
+#: lib/vutuv/accounts/user.ex:776
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:212
+#: lib/vutuv_web/templates/user/edit.html.heex:214
+#: lib/vutuv_web/templates/welcome/show.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:237
+#: lib/vutuv_web/templates/user/edit.html.heex:239
+#: lib/vutuv_web/templates/welcome/show.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:464
-#: lib/vutuv_web/templates/user/edit.html.heex:245
+#: lib/vutuv_web/templates/user/edit.html.heex:247
+#: lib/vutuv_web/templates/welcome/show.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:255
+#: lib/vutuv_web/templates/user/edit.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:228
+#: lib/vutuv_web/templates/user/edit.html.heex:230
+#: lib/vutuv_web/templates/welcome/show.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:231
+#: lib/vutuv_web/templates/user/edit.html.heex:233
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:471
-#: lib/vutuv_web/templates/user/edit.html.heex:241
+#: lib/vutuv_web/templates/user/edit.html.heex:243
+#: lib/vutuv_web/templates/welcome/show.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:222
+#: lib/vutuv_web/templates/user/show.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:252
+#: lib/vutuv_web/templates/user/edit.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr ""
@@ -11168,7 +11166,7 @@ msgstr ""
 msgid "Exclude an email domain"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:269
+#: lib/vutuv_web/templates/user/edit.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr ""
@@ -11179,12 +11177,12 @@ msgstr ""
 msgid "Job-search exclusion list"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:272
+#: lib/vutuv_web/templates/user/edit.html.heex:313
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:280
+#: lib/vutuv_web/templates/user/edit.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -11837,8 +11835,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:706
-#: lib/vutuv_web/agent_docs/text.ex:542
+#: lib/vutuv_web/agent_docs/markdown.ex:708
+#: lib/vutuv_web/agent_docs/text.ex:544
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -12058,7 +12056,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:699
+#: lib/vutuv_web/live/notification_live/index.ex:817
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12069,7 +12067,7 @@ msgid "Organization unfrozen."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:3028
+#: lib/vutuv_web/components/ui.ex:3175
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
@@ -12161,22 +12159,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:807
+#: lib/vutuv_web/live/notification_live/index.ex:956
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:804
+#: lib/vutuv_web/live/notification_live/index.ex:953
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:801
+#: lib/vutuv_web/live/notification_live/index.ex:950
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:798
+#: lib/vutuv_web/live/notification_live/index.ex:947
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12373,6 +12371,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:747
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12492,6 +12491,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:746
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12543,6 +12543,7 @@ msgid "Post as"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:398
+#: lib/vutuv_web/templates/welcome/show.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Postal code"
 msgstr ""
@@ -12572,6 +12573,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:748
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
 #: lib/vutuv_web/agent_docs/markdown.ex:332
@@ -12706,7 +12708,7 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:856
+#: lib/vutuv/notifications/emailer.ex:862
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
@@ -13243,7 +13245,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3066
+#: lib/vutuv_web/components/ui.ex:3213
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13504,11 +13506,6 @@ msgstr ""
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:818
-#, elixir-autogen, elixir-format
-msgid "An image was removed from your vutuv account"
-msgstr ""
-
 #: lib/vutuv_web/components/post_components.ex:1030
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
@@ -13522,7 +13519,7 @@ msgstr ""
 msgid "Image is being reviewed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:697
+#: lib/vutuv_web/live/notification_live/index.ex:815
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13531,11 +13528,6 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
-msgstr ""
-
-#: lib/vutuv_web/live/notification_live/index.ex:829
-#, elixir-autogen, elixir-format
-msgid "Our automated image review removed %{what}. Only family-friendly images suitable for a work environment are allowed."
 msgstr ""
 
 #: lib/vutuv_web/templates/user/show.html.heex:159
@@ -13568,36 +13560,36 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:647
+#: lib/vutuv/accounts/user.ex:791
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:331
+#: lib/vutuv_web/templates/user/edit.html.heex:372
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:650
+#: lib/vutuv/accounts/user.ex:794
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:653
+#: lib/vutuv/accounts/user.ex:797
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:644
+#: lib/vutuv/accounts/user.ex:788
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:328
+#: lib/vutuv_web/templates/user/edit.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr ""
@@ -13614,7 +13606,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:700
+#: lib/vutuv_web/live/notification_live/index.ex:818
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13626,7 +13618,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:855
+#: lib/vutuv_web/live/notification_live/index.ex:1006
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13718,7 +13710,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3055
+#: lib/vutuv_web/components/ui.ex:3202
 #: lib/vutuv_web/controllers/settings_controller.ex:259
 #: lib/vutuv_web/live/post_live/feed.ex:651
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13768,7 +13760,7 @@ msgid "Signal and WhatsApp accept a phone number or a username; the other messen
 msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1000
+#: lib/vutuv_web/templates/user/show.html.heex:1005
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13797,7 +13789,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3019
+#: lib/vutuv_web/components/ui.ex:3166
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:3
@@ -13805,7 +13797,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:3
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:998
+#: lib/vutuv_web/templates/user/show.html.heex:1003
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13825,34 +13817,34 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2609
+#: lib/vutuv_web/components/ui.ex:2756
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:2619
+#: lib/vutuv_web/components/ui.ex:2766
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:701
+#: lib/vutuv_web/live/notification_live/index.ex:819
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:875
+#: lib/vutuv_web/live/notification_live/index.ex:1026
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:867
+#: lib/vutuv_web/live/notification_live/index.ex:1018
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:872
+#: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13877,7 +13869,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:880
+#: lib/vutuv_web/live/notification_live/index.ex:1031
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -13897,7 +13889,7 @@ msgstr ""
 msgid "Book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:836
+#: lib/vutuv_web/agent_docs/markdown.ex:838
 #: lib/vutuv_web/components/post_components.ex:1659
 #: lib/vutuv_web/live/post_live/composer.ex:659
 #, elixir-autogen, elixir-format
@@ -13929,7 +13921,7 @@ msgstr ""
 msgid "Film"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:836
+#: lib/vutuv_web/agent_docs/markdown.ex:838
 #: lib/vutuv_web/components/post_components.ex:1658
 #: lib/vutuv_web/live/post_live/composer.ex:658
 #, elixir-autogen, elixir-format
@@ -14060,7 +14052,7 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:572
+#: lib/vutuv_web/agent_docs/markdown.ex:574
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
@@ -14070,45 +14062,45 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:576
+#: lib/vutuv_web/live/notification_live/index.ex:701
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:590
+#: lib/vutuv_web/live/notification_live/index.ex:715
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:285
+#: lib/vutuv_web/live/notification_live/index.ex:321
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:300
+#: lib/vutuv_web/live/notification_live/index.ex:336
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:542
-#: lib/vutuv_web/live/notification_live/index.ex:735
+#: lib/vutuv_web/live/notification_live/index.ex:667
+#: lib/vutuv_web/live/notification_live/index.ex:867
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:715
+#: lib/vutuv_web/live/notification_live/index.ex:834
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:710
+#: lib/vutuv_web/live/notification_live/index.ex:829
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:725
+#: lib/vutuv_web/live/notification_live/index.ex:844
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -14118,12 +14110,12 @@ msgstr ""
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1065
+#: lib/vutuv_web/components/ui.ex:1154
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1067
+#: lib/vutuv_web/components/ui.ex:1158
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14156,19 +14148,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:675
+#: lib/vutuv_web/agent_docs/markdown.ex:677
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:674
+#: lib/vutuv_web/agent_docs/markdown.ex:676
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:680
+#: lib/vutuv_web/agent_docs/markdown.ex:682
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14247,118 +14239,105 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:643
-#: lib/vutuv_web/agent_docs/text.ex:534
+#: lib/vutuv_web/agent_docs/markdown.ex:645
+#: lib/vutuv_web/agent_docs/text.ex:536
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
 
-#: lib/vutuv/prefs.ex:112
 #: lib/vutuv_web/gettext_extraction_anchors.ex:75
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
 
-#: lib/vutuv/prefs.ex:127
 #: lib/vutuv_web/gettext_extraction_anchors.ex:77
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:166
+#: lib/vutuv_web/templates/settings/preferences.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:169
+#: lib/vutuv_web/templates/settings/preferences.html.heex:168
 #, elixir-autogen, elixir-format
-msgid ""
-"Your notifications quote the post someone liked or replied to. Leave the "
-"field empty to follow the site default."
+msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/welcome_controller.ex
+#: lib/vutuv_web/controllers/welcome_controller.ex:102
 #, elixir-autogen, elixir-format
 msgid "Welcome"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:18
 #, elixir-autogen, elixir-format
-msgid ""
-"Two questions before you start. They decide who finds you and which jobs "
-"we show you. Answer as much or as little as you like."
+msgid "Two questions before you start. They decide who finds you and which jobs we show you. Answer as much or as little as you like."
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Where are you?"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:43
 #, elixir-autogen, elixir-format
-msgid ""
-"A city alone is enough. It appears on your profile and lets people search "
-"for members near them."
+msgid "A city alone is enough. It appears on your profile and lets people search for members near them."
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Type of address"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "Are you looking for a job?"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:118
 #, elixir-autogen, elixir-format
-msgid ""
-"Optional, and nobody else sees it. It filters postings below it out of "
-"your own job search."
+msgid "Optional, and nobody else sees it. It filters postings below it out of your own job search."
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/user/edit.html.heex:277
+#: lib/vutuv_web/templates/welcome/show.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/user/edit.html.heex:297
+#: lib/vutuv_web/templates/welcome/show.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "Shown next to your availability, and used to match you with postings."
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Save and continue"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex
-#, elixir-autogen, elixir-format
-msgid "No preference"
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/markdown.ex
+#: lib/vutuv_web/agent_docs/markdown.ex:419
+#: lib/vutuv_web/agent_docs/text.ex:422
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/user/edit.html.heex:205
+#: lib/vutuv_web/templates/welcome/show.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex
+#: lib/vutuv_web/live/notification_live/index.ex:637
 #, elixir-autogen, elixir-format
-msgid ""
-"Your automatically assigned vutuv username is {handle}. You can change it "
-"any time at {url}."
+msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
 
 #: lib/vutuv/notifications/emailer.ex:824
@@ -14366,10 +14345,19 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:901
+#: lib/vutuv_web/live/notification_live/index.ex:980
 #, elixir-autogen, elixir-format
-msgid ""
-"An AI, not a person, removed %{what}: it judged the image not family-"
-"friendly enough for a work environment. It can be wrong, so reply to our "
-"email if you disagree."
+msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:811
+#, elixir-autogen, elixir-format
+msgid "Thread reply"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:854
+#, elixir-autogen, elixir-format
+msgid "replied in a thread you posted in."
+msgid_plural "replied in a thread you posted in."
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -9,14 +9,14 @@
 msgid ""
 msgstr "Language: en\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:71
+#: lib/vutuv_web/controllers/page_controller.ex:72
 #: lib/vutuv_web/templates/layout/app.html.heex:93
 #, elixir-autogen
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2877
-#: lib/vutuv_web/components/ui.ex:2882
+#: lib/vutuv_web/components/ui.ex:3024
+#: lib/vutuv_web/components/ui.ex:3029
 #: lib/vutuv_web/live/organization_live/domains.ex:235
 #: lib/vutuv_web/live/organization_live/edit.ex:382
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -32,9 +32,10 @@ msgstr ""
 #: lib/vutuv_web/live/cv_live.ex:110
 #: lib/vutuv_web/live/organization_live/show.ex:350
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
+#: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1154
+#: lib/vutuv_web/templates/user/show.html.heex:1159
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -58,7 +59,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3022
+#: lib/vutuv_web/components/ui.ex:3169
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -71,13 +72,13 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:171
+#: lib/vutuv_web/templates/page/index.html.heex:174
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2682
-#: lib/vutuv_web/components/ui.ex:2776
+#: lib/vutuv_web/components/ui.ex:2829
+#: lib/vutuv_web/components/ui.ex:2923
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #, elixir-autogen
 msgid "Are you sure?"
@@ -88,22 +89,22 @@ msgstr ""
 msgid "Avatar"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:292
+#: lib/vutuv_web/templates/user/edit.html.heex:333
 #, elixir-autogen
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:422
-#: lib/vutuv_web/agent_docs/markdown.ex:423
-#: lib/vutuv_web/agent_docs/text.ex:425
-#: lib/vutuv_web/agent_docs/text.ex:426
-#: lib/vutuv_web/templates/user/show.html.heex:819
+#: lib/vutuv_web/agent_docs/markdown.ex:424
+#: lib/vutuv_web/agent_docs/markdown.ex:425
+#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/agent_docs/text.ex:428
+#: lib/vutuv_web/templates/user/show.html.heex:824
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:2675
+#: lib/vutuv_web/components/ui.ex:2822
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -118,8 +119,8 @@ msgstr ""
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:25
 #: lib/vutuv_web/templates/user/edit.html.heex:50
 #: lib/vutuv_web/templates/user/edit.html.heex:103
-#: lib/vutuv_web/templates/user/edit.html.heex:347
-#: lib/vutuv_web/templates/user/edit.html.heex:382
+#: lib/vutuv_web/templates/user/edit.html.heex:388
+#: lib/vutuv_web/templates/user/edit.html.heex:423
 #, elixir-autogen
 msgid "Cancel"
 msgstr ""
@@ -139,7 +140,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:13
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:857
+#: lib/vutuv_web/templates/user/show.html.heex:862
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -149,7 +150,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:816
-#: lib/vutuv_web/components/ui.ex:2779
+#: lib/vutuv_web/components/ui.ex:2926
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -188,14 +189,14 @@ msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:398
 #: lib/vutuv_web/templates/export/index.html.heex:41
-#: lib/vutuv_web/templates/user/show.html.heex:273
+#: lib/vutuv_web/templates/user/show.html.heex:278
 #: lib/vutuv_web/views/qualification_html.ex:237
 #, elixir-autogen
 msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:809
-#: lib/vutuv_web/components/ui.ex:2770
+#: lib/vutuv_web/components/ui.ex:2917
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -217,7 +218,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/url/edit.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:842
+#: lib/vutuv_web/templates/user/show.html.heex:847
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #, elixir-autogen
 msgid "Edit"
@@ -276,29 +277,29 @@ msgstr ""
 msgid "English"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:114
+#: lib/vutuv_web/templates/page/index.html.heex:117
 #: lib/vutuv_web/templates/session/new.html.heex:37
 #, elixir-autogen
 msgid "Enter your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:75
+#: lib/vutuv_web/templates/page/index.html.heex:78
 #, elixir-autogen
 msgid "Enter your first name"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:79
+#: lib/vutuv_web/templates/page/index.html.heex:82
 #, elixir-autogen
 msgid "Enter your last name"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3013
+#: lib/vutuv_web/components/ui.ex:3160
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:489
+#: lib/vutuv_web/templates/user/show.html.heex:494
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:3
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -318,43 +319,43 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:434
-#: lib/vutuv_web/agent_docs/text.ex:437
+#: lib/vutuv_web/agent_docs/markdown.ex:436
+#: lib/vutuv_web/agent_docs/text.ex:439
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/notification_live/index.ex:646
+#: lib/vutuv_web/live/notification_live/index.ex:759
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
 #, elixir-autogen
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:435
-#: lib/vutuv_web/agent_docs/text.ex:438
-#: lib/vutuv_web/components/ui.ex:1413
-#: lib/vutuv_web/components/ui.ex:1438
-#: lib/vutuv_web/components/ui.ex:1441
-#: lib/vutuv_web/components/ui.ex:1448
-#: lib/vutuv_web/components/ui.ex:1451
-#: lib/vutuv_web/components/ui.ex:1509
+#: lib/vutuv_web/agent_docs/markdown.ex:437
+#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/components/ui.ex:1551
+#: lib/vutuv_web/components/ui.ex:1576
+#: lib/vutuv_web/components/ui.ex:1579
+#: lib/vutuv_web/components/ui.ex:1586
+#: lib/vutuv_web/components/ui.ex:1589
+#: lib/vutuv_web/components/ui.ex:1647
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:767
+#: lib/vutuv_web/templates/user/show.html.heex:772
 #, elixir-autogen
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:421
-#: lib/vutuv_web/agent_docs/text.ex:424
+#: lib/vutuv_web/agent_docs/markdown.ex:423
+#: lib/vutuv_web/agent_docs/text.ex:426
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
 #: lib/vutuv_web/cv/odt.ex:109
 #: lib/vutuv_web/live/cv_live.ex:113
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
-#: lib/vutuv_web/templates/page/index.html.heex:62
+#: lib/vutuv_web/templates/page/index.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:814
+#: lib/vutuv_web/templates/user/show.html.heex:819
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -415,7 +416,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:52
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:3017
+#: lib/vutuv_web/components/ui.ex:3164
 #: lib/vutuv_web/controllers/url_controller.ex:23
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
@@ -465,8 +466,8 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3033
-#: lib/vutuv_web/live/notification_live/index.ex:558
+#: lib/vutuv_web/components/ui.ex:3180
+#: lib/vutuv_web/live/notification_live/index.ex:683
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -483,7 +484,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:435
+#: lib/vutuv_web/live/notification_live/index.ex:486
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/templates/access_token/new.html.heex:1
 #: lib/vutuv_web/templates/ad/new.html.heex:3
@@ -605,6 +606,7 @@ msgstr ""
 #: lib/vutuv_web/templates/email/form_content.html.heex:15
 #: lib/vutuv_web/templates/email/show.html.heex:25
 #: lib/vutuv_web/views/phone_number_html.ex:15
+#: lib/vutuv_web/views/welcome_html.ex:37
 #, elixir-autogen
 msgid "Private"
 msgstr ""
@@ -647,10 +649,10 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
-#: lib/vutuv_web/templates/settings/preferences.html.heex:180
+#: lib/vutuv_web/templates/settings/preferences.html.heex:205
 #: lib/vutuv_web/templates/settings/privacy.html.heex:64
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
-#: lib/vutuv_web/templates/user/edit.html.heex:342
+#: lib/vutuv_web/templates/user/edit.html.heex:383
 #: lib/vutuv_web/views/settings_html.ex:131
 #, elixir-autogen
 msgid "Save"
@@ -678,7 +680,7 @@ msgstr ""
 msgid "Show"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:150
+#: lib/vutuv_web/templates/page/index.html.heex:153
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr ""
@@ -691,7 +693,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:55
 #: lib/vutuv_web/agent_docs/text.ex:52
-#: lib/vutuv_web/components/ui.ex:3018
+#: lib/vutuv_web/components/ui.ex:3165
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
@@ -704,13 +706,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:968
+#: lib/vutuv_web/templates/user/show.html.heex:973
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:970
+#: lib/vutuv_web/templates/user/show.html.heex:975
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -758,7 +760,7 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2676
+#: lib/vutuv_web/components/ui.ex:2823
 #, elixir-autogen
 msgid "Submit"
 msgstr ""
@@ -812,6 +814,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
+#: lib/vutuv_web/live/notification_live/index.ex:820
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
 #: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:5
@@ -845,7 +848,7 @@ msgstr ""
 #: lib/vutuv_web/templates/url/index.html.heex:8
 #: lib/vutuv_web/templates/url/show.html.heex:4
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:2
-#: lib/vutuv_web/templates/user_tag/index.html.heex:15
+#: lib/vutuv_web/templates/user_tag/index.html.heex:24
 #: lib/vutuv_web/templates/user_tag/show.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:8
 #: lib/vutuv_web/templates/work_experience/show.html.heex:4
@@ -854,14 +857,14 @@ msgid "Users"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:581
-#: lib/vutuv_web/templates/user/show.html.heex:279
+#: lib/vutuv_web/templates/user/show.html.heex:284
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2840
-#: lib/vutuv_web/templates/user/show.html.heex:761
-#: lib/vutuv_web/templates/user/show.html.heex:781
+#: lib/vutuv_web/components/ui.ex:2987
+#: lib/vutuv_web/templates/user/show.html.heex:766
+#: lib/vutuv_web/templates/user/show.html.heex:786
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -878,20 +881,20 @@ msgstr ""
 msgid "We can't find em' cap'n!"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:174
+#: lib/vutuv_web/templates/page/index.html.heex:177
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:436
+#: lib/vutuv_web/controllers/session_controller.ex:459
 #, elixir-autogen
 msgid "Welcome back!"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/email_html.ex:11
 #: lib/vutuv_web/views/phone_number_html.ex:17
+#: lib/vutuv_web/views/welcome_html.ex:37
 #, elixir-autogen
 msgid "Work"
 msgstr ""
@@ -953,12 +956,12 @@ msgstr ""
 msgid "An email has been sent to your email address with instructions on how to delete your account."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:122
+#: lib/vutuv_web/templates/page/index.html.heex:125
 #, elixir-autogen
 msgid "Allow others to view your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:160
+#: lib/vutuv_web/templates/page/index.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1040,14 +1043,14 @@ msgstr ""
 msgid "Select a year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:740
+#: lib/vutuv/accounts/user.ex:884
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:739
+#: lib/vutuv/accounts/user.ex:883
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1108,7 +1111,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:803
+#: lib/vutuv_web/templates/user/show.html.heex:808
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1148,7 +1151,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:182
+#: lib/vutuv_web/controllers/page_controller.ex:183
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1289,7 +1292,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:483
+#: lib/vutuv_web/templates/user/show.html.heex:488
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1458,13 +1461,13 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
 #: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/agent_docs/markdown.ex:793
+#: lib/vutuv_web/agent_docs/markdown.ex:795
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:393
-#: lib/vutuv_web/agent_docs/text.ex:568
-#: lib/vutuv_web/components/ui.ex:3023
-#: lib/vutuv_web/controllers/user_tag_controller.ex:38
-#: lib/vutuv_web/controllers/user_tag_controller.ex:55
+#: lib/vutuv_web/agent_docs/text.ex:570
+#: lib/vutuv_web/components/ui.ex:3170
+#: lib/vutuv_web/controllers/user_tag_controller.ex:39
+#: lib/vutuv_web/controllers/user_tag_controller.ex:56
 #: lib/vutuv_web/cv/docx.ex:174
 #: lib/vutuv_web/cv/html.ex:159
 #: lib/vutuv_web/cv/latex.ex:131
@@ -1487,9 +1490,9 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:453
+#: lib/vutuv_web/templates/user/show.html.heex:458
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
-#: lib/vutuv_web/templates/user_tag/index.html.heex:17
+#: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
 #: lib/vutuv_web/templates/user_tag/show.html.heex:6
 #, elixir-autogen
@@ -1497,7 +1500,7 @@ msgid "Tags"
 msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:156
-#: lib/vutuv_web/controllers/session_controller.ex:395
+#: lib/vutuv_web/controllers/session_controller.ex:433
 #: lib/vutuv_web/controllers/user_controller.ex:311
 #, elixir-autogen
 msgid "Too many incorrect attempts."
@@ -1616,7 +1619,7 @@ msgstr ""
 msgid "User tag created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:134
+#: lib/vutuv_web/controllers/user_tag_controller.ex:144
 #, elixir-autogen
 msgid "User tag deleted successfully."
 msgstr ""
@@ -1650,11 +1653,13 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/new.ex:127
 #: lib/vutuv_web/templates/ad/new.html.heex:111
 #: lib/vutuv_web/templates/address/country_input.html.heex:2
+#: lib/vutuv_web/templates/welcome/show.html.heex:81
 #, elixir-autogen
 msgid "Country"
 msgstr ""
 
-#: lib/vutuv_web/templates/address/country_input.html.heex:5
+#: lib/vutuv_web/templates/address/country_input.html.heex:6
+#: lib/vutuv_web/templates/welcome/show.html.heex:83
 #, elixir-autogen
 msgid "Select a Country"
 msgstr ""
@@ -1722,17 +1727,17 @@ msgstr ""
 msgid "Confirm account deletion"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:75
+#: lib/vutuv_web/controllers/page_controller.ex:76
 #: lib/vutuv_web/templates/layout/app.html.heex:89
-#: lib/vutuv_web/templates/page/index.html.heex:167
+#: lib/vutuv_web/templates/page/index.html.heex:170
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:81
+#: lib/vutuv_web/controllers/page_controller.ex:82
 #: lib/vutuv_web/templates/layout/app.html.heex:91
-#: lib/vutuv_web/templates/page/index.html.heex:167
+#: lib/vutuv_web/templates/page/index.html.heex:170
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1750,23 +1755,23 @@ msgstr ""
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:950
-#: lib/vutuv_web/components/ui.ex:959
-#: lib/vutuv_web/components/ui.ex:1260
+#: lib/vutuv_web/components/ui.ex:976
+#: lib/vutuv_web/components/ui.ex:985
+#: lib/vutuv_web/components/ui.ex:1378
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1378
-#: lib/vutuv_web/components/ui.ex:1378
-#: lib/vutuv_web/components/ui.ex:1395
-#: lib/vutuv_web/components/ui.ex:1404
-#: lib/vutuv_web/components/ui.ex:1420
-#: lib/vutuv_web/components/ui.ex:1457
-#: lib/vutuv_web/components/ui.ex:1460
-#: lib/vutuv_web/components/ui.ex:1467
-#: lib/vutuv_web/components/ui.ex:1470
-#: lib/vutuv_web/components/ui.ex:1543
+#: lib/vutuv_web/components/ui.ex:1516
+#: lib/vutuv_web/components/ui.ex:1516
+#: lib/vutuv_web/components/ui.ex:1533
+#: lib/vutuv_web/components/ui.ex:1542
+#: lib/vutuv_web/components/ui.ex:1558
+#: lib/vutuv_web/components/ui.ex:1595
+#: lib/vutuv_web/components/ui.ex:1598
+#: lib/vutuv_web/components/ui.ex:1605
+#: lib/vutuv_web/components/ui.ex:1608
+#: lib/vutuv_web/components/ui.ex:1681
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1818,21 +1823,21 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:285
-#: lib/vutuv_web/components/ui.ex:2879
+#: lib/vutuv_web/components/ui.ex:3026
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:277
+#: lib/vutuv_web/live/notification_live/index.ex:305
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3037
-#: lib/vutuv_web/live/notification_live/index.ex:81
-#: lib/vutuv_web/live/notification_live/index.ex:245
+#: lib/vutuv_web/components/ui.ex:3184
+#: lib/vutuv_web/live/notification_live/index.ex:103
+#: lib/vutuv_web/live/notification_live/index.ex:268
 #: lib/vutuv_web/live/shell_live.ex:447
 #: lib/vutuv_web/templates/layout/app.html.heex:118
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -1876,7 +1881,7 @@ msgid "Submit a bug report or feature request"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/section_docs.ex:106
-#: lib/vutuv_web/templates/user_tag/index.html.heex:12
+#: lib/vutuv_web/templates/user_tag/index.html.heex:21
 #, elixir-autogen, elixir-format
 msgid "Tags of %{name}"
 msgstr ""
@@ -1920,7 +1925,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1238
+#: lib/vutuv_web/templates/user/show.html.heex:1247
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1939,14 +1944,14 @@ msgstr ""
 
 #: lib/vutuv_web/open_graph.ex:256
 #: lib/vutuv_web/templates/tag/show.html.heex:13
-#: lib/vutuv_web/templates/user/show.html.heex:248
+#: lib/vutuv_web/templates/user/show.html.heex:253
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:252
+#: lib/vutuv_web/templates/user/show.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr ""
@@ -1956,35 +1961,29 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:722
+#: lib/vutuv_web/live/notification_live/index.ex:841
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:717
+#: lib/vutuv_web/live/notification_live/index.ex:836
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:712
+#: lib/vutuv_web/live/notification_live/index.ex:831
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2271
-#: lib/vutuv_web/components/ui.ex:2416
+#: lib/vutuv_web/components/ui.ex:2409
+#: lib/vutuv_web/components/ui.ex:2560
 #: lib/vutuv_web/live/organization_live/index.ex:130
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:627
-#, elixir-autogen, elixir-format
-msgid "Load %{count} of %{remaining} more"
-msgstr ""
-
-#: lib/vutuv_web/components/ui.ex:2904
-#: lib/vutuv_web/live/notification_live/index.ex:624
+#: lib/vutuv_web/components/ui.ex:3051
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -1994,7 +1993,7 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2685
+#: lib/vutuv_web/components/ui.ex:2832
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -2039,12 +2038,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2034
+#: lib/vutuv_web/components/ui.ex:2172
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2038
+#: lib/vutuv_web/components/ui.ex:2176
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2069,37 +2068,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2042
+#: lib/vutuv_web/components/ui.ex:2180
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2032
+#: lib/vutuv_web/components/ui.ex:2170
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2031
+#: lib/vutuv_web/components/ui.ex:2169
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2037
+#: lib/vutuv_web/components/ui.ex:2175
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2036
+#: lib/vutuv_web/components/ui.ex:2174
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2033
+#: lib/vutuv_web/components/ui.ex:2171
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2035
+#: lib/vutuv_web/components/ui.ex:2173
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2114,17 +2113,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2041
+#: lib/vutuv_web/components/ui.ex:2179
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2040
+#: lib/vutuv_web/components/ui.ex:2178
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2039
+#: lib/vutuv_web/components/ui.ex:2177
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2262,13 +2261,13 @@ msgstr ""
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:73
-#: lib/vutuv_web/gettext_extraction_anchors.ex:77
+#: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/notification_live/index.ex:556
+#: lib/vutuv_web/live/notification_live/index.ex:681
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:179
 #: lib/vutuv_web/live/search_live.ex:375
-#: lib/vutuv_web/templates/settings/preferences.html.heex:114
+#: lib/vutuv_web/templates/settings/preferences.html.heex:118
 #: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "Posts"
@@ -2352,7 +2351,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3210
+#: lib/vutuv_web/components/ui.ex:3357
 #: lib/vutuv_web/live/shell_live.ex:490
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2422,7 +2421,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:443
+#: lib/vutuv_web/templates/user/show.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2433,15 +2432,15 @@ msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1911
-#: lib/vutuv_web/components/ui.ex:1738
-#: lib/vutuv_web/components/ui.ex:1738
-#: lib/vutuv_web/components/ui.ex:2346
+#: lib/vutuv_web/components/ui.ex:1876
+#: lib/vutuv_web/components/ui.ex:1876
+#: lib/vutuv_web/components/ui.ex:2484
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:825
+#: lib/vutuv_web/agent_docs/markdown.ex:827
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:429
@@ -2452,17 +2451,17 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1878
-#: lib/vutuv_web/components/ui.ex:1767
-#: lib/vutuv_web/components/ui.ex:1767
-#: lib/vutuv_web/components/ui.ex:2332
-#: lib/vutuv_web/live/notification_live/index.ex:694
+#: lib/vutuv_web/components/ui.ex:1905
+#: lib/vutuv_web/components/ui.ex:1905
+#: lib/vutuv_web/components/ui.ex:2470
+#: lib/vutuv_web/live/notification_live/index.ex:812
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:824
-#: lib/vutuv_web/live/notification_live/index.ex:648
+#: lib/vutuv_web/agent_docs/markdown.ex:826
+#: lib/vutuv_web/live/notification_live/index.ex:761
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:498
@@ -2487,8 +2486,8 @@ msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1911
-#: lib/vutuv_web/components/ui.ex:1728
-#: lib/vutuv_web/components/ui.ex:1728
+#: lib/vutuv_web/components/ui.ex:1866
+#: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2512,24 +2511,24 @@ msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1878
-#: lib/vutuv_web/components/ui.ex:1757
-#: lib/vutuv_web/components/ui.ex:1757
+#: lib/vutuv_web/components/ui.ex:1895
+#: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Unlike"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1373
-#: lib/vutuv_web/components/ui.ex:1373
-#: lib/vutuv_web/components/ui.ex:1510
+#: lib/vutuv_web/components/ui.ex:1511
+#: lib/vutuv_web/components/ui.ex:1511
+#: lib/vutuv_web/components/ui.ex:1648
 #: lib/vutuv_web/live/post_live/feed.ex:665
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:416
+#: lib/vutuv_web/views/welcome_html.ex:28
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv!"
 msgstr ""
@@ -2542,7 +2541,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:109
 #: lib/vutuv_web/agent_docs/text.ex:105
 #: lib/vutuv_web/components/post_components.ex:274
-#: lib/vutuv_web/live/notification_live/index.ex:649
+#: lib/vutuv_web/live/notification_live/index.ex:762
 #: lib/vutuv_web/templates/post/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Replies"
@@ -2550,7 +2549,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1934
 #: lib/vutuv_web/components/post_components.ex:1935
-#: lib/vutuv_web/live/notification_live/index.ex:693
+#: lib/vutuv_web/live/notification_live/index.ex:810
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2572,7 +2571,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:793
+#: lib/vutuv_web/live/notification_live/index.ex:939
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2648,7 +2647,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1910
+#: lib/vutuv_web/components/ui.ex:2048
 #: lib/vutuv_web/live/message_live/index.ex:596
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2720,13 +2719,13 @@ msgstr ""
 msgid "“Tired of LinkedIn, and want your data to stay in Germany? I can help.”"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:140
+#: lib/vutuv_web/templates/page/index.html.heex:143
 #: lib/vutuv_web/templates/settings/privacy.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:433
+#: lib/vutuv_web/controllers/session_controller.ex:456
 #, elixir-autogen, elixir-format
 msgid "Welcome back, %{name}!"
 msgstr ""
@@ -2757,73 +2756,73 @@ msgid "Use a different email address"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:693
+#: lib/vutuv_web/templates/user/show.html.heex:698
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:931
+#: lib/vutuv_web/templates/user/show.html.heex:936
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1156
+#: lib/vutuv_web/templates/user/show.html.heex:1161
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:859
+#: lib/vutuv_web/templates/user/show.html.heex:864
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:805
+#: lib/vutuv_web/templates/user/show.html.heex:810
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:492
+#: lib/vutuv_web/templates/user/show.html.heex:497
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
 #: lib/vutuv_web/live/user_profile_live.ex:965
-#: lib/vutuv_web/templates/user/show.html.heex:395
+#: lib/vutuv_web/templates/user/show.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2477
-#: lib/vutuv_web/components/ui.ex:2842
+#: lib/vutuv_web/components/ui.ex:2624
+#: lib/vutuv_web/components/ui.ex:2989
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
 #: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
-#: lib/vutuv_web/templates/user/show.html.heex:483
+#: lib/vutuv_web/templates/user/show.html.heex:488
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:564
-#: lib/vutuv_web/templates/user/show.html.heex:395
+#: lib/vutuv_web/templates/user/show.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:103
+#: lib/vutuv_web/views/user_helpers.ex:117
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_helpers.ex:107
+#: lib/vutuv_web/views/user_helpers.ex:121
 #, elixir-autogen, elixir-format
 msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
 msgstr ""
@@ -2842,10 +2841,10 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:436
-#: lib/vutuv_web/agent_docs/text.ex:439
+#: lib/vutuv_web/agent_docs/markdown.ex:438
+#: lib/vutuv_web/agent_docs/text.ex:441
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:647
+#: lib/vutuv_web/live/notification_live/index.ex:760
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2881,7 +2880,7 @@ msgstr ""
 msgid "This post is for the connections of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:261
+#: lib/vutuv_web/templates/user/show.html.heex:266
 #: lib/vutuv_web/views/admin/moderation_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "connection"
@@ -2899,35 +2898,35 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:702
+#: lib/vutuv_web/live/notification_live/index.ex:821
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:695
+#: lib/vutuv_web/live/notification_live/index.ex:813
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:692
+#: lib/vutuv_web/live/notification_live/index.ex:809
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:691
-#: lib/vutuv_web/templates/user/show.html.heex:748
+#: lib/vutuv_web/live/notification_live/index.ex:808
+#: lib/vutuv_web/templates/user/show.html.heex:753
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:412
+#: lib/vutuv_web/views/welcome_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:719
+#: lib/vutuv_web/live/notification_live/index.ex:838
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2959,12 +2958,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:815
+#: lib/vutuv_web/live/notification_live/index.ex:964
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:816
+#: lib/vutuv_web/live/notification_live/index.ex:965
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -2996,7 +2995,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:280
 #: lib/vutuv_web/agent_docs/text.ex:271
-#: lib/vutuv_web/controllers/page_controller.ex:54
+#: lib/vutuv_web/controllers/page_controller.ex:55
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
@@ -3070,7 +3069,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:696
+#: lib/vutuv_web/live/notification_live/index.ex:814
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3144,8 +3143,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:899
-#: lib/vutuv_web/templates/user/show.html.heex:900
+#: lib/vutuv_web/templates/user/show.html.heex:904
+#: lib/vutuv_web/templates/user/show.html.heex:905
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -3199,7 +3198,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3010
+#: lib/vutuv_web/components/ui.ex:3157
 #: lib/vutuv_web/live/shell_live.ex:382
 #: lib/vutuv_web/live/shell_live.ex:583
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3308,7 +3307,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2246
+#: lib/vutuv_web/components/ui.ex:2384
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3409,13 +3408,13 @@ msgid "The report is justified. The content stays hidden and the owner gets a st
 msgstr ""
 
 #: lib/vutuv_web/controllers/session_controller.ex:270
-#: lib/vutuv_web/controllers/session_controller.ex:384
+#: lib/vutuv_web/controllers/session_controller.ex:387
 #, elixir-autogen, elixir-format
 msgid "This account has been deactivated."
 msgstr ""
 
 #: lib/vutuv_web/controllers/session_controller.ex:261
-#: lib/vutuv_web/controllers/session_controller.ex:375
+#: lib/vutuv_web/controllers/session_controller.ex:378
 #, elixir-autogen, elixir-format
 msgid "This account is suspended until %{date}."
 msgstr ""
@@ -3489,12 +3488,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:818
+#: lib/vutuv_web/live/notification_live/index.ex:967
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:817
+#: lib/vutuv_web/live/notification_live/index.ex:966
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3504,7 +3503,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:819
+#: lib/vutuv_web/live/notification_live/index.ex:968
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3535,17 +3534,17 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:826
+#: lib/vutuv/notifications/emailer.ex:832
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:910
+#: lib/vutuv/notifications/emailer.ex:916
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:888
+#: lib/vutuv/notifications/emailer.ex:894
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
@@ -3565,12 +3564,12 @@ msgstr ""
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:840
+#: lib/vutuv/notifications/emailer.ex:846
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:833
+#: lib/vutuv/notifications/emailer.ex:839
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -3693,7 +3692,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:841
+#: lib/vutuv_web/live/notification_live/index.ex:992
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3718,7 +3717,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:698
+#: lib/vutuv_web/live/notification_live/index.ex:816
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3793,7 +3792,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:846
+#: lib/vutuv_web/live/notification_live/index.ex:997
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -3878,12 +3877,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:526
+#: lib/vutuv_web/agent_docs/markdown.ex:528
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:869
+#: lib/vutuv_web/agent_docs/markdown.ex:871
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3897,11 +3896,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:144
 #: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:793
+#: lib/vutuv_web/agent_docs/markdown.ex:795
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:139
 #: lib/vutuv_web/agent_docs/text.ex:152
-#: lib/vutuv_web/agent_docs/text.ex:568
+#: lib/vutuv_web/agent_docs/text.ex:570
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3918,26 +3917,26 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:811
-#: lib/vutuv_web/agent_docs/text.ex:579
+#: lib/vutuv_web/agent_docs/markdown.ex:813
+#: lib/vutuv_web/agent_docs/text.ex:581
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:808
-#: lib/vutuv_web/agent_docs/text.ex:576
+#: lib/vutuv_web/agent_docs/markdown.ex:810
+#: lib/vutuv_web/agent_docs/text.ex:578
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:815
-#: lib/vutuv_web/agent_docs/text.ex:582
+#: lib/vutuv_web/agent_docs/markdown.ex:817
+#: lib/vutuv_web/agent_docs/text.ex:584
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:419
-#: lib/vutuv_web/agent_docs/text.ex:422
+#: lib/vutuv_web/agent_docs/markdown.ex:421
+#: lib/vutuv_web/agent_docs/text.ex:424
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
@@ -3983,17 +3982,17 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:762
+#: lib/vutuv_web/agent_docs/markdown.ex:764
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:692
+#: lib/vutuv_web/agent_docs/markdown.ex:694
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:693
+#: lib/vutuv_web/agent_docs/markdown.ex:695
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4097,6 +4096,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/edit.ex:278
 #: lib/vutuv_web/live/organization_live/new.ex:123
 #: lib/vutuv_web/templates/ad/new.html.heex:105
+#: lib/vutuv_web/templates/welcome/show.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "City"
 msgstr ""
@@ -4576,7 +4576,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:767
+#: lib/vutuv_web/templates/user/show.html.heex:772
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4619,7 +4619,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:309
 #: lib/vutuv_web/agent_docs/text.ex:341
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:557
+#: lib/vutuv_web/live/notification_live/index.ex:682
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:177
@@ -4641,7 +4641,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:271
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:555
+#: lib/vutuv_web/live/notification_live/index.ex:680
 #: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -4689,7 +4689,7 @@ msgid "searches first names only (last: for last names)"
 msgstr ""
 
 #: lib/vutuv_web/live/user_profile_live.ex:953
-#: lib/vutuv_web/templates/user/show.html.heex:456
+#: lib/vutuv_web/templates/user/show.html.heex:461
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5260,7 +5260,7 @@ msgstr ""
 msgid "vutuv POSTs signed JSON envelopes here (see the webhooks documentation). https:// only; http://localhost is allowed for development."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:145
+#: lib/vutuv_web/templates/page/index.html.heex:148
 #: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
@@ -5276,7 +5276,7 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3043
+#: lib/vutuv_web/components/ui.ex:3190
 #: lib/vutuv_web/controllers/settings_controller.ex:129
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5354,9 +5354,9 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3129
-#: lib/vutuv_web/components/ui.ex:3134
-#: lib/vutuv_web/components/ui.ex:3202
+#: lib/vutuv_web/components/ui.ex:3276
+#: lib/vutuv_web/components/ui.ex:3281
+#: lib/vutuv_web/components/ui.ex:3349
 #: lib/vutuv_web/controllers/settings_controller.ex:51
 #: lib/vutuv_web/live/shell_live.ex:518
 #: lib/vutuv_web/live/tag_new_live.ex:44
@@ -5410,12 +5410,12 @@ msgstr ""
 msgid "Your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:301
+#: lib/vutuv_web/templates/user/show.html.heex:306
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:323
+#: lib/vutuv_web/templates/user/show.html.heex:328
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
@@ -5449,6 +5449,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:899
 #: lib/vutuv_web/components/post_components.ex:953
 #: lib/vutuv_web/components/post_components.ex:1268
+#: lib/vutuv_web/live/notification_live/index.ex:519
 #: lib/vutuv_web/live/post_live/feed.ex:737
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5459,19 +5460,18 @@ msgstr ""
 msgid "Someone tried to register with your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:84
+#: lib/vutuv_web/templates/page/index.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:743
+#: lib/vutuv/accounts/user.ex:887
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/directory_html.ex:8
 #: lib/vutuv_web/views/email_html.ex:13
 #: lib/vutuv_web/views/invitation_html.ex:18
@@ -5480,7 +5480,6 @@ msgid "Other"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:30
-#: lib/vutuv_web/templates/page/index.html.heex:40
 #: lib/vutuv_web/views/email_html.ex:12
 #: lib/vutuv_web/views/user_html.ex:516
 #, elixir-autogen, elixir-format
@@ -5492,7 +5491,7 @@ msgstr ""
 msgid "Type of Email"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:102
+#: lib/vutuv_web/templates/page/index.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Type of email address"
 msgstr ""
@@ -5502,7 +5501,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3025
+#: lib/vutuv_web/components/ui.ex:3172
 #: lib/vutuv_web/live/admin/user_live.ex:266
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:13
 #, elixir-autogen, elixir-format
@@ -5525,7 +5524,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3020
+#: lib/vutuv_web/components/ui.ex:3167
 #: lib/vutuv_web/controllers/email_controller.ex:30
 #: lib/vutuv_web/controllers/email_controller.ex:49
 #: lib/vutuv_web/controllers/email_controller.ex:191
@@ -5556,7 +5555,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3035
+#: lib/vutuv_web/components/ui.ex:3182
 #: lib/vutuv_web/templates/settings/privacy.html.heex:9
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -5582,7 +5581,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:382
+#: lib/vutuv_web/live/notification_live/index.ex:434
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5669,7 +5668,7 @@ msgstr ""
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3042
+#: lib/vutuv_web/components/ui.ex:3189
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
@@ -5680,8 +5679,8 @@ msgstr ""
 msgid "Apps & API"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:104
-#: lib/vutuv_web/live/notification_live/index.ex:650
+#: lib/vutuv_web/controllers/user_tag_controller.ex:105
+#: lib/vutuv_web/live/notification_live/index.ex:763
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #, elixir-autogen, elixir-format
@@ -5905,7 +5904,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:402
+#: lib/vutuv_web/controllers/settings_controller.ex:411
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5945,7 +5944,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:391
+#: lib/vutuv_web/controllers/settings_controller.ex:400
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -6105,14 +6104,14 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:174
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:691
+#: lib/vutuv_web/templates/user/show.html.heex:696
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:376
+#: lib/vutuv_web/templates/user/show.html.heex:381
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6126,7 +6125,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1203
+#: lib/vutuv_web/templates/user/show.html.heex:1212
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6169,16 +6168,16 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:825
-#: lib/vutuv_web/templates/user/show.html.heex:835
+#: lib/vutuv_web/templates/user/show.html.heex:830
+#: lib/vutuv_web/templates/user/show.html.heex:840
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:424
-#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/agent_docs/markdown.ex:426
+#: lib/vutuv_web/agent_docs/text.ex:429
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6210,12 +6209,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:946
+#: lib/vutuv_web/templates/user/show.html.heex:951
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:957
+#: lib/vutuv_web/templates/user/show.html.heex:962
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6250,14 +6249,14 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:824
+#: lib/vutuv_web/agent_docs/markdown.ex:826
 #: lib/vutuv_web/components/post_components.ex:273
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:955
+#: lib/vutuv_web/templates/user/show.html.heex:960
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6282,9 +6281,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:950
-#: lib/vutuv_web/components/ui.ex:959
-#: lib/vutuv_web/components/ui.ex:1261
+#: lib/vutuv_web/components/ui.ex:976
+#: lib/vutuv_web/components/ui.ex:985
+#: lib/vutuv_web/components/ui.ex:1379
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6305,20 +6304,20 @@ msgstr ""
 msgid "Map services to show"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:78
+#: lib/vutuv_web/gettext_extraction_anchors.ex:80
 #: lib/vutuv_web/templates/settings/preferences.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1189
-#: lib/vutuv_web/templates/user/show.html.heex:1197
-#: lib/vutuv_web/templates/user/show.html.heex:1209
+#: lib/vutuv_web/templates/user/show.html.heex:1198
+#: lib/vutuv_web/templates/user/show.html.heex:1206
+#: lib/vutuv_web/templates/user/show.html.heex:1218
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:76
+#: lib/vutuv_web/gettext_extraction_anchors.ex:78
 #: lib/vutuv_web/templates/settings/preferences.html.heex:80
 #, elixir-autogen, elixir-format
 msgid "Opens first, as the main button. The others appear as alternatives."
@@ -6345,16 +6344,16 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1214
-#: lib/vutuv_web/live/notification_live/index.ex:413
-#: lib/vutuv_web/live/notification_live/index.ex:428
-#: lib/vutuv_web/live/notification_live/index.ex:514
-#: lib/vutuv_web/live/notification_live/index.ex:516
+#: lib/vutuv_web/components/ui.ex:1332
+#: lib/vutuv_web/live/notification_live/index.ex:464
+#: lib/vutuv_web/live/notification_live/index.ex:479
+#: lib/vutuv_web/live/notification_live/index.ex:602
+#: lib/vutuv_web/live/notification_live/index.ex:604
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:806
+#: lib/vutuv_web/agent_docs/markdown.ex:808
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6628,7 +6627,7 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1698
+#: lib/vutuv_web/components/ui.ex:1836
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Mute"
@@ -6650,7 +6649,7 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1697
+#: lib/vutuv_web/components/ui.ex:1835
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Unmute"
@@ -6687,33 +6686,33 @@ msgstr ""
 msgid "Unmute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1668
+#: lib/vutuv_web/components/ui.ex:1806
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1662
+#: lib/vutuv_web/components/ui.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1652
+#: lib/vutuv_web/components/ui.ex:1790
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1603
-#: lib/vutuv_web/components/ui.ex:1652
+#: lib/vutuv_web/components/ui.ex:1741
+#: lib/vutuv_web/components/ui.ex:1790
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1601
+#: lib/vutuv_web/components/ui.ex:1739
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1602
+#: lib/vutuv_web/components/ui.ex:1740
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -7275,13 +7274,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2284
+#: lib/vutuv_web/components/ui.ex:2422
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2300
+#: lib/vutuv_web/components/ui.ex:2438
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7534,17 +7533,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:874
+#: lib/vutuv_web/agent_docs/markdown.ex:876
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:877
+#: lib/vutuv_web/agent_docs/markdown.ex:879
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:884
+#: lib/vutuv_web/agent_docs/markdown.ex:886
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -7751,13 +7750,13 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:584
+#: lib/vutuv_web/live/notification_live/index.ex:709
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:587
+#: lib/vutuv_web/live/notification_live/index.ex:712
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7976,8 +7975,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:911
-#: lib/vutuv/accounts.ex:960
+#: lib/vutuv/accounts.ex:922
+#: lib/vutuv/accounts.ex:971
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8015,7 +8014,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:928
+#: lib/vutuv/accounts.ex:939
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8026,7 +8025,7 @@ msgstr ""
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2287
+#: lib/vutuv_web/components/ui.ex:2425
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
@@ -8145,7 +8144,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:544
+#: lib/vutuv_web/templates/user/show.html.heex:549
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8157,7 +8156,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3014
+#: lib/vutuv_web/components/ui.ex:3161
 #: lib/vutuv_web/controllers/education_controller.ex:38
 #: lib/vutuv_web/controllers/education_controller.ex:53
 #: lib/vutuv_web/controllers/education_controller.ex:103
@@ -8170,7 +8169,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:541
+#: lib/vutuv_web/templates/user/show.html.heex:546
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -8211,7 +8210,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3030
+#: lib/vutuv_web/components/ui.ex:3177
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8220,7 +8219,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/import_controller.ex:114
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:364
+#: lib/vutuv_web/templates/user/show.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Import from LinkedIn"
 msgstr ""
@@ -8240,7 +8239,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3021
+#: lib/vutuv_web/components/ui.ex:3168
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8329,17 +8328,12 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:429
-#, elixir-autogen, elixir-format
-msgid "A photo and a short tagline make your profile complete."
-msgstr ""
-
 #: lib/vutuv_web/live/user_profile_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2523
+#: lib/vutuv_web/components/ui.ex:2670
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:36
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:42
@@ -8360,7 +8354,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:94
-#: lib/vutuv_web/templates/user/show.html.heex:1060
+#: lib/vutuv_web/templates/user/show.html.heex:1065
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8420,25 +8414,25 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3012
+#: lib/vutuv_web/components/ui.ex:3159
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3029
+#: lib/vutuv_web/components/ui.ex:3176
 #: lib/vutuv_web/controllers/settings_controller.ex:106
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:401
+#: lib/vutuv_web/templates/user/edit.html.heex:442
 #, elixir-autogen, elixir-format
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3027
+#: lib/vutuv_web/components/ui.ex:3174
 #: lib/vutuv_web/controllers/settings_controller.ex:89
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:5
@@ -8447,7 +8441,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3031
+#: lib/vutuv_web/components/ui.ex:3178
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8671,7 +8665,7 @@ msgstr ""
 msgid "Allow followers from the Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3036
+#: lib/vutuv_web/components/ui.ex:3183
 #: lib/vutuv_web/controllers/settings_controller.ex:186
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:265
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
@@ -8736,7 +8730,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:923
+#: lib/vutuv/accounts.ex:934
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8761,7 +8755,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:586
+#: lib/vutuv_web/agent_docs/markdown.ex:588
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8782,7 +8776,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/markdown.ex:589
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8813,13 +8807,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:624
+#: lib/vutuv_web/agent_docs/markdown.ex:626
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:623
+#: lib/vutuv_web/agent_docs/markdown.ex:625
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8852,7 +8846,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:765
+#: lib/vutuv_web/agent_docs/markdown.ex:767
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8930,14 +8924,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:585
+#: lib/vutuv_web/agent_docs/markdown.ex:587
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:588
+#: lib/vutuv_web/agent_docs/markdown.ex:590
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9054,7 +9048,7 @@ msgstr ""
 msgid "Removed @%{handle} from this tag."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:139
+#: lib/vutuv_web/controllers/user_tag_controller.ex:149
 #, elixir-autogen, elixir-format
 msgid "This tag can only be removed by a site admin."
 msgstr ""
@@ -9064,8 +9058,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:994
-#: lib/vutuv_web/components/ui.ex:995
+#: lib/vutuv_web/components/ui.ex:1020
+#: lib/vutuv_web/components/ui.ex:1021
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:64
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9077,8 +9071,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:445
-#: lib/vutuv_web/agent_docs/text.ex:446
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/text.ex:448
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9094,7 +9088,7 @@ msgid "A2 (Elementary)"
 msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:606
+#: lib/vutuv_web/templates/user/show.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9306,7 +9300,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:49
 #: lib/vutuv_web/agent_docs/text.ex:46
-#: lib/vutuv_web/components/ui.ex:3016
+#: lib/vutuv_web/components/ui.ex:3163
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
@@ -9319,7 +9313,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:3
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:603
+#: lib/vutuv_web/templates/user/show.html.heex:608
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9502,12 +9496,11 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:417
 #: lib/vutuv_web/agent_docs/text.ex:420
-#: lib/vutuv_web/templates/user/edit.html.heex:203
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:617
+#: lib/vutuv/accounts/user.ex:735
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9518,13 +9511,13 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:614
+#: lib/vutuv/accounts/user.ex:732
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:206
+#: lib/vutuv_web/templates/user/edit.html.heex:208
 #, elixir-autogen, elixir-format
 msgid "Shown as a badge next to your tagline so people can see whether you are open to opportunities."
 msgstr ""
@@ -9600,12 +9593,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:646
+#: lib/vutuv_web/templates/user/show.html.heex:651
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:686
+#: lib/vutuv_web/agent_docs/markdown.ex:688
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9633,7 +9626,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3015
+#: lib/vutuv_web/components/ui.ex:3162
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -9648,7 +9641,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:3
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:643
+#: lib/vutuv_web/templates/user/show.html.heex:648
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr ""
@@ -9692,7 +9685,7 @@ msgstr ""
 msgid "Expiry year"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
+#: lib/vutuv_web/agent_docs/markdown.ex:663
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9718,7 +9711,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:685
+#: lib/vutuv_web/agent_docs/markdown.ex:687
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9745,7 +9738,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:659
+#: lib/vutuv_web/agent_docs/markdown.ex:661
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9760,7 +9753,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:660
+#: lib/vutuv_web/agent_docs/markdown.ex:662
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -9777,15 +9770,15 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:543
+#: lib/vutuv_web/agent_docs/markdown.ex:545
 #: lib/vutuv_web/live/section_reorder_live.ex:269
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:921
-#: lib/vutuv_web/templates/user/show.html.heex:922
+#: lib/vutuv_web/templates/user/show.html.heex:926
+#: lib/vutuv_web/templates/user/show.html.heex:927
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9799,18 +9792,18 @@ msgstr ""
 msgid "Date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:320
-#: lib/vutuv_web/templates/user/edit.html.heex:389
+#: lib/vutuv_web/templates/user/edit.html.heex:361
+#: lib/vutuv_web/templates/user/edit.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "Remove date of birth"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:369
+#: lib/vutuv_web/templates/user/edit.html.heex:410
 #, elixir-autogen, elixir-format
 msgid "Remove your date of birth?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:372
+#: lib/vutuv_web/templates/user/edit.html.heex:413
 #, elixir-autogen, elixir-format
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
@@ -9958,8 +9951,8 @@ msgstr ""
 msgid "Permanent profile link"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:312
-#: lib/vutuv_web/templates/user/show.html.heex:313
+#: lib/vutuv_web/templates/user/show.html.heex:317
+#: lib/vutuv_web/templates/user/show.html.heex:318
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
@@ -10418,21 +10411,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:503
+#: lib/vutuv_web/agent_docs/markdown.ex:505
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:503
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:499
+#: lib/vutuv_web/agent_docs/markdown.ex:501
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10455,7 +10448,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1034
+#: lib/vutuv_web/templates/user/show.html.heex:1039
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10485,12 +10478,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:517
+#: lib/vutuv_web/agent_docs/markdown.ex:519
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:504
+#: lib/vutuv_web/agent_docs/markdown.ex:506
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10680,7 +10673,7 @@ msgstr ""
 msgid "vutuv is the open business network where professionals connect, share, and get found. Free to join."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:91
+#: lib/vutuv_web/templates/page/index.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "At least three tags, separated by a comma or a space. Multi-word tags go in quotes: \"Ruby on Rails\"."
 msgstr ""
@@ -10705,53 +10698,53 @@ msgstr ""
 msgid "%{n}y"
 msgstr ""
 
-#: lib/vutuv_web/controllers/session_controller.ex:448
+#: lib/vutuv_web/controllers/session_controller.ex:471
 #, elixir-autogen, elixir-format
 msgid "You have %{formatted} new message."
 msgid_plural "You have %{formatted} new messages."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:164
+#: lib/vutuv_web/templates/settings/preferences.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Break long words at syllable points so the text wraps evenly. Helpful in the narrow phone column."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:116
+#: lib/vutuv_web/templates/settings/preferences.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "How posts you read are shortened in your feed and on profiles. These are your own reading preferences."
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:69
-#: lib/vutuv_web/templates/settings/preferences.html.heex:171
+#: lib/vutuv_web/templates/settings/preferences.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:70
-#: lib/vutuv_web/templates/settings/preferences.html.heex:175
+#: lib/vutuv_web/templates/settings/preferences.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Hyphenate on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:161
+#: lib/vutuv_web/templates/settings/preferences.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Hyphenation"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:67
-#: lib/vutuv_web/templates/settings/preferences.html.heex:139
+#: lib/vutuv_web/templates/settings/preferences.html.heex:143
 #, elixir-autogen, elixir-format
 msgid "Lines on desktop"
 msgstr ""
 
 #: lib/vutuv_web/gettext_extraction_anchors.ex:68
-#: lib/vutuv_web/templates/settings/preferences.html.heex:148
+#: lib/vutuv_web/templates/settings/preferences.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Lines on mobile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:134
+#: lib/vutuv_web/templates/settings/preferences.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
@@ -10761,7 +10754,7 @@ msgstr ""
 msgid "Post display settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:131
+#: lib/vutuv_web/templates/settings/preferences.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Shorten a post after"
 msgstr ""
@@ -10805,7 +10798,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:366
+#: lib/vutuv_web/controllers/settings_controller.ex:375
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10820,7 +10813,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:362
+#: lib/vutuv_web/controllers/settings_controller.ex:371
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -10847,7 +10840,7 @@ msgid "Preferences of %{name}"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:102
-#: lib/vutuv_web/templates/settings/preferences.html.heex:195
+#: lib/vutuv_web/templates/settings/preferences.html.heex:220
 #, elixir-autogen, elixir-format
 msgid "Reset to the site defaults"
 msgstr ""
@@ -10878,17 +10871,17 @@ msgstr ""
 msgid "What every member gets until they choose for themselves on their settings pages, and what logged-out visitors see. Changes apply immediately; members who set their own value are not affected."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:75
+#: lib/vutuv_web/gettext_extraction_anchors.ex:76
 #, elixir-autogen, elixir-format
 msgid "0 means posts are never shortened."
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:80
+#: lib/vutuv_web/gettext_extraction_anchors.ex:82
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/vutuv_web/gettext_extraction_anchors.ex:79
+#: lib/vutuv_web/gettext_extraction_anchors.ex:81
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
@@ -11031,73 +11024,78 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:215
+#: lib/vutuv_web/templates/user/edit.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:629
+#: lib/vutuv/accounts/user.ex:773
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:634
+#: lib/vutuv/accounts/user.ex:778
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:632
+#: lib/vutuv/accounts/user.ex:776
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
 msgid "Signed-in members only"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:212
+#: lib/vutuv_web/templates/user/edit.html.heex:214
+#: lib/vutuv_web/templates/welcome/show.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Who can see your availability?"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:237
+#: lib/vutuv_web/templates/user/edit.html.heex:239
+#: lib/vutuv_web/templates/welcome/show.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Amount"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:464
-#: lib/vutuv_web/templates/user/edit.html.heex:245
+#: lib/vutuv_web/templates/user/edit.html.heex:247
+#: lib/vutuv_web/templates/welcome/show.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Currency"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:255
+#: lib/vutuv_web/templates/user/edit.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "Hidden by default, and it still does its job while hidden. \"Signed-in members only\" adds a quiet line to your profile for members; \"Everyone\" also shows it to logged-out visitors."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:228
+#: lib/vutuv_web/templates/user/edit.html.heex:230
+#: lib/vutuv_web/templates/welcome/show.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Minimum salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:231
+#: lib/vutuv_web/templates/user/edit.html.heex:233
 #, elixir-autogen, elixir-format
 msgid "Optional. Even when hidden, it sharpens your own job search and alerts by filtering out postings below it. Leave the amount empty to remove it."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:471
-#: lib/vutuv_web/templates/user/edit.html.heex:241
+#: lib/vutuv_web/templates/user/edit.html.heex:243
+#: lib/vutuv_web/templates/welcome/show.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Per"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:222
+#: lib/vutuv_web/templates/user/show.html.heex:227
 #, elixir-autogen, elixir-format
 msgid "Salary expectation from %{amount} %{currency} per %{period}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:252
+#: lib/vutuv_web/templates/user/edit.html.heex:254
 #, elixir-autogen, elixir-format
 msgid "Who can see your salary expectation?"
 msgstr ""
@@ -11166,7 +11164,7 @@ msgstr ""
 msgid "Exclude an email domain"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:269
+#: lib/vutuv_web/templates/user/edit.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "Hide from specific people"
 msgstr ""
@@ -11177,12 +11175,12 @@ msgstr ""
 msgid "Job-search exclusion list"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:272
+#: lib/vutuv_web/templates/user/edit.html.heex:313
 #, elixir-autogen, elixir-format
 msgid "Keep your availability broadly visible while making sure your own employer never sees it. Exclude specific members or email domains, and they never see your availability or salary expectation, even at \"Everyone\"."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:280
+#: lib/vutuv_web/templates/user/edit.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Manage exclusion list (1 entry)"
 msgid_plural "Manage exclusion list (%{formatted} entries)"
@@ -11835,8 +11833,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:706
-#: lib/vutuv_web/agent_docs/text.ex:542
+#: lib/vutuv_web/agent_docs/markdown.ex:708
+#: lib/vutuv_web/agent_docs/text.ex:544
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -12056,7 +12054,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:699
+#: lib/vutuv_web/live/notification_live/index.ex:817
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12067,7 +12065,7 @@ msgid "Organization unfrozen."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:3028
+#: lib/vutuv_web/components/ui.ex:3175
 #: lib/vutuv_web/controllers/settings_controller.ex:157
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
@@ -12159,22 +12157,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:807
+#: lib/vutuv_web/live/notification_live/index.ex:956
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:804
+#: lib/vutuv_web/live/notification_live/index.ex:953
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:801
+#: lib/vutuv_web/live/notification_live/index.ex:950
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:798
+#: lib/vutuv_web/live/notification_live/index.ex:947
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12371,6 +12369,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:747
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12490,6 +12489,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:746
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12541,6 +12541,7 @@ msgid "Post as"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:398
+#: lib/vutuv_web/templates/welcome/show.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Postal code"
 msgstr ""
@@ -12570,6 +12571,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
+#: lib/vutuv/accounts/user.ex:748
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
 #: lib/vutuv_web/agent_docs/markdown.ex:332
@@ -12704,7 +12706,7 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:856
+#: lib/vutuv/notifications/emailer.ex:862
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
@@ -13241,7 +13243,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3066
+#: lib/vutuv_web/components/ui.ex:3213
 #: lib/vutuv_web/controllers/settings_controller.ex:245
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13502,11 +13504,6 @@ msgstr ""
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:818
-#, elixir-autogen, elixir-format
-msgid "An image was removed from your vutuv account"
-msgstr ""
-
 #: lib/vutuv_web/components/post_components.ex:1030
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
@@ -13520,7 +13517,7 @@ msgstr ""
 msgid "Image is being reviewed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:697
+#: lib/vutuv_web/live/notification_live/index.ex:815
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13529,11 +13526,6 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "No images waiting for the AI scan. %{formatted} rejected in the last 7 days."
-msgstr ""
-
-#: lib/vutuv_web/live/notification_live/index.ex:829
-#, elixir-autogen, elixir-format
-msgid "Our automated image review removed %{what}. Only family-friendly images suitable for a work environment are allowed."
 msgstr ""
 
 #: lib/vutuv_web/templates/user/show.html.heex:159
@@ -13566,36 +13558,36 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:647
+#: lib/vutuv/accounts/user.ex:791
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:331
+#: lib/vutuv_web/templates/user/edit.html.heex:372
 #, elixir-autogen, elixir-format
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:650
+#: lib/vutuv/accounts/user.ex:794
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:653
+#: lib/vutuv/accounts/user.ex:797
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:644
+#: lib/vutuv/accounts/user.ex:788
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/edit.html.heex:328
+#: lib/vutuv_web/templates/user/edit.html.heex:369
 #, elixir-autogen, elixir-format
 msgid "Show my birthday as"
 msgstr ""
@@ -13612,7 +13604,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:700
+#: lib/vutuv_web/live/notification_live/index.ex:818
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13624,7 +13616,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:855
+#: lib/vutuv_web/live/notification_live/index.ex:1006
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13716,7 +13708,7 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3055
+#: lib/vutuv_web/components/ui.ex:3202
 #: lib/vutuv_web/controllers/settings_controller.ex:259
 #: lib/vutuv_web/live/post_live/feed.ex:651
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
@@ -13766,7 +13758,7 @@ msgid "Signal and WhatsApp accept a phone number or a username; the other messen
 msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1000
+#: lib/vutuv_web/templates/user/show.html.heex:1005
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13795,7 +13787,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3019
+#: lib/vutuv_web/components/ui.ex:3166
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:3
@@ -13803,7 +13795,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:3
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:998
+#: lib/vutuv_web/templates/user/show.html.heex:1003
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13823,34 +13815,34 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2609
+#: lib/vutuv_web/components/ui.ex:2756
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:2619
+#: lib/vutuv_web/components/ui.ex:2766
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:701
+#: lib/vutuv_web/live/notification_live/index.ex:819
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:875
+#: lib/vutuv_web/live/notification_live/index.ex:1026
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:867
+#: lib/vutuv_web/live/notification_live/index.ex:1018
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:872
+#: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13875,7 +13867,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:880
+#: lib/vutuv_web/live/notification_live/index.ex:1031
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -13895,7 +13887,7 @@ msgstr ""
 msgid "Book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:836
+#: lib/vutuv_web/agent_docs/markdown.ex:838
 #: lib/vutuv_web/components/post_components.ex:1659
 #: lib/vutuv_web/live/post_live/composer.ex:659
 #, elixir-autogen, elixir-format
@@ -13927,7 +13919,7 @@ msgstr ""
 msgid "Film"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:836
+#: lib/vutuv_web/agent_docs/markdown.ex:838
 #: lib/vutuv_web/components/post_components.ex:1658
 #: lib/vutuv_web/live/post_live/composer.ex:658
 #, elixir-autogen, elixir-format
@@ -14058,7 +14050,7 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:572
+#: lib/vutuv_web/agent_docs/markdown.ex:574
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
@@ -14068,45 +14060,45 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:576
+#: lib/vutuv_web/live/notification_live/index.ex:701
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:590
+#: lib/vutuv_web/live/notification_live/index.ex:715
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:285
+#: lib/vutuv_web/live/notification_live/index.ex:321
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:300
+#: lib/vutuv_web/live/notification_live/index.ex:336
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:542
-#: lib/vutuv_web/live/notification_live/index.ex:735
+#: lib/vutuv_web/live/notification_live/index.ex:667
+#: lib/vutuv_web/live/notification_live/index.ex:867
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:715
+#: lib/vutuv_web/live/notification_live/index.ex:834
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:710
+#: lib/vutuv_web/live/notification_live/index.ex:829
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:725
+#: lib/vutuv_web/live/notification_live/index.ex:844
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -14116,12 +14108,12 @@ msgstr ""
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1065
+#: lib/vutuv_web/components/ui.ex:1154
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1067
+#: lib/vutuv_web/components/ui.ex:1158
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14154,19 +14146,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:675
+#: lib/vutuv_web/agent_docs/markdown.ex:677
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:674
+#: lib/vutuv_web/agent_docs/markdown.ex:676
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:680
+#: lib/vutuv_web/agent_docs/markdown.ex:682
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14245,118 +14237,105 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:643
-#: lib/vutuv_web/agent_docs/text.ex:534
+#: lib/vutuv_web/agent_docs/markdown.ex:645
+#: lib/vutuv_web/agent_docs/text.ex:536
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
 
-#: lib/vutuv/prefs.ex:112
 #: lib/vutuv_web/gettext_extraction_anchors.ex:75
 #: lib/vutuv_web/templates/settings/preferences.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Lines in notifications"
 msgstr ""
 
-#: lib/vutuv/prefs.ex:127
 #: lib/vutuv_web/gettext_extraction_anchors.ex:77
 #, elixir-autogen, elixir-format
 msgid "How much of a post a notification quotes before it is cut off."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:166
+#: lib/vutuv_web/templates/settings/preferences.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Quoted posts in notifications"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/preferences.html.heex:169
+#: lib/vutuv_web/templates/settings/preferences.html.heex:168
 #, elixir-autogen, elixir-format
-msgid ""
-"Your notifications quote the post someone liked or replied to. Leave the "
-"field empty to follow the site default."
+msgid "Your notifications quote the post someone liked or replied to. Leave the field empty to follow the site default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/welcome_controller.ex
+#: lib/vutuv_web/controllers/welcome_controller.ex:102
 #, elixir-autogen, elixir-format
 msgid "Welcome"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:18
 #, elixir-autogen, elixir-format
-msgid ""
-"Two questions before you start. They decide who finds you and which jobs "
-"we show you. Answer as much or as little as you like."
+msgid "Two questions before you start. They decide who finds you and which jobs we show you. Answer as much or as little as you like."
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Where are you?"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:43
 #, elixir-autogen, elixir-format
-msgid ""
-"A city alone is enough. It appears on your profile and lets people search "
-"for members near them."
+msgid "A city alone is enough. It appears on your profile and lets people search for members near them."
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "Type of address"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:94
 #, elixir-autogen, elixir-format
 msgid "Are you looking for a job?"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:118
 #, elixir-autogen, elixir-format
-msgid ""
-"Optional, and nobody else sees it. It filters postings below it out of "
-"your own job search."
+msgid "Optional, and nobody else sees it. It filters postings below it out of your own job search."
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/user/edit.html.heex:277
+#: lib/vutuv_web/templates/welcome/show.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "How do you want to work?"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/user/edit.html.heex:297
+#: lib/vutuv_web/templates/welcome/show.html.heex:163
 #, elixir-autogen, elixir-format
 msgid "Shown next to your availability, and used to match you with postings."
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Save and continue"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/welcome/show.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex
-#, elixir-autogen, elixir-format
-msgid "No preference"
-msgstr ""
-
-#: lib/vutuv_web/agent_docs/markdown.ex
+#: lib/vutuv_web/agent_docs/markdown.ex:419
+#: lib/vutuv_web/agent_docs/text.ex:422
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
 
-#: lib/vutuv_web/templates/welcome/show.html.heex
+#: lib/vutuv_web/templates/user/edit.html.heex:205
+#: lib/vutuv_web/templates/welcome/show.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex
+#: lib/vutuv_web/live/notification_live/index.ex:637
 #, elixir-autogen, elixir-format
-msgid ""
-"Your automatically assigned vutuv username is {handle}. You can change it "
-"any time at {url}."
+msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
 
 #: lib/vutuv/notifications/emailer.ex:824
@@ -14364,10 +14343,19 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:901
+#: lib/vutuv_web/live/notification_live/index.ex:980
 #, elixir-autogen, elixir-format
-msgid ""
-"An AI, not a person, removed %{what}: it judged the image not family-"
-"friendly enough for a work environment. It can be wrong, so reply to our "
-"email if you disagree."
+msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:811
+#, elixir-autogen, elixir-format
+msgid "Thread reply"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:854
+#, elixir-autogen, elixir-format
+msgid "replied in a thread you posted in."
+msgid_plural "replied in a thread you posted in."
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/repo/migrations/20260723140620_add_root_post_id_to_post_replies.exs
+++ b/priv/repo/migrations/20260723140620_add_root_post_id_to_post_replies.exs
@@ -1,0 +1,51 @@
+defmodule Vutuv.Repo.Migrations.AddRootPostIdToPostReplies do
+  use Ecto.Migration
+
+  @moduledoc """
+  Denormalizes each reply's thread root onto its `post_replies` row.
+
+  Threading is a parent-pointer chain (a reply is a post, so it can itself be
+  replied to), which makes "all replies in this thread" unanswerable without a
+  recursive walk. The thread-participation notifications (the "thread" feed
+  kind: tell everyone who wrote in a thread about new replies anywhere in it,
+  not only the directly answered author) need that set in one indexed lookup,
+  so every reply now records its root. Nullable and nilified when the root is
+  deleted; a NULL root simply keeps the reply out of thread notifications
+  (the chain above it is gone anyway). Plain addition + backfill, so the
+  currently deployed release keeps working (N-1 safe).
+  """
+
+  def up do
+    alter table(:post_replies) do
+      add(:root_post_id, references(:posts, on_delete: :nilify_all))
+    end
+
+    create(index(:post_replies, [:root_post_id]))
+
+    # Walk each existing reply's parent chain to its top; a chain broken by a
+    # deleted ancestor (parent_post_id NULL somewhere above) finds no root and
+    # stays NULL.
+    execute("""
+    WITH RECURSIVE chain AS (
+      SELECT pr.id, pr.parent_post_id AS cur
+      FROM post_replies pr
+      UNION ALL
+      SELECT c.id, pr2.parent_post_id
+      FROM chain c
+      JOIN post_replies pr2 ON pr2.post_id = c.cur
+    )
+    UPDATE post_replies
+    SET root_post_id = c.cur
+    FROM chain c
+    WHERE post_replies.id = c.id
+      AND c.cur IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM post_replies prx WHERE prx.post_id = c.cur)
+    """)
+  end
+
+  def down do
+    alter table(:post_replies) do
+      remove(:root_post_id)
+    end
+  end
+end

--- a/test/vutuv/activity_test.exs
+++ b/test/vutuv/activity_test.exs
@@ -242,6 +242,218 @@ defmodule Vutuv.ActivityTest do
     end
   end
 
+  describe "thread events (answers elsewhere in a thread the user writes in)" do
+    test "a nested reply in the user's thread derives a thread event for the root author" do
+      me = insert(:user)
+      other = insert(:user, first_name: "Joe", last_name: "Armstrong")
+      first_replier = insert(:user)
+      root = insert(:post, user: me)
+      first = insert(:post, user: first_replier)
+      insert(:post_reply, post: first, parent_post: root, parent_author: me, root_post: root)
+      nested = insert(:post, user: other)
+
+      ref =
+        insert(:post_reply,
+          post: nested,
+          parent_post: first,
+          parent_author: first_replier,
+          root_post: root
+        )
+
+      notifications = recent_notifications(me.id)
+
+      # The direct answer to `root` is a "reply" event; the nested answer to
+      # the first replier surfaces as the "thread" event.
+      assert Enum.frequencies_by(notifications, & &1.kind) == %{"reply" => 1, "thread" => 1}
+
+      thread = Enum.find(notifications, &(&1.kind == "thread"))
+      assert thread.id == "thread-#{ref.id}"
+      assert thread.actor_name == "Joe Armstrong"
+      assert thread.actor_param == other.username
+      assert thread.reply_post_id == nested.id
+      assert thread.root_post_id == root.id
+    end
+
+    test "an earlier replier gets thread events for later answers to others" do
+      me = insert(:user)
+      root_author = insert(:user)
+      root = insert(:post, user: root_author)
+      mine = insert(:post, user: me)
+
+      insert(:post_reply,
+        post: mine,
+        parent_post: root,
+        parent_author: root_author,
+        root_post: root
+      )
+
+      later = insert(:post, user: insert(:user))
+
+      ref =
+        insert(:post_reply,
+          post: later,
+          parent_post: root,
+          parent_author: root_author,
+          root_post: root
+        )
+
+      assert [n] = recent_notifications(me.id)
+      assert n.kind == "thread"
+      assert n.id == "thread-#{ref.id}"
+    end
+
+    test "an answer to the user directly stays a reply event, never also a thread one" do
+      me = insert(:user)
+      root = insert(:post, user: me)
+      answer = insert(:post, user: insert(:user))
+      insert(:post_reply, post: answer, parent_post: root, parent_author: me, root_post: root)
+
+      assert [%{kind: "reply"}] = recent_notifications(me.id)
+    end
+
+    test "the user's own replies are no thread events" do
+      me = insert(:user)
+      root = insert(:post, user: me)
+      mine = insert(:post, user: me)
+      other = insert(:user)
+      first = insert(:post, user: other)
+      insert(:post_reply, post: first, parent_post: root, parent_author: me, root_post: root)
+      insert(:post_reply, post: mine, parent_post: first, parent_author: other, root_post: root)
+
+      assert [%{kind: "reply"}] = recent_notifications(me.id)
+    end
+
+    test "answers from before the user joined the thread are not news" do
+      me = insert(:user)
+      root_author = insert(:user)
+      root = insert(:post, user: root_author)
+
+      early = insert(:post, user: insert(:user))
+
+      early_ref =
+        insert(:post_reply,
+          post: early,
+          parent_post: root,
+          parent_author: root_author,
+          root_post: root
+        )
+
+      backdate_reply(early_ref, ~N[2020-01-01 12:00:00])
+
+      mine = insert(:post, user: me)
+
+      insert(:post_reply,
+        post: mine,
+        parent_post: root,
+        parent_author: root_author,
+        root_post: root
+      )
+
+      # The early answer was on screen when the user replied; only answers
+      # from after their own post in the thread would surface.
+      assert recent_notifications(me.id) == []
+    end
+
+    test "a blocked replier never surfaces as a thread event" do
+      me = insert(:user)
+      root = insert(:post, user: me)
+      other = insert(:user)
+      first = insert(:post, user: other)
+      insert(:post_reply, post: first, parent_post: root, parent_author: me, root_post: root)
+
+      blocked = insert(:user)
+      {:ok, _} = Vutuv.Social.block_user(me, blocked)
+
+      answer = insert(:post, user: blocked)
+      insert(:post_reply, post: answer, parent_post: first, parent_author: other, root_post: root)
+
+      assert Enum.frequencies_by(recent_notifications(me.id), & &1.kind) == %{"reply" => 1}
+    end
+
+    test "a reply without a root (broken legacy chain) stays out" do
+      me = insert(:user)
+      root = insert(:post, user: me)
+      other = insert(:user)
+      first = insert(:post, user: other)
+      insert(:post_reply, post: first, parent_post: root, parent_author: me, root_post: root)
+
+      orphan = insert(:post, user: insert(:user))
+      insert(:post_reply, post: orphan, parent_post: first, parent_author: other, root_post: nil)
+
+      assert Enum.frequencies_by(recent_notifications(me.id), & &1.kind) == %{"reply" => 1}
+    end
+
+    test "thread events count as unread" do
+      me = insert(:user)
+      first_replier = insert(:user)
+      root = insert(:post, user: me)
+      first = insert(:post, user: first_replier)
+      insert(:post_reply, post: first, parent_post: root, parent_author: me, root_post: root)
+      nested = insert(:post, user: insert(:user))
+
+      insert(:post_reply,
+        post: nested,
+        parent_post: first,
+        parent_author: first_replier,
+        root_post: root
+      )
+
+      # One direct reply + one thread event.
+      assert Activity.unread_notification_count(me.id) == 2
+    end
+
+    test "the read marker anchors to thread events too" do
+      me = insert(:user)
+      root_author = insert(:user)
+      root = insert(:post, user: root_author)
+
+      mine = insert(:post, user: me)
+
+      mine_ref =
+        insert(:post_reply,
+          post: mine,
+          parent_post: root,
+          parent_author: root_author,
+          root_post: root
+        )
+
+      backdate_reply(mine_ref, ~N[2020-01-01 11:00:00])
+
+      old = insert(:post, user: insert(:user))
+
+      old_ref =
+        insert(:post_reply,
+          post: old,
+          parent_post: root,
+          parent_author: root_author,
+          root_post: root
+        )
+
+      backdate_reply(old_ref, ~N[2020-01-01 12:00:00])
+
+      # Like the reply anchoring test above: with only thread events in the
+      # feed the marker must anchor to the newest of them, not the wall
+      # clock, or an answer landing in the marking second would be swallowed.
+      now_second = NaiveDateTime.utc_now(:second)
+      Activity.mark_notifications_read(me.id)
+      assert Activity.unread_notification_count(me.id) == 0
+
+      fresh = insert(:post, user: insert(:user))
+
+      fresh_ref =
+        insert(:post_reply,
+          post: fresh,
+          parent_post: root,
+          parent_author: root_author,
+          root_post: root
+        )
+
+      backdate_reply(fresh_ref, now_second)
+
+      assert Activity.unread_notification_count(me.id) == 1
+    end
+  end
+
   describe "notifications_page/2" do
     test "reports more? and hands out a cursor only when older events exist" do
       me = insert(:user)

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -1780,6 +1780,69 @@ defmodule Vutuv.PostsTest do
       {:ok, _} = Posts.create_reply(author, parent, %{body: "my own follow-up"})
       refute_receive {:new_notification, _}
     end
+
+    test "stamps the thread root: the parent for a direct reply, the top post for a nested one" do
+      root = create_post!(user(), %{body: "root"})
+      {:ok, reply} = Posts.create_reply(user(), root, %{body: "first"})
+      {:ok, nested} = Posts.create_reply(user(), reply, %{body: "second"})
+      {:ok, deep} = Posts.create_reply(user(), nested, %{body: "third"})
+
+      assert reply.reply_ref.root_post_id == root.id
+      assert nested.reply_ref.root_post_id == root.id
+      assert deep.reply_ref.root_post_id == root.id
+    end
+
+    test "a reply notifies the thread's other participants, not only the answered author" do
+      root_author = user()
+      first_replier = user()
+      second_replier = user()
+      root = create_post!(root_author, %{body: "root"})
+      {:ok, first} = Posts.create_reply(first_replier, root, %{body: "first"})
+
+      Vutuv.Activity.subscribe(root_author.id)
+      Vutuv.Activity.subscribe(first_replier.id)
+
+      # Answering the first reply: its author gets the direct "reply" event,
+      # the root author — in the thread but not directly answered — the
+      # "thread" event. This is the miss the kind exists for: before it, an
+      # answer to a third participant reached nobody else in the thread.
+      {:ok, second} = Posts.create_reply(second_replier, first, %{body: "second"})
+      second_id = second.id
+      root_id = root.id
+
+      assert_receive {:new_notification,
+                      %{kind: "thread", reply_post_id: ^second_id, root_post_id: ^root_id} = n}
+
+      assert n.actor_param == second_replier.username
+      assert_receive {:new_notification, %{kind: "reply"}}
+
+      # The directly answered author must not get the thread event on top.
+      refute_receive {:new_notification, %{kind: "thread"}}, 50
+    end
+
+    test "your own reply deeper in your thread does not notify you" do
+      author = user()
+      root = create_post!(author, %{body: "root"})
+      {:ok, first} = Posts.create_reply(user(), root, %{body: "first"})
+
+      Vutuv.Activity.subscribe(author.id)
+
+      {:ok, _} = Posts.create_reply(author, first, %{body: "back at you"})
+      refute_receive {:new_notification, %{kind: "thread"}}, 50
+    end
+
+    test "a participant with a block either way to the replier is not told" do
+      root_author = user()
+      replier = user()
+      root = create_post!(root_author, %{body: "root"})
+      {:ok, first} = Posts.create_reply(user(), root, %{body: "first"})
+      {:ok, _} = Vutuv.Social.block_user(root_author, replier)
+
+      Vutuv.Activity.subscribe(root_author.id)
+
+      {:ok, _} = Posts.create_reply(replier, first, %{body: "second"})
+      refute_receive {:new_notification, %{kind: "thread"}}, 50
+    end
   end
 
   describe "reply tombstones" do

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -419,6 +419,79 @@ defmodule VutuvWeb.NotificationLiveTest do
       refute html =~ "**Which editor**"
     end
 
+    test "an answer to someone else in my thread renders as a thread row linking the reply", %{
+      conn: conn
+    } do
+      {conn, user} = create_and_login_user(conn)
+
+      first_replier = insert(:user)
+      other = insert(:user, first_name: "Joe", last_name: "Armstrong")
+      root = insert(:post, user: user, body: "The root question")
+      {:ok, first} = Vutuv.Posts.create_reply(first_replier, root, %{body: "First answer"})
+
+      {:ok, missed} =
+        Vutuv.Posts.create_reply(other, first, %{body: "The answer I used to miss"})
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+      html = render(live)
+
+      assert length(row_ids(html, "thread")) == 1
+      assert html =~ "Joe Armstrong"
+      assert html =~ "replied in a thread you posted in."
+
+      # The row quotes the reply and links to its permalink. The quote is a
+      # formatted block with a stretched link, so the href sits on the inner
+      # <a>, not on the element carrying the marker.
+      assert has_element?(live, ~s([data-reply-preview]), "The answer I used to miss")
+
+      assert has_element?(
+               live,
+               ~s([data-reply-preview] a[href="/#{other.username}/posts/#{missed.id}"])
+             )
+    end
+
+    test "several same-day answers in one thread merge into one thread row", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      root = insert(:post, user: user, body: "The root question")
+      {:ok, first} = Vutuv.Posts.create_reply(insert(:user), root, %{body: "First answer"})
+
+      {:ok, _} =
+        Vutuv.Posts.create_reply(
+          insert(:user, first_name: "Anna", last_name: "Arnold"),
+          first,
+          %{body: "Second answer"}
+        )
+
+      {:ok, _} =
+        Vutuv.Posts.create_reply(
+          insert(:user, first_name: "Ben", last_name: "Otto"),
+          first,
+          %{body: "Third answer"}
+        )
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+      html = render(live)
+
+      # One grouped row names both answerers; the direct reply row stays its own.
+      assert length(row_ids(html, "thread")) == 1
+      assert html =~ "Anna Arnold"
+      assert html =~ "Ben Otto"
+      assert length(row_ids(html, "reply")) == 1
+    end
+
+    test "the posts filter tab keeps thread rows", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      root = insert(:post, user: user, body: "The root question")
+      {:ok, first} = Vutuv.Posts.create_reply(insert(:user), root, %{body: "First answer"})
+      {:ok, _} = Vutuv.Posts.create_reply(insert(:user), first, %{body: "Deeper answer"})
+
+      {:ok, live, _html} = live(conn, ~p"/notifications?filter=posts")
+
+      assert length(row_ids(render(live), "thread")) == 1
+    end
+
     test "a reply hidden from the recipient is not quoted", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 


### PR DESCRIPTION
## Why

In the last 48 hours, three answers in an active thread went completely unseen: a reply only ever notified the author of the post it *directly* answered, so an answer to a third participant was invisible to everyone else in the thread (no badge, no feed entry, no email). Verified against a production copy: the thread had 11 replies over two days, and exactly the three that answered other participants produced no indicator.

## What

A new derived notification kind **"thread"**: once a member writes in a thread (rooted it or replied in it), every later reply anywhere in that thread shows up in their notifications and bell badge.

- **Data:** `post_replies.root_post_id` denormalizes the thread root (threading is otherwise only a parent-pointer chain), recursively backfilled, nilified with the root. N-1-safe plain addition + index.
- **Rules:** direct answers to you stay the "reply" kind (an event is always exactly one of the two); replies from before you joined the thread, your own replies and blocked members never surface.
- **UI:** same-day events of one thread merge into one grouped row ("Anna and Ben replied in a thread you posted in."), quoting and linking the newest reply; ⤷ kind badge; part of the *Posts* filter tab. Live badge push to every participant on reply creation. German copy in Sie-form.
- Feed is retroactive by design, so older missed answers surface too (read-marker rules unchanged).

## Testing

- 15 new tests (derived feed rules, write-side pushes, root stamping, grouping, rendering, filter tab); `mix precommit` green (4392 tests).
- Migration + backfill run against the production copy: 90/90 replies rooted; the derived feed for the affected member surfaces exactly the three missed answers.
- Browser smoke test (German, dark mode) on real data: grouped row renders, links resolve.

https://claude.ai/code/session_01NVLQEFVHydm1LWPJoLn4x4