### PR TITLE
Render the post permalink as the whole conversation (#1006)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -40,6 +40,14 @@ onReady(() =>
   document.querySelectorAll("time[data-localtime]").forEach(localizeTime)
 )
 
+// The post permalink renders the whole conversation (issue #1006). When the
+// permalinked post has thread context above it, jump it into view on arrival —
+// its wrapper carries data-thread-scroll plus scroll-mt for the sticky bar.
+onReady(() => {
+  const focus = document.querySelector("[data-thread-scroll]")
+  if (focus) focus.scrollIntoView()
+})
+
 // Feed/profile post previews ship the whole body and clamp it to a few lines
 // via CSS. Reveal the "Read more" affordance only when the body is really cut —
 // i.e. the clamped body overflows, which the server can't know since wrapping is

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -207,18 +207,31 @@ On the feed and the profile Posts section `Vutuv.Posts.collapse_threads/1` folds
 each visible chain: it drops the ancestors' own standalone rows (so a middle
 post is no longer shown twice) and hands each surviving leaf its ordered
 `:ancestors`, so however many posts or authors a thread spans it renders once;
-the archive, saved lists and permalink fall back to nesting the single direct
-parent.
+the archive and saved lists fall back to nesting the single direct parent.
 
 All read the same (each a single card of flat `divide-y` rows).
 
 The notification page reuses the compact `post_preview/1` for the post a
 like/reply quotes.
 
-The permalink page lists the visible replies oldest-first (nesting off there —
-the parent is the page itself), the action bar carries a live reply counter, and
-the parent's author gets a derived "replied to your post" notification
-(self-replies excluded).
+**The permalink page renders the whole conversation** (issue #1006):
+`Vutuv.Posts.list_thread/3` fetches the thread's root plus every visible post
+of the thread in one `root_post_id` lookup, oldest first (capped at 200 with a
+"conversation is longer" note; the permalinked post, its surviving ancestor
+chain and its direct replies are always unioned back in, which is also the
+degraded floor once a deleted root has nilified the thread's root links), and
+`PostComponents.thread_conversation/1` renders it as one feed-style chain. The
+permalinked post is the tinted `:full`-mode card (`#thread-focus`; an
+absolutely positioned `::before` so the connector geometry is untouched) and,
+when it has context above, app.js scrolls it into view on arrival
+(`data-thread-scroll`). The chain is chronological, not a tree, so a reply
+that does not answer the card directly above it keeps its own "Replying to
+@handle" banner — that is how branch points read. A post with no thread
+renders standalone exactly as before. The action bar carries a live reply
+counter, and the parent's author gets a derived "replied to your post"
+notification (self-replies excluded). The agent-format siblings mirror the
+page: `PostDoc` carries the conversation as `thread` (each entry with its
+parent pointer), the md/txt renderers as a "Conversation" section.
 
 A reply **outlives its parent**: where the parent is gone the card falls back to
 a banner (which names the account as `@handle`, never the clear name) that

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -71,6 +71,10 @@ defmodule Vutuv.Posts do
   @default_feed_limit 20
   @default_profile_limit 3
   @default_thread_limit 100
+  # The permalink conversation's cap (issue #1006): strictly above the
+  # one-level reply cap plus the post itself, so the whole-thread page can
+  # never show fewer posts than the old post-plus-direct-replies page did.
+  @default_conversation_limit 200
   @pending_max_age_hours 24
   @max_tags 5
   @tag_posts_per_page 20
@@ -1811,6 +1815,77 @@ defmodule Vutuv.Posts do
     |> scope_visible(viewer)
     |> Repo.all()
     |> Repo.preload(post_preloads())
+  end
+
+  @doc """
+  The whole conversation `post` belongs to, as `viewer` sees it: the thread's
+  root plus every visible post of the thread, oldest first — what the
+  permalink page renders (issue #1006). Fetched in one indexed query over the
+  denormalized `post_replies.root_post_id`.
+
+  Returns `%{posts:, truncated?:}`; `truncated?` says the `:limit` cap
+  (default #{@default_conversation_limit}) cut the newest tail. The
+  permalinked post, its surviving ancestor chain and its direct replies are
+  always unioned back in, so the page never loses its own subject — that
+  union is also the degraded floor when a deleted root nilified the thread's
+  `root_post_id` links and the conversation can no longer be found by root.
+  """
+  def list_thread(%Post{} = post, viewer, opts \\ []) do
+    limit = Keyword.get(opts, :limit, @default_conversation_limit)
+    {anchor_id, up} = thread_anchor(post, viewer)
+
+    scoped =
+      from(p in Post,
+        left_join: r in PostReply,
+        on: r.post_id == p.id,
+        where: r.root_post_id == ^anchor_id or p.id == ^anchor_id,
+        order_by: [asc: p.inserted_at, asc: p.id],
+        limit: ^(limit + 1)
+      )
+      |> scope_visible(viewer)
+      |> Repo.all()
+
+    truncated? = length(scoped) > limit
+
+    posts =
+      (Enum.take(scoped, limit) ++ up ++ [post] ++ list_replies(post, viewer))
+      |> Enum.uniq_by(& &1.id)
+      |> Enum.sort_by(&{NaiveDateTime.to_erl(&1.inserted_at), &1.id})
+      |> Repo.preload(post_preloads())
+
+    %{posts: posts, truncated?: truncated?}
+  end
+
+  # Where the conversation is anchored: the denormalized root for a normal
+  # reply, the post itself for a top-level post. A degraded reply (root
+  # deleted, `root_post_id` NULL) anchors at its topmost surviving ancestor
+  # instead and carries that visible chain along, since the nilified links can
+  # no longer reach it by root.
+  defp thread_anchor(%Post{} = post, viewer) do
+    case Repo.one(
+           from(r in PostReply, where: r.post_id == ^post.id, select: {r.id, r.root_post_id})
+         ) do
+      nil -> {post.id, []}
+      {_, root_id} when is_binary(root_id) -> {root_id, []}
+      {_, nil} -> surviving_chain(post, viewer)
+    end
+  end
+
+  # Walks parent links up as far as posts still exist, collecting the ones
+  # `viewer` may see. Parents are strictly older posts, so the walk cannot
+  # cycle. Returns `{topmost_id, chain}` with the chain oldest first.
+  defp surviving_chain(%Post{} = post, viewer, chain \\ []) do
+    parent_id =
+      Repo.one(from(r in PostReply, where: r.post_id == ^post.id, select: r.parent_post_id))
+
+    case parent_id && Repo.one(from(p in Post, where: p.id == ^parent_id)) do
+      nil ->
+        {post.id, chain}
+
+      %Post{} = parent ->
+        chain = if visible_to?(parent, viewer), do: [parent | chain], else: chain
+        surviving_chain(parent, viewer, chain)
+    end
   end
 
   @doc """

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -106,7 +106,14 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       tags_line(doc.tags),
       engagement_line(doc),
       section(gettext("Images"), Enum.map(doc.images, &image_line/1)),
-      section("#{gettext("Replies")} (#{doc.reply_count})", Enum.map(doc.replies, &reply_block/1))
+      # The whole conversation (issue #1006), like the HTML permalink: every
+      # other thread post oldest first (the page's own post already reads in
+      # full above), each naming its parent when it is one of them.
+      section(
+        "#{gettext("Conversation")} (#{length(doc.thread)})",
+        doc.thread |> Enum.reject(&(&1.id == doc.id)) |> Enum.map(&thread_block/1)
+      ),
+      if(doc.thread_truncated, do: gettext("Only part of this long conversation is shown."))
     ]
     |> join_blocks()
   end
@@ -896,8 +903,18 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   @doc false
   def image_url(image), do: image.urls[:feed] || image.urls |> Map.values() |> List.first()
 
-  defp reply_block(reply) do
-    "### [#{md_text(reply.author)}](#{reply.url}) · #{reply.published_on}\n\n#{reply.body_markdown}"
+  defp thread_block(entry) do
+    reply_to =
+      entry.in_reply_to_author &&
+        "> " <> gettext("In reply to a post by %{name}.", name: entry.in_reply_to_author)
+
+    [
+      "### [#{md_text(entry.author)}](#{entry.url}) · #{entry.published_on}",
+      reply_to,
+      entry.body_markdown
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n\n")
   end
 
   defp section(_title, []), do: nil

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -34,7 +34,9 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   for the extension URLs, they must stay cache-safe.
   """
   def build(author, %Post{} = post, opts \\ []) do
-    replies = Posts.list_replies(post, Keyword.get(opts, :viewer))
+    viewer = Keyword.get(opts, :viewer)
+    replies = Posts.list_replies(post, viewer)
+    %{posts: thread, truncated?: thread_truncated?} = Posts.list_thread(post, viewer)
     {noindex?, noai?} = robots_axes(author, Posts.restricted?(post))
     engagement = Posts.engagement_counts(post.id)
 
@@ -60,6 +62,12 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # a second query and can never drift from the list.)
       reply_count: length(replies),
       replies: Enum.map(replies, &reply_entry/1),
+      # The whole conversation the HTML permalink renders (issue #1006),
+      # oldest first; every entry carries its parent pointer so the tree is
+      # recoverable. `replies` above stays the one-level list for API
+      # consumers that relied on it.
+      thread: thread_entries(thread),
+      thread_truncated: thread_truncated?,
       # The public engagement counters the HTML action bar shows to everyone.
       like_count: engagement.likes,
       repost_count: engagement.reposts,
@@ -111,6 +119,28 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       reposted_by: entry[:reposted_by] && UserHelpers.full_name(entry[:reposted_by]),
       reposters: Enum.map(reposters, &UserHelpers.full_name/1)
     }
+  end
+
+  # The conversation entries, oldest first. `in_reply_to_author` resolves only
+  # inside the thread (a deleted or invisible parent stays nil), so the
+  # markdown/text renderers can name a branch's parent without another lookup.
+  defp thread_entries(posts) do
+    authors = Map.new(posts, &{&1.id, UserHelpers.full_name(&1.user)})
+
+    Enum.map(posts, fn post ->
+      parent_id = post.reply_ref && post.reply_ref.parent_post_id
+
+      %{
+        id: post.id,
+        url: AgentDocs.abs_url(Posts.path(post)),
+        author: UserHelpers.full_name(post.user),
+        author_username: post.user.username,
+        published_on: post.published_on,
+        body_markdown: post.body,
+        in_reply_to_id: parent_id,
+        in_reply_to_author: parent_id && authors[parent_id]
+      }
+    end)
   end
 
   defp reply_entry(%Post{} = reply) do

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -102,9 +102,10 @@ defmodule VutuvWeb.AgentDocs.Text do
       Markdown.engagement_line(doc),
       section(gettext("Images"), Enum.map(doc.images, &image_lines/1)),
       section(
-        "#{gettext("Replies")} (#{doc.reply_count})",
-        Enum.map(doc.replies, &reply_lines/1)
+        "#{gettext("Conversation")} (#{length(doc.thread)})",
+        doc.thread |> Enum.reject(&(&1.id == doc.id)) |> Enum.map(&thread_lines/1)
       ),
+      if(doc.thread_truncated, do: gettext("Only part of this long conversation is shown.")),
       footer(doc)
     ]
     |> join_blocks()
@@ -596,9 +597,16 @@ defmodule VutuvWeb.AgentDocs.Text do
     "* #{alt}\n  #{Markdown.image_url(image)}"
   end
 
-  defp reply_lines(reply) do
-    "* #{reply.author} · #{reply.published_on} · #{reply.url}\n" <>
-      indent_block(reply.body_markdown)
+  defp thread_lines(entry) do
+    reply_to =
+      if entry.in_reply_to_author,
+        do:
+          "  " <>
+            gettext("In reply to a post by %{name}.", name: entry.in_reply_to_author) <> "\n",
+        else: ""
+
+    "* #{entry.author} · #{entry.published_on} · #{entry.url}\n" <>
+      reply_to <> indent_block(entry.body_markdown)
   end
 
   defp indent_block(text) do

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -31,6 +31,7 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Posts
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.PostReply
   alias Vutuv.Posts.PostReview
   alias Vutuv.Posts.PostScreenshot
   alias Vutuv.ReviewCover
@@ -587,7 +588,19 @@ defmodule VutuvWeb.PostComponents do
     ~H"""
     <%= case @chain do %>
       <% [item | rest] -> %>
-        <div class="relative">
+        <div
+          id={Map.get(item, :focus?) && "thread-focus"}
+          data-thread-scroll={Map.get(item, :scroll?)}
+          class={[
+            "relative",
+            # The permalink's highlighted subject (issue #1006): the tint is an
+            # absolutely positioned ::before so the chain's connector geometry
+            # (avatar columns, elbows) is untouched; z-0 opens a stacking
+            # context so -z-10 stays in front of the page card's background.
+            Map.get(item, :focus?) &&
+              "z-0 scroll-mt-24 before:absolute before:-inset-x-3 before:-inset-y-2 before:-z-10 before:rounded-xl before:bg-brand-50/70 before:ring-1 before:ring-brand-200 before:content-[''] dark:before:bg-brand-900/20 dark:before:ring-brand-800"
+          ]}
+        >
           <%!-- Drops from this avatar's bottom (top-9) to the card's bottom; the
           elbow below continues it into the reply's avatar. Only when a reply
           follows this card. Height is an explicit `calc(100% - top)`, not
@@ -611,7 +624,8 @@ defmodule VutuvWeb.PostComponents do
             entry_id={item.entry_id}
             surface={@surface}
             conn_or_socket={@conn_or_socket}
-            show_reply_banner={false}
+            mode={Map.get(item, :mode, :preview)}
+            show_reply_banner={Map.get(item, :show_reply_banner, false)}
           />
         </div>
         <div :if={rest != []} class={["relative pt-3", @indent? && "pl-7"]}>
@@ -644,6 +658,64 @@ defmodule VutuvWeb.PostComponents do
     <% end %>
     """
   end
