### PR TITLE
Refuse a tagline or tag that is nothing but a web address

### DIFF
--- a/docs/architecture/profiles.md
+++ b/docs/architecture/profiles.md
@@ -546,6 +546,39 @@ profile's Tags card always offers a visitor the "All tags" footer link — not
 only once the card is truncated, which with the 15-tag cap it never is. The
 owner's footer stays the "Manage" bridge into `/settings/tags`.
 
+## No field is a billboard: the tagline and tags refuse a bare link
+
+A profile field has to say something about the member. `Vutuv.WebAddress.link_only?/1`
+recognizes text that is **nothing but** a web address — a URL with any scheme, a
+`www.` host, a bare domain under a curated list of website TLDs, a dotted host
+with a path, an email address, or any of those wrapped in Markdown / BBCode /
+`<a>` link markup, label and all. Three places refuse such a value:
+
+- the **tagline** (`Vutuv.Accounts.User.changeset/2`, so the Basics form, the
+  LinkedIn import and `PATCH /api/2.0/me` alike),
+- a **tag name** (`Vutuv.Tags.Tag`: the changeset head blocks minting one, and
+  `create_or_link_tag/2` blocks *linking* one of the URL tags minted before this
+  rule, since the lookup would otherwise never build a changeset), and
+- the **sign-up tag list** (`registration_changeset/2` — `register_user/3`
+  materializes tags after the insert and ignores per-tag failures, so without
+  this the account would be created with the tag quietly missing).
+
+The rule is about the **whole** value, never about addresses as such: "Co-Founder
+of Taxdoo (www.taxdoo.com)" is an ordinary tagline and stays valid, and a tag
+whose name merely looks domain-shaped (`node.js`, `asp.net`, `socket.io`,
+`stud.ip`) stays valid too — which is why the TLD list is curated rather than the
+whole registry. Text with no words in it at all (`"-"`, `"???"`) is **not** a
+link: junk, but nothing this rule may claim is a web address.
+
+Two knock-on places keep the promise honest: the add-tag form's live preview
+(`Vutuv.Tags.preview_tag_names/1`) drops such a name instead of promising a tag
+the submit refuses, and the LinkedIn import drops a link-only `Headline` while
+parsing (it is applied in the same update as the names, so it would otherwise
+take the name fill down with it). Post tags (`Vutuv.Posts`) drop it as well, so
+the composer is not a back door into the shared tag namespace.
+
+Existing rows are left alone — the validations bite when a value changes.
+
 ## Ordered profile sections
 
 Members arrange their links, phone numbers, addresses, social media accounts,

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -8,6 +8,7 @@ defmodule Vutuv.Accounts.User do
   alias Vutuv.Handles
   alias Vutuv.Mentions
   alias Vutuv.Prefs
+  alias Vutuv.WebAddress
   @derive {Phoenix.Param, key: :username}
 
   schema "users" do
@@ -436,6 +437,7 @@ defmodule Vutuv.Accounts.User do
     |> validate_length(:headline, max: 255)
     # The tagline may only mention handles that exist (relaxed for the import).
     |> Mentions.validate_mentions_exist(:headline)
+    |> validate_headline_not_link_only()
     # locale is user-writable (profile form + PATCH /api/2.0/me) over a
     # varchar(255) column, so cap it or an oversized value raises Postgres 22001.
     |> validate_length(:locale, max: 255)
@@ -480,6 +482,20 @@ defmodule Vutuv.Accounts.User do
     |> validate_birthdate()
     |> validate_inclusion(:birthdate_visibility, @birthdate_visibilities)
     |> revoke_verification_on_identity_change()
+  end
+
+  # The tagline is the one line under a member's name, so it has to say
+  # something about them: a value that is nothing but a URL, a domain, an email
+  # address or a wrapped-up link (`Vutuv.WebAddress`) is a billboard, and it is
+  # what a spam sign-up puts there. A tagline that *mentions* an address inside
+  # a sentence ("Co-Founder of Taxdoo (www.taxdoo.com)") is ordinary and stays
+  # valid — members have the Links section for the address itself.
+  defp validate_headline_not_link_only(changeset) do
+    validate_change(changeset, :headline, fn :headline, headline ->
+      if WebAddress.link_only?(headline),
+        do: [headline: "can't be only a link. Please describe yourself in a few words."],
+        else: []
+    end)
   end
 
   # Every identity detail the verified badge vouches for: the legal name parts,
