### PR TITLE
Refuse a tag that is only punctuation

### DIFF
--- a/docs/architecture/profiles.md
+++ b/docs/architecture/profiles.md
@@ -546,6 +546,26 @@ profile's Tags card always offers a visitor the "All tags" footer link — not
 only once the card is truncated, which with the 15-tag cap it never is. The
 owner's footer stays the "Manage" bridge into `/settings/tags`.
 
+## A tag has to name something
+
+Two shapes of tag name are refused, both by `Vutuv.Tags.Tag`: a **web address**
+(see the section below, which the tagline shares) and a **wordless** name —
+`Tag.wordless?/1`, no letter and no number anywhere in it (`"-"`, `"."`, `"???"`).
+A wordless name names no topic, nobody searches for it, and the slug it
+generates — the tag page's URL — carries nothing either; one letter or digit
+anywhere is enough, so `C#`, `C++` and `3D` are ordinary tags. Three such rows
+exist from before the rule (2026-07-23) and stay; no new one is minted.
+
+Both refusals sit in two places, because the two entry shapes differ: the
+`changeset/2` heads (nothing can *mint* such a tag) and `create_or_link_tag/2`
+(nothing can *link* one of the legacy rows — that path resolves an existing tag
+by lookup and would never build a changeset). The error lands on `:tag_id`,
+where the tags editor renders its other refusals, so it shows inline. The
+callers that skip unusable values rather than erroring — the add-tag live
+preview and post tags — filter on the same two predicates, and the sign-up form
+names the offending token (`registration_changeset/2`), since `register_user/3`
+attaches tags after the insert and ignores per-tag failures.
+
 ## No field is a billboard: the tagline and tags refuse a bare link
 
 A profile field has to say something about the member. `Vutuv.WebAddress.link_only?/1`

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -8,6 +8,7 @@ defmodule Vutuv.Accounts.User do
   alias Vutuv.Handles
   alias Vutuv.Mentions
   alias Vutuv.Prefs
+  alias Vutuv.Tags.Tag
   alias Vutuv.WebAddress
   @derive {Phoenix.Param, key: :username}
 
@@ -554,7 +555,7 @@ defmodule Vutuv.Accounts.User do
     |> changeset(params)
     |> validate_minimum_tags()
     |> validate_maximum_tags()
-    |> validate_no_web_address_tags()
+    |> validate_usable_tags()
     |> cast_assoc(:emails)
   end
 
@@ -598,23 +599,34 @@ defmodule Vutuv.Accounts.User do
     end
   end
 
-  # `Vutuv.Tags.Tag` refuses a tag that is only a web or email address, but
+  # `Vutuv.Tags.Tag` refuses a name that names no topic — one that is only a web
+  # or email address, and one with no letter or number in it — but
   # `Accounts.register_user/3` materializes the sign-up tags *after* the insert
   # and ignores per-tag failures, so without this the account would be created
   # with that tag quietly missing. Naming the offending token here lets the
   # sign-up form say what to fix instead.
-  defp validate_no_web_address_tags(changeset) do
-    case Enum.find(distinct_tag_names(changeset), &WebAddress.link_only?/1) do
-      nil ->
-        changeset
+  defp validate_usable_tags(changeset) do
+    names = distinct_tag_names(changeset)
 
-      address ->
+    cond do
+      address = Enum.find(names, &WebAddress.link_only?/1) ->
         add_error(
           changeset,
           :tag_list,
           "\"%{tag}\" is a web address, not a tag. Please describe yourself with words.",
           tag: address
         )
+
+      wordless = Enum.find(names, &Tag.wordless?/1) ->
+        add_error(
+          changeset,
+          :tag_list,
+          "\"%{tag}\" needs at least one letter or number to be a tag.",
+          tag: wordless
+        )
+
+      true ->
+        changeset
     end
   end
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2151,15 +2151,16 @@ defmodule Vutuv.Posts do
 
   # Tag.normalize_value strips a leading `#` (the hashtag form), so "#Elixir"
   # becomes "Elixir" and dedupes/links against the bare tag; a bare "#" drops.
-  # A value that is nothing but a web or email address drops too: post tags
-  # share the global tag namespace with profile tags, where that is refused
-  # (`Vutuv.WebAddress`), so the composer must not be the back door. Dropping
-  # it silently matches how this function treats every other odd value — the
-  # post itself still publishes.
+  # A value the tags themselves refuse drops too — one that is nothing but a
+  # web or email address, and one with no letter or number in it (`Tag.wordless?/1`,
+  # which also covers the blank left by a bare "#"). Post tags share the global
+  # namespace with profile tags, so the composer must not be the back door.
+  # Dropping them silently matches how this function treats every other odd
+  # value — the post itself still publishes.
   defp parse_tag_values(values) when is_list(values) do
     values
     |> Enum.map(&Tag.normalize_value/1)
