### PR TITLE
Let an emoji be a tag

### DIFF
--- a/docs/architecture/profiles.md
+++ b/docs/architecture/profiles.md
@@ -549,12 +549,16 @@ owner's footer stays the "Manage" bridge into `/settings/tags`.
 ## A tag has to name something
 
 Two shapes of tag name are refused, both by `Vutuv.Tags.Tag`: a **web address**
-(see the section below, which the tagline shares) and a **wordless** name —
-`Tag.wordless?/1`, no letter and no number anywhere in it (`"-"`, `"."`, `"???"`).
-A wordless name names no topic, nobody searches for it, and the slug it
-generates — the tag page's URL — carries nothing either; one letter or digit
-anywhere is enough, so `C#`, `C++` and `3D` are ordinary tags. Three such rows
-exist from before the rule (2026-07-23) and stay; no new one is minted.
+(see the section below, which the tagline shares) and a name that is
+**punctuation only** — `Tag.punctuation_only?/1`, nothing in it but `\p{P}`,
+`\p{Z}` and `\p{C}` (`"-"`, `"."`, `"???"`). Such a name names no topic, nobody
+searches for it, and the slug it generates — the tag page's URL — carries
+nothing either. One character of content anywhere is enough, and a **symbol
+counts as content**, so `C#`, `C++`, `3D` and an emoji tag like `☕` are all
+ordinary tags (an emoji is a name people use and search for, unlike a run of
+question marks; it slugifies to nothing, so `Vutuv.SlugHelpers` gives the page a
+short-sha slug). Three punctuation rows exist from before the rule
+(2026-07-23) and stay; no new one is minted.
 
 Both refusals sit in two places, because the two entry shapes differ: the
 `changeset/2` heads (nothing can *mint* such a tag) and `create_or_link_tag/2`

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -600,7 +600,7 @@ defmodule Vutuv.Accounts.User do
   end
 
   # `Vutuv.Tags.Tag` refuses a name that names no topic — one that is only a web
-  # or email address, and one with no letter or number in it — but
+  # or email address, and one that is only punctuation — but
   # `Accounts.register_user/3` materializes the sign-up tags *after* the insert
   # and ignores per-tag failures, so without this the account would be created
   # with that tag quietly missing. Naming the offending token here lets the
@@ -617,12 +617,12 @@ defmodule Vutuv.Accounts.User do
           tag: address
         )
 
-      wordless = Enum.find(names, &Tag.wordless?/1) ->
+      punctuation = Enum.find(names, &Tag.punctuation_only?/1) ->
         add_error(
           changeset,
           :tag_list,
-          "\"%{tag}\" needs at least one letter or number to be a tag.",
-          tag: wordless
+          "\"%{tag}\" is only punctuation, not a tag.",
+          tag: punctuation
         )
 
       true ->

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2152,15 +2152,15 @@ defmodule Vutuv.Posts do
   # Tag.normalize_value strips a leading `#` (the hashtag form), so "#Elixir"
   # becomes "Elixir" and dedupes/links against the bare tag; a bare "#" drops.
   # A value the tags themselves refuse drops too — one that is nothing but a
-  # web or email address, and one with no letter or number in it (`Tag.wordless?/1`,
-  # which also covers the blank left by a bare "#"). Post tags share the global
-  # namespace with profile tags, so the composer must not be the back door.
-  # Dropping them silently matches how this function treats every other odd
-  # value — the post itself still publishes.
+  # web or email address, and one that is only punctuation
+  # (`Tag.punctuation_only?/1`, which also covers the blank left by a bare "#").
+  # Post tags share the global namespace with profile tags, so the composer must
+  # not be the back door. Dropping them silently matches how this function
+  # treats every other odd value — the post itself still publishes.
   defp parse_tag_values(values) when is_list(values) do
     values
     |> Enum.map(&Tag.normalize_value/1)
-    |> Enum.reject(&(Tag.wordless?(&1) or WebAddress.link_only?(&1)))
+    |> Enum.reject(&(Tag.punctuation_only?(&1) or WebAddress.link_only?(&1)))
     |> Enum.uniq_by(&String.downcase/1)
     |> Enum.take(@max_tags)
   end

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -86,13 +86,13 @@ defmodule Vutuv.Tags do
   single row the profile would end up with (the form's save path dedupes the
   same way, so preview and outcome always agree). A name `add_user_tag/2` would
   refuse drops out for the same reason — one that is nothing but a web or email