+
+  @doc """
+  The permalink page's whole-conversation rendering (issue #1006): every post
+  of `posts` (the thread oldest first, `Vutuv.Posts.list_thread/3`) as one
+  connected chain — the same look as a feed thread row. The permalinked
+  `focus_id` post renders in `:full` mode, tinted as the page's subject and,
+  when it has context above it, marked for the arrival auto-scroll
+  (`data-thread-scroll`, wired in app.js). The chain is chronological, not a
+  tree, so a reply that does not answer the card right above it keeps its own
+  "Replying to @handle" banner — that is how a branch point stays readable.
+  """
+  attr(:posts, :list, required: true, doc: "the whole conversation, oldest first")
+  attr(:focus_id, :string, required: true, doc: "the permalinked post's id")
+  attr(:viewer, :any, default: nil)
+
+  attr(:viewer_follows, :map,
+    default: %{},
+    doc:
+      "the viewer's follow edges by author id (Vutuv.Social.follow_edges/2), " <>
+        "batched for the cards' mute menu items like the feed does"
+  )
+
+  attr(:conn_or_socket, :any, required: true)
+
+  def thread_conversation(assigns) do
+    assigns = assign(assigns, :chain, conversation_chain(assigns))
+
+    ~H"""
+    <.thread_chain chain={@chain} viewer={@viewer} surface={:flat} conn_or_socket={@conn_or_socket} />
+    """
+  end
+
+  defp conversation_chain(%{posts: posts} = assigns) do
+    [nil | posts]
+    |> Enum.zip(posts)
+    |> Enum.map(fn {prev, post} ->
+      focus? = post.id == assigns.focus_id
+
+      %{
+        post: post,
+        engagement: nil,
+        viewer_follow: assigns.viewer_follows[post.user_id],
+        reposted_by: nil,
+        reposters: nil,
+        entry_id: nil,
+        mode: if(focus?, do: :full, else: :preview),
+        focus?: focus?,
+        scroll?: focus? and prev != nil,
+        # A branch point: this reply does not answer the card right above it,
+        # so its own banner must name the real parent. The first card keeps
+        # its banner too — a degraded chain top is itself a reply.
+        show_reply_banner: prev == nil or thread_parent_id(post) != prev.id
+      }
+    end)
+  end
+
+  defp thread_parent_id(%{reply_ref: %PostReply{parent_post_id: id}}), do: id
+  defp thread_parent_id(_post), do: nil
 
   # Fallback when a caller does not compute the full visible chain: the single
   # preloaded `reply_ref` parent (one level), or none when nesting is off (the

--- a/lib/vutuv_web/controllers/post_controller.ex
+++ b/lib/vutuv_web/controllers/post_controller.ex
@@ -221,11 +221,21 @@ defmodule VutuvWeb.PostController do
     restricted? = Posts.restricted?(post)
     {noindex?, noai?} = PostDoc.robots_axes(author, restricted?)
 
-    # The viewer's follow edge to the author drives the card's mute toggle —
-    # only when the viewer follows them and is not the author themselves.
-    viewer_follow =
-      if viewer && not Posts.author?(post, viewer),
-        do: Social.follow_edge(viewer.id, author.id)
+    # The whole conversation this post belongs to (issue #1006), root first.
+    %{posts: thread, truncated?: thread_truncated?} = Posts.list_thread(post, viewer)
+
+    # The viewer's follow edges to every author on the page drive the cards'
+    # mute toggles — batched, the way the feed does it.
+    viewer_follows =
+      if viewer do
+        thread
+        |> Enum.map(& &1.user_id)
+        |> Enum.uniq()
+        |> Enum.reject(&(&1 == viewer.id))
+        |> then(&Social.follow_edges(viewer.id, &1))
+      else
+        %{}
+      end
 
     conn
     |> VutuvWeb.ContentPolicy.put_robots_header(noindex?, noai?)
@@ -234,8 +244,9 @@ defmodule VutuvWeb.PostController do
       author: author,
       owner?: Posts.author?(post, viewer),
       restricted?: restricted?,
-      viewer_follow: viewer_follow,
-      replies: Posts.list_replies(post, viewer),
+      viewer_follows: viewer_follows,
+      thread: thread,
+      thread_truncated?: thread_truncated?,
       # The "Other formats" card links to the post's agent siblings — shown only
       # when the anonymous .md/.txt/.json/.xml would actually resolve (the same
       # gate as maybe_put_alternates/2 advertising them in the head).

--- a/lib/vutuv_web/templates/post/show.html.heex
+++ b/lib/vutuv_web/templates/post/show.html.heex
@@ -8,8 +8,35 @@
     heading hierarchy (crawlers, screen readers) without a visible title on the
     card — the same sr-only pattern <.page_header> uses for crumbs-only pages. --%>
     <h1 class="sr-only">{gettext("Post by %{name}", name: full_name(@author))}</h1>
-    <%!-- The author's Edit/Delete live in the card's own ⋯ menu. --%>
-    <.post_card post={@post} viewer={@current_user} viewer_follow={@viewer_follow} mode={:full} conn_or_socket={@conn} />
+    <%= if length(@thread) == 1 do %>
+      <%!-- No conversation: the post stands alone as its own card. The
+      author's Edit/Delete live in the card's own ⋯ menu. --%>
+      <.post_card
+        post={@post}
+        viewer={@current_user}
+        viewer_follow={@viewer_follows[@post.user_id]}
+        mode={:full}
+        conn_or_socket={@conn}
+      />
+    <% else %>
+      <%!-- The whole conversation (issue #1006), rendered like a feed thread
+      row: the root on top, every visible reply below in chronological order,
+      connector lines between the cards. The permalinked post is the tinted
+      full-mode card; with context above it, app.js scrolls it into view on
+      arrival ([data-thread-scroll]). --%>
+      <.card id="post-thread">
+        <.thread_conversation
+          posts={@thread}
+          focus_id={@post.id}
+          viewer={@current_user}
+          viewer_follows={@viewer_follows}
+          conn_or_socket={@conn}
+        />
+      </.card>
+      <p :if={@thread_truncated?} class="mt-3 px-2 text-sm text-slate-600 dark:text-slate-400">
+        {gettext("Only part of this long conversation is shown.")}
+      </p>
+    <% end %>
 
     <%!-- The deny list is the author's private configuration — never shown
     to other viewers (the card shows them only the generic lock). --%>
@@ -20,28 +47,6 @@
         {gettext("Restricted posts are also hidden from logged-out visitors and search engines.")}
       </span>
     </div>
-
-    <%!-- The thread: the replies this viewer may see, oldest first — flat
-    divide-y rows via the shared <.post_thread_entry>, the same treatment as the
-    feed and the profile. Nesting is off here (nest_parent={false}): every reply
-    answers the post shown above, so nesting its parent would just duplicate the
-    page. The card's own reply banner is dropped for the same reason. --%>
-    <section :if={@replies != []} id="post-replies" class="mt-8">
-      <h2 class="px-2 text-sm font-semibold uppercase tracking-wide text-slate-500">
-        {gettext("Replies")} ({compact_count(length(@replies))})
-      </h2>
-      <.post_list class="mt-3" data-post-list>
-        <div :for={reply <- @replies} class={post_row_class()}>
-          <.post_thread_entry
-            post={reply}
-            viewer={@current_user}
-            conn_or_socket={@conn}
-            surface={:flat}
-            nest_parent={false}
-          />
-        </div>
-      </.post_list>
-    </section>
 
     <%!-- This post in agent-/machine-readable formats (VutuvWeb.AgentDocs):
     the same permalink as Markdown, plain text, JSON and XML. Shown only when

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.137.0",
+      version: "7.138.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -24,9 +24,9 @@ msgstr "Impressum"
 msgid "Add"
 msgstr "Eintrag hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:201
+#: lib/vutuv_web/agent_docs/markdown.ex:208
 #: lib/vutuv_web/agent_docs/section_docs.ex:121
-#: lib/vutuv_web/agent_docs/text.ex:196
+#: lib/vutuv_web/agent_docs/text.ex:197
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:110
@@ -94,10 +94,10 @@ msgstr "Avatar"
 msgid "Birthdate"
 msgstr "Geburtstag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:424
-#: lib/vutuv_web/agent_docs/markdown.ex:425
-#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/agent_docs/markdown.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:432
 #: lib/vutuv_web/agent_docs/text.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:429
 #: lib/vutuv_web/templates/user/show.html.heex:824
 #, elixir-autogen
 msgid "Birthday"
@@ -151,7 +151,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "Konnte nicht zu %{name} zurückfolgen."
 
-#: lib/vutuv_web/components/post_components.ex:816
+#: lib/vutuv_web/components/post_components.ex:888
 #: lib/vutuv_web/components/ui.ex:2926
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -197,7 +197,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:809
+#: lib/vutuv_web/components/post_components.ex:881
 #: lib/vutuv_web/components/ui.ex:2917
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -321,8 +321,8 @@ msgstr "Fax"
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:436
-#: lib/vutuv_web/agent_docs/text.ex:439
+#: lib/vutuv_web/agent_docs/markdown.ex:443
+#: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/live/notification_live/index.ex:759
 #: lib/vutuv_web/templates/follower/index.html.heex:4
@@ -331,8 +331,8 @@ msgstr "Vorname"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:437
-#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:444
+#: lib/vutuv_web/agent_docs/text.ex:441
 #: lib/vutuv_web/components/ui.ex:1551
 #: lib/vutuv_web/components/ui.ex:1576
 #: lib/vutuv_web/components/ui.ex:1579
@@ -347,8 +347,8 @@ msgstr "Follower"
 msgid "Following"
 msgstr "Folge ich"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:423
-#: lib/vutuv_web/agent_docs/text.ex:426
+#: lib/vutuv_web/agent_docs/markdown.ex:430
+#: lib/vutuv_web/agent_docs/text.ex:427
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -1490,11 +1490,11 @@ msgid "Tag urls"
 msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
-#: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/agent_docs/markdown.ex:795
+#: lib/vutuv_web/agent_docs/markdown.ex:368
+#: lib/vutuv_web/agent_docs/markdown.ex:802
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:393
-#: lib/vutuv_web/agent_docs/text.ex:570
+#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/agent_docs/text.ex:571
 #: lib/vutuv_web/components/ui.ex:3170
 #: lib/vutuv_web/controllers/user_tag_controller.ex:39
 #: lib/vutuv_web/controllers/user_tag_controller.ex:56
@@ -1860,7 +1860,7 @@ msgstr "Nachrichten"
 msgid "Network"
 msgstr "Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:285
+#: lib/vutuv_web/components/post_components.ex:286
 #: lib/vutuv_web/components/ui.ex:3026
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
@@ -2210,7 +2210,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:813
+#: lib/vutuv_web/components/post_components.ex:885
 #: lib/vutuv_web/live/post_live/edit.ex:117
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2241,7 +2241,7 @@ msgstr "Feed"
 msgid "Follow %{name} to read it."
 msgstr "Folgen Sie %{name}, um ihn zu lesen."
 
-#: lib/vutuv_web/templates/post/show.html.heex:17
+#: lib/vutuv_web/templates/post/show.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
@@ -2256,8 +2256,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:798
-#: lib/vutuv_web/components/post_components.ex:800
+#: lib/vutuv_web/components/post_components.ex:870
+#: lib/vutuv_web/components/post_components.ex:872
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2307,7 +2307,7 @@ msgstr "Posten"
 msgid "Post deleted successfully."
 msgstr "Beitrag erfolgreich gelöscht."
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:80
+#: lib/vutuv_web/agent_docs/post_doc.ex:88
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:73
@@ -2323,13 +2323,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1206
-#: lib/vutuv_web/components/post_components.ex:1210
+#: lib/vutuv_web/components/post_components.ex:1278
+#: lib/vutuv_web/components/post_components.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:1207
+#: lib/vutuv_web/components/post_components.ex:1279
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
@@ -2353,7 +2353,7 @@ msgstr "Entfernen"
 msgid "Remove image"
 msgstr "Bild entfernen"
 
-#: lib/vutuv_web/templates/post/show.html.heex:20
+#: lib/vutuv_web/templates/post/show.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
@@ -2422,27 +2422,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:795
+#: lib/vutuv_web/components/post_components.ex:867
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:1839
+#: lib/vutuv_web/components/post_components.ex:1911
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:1843
+#: lib/vutuv_web/components/post_components.ex:1915
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:1841
+#: lib/vutuv_web/components/post_components.ex:1913
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:1842
+#: lib/vutuv_web/components/post_components.ex:1914
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2483,7 +2483,7 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/post_components.ex:1983
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2484
@@ -2492,7 +2492,7 @@ msgstr "Alle Beiträge"
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:827
+#: lib/vutuv_web/agent_docs/markdown.ex:834
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:429
@@ -2502,7 +2502,7 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1878
+#: lib/vutuv_web/components/post_components.ex:1950
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2470
@@ -2512,7 +2512,7 @@ msgstr "Lesezeichen"
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:826
+#: lib/vutuv_web/agent_docs/markdown.ex:833
 #: lib/vutuv_web/live/notification_live/index.ex:761
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2532,12 +2532,12 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:1900
+#: lib/vutuv_web/components/post_components.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/post_components.ex:1983
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2546,23 +2546,23 @@ msgstr "Nur öffentliche Beiträge können repostet werden."
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1897
+#: lib/vutuv_web/components/post_components.ex:1969
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1324
+#: lib/vutuv_web/components/post_components.ex:1396
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1897
+#: lib/vutuv_web/components/post_components.ex:1969
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:1878
+#: lib/vutuv_web/components/post_components.ex:1950
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2585,29 +2585,26 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:1951
+#: lib/vutuv_web/components/post_components.ex:2023
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:109
-#: lib/vutuv_web/agent_docs/text.ex:105
-#: lib/vutuv_web/components/post_components.ex:274
+#: lib/vutuv_web/components/post_components.ex:275
 #: lib/vutuv_web/live/notification_live/index.ex:762
-#: lib/vutuv_web/templates/post/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1934
-#: lib/vutuv_web/components/post_components.ex:1935
+#: lib/vutuv_web/components/post_components.ex:2006
+#: lib/vutuv_web/components/post_components.ex:2007
 #: lib/vutuv_web/live/notification_live/index.ex:810
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:766
+#: lib/vutuv_web/components/post_components.ex:838
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2637,12 +2634,12 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:761
+#: lib/vutuv_web/components/post_components.ex:833
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:755
+#: lib/vutuv_web/components/post_components.ex:827
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2903,8 +2900,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 weiteres Tag"
 msgstr[1] "+%{formatted} weitere Tags"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:438
-#: lib/vutuv_web/agent_docs/text.ex:441
+#: lib/vutuv_web/agent_docs/markdown.ex:445
+#: lib/vutuv_web/agent_docs/text.ex:442
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/live/notification_live/index.ex:760
 #: lib/vutuv_web/templates/connection/index.html.heex:5
@@ -2950,7 +2947,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:1840
+#: lib/vutuv_web/components/post_components.ex:1912
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3055,8 +3052,8 @@ msgstr "Gibt es etwas, das unsere Admins wissen sollten? (optional)"
 msgid "Bullying or harassment"
 msgstr "Mobbing oder Belästigung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:280
-#: lib/vutuv_web/agent_docs/text.ex:271
+#: lib/vutuv_web/agent_docs/markdown.ex:287
+#: lib/vutuv_web/agent_docs/text.ex:272
 #: lib/vutuv_web/controllers/page_controller.ex:55
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3229,7 +3226,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:743
+#: lib/vutuv_web/components/post_components.ex:815
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3310,7 +3307,7 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:837
+#: lib/vutuv_web/components/post_components.ex:909
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4020,30 +4017,30 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:528
+#: lib/vutuv_web/agent_docs/markdown.ex:535
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:871
+#: lib/vutuv_web/agent_docs/markdown.ex:878
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:121
-#: lib/vutuv_web/agent_docs/text.ex:116
+#: lib/vutuv_web/agent_docs/markdown.ex:128
+#: lib/vutuv_web/agent_docs/text.ex:117
 #, elixir-autogen, elixir-format
 msgid "%{count} posts by %{name}"
 msgstr "%{count} Beiträge von %{name}"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:82
-#: lib/vutuv_web/agent_docs/markdown.ex:144
-#: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:795
+#: lib/vutuv_web/agent_docs/markdown.ex:151
+#: lib/vutuv_web/agent_docs/markdown.ex:164
+#: lib/vutuv_web/agent_docs/markdown.ex:802
 #: lib/vutuv_web/agent_docs/text.ex:79
-#: lib/vutuv_web/agent_docs/text.ex:139
-#: lib/vutuv_web/agent_docs/text.ex:152
-#: lib/vutuv_web/agent_docs/text.ex:570
+#: lib/vutuv_web/agent_docs/text.ex:140
+#: lib/vutuv_web/agent_docs/text.ex:153
+#: lib/vutuv_web/agent_docs/text.ex:571
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
@@ -4060,32 +4057,34 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:813
-#: lib/vutuv_web/agent_docs/text.ex:581
+#: lib/vutuv_web/agent_docs/markdown.ex:820
+#: lib/vutuv_web/agent_docs/text.ex:582
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:810
-#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:817
+#: lib/vutuv_web/agent_docs/text.ex:579
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:817
-#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/markdown.ex:824
+#: lib/vutuv_web/agent_docs/markdown.ex:909
+#: lib/vutuv_web/agent_docs/text.ex:585
+#: lib/vutuv_web/agent_docs/text.ex:605
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:421
-#: lib/vutuv_web/agent_docs/text.ex:424
+#: lib/vutuv_web/agent_docs/markdown.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:425
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Mitglied seit"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:170
-#: lib/vutuv_web/agent_docs/text.ex:165
+#: lib/vutuv_web/agent_docs/markdown.ex:177
+#: lib/vutuv_web/agent_docs/text.ex:166
 #, elixir-autogen, elixir-format
 msgid "Most endorsed members"
 msgstr "Am häufigsten empfohlene Mitglieder"
@@ -4100,7 +4099,7 @@ msgstr "Mitglieder mit den meisten Followern"
 msgid "People %{name} follows"
 msgstr "Wem %{name} folgt"
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:81
+#: lib/vutuv_web/agent_docs/post_doc.ex:89
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr "Beitragsarchiv von %{name}"
@@ -4119,23 +4118,23 @@ msgstr "Beitrag von %{name}"
 msgid "Posts (%{count} total)"
 msgstr "Beiträge (insgesamt %{count})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:415
-#: lib/vutuv_web/agent_docs/text.ex:418
+#: lib/vutuv_web/agent_docs/markdown.ex:422
+#: lib/vutuv_web/agent_docs/text.ex:419
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:764
+#: lib/vutuv_web/agent_docs/markdown.ex:771
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:694
+#: lib/vutuv_web/agent_docs/markdown.ex:701
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:695
+#: lib/vutuv_web/agent_docs/markdown.ex:702
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4212,8 +4211,8 @@ msgstr ""
 msgid "Billing name"
 msgstr "Name für die Rechnung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:294
-#: lib/vutuv_web/agent_docs/text.ex:279
+#: lib/vutuv_web/agent_docs/markdown.ex:301
+#: lib/vutuv_web/agent_docs/text.ex:280
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr "Online buchen (Login erforderlich): %{url}"
@@ -4263,8 +4262,8 @@ msgstr "Tag"
 msgid "Markdown is supported. At most %{max} characters."
 msgstr "Markdown wird unterstützt. Höchstens %{max} Zeichen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:284
-#: lib/vutuv_web/agent_docs/text.ex:275
+#: lib/vutuv_web/agent_docs/markdown.ex:291
+#: lib/vutuv_web/agent_docs/text.ex:276
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4280,8 +4279,8 @@ msgstr "Ein Tag. Eine Anzeige. Alle Besucher."
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr "Eine reine Textanzeige pro Kalendertag, gesehen von allen Besuchern."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:281
-#: lib/vutuv_web/agent_docs/text.ex:272
+#: lib/vutuv_web/agent_docs/markdown.ex:288
+#: lib/vutuv_web/agent_docs/text.ex:273
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4515,14 +4514,14 @@ msgstr "gebucht am"
 msgid "deleted account"
 msgstr "gelöschtes Konto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/text.ex:277
+#: lib/vutuv_web/agent_docs/markdown.ex:293
+#: lib/vutuv_web/agent_docs/text.ex:278
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr "Bereits gebucht"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:289
+#: lib/vutuv_web/agent_docs/text.ex:274
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr "Buchungszeitraum"
@@ -4804,8 +4803,8 @@ msgstr "Keine Ergebnisse für \"%{query}\""
 msgid "Not an exact match, but sounds like your search."
 msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:309
-#: lib/vutuv_web/agent_docs/text.ex:341
+#: lib/vutuv_web/agent_docs/markdown.ex:316
+#: lib/vutuv_web/agent_docs/text.ex:342
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:682
 #: lib/vutuv_web/live/organization_live/show.ex:300
@@ -4828,7 +4827,7 @@ msgstr ""
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
-#: lib/vutuv_web/components/post_components.ex:271
+#: lib/vutuv_web/components/post_components.ex:272
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/notification_live/index.ex:680
@@ -4929,8 +4928,8 @@ msgstr "Entwickler"
 msgid "Edit your profile and its sections"
 msgstr "Ihr Profil und seine Bereiche bearbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:223
-#: lib/vutuv_web/agent_docs/text.ex:217
+#: lib/vutuv_web/agent_docs/markdown.ex:230
+#: lib/vutuv_web/agent_docs/text.ex:218
 #: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
@@ -5688,9 +5687,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:899
-#: lib/vutuv_web/components/post_components.ex:953
-#: lib/vutuv_web/components/post_components.ex:1268
+#: lib/vutuv_web/components/post_components.ex:971
+#: lib/vutuv_web/components/post_components.ex:1025
+#: lib/vutuv_web/components/post_components.ex:1340
 #: lib/vutuv_web/live/notification_live/index.ex:519
 #: lib/vutuv_web/live/post_live/feed.ex:737
 #, elixir-autogen, elixir-format
@@ -6439,8 +6438,8 @@ msgid_plural "%{count} years old"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:426
-#: lib/vutuv_web/agent_docs/text.ex:429
+#: lib/vutuv_web/agent_docs/markdown.ex:433
+#: lib/vutuv_web/agent_docs/text.ex:430
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Alter"
@@ -6514,8 +6513,8 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:826
-#: lib/vutuv_web/components/post_components.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:833
+#: lib/vutuv_web/components/post_components.ex:274
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
@@ -6624,7 +6623,7 @@ msgstr "Noch keine Empfehlungen."
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:808
+#: lib/vutuv_web/agent_docs/markdown.ex:815
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -6972,7 +6971,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:834
+#: lib/vutuv_web/components/post_components.ex:906
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6982,7 +6981,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:833
+#: lib/vutuv_web/components/post_components.ex:905
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7187,8 +7186,8 @@ msgstr "Filtern"
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:197
-#: lib/vutuv_web/agent_docs/text.ex:192
+#: lib/vutuv_web/agent_docs/markdown.ex:204
+#: lib/vutuv_web/agent_docs/text.ex:193
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -7872,17 +7871,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:876
+#: lib/vutuv_web/agent_docs/markdown.ex:883
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Dein Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:879
+#: lib/vutuv_web/agent_docs/markdown.ex:886
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:886
+#: lib/vutuv_web/agent_docs/markdown.ex:893
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -9233,7 +9232,7 @@ msgid "Employment"
 msgstr "Anstellung"
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:588
+#: lib/vutuv_web/agent_docs/markdown.ex:595
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -9256,7 +9255,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr "Berufserfahrung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:589
+#: lib/vutuv_web/agent_docs/markdown.ex:596
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -9287,13 +9286,13 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:626
+#: lib/vutuv_web/agent_docs/markdown.ex:633
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:625
+#: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9322,14 +9321,14 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:1327
+#: lib/vutuv_web/components/post_components.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:767
+#: lib/vutuv_web/agent_docs/markdown.ex:774
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9422,14 +9421,14 @@ msgstr ""
 "Der Lebenslauf von %{name} auf vutuv: Berufserfahrung, Ausbildung und "
 "Kenntnisse zum Ansehen und Herunterladen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/markdown.ex:594
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr "Freiberuflich / Selbstständig"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:590
+#: lib/vutuv_web/agent_docs/markdown.ex:597
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9581,8 +9580,8 @@ msgstr "Ehren-Tag"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Ehren-Tag (nur Admins können es vergeben)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:447
-#: lib/vutuv_web/agent_docs/text.ex:448
+#: lib/vutuv_web/agent_docs/markdown.ex:454
+#: lib/vutuv_web/agent_docs/text.ex:449
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "Ehren-Tag"
@@ -10004,8 +10003,8 @@ msgstr "Walisisch"
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:417
-#: lib/vutuv_web/agent_docs/text.ex:420
+#: lib/vutuv_web/agent_docs/markdown.ex:424
+#: lib/vutuv_web/agent_docs/text.ex:421
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
@@ -10119,7 +10118,7 @@ msgstr[1] "%{count} Zertifikate oder Lizenzen"
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:695
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -10206,7 +10205,7 @@ msgstr "Ablaufmonat"
 msgid "Expiry year"
 msgstr "Ablaufjahr"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:663
+#: lib/vutuv_web/agent_docs/markdown.ex:670
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10232,7 +10231,7 @@ msgstr "Ausstellungsjahr"
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:687
+#: lib/vutuv_web/agent_docs/markdown.ex:694
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10262,7 +10261,7 @@ msgstr "Nachweis"
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
+#: lib/vutuv_web/agent_docs/markdown.ex:668
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10277,7 +10276,7 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:662
+#: lib/vutuv_web/agent_docs/markdown.ex:669
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -10296,7 +10295,7 @@ msgstr ""
 msgid "Preferred"
 msgstr "Bevorzugt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:545
+#: lib/vutuv_web/agent_docs/markdown.ex:552
 #: lib/vutuv_web/live/section_reorder_live.ex:269
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -10999,21 +10998,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr "auf diesem Gerät einrichten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:512
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} Follower"
 msgstr[1] "%{count} Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:503