-    |> Enum.reject(&(&1 == "" or WebAddress.link_only?(&1)))
+    |> Enum.reject(&(Tag.wordless?(&1) or WebAddress.link_only?(&1)))
     |> Enum.uniq_by(&String.downcase/1)
     |> Enum.take(@max_tags)
   end

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -84,14 +84,15 @@ defmodule Vutuv.Tags do
   while an unmatched name becomes a fresh tag displaying exactly as typed.
   Case-insensitive duplicates collapse to the first spelling, mirroring the
   single row the profile would end up with (the form's save path dedupes the
-  same way, so preview and outcome always agree). A name that is nothing but a
-  web or email address drops out for the same reason: `add_user_tag/2` refuses
-  it, so promising it here would be a lie the submit then takes back.
+  same way, so preview and outcome always agree). A name `add_user_tag/2` would
+  refuse drops out for the same reason — one that is nothing but a web or email
+  address, or one with no letter or number in it — since promising it here
+  would be a lie the submit then takes back.
   """
   def preview_tag_names(value) do
     case value
          |> parse_tag_names()
-         |> Enum.reject(&WebAddress.link_only?/1)
+         |> Enum.reject(&(WebAddress.link_only?(&1) or Tag.wordless?(&1)))
          |> Enum.uniq_by(&String.downcase/1) do
       [] ->
         []

--- a/lib/vutuv/tags/tag.ex
+++ b/lib/vutuv/tags/tag.ex
@@ -16,6 +16,15 @@ defmodule Vutuv.Tags.Tag do
   # this rule) report the same thing.
   @web_address_message "must not be a web or email address"
 
+  # The other way a value names no topic: it carries no letter and no number at
+  # all ("-", ".", "???"). Nobody searches for it, nobody else can share it, and
+  # the slug it generates — the tag page's URL — is just as empty. Three such
+  # tags exist from before this rule; they stay, but no new one is minted or
+  # linked (see `wordless?/1` and the guard in `create_or_link_tag/2`).
+  @wordless_message "must contain at least one letter or number"
+
+  @word_char ~r/[\p{L}\p{N}]/u
+
   schema "tags" do
     field(:slug, :string)
     field(:name, :string)
@@ -65,6 +74,7 @@ defmodule Vutuv.Tags.Tag do
     # edit form) against a stray line break or tab sneaking in.
     |> validate_format(:name, ~r/^[^\r\n\t]+$/, message: "must be a single line")
     |> validate_web_address()
+    |> validate_wordless()
     |> validate_length(:slug, max: 60)
     |> validate_length(:name, max: 255)
     |> unique_constraint(:slug)
@@ -81,6 +91,27 @@ defmodule Vutuv.Tags.Tag do
       if WebAddress.link_only?(name), do: [name: @web_address_message], else: []
     end)
   end
+
+  defp validate_wordless(changeset) do
+    validate_change(changeset, :name, fn :name, name ->
+      if wordless?(name), do: [name: @wordless_message], else: []
+    end)
+  end
+
+  @doc """
+  Whether `name` carries no letter and no number at all, so it can't be a tag:
+  `"-"`, `"."`, `"???"`, `"!!!"` — punctuation and symbols only. A name with a
+  single letter or digit anywhere in it is fine, so `"C#"`, `"C++"` and
+  `"3D"` stay ordinary tags.
+
+  Both refusal points call this: the `changeset/2` heads (so no path mints such
+  a tag) and `create_or_link_tag/2` (so none of the three legacy ones can be
+  linked either — that path resolves an existing tag by lookup and would never
+  build a changeset). Callers that quietly skip unusable values rather than
+  erroring — the add-tag preview, post tags — filter on it too.
+  """
+  def wordless?(name) when is_binary(name), do: not Regex.match?(@word_char, name)
+  def wordless?(_), do: true
 
   defp maybe_gen_slug(changeset) do
     case {get_field(changeset, :slug), get_field(changeset, :name)} do
@@ -114,10 +145,11 @@ defmodule Vutuv.Tags.Tag do
   `Vutuv.Tags.parse_tag_names/1`, which honours quotes; the JSON API reaches
   here with a single already-whole name.
 
-  A value that is nothing but a web or email address is refused outright
-  (`Vutuv.WebAddress`), before the lookup: the changeset head already keeps a
-  new one from being minted, and this also blocks *linking* one of the URL tags
-  a few profiles created before the rule existed.
+  A value that names no topic is refused outright, before the lookup: one that
+  is nothing but a web or email address (`Vutuv.WebAddress`), and one with no
+  letter or number in it at all (`wordless?/1`). The changeset heads already
+  keep such a tag from being minted; refusing here also blocks *linking* the
+  handful of URL and punctuation tags that exist from before these rules.
   """
   def create_or_link_tag(changeset, %{"value" => value} = params) do
     # Strip the hashtag form before both the existing-tag lookup and the build,
