### PR TITLE
Suggested-posts rail: rank by likes, not just recency

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1486,57 +1486,173 @@ defmodule Vutuv.Posts do
 
   @discover_limit 5
   @discover_pool 100
+  # The rail's quality bar: how many members other than the author must have
+  # liked a post before it is worth suggesting, and how far back the draw
+  # looks for those posts first.
+  @discover_min_likes 2
+  @discover_window_days 14
 
   @doc """
-  A random handful of recent public posts for the feed's discovery rail:
-  posts by members who share `viewer`'s language but whom the viewer does
-  not follow — the post-shaped sibling of the "Who to follow" suggestions.
+  A random handful of well-received public posts for the feed's rail: posts
+  in `viewer`'s language that other members liked, from someone other than
+  the viewer.
 
-  One post per author (their newest eligible one), drawn at random from the
-  `@discover_pool` newest such posts, so the rail surfaces different voices
-  on every draw while staying "new". Language matches on `users.locale` with
-  the empty value counting as English, mirroring `VutuvWeb.LiveLocale`'s
-  fallback. Replies (confusing without their thread) and image-only posts
-  (nothing to excerpt in a compact row) are skipped; a *muted* follow is
-  still a follow, so those authors stay excluded too. Preloaded like every
-  rendered post.
+  Suggestions are picked for **reception**, not just recency: a post needs
+  likes from at least `#{@discover_min_likes}` members other than its author
+  (liking your own post is not a recommendation). Each author contributes one
+  post, their best-liked eligible one, and the handful is drawn at random
+  from the `@discover_pool` best-liked of those, so the card varies between
+  reloads while everything in it cleared the bar.
+
+  The draw walks three tiers and stops as soon as it has a full card, so a
+  quiet fortnight or a viewer who already follows everyone active still gets
+  a full one:
+
+    1. strangers (nobody `viewer` follows) from the last
+       #{@discover_window_days} days — the post-shaped sibling of the "Who to
+       follow" suggestions, and the tier that normally fills the card;
+    2. strangers of any age — the installation's lasting favourites;
+    3. anyone (bar the viewer themselves) from the last
+       #{@discover_window_days} days — the fortnight's best posts, even from
+       an author `viewer` already follows.
+
+  A *muted* follow is never suggested, in any tier: muting means "keep this
+  person's posts away from me". Only when nothing at all cleared the bar —
+  a brand-new installation where nobody has liked anything yet — does the
+  rail fall back to the newest eligible posts, so it is never permanently
+  empty.
+
+  Language matches on `users.locale` with the empty value counting as
+  English, mirroring `VutuvWeb.LiveLocale`'s fallback. Replies (confusing
+  without their thread) and image-only posts (nothing to excerpt in a
+  compact row) are skipped. Preloaded like every rendered post.
   """
   def discover_posts(%User{} = viewer, opts \\ []) do
     limit = Keyword.get(opts, :limit, @discover_limit)
+    window = discover_window_start()
+
+    rows =
+      Enum.reduce_while(
+        [{:strangers, window}, {:strangers, nil}, {:everyone, window}],
+        [],
+        fn {audience, since}, rows ->
+          drawn = discover_liked_draw(discover_candidates(viewer, audience), since, limit)
+          # Tiers overlap, and one author must not fill two rows of the card.
+          rows = Enum.uniq_by(rows ++ drawn, & &1.user_id)
+          if length(rows) >= limit, do: {:halt, rows}, else: {:cont, rows}
+        end
+      )
+
+    rows =
+      if rows == [],
+        do: discover_recent_draw(discover_candidates(viewer, :strangers), limit),
+        else: rows
+
+    rows
+    |> Enum.take(limit)
+    |> Enum.map(& &1.id)
+    |> load_discover_posts()
+  end
+
+  # Everything the rail requires of a post regardless of how well it did: a
+  # same-language member's own readable, publicly visible top-level post,
+  # from someone the viewer has neither blocked nor muted. `:strangers`
+  # additionally drops everyone the viewer already follows.
+  defp discover_candidates(%User{} = viewer, audience) do
     locale = locale_or_english(viewer.locale)
 