+#: lib/vutuv_web/agent_docs/markdown.ex:510
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} Repository"
 msgstr[1] "%{count} Repositories"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:508
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -11071,12 +11070,12 @@ msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten nur als einfache "
 "Links."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:519
+#: lib/vutuv_web/agent_docs/markdown.ex:526
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:506
+#: lib/vutuv_web/agent_docs/markdown.ex:513
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "seit %{date}"
@@ -12023,8 +12022,8 @@ msgstr "Verifizierungsmethode"
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:198
-#: lib/vutuv_web/agent_docs/text.ex:193
+#: lib/vutuv_web/agent_docs/markdown.ex:205
+#: lib/vutuv_web/agent_docs/text.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr "Verifiziert über"
@@ -12053,8 +12052,8 @@ msgstr ""
 "Wir konnten den Eintrag oder die Datei noch nicht finden. Die Verbreitung "
 "kann etwas dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:200
-#: lib/vutuv_web/agent_docs/text.ex:195
+#: lib/vutuv_web/agent_docs/markdown.ex:207
+#: lib/vutuv_web/agent_docs/text.ex:196
 #: lib/vutuv_web/live/organization_live/edit.ex:273
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -12140,8 +12139,8 @@ msgstr "Alias hinzugefügt."
 msgid "Alias removed."
 msgstr "Alias entfernt."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:301
-#: lib/vutuv_web/agent_docs/text.ex:334
+#: lib/vutuv_web/agent_docs/markdown.ex:308
+#: lib/vutuv_web/agent_docs/text.ex:335
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
@@ -12383,8 +12382,8 @@ msgstr "ausstehend"
 msgid "primary"
 msgstr "primär"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:322
-#: lib/vutuv_web/agent_docs/text.ex:354
+#: lib/vutuv_web/agent_docs/markdown.ex:329
+#: lib/vutuv_web/agent_docs/text.ex:355
 #: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -12525,8 +12524,8 @@ msgstr ""
 "Wir konnten den Nachweis noch nicht finden. Die Verbreitung kann etwas "
 "dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:708
-#: lib/vutuv_web/agent_docs/text.ex:544
+#: lib/vutuv_web/agent_docs/markdown.ex:715
+#: lib/vutuv_web/agent_docs/text.ex:545
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -12562,8 +12561,8 @@ msgstr "Verknüpft mit {name}"
 msgid "Remove link"
 msgstr "Verknüpfung entfernen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:313
-#: lib/vutuv_web/agent_docs/text.ex:345
+#: lib/vutuv_web/agent_docs/markdown.ex:320
+#: lib/vutuv_web/agent_docs/text.ex:346
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr "ehemalig"
@@ -13040,10 +13039,10 @@ msgstr "Entwürfe"
 msgid "Edit posting"
 msgstr "Anzeige bearbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:217
-#: lib/vutuv_web/agent_docs/markdown.ex:346
-#: lib/vutuv_web/agent_docs/text.ex:211
-#: lib/vutuv_web/agent_docs/text.ex:378
+#: lib/vutuv_web/agent_docs/markdown.ex:224
+#: lib/vutuv_web/agent_docs/markdown.ex:353
+#: lib/vutuv_web/agent_docs/text.ex:212
+#: lib/vutuv_web/agent_docs/text.ex:379
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Employer"
@@ -13054,10 +13053,10 @@ msgstr "Arbeitgeber"
 msgid "Employer name (optional)"
 msgstr "Name des Arbeitgebers (optional)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/markdown.ex:347
-#: lib/vutuv_web/agent_docs/text.ex:212
-#: lib/vutuv_web/agent_docs/text.ex:379
+#: lib/vutuv_web/agent_docs/markdown.ex:225
+#: lib/vutuv_web/agent_docs/markdown.ex:354
+#: lib/vutuv_web/agent_docs/text.ex:213
+#: lib/vutuv_web/agent_docs/text.ex:380
 #: lib/vutuv_web/live/job_board_live.ex:281
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
@@ -13132,12 +13131,12 @@ msgstr "Jobs"
 msgid "Let search engines index this posting."
 msgstr "Suchmaschinen dürfen diese Anzeige indexieren."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:328
-#: lib/vutuv_web/agent_docs/markdown.ex:332
-#: lib/vutuv_web/agent_docs/markdown.ex:334
-#: lib/vutuv_web/agent_docs/text.ex:360
-#: lib/vutuv_web/agent_docs/text.ex:364
-#: lib/vutuv_web/agent_docs/text.ex:366
+#: lib/vutuv_web/agent_docs/markdown.ex:335
+#: lib/vutuv_web/agent_docs/markdown.ex:339
+#: lib/vutuv_web/agent_docs/markdown.ex:341
+#: lib/vutuv_web/agent_docs/text.ex:361
+#: lib/vutuv_web/agent_docs/text.ex:365
+#: lib/vutuv_web/agent_docs/text.ex:367
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -13186,8 +13185,8 @@ msgstr "Neue Konten können nach einigen Tagen veröffentlichen."
 msgid "New posting"
 msgstr "Neue Anzeige"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:229
