### PR TITLE
Render a conversation as the reply tree it is (#1027)

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -192,22 +192,36 @@ Replies to replies are allowed.
 **A post is rendered by one shared component everywhere**
 (`VutuvWeb.PostComponents`): `post_thread_entry/1` shows a reply as a **nested
 conversation** — the posts it answers are stacked **above** it as full cards
-(each keeping its own like/repost/bookmark bar), oldest-first, with a
-**connector line that runs from each avatar into the reply's avatar** (a
-vertical drop down the card, then an elbow curving into the next avatar) and
-every reply **indented one step further right** under the post it answers, so
-the thread of a whole multi-post, multi-author conversation reads at a glance,
-instead of the feed's old flat "Replying to @handle" text banner.
+(each keeping its own like/repost/bookmark bar), with a **connector line that
+runs from each avatar into the avatars of the replies it got** (a vertical drop
+down the card, then an elbow curving into the next avatar) and every reply
+**indented one step further right** under the post it answers, so the thread of
+a whole multi-post, multi-author conversation reads at a glance, instead of the
+feed's old flat "Replying to @handle" text banner.
+
+**A conversation is a tree, not a timeline** (issue #1027).
+`Vutuv.Posts.thread_forest/1` nests the visible posts by their parent pointer
+(roots and siblings oldest first) and `thread_order/1` is its depth-first walk —
+the reading order every surface uses. Rendering a branching thread flat and
+chronologically put a reply written hours after a busy branch point under a
+stranger's post, where it read as answering that one. A post answered twice
+therefore branches: the spine keeps running past the first answer's whole
+subtree down into the next, and only the last sibling closes it with the
+rounded elbow.
 
 Indentation is capped at 2 levels (`@thread_indent_cap`) so a deep thread can't
 scroll a phone sideways; past the cap replies stay in the same column and the
-connector is a straight vertical drop.
+connector is a straight vertical drop. There the nesting can no longer say who
+answered whom, so the "Replying to @handle" banner comes back for every card
+that is *not* the first answer under its parent (`reply_banner?/4`) — a forest
+root, whose parent is off the page, keeps it at any depth.
 
 On the feed and the profile Posts section `Vutuv.Posts.collapse_threads/1` folds
 each visible chain: it drops the ancestors' own standalone rows (so a middle
-post is no longer shown twice) and hands each surviving leaf its ordered
-`:ancestors`, so however many posts or authors a thread spans it renders once;
-the archive and saved lists fall back to nesting the single direct parent.
+post is no longer shown twice) and hands each surviving leaf its
+`:ancestors`, which the component nests into the same tree, so however many
+posts, authors or branches a thread spans it renders once; the archive and saved
+lists fall back to nesting the single direct parent.
 
 All read the same (each a single card of flat `divide-y` rows).
 