@@ -538,6 +554,7 @@ defmodule Vutuv.Accounts.User do
     |> changeset(params)
     |> validate_minimum_tags()
     |> validate_maximum_tags()
+    |> validate_no_web_address_tags()
     |> cast_assoc(:emails)
   end
 
@@ -578,6 +595,26 @@ defmodule Vutuv.Accounts.User do
       changeset
     else
       add_error(changeset, :tag_list, "Please enter at most %{max} different tags.", max: max)
+    end
+  end
+
+  # `Vutuv.Tags.Tag` refuses a tag that is only a web or email address, but
+  # `Accounts.register_user/3` materializes the sign-up tags *after* the insert
+  # and ignores per-tag failures, so without this the account would be created
+  # with that tag quietly missing. Naming the offending token here lets the
+  # sign-up form say what to fix instead.
+  defp validate_no_web_address_tags(changeset) do
+    case Enum.find(distinct_tag_names(changeset), &WebAddress.link_only?/1) do
+      nil ->
+        changeset
+
+      address ->
+        add_error(
+          changeset,
+          :tag_list,
+          "\"%{tag}\" is a web address, not a tag. Please describe yourself with words.",
+          tag: address
+        )
     end
   end
 

--- a/lib/vutuv/imports/linked_in.ex
+++ b/lib/vutuv/imports/linked_in.ex
@@ -36,6 +36,7 @@ defmodule Vutuv.Imports.LinkedIn do
   alias Vutuv.Tags
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.UserTag
+  alias Vutuv.WebAddress
 
   @empty %{
     profile: %{},
@@ -320,7 +321,11 @@ defmodule Vutuv.Imports.LinkedIn do
       %{
         first_name: blank_nil(row["First Name"]),
         last_name: blank_nil(row["Last Name"]),
-        headline: blank_nil(row["Headline"])
+        # A headline that is nothing but a link is refused by the profile
+        # changeset (Vutuv.WebAddress) — and it is applied in the SAME update as
+        # the names, so dropping it here keeps it from taking the name fill down
+        # with it, and the preview stops offering something that can't be saved.
+        headline: row["Headline"] |> blank_nil() |> reject_link_only()
       }
       |> Enum.reject(fn {_k, v} -> is_nil(v) end)
       |> Map.new()
@@ -972,6 +977,12 @@ defmodule Vutuv.Imports.LinkedIn do
       "" -> nil
       trimmed -> trimmed
     end
+  end
+
+  defp reject_link_only(nil), do: nil
+
+  defp reject_link_only(value) do
+    if WebAddress.link_only?(value), do: nil, else: value
   end
 
   defp compact(list), do: Enum.reject(list, &is_nil/1)

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -66,6 +66,7 @@ defmodule Vutuv.Posts do
   alias Vutuv.Tags
   alias Vutuv.Tags.Tag
   alias Vutuv.UUIDv7
+  alias Vutuv.WebAddress
 
   @default_feed_limit 20
   @default_profile_limit 3
@@ -2150,10 +2151,15 @@ defmodule Vutuv.Posts do
 
   # Tag.normalize_value strips a leading `#` (the hashtag form), so "#Elixir"
   # becomes "Elixir" and dedupes/links against the bare tag; a bare "#" drops.
+  # A value that is nothing but a web or email address drops too: post tags
+  # share the global tag namespace with profile tags, where that is refused
+  # (`Vutuv.WebAddress`), so the composer must not be the back door. Dropping
+  # it silently matches how this function treats every other odd value — the
+  # post itself still publishes.
   defp parse_tag_values(values) when is_list(values) do
     values
     |> Enum.map(&Tag.normalize_value/1)
-    |> Enum.reject(&(&1 == ""))
+    |> Enum.reject(&(&1 == "" or WebAddress.link_only?(&1)))
     |> Enum.uniq_by(&String.downcase/1)
     |> Enum.take(@max_tags)
   end

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -18,6 +18,7 @@ defmodule Vutuv.Tags do
   alias Vutuv.Tags.TagFollow
   alias Vutuv.Tags.UserTag
   alias Vutuv.Tags.UserTagEndorsement
+  alias Vutuv.WebAddress
 
   # The endorsers list: which columns it can be sorted by, and a denser page
   # size than the site-wide default so a popular tag's list actually paginates.
@@ -83,10 +84,15 @@ defmodule Vutuv.Tags do
   while an unmatched name becomes a fresh tag displaying exactly as typed.
   Case-insensitive duplicates collapse to the first spelling, mirroring the
   single row the profile would end up with (the form's save path dedupes the
-  same way, so preview and outcome always agree).
+  same way, so preview and outcome always agree). A name that is nothing but a
+  web or email address drops out for the same reason: `add_user_tag/2` refuses
+  it, so promising it here would be a lie the submit then takes back.
   """
   def preview_tag_names(value) do
-    case value |> parse_tag_names() |> Enum.uniq_by(&String.downcase/1) do
+    case value
+         |> parse_tag_names()
+         |> Enum.reject(&WebAddress.link_only?/1)
+         |> Enum.uniq_by(&String.downcase/1) do
       [] ->
         []
 

--- a/lib/vutuv/tags/tag.ex
+++ b/lib/vutuv/tags/tag.ex
@@ -6,6 +6,15 @@ defmodule Vutuv.Tags.Tag do
 
   alias Vutuv.Accounts.User
   alias Vutuv.Repo
+  alias Vutuv.WebAddress
+
+  # A tag names a skill, a topic or an interest. A member who pastes their
+  # homepage or their email address into the field is advertising, not tagging
+  # themselves — and the tag becomes a public page nobody else will ever share.
+  # Kept as one string so the name validation below and the link guard in
+  # `create_or_link_tag/2` (which also covers *linking* a URL tag minted before
+  # this rule) report the same thing.
+  @web_address_message "must not be a web or email address"
 
   schema "tags" do
     field(:slug, :string)
@@ -55,9 +64,22 @@ defmodule Vutuv.Tags.Tag do
     # entry point, so this only backstops the raw name/slug head (the admin
     # edit form) against a stray line break or tab sneaking in.
     |> validate_format(:name, ~r/^[^\r\n\t]+$/, message: "must be a single line")
+    |> validate_web_address()
     |> validate_length(:slug, max: 60)
     |> validate_length(:name, max: 255)
     |> unique_constraint(:slug)
+  end
+
+  # A name that is nothing but a URL, a domain or an email address is refused
+  # here, so no entry point can mint such a tag: the member paths reach this
+  # through `create_or_link_tag/2`, the admin edit form and the post-hashtag
+  # path (`Vutuv.Posts`) through the changeset heads directly. A name that only
+  # *mentions* an address stays valid ("Frontend for shop.example"), the same
+  # whole-value rule the profile tagline uses.
+  defp validate_web_address(changeset) do
+    validate_change(changeset, :name, fn :name, name ->
+      if WebAddress.link_only?(name), do: [name: @web_address_message], else: []
+    end)
   end
 
   defp maybe_gen_slug(changeset) do
@@ -91,6 +113,11 @@ defmodule Vutuv.Tags.Tag do
   (sign-up, the tags page, the post composer) tokenize their input first with
   `Vutuv.Tags.parse_tag_names/1`, which honours quotes; the JSON API reaches
   here with a single already-whole name.
+
+  A value that is nothing but a web or email address is refused outright
+  (`Vutuv.WebAddress`), before the lookup: the changeset head already keeps a
+  new one from being minted, and this also blocks *linking* one of the URL tags
+  a few profiles created before the rule existed.
   """
   def create_or_link_tag(changeset, %{"value" => value} = params) do
     # Strip the hashtag form before both the existing-tag lookup and the build,