-#: lib/vutuv_web/agent_docs/text.ex:222
+#: lib/vutuv_web/agent_docs/markdown.ex:236
+#: lib/vutuv_web/agent_docs/text.ex:223
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
@@ -13271,10 +13270,10 @@ msgstr "Veröffentlichen als"
 msgid "Postal code"
 msgstr "Postleitzahl"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:222
-#: lib/vutuv_web/agent_docs/markdown.ex:351
-#: lib/vutuv_web/agent_docs/text.ex:216
-#: lib/vutuv_web/agent_docs/text.ex:383
+#: lib/vutuv_web/agent_docs/markdown.ex:229
+#: lib/vutuv_web/agent_docs/markdown.ex:358
+#: lib/vutuv_web/agent_docs/text.ex:217
+#: lib/vutuv_web/agent_docs/text.ex:384
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -13299,10 +13298,10 @@ msgstr "Veröffentlichen"
 #: lib/vutuv/accounts/user.ex:748
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
-#: lib/vutuv_web/agent_docs/markdown.ex:332
-#: lib/vutuv_web/agent_docs/markdown.ex:334
-#: lib/vutuv_web/agent_docs/text.ex:364
-#: lib/vutuv_web/agent_docs/text.ex:366
+#: lib/vutuv_web/agent_docs/markdown.ex:339
+#: lib/vutuv_web/agent_docs/markdown.ex:341
+#: lib/vutuv_web/agent_docs/text.ex:365
+#: lib/vutuv_web/agent_docs/text.ex:367
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format
@@ -13314,18 +13313,18 @@ msgstr "Remote"
 msgid "Report this posting"
 msgstr "Diese Anzeige melden"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:228
-#: lib/vutuv_web/agent_docs/text.ex:221
+#: lib/vutuv_web/agent_docs/markdown.ex:235
+#: lib/vutuv_web/agent_docs/text.ex:222
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Erforderlich"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:221
-#: lib/vutuv_web/agent_docs/markdown.ex:350
-#: lib/vutuv_web/agent_docs/text.ex:215
-#: lib/vutuv_web/agent_docs/text.ex:382
+#: lib/vutuv_web/agent_docs/markdown.ex:228
+#: lib/vutuv_web/agent_docs/markdown.ex:357
+#: lib/vutuv_web/agent_docs/text.ex:216
+#: lib/vutuv_web/agent_docs/text.ex:383
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr "Gehalt"
@@ -13417,10 +13416,10 @@ msgstr "Wer kann sie sehen"
 msgid "Working student"
 msgstr "Werkstudent:in"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:219
-#: lib/vutuv_web/agent_docs/markdown.ex:348
-#: lib/vutuv_web/agent_docs/text.ex:213
-#: lib/vutuv_web/agent_docs/text.ex:380
+#: lib/vutuv_web/agent_docs/markdown.ex:226
+#: lib/vutuv_web/agent_docs/markdown.ex:355
+#: lib/vutuv_web/agent_docs/text.ex:214
+#: lib/vutuv_web/agent_docs/text.ex:381
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -13593,13 +13592,13 @@ msgstr "%{km} km"
 msgid "All countries"
 msgstr "Alle Länder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:369
+#: lib/vutuv_web/agent_docs/markdown.ex:376
 #: lib/vutuv_web/templates/tag/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Alle Stellen mit diesem Tag"
 
-#: lib/vutuv_web/agent_docs/text.ex:400
+#: lib/vutuv_web/agent_docs/text.ex:401
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr "Alle Stellen mit diesem Tag: %{url}"
@@ -13645,12 +13644,12 @@ msgstr "Mindestgehalt pro Jahr"
 msgid "More jobs"
 msgstr "Weitere Stellen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:241
+#: lib/vutuv_web/agent_docs/markdown.ex:248
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr "Nächste Seite"
 
-#: lib/vutuv_web/agent_docs/text.ex:234
+#: lib/vutuv_web/agent_docs/text.ex:235
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr "Nächste Seite: %{url}"
@@ -13665,10 +13664,10 @@ msgstr "Noch keine Stellenanzeigen."
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Keine passenden Stellen. Passe die Filter an."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:367
-#: lib/vutuv_web/agent_docs/markdown.ex:379
-#: lib/vutuv_web/agent_docs/text.ex:398
-#: lib/vutuv_web/agent_docs/text.ex:410
+#: lib/vutuv_web/agent_docs/markdown.ex:374
+#: lib/vutuv_web/agent_docs/markdown.ex:386
+#: lib/vutuv_web/agent_docs/text.ex:399
+#: lib/vutuv_web/agent_docs/text.ex:411
 #: lib/vutuv_web/live/organization_live/show.ex:329
 #: lib/vutuv_web/templates/tag/show.html.heex:57
 #, elixir-autogen, elixir-format
@@ -14229,7 +14228,7 @@ msgstr "Dieses Mitglied existiert nicht mehr."
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 Tagen abgelehnt. Eine wachsende Warteschlange bedeutet meist, dass Ollama nicht erreichbar ist."
 
-#: lib/vutuv_web/components/post_components.ex:1030
+#: lib/vutuv_web/components/post_components.ex:1102
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -14237,7 +14236,7 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:1020
+#: lib/vutuv_web/components/post_components.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr "Bild wird geprüft"
@@ -14381,8 +14380,8 @@ msgstr "Bild einfügen"
 msgid "Insert into text"
 msgstr "In den Text einfügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:173
-#: lib/vutuv_web/agent_docs/text.ex:168
+#: lib/vutuv_web/agent_docs/markdown.ex:180
+#: lib/vutuv_web/agent_docs/text.ex:169
 #: lib/vutuv_web/templates/tag/show.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
@@ -14410,22 +14409,22 @@ msgstr "Mobil (privat)"
 msgid "Work mobile"
 msgstr "Mobil (Arbeit)"
 
-#: lib/vutuv_web/components/post_components.ex:282
+#: lib/vutuv_web/components/post_components.ex:283
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Noch keine Beiträge."
 
-#: lib/vutuv_web/components/post_components.ex:284
+#: lib/vutuv_web/components/post_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Noch keine Antworten."
 
-#: lib/vutuv_web/components/post_components.ex:283
+#: lib/vutuv_web/components/post_components.ex:284
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Noch keine Reposts."
 
-#: lib/vutuv_web/components/post_components.ex:272
+#: lib/vutuv_web/components/post_components.ex:273
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Eigene Beiträge"
@@ -14599,7 +14598,7 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:1702
+#: lib/vutuv_web/components/post_components.ex:1774
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
@@ -14614,19 +14613,19 @@ msgstr "Autor/in"
 msgid "Book"
 msgstr "Buch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:838
-#: lib/vutuv_web/components/post_components.ex:1659
+#: lib/vutuv_web/agent_docs/markdown.ex:845
+#: lib/vutuv_web/components/post_components.ex:1731
 #: lib/vutuv_web/live/post_live/composer.ex:659
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:1703
+#: lib/vutuv_web/components/post_components.ex:1775
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:1705
+#: lib/vutuv_web/components/post_components.ex:1777
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
@@ -14636,7 +14635,7 @@ msgstr "DVD/Blu-ray"
 msgid "Director"
 msgstr "Regie"
 
-#: lib/vutuv_web/components/post_components.ex:1701
+#: lib/vutuv_web/components/post_components.ex:1773
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
@@ -14646,8 +14645,8 @@ msgstr "E-Book"
 msgid "Film"
 msgstr "Film"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:838
-#: lib/vutuv_web/components/post_components.ex:1658
+#: lib/vutuv_web/agent_docs/markdown.ex:845
+#: lib/vutuv_web/components/post_components.ex:1730
 #: lib/vutuv_web/live/post_live/composer.ex:658
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -14678,7 +14677,7 @@ msgstr "Schlage nach …"
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr "Zu dieser ISBN wurde nichts gefunden. Bitte füllen Sie die Felder selbst aus."
 
-#: lib/vutuv_web/components/post_components.ex:1700
+#: lib/vutuv_web/components/post_components.ex:1772
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
@@ -14705,7 +14704,7 @@ msgstr "Ein Buch besprechen"
 msgid "Review a film"
 msgstr "Einen Film besprechen"
 
-#: lib/vutuv_web/components/post_components.ex:1704
+#: lib/vutuv_web/components/post_components.ex:1776
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14725,34 +14724,34 @@ msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:1741
+#: lib/vutuv_web/components/post_components.ex:1813
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:1771
+#: lib/vutuv_web/components/post_components.ex:1843
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:1772
+#: lib/vutuv_web/components/post_components.ex:1844
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:1770
+#: lib/vutuv_web/components/post_components.ex:1842
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:1730
+#: lib/vutuv_web/components/post_components.ex:1802
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:1777
+#: lib/vutuv_web/components/post_components.ex:1849
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14777,12 +14776,12 @@ msgstr "Qualifikation"
 msgid "With qualification:"
 msgstr "Mit Qualifikation:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:574
+#: lib/vutuv_web/agent_docs/markdown.ex:581
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1544
+#: lib/vutuv_web/components/post_components.ex:1616
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14830,7 +14829,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:1535
+#: lib/vutuv_web/components/post_components.ex:1607
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14873,19 +14872,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] "Für %{formatted} Job genutzt"
 msgstr[1] "Für %{formatted} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:677
+#: lib/vutuv_web/agent_docs/markdown.ex:684
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr "aktuell genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:676
+#: lib/vutuv_web/agent_docs/markdown.ex:683
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] "für %{count} Job genutzt"
 msgstr[1] "für %{count} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:682
+#: lib/vutuv_web/agent_docs/markdown.ex:689
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14964,8 +14963,8 @@ msgstr "Hochgeladener Nachweis für %{name}"
 msgid "View the uploaded proof (%{label})"
 msgstr "Hochgeladenen Nachweis ansehen (%{label})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:645
-#: lib/vutuv_web/agent_docs/text.ex:536
+#: lib/vutuv_web/agent_docs/markdown.ex:652
+#: lib/vutuv_web/agent_docs/text.ex:537
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "Nachweis"
@@ -15060,8 +15059,8 @@ msgstr "Speichern und weiter"
 msgid "Skip for now"
 msgstr "Erstmal überspringen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:419
-#: lib/vutuv_web/agent_docs/text.ex:422
+#: lib/vutuv_web/agent_docs/markdown.ex:426
+#: lib/vutuv_web/agent_docs/text.ex:423
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr "Bevorzugte Arbeitsform"
@@ -15103,3 +15102,16 @@ msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
 msgstr[0] "hat in einem Thread geantwortet, in dem Sie geschrieben haben."
 msgstr[1] "haben in einem Thread geantwortet, in dem Sie geschrieben haben."
+
+#: lib/vutuv_web/agent_docs/markdown.ex:113
+#: lib/vutuv_web/agent_docs/text.ex:105
+#, elixir-autogen, elixir-format
+msgid "Conversation"
+msgstr "Unterhaltung"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:116
+#: lib/vutuv_web/agent_docs/text.ex:108
+#: lib/vutuv_web/templates/post/show.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "Only part of this long conversation is shown."
+msgstr "Von dieser langen Unterhaltung wird nur ein Teil angezeigt."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -26,9 +26,9 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:201
+#: lib/vutuv_web/agent_docs/markdown.ex:208
 #: lib/vutuv_web/agent_docs/section_docs.ex:121
-#: lib/vutuv_web/agent_docs/text.ex:196
+#: lib/vutuv_web/agent_docs/text.ex:197
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:110
@@ -96,10 +96,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:424
-#: lib/vutuv_web/agent_docs/markdown.ex:425
-#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/agent_docs/markdown.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:432
 #: lib/vutuv_web/agent_docs/text.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:429
 #: lib/vutuv_web/templates/user/show.html.heex:824
 #, elixir-autogen
 msgid "Birthday"
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:816
+#: lib/vutuv_web/components/post_components.ex:888
 #: lib/vutuv_web/components/ui.ex:2926
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:809
+#: lib/vutuv_web/components/post_components.ex:881
 #: lib/vutuv_web/components/ui.ex:2917
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -321,8 +321,8 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:436
-#: lib/vutuv_web/agent_docs/text.ex:439
+#: lib/vutuv_web/agent_docs/markdown.ex:443
+#: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/live/notification_live/index.ex:759
 #: lib/vutuv_web/templates/follower/index.html.heex:4
@@ -331,8 +331,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:437
-#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:444
+#: lib/vutuv_web/agent_docs/text.ex:441
 #: lib/vutuv_web/components/ui.ex:1551
 #: lib/vutuv_web/components/ui.ex:1576
 #: lib/vutuv_web/components/ui.ex:1579
@@ -347,8 +347,8 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:423
-#: lib/vutuv_web/agent_docs/text.ex:426
+#: lib/vutuv_web/agent_docs/markdown.ex:430
+#: lib/vutuv_web/agent_docs/text.ex:427
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -1462,11 +1462,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
-#: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/agent_docs/markdown.ex:795
+#: lib/vutuv_web/agent_docs/markdown.ex:368
+#: lib/vutuv_web/agent_docs/markdown.ex:802
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:393
-#: lib/vutuv_web/agent_docs/text.ex:570
+#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/agent_docs/text.ex:571
 #: lib/vutuv_web/components/ui.ex:3170
 #: lib/vutuv_web/controllers/user_tag_controller.ex:39
 #: lib/vutuv_web/controllers/user_tag_controller.ex:56
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:285
+#: lib/vutuv_web/components/post_components.ex:286
 #: lib/vutuv_web/components/ui.ex:3026
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
@@ -2164,7 +2164,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:813
+#: lib/vutuv_web/components/post_components.ex:885
 #: lib/vutuv_web/live/post_live/edit.ex:117
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Follow %{name} to read it."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/show.html.heex:17
+#: lib/vutuv_web/templates/post/show.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Hidden from:"
 msgstr ""
@@ -2210,8 +2210,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:798
-#: lib/vutuv_web/components/post_components.ex:800
+#: lib/vutuv_web/components/post_components.ex:870
+#: lib/vutuv_web/components/post_components.ex:872
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2259,7 +2259,7 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:80
+#: lib/vutuv_web/agent_docs/post_doc.ex:88
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:73
@@ -2275,13 +2275,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1206
-#: lib/vutuv_web/components/post_components.ex:1210
+#: lib/vutuv_web/components/post_components.ex:1278
+#: lib/vutuv_web/components/post_components.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1207
+#: lib/vutuv_web/components/post_components.ex:1279
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2305,7 +2305,7 @@ msgstr ""
 msgid "Remove image"
 msgstr ""
 