-  address, or one with no letter or number in it — since promising it here
-  would be a lie the submit then takes back.
+  address, or one that is only punctuation — since promising it here would be a
+  lie the submit then takes back.
   """
   def preview_tag_names(value) do
     case value
          |> parse_tag_names()
-         |> Enum.reject(&(WebAddress.link_only?(&1) or Tag.wordless?(&1)))
+         |> Enum.reject(&(WebAddress.link_only?(&1) or Tag.punctuation_only?(&1)))
          |> Enum.uniq_by(&String.downcase/1) do
       [] ->
         []

--- a/lib/vutuv/tags/tag.ex
+++ b/lib/vutuv/tags/tag.ex
@@ -16,14 +16,19 @@ defmodule Vutuv.Tags.Tag do
   # this rule) report the same thing.
   @web_address_message "must not be a web or email address"
 
-  # The other way a value names no topic: it carries no letter and no number at
-  # all ("-", ".", "???"). Nobody searches for it, nobody else can share it, and
-  # the slug it generates — the tag page's URL — is just as empty. Three such
-  # tags exist from before this rule; they stay, but no new one is minted or
-  # linked (see `wordless?/1` and the guard in `create_or_link_tag/2`).
-  @wordless_message "must contain at least one letter or number"
+  # The other way a value names no topic: it is punctuation and nothing else
+  # ("-", ".", "???"). Nobody searches for it, nobody else can share it, and the
+  # slug it generates — the tag page's URL — is just as empty. Three such tags
+  # exist from before this rule; they stay, but no new one is minted or linked
+  # (see `punctuation_only?/1` and the guard in `create_or_link_tag/2`).
+  @punctuation_message "must not be only punctuation"
 
-  @word_char ~r/[\p{L}\p{N}]/u
+  # What counts as content: anything that is not punctuation (`\p{P}`), a
+  # separator/whitespace (`\p{Z}`) or an invisible control character (`\p{C}`).
+  # Letters and digits, of course — and **symbols** (`\p{S}`), which is what
+  # makes an emoji a tag of its own ("☕", "🎸"): an emoji is a name people
+  # actually use and search for, unlike a run of question marks.
+  @content_char ~r/[^\p{P}\p{Z}\p{C}]/u
 
   schema "tags" do
     field(:slug, :string)
@@ -74,7 +79,7 @@ defmodule Vutuv.Tags.Tag do
     # edit form) against a stray line break or tab sneaking in.
     |> validate_format(:name, ~r/^[^\r\n\t]+$/, message: "must be a single line")
     |> validate_web_address()
-    |> validate_wordless()
+    |> validate_punctuation_only()
     |> validate_length(:slug, max: 60)
     |> validate_length(:name, max: 255)
     |> unique_constraint(:slug)
@@ -92,17 +97,17 @@ defmodule Vutuv.Tags.Tag do
     end)
   end
 
-  defp validate_wordless(changeset) do
+  defp validate_punctuation_only(changeset) do
     validate_change(changeset, :name, fn :name, name ->
-      if wordless?(name), do: [name: @wordless_message], else: []
+      if punctuation_only?(name), do: [name: @punctuation_message], else: []
     end)
   end
 
   @doc """
-  Whether `name` carries no letter and no number at all, so it can't be a tag:
-  `"-"`, `"."`, `"???"`, `"!!!"` — punctuation and symbols only. A name with a
-  single letter or digit anywhere in it is fine, so `"C#"`, `"C++"` and
-  `"3D"` stay ordinary tags.
+  Whether `name` is punctuation (and whitespace) and nothing else, so it can't
+  be a tag: `"-"`, `"."`, `"???"`, `"!!!"`. One character of actual content
+  anywhere is enough, and a **symbol counts as content**, so `"C#"`, `"C++"`,
+  `"3D"` and an emoji tag like `"☕"` are all ordinary tags.
 
   Both refusal points call this: the `changeset/2` heads (so no path mints such
   a tag) and `create_or_link_tag/2` (so none of the three legacy ones can be
@@ -110,8 +115,8 @@ defmodule Vutuv.Tags.Tag do
   build a changeset). Callers that quietly skip unusable values rather than
   erroring — the add-tag preview, post tags — filter on it too.
   """
-  def wordless?(name) when is_binary(name), do: not Regex.match?(@word_char, name)
-  def wordless?(_), do: true
+  def punctuation_only?(name) when is_binary(name), do: not Regex.match?(@content_char, name)
+  def punctuation_only?(_), do: true
 
   defp maybe_gen_slug(changeset) do
     case {get_field(changeset, :slug), get_field(changeset, :name)} do
@@ -146,10 +151,10 @@ defmodule Vutuv.Tags.Tag do
   here with a single already-whole name.
 
   A value that names no topic is refused outright, before the lookup: one that
-  is nothing but a web or email address (`Vutuv.WebAddress`), and one with no
-  letter or number in it at all (`wordless?/1`). The changeset heads already
-  keep such a tag from being minted; refusing here also blocks *linking* the
-  handful of URL and punctuation tags that exist from before these rules.
+  is nothing but a web or email address (`Vutuv.WebAddress`), and one that is
+  only punctuation (`punctuation_only?/1`). The changeset heads already keep
+  such a tag from being minted; refusing here also blocks *linking* the handful
+  of URL and punctuation tags that exist from before these rules.
   """
   def create_or_link_tag(changeset, %{"value" => value} = params) do
     # Strip the hashtag form before both the existing-tag lookup and the build,