@@ -98,7 +125,14 @@ defmodule Vutuv.Tags.Tag do
     # the bare name. The rewritten params carry the normalized value downstream.
     value = normalize_value(value)
     params = Map.put(params, "value", value)
-    link_or_build_tag(changeset, value, params)
+
+    if WebAddress.link_only?(value) do
+      # The error lands on :tag_id, where the tags editor renders the other
+      # refusals (at the ceiling, reserved honor tag) too.
+      add_error(changeset, :tag_id, @web_address_message)
+    else
+      link_or_build_tag(changeset, value, params)
+    end
   end
 
   @leading_hash ~r/^#+\s*/

--- a/lib/vutuv/web_address.ex
+++ b/lib/vutuv/web_address.ex
@@ -1,0 +1,96 @@
+defmodule Vutuv.WebAddress do
+  @moduledoc """
+  Recognizes free text that is **nothing but** a web address.
+
+  Some sign-ups use a profile field as a billboard: the tagline is one bare
+  `https://example.com/`, a tag is `www.example.com` or an email address. Such
+  a value says nothing about the member, so the changesets that own those
+  fields refuse it — the profile tagline (`Vutuv.Accounts.User`), a tag name
+  (`Vutuv.Tags.Tag`) and the sign-up form's tag list.
+
+  The rule deliberately applies to the **whole** value, not to addresses as
+  such: a tagline that names a company site inside a sentence ("Co-Founder of
+  Taxdoo (www.taxdoo.com)") is ordinary and stays valid. Only a value with no
+  words of its own left over is refused.
+  """
+
+  # Link markup an address can be wrapped in: an `<a>` element, a `[url=…]…[/url]`
+  # BBCode pair, a Markdown `[label](target)` link (image form included), and
+  # any leftover HTML tag. The label is stripped with the link — it belongs to
+  # the address, not to the member's own words, so `[Cheap Casino](https://…)`
+  # is still link-only. The anchor's closing tag is matched as "any letters"
+  # rather than a literal `</a>`, because the spam seen in production wrote it
+  # with a Cyrillic а.
+  @markup [
+    ~r"<a\b[^>]*>[\s\S]*?</\p{L}+>"iu,
+    ~r"\[url[^\]]*\][\s\S]*?\[/url\]"iu,
+    ~r"!?\[[^\]]*\]\([^)]*\)"u,
+    ~r"</?\p{L}[^>]*>"u
+  ]
+
+  # Word endings that only ever mean "a website". Deliberately a short curated
+  # list rather than the whole TLD registry: several real TLDs double as
+  # technology names members legitimately tag themselves with (`socket.io`,
+  # `asp.net`, `node.js`, `stud.ip`, `xamarin.forms`), and rejecting those
+  # would be worse than letting a domain under a rare TLD through — the scheme
+  # and `www.` spellings below catch it whenever it is written out in full.
+  @website_tlds ~w(com de org info biz eu ch at ru cn uk nl fr es it pl br in
+                   tv shop store online site xyz top club casino bet vip)
+
+  @addresses [
+    # `https://…` and any other scheme-with-authority URL. The `://` is
+    # required: a bare `scheme:` would swallow the German gender colon
+    # ("Berater:innen") and turn an ordinary tagline into a link.
+    ~r"\p{L}[\p{L}\d+.-]*://\S+"u,
+    # A `www.` host, with or without a path.
+    ~r"\bwww\.\S+"iu,
+    # An email address, `mailto:` prefix included so it strips whole.
+    ~r"(?:mailto:)?[\p{L}\d._%+'-]+@[\p{L}\d.-]+\.\p{L}{2,}"u,
+    # A dotted host carrying a path ("mastodon.social/@someone").
+    ~r"\b[\p{L}\d][\p{L}\d-]*(?:\.[\p{L}\d-]+)+/\S*"u,
+    # A bare domain: no scheme, no path ("sbasf.com").
+    ~r"\b[\p{L}\d][\p{L}\d-]*(?:\.[\p{L}\d-]+)*\.(?:#{Enum.join(@website_tlds, "|")})\b/?"iu
+  ]
+
+  @doc """
+  Whether `text` consists of web addresses and punctuation only, with no words
+  of the member's own.
+
+  There has to be an address: blank text is `false` (an empty field is the
+  business of `validate_required`), and so is text that merely has no words in
+  it, like `"-"` or `"???"` — junk, but nothing this rule should claim is a
+  web address.
+
+      iex> Vutuv.WebAddress.link_only?("https://www.example.com/")
+      true
+
+      iex> Vutuv.WebAddress.link_only?("Co-Founder of Taxdoo (www.taxdoo.com)")
+      false
+
+      iex> Vutuv.WebAddress.link_only?("node.js")
+      false
+
+      iex> Vutuv.WebAddress.link_only?("???")
+      false
+  """
+  def link_only?(text) when is_binary(text) do
+    case String.trim(text) do
+      "" ->
+        false
+
+      trimmed ->
+        stripped = strip_addresses(trimmed)
+        stripped != trimmed and not has_words?(stripped)
+    end
+  end
+
+  def link_only?(_), do: false
+
+  # Every address and every piece of link markup removed, so what remains is
+  # whatever the member wrote themselves.
+  defp strip_addresses(text) do
+    Enum.reduce(@markup ++ @addresses, text, &Regex.replace(&1, &2, " "))
+  end
+
+  defp has_words?(text), do: Regex.match?(~r/[\p{L}\p{N}]/u, text)
+end