-#: lib/vutuv_web/templates/post/show.html.heex:20
+#: lib/vutuv_web/templates/post/show.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
@@ -2372,27 +2372,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:795
+#: lib/vutuv_web/components/post_components.ex:867
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1839
+#: lib/vutuv_web/components/post_components.ex:1911
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1843
+#: lib/vutuv_web/components/post_components.ex:1915
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1841
+#: lib/vutuv_web/components/post_components.ex:1913
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1842
+#: lib/vutuv_web/components/post_components.ex:1914
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2433,7 +2433,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/post_components.ex:1983
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2484
@@ -2442,7 +2442,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:827
+#: lib/vutuv_web/agent_docs/markdown.ex:834
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:429
@@ -2452,7 +2452,7 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1878
+#: lib/vutuv_web/components/post_components.ex:1950
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2470
@@ -2462,7 +2462,7 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:826
+#: lib/vutuv_web/agent_docs/markdown.ex:833
 #: lib/vutuv_web/live/notification_live/index.ex:761
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2482,12 +2482,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1900
+#: lib/vutuv_web/components/post_components.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/post_components.ex:1983
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2496,23 +2496,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1897
+#: lib/vutuv_web/components/post_components.ex:1969
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1324
+#: lib/vutuv_web/components/post_components.ex:1396
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1897
+#: lib/vutuv_web/components/post_components.ex:1969
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1878
+#: lib/vutuv_web/components/post_components.ex:1950
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2535,29 +2535,26 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1951
+#: lib/vutuv_web/components/post_components.ex:2023
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:109
-#: lib/vutuv_web/agent_docs/text.ex:105
-#: lib/vutuv_web/components/post_components.ex:274
+#: lib/vutuv_web/components/post_components.ex:275
 #: lib/vutuv_web/live/notification_live/index.ex:762
-#: lib/vutuv_web/templates/post/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1934
-#: lib/vutuv_web/components/post_components.ex:1935
+#: lib/vutuv_web/components/post_components.ex:2006
+#: lib/vutuv_web/components/post_components.ex:2007
 #: lib/vutuv_web/live/notification_live/index.ex:810
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:766
+#: lib/vutuv_web/components/post_components.ex:838
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2583,12 +2580,12 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:761
+#: lib/vutuv_web/components/post_components.ex:833
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:755
+#: lib/vutuv_web/components/post_components.ex:827
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2843,8 +2840,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:438
-#: lib/vutuv_web/agent_docs/text.ex:441
+#: lib/vutuv_web/agent_docs/markdown.ex:445
+#: lib/vutuv_web/agent_docs/text.ex:442
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/live/notification_live/index.ex:760
 #: lib/vutuv_web/templates/connection/index.html.heex:5
@@ -2890,7 +2887,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1840
+#: lib/vutuv_web/components/post_components.ex:1912
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2995,8 +2992,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:280
-#: lib/vutuv_web/agent_docs/text.ex:271
+#: lib/vutuv_web/agent_docs/markdown.ex:287
+#: lib/vutuv_web/agent_docs/text.ex:272
 #: lib/vutuv_web/controllers/page_controller.ex:55
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3151,7 +3148,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:743
+#: lib/vutuv_web/components/post_components.ex:815
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3226,7 +3223,7 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:837
+#: lib/vutuv_web/components/post_components.ex:909
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3879,30 +3876,30 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:528
+#: lib/vutuv_web/agent_docs/markdown.ex:535
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:871
+#: lib/vutuv_web/agent_docs/markdown.ex:878
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:121
-#: lib/vutuv_web/agent_docs/text.ex:116
+#: lib/vutuv_web/agent_docs/markdown.ex:128
+#: lib/vutuv_web/agent_docs/text.ex:117
 #, elixir-autogen, elixir-format
 msgid "%{count} posts by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:82
-#: lib/vutuv_web/agent_docs/markdown.ex:144
-#: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:795
+#: lib/vutuv_web/agent_docs/markdown.ex:151
+#: lib/vutuv_web/agent_docs/markdown.ex:164
+#: lib/vutuv_web/agent_docs/markdown.ex:802
 #: lib/vutuv_web/agent_docs/text.ex:79
-#: lib/vutuv_web/agent_docs/text.ex:139
-#: lib/vutuv_web/agent_docs/text.ex:152
-#: lib/vutuv_web/agent_docs/text.ex:570
+#: lib/vutuv_web/agent_docs/text.ex:140
+#: lib/vutuv_web/agent_docs/text.ex:153
+#: lib/vutuv_web/agent_docs/text.ex:571
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3919,32 +3916,34 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:813
-#: lib/vutuv_web/agent_docs/text.ex:581
+#: lib/vutuv_web/agent_docs/markdown.ex:820
+#: lib/vutuv_web/agent_docs/text.ex:582
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:810
-#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:817
+#: lib/vutuv_web/agent_docs/text.ex:579
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:817
-#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/markdown.ex:824
+#: lib/vutuv_web/agent_docs/markdown.ex:909
+#: lib/vutuv_web/agent_docs/text.ex:585
+#: lib/vutuv_web/agent_docs/text.ex:605
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:421
-#: lib/vutuv_web/agent_docs/text.ex:424
+#: lib/vutuv_web/agent_docs/markdown.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:425
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:170
-#: lib/vutuv_web/agent_docs/text.ex:165
+#: lib/vutuv_web/agent_docs/markdown.ex:177
+#: lib/vutuv_web/agent_docs/text.ex:166
 #, elixir-autogen, elixir-format
 msgid "Most endorsed members"
 msgstr ""
@@ -3959,7 +3958,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:81
+#: lib/vutuv_web/agent_docs/post_doc.ex:89
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -3978,23 +3977,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:415
-#: lib/vutuv_web/agent_docs/text.ex:418
+#: lib/vutuv_web/agent_docs/markdown.ex:422
+#: lib/vutuv_web/agent_docs/text.ex:419
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:764
+#: lib/vutuv_web/agent_docs/markdown.ex:771
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:694
+#: lib/vutuv_web/agent_docs/markdown.ex:701
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:695
+#: lib/vutuv_web/agent_docs/markdown.ex:702
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4069,8 +4068,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:294
-#: lib/vutuv_web/agent_docs/text.ex:279
+#: lib/vutuv_web/agent_docs/markdown.ex:301
+#: lib/vutuv_web/agent_docs/text.ex:280
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4120,8 +4119,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:284
-#: lib/vutuv_web/agent_docs/text.ex:275
+#: lib/vutuv_web/agent_docs/markdown.ex:291
+#: lib/vutuv_web/agent_docs/text.ex:276
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4137,8 +4136,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:281
-#: lib/vutuv_web/agent_docs/text.ex:272
+#: lib/vutuv_web/agent_docs/markdown.ex:288
+#: lib/vutuv_web/agent_docs/text.ex:273
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4352,14 +4351,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/text.ex:277
+#: lib/vutuv_web/agent_docs/markdown.ex:293
+#: lib/vutuv_web/agent_docs/text.ex:278
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:289
+#: lib/vutuv_web/agent_docs/text.ex:274
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4618,8 +4617,8 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:309
-#: lib/vutuv_web/agent_docs/text.ex:341
+#: lib/vutuv_web/agent_docs/markdown.ex:316
+#: lib/vutuv_web/agent_docs/text.ex:342
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:682
 #: lib/vutuv_web/live/organization_live/show.ex:300
@@ -4640,7 +4639,7 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:271
+#: lib/vutuv_web/components/post_components.ex:272
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/notification_live/index.ex:680
@@ -4739,8 +4738,8 @@ msgstr ""
 msgid "Edit your profile and its sections"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:223
-#: lib/vutuv_web/agent_docs/text.ex:217
+#: lib/vutuv_web/agent_docs/markdown.ex:230
+#: lib/vutuv_web/agent_docs/text.ex:218
 #: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
@@ -5448,9 +5447,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:899
-#: lib/vutuv_web/components/post_components.ex:953
-#: lib/vutuv_web/components/post_components.ex:1268
+#: lib/vutuv_web/components/post_components.ex:971
+#: lib/vutuv_web/components/post_components.ex:1025
+#: lib/vutuv_web/components/post_components.ex:1340
 #: lib/vutuv_web/live/notification_live/index.ex:519
 #: lib/vutuv_web/live/post_live/feed.ex:737
 #, elixir-autogen, elixir-format
@@ -6178,8 +6177,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:426
-#: lib/vutuv_web/agent_docs/text.ex:429
+#: lib/vutuv_web/agent_docs/markdown.ex:433
+#: lib/vutuv_web/agent_docs/text.ex:430
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6251,8 +6250,8 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:826
-#: lib/vutuv_web/components/post_components.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:833
+#: lib/vutuv_web/components/post_components.ex:274
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
@@ -6355,7 +6354,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:808
+#: lib/vutuv_web/agent_docs/markdown.ex:815
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6673,7 +6672,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:834
+#: lib/vutuv_web/components/post_components.ex:906
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6683,7 +6682,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:833
+#: lib/vutuv_web/components/post_components.ex:905
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -6878,8 +6877,8 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:197
-#: lib/vutuv_web/agent_docs/text.ex:192
+#: lib/vutuv_web/agent_docs/markdown.ex:204
+#: lib/vutuv_web/agent_docs/text.ex:193
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -7535,17 +7534,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:876
+#: lib/vutuv_web/agent_docs/markdown.ex:883
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:879
+#: lib/vutuv_web/agent_docs/markdown.ex:886
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:886
+#: lib/vutuv_web/agent_docs/markdown.ex:893
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8757,7 +8756,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:588
+#: lib/vutuv_web/agent_docs/markdown.ex:595
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8778,7 +8777,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:589
+#: lib/vutuv_web/agent_docs/markdown.ex:596
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8809,13 +8808,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:626
+#: lib/vutuv_web/agent_docs/markdown.ex:633
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:625
+#: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8841,14 +8840,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1327
+#: lib/vutuv_web/components/post_components.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:767
+#: lib/vutuv_web/agent_docs/markdown.ex:774
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8926,14 +8925,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/markdown.ex:594
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:590
+#: lib/vutuv_web/agent_docs/markdown.ex:597
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9073,8 +9072,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:447
-#: lib/vutuv_web/agent_docs/text.ex:448
+#: lib/vutuv_web/agent_docs/markdown.ex:454
+#: lib/vutuv_web/agent_docs/text.ex:449
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9496,8 +9495,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:417
-#: lib/vutuv_web/agent_docs/text.ex:420
+#: lib/vutuv_web/agent_docs/markdown.ex:424
+#: lib/vutuv_web/agent_docs/text.ex:421
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
@@ -9600,7 +9599,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:695
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9687,7 +9686,7 @@ msgstr ""
 msgid "Expiry year"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:663
+#: lib/vutuv_web/agent_docs/markdown.ex:670
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9713,7 +9712,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:687
+#: lib/vutuv_web/agent_docs/markdown.ex:694
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9740,7 +9739,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
+#: lib/vutuv_web/agent_docs/markdown.ex:668
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9755,7 +9754,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:662
+#: lib/vutuv_web/agent_docs/markdown.ex:669
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -9772,7 +9771,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:545
+#: lib/vutuv_web/agent_docs/markdown.ex:552
 #: lib/vutuv_web/live/section_reorder_live.ex:269
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -10413,21 +10412,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:512
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:503
+#: lib/vutuv_web/agent_docs/markdown.ex:510
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:508
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10480,12 +10479,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:519
+#: lib/vutuv_web/agent_docs/markdown.ex:526
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:506
+#: lib/vutuv_web/agent_docs/markdown.ex:513
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -11354,8 +11353,8 @@ msgstr ""
 msgid "Verified domains"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:198
-#: lib/vutuv_web/agent_docs/text.ex:193
+#: lib/vutuv_web/agent_docs/markdown.ex:205
+#: lib/vutuv_web/agent_docs/text.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr ""
@@ -11382,8 +11381,8 @@ msgstr ""
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:200
-#: lib/vutuv_web/agent_docs/text.ex:195
+#: lib/vutuv_web/agent_docs/markdown.ex:207
+#: lib/vutuv_web/agent_docs/text.ex:196
 #: lib/vutuv_web/live/organization_live/edit.ex:273
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -11467,8 +11466,8 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:301
-#: lib/vutuv_web/agent_docs/text.ex:334
+#: lib/vutuv_web/agent_docs/markdown.ex:308
+#: lib/vutuv_web/agent_docs/text.ex:335
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
@@ -11701,8 +11700,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:322
-#: lib/vutuv_web/agent_docs/text.ex:354
+#: lib/vutuv_web/agent_docs/markdown.ex:329
+#: lib/vutuv_web/agent_docs/text.ex:355
 #: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11835,8 +11834,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:708
-#: lib/vutuv_web/agent_docs/text.ex:544
+#: lib/vutuv_web/agent_docs/markdown.ex:715
+#: lib/vutuv_web/agent_docs/text.ex:545
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11872,8 +11871,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:313
-#: lib/vutuv_web/agent_docs/text.ex:345
+#: lib/vutuv_web/agent_docs/markdown.ex:320
+#: lib/vutuv_web/agent_docs/text.ex:346
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -12317,10 +12316,10 @@ msgstr ""
 msgid "Edit posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:217
-#: lib/vutuv_web/agent_docs/markdown.ex:346
-#: lib/vutuv_web/agent_docs/text.ex:211
-#: lib/vutuv_web/agent_docs/text.ex:378
+#: lib/vutuv_web/agent_docs/markdown.ex:224
+#: lib/vutuv_web/agent_docs/markdown.ex:353
+#: lib/vutuv_web/agent_docs/text.ex:212
+#: lib/vutuv_web/agent_docs/text.ex:379
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Employer"
@@ -12331,10 +12330,10 @@ msgstr ""
 msgid "Employer name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/markdown.ex:347
-#: lib/vutuv_web/agent_docs/text.ex:212
-#: lib/vutuv_web/agent_docs/text.ex:379
+#: lib/vutuv_web/agent_docs/markdown.ex:225
+#: lib/vutuv_web/agent_docs/markdown.ex:354
+#: lib/vutuv_web/agent_docs/text.ex:213
+#: lib/vutuv_web/agent_docs/text.ex:380
 #: lib/vutuv_web/live/job_board_live.ex:281
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
@@ -12409,12 +12408,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:328
-#: lib/vutuv_web/agent_docs/markdown.ex:332
-#: lib/vutuv_web/agent_docs/markdown.ex:334
-#: lib/vutuv_web/agent_docs/text.ex:360
-#: lib/vutuv_web/agent_docs/text.ex:364
-#: lib/vutuv_web/agent_docs/text.ex:366
+#: lib/vutuv_web/agent_docs/markdown.ex:335
+#: lib/vutuv_web/agent_docs/markdown.ex:339
+#: lib/vutuv_web/agent_docs/markdown.ex:341
+#: lib/vutuv_web/agent_docs/text.ex:361
+#: lib/vutuv_web/agent_docs/text.ex:365
+#: lib/vutuv_web/agent_docs/text.ex:367
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12463,8 +12462,8 @@ msgstr ""
 msgid "New posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:229