@@ -162,7 +167,7 @@ defmodule Vutuv.Tags.Tag do
     # refusals (at the ceiling, reserved honor tag) too.
     cond do
       WebAddress.link_only?(value) -> add_error(changeset, :tag_id, @web_address_message)
-      wordless?(value) -> add_error(changeset, :tag_id, @wordless_message)
+      punctuation_only?(value) -> add_error(changeset, :tag_id, @punctuation_message)
       true -> link_or_build_tag(changeset, value, params)
     end
   end

--- a/lib/vutuv_web/views/error_helpers.ex
+++ b/lib/vutuv_web/views/error_helpers.ex
@@ -69,8 +69,8 @@ defmodule VutuvWeb.ErrorHelpers do
         "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
       ),
       # Vutuv.Tags.Tag, a name of punctuation only.
-      dgettext_noop("errors", "must contain at least one letter or number"),
-      dgettext_noop("errors", "\"%{tag}\" needs at least one letter or number to be a tag.")
+      dgettext_noop("errors", "must not be only punctuation"),
+      dgettext_noop("errors", "\"%{tag}\" is only punctuation, not a tag.")
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.133.2",
+      version: "7.133.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -219,10 +219,10 @@ msgstr "„%{tag}“ ist eine Web-Adresse, kein Tag. Bitte beschreiben Sie sich 
 
 #: lib/vutuv_web/views/error_helpers.ex:72
 #, elixir-autogen, elixir-format
-msgid "must contain at least one letter or number"
-msgstr "muss mindestens einen Buchstaben oder eine Zahl enthalten"
+msgid "must not be only punctuation"
+msgstr "darf nicht nur aus Satzzeichen bestehen"
 
 #: lib/vutuv_web/views/error_helpers.ex:73
 #, elixir-autogen, elixir-format
-msgid "\"%{tag}\" needs at least one letter or number to be a tag."
-msgstr "„%{tag}“ braucht mindestens einen Buchstaben oder eine Zahl, um ein Tag zu sein."
+msgid "\"%{tag}\" is only punctuation, not a tag."
+msgstr "„%{tag}“ besteht nur aus Satzzeichen und ist kein Tag."

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -217,10 +217,10 @@ msgstr ""
 
 #: lib/vutuv_web/views/error_helpers.ex:72
 #, elixir-autogen, elixir-format
-msgid "must contain at least one letter or number"
+msgid "must not be only punctuation"
 msgstr ""
 
 #: lib/vutuv_web/views/error_helpers.ex:73
 #, elixir-autogen, elixir-format
-msgid "\"%{tag}\" needs at least one letter or number to be a tag."
+msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -220,10 +220,10 @@ msgstr ""
 
 #: lib/vutuv_web/views/error_helpers.ex:72
 #, elixir-autogen, elixir-format
-msgid "must contain at least one letter or number"
+msgid "must not be only punctuation"
 msgstr ""
 
 #: lib/vutuv_web/views/error_helpers.ex:73
 #, elixir-autogen, elixir-format
-msgid "\"%{tag}\" needs at least one letter or number to be a tag."
+msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""

--- a/test/vutuv/accounts_test.exs
+++ b/test/vutuv/accounts_test.exs
@@ -179,7 +179,7 @@ defmodule Vutuv.AccountsTest do
 
       assert {:error, changeset} = Accounts.register_user(conn, attrs)
 
-      assert "\"???\" needs at least one letter or number to be a tag." in errors_on(changeset).tag_list
+      assert "\"???\" is only punctuation, not a tag." in errors_on(changeset).tag_list
 
       refute Repo.get_by(User, first_name: "Test")
     end