--- a/lib/vutuv_web/views/error_helpers.ex
+++ b/lib/vutuv_web/views/error_helpers.ex
@@ -56,7 +56,18 @@ defmodule VutuvWeb.ErrorHelpers do
         "errors",
         "PDF uploads are not available on this installation. Please upload an image instead."
       ),
-      dgettext_noop("errors", "could not be read. Please upload a PDF, JPG, PNG or WebP file.")
+      dgettext_noop("errors", "could not be read. Please upload a PDF, JPG, PNG or WebP file."),
+      # Vutuv.Tags.Tag / Vutuv.Accounts.User, the "this field is not a
+      # billboard" rule (Vutuv.WebAddress).
+      dgettext_noop("errors", "must not be a web or email address"),
+      dgettext_noop(
+        "errors",
+        "can't be only a link. Please describe yourself in a few words."
+      ),
+      dgettext_noop(
+        "errors",
+        "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
+      )
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.133.0",
+      version: "7.133.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -201,3 +201,18 @@ msgstr "konnte nicht gelesen werden. Bitte laden Sie eine PDF-, JPG-, PNG- oder 
 #, elixir-autogen, elixir-format
 msgid "is larger than 10 MB. Please upload a smaller file."
 msgstr "ist größer als 10 MB. Bitte laden Sie eine kleinere Datei hoch."