-#: lib/vutuv_web/agent_docs/text.ex:222
+#: lib/vutuv_web/agent_docs/markdown.ex:236
+#: lib/vutuv_web/agent_docs/text.ex:223
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
@@ -12548,10 +12547,10 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:222
-#: lib/vutuv_web/agent_docs/markdown.ex:351
-#: lib/vutuv_web/agent_docs/text.ex:216
-#: lib/vutuv_web/agent_docs/text.ex:383
+#: lib/vutuv_web/agent_docs/markdown.ex:229
+#: lib/vutuv_web/agent_docs/markdown.ex:358
+#: lib/vutuv_web/agent_docs/text.ex:217
+#: lib/vutuv_web/agent_docs/text.ex:384
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12576,10 +12575,10 @@ msgstr ""
 #: lib/vutuv/accounts/user.ex:748
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
-#: lib/vutuv_web/agent_docs/markdown.ex:332
-#: lib/vutuv_web/agent_docs/markdown.ex:334
-#: lib/vutuv_web/agent_docs/text.ex:364
-#: lib/vutuv_web/agent_docs/text.ex:366
+#: lib/vutuv_web/agent_docs/markdown.ex:339
+#: lib/vutuv_web/agent_docs/markdown.ex:341
+#: lib/vutuv_web/agent_docs/text.ex:365
+#: lib/vutuv_web/agent_docs/text.ex:367
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format
@@ -12591,18 +12590,18 @@ msgstr ""
 msgid "Report this posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:228
-#: lib/vutuv_web/agent_docs/text.ex:221
+#: lib/vutuv_web/agent_docs/markdown.ex:235
+#: lib/vutuv_web/agent_docs/text.ex:222
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:221
-#: lib/vutuv_web/agent_docs/markdown.ex:350
-#: lib/vutuv_web/agent_docs/text.ex:215
-#: lib/vutuv_web/agent_docs/text.ex:382
+#: lib/vutuv_web/agent_docs/markdown.ex:228
+#: lib/vutuv_web/agent_docs/markdown.ex:357
+#: lib/vutuv_web/agent_docs/text.ex:216
+#: lib/vutuv_web/agent_docs/text.ex:383
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12694,10 +12693,10 @@ msgstr ""
 msgid "Working student"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:219
-#: lib/vutuv_web/agent_docs/markdown.ex:348
-#: lib/vutuv_web/agent_docs/text.ex:213
-#: lib/vutuv_web/agent_docs/text.ex:380
+#: lib/vutuv_web/agent_docs/markdown.ex:226
+#: lib/vutuv_web/agent_docs/markdown.ex:355
+#: lib/vutuv_web/agent_docs/text.ex:214
+#: lib/vutuv_web/agent_docs/text.ex:381
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -12870,13 +12869,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:369
+#: lib/vutuv_web/agent_docs/markdown.ex:376
 #: lib/vutuv_web/templates/tag/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:400
+#: lib/vutuv_web/agent_docs/text.ex:401
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12922,12 +12921,12 @@ msgstr ""
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:241
+#: lib/vutuv_web/agent_docs/markdown.ex:248
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:234
+#: lib/vutuv_web/agent_docs/text.ex:235
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
@@ -12942,10 +12941,10 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:367
-#: lib/vutuv_web/agent_docs/markdown.ex:379
-#: lib/vutuv_web/agent_docs/text.ex:398
-#: lib/vutuv_web/agent_docs/text.ex:410
+#: lib/vutuv_web/agent_docs/markdown.ex:374
+#: lib/vutuv_web/agent_docs/markdown.ex:386
+#: lib/vutuv_web/agent_docs/text.ex:399
+#: lib/vutuv_web/agent_docs/text.ex:411
 #: lib/vutuv_web/live/organization_live/show.ex:329
 #: lib/vutuv_web/templates/tag/show.html.heex:57
 #, elixir-autogen, elixir-format
@@ -13506,7 +13505,7 @@ msgstr ""
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1030
+#: lib/vutuv_web/components/post_components.ex:1102
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -13514,7 +13513,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1020
+#: lib/vutuv_web/components/post_components.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr ""
@@ -13658,8 +13657,8 @@ msgstr ""
 msgid "Insert into text"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:173
-#: lib/vutuv_web/agent_docs/text.ex:168
+#: lib/vutuv_web/agent_docs/markdown.ex:180
+#: lib/vutuv_web/agent_docs/text.ex:169
 #: lib/vutuv_web/templates/tag/show.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
@@ -13685,22 +13684,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:282
+#: lib/vutuv_web/components/post_components.ex:283
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:284
+#: lib/vutuv_web/components/post_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:283
+#: lib/vutuv_web/components/post_components.ex:284
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:272
+#: lib/vutuv_web/components/post_components.ex:273
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13874,7 +13873,7 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1702
+#: lib/vutuv_web/components/post_components.ex:1774
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
@@ -13889,19 +13888,19 @@ msgstr ""
 msgid "Book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:838
-#: lib/vutuv_web/components/post_components.ex:1659
+#: lib/vutuv_web/agent_docs/markdown.ex:845
+#: lib/vutuv_web/components/post_components.ex:1731
 #: lib/vutuv_web/live/post_live/composer.ex:659
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1703
+#: lib/vutuv_web/components/post_components.ex:1775
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1705
+#: lib/vutuv_web/components/post_components.ex:1777
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
@@ -13911,7 +13910,7 @@ msgstr ""
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1701
+#: lib/vutuv_web/components/post_components.ex:1773
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
@@ -13921,8 +13920,8 @@ msgstr ""
 msgid "Film"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:838
-#: lib/vutuv_web/components/post_components.ex:1658
+#: lib/vutuv_web/agent_docs/markdown.ex:845
+#: lib/vutuv_web/components/post_components.ex:1730
 #: lib/vutuv_web/live/post_live/composer.ex:658
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13953,7 +13952,7 @@ msgstr ""
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1700
+#: lib/vutuv_web/components/post_components.ex:1772
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
@@ -13980,7 +13979,7 @@ msgstr ""
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1704
+#: lib/vutuv_web/components/post_components.ex:1776
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -14000,34 +13999,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1741
+#: lib/vutuv_web/components/post_components.ex:1813
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1771
+#: lib/vutuv_web/components/post_components.ex:1843
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1772
+#: lib/vutuv_web/components/post_components.ex:1844
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1770
+#: lib/vutuv_web/components/post_components.ex:1842
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1730
+#: lib/vutuv_web/components/post_components.ex:1802
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1777
+#: lib/vutuv_web/components/post_components.ex:1849
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14052,12 +14051,12 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:574
+#: lib/vutuv_web/agent_docs/markdown.ex:581
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1544
+#: lib/vutuv_web/components/post_components.ex:1616
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14105,7 +14104,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1535
+#: lib/vutuv_web/components/post_components.ex:1607
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14148,19 +14147,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:677
+#: lib/vutuv_web/agent_docs/markdown.ex:684
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:676
+#: lib/vutuv_web/agent_docs/markdown.ex:683
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:682
+#: lib/vutuv_web/agent_docs/markdown.ex:689
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14239,8 +14238,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:645
-#: lib/vutuv_web/agent_docs/text.ex:536
+#: lib/vutuv_web/agent_docs/markdown.ex:652
+#: lib/vutuv_web/agent_docs/text.ex:537
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14323,8 +14322,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:419
-#: lib/vutuv_web/agent_docs/text.ex:422
+#: lib/vutuv_web/agent_docs/markdown.ex:426
+#: lib/vutuv_web/agent_docs/text.ex:423
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14361,3 +14360,16 @@ msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:113
+#: lib/vutuv_web/agent_docs/text.ex:105
+#, elixir-autogen, elixir-format
+msgid "Conversation"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:116
+#: lib/vutuv_web/agent_docs/text.ex:108
+#: lib/vutuv_web/templates/post/show.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "Only part of this long conversation is shown."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -24,9 +24,9 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:201
+#: lib/vutuv_web/agent_docs/markdown.ex:208
 #: lib/vutuv_web/agent_docs/section_docs.ex:121
-#: lib/vutuv_web/agent_docs/text.ex:196
+#: lib/vutuv_web/agent_docs/text.ex:197
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:110
@@ -94,10 +94,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:424
-#: lib/vutuv_web/agent_docs/markdown.ex:425
-#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/agent_docs/markdown.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:432
 #: lib/vutuv_web/agent_docs/text.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:429
 #: lib/vutuv_web/templates/user/show.html.heex:824
 #, elixir-autogen
 msgid "Birthday"
@@ -149,7 +149,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:816
+#: lib/vutuv_web/components/post_components.ex:888
 #: lib/vutuv_web/components/ui.ex:2926
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -195,7 +195,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:809
+#: lib/vutuv_web/components/post_components.ex:881
 #: lib/vutuv_web/components/ui.ex:2917
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -319,8 +319,8 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:436
-#: lib/vutuv_web/agent_docs/text.ex:439
+#: lib/vutuv_web/agent_docs/markdown.ex:443
+#: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/live/notification_live/index.ex:759
 #: lib/vutuv_web/templates/follower/index.html.heex:4
@@ -329,8 +329,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:437
-#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:444
+#: lib/vutuv_web/agent_docs/text.ex:441
 #: lib/vutuv_web/components/ui.ex:1551
 #: lib/vutuv_web/components/ui.ex:1576
 #: lib/vutuv_web/components/ui.ex:1579
@@ -345,8 +345,8 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:423
-#: lib/vutuv_web/agent_docs/text.ex:426
+#: lib/vutuv_web/agent_docs/markdown.ex:430
+#: lib/vutuv_web/agent_docs/text.ex:427
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -1460,11 +1460,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
-#: lib/vutuv_web/agent_docs/markdown.ex:361
-#: lib/vutuv_web/agent_docs/markdown.ex:795
+#: lib/vutuv_web/agent_docs/markdown.ex:368
+#: lib/vutuv_web/agent_docs/markdown.ex:802
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:393
-#: lib/vutuv_web/agent_docs/text.ex:570
+#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/agent_docs/text.ex:571
 #: lib/vutuv_web/components/ui.ex:3170
 #: lib/vutuv_web/controllers/user_tag_controller.ex:39
 #: lib/vutuv_web/controllers/user_tag_controller.ex:56
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:285
+#: lib/vutuv_web/components/post_components.ex:286
 #: lib/vutuv_web/components/ui.ex:3026
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:813
+#: lib/vutuv_web/components/post_components.ex:885
 #: lib/vutuv_web/live/post_live/edit.ex:117
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2193,7 +2193,7 @@ msgstr ""
 msgid "Follow %{name} to read it."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/show.html.heex:17
+#: lib/vutuv_web/templates/post/show.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "Hidden from:"
 msgstr ""
@@ -2208,8 +2208,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:798
-#: lib/vutuv_web/components/post_components.ex:800
+#: lib/vutuv_web/components/post_components.ex:870
+#: lib/vutuv_web/components/post_components.ex:872
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2257,7 +2257,7 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:80
+#: lib/vutuv_web/agent_docs/post_doc.ex:88
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:73
@@ -2273,13 +2273,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1206
-#: lib/vutuv_web/components/post_components.ex:1210
+#: lib/vutuv_web/components/post_components.ex:1278
+#: lib/vutuv_web/components/post_components.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1207
+#: lib/vutuv_web/components/post_components.ex:1279
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Remove image"
 msgstr ""
 
-#: lib/vutuv_web/templates/post/show.html.heex:20
+#: lib/vutuv_web/templates/post/show.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
@@ -2370,27 +2370,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:795
+#: lib/vutuv_web/components/post_components.ex:867
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1839
+#: lib/vutuv_web/components/post_components.ex:1911
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1843
+#: lib/vutuv_web/components/post_components.ex:1915
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1841
+#: lib/vutuv_web/components/post_components.ex:1913
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1842
+#: lib/vutuv_web/components/post_components.ex:1914
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2431,7 +2431,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/post_components.ex:1983
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2484
@@ -2440,7 +2440,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:827
+#: lib/vutuv_web/agent_docs/markdown.ex:834
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:429
@@ -2450,7 +2450,7 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1878
+#: lib/vutuv_web/components/post_components.ex:1950
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2470
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:826
+#: lib/vutuv_web/agent_docs/markdown.ex:833
 #: lib/vutuv_web/live/notification_live/index.ex:761
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2480,12 +2480,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1900
+#: lib/vutuv_web/components/post_components.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1911
+#: lib/vutuv_web/components/post_components.ex:1983
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2494,23 +2494,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1897
+#: lib/vutuv_web/components/post_components.ex:1969
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1324
+#: lib/vutuv_web/components/post_components.ex:1396
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1897
+#: lib/vutuv_web/components/post_components.ex:1969
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1878
+#: lib/vutuv_web/components/post_components.ex:1950
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2533,29 +2533,26 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1951
+#: lib/vutuv_web/components/post_components.ex:2023
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:109
-#: lib/vutuv_web/agent_docs/text.ex:105
-#: lib/vutuv_web/components/post_components.ex:274
+#: lib/vutuv_web/components/post_components.ex:275
 #: lib/vutuv_web/live/notification_live/index.ex:762
-#: lib/vutuv_web/templates/post/show.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1934
-#: lib/vutuv_web/components/post_components.ex:1935
+#: lib/vutuv_web/components/post_components.ex:2006
+#: lib/vutuv_web/components/post_components.ex:2007
 #: lib/vutuv_web/live/notification_live/index.ex:810
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:766
+#: lib/vutuv_web/components/post_components.ex:838
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2581,12 +2578,12 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:761
+#: lib/vutuv_web/components/post_components.ex:833
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:755
+#: lib/vutuv_web/components/post_components.ex:827
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2841,8 +2838,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:438
-#: lib/vutuv_web/agent_docs/text.ex:441
+#: lib/vutuv_web/agent_docs/markdown.ex:445
+#: lib/vutuv_web/agent_docs/text.ex:442
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/live/notification_live/index.ex:760
 #: lib/vutuv_web/templates/connection/index.html.heex:5
@@ -2888,7 +2885,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1840
+#: lib/vutuv_web/components/post_components.ex:1912
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2993,8 +2990,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:280
-#: lib/vutuv_web/agent_docs/text.ex:271
+#: lib/vutuv_web/agent_docs/markdown.ex:287
+#: lib/vutuv_web/agent_docs/text.ex:272
 #: lib/vutuv_web/controllers/page_controller.ex:55
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3149,7 +3146,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:743
+#: lib/vutuv_web/components/post_components.ex:815
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3224,7 +3221,7 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:837
+#: lib/vutuv_web/components/post_components.ex:909
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3877,30 +3874,30 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:528
+#: lib/vutuv_web/agent_docs/markdown.ex:535
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:871
+#: lib/vutuv_web/agent_docs/markdown.ex:878
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:121
-#: lib/vutuv_web/agent_docs/text.ex:116
+#: lib/vutuv_web/agent_docs/markdown.ex:128
+#: lib/vutuv_web/agent_docs/text.ex:117
 #, elixir-autogen, elixir-format
 msgid "%{count} posts by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:82