@@ -216,22 +230,21 @@ like/reply quotes.
 
 **The permalink page renders the whole conversation** (issue #1006):
 `Vutuv.Posts.list_thread/3` fetches the thread's root plus every visible post
-of the thread in one `root_post_id` lookup, oldest first (capped at 200 with a
-"conversation is longer" note; the permalinked post, its surviving ancestor
-chain and its direct replies are always unioned back in, which is also the
-degraded floor once a deleted root has nilified the thread's root links), and
-`PostComponents.thread_conversation/1` renders it as one feed-style chain. The
-permalinked post is the tinted `:full`-mode card (`#thread-focus`; an
-absolutely positioned `::before` so the connector geometry is untouched) and,
-when it has context above, app.js scrolls it into view on arrival
-(`data-thread-scroll`). The chain is chronological, not a tree, so a reply
-that does not answer the card directly above it keeps its own "Replying to
-@handle" banner — that is how branch points read. A post with no thread
-renders standalone exactly as before. The action bar carries a live reply
-counter, and the parent's author gets a derived "replied to your post"
-notification (self-replies excluded). The agent-format siblings mirror the
-page: `PostDoc` carries the conversation as `thread` (each entry with its
-parent pointer), the md/txt renderers as a "Conversation" section.
+of the thread in one `root_post_id` lookup (capped at 200 with a "conversation
+is longer" note; the permalinked post, its surviving ancestor chain and its
+direct replies are always unioned back in, which is also the degraded floor
+once a deleted root has nilified the thread's root links), returns them in
+`thread_order/1` reading order, and `PostComponents.thread_conversation/1`
+renders it as one feed-style conversation. The permalinked post is the tinted
+`:full`-mode card (`#thread-focus`; an absolutely positioned `::before` so the
+connector geometry is untouched) and, when it has context above, app.js scrolls
+it into view on arrival (`data-thread-scroll`). A post with no thread renders
+standalone exactly as before. The action bar carries a live reply counter, and
+the parent's author gets a derived "replied to your post" notification
+(self-replies excluded). The agent-format siblings mirror the page: `PostDoc`
+carries the conversation as `thread` in the same reading order (each entry with
+its parent pointer **and** its nesting `depth`), which the md renderer turns
+into a heading level per step and the txt renderer into two spaces per step.
 
 A reply **outlives its parent**: where the parent is gone the card falls back to
 a banner (which names the account as `@handle`, never the clear name) that

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1819,9 +1819,10 @@ defmodule Vutuv.Posts do
 
   @doc """
   The whole conversation `post` belongs to, as `viewer` sees it: the thread's
-  root plus every visible post of the thread, oldest first — what the
-  permalink page renders (issue #1006). Fetched in one indexed query over the
-  denormalized `post_replies.root_post_id`.
+  root plus every visible post of the thread, in reading order (`thread_order/1`
+  — the reply tree walked depth-first, so every reply follows the post it
+  answers) — what the permalink page renders (issue #1006). Fetched in one
+  indexed query over the denormalized `post_replies.root_post_id`.
 
   Returns `%{posts:, truncated?:}`; `truncated?` says the `:limit` cap
   (default #{@default_conversation_limit}) cut the newest tail. The
@@ -1850,11 +1851,64 @@ defmodule Vutuv.Posts do
     posts =
       (Enum.take(scoped, limit) ++ up ++ [post] ++ list_replies(post, viewer))
       |> Enum.uniq_by(& &1.id)
-      |> Enum.sort_by(&{NaiveDateTime.to_erl(&1.inserted_at), &1.id})
       |> Repo.preload(post_preloads())
+      |> thread_order()
 
     %{posts: posts, truncated?: truncated?}
   end
+
+  @doc """
+  The reply tree `entries` really form: a forest of those same maps (anything
+  carrying a `:post`), each gaining a `:children` list of the entries that
+  answer it. Roots — a top-level post, or a reply whose parent is not among the
+  entries — and siblings come oldest first, so a walk reads as the conversation
+  happened.
+
+  A thread **branches**: one post can be answered many times, and an answer
+  written hours later is not an answer to whatever was posted last. Rendering
+  the conversation as a flat chronological list therefore put replies under
+  strangers' posts (issue #1027). The permalink page and the feed both nest
+  from this, so a reply always sits under its own parent.
+  """
+  def thread_forest(entries) do
+    present = MapSet.new(entries, & &1.post.id)
+
+    {roots, answers} =
+      entries
+      |> Enum.sort_by(&{NaiveDateTime.to_erl(&1.post.inserted_at), &1.post.id})
+      |> Enum.split_with(fn %{post: post} ->
+        parent_id = preloaded_parent_id(post)
+        is_nil(parent_id) or not MapSet.member?(present, parent_id)
+      end)
+
+    by_parent = Enum.group_by(answers, &preloaded_parent_id(&1.post))
+
+    Enum.map(roots, &subtree(&1, by_parent))
+  end
+
+  # A reply is always newer than the post it answers, so the parent links form
+  # a forest and can never cycle — the walk terminates.
+  defp subtree(entry, by_parent) do
+    children = by_parent |> Map.get(entry.post.id, []) |> Enum.map(&subtree(&1, by_parent))
+    Map.put(entry, :children, children)
+  end
+
+  @doc """
+  `posts` in reading order: `thread_forest/1` walked depth-first, so every
+  reply directly follows the post it answers and a branch's answers stay
+  together instead of being interleaved by the clock.
+  """
+  def thread_order(posts) do
+    posts |> Enum.map(&%{post: &1}) |> thread_forest() |> flatten_forest()
+  end
+
+  defp flatten_forest(nodes), do: Enum.flat_map(nodes, &[&1.post | flatten_forest(&1.children)])
+
+  # The id of the post a reply answers, straight off the preloaded `reply_ref`
+  # (an un-preloaded one is a truthy %NotLoaded{}, hence the struct match) —
+  # no query, unlike its `reply_parent_id/1` namesake further down.
+  defp preloaded_parent_id(%Post{reply_ref: %PostReply{parent_post_id: id}}), do: id
+  defp preloaded_parent_id(_post), do: nil
 
   # Where the conversation is anchored: the denormalized root for a normal
   # reply, the post itself for a top-level post. A degraded reply (root

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -903,13 +903,19 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   @doc false
   def image_url(image), do: image.urls[:feed] || image.urls |> Map.values() |> List.first()
 
+  # A reply is a subsection of the post it answers, so the entry's heading level
+  # carries its nesting depth (`###` at the top of the thread, one `#` deeper
+  # per level, floored at Markdown's `######`) — the document form of the
+  # indentation the HTML page draws.
   defp thread_block(entry) do
     reply_to =
       entry.in_reply_to_author &&
         "> " <> gettext("In reply to a post by %{name}.", name: entry.in_reply_to_author)
 
+    heading = String.duplicate("#", min(3 + entry.depth, 6))
+
     [
-      "### [#{md_text(entry.author)}](#{entry.url}) · #{entry.published_on}",
+      "#{heading} [#{md_text(entry.author)}](#{entry.url}) · #{entry.published_on}",
       reply_to,
       entry.body_markdown
     ]

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -62,10 +62,11 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # a second query and can never drift from the list.)
       reply_count: length(replies),
       replies: Enum.map(replies, &reply_entry/1),
-      # The whole conversation the HTML permalink renders (issue #1006),
-      # oldest first; every entry carries its parent pointer so the tree is
-      # recoverable. `replies` above stays the one-level list for API
-      # consumers that relied on it.
+      # The whole conversation the HTML permalink renders (issue #1006), in
+      # the same reading order (the reply tree depth-first, issue #1027);
+      # every entry carries its parent pointer and its nesting depth, so the
+      # tree is recoverable without re-deriving it. `replies` above stays the
+      # one-level list for API consumers that relied on it.
       thread: thread_entries(thread),
       thread_truncated: thread_truncated?,
       # The public engagement counters the HTML action bar shows to everyone.
@@ -121,11 +122,15 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     }
   end
 
-  # The conversation entries, oldest first. `in_reply_to_author` resolves only
-  # inside the thread (a deleted or invisible parent stays nil), so the
-  # markdown/text renderers can name a branch's parent without another lookup.
+  # The conversation entries, in `Posts.list_thread/3` reading order.
+  # `in_reply_to_author` resolves only inside the thread (a deleted or
+  # invisible parent stays nil), so the markdown/text renderers can name a
+  # branch's parent without another lookup, and `depth` is how deep the entry
+  # hangs in the thread — the nesting the HTML page draws, as a number the
+  # other formats can indent by.
   defp thread_entries(posts) do
     authors = Map.new(posts, &{&1.id, UserHelpers.full_name(&1.user)})
+    depths = thread_depths(posts)
 
     Enum.map(posts, fn post ->
       parent_id = post.reply_ref && post.reply_ref.parent_post_id
@@ -137,9 +142,20 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
         author_username: post.user.username,
         published_on: post.published_on,
         body_markdown: post.body,
+        depth: depths[post.id],
         in_reply_to_id: parent_id,
         in_reply_to_author: parent_id && authors[parent_id]
       }
+    end)
+  end
+
+  # One pass suffices: reading order puts every post after the one it answers,
+  # so its parent's depth is already known. A post whose parent is not in the
+  # thread (the root, or a chain broken by a deletion) starts at 0.
+  defp thread_depths(posts) do
+    Enum.reduce(posts, %{}, fn post, depths ->
+      parent_id = post.reply_ref && post.reply_ref.parent_post_id
+      Map.put(depths, post.id, (parent_id && depths[parent_id] && depths[parent_id] + 1) || 0)
     end)
   end
 

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -597,22 +597,31 @@ defmodule VutuvWeb.AgentDocs.Text do
     "* #{alt}\n  #{Markdown.image_url(image)}"
   end
 
+  # How deep a thread entry still indents. Past this the entries stay in one
+  # column (the plain-text twin of the HTML indent cap), so a long back-and-forth
+  # does not push its bodies off an 80-column terminal.
+  @thread_indent_cap 4
+
   defp thread_lines(entry) do
+    pad = String.duplicate("  ", min(entry.depth, @thread_indent_cap))
+
     reply_to =
       if entry.in_reply_to_author,
         do:
-          "  " <>
+          pad <>
+            "  " <>
             gettext("In reply to a post by %{name}.", name: entry.in_reply_to_author) <> "\n",
         else: ""
 
-    "* #{entry.author} · #{entry.published_on} · #{entry.url}\n" <>
-      reply_to <> indent_block(entry.body_markdown)
+    pad <>
+      "* #{entry.author} · #{entry.published_on} · #{entry.url}\n" <>
+      reply_to <> indent_block(entry.body_markdown, pad <> "  ")
   end
 
-  defp indent_block(text) do
+  defp indent_block(text, pad) do
     text
     |> String.split("\n")
-    |> Enum.map_join("\n", &("  " <> &1))
+    |> Enum.map_join("\n", &(pad <> &1))
   end
 
   defp section(_title, []), do: nil

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -31,7 +31,6 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Posts
   alias Vutuv.Posts.PostImage
-  alias Vutuv.Posts.PostReply
   alias Vutuv.Posts.PostReview
   alias Vutuv.Posts.PostScreenshot
   alias Vutuv.ReviewCover
@@ -491,7 +490,7 @@ defmodule VutuvWeb.PostComponents do
     # not fall back; only a missing (nil) list falls back to the one-level parent.
     ancestors = assigns.ancestors || one_level_ancestors(assigns.post, assigns.nest_parent)
     assigns = assign(assigns, :ancestors, ancestors)
-    assigns = assign(assigns, :chain, thread_chain_items(assigns))
+    assigns = assign(assigns, :roots, thread_entry_roots(assigns))
 
     ~H"""
     <%= if @ancestors == [] do %>
@@ -509,12 +508,12 @@ defmodule VutuvWeb.PostComponents do
       />
     <% else %>
       <%!-- The reply and the posts it answers, as one conversation: each is a
-      full post card (its own like / repost / bookmark bar), oldest-first, and
-      every reply is nested one step further right under the post it answers —
-      a left-rail, left-padded block per level — so the reply depth reads at a
-      glance the way a threaded comment tree does. --%>
+      full post card (its own like / repost / bookmark bar), and every reply is
+      nested one step further right under the post it answers — a left-rail,
+      left-padded block per level — so the reply depth reads at a glance the way
+      a threaded comment tree does. --%>
       <.thread_chain
-        chain={@chain}
+        nodes={@roots}
         viewer={@viewer}
         surface={@surface}
         conn_or_socket={@conn_or_socket}
@@ -523,12 +522,13 @@ defmodule VutuvWeb.PostComponents do
     """
   end
 
-  # The ordered card specs for a threaded conversation: the ancestors (oldest
-  # first, banners off, engagement from the batched map) followed by the leaf
-  # (which keeps its own follow edge, repost line and engagement). Each ancestor's
-  # `entry_id` is derived from the leaf entry so DOM ids stay unique even when the
-  # same post is nested under more than one reply on the page.
-  defp thread_chain_items(assigns) do
+  # The card specs for a threaded conversation, nested into the reply tree they
+  # really form (`Vutuv.Posts.thread_forest/1`): the ancestors (engagement from
+  # the batched map) plus the leaf (which keeps its own follow edge, repost line
+  # and engagement). Each ancestor's `entry_id` is derived from the leaf entry so
+  # DOM ids stay unique even when the same post is nested under more than one
+  # reply on the page.
+  defp thread_entry_roots(assigns) do
     leaf_key = assigns.entry_id || assigns.post.id
 
     ancestors =
@@ -543,18 +543,23 @@ defmodule VutuvWeb.PostComponents do
         }
       end)
 
-    ancestors ++
-      [
-        %{
-          post: assigns.post,
-          engagement: assigns.engagement,
-          viewer_follow: assigns.viewer_follow,
-          reposted_by: assigns.reposted_by,
-          reposters: assigns.reposters,
-          entry_id: assigns.entry_id
-        }
-      ]
+    leaf = %{
+      post: assigns.post,
+      engagement: assigns.engagement,
+      viewer_follow: assigns.viewer_follow,
+      reposted_by: assigns.reposted_by,
+      reposters: assigns.reposters,
+      entry_id: assigns.entry_id
+    }
+
+    (ancestors ++ [leaf]) |> Posts.thread_forest() |> banner_on_roots()
   end
+
+  # A card that hangs under the post it answers needs no "Replying to @handle"
+  # banner — the nesting already says it. A forest root is the other case: its
+  # parent is off the page (or gone), so it keeps the banner naming the author
+  # it answers.
+  defp banner_on_roots(roots), do: Enum.map(roots, &Map.put(&1, :show_reply_banner, true))
 
   # How many levels of a thread visibly indent before the indentation is capped.
   # Beyond this, deeper replies keep stacking in the same column (the connector
@@ -564,112 +569,168 @@ defmodule VutuvWeb.PostComponents do
   # on-screen; letting the indent grow unbounded scrolled a deep thread sideways.
   @thread_indent_cap 2
 
-  # Renders a reply chain as a threaded conversation with a **connector line that
-  # runs from each avatar into the reply's avatar** (like a mail/forum thread):
-  # a vertical drop from the head avatar down its card, then — in the indented
-  # block holding the reply — an elbow that curves from that column into the
-  # reply's avatar. Each reply is indented one `pl-7` step under the post it
-  # answers until the indent is capped (see above), past which replies stay in
-  # the same column and the connector is a straight vertical drop. Recursion draws
-  # the same connector at every level, so the line threads avatar-to-avatar all
-  # the way down. The avatar centre is `1.125rem` in from the card's left (the
-  # `sm` avatar), which is why the connectors sit at `left-[1.125rem]`.
-  attr(:chain, :list, required: true)
+  # Renders a conversation **tree** with a **connector line that runs from each
+  # avatar into the avatars of the replies it got** (like a mail/forum thread):
+  # a vertical drop from a card's avatar down past everything that answers it,
+  # then — in the block holding each answer — an elbow curving from that column
+  # into the answer's avatar. Every reply is indented one `pl-7` step under the
+  # post it answers until the indent is capped (see above), past which replies
+  # stay in the same column and the connector is a straight vertical drop.
+  # The avatar centre is `1.125rem` in from the card's left (the `sm` avatar),
+  # which is why the connectors sit at `left-[1.125rem]`.
+  #
+  # `nodes` are siblings — the conversation's roots at depth 0, one post's
+  # answers below that (`Vutuv.Posts.thread_forest/1`), each carrying its own
+  # `:children`. A post answered **twice** therefore branches: the spine keeps
+  # running past the first answer's whole subtree down into the next one, and
+  # only the last sibling closes it with the rounded elbow. Before this the
+  # chain was flat and chronological, so a reply written after a busy branch
+  # point rendered under a post it had nothing to do with (issue #1027).
+  attr(:nodes, :list, required: true)
   attr(:depth, :integer, default: 0)
   attr(:viewer, :any, default: nil)
   attr(:surface, :atom, required: true)
   attr(:conn_or_socket, :any, required: true)
 
+  attr(:connected?, :boolean,
+    default: false,
+    doc: "these nodes answer a card above them, so each draws its connector back into its column"
+  )
+
   defp thread_chain(assigns) do
     # `@thread_indent_cap` is a module attribute, not an assign, so resolve the
     # "still indenting?" flag here — inside ~H, `@name` would mean assigns.name.
-    assigns = assign(assigns, :indent?, assigns.depth < @thread_indent_cap)
+    assigns =
+      assigns
+      |> assign(:indent?, assigns.depth <= @thread_indent_cap)
+      |> assign(:nodes, mark_last(assigns.nodes))
 
     ~H"""
-    <%= case @chain do %>
-      <% [item | rest] -> %>
-        <div
-          id={Map.get(item, :focus?) && "thread-focus"}
-          data-thread-scroll={Map.get(item, :scroll?)}
-          class={[
-            "relative",
-            # The permalink's highlighted subject (issue #1006): the tint is an
-            # absolutely positioned ::before so the chain's connector geometry
-            # (avatar columns, elbows) is untouched; z-0 opens a stacking
-            # context so -z-10 stays in front of the page card's background.
-            Map.get(item, :focus?) &&
-              "z-0 scroll-mt-24 before:absolute before:-inset-x-3 before:-inset-y-2 before:-z-10 before:rounded-xl before:bg-brand-50/70 before:ring-1 before:ring-brand-200 before:content-[''] dark:before:bg-brand-900/20 dark:before:ring-brand-800"
-          ]}
+    <div
+      :for={{node, first?, last?} <- @nodes}
+      class={[
+        @connected? && "relative pt-3",
+        @connected? && @indent? && "pl-7",
+        # Separate roots: unrelated conversations (a thread whose links a
+        # deleted post broke), so they get air instead of a connector.
+        !@connected? && !first? && "mt-4"
+      ]}
+    >
+      <%!-- The connector into this answer's avatar, drawn in the column of the
+      card it answers (left-[1.125rem] of this block, which the pl-7 does not
+      move). The last answer closes the spine with an elbow curving into its
+      avatar's left edge at the avatar's vertical centre (pt-3 + 1.125rem =
+      1.875rem down); an earlier answer instead lets the spine run the full
+      height of its subtree — down to the next sibling — and taps into its own
+      avatar with a short horizontal tick at that same 1.875rem. Capped depth
+      puts the answer in the same column as its parent, so the connector is a
+      straight vertical drop through the padding. --%>
+      <span
+        :if={@connected? && @indent? && last?}
+        class="absolute left-[1.125rem] top-0 h-[1.875rem] w-2.5 rounded-bl-xl border-b-2 border-l-2 border-slate-200 dark:border-slate-700"
+        aria-hidden="true"
+      >
+      </span>
+      <span
+        :if={@connected? && @indent? && !last?}
+        class="absolute left-[1.125rem] top-0 h-full w-0.5 rounded-full bg-slate-200 dark:bg-slate-700"
+        aria-hidden="true"
+      >
+      </span>
+      <span
+        :if={@connected? && @indent? && !last?}
+        class="absolute left-[1.125rem] top-[1.875rem] h-0.5 w-2.5 rounded-full bg-slate-200 dark:bg-slate-700"
+        aria-hidden="true"
+      >
+      </span>
+      <span
+        :if={@connected? && !@indent?}
+        class="absolute left-[1.125rem] top-0 h-3 w-0.5 rounded-full bg-slate-200 dark:bg-slate-700"
+        aria-hidden="true"
+      >
+      </span>
+      <div
+        id={Map.get(node, :focus?) && "thread-focus"}
+        data-thread-scroll={Map.get(node, :scroll?)}
+        class={[
+          "relative",
+          # The permalink's highlighted subject (issue #1006): the tint is an
+          # absolutely positioned ::before so the chain's connector geometry
+          # (avatar columns, elbows) is untouched; z-0 opens a stacking
+          # context so -z-10 stays in front of the page card's background.
+          Map.get(node, :focus?) &&
+            "z-0 scroll-mt-24 before:absolute before:-inset-x-3 before:-inset-y-2 before:-z-10 before:rounded-xl before:bg-brand-50/70 before:ring-1 before:ring-brand-200 before:content-[''] dark:before:bg-brand-900/20 dark:before:ring-brand-800"
+        ]}
+      >
+        <%!-- Drops from this avatar's bottom (top-9) to the card's bottom; the
+        elbow below continues it into the answer's avatar. Only when this card
+        was answered. Height is an explicit `calc(100% - top)`, not `top-9` +
+        `bottom-0`: an empty absolutely-positioned box sized only by
+        `top`/`bottom` (auto height) collapses to zero on iOS/mobile Safari, so
+        the whole thread line vanished on phones while the explicit-height
+        elbows survived. An explicit height renders identically everywhere. --%>
+        <span
+          :if={node.children != []}
+          class="absolute left-[1.125rem] top-9 h-[calc(100%-2.25rem)] w-0.5 rounded-full bg-slate-200 dark:bg-slate-700"
+          aria-hidden="true"
         >
-          <%!-- Drops from this avatar's bottom (top-9) to the card's bottom; the
-          elbow below continues it into the reply's avatar. Only when a reply
-          follows this card. Height is an explicit `calc(100% - top)`, not
-          `top-9` + `bottom-0`: an empty absolutely-positioned box sized only by
-          `top`/`bottom` (auto height) collapses to zero on iOS/mobile Safari, so
-          the whole thread line vanished on phones while the explicit-height
-          elbows survived. An explicit height renders identically everywhere. --%>
-          <span
-            :if={rest != []}
-            class="absolute left-[1.125rem] top-9 h-[calc(100%-2.25rem)] w-0.5 rounded-full bg-slate-200 dark:bg-slate-700"
-            aria-hidden="true"
-          >
-          </span>
-          <.post_card
-            post={item.post}
-            viewer={@viewer}
-            viewer_follow={item.viewer_follow}
-            engagement={item.engagement}
-            reposted_by={item.reposted_by}
-            reposters={item.reposters}
-            entry_id={item.entry_id}
-            surface={@surface}
-            conn_or_socket={@conn_or_socket}
-            mode={Map.get(item, :mode, :preview)}
-            show_reply_banner={Map.get(item, :show_reply_banner, false)}
-          />
-        </div>
-        <div :if={rest != []} class={["relative pt-3", @indent? && "pl-7"]}>
-          <%!-- The connector into the reply's avatar. Indented: an elbow curving
-          from the parent column (left-[1.125rem]) right into the reply avatar's
-          left edge, at the reply avatar's vertical centre (pt-3 + 1.125rem =
-          1.875rem down). Capped: the reply is in the same column, so a straight
-          vertical drop to its avatar. --%>
-          <span
-            :if={@indent?}
-            class="absolute left-[1.125rem] top-0 h-[1.875rem] w-2.5 rounded-bl-xl border-b-2 border-l-2 border-slate-200 dark:border-slate-700"
-            aria-hidden="true"
-          >
-          </span>
-          <span
-            :if={!@indent?}
-            class="absolute left-[1.125rem] top-0 h-3 w-0.5 rounded-full bg-slate-200 dark:bg-slate-700"
-            aria-hidden="true"
-          >
-          </span>
-          <.thread_chain
-            chain={rest}
-            depth={@depth + 1}
-            viewer={@viewer}
-            surface={@surface}
-            conn_or_socket={@conn_or_socket}
-          />
-        </div>
-      <% [] -> %>
-    <% end %>
+        </span>
+        <.post_card
+          post={node.post}
+          viewer={@viewer}
+          viewer_follow={node.viewer_follow}
+          engagement={node.engagement}
+          reposted_by={node.reposted_by}
+          reposters={node.reposters}
+          entry_id={node.entry_id}
+          surface={@surface}
+          conn_or_socket={@conn_or_socket}
+          mode={Map.get(node, :mode, :preview)}
+          show_reply_banner={reply_banner?(node, @connected?, @indent?, first?)}
+        />
+      </div>
+      <.thread_chain
+        :if={node.children != []}
+        nodes={node.children}
+        depth={@depth + 1}
+        connected?={true}
+        viewer={@viewer}
+        surface={@surface}
+        conn_or_socket={@conn_or_socket}
+      />
+    </div>
     """
+  end
+
+  # A card names the post it answers only when its position alone does not say
+  # it. While the thread still indents, the nesting says it. Past
+  # @thread_indent_cap every card shares its parent's column, so only the
+  # *first* answer — the one rendered directly below its parent — reads
+  # unambiguously and every later sibling (which follows the previous branch's
+  # whole subtree) gets its banner back. A forest root keeps it either way: its
+  # parent is off the page.
+  defp reply_banner?(node, connected?, indent?, first?) do
+    Map.get(node, :show_reply_banner, false) or (connected? and not indent? and not first?)
+  end
+
+  # Each node paired with whether it is the first and the last of its siblings —
+  # what the connector geometry above branches on.
+  defp mark_last(nodes) do
+    last = length(nodes) - 1
+    Enum.with_index(nodes, fn node, i -> {node, i == 0, i == last} end)
   end
 
   @doc """
   The permalink page's whole-conversation rendering (issue #1006): every post
-  of `posts` (the thread oldest first, `Vutuv.Posts.list_thread/3`) as one
-  connected chain — the same look as a feed thread row. The permalinked
+  of `posts` (the thread in reading order, `Vutuv.Posts.list_thread/3`) as one
+  connected conversation — the same look as a feed thread row. The permalinked
   `focus_id` post renders in `:full` mode, tinted as the page's subject and,
   when it has context above it, marked for the arrival auto-scroll
-  (`data-thread-scroll`, wired in app.js). The chain is chronological, not a
-  tree, so a reply that does not answer the card right above it keeps its own
-  "Replying to @handle" banner — that is how a branch point stays readable.
+  (`data-thread-scroll`, wired in app.js). Every reply hangs under the post it
+  actually answers (`Vutuv.Posts.thread_forest/1`), so only a card whose parent
+  is off the page keeps its own "Replying to @handle" banner.
   """
-  attr(:posts, :list, required: true, doc: "the whole conversation, oldest first")
+  attr(:posts, :list, required: true, doc: "the whole conversation, in reading order")
   attr(:focus_id, :string, required: true, doc: "the permalinked post's id")
   attr(:viewer, :any, default: nil)
 
@@ -683,17 +744,21 @@ defmodule VutuvWeb.PostComponents do
   attr(:conn_or_socket, :any, required: true)
 
   def thread_conversation(assigns) do
-    assigns = assign(assigns, :chain, conversation_chain(assigns))
+    assigns = assign(assigns, :roots, conversation_roots(assigns))
 
     ~H"""
-    <.thread_chain chain={@chain} viewer={@viewer} surface={:flat} conn_or_socket={@conn_or_socket} />
+    <.thread_chain nodes={@roots} viewer={@viewer} surface={:flat} conn_or_socket={@conn_or_socket} />
     """
   end
 
-  defp conversation_chain(%{posts: posts} = assigns) do
-    [nil | posts]
-    |> Enum.zip(posts)
-    |> Enum.map(fn {prev, post} ->
+  defp conversation_roots(%{posts: posts} = assigns) do
+    # `posts` is already in reading order, so the head is the card that renders
+    # first — the one case where the focused post has no context above it and
+    # the page must not jump on arrival.
+    top_id = with %{id: id} <- List.first(posts), do: id
+
+    posts
+    |> Enum.map(fn post ->
       focus? = post.id == assigns.focus_id
 
       %{
@@ -705,17 +770,12 @@ defmodule VutuvWeb.PostComponents do
         entry_id: nil,
         mode: if(focus?, do: :full, else: :preview),
         focus?: focus?,
-        scroll?: focus? and prev != nil,
-        # A branch point: this reply does not answer the card right above it,
-        # so its own banner must name the real parent. The first card keeps
-        # its banner too — a degraded chain top is itself a reply.
-        show_reply_banner: prev == nil or thread_parent_id(post) != prev.id
+        scroll?: focus? and post.id != top_id
       }
     end)
+    |> Posts.thread_forest()
+    |> banner_on_roots()
   end
-
-  defp thread_parent_id(%{reply_ref: %PostReply{parent_post_id: id}}), do: id
-  defp thread_parent_id(_post), do: nil
 
   # Fallback when a caller does not compute the full visible chain: the single
   # preloaded `reply_ref` parent (one level), or none when nesting is off (the

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.138.0",
+      version: "7.138.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -14,6 +14,10 @@ defmodule Vutuv.PostsTest do
   # the default test user is.
   defp user(attrs \\ []), do: insert(:activated_user, attrs)
 
+  # `thread_forest/1` reads each post's preloaded `reply_ref`; the structs the
+  # create helpers hand back don't carry one.
+  defp reload(%Post{} = post), do: Repo.preload(post, :reply_ref, force: true)
+
   # Timeline ordering ties at second precision; shift a post into the past so
   # order assertions stay deterministic.
   defp backdate_post!(post, seconds) do
@@ -1927,20 +1931,36 @@ defmodule Vutuv.PostsTest do
 
   describe "list_thread/3" do
     # The permalink page renders the whole conversation (issue #1006): the
-    # thread's root plus every visible reply, oldest first, from ANY post in it.
-    test "returns the whole conversation oldest-first from any post in it" do
+    # thread's root plus every visible reply, in reading order (the reply tree
+    # walked depth-first), from ANY post in it.
+    test "returns the whole conversation in reading order from any post in it" do
       root = create_post!(user(), %{body: "thread root"})
       {:ok, mid} = Posts.create_reply(user(), root, %{body: "mid"})
       {:ok, branch_a} = Posts.create_reply(user(), mid, %{body: "branch a"})
       {:ok, branch_b} = Posts.create_reply(user(), mid, %{body: "branch b"})
       {:ok, leaf} = Posts.create_reply(user(), branch_a, %{body: "leaf"})
 
-      expected = [root.id, mid.id, branch_a.id, branch_b.id, leaf.id]
+      # branch_a's own answer follows branch_a, ahead of the older sibling
+      # branch_b — a conversation is a tree, not a timeline.
+      expected = [root.id, mid.id, branch_a.id, leaf.id, branch_b.id]
 
       for post <- [root, branch_b, leaf] do
         assert %{posts: posts, truncated?: false} = Posts.list_thread(post, nil)
         assert Enum.map(posts, & &1.id) == expected
       end
+    end
+
+    # The production bug behind this: a reply written hours after a busy branch
+    # point landed at the bottom of a chronological list, so the card above it
+    # was a stranger's post and it read as answering that one.
+    test "a reply follows the post it answers, not the newest post before it" do
+      root = create_post!(user(), %{body: "root"})
+      {:ok, early} = Posts.create_reply(user(), root, %{body: "early branch"})
+      {:ok, other} = Posts.create_reply(user(), root, %{body: "other branch"})
+      {:ok, late} = Posts.create_reply(user(), early, %{body: "the late answer"})
+
+      assert %{posts: posts} = Posts.list_thread(late, nil)
+      assert Enum.map(posts, & &1.id) == [root.id, early.id, late.id, other.id]
     end
 
     test "a post with no replies is a one-post thread" do
@@ -1989,6 +2009,42 @@ defmodule Vutuv.PostsTest do
       # The cap keeps the oldest posts; the permalinked post itself is always
       # unioned back in so the page never loses its own subject.
       assert Enum.map(posts, & &1.id) == [root.id, r1.id, r3.id]
+    end
+  end
+
+  describe "thread_forest/1" do
+    test "nests every entry under the entry it answers, siblings oldest first" do
+      root = create_post!(user(), %{body: "root"})
+      {:ok, first} = Posts.create_reply(user(), root, %{body: "first branch"})
+      {:ok, second} = Posts.create_reply(user(), root, %{body: "second branch"})
+      {:ok, deep} = Posts.create_reply(user(), first, %{body: "under the first"})
+
+      entries = for post <- Enum.shuffle([root, first, second, deep]), do: %{post: reload(post)}
+
+      assert [%{post: %Post{id: root_id}, children: children}] = Posts.thread_forest(entries)
+      assert root_id == root.id
+
+      assert [
+               %{
+                 post: %Post{id: first_id},
+                 children: [%{post: %Post{id: deep_id}, children: []}]
+               },
+               %{post: %Post{id: second_id}, children: []}
+             ] = children
+
+      assert [first_id, deep_id, second_id] == [first.id, deep.id, second.id]
+    end
+
+    test "an entry whose parent is not present becomes its own root" do
+      root = create_post!(user(), %{body: "root"})
+      {:ok, orphan} = Posts.create_reply(user(), root, %{body: "parent is off the page"})
+
+      # Only the reply is present (the feed page it renders on never loaded the
+      # parent), so it heads its own tree instead of vanishing.
+      assert [%{post: %Post{id: id}, children: []}] =
+               Posts.thread_forest([%{post: reload(orphan)}])
+
+      assert id == orphan.id
     end
   end
 

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -449,6 +449,38 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert nested_entry["id"] == nested.id
     assert nested_entry["in_reply_to_id"] == focus.id
     refute doc["thread_truncated"]
+
+    # Each entry also carries how deep it hangs, so a reader gets the tree
+    # without walking the parent pointers itself.
+    assert [0, 1, 2] == Enum.map(doc["thread"], & &1["depth"])
+
+    # And the depth is what the human-readable formats indent by: a heading
+    # level per step in Markdown, two spaces per step in plain text.
+    author = nested_entry["author"]
+    assert rendered.md =~ "##### [#{author}]"
+    assert rendered.txt =~ "\n    * #{author} ·"
+  end
+
+  # A thread branches, and the branch has to survive into the agent formats the
+  # same way it does on the page: depth-first, so a reply follows the post it
+  # answers rather than whatever was written last (issue #1027).
+  test "post permalink: a branching conversation reaches every format in reading order", %{
+    user: user,
+    post: post
+  } do
+    {:ok, alpha} = Vutuv.Posts.create_reply(user, post, %{"body" => "The alpha drift branch."})
+    {:ok, beta} = Vutuv.Posts.create_reply(user, post, %{"body" => "The beta drift branch."})
+    {:ok, late} = Vutuv.Posts.create_reply(user, alpha, %{"body" => "The late drift answer."})
+
+    rendered = formats_for("/drift_tester/posts/#{late.id}")
+
+    for fact <- ["The alpha drift branch.", "The beta drift branch.", "The late drift answer."],
+        do: assert_fact_everywhere(rendered, fact)
+
+    doc = Jason.decode!(rendered.json)
+
+    assert [post.id, alpha.id, late.id, beta.id] == Enum.map(doc["thread"], & &1["id"])
+    assert [0, 1, 2, 1] == Enum.map(doc["thread"], & &1["depth"])
   end
 
   test "post permalink: a book review's facts reach every format", %{user: user} do

--- a/test/vutuv_web/controllers/post_controller_test.exs
+++ b/test/vutuv_web/controllers/post_controller_test.exs
@@ -24,6 +24,15 @@ defmodule VutuvWeb.PostControllerTest do
 
   defp pad(int), do: String.pad_leading(Integer.to_string(int), 2, "0")
 
+  # Where `text` first shows up in the rendered page — how the thread tests
+  # assert reading order without parsing the whole card tree.
+  defp position(html, text) do
+    case :binary.match(html, text) do
+      {at, _} -> at
+      :nomatch -> flunk("#{inspect(text)} is not on the page")
+    end
+  end
+
   describe "the review card on the permalink" do
     # Stores a served cover version for `review` under a throwaway uploads
     # tree, so the card renders the <img> (and its source credit) instead of
@@ -626,9 +635,66 @@ defmodule VutuvWeb.PostControllerTest do
       assert html =~ ~s(id="thread-focus")
       assert html =~ "data-thread-scroll"
 
-      # The sibling branch answers the root, not the card right above it, so
-      # its own "Replying to" banner names the real parent.
-      assert html =~ "Replying to"
+      # Every card hangs under the post it answers, so no card needs a
+      # "Replying to" banner to correct the nesting.
+      refute html =~ "Replying to"
+    end
+
+    # The production report behind issue #1027: in a long branching thread the
+    # newest reply was written hours after a busy branch point, so a flat
+    # chronological chain put it under a stranger's post and it read as
+    # answering that one.
+    test "a branching thread nests each reply under the post it answers", %{conn: conn} do
+      author = insert_activated_user()
+      other = insert_activated_user()
+      root = create_post!(author, %{body: "the conversation root"})
+      {:ok, alpha} = Posts.create_reply(other, root, %{body: "alpha branch"})
+      {:ok, beta} = Posts.create_reply(author, root, %{body: "beta branch"})
+      {:ok, _under_beta} = Posts.create_reply(other, beta, %{body: "answer under beta"})
+      {:ok, late} = Posts.create_reply(author, alpha, %{body: "the late answer"})
+
+      # Only the conversation card, so the page's own <meta> excerpt of the
+      # permalinked post cannot pass for its position in the thread.
+      html =
+        conn
+        |> get(Posts.path(late))
+        |> html_response(200)
+        |> String.split(~s(id="post-thread"), parts: 2)
+        |> List.last()
+
+      # Reading order follows the reply tree: the late answer sits right under
+      # the branch it answers, ahead of the whole beta branch it has nothing to
+      # do with — not at the bottom where the clock would have put it.
+      assert position(html, "alpha branch") < position(html, "the late answer")
+      assert position(html, "the late answer") < position(html, "beta branch")
+      assert position(html, "beta branch") < position(html, "answer under beta")
+
+      # The branch point (root answered twice) keeps the spine running past the
+      # first branch's subtree: an earlier sibling draws the full-height line
+      # plus its own tick, only the last one closes with the rounded elbow.
+      assert html =~ "h-full w-0.5 rounded-full bg-slate-200"
+      assert html =~ "rounded-bl-xl"
+    end
+
+    # Past the indent cap every card sits in its parent's column, so nesting
+    # can no longer show who answered whom — the banner takes that job back.
+    test "a branch below the indent cap names the post it answers", %{conn: conn} do
+      author = insert_activated_user()
+      brancher = insert_activated_user(first_name: "Bea", last_name: "Brancher")
+
+      # root(0) → r1(1) → r2(2), both of whose answers render past the cap.
+      root = create_post!(author, %{body: "capped root"})
+      {:ok, r1} = Posts.create_reply(author, root, %{body: "first step"})
+      {:ok, r2} = Posts.create_reply(brancher, r1, %{body: "second step"})
+      {:ok, _first} = Posts.create_reply(author, r2, %{body: "the first answer"})
+      {:ok, second} = Posts.create_reply(author, r2, %{body: "the second answer"})
+
+      html = html_response(get(conn, Posts.path(second)), 200)
+
+      # The first answer follows its parent card directly, so it needs no
+      # banner; the second one follows its sibling instead and names the
+      # author it really answers.
+      assert html =~ "Replying to @#{brancher.username}"
     end
 
     test "the root's permalink shows its thread without the auto-scroll marker", %{conn: conn} do

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -13,6 +13,15 @@ defmodule VutuvWeb.PostFeedLiveTest do
 
   defp other_user(attrs \\ []), do: insert(:user, Keyword.merge([email_confirmed?: true], attrs))
 
+  # Where `text` first shows up in the rendered feed — how the thread tests
+  # assert reading order without parsing the whole card tree.
+  defp position(html, text) do
+    case :binary.match(html, text) do
+      {at, _} -> at
+      :nomatch -> flunk("#{inspect(text)} is not on the page")
+    end
+  end
+
   describe "engagement query batching" do
     test "feed engagement queries do not grow with post count", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
@@ -170,6 +179,33 @@ defmodule VutuvWeb.PostFeedLiveTest do
       assert has_element?(live, "#post-actions-post-#{leaf.id}-like")
       assert has_element?(live, "#post-actions-post-#{leaf.id}-parent-#{mid.id}-like")
       assert has_element?(live, "#post-actions-post-#{leaf.id}-parent-#{root.id}-like")
+    end
+
+    test "a branching thread nests each reply under the post it answers", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      friend = other_user()
+      insert(:follow, follower: user, followee: friend)
+
+      # One root answered twice; the newest reply belongs to the *first* branch.
+      {:ok, root} = Posts.create_post(user, %{body: "the branch root"})
+      {:ok, alpha} = Posts.create_reply(friend, root, %{body: "alpha branch"})
+      {:ok, beta} = Posts.create_reply(friend, root, %{body: "beta branch"})
+      {:ok, _} = Posts.create_reply(user, beta, %{body: "answer under beta"})
+      {:ok, _} = Posts.create_reply(user, alpha, %{body: "the late answer"})
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+      feed_html = live |> element("#feed-posts") |> render()
+
+      # The collapsed thread renders as the tree it is, not as a timeline: the
+      # newest reply hangs under the alpha branch it answers, ahead of the whole
+      # beta branch (issue #1027).
+      assert position(feed_html, "alpha branch") < position(feed_html, "the late answer")
+      assert position(feed_html, "the late answer") < position(feed_html, "beta branch")
+      assert position(feed_html, "beta branch") < position(feed_html, "answer under beta")
+
+      # A card whose parent is nested right above it says so by its position;
+      # the redundant "Replying to @handle" banner stays off.
+      refute feed_html =~ "Replying to"
     end
 
     test "a deep thread caps its indentation so it can't scroll a phone sideways", %{conn: conn} do


### PR DESCRIPTION
Closes #1027.

A thread branches, so ordering its posts by the clock and drawing them as one linear chain says the wrong thing: a reply written after a busy branch point rendered under a stranger's post, with a connector line claiming it answered that one. The `post_replies` rows were correct all along; only the rendering lied.

### What changed

- **`Vutuv.Posts.thread_forest/1`** nests entries by their preloaded `reply_ref.parent_post_id` into `%{…, children: […]}` nodes (roots and siblings oldest first); **`thread_order/1`** is its depth-first walk. That is now the single ordering source for every surface.
- **Permalink** (`list_thread/3`) returns reading order. **Feed, profile Posts section, archive, saved lists, tag pages** nest the collapsed thread's `:ancestors` through the same forest instead of stacking them by time.
- **`thread_chain`** renders a forest instead of a `[head | rest]` list. A post answered twice keeps its spine running past the first branch's whole subtree into the next; only the last sibling closes it with the rounded elbow.
- The indent cap stays at 2 levels (phone width), but past it every card shares its parent's column, so the "Replying to @handle" banner comes back for every card that is not the first answer under its parent (`reply_banner?/4`). A forest root keeps it at any depth.
- **Agent formats:** `PostDoc`'s `thread` carries the same reading order plus a per-entry `depth`. Markdown renders a heading level per step, plain text two spaces per step.

### Verification

`mix precommit` green (4533 tests, `--warnings-as-errors`, credo `--strict`, format). New coverage for the tree order in `Posts`, the permalink, the feed and the agent-format drift test.

Smoke-tested in a browser against a production copy on the thread from the issue: the reply now sits directly under the post it answers, and the six cards that return to an outer branch below the indent cap each name their parent.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