@@ -126,12 +158,12 @@ defmodule Vutuv.Tags.Tag do
     value = normalize_value(value)
     params = Map.put(params, "value", value)
 
-    if WebAddress.link_only?(value) do
-      # The error lands on :tag_id, where the tags editor renders the other
-      # refusals (at the ceiling, reserved honor tag) too.
-      add_error(changeset, :tag_id, @web_address_message)
-    else
-      link_or_build_tag(changeset, value, params)
+    # The errors land on :tag_id, where the tags editor renders the other
+    # refusals (at the ceiling, reserved honor tag) too.
+    cond do
+      WebAddress.link_only?(value) -> add_error(changeset, :tag_id, @web_address_message)
+      wordless?(value) -> add_error(changeset, :tag_id, @wordless_message)
+      true -> link_or_build_tag(changeset, value, params)
     end
   end
 

--- a/lib/vutuv_web/views/error_helpers.ex
+++ b/lib/vutuv_web/views/error_helpers.ex
@@ -67,7 +67,10 @@ defmodule VutuvWeb.ErrorHelpers do
       dgettext_noop(
         "errors",
         "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
-      )
+      ),
+      # Vutuv.Tags.Tag, a name of punctuation only.
+      dgettext_noop("errors", "must contain at least one letter or number"),
+      dgettext_noop("errors", "\"%{tag}\" needs at least one letter or number to be a tag.")
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.133.1",
+      version: "7.133.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -216,3 +216,13 @@ msgstr "darf nicht nur ein Link sein. Bitte beschreiben Sie sich in ein paar Wor
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
 msgstr "„%{tag}“ ist eine Web-Adresse, kein Tag. Bitte beschreiben Sie sich mit Worten."
+
+#: lib/vutuv_web/views/error_helpers.ex:72
+#, elixir-autogen, elixir-format
+msgid "must contain at least one letter or number"
+msgstr "muss mindestens einen Buchstaben oder eine Zahl enthalten"
+
+#: lib/vutuv_web/views/error_helpers.ex:73
+#, elixir-autogen, elixir-format
+msgid "\"%{tag}\" needs at least one letter or number to be a tag."
+msgstr "„%{tag}“ braucht mindestens einen Buchstaben oder eine Zahl, um ein Tag zu sein."

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -214,3 +214,13 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
 msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:72
+#, elixir-autogen, elixir-format
+msgid "must contain at least one letter or number"
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:73
+#, elixir-autogen, elixir-format
+msgid "\"%{tag}\" needs at least one letter or number to be a tag."
+msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -217,3 +217,13 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
 msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:72
+#, elixir-autogen, elixir-format
+msgid "must contain at least one letter or number"
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:73
+#, elixir-autogen, elixir-format
+msgid "\"%{tag}\" needs at least one letter or number to be a tag."
+msgstr ""

--- a/test/vutuv/accounts_test.exs
+++ b/test/vutuv/accounts_test.exs
@@ -173,6 +173,17 @@ defmodule Vutuv.AccountsTest do
       refute Repo.get_by(User, first_name: "Test")
     end
 
+    test "rejects a registration whose tag list holds a punctuation-only tag" do
+      conn = build_conn()
+      attrs = Map.put(@valid_registration, "tag_list", "Elixir Kochen ???")
+
+      assert {:error, changeset} = Accounts.register_user(conn, attrs)
+
+      assert "\"???\" needs at least one letter or number to be a tag." in errors_on(changeset).tag_list
+
+      refute Repo.get_by(User, first_name: "Test")
+    end
+
     test "accepts a registration exactly at the tag ceiling" do
       conn = build_conn()
       max = Vutuv.Tags.max_user_tags()

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -193,13 +193,16 @@ defmodule Vutuv.PostsTest do
       assert Enum.any?(post.tags, &(&1.id == existing.id))
     end
 
-    test "drops a web address from the post tags, keeping the post" do
-      # Post tags share the global namespace with profile tags, where a URL is
+    test "drops a web address or punctuation-only value from the post tags, keeping the post" do
+      # Post tags share the global namespace with profile tags, where both are
       # refused — the composer must not be the way around it.
       name = unique_tag_name("Elixir")
 
       post =
-        create_post!(user(), %{body: "tagged", tags: "#{name}, https://www.example-shop.com/"})
+        create_post!(user(), %{
+          body: "tagged",
+          tags: "#{name}, https://www.example-shop.com/, ???"
+        })
 
       assert Enum.map(post.tags, & &1.name) == [name]
     end

--- a/test/vutuv/tags_test.exs
+++ b/test/vutuv/tags_test.exs
@@ -185,6 +185,45 @@ defmodule Vutuv.TagsTest do
     end
   end
 