+
+#: lib/vutuv_web/views/error_helpers.ex:62
+#, elixir-autogen, elixir-format
+msgid "must not be a web or email address"
+msgstr "darf keine Web- oder E-Mail-Adresse sein"
+
+#: lib/vutuv_web/views/error_helpers.ex:63
+#, elixir-autogen, elixir-format
+msgid "can't be only a link. Please describe yourself in a few words."
+msgstr "darf nicht nur ein Link sein. Bitte beschreiben Sie sich in ein paar Worten."
+
+#: lib/vutuv_web/views/error_helpers.ex:67
+#, elixir-autogen, elixir-format
+msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
+msgstr "„%{tag}“ ist eine Web-Adresse, kein Tag. Bitte beschreiben Sie sich mit Worten."

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -199,3 +199,18 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "is larger than 10 MB. Please upload a smaller file."
 msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:62
+#, elixir-autogen, elixir-format
+msgid "must not be a web or email address"
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:63
+#, elixir-autogen, elixir-format
+msgid "can't be only a link. Please describe yourself in a few words."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:67
+#, elixir-autogen, elixir-format
+msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
+msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -202,3 +202,18 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "is larger than 10 MB. Please upload a smaller file."
 msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:62
+#, elixir-autogen, elixir-format
+msgid "must not be a web or email address"
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:63
+#, elixir-autogen, elixir-format
+msgid "can't be only a link. Please describe yourself in a few words."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:67
+#, elixir-autogen, elixir-format
+msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
+msgstr ""

--- a/test/vutuv/accounts_test.exs
+++ b/test/vutuv/accounts_test.exs
@@ -157,6 +157,22 @@ defmodule Vutuv.AccountsTest do
       refute Repo.get_by(User, first_name: "Test")
     end
 
+    test "rejects a registration whose tag list holds a web address" do
+      # register_user/3 materializes the tags after the insert and ignores
+      # per-tag failures, so the form has to catch this up front — otherwise
+      # the account is created with the tag silently missing.
+      conn = build_conn()
+      attrs = Map.put(@valid_registration, "tag_list", "Elixir Cooking www.example-shop.com")
+
+      assert {:error, changeset} = Accounts.register_user(conn, attrs)
+
+      assert "\"www.example-shop.com\" is a web address, not a tag. Please describe yourself with words." in errors_on(
+               changeset
+             ).tag_list
+
+      refute Repo.get_by(User, first_name: "Test")
+    end
+
     test "accepts a registration exactly at the tag ceiling" do
       conn = build_conn()
       max = Vutuv.Tags.max_user_tags()
@@ -215,6 +231,35 @@ defmodule Vutuv.AccountsTest do
 
       terms = Repo.all(from(s in SearchTerm, where: s.user_id == ^user.id))
       refute terms == []
+    end
+
+    # The tagline is the line under a member's name, so it must say something
+    # about them: a bare URL there is a billboard (the "SBASF FC" sign-up), and
+    # the profile is a member page, not a link farm.
+    test "refuses a tagline that is nothing but a link" do
+      user = insert(:user)
+
+      for headline <- [
+            "https://www.example-shop.com/",
+            "www.example-shop.com",
+            "example-shop.com",
+            "[Cheap Slots](https://example-shop.com)",
+            "kontakt@example-shop.com"
+          ] do
+        assert {:error, changeset} = Accounts.update_user(user, %{"headline" => headline})
+
+        assert "can't be only a link. Please describe yourself in a few words." in errors_on(
+                 changeset
+               ).headline
+      end
+    end
+
+    test "accepts a tagline that mentions a link inside a sentence" do
+      user = insert(:user)
+      headline = "Co-Founder of Example (www.example-shop.com)"
+
+      assert {:ok, updated} = Accounts.update_user(user, %{"headline" => headline})
+      assert updated.headline == headline
     end
   end
 