-#: lib/vutuv_web/agent_docs/markdown.ex:144
-#: lib/vutuv_web/agent_docs/markdown.ex:157
-#: lib/vutuv_web/agent_docs/markdown.ex:795
+#: lib/vutuv_web/agent_docs/markdown.ex:151
+#: lib/vutuv_web/agent_docs/markdown.ex:164
+#: lib/vutuv_web/agent_docs/markdown.ex:802
 #: lib/vutuv_web/agent_docs/text.ex:79
-#: lib/vutuv_web/agent_docs/text.ex:139
-#: lib/vutuv_web/agent_docs/text.ex:152
-#: lib/vutuv_web/agent_docs/text.ex:570
+#: lib/vutuv_web/agent_docs/text.ex:140
+#: lib/vutuv_web/agent_docs/text.ex:153
+#: lib/vutuv_web/agent_docs/text.ex:571
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3917,32 +3914,34 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:813
-#: lib/vutuv_web/agent_docs/text.ex:581
+#: lib/vutuv_web/agent_docs/markdown.ex:820
+#: lib/vutuv_web/agent_docs/text.ex:582
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:810
-#: lib/vutuv_web/agent_docs/text.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:817
+#: lib/vutuv_web/agent_docs/text.ex:579
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:817
-#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/markdown.ex:824
+#: lib/vutuv_web/agent_docs/markdown.ex:909
+#: lib/vutuv_web/agent_docs/text.ex:585
+#: lib/vutuv_web/agent_docs/text.ex:605
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:421
-#: lib/vutuv_web/agent_docs/text.ex:424
+#: lib/vutuv_web/agent_docs/markdown.ex:428
+#: lib/vutuv_web/agent_docs/text.ex:425
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:170
-#: lib/vutuv_web/agent_docs/text.ex:165
+#: lib/vutuv_web/agent_docs/markdown.ex:177
+#: lib/vutuv_web/agent_docs/text.ex:166
 #, elixir-autogen, elixir-format
 msgid "Most endorsed members"
 msgstr ""
@@ -3957,7 +3956,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:81
+#: lib/vutuv_web/agent_docs/post_doc.ex:89
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -3976,23 +3975,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:415
-#: lib/vutuv_web/agent_docs/text.ex:418
+#: lib/vutuv_web/agent_docs/markdown.ex:422
+#: lib/vutuv_web/agent_docs/text.ex:419
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:764
+#: lib/vutuv_web/agent_docs/markdown.ex:771
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:694
+#: lib/vutuv_web/agent_docs/markdown.ex:701
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:695
+#: lib/vutuv_web/agent_docs/markdown.ex:702
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4067,8 +4066,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:294
-#: lib/vutuv_web/agent_docs/text.ex:279
+#: lib/vutuv_web/agent_docs/markdown.ex:301
+#: lib/vutuv_web/agent_docs/text.ex:280
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4118,8 +4117,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:284
-#: lib/vutuv_web/agent_docs/text.ex:275
+#: lib/vutuv_web/agent_docs/markdown.ex:291
+#: lib/vutuv_web/agent_docs/text.ex:276
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4135,8 +4134,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:281
-#: lib/vutuv_web/agent_docs/text.ex:272
+#: lib/vutuv_web/agent_docs/markdown.ex:288
+#: lib/vutuv_web/agent_docs/text.ex:273
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4350,14 +4349,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:286
-#: lib/vutuv_web/agent_docs/text.ex:277
+#: lib/vutuv_web/agent_docs/markdown.ex:293
+#: lib/vutuv_web/agent_docs/text.ex:278
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:282
-#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:289
+#: lib/vutuv_web/agent_docs/text.ex:274
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4616,8 +4615,8 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:309
-#: lib/vutuv_web/agent_docs/text.ex:341
+#: lib/vutuv_web/agent_docs/markdown.ex:316
+#: lib/vutuv_web/agent_docs/text.ex:342
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/live/notification_live/index.ex:682
 #: lib/vutuv_web/live/organization_live/show.ex:300
@@ -4638,7 +4637,7 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:271
+#: lib/vutuv_web/components/post_components.ex:272
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/notification_live/index.ex:680
@@ -4737,8 +4736,8 @@ msgstr ""
 msgid "Edit your profile and its sections"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:223
-#: lib/vutuv_web/agent_docs/text.ex:217
+#: lib/vutuv_web/agent_docs/markdown.ex:230
+#: lib/vutuv_web/agent_docs/text.ex:218
 #: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
@@ -5446,9 +5445,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:899
-#: lib/vutuv_web/components/post_components.ex:953
-#: lib/vutuv_web/components/post_components.ex:1268
+#: lib/vutuv_web/components/post_components.ex:971
+#: lib/vutuv_web/components/post_components.ex:1025
+#: lib/vutuv_web/components/post_components.ex:1340
 #: lib/vutuv_web/live/notification_live/index.ex:519
 #: lib/vutuv_web/live/post_live/feed.ex:737
 #, elixir-autogen, elixir-format
@@ -6176,8 +6175,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:426
-#: lib/vutuv_web/agent_docs/text.ex:429
+#: lib/vutuv_web/agent_docs/markdown.ex:433
+#: lib/vutuv_web/agent_docs/text.ex:430
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6249,8 +6248,8 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:826
-#: lib/vutuv_web/components/post_components.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:833
+#: lib/vutuv_web/components/post_components.ex:274
 #: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reposts"
@@ -6353,7 +6352,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:808
+#: lib/vutuv_web/agent_docs/markdown.ex:815
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6671,7 +6670,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:834
+#: lib/vutuv_web/components/post_components.ex:906
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6681,7 +6680,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:833
+#: lib/vutuv_web/components/post_components.ex:905
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -6876,8 +6875,8 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:197
-#: lib/vutuv_web/agent_docs/text.ex:192
+#: lib/vutuv_web/agent_docs/markdown.ex:204
+#: lib/vutuv_web/agent_docs/text.ex:193
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -7533,17 +7532,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:876
+#: lib/vutuv_web/agent_docs/markdown.ex:883
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:879
+#: lib/vutuv_web/agent_docs/markdown.ex:886
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:886
+#: lib/vutuv_web/agent_docs/markdown.ex:893
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8755,7 +8754,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:588
+#: lib/vutuv_web/agent_docs/markdown.ex:595
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8776,7 +8775,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:589
+#: lib/vutuv_web/agent_docs/markdown.ex:596
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8807,13 +8806,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:626
+#: lib/vutuv_web/agent_docs/markdown.ex:633
 #: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:625
+#: lib/vutuv_web/agent_docs/markdown.ex:632
 #: lib/vutuv_web/views/education_html.ex:20
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8839,14 +8838,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1327
+#: lib/vutuv_web/components/post_components.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:767
+#: lib/vutuv_web/agent_docs/markdown.ex:774
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8924,14 +8923,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:587
+#: lib/vutuv_web/agent_docs/markdown.ex:594
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:590
+#: lib/vutuv_web/agent_docs/markdown.ex:597
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9071,8 +9070,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:447
-#: lib/vutuv_web/agent_docs/text.ex:448
+#: lib/vutuv_web/agent_docs/markdown.ex:454
+#: lib/vutuv_web/agent_docs/text.ex:449
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9494,8 +9493,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:417
-#: lib/vutuv_web/agent_docs/text.ex:420
+#: lib/vutuv_web/agent_docs/markdown.ex:424
+#: lib/vutuv_web/agent_docs/text.ex:421
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
@@ -9598,7 +9597,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:688
+#: lib/vutuv_web/agent_docs/markdown.ex:695
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9685,7 +9684,7 @@ msgstr ""
 msgid "Expiry year"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:663
+#: lib/vutuv_web/agent_docs/markdown.ex:670
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9711,7 +9710,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:687
+#: lib/vutuv_web/agent_docs/markdown.ex:694
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9738,7 +9737,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:661
+#: lib/vutuv_web/agent_docs/markdown.ex:668
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9753,7 +9752,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:662
+#: lib/vutuv_web/agent_docs/markdown.ex:669
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -9770,7 +9769,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:545
+#: lib/vutuv_web/agent_docs/markdown.ex:552
 #: lib/vutuv_web/live/section_reorder_live.ex:269
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -10411,21 +10410,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:505
+#: lib/vutuv_web/agent_docs/markdown.ex:512
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:503
+#: lib/vutuv_web/agent_docs/markdown.ex:510
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:508
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10478,12 +10477,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:519
+#: lib/vutuv_web/agent_docs/markdown.ex:526
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:506
+#: lib/vutuv_web/agent_docs/markdown.ex:513
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -11352,8 +11351,8 @@ msgstr ""
 msgid "Verified domains"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:198
-#: lib/vutuv_web/agent_docs/text.ex:193
+#: lib/vutuv_web/agent_docs/markdown.ex:205
+#: lib/vutuv_web/agent_docs/text.ex:194
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr ""
@@ -11380,8 +11379,8 @@ msgstr ""
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:200
-#: lib/vutuv_web/agent_docs/text.ex:195
+#: lib/vutuv_web/agent_docs/markdown.ex:207
+#: lib/vutuv_web/agent_docs/text.ex:196
 #: lib/vutuv_web/live/organization_live/edit.ex:273
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -11465,8 +11464,8 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:301
-#: lib/vutuv_web/agent_docs/text.ex:334
+#: lib/vutuv_web/agent_docs/markdown.ex:308
+#: lib/vutuv_web/agent_docs/text.ex:335
 #: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
@@ -11699,8 +11698,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:322
-#: lib/vutuv_web/agent_docs/text.ex:354
+#: lib/vutuv_web/agent_docs/markdown.ex:329
+#: lib/vutuv_web/agent_docs/text.ex:355
 #: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11833,8 +11832,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:708
-#: lib/vutuv_web/agent_docs/text.ex:544
+#: lib/vutuv_web/agent_docs/markdown.ex:715
+#: lib/vutuv_web/agent_docs/text.ex:545
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11870,8 +11869,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:313
-#: lib/vutuv_web/agent_docs/text.ex:345
+#: lib/vutuv_web/agent_docs/markdown.ex:320
+#: lib/vutuv_web/agent_docs/text.ex:346
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -12315,10 +12314,10 @@ msgstr ""
 msgid "Edit posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:217
-#: lib/vutuv_web/agent_docs/markdown.ex:346
-#: lib/vutuv_web/agent_docs/text.ex:211
-#: lib/vutuv_web/agent_docs/text.ex:378
+#: lib/vutuv_web/agent_docs/markdown.ex:224
+#: lib/vutuv_web/agent_docs/markdown.ex:353
+#: lib/vutuv_web/agent_docs/text.ex:212
+#: lib/vutuv_web/agent_docs/text.ex:379
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Employer"
@@ -12329,10 +12328,10 @@ msgstr ""
 msgid "Employer name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/markdown.ex:347
-#: lib/vutuv_web/agent_docs/text.ex:212
-#: lib/vutuv_web/agent_docs/text.ex:379
+#: lib/vutuv_web/agent_docs/markdown.ex:225
+#: lib/vutuv_web/agent_docs/markdown.ex:354
+#: lib/vutuv_web/agent_docs/text.ex:213
+#: lib/vutuv_web/agent_docs/text.ex:380
 #: lib/vutuv_web/live/job_board_live.ex:281
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
@@ -12407,12 +12406,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:328
-#: lib/vutuv_web/agent_docs/markdown.ex:332
-#: lib/vutuv_web/agent_docs/markdown.ex:334
-#: lib/vutuv_web/agent_docs/text.ex:360
-#: lib/vutuv_web/agent_docs/text.ex:364
-#: lib/vutuv_web/agent_docs/text.ex:366
+#: lib/vutuv_web/agent_docs/markdown.ex:335
+#: lib/vutuv_web/agent_docs/markdown.ex:339
+#: lib/vutuv_web/agent_docs/markdown.ex:341
+#: lib/vutuv_web/agent_docs/text.ex:361
+#: lib/vutuv_web/agent_docs/text.ex:365
+#: lib/vutuv_web/agent_docs/text.ex:367
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12461,8 +12460,8 @@ msgstr ""
 msgid "New posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:229
-#: lib/vutuv_web/agent_docs/text.ex:222
+#: lib/vutuv_web/agent_docs/markdown.ex:236
+#: lib/vutuv_web/agent_docs/text.ex:223
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
@@ -12546,10 +12545,10 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:222
-#: lib/vutuv_web/agent_docs/markdown.ex:351
-#: lib/vutuv_web/agent_docs/text.ex:216
-#: lib/vutuv_web/agent_docs/text.ex:383
+#: lib/vutuv_web/agent_docs/markdown.ex:229
+#: lib/vutuv_web/agent_docs/markdown.ex:358
+#: lib/vutuv_web/agent_docs/text.ex:217
+#: lib/vutuv_web/agent_docs/text.ex:384
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12574,10 +12573,10 @@ msgstr ""
 #: lib/vutuv/accounts/user.ex:748
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
-#: lib/vutuv_web/agent_docs/markdown.ex:332
-#: lib/vutuv_web/agent_docs/markdown.ex:334
-#: lib/vutuv_web/agent_docs/text.ex:364
-#: lib/vutuv_web/agent_docs/text.ex:366
+#: lib/vutuv_web/agent_docs/markdown.ex:339
+#: lib/vutuv_web/agent_docs/markdown.ex:341
+#: lib/vutuv_web/agent_docs/text.ex:365
+#: lib/vutuv_web/agent_docs/text.ex:367
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format
@@ -12589,18 +12588,18 @@ msgstr ""
 msgid "Report this posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:228
-#: lib/vutuv_web/agent_docs/text.ex:221
+#: lib/vutuv_web/agent_docs/markdown.ex:235
+#: lib/vutuv_web/agent_docs/text.ex:222
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:221
-#: lib/vutuv_web/agent_docs/markdown.ex:350
-#: lib/vutuv_web/agent_docs/text.ex:215
-#: lib/vutuv_web/agent_docs/text.ex:382
+#: lib/vutuv_web/agent_docs/markdown.ex:228
+#: lib/vutuv_web/agent_docs/markdown.ex:357
+#: lib/vutuv_web/agent_docs/text.ex:216
+#: lib/vutuv_web/agent_docs/text.ex:383
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12692,10 +12691,10 @@ msgstr ""
 msgid "Working student"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:219
-#: lib/vutuv_web/agent_docs/markdown.ex:348
-#: lib/vutuv_web/agent_docs/text.ex:213
-#: lib/vutuv_web/agent_docs/text.ex:380
+#: lib/vutuv_web/agent_docs/markdown.ex:226
+#: lib/vutuv_web/agent_docs/markdown.ex:355
+#: lib/vutuv_web/agent_docs/text.ex:214
+#: lib/vutuv_web/agent_docs/text.ex:381
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -12868,13 +12867,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:369
+#: lib/vutuv_web/agent_docs/markdown.ex:376
 #: lib/vutuv_web/templates/tag/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:400