--- a/test/vutuv/tags_test.exs
+++ b/test/vutuv/tags_test.exs
@@ -185,7 +185,7 @@ defmodule Vutuv.TagsTest do
     end
   end
 
-  describe "a tag needs at least one letter or number" do
+  describe "a tag may not be punctuation only" do
     # "-", "." and "????????" are real tags from before this rule. They name no
     # topic, nobody searches for them, and the slug they generate — the tag
     # page's URL — is just as empty. The three rows stay; no new one appears.
@@ -194,7 +194,7 @@ defmodule Vutuv.TagsTest do
 
       for value <- ["-", ".", "???", "!!!", "..."] do
         assert {:error, %Ecto.Changeset{} = changeset} = Tags.add_user_tag(user, value)
-        assert "must contain at least one letter or number" in errors_on(changeset).tag_id
+        assert "must not be only punctuation" in errors_on(changeset).tag_id
       end
 
       assert Repo.aggregate(Tag, :count) == 0
@@ -204,23 +204,33 @@ defmodule Vutuv.TagsTest do
       legacy = insert(:tag, name: "-", slug: "-")
 
       assert {:error, changeset} = Tags.add_user_tag(insert(:user), "-")
-      assert "must contain at least one letter or number" in errors_on(changeset).tag_id
+      assert "must not be only punctuation" in errors_on(changeset).tag_id
       refute Repo.exists?(from(ut in UserTag, where: ut.tag_id == ^legacy.id))
     end
 
-    test "one letter or digit anywhere is enough" do
+    test "one character of content anywhere is enough, emoji included" do
       user = insert(:user)
 
-      for name <- ["C#", "C++", "3D", "F#"] do
+      for name <- ["C#", "C++", "3D", "F#", "☕", "🎸 Gitarre"] do
         assert {:ok, _} = Tags.add_user_tag(user, name)
       end
+    end
+
+    test "an emoji-only tag gets a usable slug for its public page" do
+      # The name slugifies to nothing, so SlugHelpers falls back to a short sha
+      # rather than putting the raw emoji into the URL.
+      {:ok, user_tag} = Tags.add_user_tag(insert(:user), "☕")
+      tag = Repo.preload(user_tag, :tag).tag
+
+      assert tag.name == "☕"
+      assert tag.slug =~ ~r/^[a-z0-9]+$/
     end
 
     test "the tag changeset refuses the name on every other path too" do
       changeset = Tag.changeset(%Tag{}, %{"value" => "???"})
 
       refute changeset.valid?
-      assert "must contain at least one letter or number" in errors_on(changeset).name
+      assert "must not be only punctuation" in errors_on(changeset).name
     end
   end
 

--- a/test/vutuv_web/live/tag_new_live_test.exs
+++ b/test/vutuv_web/live/tag_new_live_test.exs
@@ -220,7 +220,7 @@ defmodule VutuvWeb.TagNewLiveTest do
     } do
       html = live |> form("#tag-form", tag_param: %{value: "???"}) |> render_submit()
 
-      assert html =~ "must contain at least one letter or number"
+      assert html =~ "must not be only punctuation"
       assert tag_count(user) == base
     end
 


### PR DESCRIPTION
Follow-up to #1017, which refused a tag name with no letter or number in it. That also shut out an **emoji-only tag** — and `☕` or `🎸` is a name people actually use and search for, unlike a run of question marks.

## The change

The check now asks for one character that is **not** punctuation (`\p{P}`), whitespace (`\p{Z}`) or a control character (`\p{C}`). Unicode symbols count as content, letters and digits of course. So:

- `☕`, `🎸 Gitarre`, `C#`, `C++`, `3D` — valid tags
- `-`, `.`, `???`, `!!!`, `...` — still refused, for the same reason as before

`Tag.wordless?/1` is therefore `Tag.punctuation_only?/1`, and the messages say what they mean: "darf nicht nur aus Satzzeichen bestehen" for the field, "„%{tag}“ besteht nur aus Satzzeichen und ist kein Tag." on the sign-up form.

An emoji name slugifies to nothing, which `Vutuv.SlugHelpers` already handles by falling back to a short-sha slug, so the tag page keeps a usable URL (a test pins this).

## Verification

`mix precommit` green (4453 tests). Smoke-tested on a copy of the production data: typing `??? ☕` into the add-tag form previews exactly one chip (the emoji), and submitting creates the ☕ tag while the `???` is refused.

https://claude.ai/code/session_01PFNZPyGFgYUDS2b92C2eVo