--- a/test/vutuv/imports/linked_in_apply_test.exs
+++ b/test/vutuv/imports/linked_in_apply_test.exs
@@ -220,6 +220,27 @@ defmodule Vutuv.Imports.LinkedInApplyTest do
     assert Repo.reload(set).headline == "My own headline"
   end
 
+  test "a LinkedIn headline that is only a link is dropped, the names still land" do
+    # The profile changeset refuses a link-only tagline, and the names ride in
+    # the SAME update — so the import must not offer it at all, or a member
+    # whose LinkedIn headline is their homepage would lose the name fill too.
+    user = insert(:user, first_name: nil, last_name: nil, headline: nil)
+
+    profile_csv =
+      "First Name,Last Name,Maiden Name,Address,Birth Date,Headline,Summary,Industry,Zip Code,Geo Location,Twitter Handles,Websites,Instant Messengers\n" <>
+        "Stefan,Wintermeyer,,,,https://www.example-shop.com/,,,,,,,\n"
+
+    {:ok, parsed} = LinkedIn.parse(zip([{"Profile.csv", profile_csv}]))
+    refute Map.has_key?(parsed.profile, :headline)
+
+    {:ok, summary} = LinkedIn.apply_selection(user, parsed)
+
+    assert Enum.sort(summary.created.profile) == [:first_name, :last_name]
+    reloaded = Repo.reload(user)
+    assert reloaded.first_name == "Stefan"
+    assert is_nil(reloaded.headline)
+  end
+
   test "selection_from_payload drops an unknown/tampered profile key instead of raising" do
     # The payload is client-controlled; a tampered key must be dropped, not
     # crash String.to_existing_atom/1 with an ArgumentError (a 500 on confirm).

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -193,6 +193,17 @@ defmodule Vutuv.PostsTest do
       assert Enum.any?(post.tags, &(&1.id == existing.id))
     end
 
+    test "drops a web address from the post tags, keeping the post" do
+      # Post tags share the global namespace with profile tags, where a URL is
+      # refused — the composer must not be the way around it.
+      name = unique_tag_name("Elixir")
+
+      post =
+        create_post!(user(), %{body: "tagged", tags: "#{name}, https://www.example-shop.com/"})
+
+      assert Enum.map(post.tags, & &1.name) == [name]
+    end
+
     test "keeps at most #{Vutuv.Posts.max_tags_per_post()} tags, in input order" do
       tags = Enum.map_join(1..7, ", ", &"tag-number-#{&1}")
 

--- a/test/vutuv/tags_test.exs
+++ b/test/vutuv/tags_test.exs
@@ -137,6 +137,54 @@ defmodule Vutuv.TagsTest do
     end
   end
 
+  describe "a tag may not be a web or email address" do
+    # A tag names a skill, a topic or an interest. Members occasionally paste
+    # their homepage or email address into the field instead ("SBASF FC" signed
+    # up with the tag https://www.sbasf.com/), which advertises rather than
+    # describes and mints a public tag page nobody else can ever share.
+    test "adding a URL as a tag is refused, and mints no tag" do
+      user = insert(:user)
+
+      for value <- ["https://www.example-shop.com/", "www.example-shop.com", "example-shop.com"] do
+        assert {:error, %Ecto.Changeset{} = changeset} = Tags.add_user_tag(user, value)
+        assert "must not be a web or email address" in errors_on(changeset).tag_id
+      end
+
+      assert Repo.aggregate(Tag, :count) == 0
+    end
+
+    test "adding an email address as a tag is refused" do
+      assert {:error, changeset} = Tags.add_user_tag(insert(:user), "spammer@example.com")
+      assert "must not be a web or email address" in errors_on(changeset).tag_id
+    end
+
+    test "a URL tag minted before the rule can't be linked either" do
+      # The lookup in create_or_link_tag/2 would otherwise attach one of the
+      # legacy URL tags in production without ever building a changeset.
+      name = "www.legacy-#{System.unique_integer([:positive])}.com"
+      legacy = insert(:tag, name: name, slug: String.replace(name, ".", "_"))
+
+      assert {:error, changeset} = Tags.add_user_tag(insert(:user), name)
+      assert "must not be a web or email address" in errors_on(changeset).tag_id
+      refute Repo.exists?(from(ut in UserTag, where: ut.tag_id == ^legacy.id))
+    end
+
+    test "a technology tag that merely looks domain-shaped still works" do
+      user = insert(:user)
+
+      for name <- ["node.js", "asp.net", "socket.io"] do
+        assert {:ok, _} = Tags.add_user_tag(user, name)
+      end
+    end
+
+    test "the tag changeset refuses the name on every other path too" do
+      changeset = Tag.changeset(%Tag{}, %{"value" => "https://www.example-shop.com/"})
+
+      refute changeset.valid?
+      assert "must not be a web or email address" in errors_on(changeset).name
+    end
+  end
+
   describe "a profile is capped at max_user_tags/0 tags" do
     # A few members overdid the tag count, so a profile may hold at most
     # `max_user_tags/0` tags. The cap bites only when tags *change*: an existing