+  describe "a tag needs at least one letter or number" do
+    # "-", "." and "????????" are real tags from before this rule. They name no
+    # topic, nobody searches for them, and the slug they generate — the tag
+    # page's URL — is just as empty. The three rows stay; no new one appears.
+    test "punctuation-only names are refused, and mint no tag" do
+      user = insert(:user)
+
+      for value <- ["-", ".", "???", "!!!", "..."] do
+        assert {:error, %Ecto.Changeset{} = changeset} = Tags.add_user_tag(user, value)
+        assert "must contain at least one letter or number" in errors_on(changeset).tag_id
+      end
+
+      assert Repo.aggregate(Tag, :count) == 0
+    end
+
+    test "a punctuation tag minted before the rule can't be linked either" do
+      legacy = insert(:tag, name: "-", slug: "-")
+
+      assert {:error, changeset} = Tags.add_user_tag(insert(:user), "-")
+      assert "must contain at least one letter or number" in errors_on(changeset).tag_id
+      refute Repo.exists?(from(ut in UserTag, where: ut.tag_id == ^legacy.id))
+    end
+
+    test "one letter or digit anywhere is enough" do
+      user = insert(:user)
+
+      for name <- ["C#", "C++", "3D", "F#"] do
+        assert {:ok, _} = Tags.add_user_tag(user, name)
+      end
+    end
+
+    test "the tag changeset refuses the name on every other path too" do
+      changeset = Tag.changeset(%Tag{}, %{"value" => "???"})
+
+      refute changeset.valid?
+      assert "must contain at least one letter or number" in errors_on(changeset).name
+    end
+  end
+
   describe "a profile is capped at max_user_tags/0 tags" do
     # A few members overdid the tag count, so a profile may hold at most
     # `max_user_tags/0` tags. The cap bites only when tags *change*: an existing

--- a/test/vutuv_web/live/tag_new_live_test.exs
+++ b/test/vutuv_web/live/tag_new_live_test.exs
@@ -192,10 +192,11 @@ defmodule VutuvWeb.TagNewLiveTest do
       assert tag_count(user) == base + 2
     end
 
-    test "previews no chip for a web address the save would refuse", %{live: live} do
+    test "previews no chip for a name the save would refuse", %{live: live} do
       # The preview's promise is "these tags will be created", so it must not
       # offer one add_user_tag/2 turns down a moment later.
       assert preview(live, "https://www.example-shop.com/ Elixir") == ["Elixir"]
+      assert preview(live, "??? Elixir") == ["Elixir"]
     end
 
     test "shows the web-address error inline instead of attaching a URL tag", %{
@@ -209,6 +210,17 @@ defmodule VutuvWeb.TagNewLiveTest do
         |> render_submit()
 
       assert html =~ "must not be a web or email address"
+      assert tag_count(user) == base
+    end
+
+    test "shows the punctuation-only error inline instead of attaching the tag", %{
+      live: live,
+      user: user,
+      base: base
+    } do
+      html = live |> form("#tag-form", tag_param: %{value: "???"}) |> render_submit()
+
+      assert html =~ "must contain at least one letter or number"
       assert tag_count(user) == base
     end
 


### PR DESCRIPTION
Follow-up to #1015, which closed one way a tag can name nothing (a bare web address). This closes the other: a value with **no letter and no number in it at all**.

Three such tags exist in production — `-`, `.` and `????????`. Nobody searches for them, nobody else can share them, and the slug they generate (the tag page's own URL) carries just as little. They stay; no new one appears.

## The rule

`Vutuv.Tags.Tag.wordless?/1`. One letter or digit **anywhere** is enough, so `C#`, `C++`, `F#` and `3D` remain ordinary tags.

It is refused in the same two places the web-address rule needs:

- the `changeset/2` heads, so no path mints such a tag, and
- `create_or_link_tag/2`, so none of the three legacy rows can be *linked* either — that path resolves an existing tag by lookup and would never build a changeset.

The error lands on `:tag_id`, where the tags editor renders its other refusals, so it shows inline ("muss mindestens einen Buchstaben oder eine Zahl enthalten") instead of a bare "Bitte prüfen Sie die rot markierten Felder".

The callers that skip unusable values rather than erroring filter on it too — the add-tag live preview and post tags — and the sign-up form names the offending token, since `register_user/3` attaches tags after the insert and ignores per-tag failures.

## Verification

`mix precommit` green (4452 tests). Smoke-tested in German on a copy of the production data: `???` in the add-tag form shows the inline error and creates nothing, while `C#` previews as the existing `c#` tag. Documented in `docs/architecture/profiles.md`.

Note this also rejects a symbol-only name such as an emoji tag, which seems right for something whose purpose is to be a searchable topic word and a URL slug.

https://claude.ai/code/session_01PFNZPyGFgYUDS2b92C2eVo