+#: lib/vutuv_web/agent_docs/text.ex:401
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12920,12 +12919,12 @@ msgstr ""
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:241
+#: lib/vutuv_web/agent_docs/markdown.ex:248
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:234
+#: lib/vutuv_web/agent_docs/text.ex:235
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
@@ -12940,10 +12939,10 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:367
-#: lib/vutuv_web/agent_docs/markdown.ex:379
-#: lib/vutuv_web/agent_docs/text.ex:398
-#: lib/vutuv_web/agent_docs/text.ex:410
+#: lib/vutuv_web/agent_docs/markdown.ex:374
+#: lib/vutuv_web/agent_docs/markdown.ex:386
+#: lib/vutuv_web/agent_docs/text.ex:399
+#: lib/vutuv_web/agent_docs/text.ex:411
 #: lib/vutuv_web/live/organization_live/show.ex:329
 #: lib/vutuv_web/templates/tag/show.html.heex:57
 #, elixir-autogen, elixir-format
@@ -13504,7 +13503,7 @@ msgstr ""
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1030
+#: lib/vutuv_web/components/post_components.ex:1102
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -13512,7 +13511,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1020
+#: lib/vutuv_web/components/post_components.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr ""
@@ -13656,8 +13655,8 @@ msgstr ""
 msgid "Insert into text"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:173
-#: lib/vutuv_web/agent_docs/text.ex:168
+#: lib/vutuv_web/agent_docs/markdown.ex:180
+#: lib/vutuv_web/agent_docs/text.ex:169
 #: lib/vutuv_web/templates/tag/show.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
@@ -13683,22 +13682,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:282
+#: lib/vutuv_web/components/post_components.ex:283
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:284
+#: lib/vutuv_web/components/post_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:283
+#: lib/vutuv_web/components/post_components.ex:284
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:272
+#: lib/vutuv_web/components/post_components.ex:273
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13872,7 +13871,7 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1702
+#: lib/vutuv_web/components/post_components.ex:1774
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
@@ -13887,19 +13886,19 @@ msgstr ""
 msgid "Book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:838
-#: lib/vutuv_web/components/post_components.ex:1659
+#: lib/vutuv_web/agent_docs/markdown.ex:845
+#: lib/vutuv_web/components/post_components.ex:1731
 #: lib/vutuv_web/live/post_live/composer.ex:659
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1703
+#: lib/vutuv_web/components/post_components.ex:1775
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1705
+#: lib/vutuv_web/components/post_components.ex:1777
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
@@ -13909,7 +13908,7 @@ msgstr ""
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1701
+#: lib/vutuv_web/components/post_components.ex:1773
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
@@ -13919,8 +13918,8 @@ msgstr ""
 msgid "Film"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:838
-#: lib/vutuv_web/components/post_components.ex:1658
+#: lib/vutuv_web/agent_docs/markdown.ex:845
+#: lib/vutuv_web/components/post_components.ex:1730
 #: lib/vutuv_web/live/post_live/composer.ex:658
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13951,7 +13950,7 @@ msgstr ""
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1700
+#: lib/vutuv_web/components/post_components.ex:1772
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
@@ -13978,7 +13977,7 @@ msgstr ""
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1704
+#: lib/vutuv_web/components/post_components.ex:1776
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13998,34 +13997,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1741
+#: lib/vutuv_web/components/post_components.ex:1813
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1771
+#: lib/vutuv_web/components/post_components.ex:1843
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1772
+#: lib/vutuv_web/components/post_components.ex:1844
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1770
+#: lib/vutuv_web/components/post_components.ex:1842
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1730
+#: lib/vutuv_web/components/post_components.ex:1802
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1777
+#: lib/vutuv_web/components/post_components.ex:1849
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14050,12 +14049,12 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:574
+#: lib/vutuv_web/agent_docs/markdown.ex:581
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1544
+#: lib/vutuv_web/components/post_components.ex:1616
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14103,7 +14102,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1535
+#: lib/vutuv_web/components/post_components.ex:1607
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14146,19 +14145,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:677
+#: lib/vutuv_web/agent_docs/markdown.ex:684
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:676
+#: lib/vutuv_web/agent_docs/markdown.ex:683
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:682
+#: lib/vutuv_web/agent_docs/markdown.ex:689
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14237,8 +14236,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:645
-#: lib/vutuv_web/agent_docs/text.ex:536
+#: lib/vutuv_web/agent_docs/markdown.ex:652
+#: lib/vutuv_web/agent_docs/text.ex:537
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14321,8 +14320,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:419
-#: lib/vutuv_web/agent_docs/text.ex:422
+#: lib/vutuv_web/agent_docs/markdown.ex:426
+#: lib/vutuv_web/agent_docs/text.ex:423
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14359,3 +14358,16 @@ msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:113
+#: lib/vutuv_web/agent_docs/text.ex:105
+#, elixir-autogen, elixir-format
+msgid "Conversation"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:116
+#: lib/vutuv_web/agent_docs/text.ex:108
+#: lib/vutuv_web/templates/post/show.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "Only part of this long conversation is shown."
+msgstr ""

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -1925,6 +1925,73 @@ defmodule Vutuv.PostsTest do
     end
   end
 
+  describe "list_thread/3" do
+    # The permalink page renders the whole conversation (issue #1006): the
+    # thread's root plus every visible reply, oldest first, from ANY post in it.
+    test "returns the whole conversation oldest-first from any post in it" do
+      root = create_post!(user(), %{body: "thread root"})
+      {:ok, mid} = Posts.create_reply(user(), root, %{body: "mid"})
+      {:ok, branch_a} = Posts.create_reply(user(), mid, %{body: "branch a"})
+      {:ok, branch_b} = Posts.create_reply(user(), mid, %{body: "branch b"})
+      {:ok, leaf} = Posts.create_reply(user(), branch_a, %{body: "leaf"})
+
+      expected = [root.id, mid.id, branch_a.id, branch_b.id, leaf.id]
+
+      for post <- [root, branch_b, leaf] do
+        assert %{posts: posts, truncated?: false} = Posts.list_thread(post, nil)
+        assert Enum.map(posts, & &1.id) == expected
+      end
+    end
+
+    test "a post with no replies is a one-post thread" do
+      post = create_post!(user(), %{body: "alone"})
+
+      assert %{posts: [%Post{id: id}], truncated?: false} = Posts.list_thread(post, nil)
+      assert id == post.id
+    end
+
+    test "excludes a moderation-frozen post mid-thread" do
+      root = create_post!(user(), %{body: "root"})
+      {:ok, frozen} = Posts.create_reply(user(), root, %{body: "to be frozen"})
+      {:ok, leaf} = Posts.create_reply(user(), frozen, %{body: "answer under the frozen one"})
+
+      Repo.update_all(from(p in Post, where: p.id == ^frozen.id),
+        set: [frozen_at: NaiveDateTime.utc_now(:second)]
+      )
+
+      assert %{posts: posts} = Posts.list_thread(leaf, user())
+      assert Enum.map(posts, & &1.id) == [root.id, leaf.id]
+    end
+
+    test "a deleted root degrades to the surviving chain plus direct replies" do
+      root = create_post!(user(), %{body: "root"})
+      {:ok, a} = Posts.create_reply(user(), root, %{body: "a"})
+      {:ok, b} = Posts.create_reply(user(), a, %{body: "b"})
+      {:ok, c} = Posts.create_reply(user(), b, %{body: "c"})
+
+      {:ok, _} = Posts.delete_post(root)
+
+      # Root deletion nilifies every root_post_id in the thread, so the whole
+      # conversation can no longer be fetched by root — but the permalink must
+      # still show at least the surviving ancestor chain and the direct replies.
+      assert %{posts: posts} = Posts.list_thread(Repo.preload(b, :reply_ref, force: true), nil)
+      assert Enum.map(posts, & &1.id) == [a.id, b.id, c.id]
+    end
+
+    test "caps the conversation but always keeps the permalinked post" do
+      root = create_post!(user(), %{body: "root"})
+      {:ok, r1} = Posts.create_reply(user(), root, %{body: "r1"})
+      {:ok, _r2} = Posts.create_reply(user(), root, %{body: "r2"})
+      {:ok, r3} = Posts.create_reply(user(), root, %{body: "r3"})
+
+      assert %{posts: posts, truncated?: true} = Posts.list_thread(r3, nil, limit: 2)
+
+      # The cap keeps the oldest posts; the permalinked post itself is always
+      # unioned back in so the page never loses its own subject.
+      assert Enum.map(posts, & &1.id) == [root.id, r1.id, r3.id]
+    end
+  end
+
   describe "visibility lock" do
     test "update_post/2 refuses audience changes while reposts exist" do
       author = user()

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -426,6 +426,31 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert rendered.txt =~ "Likes: 1"
   end
 
+  test "post permalink: the whole conversation reaches every format (issue #1006)", %{
+    user: user,
+    post: post
+  } do
+    {:ok, focus} = Vutuv.Posts.create_reply(user, post, %{"body" => "The conversation pivot."})
+    {:ok, nested} = Vutuv.Posts.create_reply(user, focus, %{"body" => "A deeper drift answer."})
+
+    rendered = formats_for("/drift_tester/posts/#{focus.id}")
+
+    # The HTML permalink shows the whole thread now, root above and the nested
+    # answer below — so every agent format must carry both.
+    for fact <- ["Suspension bridges are underrated.", "A deeper drift answer."],
+        do: assert_fact_everywhere(rendered, fact)
+
+    doc = Jason.decode!(rendered.json)
+    assert [root_entry, focus_entry, nested_entry] = doc["thread"]
+    assert root_entry["id"] == post.id
+    assert root_entry["in_reply_to_id"] == nil
+    assert focus_entry["id"] == focus.id
+    assert focus_entry["in_reply_to_id"] == post.id
+    assert nested_entry["id"] == nested.id
+    assert nested_entry["in_reply_to_id"] == focus.id
+    refute doc["thread_truncated"]
+  end
+
   test "post permalink: a book review's facts reach every format", %{user: user} do
     reviewed =
       create_post!(user, %{

--- a/test/vutuv_web/controllers/post_controller_test.exs
+++ b/test/vutuv_web/controllers/post_controller_test.exs
@@ -602,6 +602,60 @@ defmodule VutuvWeb.PostControllerTest do
       assert author_html =~ "/post_images/pendtok/feed.avif"
     end
 
+    test "a mid-thread reply's permalink renders the whole conversation (issue #1006)", %{
+      conn: conn
+    } do
+      author = insert_activated_user()
+      replier = insert_activated_user()
+      root = create_post!(author, %{body: "the conversation root"})
+      {:ok, focus} = Posts.create_reply(replier, root, %{body: "the focused answer"})
+      {:ok, _nested} = Posts.create_reply(author, focus, %{body: "a deeper answer"})
+      {:ok, _sibling} = Posts.create_reply(author, root, %{body: "a sibling branch"})
+
+      html = html_response(get(conn, Posts.path(focus)), 200)
+
+      # The whole thread is on the page: the root above, the deeper answer and
+      # the sibling branch below.
+      assert html =~ "the conversation root"
+      assert html =~ "the focused answer"
+      assert html =~ "a deeper answer"
+      assert html =~ "a sibling branch"
+
+      # The permalinked post is the highlighted anchor and, having context
+      # above it, marked for the arrival auto-scroll.
+      assert html =~ ~s(id="thread-focus")
+      assert html =~ "data-thread-scroll"
+
+      # The sibling branch answers the root, not the card right above it, so
+      # its own "Replying to" banner names the real parent.
+      assert html =~ "Replying to"
+    end
+
+    test "the root's permalink shows its thread without the auto-scroll marker", %{conn: conn} do
+      author = insert_activated_user()
+      root = create_post!(author, %{body: "root of it all"})
+
+      {:ok, _reply} =
+        Posts.create_reply(insert_activated_user(), root, %{body: "an answer below"})
+
+      html = html_response(get(conn, Posts.path(root)), 200)
+
+      assert html =~ "an answer below"
+      assert html =~ ~s(id="thread-focus")
+      # Nothing above the root, so no scroll jump on arrival.
+      refute html =~ "data-thread-scroll"
+    end
+
+    test "a post without replies renders standalone, no thread frame", %{conn: conn} do
+      post = create_post!(insert_activated_user(), %{body: "all alone here"})
+
+      html = html_response(get(conn, Posts.path(post)), 200)
+
+      assert html =~ "all alone here"
+      refute html =~ ~s(id="post-thread")
+      refute html =~ "thread-focus"
+    end
+
     test "redirects non-canonical URLs to the canonical form", %{conn: conn} do
       user = insert_activated_user()
       post = create_post!(user, %{body: "x"})
@@ -989,17 +1043,21 @@ defmodule VutuvWeb.PostControllerTest do
   end
 
   describe "the reply banner and thread" do
-    test "a reply's page shows the banner with the @handle, linking the parent", %{conn: conn} do
+    test "a reply's page shows the parent post itself above it, no redundant banner", %{
+      conn: conn
+    } do
       parent_author = insert_activated_user(first_name: "Petra", last_name: "Parent")
       parent = create_post!(parent_author, %{body: "original question"})
       {:ok, reply} = Posts.create_reply(insert_activated_user(), parent, %{body: "an answer"})
 
       html = conn |> get(Posts.path(reply)) |> html_response(200)
 
-      # The banner names the account handle, not the clear name.
-      assert html =~ "Replying to @#{parent_author.username}"
-      refute html =~ "Replying to Petra Parent"
+      # The conversation view (issue #1006) renders the parent post right
+      # above the reply, so the "Replying to" banner would state the obvious
+      # twice and stays off for a reply whose parent card sits directly above.
+      assert html =~ "original question"
       assert html =~ Posts.path(parent)
+      refute html =~ "Replying to @#{parent_author.username}"
     end
 
     test "after parent deletion the banner names the author's @handle and profile", %{conn: conn} do


### PR DESCRIPTION
Fixes #1006.

A post's permalink used to show only the post itself plus one level of direct replies, so following a long, branching conversation meant hopping from permalink to permalink. Now every permalink renders the whole thread the way the feed does: the root on top, every visible reply below in chronological order with connector lines, the permalinked post highlighted as a tinted full-mode card and auto-scrolled into view when it has context above it. A reply that does not answer the card directly above it keeps its "Replying to @handle" banner, which is how branch points stay readable in the linear chain.

Under the hood this builds on the `root_post_id` denormalization that #1010 introduced: `Posts.list_thread/3` fetches the root plus the whole thread in one indexed query (capped at 200, with a note when cut), and always unions the permalinked post, its surviving ancestor chain and its direct replies back in. That union doubles as the degraded floor once a deleted root has nilified the thread's root links.

The agent-format siblings mirror the page: `PostDoc` gains `thread` (each entry with its parent pointer) and `thread_truncated`, and the md/txt renderers replace the one-level Replies section with a Conversation section. The one-level `replies`/`reply_count` keys stay for API consumers. Posts without replies render exactly as before.

Tested: new context tests for `list_thread/3` (branching, frozen posts, deleted root, cap), controller tests for the conversation page, an extended agent-docs drift test, plus a browser smoke test (rendering, highlight, auto-scroll, live action bars, German render, md/txt/json/xml siblings).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01S56Mxazh7zDJfk7uEQgpPa