--- a/test/vutuv/web_address_test.exs
+++ b/test/vutuv/web_address_test.exs
@@ -1,0 +1,75 @@
+defmodule Vutuv.WebAddressTest do
+  use ExUnit.Case, async: true
+
+  alias Vutuv.WebAddress
+
+  doctest Vutuv.WebAddress
+
+  describe "link_only?/1 says yes to" do
+    test "a bare URL, with or without scheme, path or trailing slash" do
+      assert WebAddress.link_only?("https://www.sbasf.com/")
+      assert WebAddress.link_only?("http://paidviewpoint.com/?r=n6ngcs")
+      assert WebAddress.link_only?("www.mrheissam.net")
+      assert WebAddress.link_only?("Www.google.com")
+      assert WebAddress.link_only?("sbasf.com")
+      assert WebAddress.link_only?("onlinecasinoprofy.com/de/casino/")
+      assert WebAddress.link_only?("mastodon.social/@someone")
+    end
+
+    test "an email address" do
+      assert WebAddress.link_only?("norumtiye220@gmail.com")
+      assert WebAddress.link_only?("mailto:kontakt@example.de")
+    end
+
+    test "several addresses with nothing but punctuation between them" do
+      assert WebAddress.link_only?("https://example.com, https://example.org")
+    end
+
+    test "an address dressed up as a link, label and all" do
+      # The SEO-spam shape seen in production: the same URL as HTML, BBCode and
+      # Markdown. A link's label is part of the link, not a self-description.
+      assert WebAddress.link_only?(~s(<a href="https://spam.example">Cheap Slots</a>))
+      assert WebAddress.link_only?("[url=https://spam.example]Cheap Slots[/url]")
+      assert WebAddress.link_only?("[Cheap Slots](https://spam.example)")
+    end
+
+    test "surrounding whitespace" do
+      assert WebAddress.link_only?("  https://example.com \n")
+    end
+  end
+
+  describe "link_only?/1 says no to" do
+    test "a tagline that merely mentions a site" do
+      assert WebAddress.link_only?("Co-Founder of Taxdoo (www.taxdoo.com)") == false
+      assert WebAddress.link_only?("Full CV: https://example.github.io/cv.docx") == false
+      assert WebAddress.link_only?("Softwareentwickler, Inhaber (www.arcusx.com)") == false
+    end
+
+    test "a technology tag whose name merely looks domain-shaped" do
+      # These share their spelling with a real TLD, which is why the domain
+      # check runs off a curated list instead of the whole registry.
+      for name <- ~w(node.js vue.js three.js asp.net vb.net .net socket.io stud.ip
+                     xamarin.forms i.s.h.med iq.suite C# TCP/IP CI/CD) do
+        refute WebAddress.link_only?(name), "#{name} must stay a valid tag"
+      end
+    end
+
+    test "ordinary prose, German colon forms included" do
+      refute WebAddress.link_only?("Software Consultant")
+      refute WebAddress.link_only?("Berater:innen für Digitalisierung")
+      refute WebAddress.link_only?("Java")
+    end
+
+    test "blank or non-string input" do
+      refute WebAddress.link_only?("")
+      refute WebAddress.link_only?("   ")
+      refute WebAddress.link_only?(nil)
+    end
+
+    test "junk that holds no address at all" do
+      # Three tags in the production data are "-", "." and "????????". They are
+      # worthless, but this rule may not tell their author they typed a URL.
+      for junk <- ["-", ".", "????????", "!!!"], do: refute(WebAddress.link_only?(junk))
+    end
+  end
+end

--- a/test/vutuv_web/controllers/user_controller_test.exs
+++ b/test/vutuv_web/controllers/user_controller_test.exs
@@ -88,6 +88,18 @@ defmodule VutuvWeb.UserControllerTest do
     end
   end
 
+  describe "a tagline that is nothing but a link" do
+    test "re-renders the Basics form with the error instead of saving it", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      conn =
+        put(conn, ~p"/settings/profile", user: %{"headline" => "https://www.example-shop.com/"})
+
+      assert html_response(conn, 422) =~ "can&#39;t be only a link"
+      assert is_nil(Repo.get!(User, user.id).headline)
+    end
+  end
+
   describe "birthday visibility on the Basics form" do
     test "the edit form renders the visibility select with every granularity option", %{
       conn: conn

--- a/test/vutuv_web/live/tag_new_live_test.exs
+++ b/test/vutuv_web/live/tag_new_live_test.exs
@@ -192,6 +192,26 @@ defmodule VutuvWeb.TagNewLiveTest do
       assert tag_count(user) == base + 2
     end
 
+    test "previews no chip for a web address the save would refuse", %{live: live} do
+      # The preview's promise is "these tags will be created", so it must not
+      # offer one add_user_tag/2 turns down a moment later.
+      assert preview(live, "https://www.example-shop.com/ Elixir") == ["Elixir"]
+    end
+
+    test "shows the web-address error inline instead of attaching a URL tag", %{
+      live: live,
+      user: user,
+      base: base
+    } do
+      html =
+        live
+        |> form("#tag-form", tag_param: %{value: "https://www.example-shop.com/"})
+        |> render_submit()
+
+      assert html =~ "must not be a web or email address"
+      assert tag_count(user) == base
+    end
+
     test "refuses a new tag once the profile is at the tag limit", %{
       live: live,
       user: user


### PR DESCRIPTION
A new sign-up put its homepage in both fields it could reach: the tagline was a bare `https://` URL, and one of its tags was the same link. Neither says anything about the member, and a URL tag mints a public tag page nobody else can ever share, so both are validation errors now instead of moderation work afterwards.

## The rule

`Vutuv.WebAddress.link_only?/1` is the single check: any scheme URL, a `www.` host, a bare domain under a curated list of website TLDs, a dotted host with a path, an email address, or any of those wrapped in Markdown / BBCode / `<a>` markup (label included — the SEO-spam shape one profile in production already uses).

It is a **whole-value** rule, not "no URLs allowed": "Co-Founder of Taxdoo (www.taxdoo.com)" stays a valid tagline, and the TLD list is curated rather than the full registry so `node.js`, `asp.net`, `socket.io` and `stud.ip` stay valid tags. Text with no words at all (`-`, `???`) is junk but not a link, so the check leaves it alone.

## Where it bites

- **Tagline** (`User.changeset/2`) — Basics form, LinkedIn import and `PATCH /api/2.0/me` alike.
- **Tag name** (`Vutuv.Tags.Tag`) — the changeset blocks minting one, and `create_or_link_tag/2` blocks *linking* one of the URL tags minted before this rule (that path is a lookup and never builds a changeset, so it needed its own guard).
- **Sign-up tag list** — `register_user/3` attaches tags after the insert and ignores per-tag failures, so without this the account would be created with the tag quietly missing.

Three knock-ons keep the promise honest: the add-tag live preview drops such a name instead of offering a chip the submit then refuses; the LinkedIn import drops a link-only `Headline` while parsing (it rides in the same update as the names, so it would otherwise take the name fill down with it); post tags drop it too, so the composer is not a back door into the shared tag namespace.

## Calibration and verification

Run against a copy of the production data: **4 of 470 headlines** and **39 of 10,647 tags** would be refused, all of them junk (casino/SEO taglines, `Www.google.com`, `pontshoevelyn@gmail.com`, …), no legitimate tech tag among them. Existing rows are untouched — the validations bite when a value changes.

Smoke-tested in a real browser in German on that data copy: sign-up with a URL tag shows the inline error and creates nothing; a URL tagline re-renders the Basics form with the red field and "darf nicht nur ein Link sein…"; the add-tag form previews only the valid tag and refuses the URL with "darf keine Web- oder E-Mail-Adresse sein"; and a tagline that mentions a link inside a sentence saves fine.

`mix precommit` green (4446 tests). German + English error strings added to the gettext files with `dgettext_noop` anchors; the rule is documented in `docs/architecture/profiles.md`.

https://claude.ai/code/session_01PFNZPyGFgYUDS2b92C2eVo