+    excluded =
+      case audience do
+        :strangers -> all_followees_of(viewer.id)
+        :everyone -> muted_followees_of(viewer.id)
+      end
+
+    from(p in Post,
+      as: :post,
+      join: u in assoc(p, :user),
+      left_join: r in assoc(p, :reply_ref),
+      where: is_nil(r.id),
+      where: fragment("COALESCE(NULLIF(?, ''), 'en')", u.locale) == ^locale,
+      where: p.user_id != ^viewer.id,
+      where: p.user_id not in subquery(excluded),
+      where: p.user_id not in subquery(blocked_either_way(viewer.id)),
+      where: account_confirmed_row(u),
+      where: p.body != ""
+    )
+    |> scope_visible(nil)
+  end
+
+  # The like counts the rail ranks on: likes by anyone but the author, rolled
+  # up once for the whole table (likes are far rarer than posts, so this beats
+  # a correlated count per candidate row).
+  defp discover_like_counts do
+    from(l in PostLike,
+      join: p in Post,
+      on: p.id == l.post_id,
+      where: l.user_id != p.user_id,
+      group_by: l.post_id,
+      select: %{post_id: l.post_id, likes: count(l.id)}
+    )
+  end
+
+  # The main draw: each author's best-liked post that cleared the bar, from
+  # `since` onwards (or from all time when `since` is nil).
+  defp discover_liked_draw(candidates, since, limit) do
+    best_per_author =
+      candidates
+      |> join(:inner, [post: p], lc in subquery(discover_like_counts()),
+        on: lc.post_id == p.id,
+        as: :like_count
+      )
+      |> where([like_count: lc], lc.likes >= @discover_min_likes)
+      |> discover_since(since)
+      |> distinct([post: p], p.user_id)
+      |> order_by([post: p, like_count: lc], asc: p.user_id, desc: lc.likes, desc: p.id)
+      |> select([post: p, like_count: lc], %{id: p.id, user_id: p.user_id, likes: lc.likes})
+
+    discover_draw(best_per_author, [desc: :likes, desc: :id], limit)
+  end
+
+  # The empty-installation fallback: the old recency draw, one newest post per
+  # author. Only reached while nothing at all has been liked.
+  defp discover_recent_draw(candidates, limit) do
     newest_per_author =
-      from(p in Post,
-        join: u in assoc(p, :user),
-        left_join: r in assoc(p, :reply_ref),
-        where: is_nil(r.id),
-        where: fragment("COALESCE(NULLIF(?, ''), 'en')", u.locale) == ^locale,
-        where: p.user_id != ^viewer.id,
-        where: p.user_id not in subquery(all_followees_of(viewer.id)),
-        where: p.user_id not in subquery(blocked_either_way(viewer.id)),
-        where: account_confirmed_row(u),
-        where: p.body != "",
-        distinct: p.user_id,
-        order_by: [asc: p.user_id, desc: p.id],
-        select: %{id: p.id}
-      )
-      |> scope_visible(nil)
+      candidates
+      |> distinct([post: p], p.user_id)
+      |> order_by([post: p], asc: p.user_id, desc: p.id)
+      |> select([post: p], %{id: p.id, user_id: p.user_id})
 
+    discover_draw(newest_per_author, [desc: :id], limit)
+  end
+
+  defp discover_since(query, nil), do: query
+  defp discover_since(query, since), do: where(query, [post: p], p.inserted_at >= ^since)
+
+  defp discover_window_start do
+    NaiveDateTime.utc_now(:second) |> NaiveDateTime.add(-@discover_window_days, :day)
+  end
+
+  # Rank the one-post-per-author set, keep the best `@discover_pool` of them
+  # and pick the handful at random, so the card stays varied between reloads.
+  defp discover_draw(per_author, pool_order, limit) do
     pool =
-      from(s in subquery(newest_per_author),
-        order_by: [desc: s.id],
+      from(s in subquery(per_author),
+        order_by: ^pool_order,
         limit: @discover_pool,
-        select: %{id: s.id}
+        select: %{id: s.id, user_id: s.user_id}
       )
 
-    ids =
-      from(s in subquery(pool),
-        order_by: fragment("random()"),
-        limit: ^limit,
-        select: s.id
-      )
-      |> Repo.all()
+    from(s in subquery(pool),
+      order_by: fragment("random()"),
+      limit: ^limit,
+      select: %{id: s.id, user_id: s.user_id}
+    )
+    |> Repo.all()
+  end
 
+  defp load_discover_posts([]), do: []
+
+  defp load_discover_posts(ids) do
     from(p in Post, where: p.id in ^ids)
     |> Repo.all()
     |> Repo.preload(post_preloads())
@@ -1552,6 +1668,12 @@ defmodule Vutuv.Posts do
   # worth suggesting.
   defp all_followees_of(viewer_id) do
     from(c in Follow, where: c.follower_id == ^viewer_id, select: c.followee_id)
+  end
+
+  # The people the viewer told us to keep quiet — excluded from every
+  # discovery tier, including the one that may otherwise suggest a followee.
+  defp muted_followees_of(viewer_id) do
+    from(c in Follow, where: c.follower_id == ^viewer_id and c.muted, select: c.followee_id)
   end
 
   @doc """

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1517,10 +1517,10 @@ defmodule Vutuv.Posts do
        an author `viewer` already follows.
 
   A *muted* follow is never suggested, in any tier: muting means "keep this
-  person's posts away from me". Only when nothing at all cleared the bar —
-  a brand-new installation where nobody has liked anything yet — does the
-  rail fall back to the newest eligible posts, so it is never permanently
-  empty.
+  person's posts away from me". Only when no tier turned up anything at all
+  — a brand-new installation where nobody has liked yet, or a language
+  nobody has liked in yet — does the rail fall back to the newest eligible
+  posts, so it is never permanently empty.
 
   Language matches on `users.locale` with the empty value counting as
   English, mirroring `VutuvWeb.LiveLocale`'s fallback. Replies (confusing

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.132.0",
+      version: "7.133.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -22,6 +22,18 @@ defmodule Vutuv.PostsTest do
     %{post | inserted_at: at}
   end
 
+  # The discovery rail only suggests posts that cleared its like bar, so its
+  # tests hand each post enough likes (from distinct strangers) to qualify —
+  # otherwise a filter test would silently assert the like-less fallback.
+  defp liked!(post, likers \\ 2) do
+    for _ <- 1..likers//1, do: :ok = Posts.like_post(user(), post)
+    post
+  end
+
+  defp liked_post!(author, attrs, likers \\ 2) do
+    author |> create_post!(attrs) |> liked!(likers)
+  end
+
   # Repost order ties at second precision too; shift `reposter`'s repost of
   # `post` into the past so "newest reposter" assertions stay deterministic.
   defp backdate_repost!(reposter, post, seconds) do
@@ -883,35 +895,48 @@ defmodule Vutuv.PostsTest do
   end
 
   describe "discover_posts/2" do
-    test "returns a same-language stranger's public post with the author preloaded" do
+    test "returns a same-language stranger's well-liked post with the author preloaded" do
       viewer = user(locale: "de")
       author = user(locale: "de")
-      post = create_post!(author, %{body: "entdecke mich"})
+      post = liked_post!(author, %{body: "entdecke mich"})
 
       assert [found] = Posts.discover_posts(viewer)
       assert found.id == post.id
       assert found.user.id == author.id
     end
 
-    test "excludes authors the viewer follows, including muted follows" do
+    test "fills the card with strangers before it reaches for a followed author" do
       viewer = user()
       followed = user()
-      muted = user()
       follow!(viewer, followed)
+
+      insider = liked_post!(followed, %{body: "already following"}, 6)
+      fresh = liked_post!(user(), %{body: "new voice"}, 2)
+
+      # One slot: the less-liked stranger still wins it.
+      assert Enum.map(Posts.discover_posts(viewer, limit: 1), & &1.id) == [fresh.id]
+
+      # More slots than strangers: the followed author's well-liked post fills
+      # the rest rather than leaving the card short.
+      ids = Posts.discover_posts(viewer, limit: 5) |> Enum.map(& &1.id) |> Enum.sort()
+      assert ids == Enum.sort([fresh.id, insider.id])
+    end
+
+    test "never suggests a muted author, in any tier" do
+      viewer = user()
+      muted = user()
       follow!(viewer, muted)
       fid = Vutuv.Social.follow_id(viewer.id, muted.id)
       Vutuv.Social.toggle_follow_mute!(viewer.id, fid)
 
-      create_post!(followed, %{body: "already following"})
-      create_post!(muted, %{body: "muted but still followed"})
-      fresh = create_post!(user(), %{body: "new voice"})
+      liked_post!(muted, %{body: "muted but still followed"}, 6)
 
-      assert Enum.map(Posts.discover_posts(viewer), & &1.id) == [fresh.id]
+      assert Posts.discover_posts(viewer) == []
     end
 
     test "excludes the viewer's own posts" do
       viewer = user()
-      create_post!(viewer, %{body: "mine"})
+      liked_post!(viewer, %{body: "mine"})
 
       assert Posts.discover_posts(viewer) == []
     end
@@ -920,9 +945,9 @@ defmodule Vutuv.PostsTest do
       german_viewer = user(locale: "de")
       unset_viewer = user(locale: nil)
 
-      german_post = create_post!(user(locale: "de"), %{body: "auf Deutsch"})
-      english_post = create_post!(user(locale: "en"), %{body: "in English"})
-      unset_post = create_post!(user(locale: nil), %{body: "no locale set"})
+      german_post = liked_post!(user(locale: "de"), %{body: "auf Deutsch"})
+      english_post = liked_post!(user(locale: "en"), %{body: "in English"})
+      unset_post = liked_post!(user(locale: nil), %{body: "no locale set"})
 
       german_ids = Posts.discover_posts(german_viewer) |> Enum.map(& &1.id)
       assert german_ids == [german_post.id]
@@ -935,11 +960,23 @@ defmodule Vutuv.PostsTest do
       viewer = user()
       author = user()
 
-      create_post!(author, %{body: "circle only", denials: [%{"wildcard" => "non_followers"}]})
-      parent = create_post!(author, %{body: "parent"})
-      {:ok, _reply} = Posts.create_reply(user(), parent, %{body: "an answer"})
+      restricted =
+        create_post!(author, %{body: "circle only", denials: [%{"wildcard" => "non_followers"}]})
+
+      # A restricted post is only likeable by the circle it is shared with, so
+      # its likes have to come from followers — it stays out of the rail all
+      # the same, because the rail shows the anonymous public view.
+      for _ <- 1..2 do
+        insider = user()
+        follow!(insider, author)
+        :ok = Posts.like_post(insider, restricted)
+      end
+
+      parent = liked_post!(author, %{body: "parent"})
+      {:ok, reply} = Posts.create_reply(user(), parent, %{body: "an answer"})
+      liked!(reply)
       image = insert(:post_image, user: author, post: nil)
-      create_post!(author, %{body: "", image_ids: [image.id]})
+      liked_post!(author, %{body: "", image_ids: [image.id]})
 
       assert Enum.map(Posts.discover_posts(viewer), & &1.id) == [parent.id]
     end
@@ -951,20 +988,80 @@ defmodule Vutuv.PostsTest do
       {:ok, _} = Vutuv.Social.block_user(viewer, blocked)
       {:ok, _} = Vutuv.Social.block_user(blocker, viewer)
 
-      create_post!(blocked, %{body: "blocked by viewer"})
-      create_post!(blocker, %{body: "blocked the viewer"})
+      liked_post!(blocked, %{body: "blocked by viewer"})
+      liked_post!(blocker, %{body: "blocked the viewer"})
 
       assert Posts.discover_posts(viewer) == []
     end
 
     test "excludes unconfirmed authors" do
       viewer = user()
-      create_post!(user(email_confirmed?: false), %{body: "ghost"})
+      liked_post!(user(email_confirmed?: false), %{body: "ghost"})
 
       assert Posts.discover_posts(viewer) == []
     end
 
-    test "picks one post per author: their newest eligible one" do
+    test "only suggests posts that reached the like bar" do
+      viewer = user()
+
+      liked_post!(user(), %{body: "nobody liked this"}, 0)
+      liked_post!(user(), %{body: "one lonely like"}, 1)
+      well_liked = liked_post!(user(), %{body: "well received"}, 2)
+
+      assert Enum.map(Posts.discover_posts(viewer), & &1.id) == [well_liked.id]
+    end
+
+    test "does not count the author's own like towards the bar" do
+      viewer = user()
+      author = user()
+
+      self_promoted = create_post!(author, %{body: "I like me"})
+      :ok = Posts.like_post(author, self_promoted)
+      :ok = Posts.like_post(user(), self_promoted)
+
+      earned = liked_post!(user(), %{body: "liked by others"})
+
+      assert Enum.map(Posts.discover_posts(viewer), & &1.id) == [earned.id]
+    end
+
+    test "prefers well-liked posts from the last two weeks over older favourites" do
+      viewer = user()
+
+      old_favourite = liked_post!(user(), %{body: "the classic"}, 6)
+      backdate_post!(old_favourite, 20 * 24 * 60 * 60)
+      recent = liked_post!(user(), %{body: "this fortnight"}, 2)
+
+      assert Enum.map(Posts.discover_posts(viewer, limit: 1), & &1.id) == [recent.id]
+    end
+
+    test "falls back to older favourites when the fortnight has too few" do
+      viewer = user()
+
+      old_favourite = liked_post!(user(), %{body: "the classic"}, 3)
+      backdate_post!(old_favourite, 20 * 24 * 60 * 60)
+
+      assert Enum.map(Posts.discover_posts(viewer), & &1.id) == [old_favourite.id]
+    end
+
+    test "falls back to recent posts when nothing has been liked yet" do
+      viewer = user()
+      post = create_post!(user(), %{body: "a brand-new installation"})
+
+      assert Enum.map(Posts.discover_posts(viewer), & &1.id) == [post.id]
+    end
+
+    test "picks one post per author: their best-liked eligible one" do
+      viewer = user()
+      prolific = user()
+
+      best = liked_post!(prolific, %{body: "the good one"}, 4)
+      backdate_post!(best, 60)
+      liked_post!(prolific, %{body: "newer but weaker"}, 2)
+
+      assert Enum.map(Posts.discover_posts(viewer), & &1.id) == [best.id]
+    end
+
+    test "picks the newest post per author on the like-less fallback" do
       viewer = user()
       prolific = user()
 
@@ -977,7 +1074,13 @@ defmodule Vutuv.PostsTest do
 
     test "returns at most limit posts and randomizes which authors it draws" do
       viewer = user()
-      for n <- 1..8, do: create_post!(user(), %{body: "voice #{n}"})
+      # Two likers are enough for every post to clear the bar.
+      likers = [user(), user()]
+
+      for n <- 1..8 do
+        post = create_post!(user(), %{body: "voice #{n}"})
+        for liker <- likers, do: :ok = Posts.like_post(liker, post)
+      end
 
       found = Posts.discover_posts(viewer, limit: 5)
       assert length(found) == 5


### PR DESCRIPTION
The **Vorgeschlagene Beiträge** card drew a random handful from the 100 newest posts of members you do not follow, with no quality signal at all — which is why webinar spam and cold outreach kept showing up there while well-received posts never did.

**Now:** a suggestion needs likes from at least **2 members other than the author** (a self-like is not a recommendation). Each author contributes their best-liked post, and the card draws its handful at random from the top of that ranking, so it still varies between reloads and the reshuffle button still does something.

**The like bar is never dropped to fill the card — the audience widens instead.** The draw walks three tiers and stops as soon as the card is full:

1. strangers from the last 14 days — the normal case;
2. strangers of any age — the installations lasting favourites;
3. anyone from the last 14 days — including authors you follow.

Tier 3 is the one worth a second look. With strangers-only, a member who already follows everyone active has *no* eligible well-liked posts at all (verified against the dev copy of production: for `@wintermeyer`, zero non-followed German authors have a post with 2+ likes), so a strict filter would either empty the card or push it straight back to the fringe posts this change removes. Muted authors stay out of every tier. The old recency draw survives only as the brand-new-installation fallback, for a site where nobody has liked anything yet.

If you would rather have an empty card than a suggestion from someone you already follow, deleting `{:everyone, window}` from the tier list is the whole change.

## Verification

- `mix precommit` green (4419 tests).
- 15 tests around `Posts.discover_posts/2`, including the like bar, self-likes, the fortnight preference, each fallback tier, and muted authors.
- Browser smoke test on the dev copy of production: as `@wintermeyer` the card went from *(Georg Tronich / VIVI-Webinar / Veranstaltungssicherheit)* to Dirk Deimekes post and Michael Schmidts HTTP-QUERY article; as a member who follows nobody it fills all five rows with 2–4-like posts. LiveView connected, reshuffle button handled without errors.

https://claude.ai/code/session_01TDd2NWR9oaQFT6BvQ2D614