### PR TITLE
Notify a member when a post mentions them

### DIFF
--- a/docs/architecture/mentions.md
+++ b/docs/architecture/mentions.md
@@ -6,10 +6,11 @@ locked down, and what happens to stored mentions when a member renames.
 A mention is **plain text** `@handle` inside a Markdown body — nothing
 structured is stored. `VutuvWeb.Markdown` turns it into a profile link only at
 **render time**, by looking the handle up in the database. So the same text can
-mean different people over time, and three concerns have to agree on *what
-counts as a mention*. They share one definition in **`Vutuv.Mentions`**, which
-owns the entity grammar (`entity_regex/0`, read back by `VutuvWeb.Markdown` so
-the renderer can never drift from it).
+mean different people over time, and four concerns have to agree on *what
+counts as a mention*: rendering, existence validation, rename propagation and
+the notification below. They share one definition in **`Vutuv.Mentions`**,
+which owns the entity grammar (`entity_regex/0`, read back by
+`VutuvWeb.Markdown` so the renderer can never drift from it).
 
 Only the **local** `@handle` form is a vutuv handle. A fediverse `@user@host`
 handle and a `#hashtag` are never touched, and a handle inside a code span/block
@@ -56,6 +57,20 @@ block everyone, forever.
   `Mentions.without_existence_check/1` — otherwise a stray `@token` would
   silently drop the row.
 
+## Being mentioned is a notification
+
+A post that names you is news, wherever it sits. `Vutuv.Posts` resolves a saved
+body through `Mentions.mentioned_users/2` and reconciles one `post_mentions`
+row per named member; `Vutuv.Activity` reads that table as the feed's
+`"mention"` kind. Why the row exists at all, what the write and read sides each
+filter out, and the `reply` > `mention` > `thread` precedence are in
+[realtime.md](realtime.md) — the short version is that an ILIKE over every post
+on every unread count was not an option, so the scan happens once at save time.
+
+Only **members** are resolved. Organizations hold handles in the same namespace
+and the renderer links them, but they have no notification feed, so `@acme_gmbh`
+records nothing.
+
 ## Availability (anti-hijack)
 
 A handle is only claimable if `Mentions.mentioned_in_posts?/1` is false — it is
@@ -95,9 +110,10 @@ is safe.
 
 ## The notification
 
-`handle_change_notifications` is the **one** notification kind with its own
-table. The rest of the [notifications feed](realtime.md) is derived from
-current-state tables at read time, but "@old → @new" is a point-in-time fact the
+`handle_change_notifications` is, with `post_mentions` above, one of **two**
+notification kinds with their own table. The rest of the
+[notifications feed](realtime.md) is derived from current-state tables at read
+time, but "@old → @new" is a point-in-time fact the
 current state can't reconstruct, so it is persisted (recipient, actor, old +
 new handle, the affected `post_ids`). `Vutuv.Activity` reads it like any other
 source (`handle_change_items/3`, `count_handle_changes/2`, a `latest_event_at`
@@ -107,11 +123,16 @@ posts (the newest five, plus an "and N more" count).
 
 ## Key files & tests
 
-- `lib/vutuv/mentions.ex` — the chokepoint (grammar, rewrite, validation, scan).
+- `lib/vutuv/mentions.ex` — the chokepoint (grammar, rewrite, validation, scan,
+  `mentioned_users/2`).
+- `lib/vutuv/posts.ex` — `sync_mentions/1`, the `post_mentions` reconcile.
+- `lib/vutuv/posts/post_mention.ex` — the resolved index row.
+- `lib/vutuv/activity.ex` — `mention_events/1` + the `"mention"` feed source.
 - `lib/vutuv/accounts.ex` — `update_username/2` + notification creation.
 - `lib/vutuv/accounts/handle_change_notification.ex` — the durable row.
-- `lib/vutuv_web/live/notification_live/index.ex` — the `handle_change` rendering.
+- `lib/vutuv_web/live/notification_live/index.ex` — the `mention` and
+  `handle_change` renderings.
 - `test/vutuv/mentions_test.exs`, `mention_existence_test.exs`,
-  `handle_availability_test.exs`,
+  `mention_notifications_test.exs`, `handle_availability_test.exs`,
   `accounts/handle_change_propagation_test.exs`,
   `vutuv_web/live/handle_change_notification_test.exs`.

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -192,22 +192,36 @@ Replies to replies are allowed.
 **A post is rendered by one shared component everywhere**
 (`VutuvWeb.PostComponents`): `post_thread_entry/1` shows a reply as a **nested
 conversation** — the posts it answers are stacked **above** it as full cards
-(each keeping its own like/repost/bookmark bar), oldest-first, with a
-**connector line that runs from each avatar into the reply's avatar** (a
-vertical drop down the card, then an elbow curving into the next avatar) and
-every reply **indented one step further right** under the post it answers, so
-the thread of a whole multi-post, multi-author conversation reads at a glance,
-instead of the feed's old flat "Replying to @handle" text banner.
+(each keeping its own like/repost/bookmark bar), with a **connector line that
+runs from each avatar into the avatars of the replies it got** (a vertical drop
+down the card, then an elbow curving into the next avatar) and every reply
+**indented one step further right** under the post it answers, so the thread of
+a whole multi-post, multi-author conversation reads at a glance, instead of the
+feed's old flat "Replying to @handle" text banner.
+
+**A conversation is a tree, not a timeline** (issue #1027).
+`Vutuv.Posts.thread_forest/1` nests the visible posts by their parent pointer
+(roots and siblings oldest first) and `thread_order/1` is its depth-first walk —
+the reading order every surface uses. Rendering a branching thread flat and
+chronologically put a reply written hours after a busy branch point under a
+stranger's post, where it read as answering that one. A post answered twice
+therefore branches: the spine keeps running past the first answer's whole
+subtree down into the next, and only the last sibling closes it with the
+rounded elbow.
 
 Indentation is capped at 2 levels (`@thread_indent_cap`) so a deep thread can't
 scroll a phone sideways; past the cap replies stay in the same column and the
-connector is a straight vertical drop.
+connector is a straight vertical drop. There the nesting can no longer say who
+answered whom, so the "Replying to @handle" banner comes back for every card
+that is *not* the first answer under its parent (`reply_banner?/4`) — a forest
+root, whose parent is off the page, keeps it at any depth.
 
 On the feed and the profile Posts section `Vutuv.Posts.collapse_threads/1` folds
 each visible chain: it drops the ancestors' own standalone rows (so a middle
-post is no longer shown twice) and hands each surviving leaf its ordered
-`:ancestors`, so however many posts or authors a thread spans it renders once;
-the archive and saved lists fall back to nesting the single direct parent.
+post is no longer shown twice) and hands each surviving leaf its
+`:ancestors`, which the component nests into the same tree, so however many
+posts, authors or branches a thread spans it renders once; the archive and saved
+lists fall back to nesting the single direct parent.
 
 All read the same (each a single card of flat `divide-y` rows).
 
@@ -216,22 +230,21 @@ like/reply quotes.
 
 **The permalink page renders the whole conversation** (issue #1006):
 `Vutuv.Posts.list_thread/3` fetches the thread's root plus every visible post
-of the thread in one `root_post_id` lookup, oldest first (capped at 200 with a
-"conversation is longer" note; the permalinked post, its surviving ancestor
-chain and its direct replies are always unioned back in, which is also the
-degraded floor once a deleted root has nilified the thread's root links), and
-`PostComponents.thread_conversation/1` renders it as one feed-style chain. The
-permalinked post is the tinted `:full`-mode card (`#thread-focus`; an
-absolutely positioned `::before` so the connector geometry is untouched) and,
-when it has context above, app.js scrolls it into view on arrival
-(`data-thread-scroll`). The chain is chronological, not a tree, so a reply
-that does not answer the card directly above it keeps its own "Replying to
-@handle" banner — that is how branch points read. A post with no thread
-renders standalone exactly as before. The action bar carries a live reply
-counter, and the parent's author gets a derived "replied to your post"
-notification (self-replies excluded). The agent-format siblings mirror the
-page: `PostDoc` carries the conversation as `thread` (each entry with its
-parent pointer), the md/txt renderers as a "Conversation" section.
+of the thread in one `root_post_id` lookup (capped at 200 with a "conversation
+is longer" note; the permalinked post, its surviving ancestor chain and its
+direct replies are always unioned back in, which is also the degraded floor
+once a deleted root has nilified the thread's root links), returns them in
+`thread_order/1` reading order, and `PostComponents.thread_conversation/1`
+renders it as one feed-style conversation. The permalinked post is the tinted
+`:full`-mode card (`#thread-focus`; an absolutely positioned `::before` so the
+connector geometry is untouched) and, when it has context above, app.js scrolls
+it into view on arrival (`data-thread-scroll`). A post with no thread renders
+standalone exactly as before. The action bar carries a live reply counter, and
+the parent's author gets a derived "replied to your post" notification
+(self-replies excluded). The agent-format siblings mirror the page: `PostDoc`
+carries the conversation as `thread` in the same reading order (each entry with
+its parent pointer **and** its nesting `depth`), which the md renderer turns
+into a heading level per step and the txt renderer into two spaces per step.
 
 A reply **outlives its parent**: where the parent is gone the card falls back to
 a banner (which names the account as `@handle`, never the clear name) that

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -62,8 +62,8 @@ The layout is split into `root.html.heex` (document shell) and `app.html.heex`
 (chrome), shared by classic controller pages and LiveViews.
 
 Notifications are real data **derived at read time** from the existing event
-tables (followers, endorsements, connections — mutual follows —, replies, likes;
-retroactively, no notifications table); each entry links to what it reports (the
+tables (followers, endorsements, connections — mutual follows —, replies,
+mentions, likes; retroactively); each entry links to what it reports (the
 post, the actor's profile), and a reply or like entry **quotes the post it is
 about** so the feed is scannable at a glance: a like quotes the liked post, a
 reply quotes **both** the member's own post and the reply itself (each truncated
@@ -108,8 +108,38 @@ permalink and quote it; same-day events of one thread merge into one grouped
 row. The write side (`Vutuv.Posts.create_reply/3` via `broadcast_reply/2`)
 pushes the same event live to every participant's badge.
 
-The only stored state is the `users.notifications_read_at` read marker behind
-the unread badge.
+**Being named** is its own kind (`"mention"`): a post whose body says
+`@handle` notifies that member, wherever the post sits. Before it existed a
+mention reached you only by accident — if the post happened to answer one of
+yours ("reply") or to land in a thread you had written in ("thread"); a mention
+in a standalone post, or in a thread you are not part of, notified nobody.
+
+This is the one feed kind that cannot be derived from current state cheaply: a
+mention is plain text in `posts.body`, so deriving it would mean an ILIKE over
+every post on every unread count — and that count runs on every page render for
+the shell badge. So `Vutuv.Posts` resolves the body once at save time (through
+`Vutuv.Mentions.mentioned_users/2`, the same grammar the renderer links with)
+and **reconciles a `post_mentions` row per named member**; the feed reads that
+table like any other source. Create, reply and every edit re-derive the set, so
+adding a name notifies, removing one takes the event away again, and the body
+stays the source of truth — the table is only a resolved index.
+
+Left out at **write** time, because they belong to the post and are re-derived
+on the edit that changes them: the author (naming yourself is not news) and
+anyone the post is not visible to. Left out at **read** time, because they
+change outside the post: a block either way (like thread events), and the
+precedence rule below. Mentions of an **organization** handle notify nobody —
+organizations share the handle namespace but have no feed.
+
+**One post, one row.** The three post kinds are ordered `reply` > `mention` >
+`thread`: an answer to your own post stays a "reply" even when it also names
+you, and a mention supersedes the quieter "thread" event for the same reply. So
+a single post never produces two notifications for the same reader.
+
+The only stored state derived-feed-wise is the `users.notifications_read_at`
+read marker behind the unread badge; `post_mentions` and
+`handle_change_notifications` are the two event tables written for a feed kind
+rather than read from one that already existed.
 
 ### The notifications page (2026-07 redesign)
 

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -13,7 +13,8 @@ defmodule Vutuv.Activity do
   (`follows` — a one-way follow is a "follower" event, a mutual follow a
   "connection"/vernetzt one —, `user_tag_endorsements`, `post_replies` — a
   reply answering the user's post is a "reply" event, a reply elsewhere in a
-  thread the user writes in a "thread" one —, `post_likes`, and the announced
+  thread the user writes in a "thread" one —, `post_mentions` — a post naming
+  the user by `@handle` is a "mention" event —, `post_likes`, and the announced
   CV rows behind `Vutuv.Profiles.CvUpdates`) instead of being
   persisted per notification — which makes it automatically retroactive. The only stored
   state is `users.notifications_read_at`, the read marker behind the unread
@@ -32,6 +33,7 @@ defmodule Vutuv.Activity do
   alias Vutuv.Organizations.OrganizationRole
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostLike
+  alias Vutuv.Posts.PostMention
   alias Vutuv.Posts.PostReply
   alias Vutuv.Profiles.CvUpdates
   alias Vutuv.Repo
@@ -110,6 +112,8 @@ defmodule Vutuv.Activity do
 
     thread_max = select(thread_replies(user_id), [thread_ref: r], %{ts: max(r.inserted_at)})
 
+    mention_max = select(mention_events(user_id), [mention: m], %{ts: max(m.inserted_at)})
+
     like_max =
       from(l in PostLike,
         join: p in assoc(l, :post),
@@ -165,6 +169,7 @@ defmodule Vutuv.Activity do
       |> union_all(^connection_max)
       |> union_all(^reply_max)
       |> union_all(^thread_max)
+      |> union_all(^mention_max)
       |> union_all(^like_max)
       |> union_all(^moderation_max)
       |> union_all(^image_rejected_max)
@@ -334,6 +339,27 @@ defmodule Vutuv.Activity do
     )
   end
 
+  @doc ~S"""
+  Convenience: a "mentioned you in a post" notification for a member the post's
+  body names by `@handle`. `post_id` is that post — written by the actor, not by
+  the recipient, so the row links it under the **author's** profile.
+
+  Pushed by `Vutuv.Posts` only for names it just added, so an edit that leaves a
+  mention untouched never notifies twice. The durable half is the
+  `post_mentions` row written alongside it (`mention_items/3`).
+  """
+  def notify_mention(user_id, author, post_id) do
+    notify(
+      user_id,
+      Map.merge(actor_fields(author), %{
+        kind: "mention",
+        text: "mentioned you in a post.",
+        post_id: post_id,
+        at: DateTime.utc_now()
+      })
+    )
+  end
+
   @doc ~S(Convenience: a "liked your post" notification for the post's author.)
   def notify_like(author_id, liker, post_id) do
     Vutuv.Webhooks.emit(author_id, "post.liked", %{
@@ -482,6 +508,7 @@ defmodule Vutuv.Activity do
       {"connection", &connection_items(user_id, &1, &2)},
       {"reply", &reply_items(user_id, &1, &2)},
       {"thread", &thread_items(user_id, &1, &2)},
+      {"mention", &mention_items(user_id, &1, &2)},
       {"like", &like_items(user_id, &1, &2)},
       {"organization_role", &organization_role_items(user_id, &1, &2)},
       {"moderation", &moderation_items(user_id, &1, &2)},
@@ -578,6 +605,7 @@ defmodule Vutuv.Activity do
       {"connection", count_connections(user_id, read_at)},
       {"reply", count_replies(user_id, read_at)},
       {"thread", count_thread_replies(user_id, read_at)},
+      {"mention", count_mentions(user_id, read_at)},
       {"like", count_likes(user_id, read_at)},
       {"organization_role", count_organization_roles(user_id, read_at)},
       {"cv_update", count_cv_updates(user_id, read_at)},
@@ -719,12 +747,64 @@ defmodule Vutuv.Activity do
     end)
   end
 
+  # Posts that name the user with `@handle` (issue: mention notifications). The
+  # rows come from `post_mentions`, reconciled at save time by `Vutuv.Posts` —
+  # deriving them here would mean an ILIKE over every post on every unread
+  # count. Newest first, actor = the post's author.
+  defp mention_items(user_id, limit, cursor) do
+    mention_events(user_id)
+    |> join(:inner, [mention_post: p], author in User, on: author.id == p.user_id, as: :author)
+    |> order_by([mention: m], desc: m.inserted_at, desc: m.id)
+    |> limit(^limit)
+    |> select(
+      [mention: m, author: author],
+      {m.id, m.inserted_at, struct(author, ^User.listing_fields()), m.post_id}
+    )
+    |> at_or_before(cursor)
+    |> Repo.all()
+    |> Enum.map(fn {id, at, author, post_id} ->
+      "mention-#{id}"
+      |> actor_item("mention", at, author)
+      # The post that named them — the author's, not the recipient's.
+      |> Map.put(:post_id, post_id)
+    end)
+  end
+
+  # The base scope behind the "mention" kind, shared by items / count / read
+  # marker. The write side already excludes self-mentions and posts the member
+  # cannot see (both are the post's own business, re-derived on every edit);
+  # what is left here is what can change *after* the post was written:
+  #
+  #   * a **block** either way, filtered like thread events filter it, and
+  #   * the precedence rule — a post that answers the member directly is
+  #     already the stronger "reply" event, so it never also mentions. One
+  #     post, one row; `thread_replies/1` yields to a mention the same way.
+  defp mention_events(user_id) do
+    from(m in PostMention,
+      as: :mention,
+      join: p in Post,
+      on: p.id == m.post_id,
+      as: :mention_post,
+      where: m.user_id == ^user_id,
+      where:
+        not exists(
+          from(r in PostReply,
+            where: r.post_id == parent_as(:mention).post_id and r.parent_author_id == ^user_id,
+            select: 1
+          )
+        ),
+      where: p.user_id not in subquery(blocked_either_way(user_id))
+    )
+  end
+
   # The base scope behind the "thread" kind, shared by items / count / read
   # marker. A qualifying reply: sits in a thread (root known), is not the
-  # user's own, does not answer the user directly, its author has no block
-  # either way with the user, and the user had already written in the thread
-  # when it landed — they authored the root, or an earlier reply (replies from
-  # before they joined were on screen when they replied; not news).
+  # user's own, does not answer the user directly, does not name the user (that
+  # is the louder "mention" event — never both for one post), its author has no
+  # block either way with the user, and the user had already written in the
+  # thread when it landed — they authored the root, or an earlier reply
+  # (replies from before they joined were on screen when they replied; not
+  # news).
   defp thread_replies(user_id) do
     from(r in PostReply,
       as: :thread_ref,
@@ -734,6 +814,13 @@ defmodule Vutuv.Activity do
       where: not is_nil(r.root_post_id),
       where: reply.user_id != ^user_id,
       where: is_nil(r.parent_author_id) or r.parent_author_id != ^user_id,
+      where:
+        not exists(
+          from(m in PostMention,
+            where: m.post_id == parent_as(:thread_ref).post_id and m.user_id == ^user_id,
+            select: 1
+          )
+        ),
       where:
         exists(
           from(root in Post,
@@ -1058,6 +1145,12 @@ defmodule Vutuv.Activity do
   defp count_thread_replies(user_id, read_at) do
     thread_replies(user_id)
     |> select([thread_ref: r], %{count: count()})
+    |> since(read_at)
+  end
+
+  defp count_mentions(user_id, read_at) do
+    mention_events(user_id)
+    |> select([mention: m], %{count: count()})
     |> since(read_at)
   end
 

--- a/lib/vutuv/mentions.ex
+++ b/lib/vutuv/mentions.ex
@@ -4,11 +4,16 @@ defmodule Vutuv.Mentions do
 
   A mention is plain text `@handle` inside a Markdown body — nothing structured
   is stored, it becomes a profile link only at render time
-  (`VutuvWeb.Markdown`). Three concerns therefore have to agree on *what counts
+  (`VutuvWeb.Markdown`). Four concerns therefore have to agree on *what counts
   as a mention*, so they share one definition here:
 
     * **Rendering** — `VutuvWeb.Markdown` links each local `@handle` and calls
       `entity_regex/0` so the grammar can never drift from this module.
+    * **Notification** — being named in a post is news, so `Vutuv.Posts`
+      resolves a saved body through `mentioned_users/2` and reconciles the
+      `post_mentions` rows behind the feed's `"mention"` kind. That table is
+      the one place a mention *is* stored structurally, and only as a resolved
+      index: the body stays the source of truth.
     * **Validation** — a saved body may only mention handles that already exist
       (`validate_mentions_exist/2`). Without this a bad actor could seed
       `@wanted` into a post to *reserve* it: the availability rule below then
@@ -116,6 +121,30 @@ defmodule Vutuv.Mentions do
   end
 
   def mentions?(_, _), do: false
+
+  @doc """
+  The **members** `text` names, as `%User{}` structs, excluding `except_id`.
+
+  The resolution behind the `"mention"` notification kind (`Vutuv.Posts`
+  reconciles `post_mentions` from it). Organizations share the handle
+  namespace but have no notification feed, so only the member table is
+  queried — a `@acme_gmbh` in a body resolves to nobody here, even though the
+  renderer links it.
+  """
+  def mentioned_users(text, except_id \\ nil) do
+    case local_handles(text) do
+      [] ->
+        []
+
+      handles ->
+        from(u in User, where: u.username in ^handles)
+        |> reject_user(except_id)
+        |> Repo.all()
+    end
+  end
+
+  defp reject_user(query, nil), do: query
+  defp reject_user(query, id), do: where(query, [u], u.id != ^id)
 
   ## Rewrite ----------------------------------------------------------------
 

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -45,6 +45,7 @@ defmodule Vutuv.Posts do
   import Vutuv.SearchText, only: [escape_like: 1, normalize_search: 1, name_ilike: 3]
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Mentions
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Pages
   alias Vutuv.PostImageStore
@@ -53,6 +54,7 @@ defmodule Vutuv.Posts do
   alias Vutuv.Posts.PostDenial
   alias Vutuv.Posts.PostImage
   alias Vutuv.Posts.PostLike
+  alias Vutuv.Posts.PostMention
   alias Vutuv.Posts.PostReply
   alias Vutuv.Posts.PostRepost
   alias Vutuv.Posts.PostReview
@@ -115,6 +117,8 @@ defmodule Vutuv.Posts do
         {:ok, post} ->
           post = preload_post(post)
           broadcast_new_post(post)
+          # Everyone the body names by @handle is told they were named.
+          sync_mentions(post)
           # Follow-only federation: a federating author's public post goes
           # out to their remote followers (no-op for everyone else).
           Vutuv.Fediverse.federate_new_post(post)
@@ -162,6 +166,7 @@ defmodule Vutuv.Posts do
           post = preload_post(post)
           broadcast_new_post(post)
           broadcast_reply(parent, post)
+          sync_mentions(post)
           Vutuv.Fediverse.federate_new_post(post)
           reconcile_screenshot(post)
           ReviewCovers.reconcile(post)
@@ -220,6 +225,9 @@ defmodule Vutuv.Posts do
         # (the owner's self-service round; see Vutuv.Moderation).
         Vutuv.Moderation.content_edited(updated)
         updated = preload_post(updated)
+        # The edit can add a name, drop one, or (by changing the audience)
+        # move a named member out of the post's reach: re-derive the set.
+        sync_mentions(updated)
         # Remote copies follow the edit (Update) — or, if the audience just
         # closed, leave public view (Delete, best effort).
         Vutuv.Fediverse.federate_post_update(updated)
@@ -2469,6 +2477,74 @@ defmodule Vutuv.Posts do
     end
 
     :ok
+  end
+
+  # Reconcile the `post_mentions` rows behind the feed's "mention" kind against
+  # what the body says now, and push the live event to everyone newly named.
+  # Runs on create, on reply and on every edit, so adding a name notifies,
+  # removing one takes the event away again, and the set is always what the
+  # current body says — the body stays the source of truth, this table only the
+  # resolved index (see `Vutuv.Mentions`).
+  #
+  # Two members are deliberately left out here rather than in the feed query:
+  # the author (naming yourself is not news) and anyone the post is not visible
+  # to, since an audience the author can change belongs to the post and is
+  # re-derived by this very function on the edit that changes it. Blocks are
+  # the opposite case — they change outside the post — so the feed query filters
+  # those, exactly as thread events do; the live push below has to repeat that
+  # filter because there is no query in its path.
+  defp sync_mentions(%Post{} = post) do
+    wanted =
+      post.body
+      |> Mentions.mentioned_users(post.user_id)
+      |> Enum.filter(&visible_to?(post, &1))
+
+    existing = Repo.all(from(m in PostMention, where: m.post_id == ^post.id, select: m.user_id))
+    added = Enum.reject(wanted, &(&1.id in existing))
+
+    drop_mentions(post, existing -- Enum.map(wanted, & &1.id))
+    insert_mentions(post, added)
+    Enum.each(added, &notify_mentioned(post, &1))
+    :ok
+  end
+
+  defp drop_mentions(_post, []), do: :ok
+
+  defp drop_mentions(%Post{} = post, user_ids) do
+    Repo.delete_all(
+      from(m in PostMention, where: m.post_id == ^post.id and m.user_id in ^user_ids)
+    )
+
+    :ok
+  end
+
+  defp insert_mentions(_post, []), do: :ok
+
+  defp insert_mentions(%Post{} = post, users) do
+    now = NaiveDateTime.utc_now(:second)
+
+    rows =
+      Enum.map(
+        users,
+        &%{
+          id: UUIDv7.generate(),
+          post_id: post.id,
+          user_id: &1.id,
+          inserted_at: now,
+          updated_at: now
+        }
+      )
+
+    # A concurrent save of the same post (a double-submitted edit) must not
+    # raise on the unique index; the row is the same fact either way.
+    Repo.insert_all(PostMention, rows, on_conflict: :nothing)
+    :ok
+  end
+
+  defp notify_mentioned(%Post{} = post, %User{} = mentioned) do
+    unless Vutuv.Social.blocked_between?(mentioned.id, post.user_id) do
+      Vutuv.Activity.notify_mention(mentioned.id, post.user, post.id)
+    end
   end
 
   @doc """

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1819,9 +1819,10 @@ defmodule Vutuv.Posts do
 
   @doc """
   The whole conversation `post` belongs to, as `viewer` sees it: the thread's
-  root plus every visible post of the thread, oldest first — what the
-  permalink page renders (issue #1006). Fetched in one indexed query over the
-  denormalized `post_replies.root_post_id`.
+  root plus every visible post of the thread, in reading order (`thread_order/1`
+  — the reply tree walked depth-first, so every reply follows the post it
+  answers) — what the permalink page renders (issue #1006). Fetched in one
+  indexed query over the denormalized `post_replies.root_post_id`.
 
   Returns `%{posts:, truncated?:}`; `truncated?` says the `:limit` cap
   (default #{@default_conversation_limit}) cut the newest tail. The
@@ -1850,11 +1851,64 @@ defmodule Vutuv.Posts do
     posts =
       (Enum.take(scoped, limit) ++ up ++ [post] ++ list_replies(post, viewer))
       |> Enum.uniq_by(& &1.id)
-      |> Enum.sort_by(&{NaiveDateTime.to_erl(&1.inserted_at), &1.id})
       |> Repo.preload(post_preloads())
+      |> thread_order()
 
     %{posts: posts, truncated?: truncated?}
   end
+
+  @doc """
+  The reply tree `entries` really form: a forest of those same maps (anything
+  carrying a `:post`), each gaining a `:children` list of the entries that
+  answer it. Roots — a top-level post, or a reply whose parent is not among the
+  entries — and siblings come oldest first, so a walk reads as the conversation
+  happened.
+
+  A thread **branches**: one post can be answered many times, and an answer
+  written hours later is not an answer to whatever was posted last. Rendering
+  the conversation as a flat chronological list therefore put replies under
+  strangers' posts (issue #1027). The permalink page and the feed both nest
+  from this, so a reply always sits under its own parent.
+  """
+  def thread_forest(entries) do
+    present = MapSet.new(entries, & &1.post.id)
+
+    {roots, answers} =
+      entries
+      |> Enum.sort_by(&{NaiveDateTime.to_erl(&1.post.inserted_at), &1.post.id})
+      |> Enum.split_with(fn %{post: post} ->
+        parent_id = preloaded_parent_id(post)
+        is_nil(parent_id) or not MapSet.member?(present, parent_id)
+      end)
+
+    by_parent = Enum.group_by(answers, &preloaded_parent_id(&1.post))
+
+    Enum.map(roots, &subtree(&1, by_parent))
+  end
+
+  # A reply is always newer than the post it answers, so the parent links form
+  # a forest and can never cycle — the walk terminates.
+  defp subtree(entry, by_parent) do
+    children = by_parent |> Map.get(entry.post.id, []) |> Enum.map(&subtree(&1, by_parent))
+    Map.put(entry, :children, children)
+  end
+
+  @doc """
+  `posts` in reading order: `thread_forest/1` walked depth-first, so every
+  reply directly follows the post it answers and a branch's answers stay
+  together instead of being interleaved by the clock.
+  """
+  def thread_order(posts) do
+    posts |> Enum.map(&%{post: &1}) |> thread_forest() |> flatten_forest()
+  end
+
+  defp flatten_forest(nodes), do: Enum.flat_map(nodes, &[&1.post | flatten_forest(&1.children)])
+
+  # The id of the post a reply answers, straight off the preloaded `reply_ref`
+  # (an un-preloaded one is a truthy %NotLoaded{}, hence the struct match) —
+  # no query, unlike its `reply_parent_id/1` namesake further down.
+  defp preloaded_parent_id(%Post{reply_ref: %PostReply{parent_post_id: id}}), do: id
+  defp preloaded_parent_id(_post), do: nil
 
   # Where the conversation is anchored: the denormalized root for a normal
   # reply, the post itself for a top-level post. A degraded reply (root

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -45,6 +45,7 @@ defmodule Vutuv.Posts do
   import Vutuv.SearchText, only: [escape_like: 1, normalize_search: 1, name_ilike: 3]
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Mentions
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Pages
   alias Vutuv.PostImageStore
@@ -53,6 +54,7 @@ defmodule Vutuv.Posts do
   alias Vutuv.Posts.PostDenial
   alias Vutuv.Posts.PostImage
   alias Vutuv.Posts.PostLike
+  alias Vutuv.Posts.PostMention
   alias Vutuv.Posts.PostReply
   alias Vutuv.Posts.PostRepost
   alias Vutuv.Posts.PostReview
@@ -115,6 +117,8 @@ defmodule Vutuv.Posts do
         {:ok, post} ->
           post = preload_post(post)
           broadcast_new_post(post)
+          # Everyone the body names by @handle is told they were named.
+          sync_mentions(post)
           # Follow-only federation: a federating author's public post goes
           # out to their remote followers (no-op for everyone else).
           Vutuv.Fediverse.federate_new_post(post)
@@ -162,6 +166,7 @@ defmodule Vutuv.Posts do
           post = preload_post(post)
           broadcast_new_post(post)
           broadcast_reply(parent, post)
+          sync_mentions(post)
           Vutuv.Fediverse.federate_new_post(post)
           reconcile_screenshot(post)
           ReviewCovers.reconcile(post)
@@ -220,6 +225,9 @@ defmodule Vutuv.Posts do
         # (the owner's self-service round; see Vutuv.Moderation).
         Vutuv.Moderation.content_edited(updated)
         updated = preload_post(updated)
+        # The edit can add a name, drop one, or (by changing the audience)
+        # move a named member out of the post's reach: re-derive the set.
+        sync_mentions(updated)
         # Remote copies follow the edit (Update) — or, if the audience just
         # closed, leave public view (Delete, best effort).
         Vutuv.Fediverse.federate_post_update(updated)
@@ -2415,6 +2423,74 @@ defmodule Vutuv.Posts do
     end
 
     :ok
+  end
+
+  # Reconcile the `post_mentions` rows behind the feed's "mention" kind against
+  # what the body says now, and push the live event to everyone newly named.
+  # Runs on create, on reply and on every edit, so adding a name notifies,
+  # removing one takes the event away again, and the set is always what the
+  # current body says — the body stays the source of truth, this table only the
+  # resolved index (see `Vutuv.Mentions`).
+  #
+  # Two members are deliberately left out here rather than in the feed query:
+  # the author (naming yourself is not news) and anyone the post is not visible
+  # to, since an audience the author can change belongs to the post and is
+  # re-derived by this very function on the edit that changes it. Blocks are
+  # the opposite case — they change outside the post — so the feed query filters
+  # those, exactly as thread events do; the live push below has to repeat that
+  # filter because there is no query in its path.
+  defp sync_mentions(%Post{} = post) do
+    wanted =
+      post.body
+      |> Mentions.mentioned_users(post.user_id)
+      |> Enum.filter(&visible_to?(post, &1))
+
+    existing = Repo.all(from(m in PostMention, where: m.post_id == ^post.id, select: m.user_id))
+    added = Enum.reject(wanted, &(&1.id in existing))
+
+    drop_mentions(post, existing -- Enum.map(wanted, & &1.id))
+    insert_mentions(post, added)
+    Enum.each(added, &notify_mentioned(post, &1))
+    :ok
+  end
+
+  defp drop_mentions(_post, []), do: :ok
+
+  defp drop_mentions(%Post{} = post, user_ids) do
+    Repo.delete_all(
+      from(m in PostMention, where: m.post_id == ^post.id and m.user_id in ^user_ids)
+    )
+
+    :ok
+  end
+
+  defp insert_mentions(_post, []), do: :ok
+
+  defp insert_mentions(%Post{} = post, users) do
+    now = NaiveDateTime.utc_now(:second)
+
+    rows =
+      Enum.map(
+        users,
+        &%{
+          id: UUIDv7.generate(),
+          post_id: post.id,
+          user_id: &1.id,
+          inserted_at: now,
+          updated_at: now
+        }
+      )
+
+    # A concurrent save of the same post (a double-submitted edit) must not
+    # raise on the unique index; the row is the same fact either way.
+    Repo.insert_all(PostMention, rows, on_conflict: :nothing)
+    :ok
+  end
+
+  defp notify_mentioned(%Post{} = post, %User{} = mentioned) do
+    unless Vutuv.Social.blocked_between?(mentioned.id, post.user_id) do
+      Vutuv.Activity.notify_mention(mentioned.id, post.user, post.id)
+    end
   end
 
   @doc """

--- a/lib/vutuv/posts/post_mention.ex
+++ b/lib/vutuv/posts/post_mention.ex
@@ -1,0 +1,20 @@
+defmodule Vutuv.Posts.PostMention do
+  @moduledoc """
+  One member a post names with `@handle`, resolved at save time.
+
+  The mention itself stays plain text in the body (`Vutuv.Mentions` owns the
+  grammar); this row is only the resolved index behind the `"mention"`
+  notification kind, reconciled by `Vutuv.Posts` on every post write. Both
+  references cascade — the row means nothing once the post or the member is
+  gone.
+  """
+
+  use VutuvWeb, :model
+
+  schema "post_mentions" do
+    belongs_to(:post, Vutuv.Posts.Post)
+    belongs_to(:user, Vutuv.Accounts.User)
+
+    timestamps()
+  end
+end

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -903,13 +903,19 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   @doc false
   def image_url(image), do: image.urls[:feed] || image.urls |> Map.values() |> List.first()
 
+  # A reply is a subsection of the post it answers, so the entry's heading level
+  # carries its nesting depth (`###` at the top of the thread, one `#` deeper
+  # per level, floored at Markdown's `######`) — the document form of the
+  # indentation the HTML page draws.
   defp thread_block(entry) do
     reply_to =
       entry.in_reply_to_author &&
         "> " <> gettext("In reply to a post by %{name}.", name: entry.in_reply_to_author)
 
+    heading = String.duplicate("#", min(3 + entry.depth, 6))
+
     [
-      "### [#{md_text(entry.author)}](#{entry.url}) · #{entry.published_on}",
+      "#{heading} [#{md_text(entry.author)}](#{entry.url}) · #{entry.published_on}",
       reply_to,
       entry.body_markdown
     ]

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -62,10 +62,11 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # a second query and can never drift from the list.)
       reply_count: length(replies),
       replies: Enum.map(replies, &reply_entry/1),
-      # The whole conversation the HTML permalink renders (issue #1006),
-      # oldest first; every entry carries its parent pointer so the tree is
-      # recoverable. `replies` above stays the one-level list for API
-      # consumers that relied on it.
+      # The whole conversation the HTML permalink renders (issue #1006), in
+      # the same reading order (the reply tree depth-first, issue #1027);
+      # every entry carries its parent pointer and its nesting depth, so the
+      # tree is recoverable without re-deriving it. `replies` above stays the
+      # one-level list for API consumers that relied on it.
       thread: thread_entries(thread),
       thread_truncated: thread_truncated?,
       # The public engagement counters the HTML action bar shows to everyone.
@@ -121,11 +122,15 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     }
   end
 
-  # The conversation entries, oldest first. `in_reply_to_author` resolves only
-  # inside the thread (a deleted or invisible parent stays nil), so the
-  # markdown/text renderers can name a branch's parent without another lookup.
+  # The conversation entries, in `Posts.list_thread/3` reading order.
+  # `in_reply_to_author` resolves only inside the thread (a deleted or
+  # invisible parent stays nil), so the markdown/text renderers can name a
+  # branch's parent without another lookup, and `depth` is how deep the entry
+  # hangs in the thread — the nesting the HTML page draws, as a number the
+  # other formats can indent by.
   defp thread_entries(posts) do
     authors = Map.new(posts, &{&1.id, UserHelpers.full_name(&1.user)})
+    depths = thread_depths(posts)
 
     Enum.map(posts, fn post ->
       parent_id = post.reply_ref && post.reply_ref.parent_post_id
@@ -137,9 +142,20 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
         author_username: post.user.username,
         published_on: post.published_on,
         body_markdown: post.body,
+        depth: depths[post.id],
         in_reply_to_id: parent_id,
         in_reply_to_author: parent_id && authors[parent_id]
       }
+    end)
+  end
+
+  # One pass suffices: reading order puts every post after the one it answers,
+  # so its parent's depth is already known. A post whose parent is not in the
+  # thread (the root, or a chain broken by a deletion) starts at 0.
+  defp thread_depths(posts) do
+    Enum.reduce(posts, %{}, fn post, depths ->
+      parent_id = post.reply_ref && post.reply_ref.parent_post_id
+      Map.put(depths, post.id, (parent_id && depths[parent_id] && depths[parent_id] + 1) || 0)
     end)
   end
 

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -597,22 +597,31 @@ defmodule VutuvWeb.AgentDocs.Text do
     "* #{alt}\n  #{Markdown.image_url(image)}"
   end
 
+  # How deep a thread entry still indents. Past this the entries stay in one
+  # column (the plain-text twin of the HTML indent cap), so a long back-and-forth
+  # does not push its bodies off an 80-column terminal.
+  @thread_indent_cap 4
+
   defp thread_lines(entry) do
+    pad = String.duplicate("  ", min(entry.depth, @thread_indent_cap))
+
     reply_to =
       if entry.in_reply_to_author,
         do:
-          "  " <>
+          pad <>
+            "  " <>
             gettext("In reply to a post by %{name}.", name: entry.in_reply_to_author) <> "\n",
         else: ""
 
-    "* #{entry.author} · #{entry.published_on} · #{entry.url}\n" <>
-      reply_to <> indent_block(entry.body_markdown)
+    pad <>
+      "* #{entry.author} · #{entry.published_on} · #{entry.url}\n" <>
+      reply_to <> indent_block(entry.body_markdown, pad <> "  ")
   end
 
-  defp indent_block(text) do
+  defp indent_block(text, pad) do
     text
     |> String.split("\n")
-    |> Enum.map_join("\n", &("  " <> &1))
+    |> Enum.map_join("\n", &(pad <> &1))
   end
 
   defp section(_title, []), do: nil

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -31,7 +31,6 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Posts
   alias Vutuv.Posts.PostImage
-  alias Vutuv.Posts.PostReply
   alias Vutuv.Posts.PostReview
   alias Vutuv.Posts.PostScreenshot
   alias Vutuv.ReviewCover
@@ -491,7 +490,7 @@ defmodule VutuvWeb.PostComponents do
     # not fall back; only a missing (nil) list falls back to the one-level parent.
     ancestors = assigns.ancestors || one_level_ancestors(assigns.post, assigns.nest_parent)
     assigns = assign(assigns, :ancestors, ancestors)
-    assigns = assign(assigns, :chain, thread_chain_items(assigns))
+    assigns = assign(assigns, :roots, thread_entry_roots(assigns))
 
     ~H"""
     <%= if @ancestors == [] do %>
@@ -509,12 +508,12 @@ defmodule VutuvWeb.PostComponents do
       />
     <% else %>
       <%!-- The reply and the posts it answers, as one conversation: each is a
-      full post card (its own like / repost / bookmark bar), oldest-first, and
-      every reply is nested one step further right under the post it answers —
-      a left-rail, left-padded block per level — so the reply depth reads at a
-      glance the way a threaded comment tree does. --%>
+      full post card (its own like / repost / bookmark bar), and every reply is
+      nested one step further right under the post it answers — a left-rail,
+      left-padded block per level — so the reply depth reads at a glance the way
+      a threaded comment tree does. --%>
       <.thread_chain
-        chain={@chain}
+        nodes={@roots}
         viewer={@viewer}
         surface={@surface}
         conn_or_socket={@conn_or_socket}
@@ -523,12 +522,13 @@ defmodule VutuvWeb.PostComponents do
     """
   end
 
-  # The ordered card specs for a threaded conversation: the ancestors (oldest
-  # first, banners off, engagement from the batched map) followed by the leaf
-  # (which keeps its own follow edge, repost line and engagement). Each ancestor's
-  # `entry_id` is derived from the leaf entry so DOM ids stay unique even when the
-  # same post is nested under more than one reply on the page.
-  defp thread_chain_items(assigns) do
+  # The card specs for a threaded conversation, nested into the reply tree they
+  # really form (`Vutuv.Posts.thread_forest/1`): the ancestors (engagement from
+  # the batched map) plus the leaf (which keeps its own follow edge, repost line
+  # and engagement). Each ancestor's `entry_id` is derived from the leaf entry so
+  # DOM ids stay unique even when the same post is nested under more than one
+  # reply on the page.
+  defp thread_entry_roots(assigns) do
     leaf_key = assigns.entry_id || assigns.post.id
 
     ancestors =
@@ -543,18 +543,23 @@ defmodule VutuvWeb.PostComponents do
         }
       end)
 
-    ancestors ++
-      [
-        %{
-          post: assigns.post,
-          engagement: assigns.engagement,
-          viewer_follow: assigns.viewer_follow,
-          reposted_by: assigns.reposted_by,
-          reposters: assigns.reposters,
-          entry_id: assigns.entry_id
-        }
-      ]
+    leaf = %{
+      post: assigns.post,
+      engagement: assigns.engagement,
+      viewer_follow: assigns.viewer_follow,
+      reposted_by: assigns.reposted_by,
+      reposters: assigns.reposters,
+      entry_id: assigns.entry_id
+    }
+
+    (ancestors ++ [leaf]) |> Posts.thread_forest() |> banner_on_roots()
   end
+
+  # A card that hangs under the post it answers needs no "Replying to @handle"
+  # banner — the nesting already says it. A forest root is the other case: its
+  # parent is off the page (or gone), so it keeps the banner naming the author
+  # it answers.
+  defp banner_on_roots(roots), do: Enum.map(roots, &Map.put(&1, :show_reply_banner, true))
 
   # How many levels of a thread visibly indent before the indentation is capped.
   # Beyond this, deeper replies keep stacking in the same column (the connector
@@ -564,112 +569,168 @@ defmodule VutuvWeb.PostComponents do
   # on-screen; letting the indent grow unbounded scrolled a deep thread sideways.
   @thread_indent_cap 2
 
-  # Renders a reply chain as a threaded conversation with a **connector line that
-  # runs from each avatar into the reply's avatar** (like a mail/forum thread):
-  # a vertical drop from the head avatar down its card, then — in the indented
-  # block holding the reply — an elbow that curves from that column into the
-  # reply's avatar. Each reply is indented one `pl-7` step under the post it
-  # answers until the indent is capped (see above), past which replies stay in
-  # the same column and the connector is a straight vertical drop. Recursion draws
-  # the same connector at every level, so the line threads avatar-to-avatar all
-  # the way down. The avatar centre is `1.125rem` in from the card's left (the
-  # `sm` avatar), which is why the connectors sit at `left-[1.125rem]`.
-  attr(:chain, :list, required: true)
+  # Renders a conversation **tree** with a **connector line that runs from each
+  # avatar into the avatars of the replies it got** (like a mail/forum thread):
+  # a vertical drop from a card's avatar down past everything that answers it,
+  # then — in the block holding each answer — an elbow curving from that column
+  # into the answer's avatar. Every reply is indented one `pl-7` step under the
+  # post it answers until the indent is capped (see above), past which replies
+  # stay in the same column and the connector is a straight vertical drop.
+  # The avatar centre is `1.125rem` in from the card's left (the `sm` avatar),
+  # which is why the connectors sit at `left-[1.125rem]`.
+  #
+  # `nodes` are siblings — the conversation's roots at depth 0, one post's
+  # answers below that (`Vutuv.Posts.thread_forest/1`), each carrying its own
+  # `:children`. A post answered **twice** therefore branches: the spine keeps
+  # running past the first answer's whole subtree down into the next one, and
+  # only the last sibling closes it with the rounded elbow. Before this the
+  # chain was flat and chronological, so a reply written after a busy branch
+  # point rendered under a post it had nothing to do with (issue #1027).
+  attr(:nodes, :list, required: true)
   attr(:depth, :integer, default: 0)
   attr(:viewer, :any, default: nil)
   attr(:surface, :atom, required: true)
   attr(:conn_or_socket, :any, required: true)
 
+  attr(:connected?, :boolean,
+    default: false,
+    doc: "these nodes answer a card above them, so each draws its connector back into its column"
+  )
+
   defp thread_chain(assigns) do
     # `@thread_indent_cap` is a module attribute, not an assign, so resolve the
     # "still indenting?" flag here — inside ~H, `@name` would mean assigns.name.
-    assigns = assign(assigns, :indent?, assigns.depth < @thread_indent_cap)
+    assigns =
+      assigns
+      |> assign(:indent?, assigns.depth <= @thread_indent_cap)
+      |> assign(:nodes, mark_last(assigns.nodes))
 
     ~H"""
-    <%= case @chain do %>
-      <% [item | rest] -> %>
-        <div
-          id={Map.get(item, :focus?) && "thread-focus"}
-          data-thread-scroll={Map.get(item, :scroll?)}
-          class={[
-            "relative",
-            # The permalink's highlighted subject (issue #1006): the tint is an
-            # absolutely positioned ::before so the chain's connector geometry
-            # (avatar columns, elbows) is untouched; z-0 opens a stacking
-            # context so -z-10 stays in front of the page card's background.
-            Map.get(item, :focus?) &&
-              "z-0 scroll-mt-24 before:absolute before:-inset-x-3 before:-inset-y-2 before:-z-10 before:rounded-xl before:bg-brand-50/70 before:ring-1 before:ring-brand-200 before:content-[''] dark:before:bg-brand-900/20 dark:before:ring-brand-800"
-          ]}
+    <div
+      :for={{node, first?, last?} <- @nodes}
+      class={[
+        @connected? && "relative pt-3",
+        @connected? && @indent? && "pl-7",
+        # Separate roots: unrelated conversations (a thread whose links a
+        # deleted post broke), so they get air instead of a connector.
+        !@connected? && !first? && "mt-4"
+      ]}
+    >
+      <%!-- The connector into this answer's avatar, drawn in the column of the
+      card it answers (left-[1.125rem] of this block, which the pl-7 does not
+      move). The last answer closes the spine with an elbow curving into its
+      avatar's left edge at the avatar's vertical centre (pt-3 + 1.125rem =
+      1.875rem down); an earlier answer instead lets the spine run the full
+      height of its subtree — down to the next sibling — and taps into its own
+      avatar with a short horizontal tick at that same 1.875rem. Capped depth
+      puts the answer in the same column as its parent, so the connector is a
+      straight vertical drop through the padding. --%>
+      <span
+        :if={@connected? && @indent? && last?}
+        class="absolute left-[1.125rem] top-0 h-[1.875rem] w-2.5 rounded-bl-xl border-b-2 border-l-2 border-slate-200 dark:border-slate-700"
+        aria-hidden="true"
+      >
+      </span>
+      <span
+        :if={@connected? && @indent? && !last?}
+        class="absolute left-[1.125rem] top-0 h-full w-0.5 rounded-full bg-slate-200 dark:bg-slate-700"
+        aria-hidden="true"
+      >
+      </span>
+      <span
+        :if={@connected? && @indent? && !last?}
+        class="absolute left-[1.125rem] top-[1.875rem] h-0.5 w-2.5 rounded-full bg-slate-200 dark:bg-slate-700"
+        aria-hidden="true"
+      >
+      </span>
+      <span
+        :if={@connected? && !@indent?}
+        class="absolute left-[1.125rem] top-0 h-3 w-0.5 rounded-full bg-slate-200 dark:bg-slate-700"
+        aria-hidden="true"
+      >
+      </span>
+      <div
+        id={Map.get(node, :focus?) && "thread-focus"}
+        data-thread-scroll={Map.get(node, :scroll?)}
+        class={[
+          "relative",
+          # The permalink's highlighted subject (issue #1006): the tint is an
+          # absolutely positioned ::before so the chain's connector geometry
+          # (avatar columns, elbows) is untouched; z-0 opens a stacking
+          # context so -z-10 stays in front of the page card's background.
+          Map.get(node, :focus?) &&
+            "z-0 scroll-mt-24 before:absolute before:-inset-x-3 before:-inset-y-2 before:-z-10 before:rounded-xl before:bg-brand-50/70 before:ring-1 before:ring-brand-200 before:content-[''] dark:before:bg-brand-900/20 dark:before:ring-brand-800"
+        ]}
+      >
+        <%!-- Drops from this avatar's bottom (top-9) to the card's bottom; the
+        elbow below continues it into the answer's avatar. Only when this card
+        was answered. Height is an explicit `calc(100% - top)`, not `top-9` +
+        `bottom-0`: an empty absolutely-positioned box sized only by
+        `top`/`bottom` (auto height) collapses to zero on iOS/mobile Safari, so
+        the whole thread line vanished on phones while the explicit-height
+        elbows survived. An explicit height renders identically everywhere. --%>
+        <span
+          :if={node.children != []}
+          class="absolute left-[1.125rem] top-9 h-[calc(100%-2.25rem)] w-0.5 rounded-full bg-slate-200 dark:bg-slate-700"
+          aria-hidden="true"
         >
-          <%!-- Drops from this avatar's bottom (top-9) to the card's bottom; the
-          elbow below continues it into the reply's avatar. Only when a reply
-          follows this card. Height is an explicit `calc(100% - top)`, not
-          `top-9` + `bottom-0`: an empty absolutely-positioned box sized only by
-          `top`/`bottom` (auto height) collapses to zero on iOS/mobile Safari, so
-          the whole thread line vanished on phones while the explicit-height
-          elbows survived. An explicit height renders identically everywhere. --%>
-          <span
-            :if={rest != []}
-            class="absolute left-[1.125rem] top-9 h-[calc(100%-2.25rem)] w-0.5 rounded-full bg-slate-200 dark:bg-slate-700"
-            aria-hidden="true"
-          >
-          </span>
-          <.post_card
-            post={item.post}
-            viewer={@viewer}
-            viewer_follow={item.viewer_follow}
-            engagement={item.engagement}
-            reposted_by={item.reposted_by}
-            reposters={item.reposters}
-            entry_id={item.entry_id}
-            surface={@surface}
-            conn_or_socket={@conn_or_socket}
-            mode={Map.get(item, :mode, :preview)}
-            show_reply_banner={Map.get(item, :show_reply_banner, false)}
-          />
-        </div>
-        <div :if={rest != []} class={["relative pt-3", @indent? && "pl-7"]}>
-          <%!-- The connector into the reply's avatar. Indented: an elbow curving
-          from the parent column (left-[1.125rem]) right into the reply avatar's
-          left edge, at the reply avatar's vertical centre (pt-3 + 1.125rem =
-          1.875rem down). Capped: the reply is in the same column, so a straight
-          vertical drop to its avatar. --%>
-          <span
-            :if={@indent?}
-            class="absolute left-[1.125rem] top-0 h-[1.875rem] w-2.5 rounded-bl-xl border-b-2 border-l-2 border-slate-200 dark:border-slate-700"
-            aria-hidden="true"
-          >
-          </span>
-          <span
-            :if={!@indent?}
-            class="absolute left-[1.125rem] top-0 h-3 w-0.5 rounded-full bg-slate-200 dark:bg-slate-700"
-            aria-hidden="true"
-          >
-          </span>
-          <.thread_chain
-            chain={rest}
-            depth={@depth + 1}
-            viewer={@viewer}
-            surface={@surface}
-            conn_or_socket={@conn_or_socket}
-          />
-        </div>
-      <% [] -> %>
-    <% end %>
+        </span>
+        <.post_card
+          post={node.post}
+          viewer={@viewer}
+          viewer_follow={node.viewer_follow}
+          engagement={node.engagement}
+          reposted_by={node.reposted_by}
+          reposters={node.reposters}
+          entry_id={node.entry_id}
+          surface={@surface}
+          conn_or_socket={@conn_or_socket}
+          mode={Map.get(node, :mode, :preview)}
+          show_reply_banner={reply_banner?(node, @connected?, @indent?, first?)}
+        />
+      </div>
+      <.thread_chain
+        :if={node.children != []}
+        nodes={node.children}
+        depth={@depth + 1}
+        connected?={true}
+        viewer={@viewer}
+        surface={@surface}
+        conn_or_socket={@conn_or_socket}
+      />
+    </div>
     """
+  end
+
+  # A card names the post it answers only when its position alone does not say
+  # it. While the thread still indents, the nesting says it. Past
+  # @thread_indent_cap every card shares its parent's column, so only the
+  # *first* answer — the one rendered directly below its parent — reads
+  # unambiguously and every later sibling (which follows the previous branch's
+  # whole subtree) gets its banner back. A forest root keeps it either way: its
+  # parent is off the page.
+  defp reply_banner?(node, connected?, indent?, first?) do
+    Map.get(node, :show_reply_banner, false) or (connected? and not indent? and not first?)
+  end
+
+  # Each node paired with whether it is the first and the last of its siblings —
+  # what the connector geometry above branches on.
+  defp mark_last(nodes) do
+    last = length(nodes) - 1
+    Enum.with_index(nodes, fn node, i -> {node, i == 0, i == last} end)
   end
 
   @doc """
   The permalink page's whole-conversation rendering (issue #1006): every post
-  of `posts` (the thread oldest first, `Vutuv.Posts.list_thread/3`) as one
-  connected chain — the same look as a feed thread row. The permalinked
+  of `posts` (the thread in reading order, `Vutuv.Posts.list_thread/3`) as one
+  connected conversation — the same look as a feed thread row. The permalinked
   `focus_id` post renders in `:full` mode, tinted as the page's subject and,
   when it has context above it, marked for the arrival auto-scroll
-  (`data-thread-scroll`, wired in app.js). The chain is chronological, not a
-  tree, so a reply that does not answer the card right above it keeps its own
-  "Replying to @handle" banner — that is how a branch point stays readable.
+  (`data-thread-scroll`, wired in app.js). Every reply hangs under the post it
+  actually answers (`Vutuv.Posts.thread_forest/1`), so only a card whose parent
+  is off the page keeps its own "Replying to @handle" banner.
   """
-  attr(:posts, :list, required: true, doc: "the whole conversation, oldest first")
+  attr(:posts, :list, required: true, doc: "the whole conversation, in reading order")
   attr(:focus_id, :string, required: true, doc: "the permalinked post's id")
   attr(:viewer, :any, default: nil)
 
@@ -683,17 +744,21 @@ defmodule VutuvWeb.PostComponents do
   attr(:conn_or_socket, :any, required: true)
 
   def thread_conversation(assigns) do
-    assigns = assign(assigns, :chain, conversation_chain(assigns))
+    assigns = assign(assigns, :roots, conversation_roots(assigns))
 
     ~H"""
-    <.thread_chain chain={@chain} viewer={@viewer} surface={:flat} conn_or_socket={@conn_or_socket} />
+    <.thread_chain nodes={@roots} viewer={@viewer} surface={:flat} conn_or_socket={@conn_or_socket} />
     """
   end
 
-  defp conversation_chain(%{posts: posts} = assigns) do
-    [nil | posts]
-    |> Enum.zip(posts)
-    |> Enum.map(fn {prev, post} ->
+  defp conversation_roots(%{posts: posts} = assigns) do
+    # `posts` is already in reading order, so the head is the card that renders
+    # first — the one case where the focused post has no context above it and
+    # the page must not jump on arrival.
+    top_id = with %{id: id} <- List.first(posts), do: id
+
+    posts
+    |> Enum.map(fn post ->
       focus? = post.id == assigns.focus_id
 
       %{
@@ -705,17 +770,12 @@ defmodule VutuvWeb.PostComponents do
         entry_id: nil,
         mode: if(focus?, do: :full, else: :preview),
         focus?: focus?,
-        scroll?: focus? and prev != nil,
-        # A branch point: this reply does not answer the card right above it,
-        # so its own banner must name the real parent. The first card keeps
-        # its banner too — a degraded chain top is itself a reply.
-        show_reply_banner: prev == nil or thread_parent_id(post) != prev.id
+        scroll?: focus? and post.id != top_id
       }
     end)
+    |> Posts.thread_forest()
+    |> banner_on_roots()
   end
-
-  defp thread_parent_id(%{reply_ref: %PostReply{parent_post_id: id}}), do: id
-  defp thread_parent_id(_post), do: nil
 
   # Fallback when a caller does not compute the full visible chain: the single
   # preloaded `reply_ref` parent (one level), or none when nesting is off (the

--- a/lib/vutuv_web/controllers/api_v2/notification_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/notification_controller.ex
@@ -3,8 +3,8 @@ defmodule VutuvWeb.ApiV2.NotificationController do
   The member's notification feed (`GET /api/2.0/notifications`, cursor-
   paginated, with the unread count) and the read marker (`POST
   /api/2.0/notifications/read`). The feed is `Vutuv.Activity`'s derived
-  feed: followers, endorsements, connections, replies, thread answers, likes,
-  moderation notices — each entry names its kind and actor.
+  feed: followers, endorsements, connections, replies, thread answers,
+  mentions, likes, moderation notices — each entry names its kind and actor.
 
   Notifications span the social areas, so they ride on the social scopes:
   `social:read` to read, `social:write` to mark read.

--- a/lib/vutuv_web/live/notification_live/groups.ex
+++ b/lib/vutuv_web/live/notification_live/groups.ex
@@ -15,8 +15,8 @@ defmodule VutuvWeb.NotificationLive.Groups do
     * **thread** events of the same thread - "Anna and Ben replied in a
       thread you posted in."
 
-  Direct replies and every rarer kind (moderation, CV updates, handle
-  changes, ...) stay one row per event - each carries its own content.
+  Direct replies, mentions and every rarer kind (moderation, CV updates,
+  handle changes, ...) stay one row per event - each carries its own content.
 
   Everything here is a pure function over the item list, so the LiveView
   recomputes sections wholesale on every change (load more, live push,

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -74,7 +74,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   # `kinds:` option keeps. "all" passes nil (every source).
   @filters %{
     "all" => nil,
-    "posts" => ~w(reply thread like),
+    "posts" => ~w(reply thread mention like),
     "people" => ~w(follower connection endorsement),
     "other" =>
       ~w(organization_role moderation image_rejected report_protection handle_change cv_update
@@ -413,6 +413,17 @@ defmodule VutuvWeb.NotificationLive.Index do
           :if={@group.kind == "like" and @n[:post_preview]}
           data-post-preview="true"
           href={~p"/#{@current_user}/posts/#{@n.post_id}"}
+          html={@n.post_preview.html}
+          quote_lines={@quote_lines}
+          class="mt-1.5"
+        />
+
+        <%!-- A mention quotes the post that named the reader. Its permalink
+        lives under the post's own author, not under the reader. --%>
+        <.quoted_post
+          :if={@group.kind == "mention" and @n[:post_preview]}
+          data-post-preview="true"
+          href={~p"/#{@n.post_preview.post.user}/posts/#{@n.post_preview.post.id}"}
           html={@n.post_preview.html}
           quote_lines={@quote_lines}
           class="mt-1.5"
@@ -767,7 +778,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   # Event kinds that share the brand badge colour, so the class string lives
   # in one place.
   @brand_kind_classes "bg-brand-50 text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
-  @brand_kinds ~w(follower reply thread connection report_protection organization_role handle_change cv_update)
+  @brand_kinds ~w(follower reply thread mention connection report_protection organization_role handle_change cv_update)
 
   defp kind_classes("endorsement"),
     do: "bg-emerald-50 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-300"
@@ -790,6 +801,10 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp kind_glyph("reply"), do: "↩"
   # A reply elsewhere in a thread the recipient writes in.
   defp kind_glyph("thread"), do: "⤷"
+  # Being named by @handle. Shares the glyph with the (rare, "More"-tab)
+  # handle-change kind: both are about a handle, and the badge's title/sr-only
+  # label tells them apart where the glyph alone would not.
+  defp kind_glyph("mention"), do: "@"
   defp kind_glyph("like"), do: "♥"
   # "connection" is the vernetzt (mutual-follow) event; the handshake glyph.
   defp kind_glyph("connection"), do: "🤝"
@@ -809,6 +824,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp kind_label("endorsement"), do: gettext("Endorsement")
   defp kind_label("reply"), do: gettext("Reply")
   defp kind_label("thread"), do: gettext("Thread reply")
+  defp kind_label("mention"), do: gettext("Mention")
   defp kind_label("like"), do: gettext("Like")
   defp kind_label("connection"), do: gettext("Connection")
   defp kind_label("moderation"), do: gettext("Moderation")
@@ -906,6 +922,17 @@ defmodule VutuvWeb.NotificationLive.Index do
     end
   end
 
+  # A mention opens the post that named the reader. That post belongs to the
+  # *actor*, not to the reader, so the permalink is built under the actor's
+  # handle — unlike reply/like, which point at the reader's own post.
+  defp notification_target(%{kind: "mention"} = n, _viewer) do
+    if is_binary(n[:post_id]) and is_binary(n[:actor_param]) do
+      ~p"/#{n.actor_param}/posts/#{n.post_id}"
+    else
+      actor_target(n)
+    end
+  end
+
   # A thread event opens the new reply itself (on the replier's profile) —
   # the thing the recipient has not read yet.
   defp notification_target(%{kind: "thread"} = n, _viewer) do
@@ -937,6 +964,8 @@ defmodule VutuvWeb.NotificationLive.Index do
   # stored) so it translates with the viewer's locale. Unknown kinds fall
   # back to the pushed text.
   defp notification_text(%{kind: "reply"}), do: gettext("replied to your post.")
+
+  defp notification_text(%{kind: "mention"}), do: gettext("mentioned you in a post.")
 
   # Live-pushed thread events land here (no group context yet): one actor.
   defp notification_text(%{kind: "thread"}), do: thread_text(1)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.138.0",
+      version: "7.139.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.138.0",
+      version: "7.138.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.138.1",
+      version: "7.139.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -324,7 +324,7 @@ msgstr "Vorname"
 #: lib/vutuv_web/agent_docs/markdown.ex:443
 #: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/notification_live/index.ex:759
+#: lib/vutuv_web/live/notification_live/index.ex:770
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
 #, elixir-autogen
@@ -469,7 +469,7 @@ msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
 #: lib/vutuv_web/components/ui.ex:3180
-#: lib/vutuv_web/live/notification_live/index.ex:683
+#: lib/vutuv_web/live/notification_live/index.ex:694
 #, elixir-autogen
 msgid "More"
 msgstr "Mehr"
@@ -486,7 +486,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:486
+#: lib/vutuv_web/live/notification_live/index.ex:497
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/templates/access_token/new.html.heex:1
 #: lib/vutuv_web/templates/ad/new.html.heex:3
@@ -819,7 +819,7 @@ msgstr "User wurde verifiziert."
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
-#: lib/vutuv_web/live/notification_live/index.ex:820
+#: lib/vutuv_web/live/notification_live/index.ex:836
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
 #: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:5
@@ -2005,17 +2005,17 @@ msgstr "folgt"
 msgid "submit a bug report"
 msgstr "einen Fehlerbericht erstellen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:841
+#: lib/vutuv_web/live/notification_live/index.ex:857
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr "hat Sie für %{tag} empfohlen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:836
+#: lib/vutuv_web/live/notification_live/index.ex:852
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr "ist jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:831
+#: lib/vutuv_web/live/notification_live/index.ex:847
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
@@ -2313,7 +2313,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/controllers/user_controller.ex:73
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/notification_live/index.ex:681
+#: lib/vutuv_web/live/notification_live/index.ex:692
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:179
 #: lib/vutuv_web/live/search_live.ex:375
@@ -2506,14 +2506,14 @@ msgstr "Lesezeichen"
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2470
-#: lib/vutuv_web/live/notification_live/index.ex:812
+#: lib/vutuv_web/live/notification_live/index.ex:828
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:833
-#: lib/vutuv_web/live/notification_live/index.ex:761
+#: lib/vutuv_web/live/notification_live/index.ex:772
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:498
@@ -2591,14 +2591,14 @@ msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
 #: lib/vutuv_web/components/post_components.ex:275
-#: lib/vutuv_web/live/notification_live/index.ex:762
+#: lib/vutuv_web/live/notification_live/index.ex:773
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:2006
 #: lib/vutuv_web/components/post_components.ex:2007
-#: lib/vutuv_web/live/notification_live/index.ex:810
+#: lib/vutuv_web/live/notification_live/index.ex:825
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2624,7 +2624,7 @@ msgstr ""
 "Dieser Beitrag wurde repostet oder beantwortet. Er bleibt öffentlich, "
 "solange Reposts oder Antworten existieren; löschen können Sie ihn jederzeit."
 
-#: lib/vutuv_web/live/notification_live/index.ex:939
+#: lib/vutuv_web/live/notification_live/index.ex:966
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
@@ -2903,7 +2903,7 @@ msgstr[1] "+%{formatted} weitere Tags"
 #: lib/vutuv_web/agent_docs/markdown.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:442
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:760
+#: lib/vutuv_web/live/notification_live/index.ex:771
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2957,22 +2957,22 @@ msgstr "Personen, mit denen Sie nicht vernetzt sind"
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:821
+#: lib/vutuv_web/live/notification_live/index.ex:837
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:813
+#: lib/vutuv_web/live/notification_live/index.ex:829
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:809
+#: lib/vutuv_web/live/notification_live/index.ex:824
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:808
+#: lib/vutuv_web/live/notification_live/index.ex:823
 #: lib/vutuv_web/templates/user/show.html.heex:753
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2985,7 +2985,7 @@ msgstr[1] "Follower"
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Willkommen bei vutuv, %{name}!"
 
-#: lib/vutuv_web/live/notification_live/index.ex:838
+#: lib/vutuv_web/live/notification_live/index.ex:854
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr "gefällt Ihr Beitrag."
@@ -3017,12 +3017,12 @@ msgstr "(gelöschtes Konto)"
 msgid "(no text)"
 msgstr "(kein Text)"
 
-#: lib/vutuv_web/live/notification_live/index.ex:964
+#: lib/vutuv_web/live/notification_live/index.ex:993
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde bestätigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:965
+#: lib/vutuv_web/live/notification_live/index.ex:994
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
@@ -3137,7 +3137,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:814
+#: lib/vutuv_web/live/notification_live/index.ex:830
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3594,12 +3594,12 @@ msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
 
-#: lib/vutuv_web/live/notification_live/index.ex:967
+#: lib/vutuv_web/live/notification_live/index.ex:996
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt gelöscht; der Fall ist abgeschlossen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:966
+#: lib/vutuv_web/live/notification_live/index.ex:995
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
@@ -3609,7 +3609,7 @@ msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
 msgid "Your content was reported"
 msgstr "Ihr Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/live/notification_live/index.ex:968
+#: lib/vutuv_web/live/notification_live/index.ex:997
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3811,7 +3811,7 @@ msgstr "Verlauf"
 msgid "Open the profile"
 msgstr "Profil öffnen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:992
+#: lib/vutuv_web/live/notification_live/index.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3838,7 +3838,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:816
+#: lib/vutuv_web/live/notification_live/index.ex:832
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -3920,7 +3920,7 @@ msgstr "Bestätigt"
 msgid "Waiting for the owner"
 msgstr "Wartet auf den Besitzer"
 
-#: lib/vutuv_web/live/notification_live/index.ex:997
+#: lib/vutuv_web/live/notification_live/index.ex:1026
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4806,7 +4806,7 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/agent_docs/markdown.ex:316
 #: lib/vutuv_web/agent_docs/text.ex:342
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:682
+#: lib/vutuv_web/live/notification_live/index.ex:693
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:177
@@ -4830,7 +4830,7 @@ msgstr "Ähnliche Namen"
 #: lib/vutuv_web/components/post_components.ex:272
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:680
+#: lib/vutuv_web/live/notification_live/index.ex:691
 #: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -5690,7 +5690,7 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:971
 #: lib/vutuv_web/components/post_components.ex:1025
 #: lib/vutuv_web/components/post_components.ex:1340
-#: lib/vutuv_web/live/notification_live/index.ex:519
+#: lib/vutuv_web/live/notification_live/index.ex:530
 #: lib/vutuv_web/live/post_live/feed.ex:737
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5823,7 +5823,7 @@ msgstr "Ansehen"
 msgid "Your name"
 msgstr "Ihr Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:434
+#: lib/vutuv_web/live/notification_live/index.ex:445
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Ihr Beitrag"
@@ -5924,7 +5924,7 @@ msgid "Apps & API"
 msgstr "Apps & API-Zugang"
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:105
-#: lib/vutuv_web/live/notification_live/index.ex:763
+#: lib/vutuv_web/live/notification_live/index.ex:774
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #, elixir-autogen, elixir-format
@@ -6615,10 +6615,10 @@ msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
 #: lib/vutuv_web/components/ui.ex:1332
-#: lib/vutuv_web/live/notification_live/index.ex:464
-#: lib/vutuv_web/live/notification_live/index.ex:479
-#: lib/vutuv_web/live/notification_live/index.ex:602
-#: lib/vutuv_web/live/notification_live/index.ex:604
+#: lib/vutuv_web/live/notification_live/index.ex:475
+#: lib/vutuv_web/live/notification_live/index.ex:490
+#: lib/vutuv_web/live/notification_live/index.ex:613
+#: lib/vutuv_web/live/notification_live/index.ex:615
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
@@ -8109,13 +8109,13 @@ msgstr "Neue Mitglieder"
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:709
+#: lib/vutuv_web/live/notification_live/index.ex:720
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Heute"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:712
+#: lib/vutuv_web/live/notification_live/index.ex:723
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Gestern"
@@ -12765,7 +12765,7 @@ msgstr "Organisation"
 msgid "Organization pages"
 msgstr "Organisation"
 
-#: lib/vutuv_web/live/notification_live/index.ex:817
+#: lib/vutuv_web/live/notification_live/index.ex:833
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisation"
@@ -12876,22 +12876,22 @@ msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
 msgid "Your organization page was updated."
 msgstr "Ihre Organisationsseite wurde aktualisiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:956
+#: lib/vutuv_web/live/notification_live/index.ex:985
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr "hat dir eine Rolle bei %{company} gegeben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:953
+#: lib/vutuv_web/live/notification_live/index.ex:982
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr "hat dich zum Recruiter für %{company} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:950
+#: lib/vutuv_web/live/notification_live/index.ex:979
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr "hat dich zum Administrator von %{company} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:947
+#: lib/vutuv_web/live/notification_live/index.ex:976
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr "hat dich zum Inhaber von %{company} gemacht."
@@ -14241,7 +14241,7 @@ msgstr "Bild wird geprüft, nur für Sie sichtbar"
 msgid "Image is being reviewed"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/live/notification_live/index.ex:815
+#: lib/vutuv_web/live/notification_live/index.ex:831
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -14328,7 +14328,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:818
+#: lib/vutuv_web/live/notification_live/index.ex:834
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -14340,7 +14340,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] "Wir haben %{formatted} Beitrag aktualisiert, der Ihren alten Handle erwähnt hat, und dessen Verfasser benachrichtigt."
 msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle erwähnt haben, und deren Verfasser benachrichtigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1006
+#: lib/vutuv_web/live/notification_live/index.ex:1035
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
@@ -14553,22 +14553,22 @@ msgstr[1] "Meine %{formatted} Follower darüber informieren"
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:819
+#: lib/vutuv_web/live/notification_live/index.ex:835
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1026
+#: lib/vutuv_web/live/notification_live/index.ex:1055
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr "hat eine neue Station im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1018
+#: lib/vutuv_web/live/notification_live/index.ex:1047
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr "hat eine neue Ausbildung im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1023
+#: lib/vutuv_web/live/notification_live/index.ex:1052
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr "hat ein neues Zertifikat im Lebenslauf: %{entry}"
@@ -14593,7 +14593,7 @@ msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folg
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1031
+#: lib/vutuv_web/live/notification_live/index.ex:1060
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
@@ -14786,14 +14786,14 @@ msgstr "Mit Qualifikation: %{name}"
 msgid "Publisher:"
 msgstr "Verlag:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:701
+#: lib/vutuv_web/live/notification_live/index.ex:712
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} neue Mitteilung"
 msgstr[1] "%{formatted} neue Mitteilungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:715
+#: lib/vutuv_web/live/notification_live/index.ex:726
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day}. %{month} %{year}"
@@ -14808,23 +14808,23 @@ msgstr "Zurückfolgen"
 msgid "Last 30 days"
 msgstr "Letzte 30 Tage"
 
-#: lib/vutuv_web/live/notification_live/index.ex:667
-#: lib/vutuv_web/live/notification_live/index.ex:867
+#: lib/vutuv_web/live/notification_live/index.ex:678
+#: lib/vutuv_web/live/notification_live/index.ex:883
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/vutuv_web/live/notification_live/index.ex:834
+#: lib/vutuv_web/live/notification_live/index.ex:850
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "sind jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:829
+#: lib/vutuv_web/live/notification_live/index.ex:845
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "folgen Ihnen jetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:844
+#: lib/vutuv_web/live/notification_live/index.ex:860
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
@@ -15071,7 +15071,7 @@ msgstr "Bevorzugte Arbeitsform"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: lib/vutuv_web/live/notification_live/index.ex:637
+#: lib/vutuv_web/live/notification_live/index.ex:648
 #, elixir-autogen, elixir-format
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
@@ -15083,7 +15083,7 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/live/notification_live/index.ex:980
+#: lib/vutuv_web/live/notification_live/index.ex:1009
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
@@ -15091,12 +15091,12 @@ msgstr ""
 "familienfreundlich genug für ein Arbeitsumfeld. Sie kann sich irren, "
 "antworten Sie in dem Fall einfach auf unsere E-Mail."
 
-#: lib/vutuv_web/live/notification_live/index.ex:811
+#: lib/vutuv_web/live/notification_live/index.ex:826
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Thread-Antwort"
 
-#: lib/vutuv_web/live/notification_live/index.ex:854
+#: lib/vutuv_web/live/notification_live/index.ex:870
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -15115,3 +15115,13 @@ msgstr "Unterhaltung"
 #, elixir-autogen, elixir-format
 msgid "Only part of this long conversation is shown."
 msgstr "Von dieser langen Unterhaltung wird nur ein Teil angezeigt."
+
+#: lib/vutuv_web/live/notification_live/index.ex:827
+#, elixir-autogen, elixir-format
+msgid "Mention"
+msgstr "Erwähnung"
+
+#: lib/vutuv_web/live/notification_live/index.ex:968
+#, elixir-autogen, elixir-format
+msgid "mentioned you in a post."
+msgstr "hat Sie in einem Beitrag erwähnt."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -324,7 +324,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:443
 #: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/notification_live/index.ex:759
+#: lib/vutuv_web/live/notification_live/index.ex:770
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
 #, elixir-autogen
@@ -469,7 +469,7 @@ msgid "Middle Name"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3180
-#: lib/vutuv_web/live/notification_live/index.ex:683
+#: lib/vutuv_web/live/notification_live/index.ex:694
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -486,7 +486,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:486
+#: lib/vutuv_web/live/notification_live/index.ex:497
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/templates/access_token/new.html.heex:1
 #: lib/vutuv_web/templates/ad/new.html.heex:3
@@ -816,7 +816,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
-#: lib/vutuv_web/live/notification_live/index.ex:820
+#: lib/vutuv_web/live/notification_live/index.ex:836
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
 #: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:5
@@ -1963,17 +1963,17 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:841
+#: lib/vutuv_web/live/notification_live/index.ex:857
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:836
+#: lib/vutuv_web/live/notification_live/index.ex:852
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:831
+#: lib/vutuv_web/live/notification_live/index.ex:847
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -2265,7 +2265,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:73
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/notification_live/index.ex:681
+#: lib/vutuv_web/live/notification_live/index.ex:692
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:179
 #: lib/vutuv_web/live/search_live.ex:375
@@ -2456,14 +2456,14 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2470
-#: lib/vutuv_web/live/notification_live/index.ex:812
+#: lib/vutuv_web/live/notification_live/index.ex:828
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:833
-#: lib/vutuv_web/live/notification_live/index.ex:761
+#: lib/vutuv_web/live/notification_live/index.ex:772
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:498
@@ -2541,14 +2541,14 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:275
-#: lib/vutuv_web/live/notification_live/index.ex:762
+#: lib/vutuv_web/live/notification_live/index.ex:773
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2006
 #: lib/vutuv_web/components/post_components.ex:2007
-#: lib/vutuv_web/live/notification_live/index.ex:810
+#: lib/vutuv_web/live/notification_live/index.ex:825
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2570,7 +2570,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:939
+#: lib/vutuv_web/live/notification_live/index.ex:966
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2843,7 +2843,7 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:442
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:760
+#: lib/vutuv_web/live/notification_live/index.ex:771
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2897,22 +2897,22 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:821
+#: lib/vutuv_web/live/notification_live/index.ex:837
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:813
+#: lib/vutuv_web/live/notification_live/index.ex:829
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:809
+#: lib/vutuv_web/live/notification_live/index.ex:824
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:808
+#: lib/vutuv_web/live/notification_live/index.ex:823
 #: lib/vutuv_web/templates/user/show.html.heex:753
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2925,7 +2925,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:838
+#: lib/vutuv_web/live/notification_live/index.ex:854
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2957,12 +2957,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:964
+#: lib/vutuv_web/live/notification_live/index.ex:993
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:965
+#: lib/vutuv_web/live/notification_live/index.ex:994
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3068,7 +3068,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:814
+#: lib/vutuv_web/live/notification_live/index.ex:830
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3487,12 +3487,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:967
+#: lib/vutuv_web/live/notification_live/index.ex:996
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:966
+#: lib/vutuv_web/live/notification_live/index.ex:995
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3502,7 +3502,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:968
+#: lib/vutuv_web/live/notification_live/index.ex:997
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3691,7 +3691,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:992
+#: lib/vutuv_web/live/notification_live/index.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3716,7 +3716,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:816
+#: lib/vutuv_web/live/notification_live/index.ex:832
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3791,7 +3791,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:997
+#: lib/vutuv_web/live/notification_live/index.ex:1026
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4620,7 +4620,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:316
 #: lib/vutuv_web/agent_docs/text.ex:342
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:682
+#: lib/vutuv_web/live/notification_live/index.ex:693
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:177
@@ -4642,7 +4642,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:272
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:680
+#: lib/vutuv_web/live/notification_live/index.ex:691
 #: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -5450,7 +5450,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:971
 #: lib/vutuv_web/components/post_components.ex:1025
 #: lib/vutuv_web/components/post_components.ex:1340
-#: lib/vutuv_web/live/notification_live/index.ex:519
+#: lib/vutuv_web/live/notification_live/index.ex:530
 #: lib/vutuv_web/live/post_live/feed.ex:737
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5582,7 +5582,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:434
+#: lib/vutuv_web/live/notification_live/index.ex:445
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5681,7 +5681,7 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:105
-#: lib/vutuv_web/live/notification_live/index.ex:763
+#: lib/vutuv_web/live/notification_live/index.ex:774
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #, elixir-autogen, elixir-format
@@ -6346,10 +6346,10 @@ msgid "No endorsements yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1332
-#: lib/vutuv_web/live/notification_live/index.ex:464
-#: lib/vutuv_web/live/notification_live/index.ex:479
-#: lib/vutuv_web/live/notification_live/index.ex:602
-#: lib/vutuv_web/live/notification_live/index.ex:604
+#: lib/vutuv_web/live/notification_live/index.ex:475
+#: lib/vutuv_web/live/notification_live/index.ex:490
+#: lib/vutuv_web/live/notification_live/index.ex:613
+#: lib/vutuv_web/live/notification_live/index.ex:615
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -7751,13 +7751,13 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:709
+#: lib/vutuv_web/live/notification_live/index.ex:720
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:712
+#: lib/vutuv_web/live/notification_live/index.ex:723
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -12055,7 +12055,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:817
+#: lib/vutuv_web/live/notification_live/index.ex:833
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12158,22 +12158,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:956
+#: lib/vutuv_web/live/notification_live/index.ex:985
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:953
+#: lib/vutuv_web/live/notification_live/index.ex:982
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:950
+#: lib/vutuv_web/live/notification_live/index.ex:979
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:947
+#: lib/vutuv_web/live/notification_live/index.ex:976
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -13518,7 +13518,7 @@ msgstr ""
 msgid "Image is being reviewed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:815
+#: lib/vutuv_web/live/notification_live/index.ex:831
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13605,7 +13605,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:818
+#: lib/vutuv_web/live/notification_live/index.ex:834
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13617,7 +13617,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1006
+#: lib/vutuv_web/live/notification_live/index.ex:1035
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13828,22 +13828,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:819
+#: lib/vutuv_web/live/notification_live/index.ex:835
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1026
+#: lib/vutuv_web/live/notification_live/index.ex:1055
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1018
+#: lib/vutuv_web/live/notification_live/index.ex:1047
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1023
+#: lib/vutuv_web/live/notification_live/index.ex:1052
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13868,7 +13868,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1031
+#: lib/vutuv_web/live/notification_live/index.ex:1060
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -14061,14 +14061,14 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:701
+#: lib/vutuv_web/live/notification_live/index.ex:712
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:715
+#: lib/vutuv_web/live/notification_live/index.ex:726
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
@@ -14083,23 +14083,23 @@ msgstr ""
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:667
-#: lib/vutuv_web/live/notification_live/index.ex:867
+#: lib/vutuv_web/live/notification_live/index.ex:678
+#: lib/vutuv_web/live/notification_live/index.ex:883
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:834
+#: lib/vutuv_web/live/notification_live/index.ex:850
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:829
+#: lib/vutuv_web/live/notification_live/index.ex:845
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:844
+#: lib/vutuv_web/live/notification_live/index.ex:860
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -14334,7 +14334,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:637
+#: lib/vutuv_web/live/notification_live/index.ex:648
 #, elixir-autogen, elixir-format
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
@@ -14344,17 +14344,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:980
+#: lib/vutuv_web/live/notification_live/index.ex:1009
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:811
+#: lib/vutuv_web/live/notification_live/index.ex:826
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:854
+#: lib/vutuv_web/live/notification_live/index.ex:870
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14372,4 +14372,14 @@ msgstr ""
 #: lib/vutuv_web/templates/post/show.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "Only part of this long conversation is shown."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:827
+#, elixir-autogen, elixir-format
+msgid "Mention"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:968
+#, elixir-autogen, elixir-format
+msgid "mentioned you in a post."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -322,7 +322,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:443
 #: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/notification_live/index.ex:759
+#: lib/vutuv_web/live/notification_live/index.ex:770
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
 #, elixir-autogen
@@ -467,7 +467,7 @@ msgid "Middle Name"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3180
-#: lib/vutuv_web/live/notification_live/index.ex:683
+#: lib/vutuv_web/live/notification_live/index.ex:694
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -484,7 +484,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:486
+#: lib/vutuv_web/live/notification_live/index.ex:497
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/templates/access_token/new.html.heex:1
 #: lib/vutuv_web/templates/ad/new.html.heex:3
@@ -814,7 +814,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
-#: lib/vutuv_web/live/notification_live/index.ex:820
+#: lib/vutuv_web/live/notification_live/index.ex:836
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
 #: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:5
@@ -1961,17 +1961,17 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:841
+#: lib/vutuv_web/live/notification_live/index.ex:857
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:836
+#: lib/vutuv_web/live/notification_live/index.ex:852
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:831
+#: lib/vutuv_web/live/notification_live/index.ex:847
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -2263,7 +2263,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:73
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/notification_live/index.ex:681
+#: lib/vutuv_web/live/notification_live/index.ex:692
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:179
 #: lib/vutuv_web/live/search_live.ex:375
@@ -2454,14 +2454,14 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2470
-#: lib/vutuv_web/live/notification_live/index.ex:812
+#: lib/vutuv_web/live/notification_live/index.ex:828
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:833
-#: lib/vutuv_web/live/notification_live/index.ex:761
+#: lib/vutuv_web/live/notification_live/index.ex:772
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:498
@@ -2539,14 +2539,14 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:275
-#: lib/vutuv_web/live/notification_live/index.ex:762
+#: lib/vutuv_web/live/notification_live/index.ex:773
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2006
 #: lib/vutuv_web/components/post_components.ex:2007
-#: lib/vutuv_web/live/notification_live/index.ex:810
+#: lib/vutuv_web/live/notification_live/index.ex:825
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2568,7 +2568,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:939
+#: lib/vutuv_web/live/notification_live/index.ex:966
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2841,7 +2841,7 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:442
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:760
+#: lib/vutuv_web/live/notification_live/index.ex:771
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2895,22 +2895,22 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:821
+#: lib/vutuv_web/live/notification_live/index.ex:837
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:813
+#: lib/vutuv_web/live/notification_live/index.ex:829
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:809
+#: lib/vutuv_web/live/notification_live/index.ex:824
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:808
+#: lib/vutuv_web/live/notification_live/index.ex:823
 #: lib/vutuv_web/templates/user/show.html.heex:753
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2923,7 +2923,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:838
+#: lib/vutuv_web/live/notification_live/index.ex:854
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2955,12 +2955,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:964
+#: lib/vutuv_web/live/notification_live/index.ex:993
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:965
+#: lib/vutuv_web/live/notification_live/index.ex:994
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3066,7 +3066,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:814
+#: lib/vutuv_web/live/notification_live/index.ex:830
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3485,12 +3485,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:967
+#: lib/vutuv_web/live/notification_live/index.ex:996
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:966
+#: lib/vutuv_web/live/notification_live/index.ex:995
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3500,7 +3500,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:968
+#: lib/vutuv_web/live/notification_live/index.ex:997
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3689,7 +3689,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:992
+#: lib/vutuv_web/live/notification_live/index.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3714,7 +3714,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:816
+#: lib/vutuv_web/live/notification_live/index.ex:832
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3789,7 +3789,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:997
+#: lib/vutuv_web/live/notification_live/index.ex:1026
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4618,7 +4618,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:316
 #: lib/vutuv_web/agent_docs/text.ex:342
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:682
+#: lib/vutuv_web/live/notification_live/index.ex:693
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:177
@@ -4640,7 +4640,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:272
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:680
+#: lib/vutuv_web/live/notification_live/index.ex:691
 #: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -5448,7 +5448,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:971
 #: lib/vutuv_web/components/post_components.ex:1025
 #: lib/vutuv_web/components/post_components.ex:1340
-#: lib/vutuv_web/live/notification_live/index.ex:519
+#: lib/vutuv_web/live/notification_live/index.ex:530
 #: lib/vutuv_web/live/post_live/feed.ex:737
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5580,7 +5580,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:434
+#: lib/vutuv_web/live/notification_live/index.ex:445
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5679,7 +5679,7 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:105
-#: lib/vutuv_web/live/notification_live/index.ex:763
+#: lib/vutuv_web/live/notification_live/index.ex:774
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #, elixir-autogen, elixir-format
@@ -6344,10 +6344,10 @@ msgid "No endorsements yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1332
-#: lib/vutuv_web/live/notification_live/index.ex:464
-#: lib/vutuv_web/live/notification_live/index.ex:479
-#: lib/vutuv_web/live/notification_live/index.ex:602
-#: lib/vutuv_web/live/notification_live/index.ex:604
+#: lib/vutuv_web/live/notification_live/index.ex:475
+#: lib/vutuv_web/live/notification_live/index.ex:490
+#: lib/vutuv_web/live/notification_live/index.ex:613
+#: lib/vutuv_web/live/notification_live/index.ex:615
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -7749,13 +7749,13 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:709
+#: lib/vutuv_web/live/notification_live/index.ex:720
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:712
+#: lib/vutuv_web/live/notification_live/index.ex:723
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -12053,7 +12053,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:817
+#: lib/vutuv_web/live/notification_live/index.ex:833
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12156,22 +12156,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:956
+#: lib/vutuv_web/live/notification_live/index.ex:985
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:953
+#: lib/vutuv_web/live/notification_live/index.ex:982
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:950
+#: lib/vutuv_web/live/notification_live/index.ex:979
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:947
+#: lib/vutuv_web/live/notification_live/index.ex:976
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -13516,7 +13516,7 @@ msgstr ""
 msgid "Image is being reviewed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:815
+#: lib/vutuv_web/live/notification_live/index.ex:831
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13603,7 +13603,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:818
+#: lib/vutuv_web/live/notification_live/index.ex:834
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13615,7 +13615,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1006
+#: lib/vutuv_web/live/notification_live/index.ex:1035
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13826,22 +13826,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:819
+#: lib/vutuv_web/live/notification_live/index.ex:835
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1026
+#: lib/vutuv_web/live/notification_live/index.ex:1055
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1018
+#: lib/vutuv_web/live/notification_live/index.ex:1047
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1023
+#: lib/vutuv_web/live/notification_live/index.ex:1052
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13866,7 +13866,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1031
+#: lib/vutuv_web/live/notification_live/index.ex:1060
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -14059,14 +14059,14 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:701
+#: lib/vutuv_web/live/notification_live/index.ex:712
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:715
+#: lib/vutuv_web/live/notification_live/index.ex:726
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
@@ -14081,23 +14081,23 @@ msgstr ""
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:667
-#: lib/vutuv_web/live/notification_live/index.ex:867
+#: lib/vutuv_web/live/notification_live/index.ex:678
+#: lib/vutuv_web/live/notification_live/index.ex:883
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:834
+#: lib/vutuv_web/live/notification_live/index.ex:850
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:829
+#: lib/vutuv_web/live/notification_live/index.ex:845
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:844
+#: lib/vutuv_web/live/notification_live/index.ex:860
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -14332,7 +14332,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:637
+#: lib/vutuv_web/live/notification_live/index.ex:648
 #, elixir-autogen, elixir-format
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
@@ -14342,17 +14342,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:980
+#: lib/vutuv_web/live/notification_live/index.ex:1009
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:811
+#: lib/vutuv_web/live/notification_live/index.ex:826
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:854
+#: lib/vutuv_web/live/notification_live/index.ex:870
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14370,4 +14370,14 @@ msgstr ""
 #: lib/vutuv_web/templates/post/show.html.heex:37
 #, elixir-autogen, elixir-format
 msgid "Only part of this long conversation is shown."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:827
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Mention"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:968
+#, elixir-autogen, elixir-format
+msgid "mentioned you in a post."
 msgstr ""

--- a/priv/repo/migrations/20260723162235_create_post_mentions.exs
+++ b/priv/repo/migrations/20260723162235_create_post_mentions.exs
@@ -1,0 +1,88 @@
+defmodule Vutuv.Repo.Migrations.CreatePostMentions do
+  use Ecto.Migration
+
+  # Who a post names with `@handle`, resolved to members once at write time.
+  #
+  # A mention is plain text inside `posts.body` — nothing structured is stored —
+  # so deriving "who was mentioned" the way the rest of the notifications feed
+  # derives its events would mean an ILIKE scan over every post on every unread
+  # count, and that count runs on every page render for the shell badge. This
+  # table is that scan done once, at save time, so the feed source becomes one
+  # indexed lookup. It is the second notification kind needing its own table,
+  # for a kindred reason to `handle_change_notifications`.
+  #
+  # Both sides cascade: the row says "this post names this member" and is
+  # meaningless once either is gone.
+
+  def up do
+    create table(:post_mentions) do
+      add(:post_id, references(:posts, on_delete: :delete_all), null: false)
+      add(:user_id, references(:users, on_delete: :delete_all), null: false)
+
+      timestamps()
+    end
+
+    # One row per (post, member): a body naming someone three times is one
+    # mention. Also the conflict target when a post is saved again.
+    create(unique_index(:post_mentions, [:post_id, :user_id]))
+    # The feed source — "everything that mentioned me", newest first.
+    create(index(:post_mentions, [:user_id, :inserted_at]))
+
+    flush()
+
+    backfill()
+  end
+
+  def down do
+    drop(table(:post_mentions))
+  end
+
+  # Existing posts get their mentions recorded too, so the kind is retroactive
+  # like every other one in this feed: someone mentioned last week sees it the
+  # first time they open /notifications after this ships.
+  #
+  # The grammar lives in `Vutuv.Mentions` and is deliberately called rather than
+  # re-implemented here — a backfill that disagreed with the running code about
+  # what counts as a mention would be worse than no backfill at all. Bodies
+  # without an `@` short-circuit inside `local_handles/1`.
+  #
+  # Timestamps and the UUID v7 id are stamped from the **post**, not from now,
+  # so a backfilled mention lands in the feed at the moment it was written
+  # instead of bunching every historical mention onto deploy day — and so the
+  # id keeps sorting by creation time like every other id in the schema.
+  #
+  # Every id is passed as `$n::text::uuid` (and matched as `id::text`): raw
+  # Postgrex wants a 16-byte binary for a bare `uuid` parameter, so the cast
+  # keeps the parameter a plain string, the way the `RepairMilkdownEscaped*`
+  # migrations do it. The two timestamps are read off the `posts` row inside
+  # the statement rather than round-tripped through Elixir.
+  defp backfill do
+    %{rows: users} = repo().query!("SELECT id::text, username FROM users", [])
+    by_handle = Map.new(users, fn [id, username] -> {username, id} end)
+
+    %{rows: posts} =
+      repo().query!("SELECT id::text, user_id::text, body, inserted_at FROM posts", [])
+
+    for [post_id, author_id, body, at] <- posts,
+        is_binary(body),
+        user_id <- resolve(body, by_handle),
+        user_id != author_id do
+      repo().query!(
+        """
+        INSERT INTO post_mentions (id, post_id, user_id, inserted_at, updated_at)
+        SELECT $1::text::uuid, p.id, $2::text::uuid, p.inserted_at, p.inserted_at
+        FROM posts p WHERE p.id::text = $3
+        ON CONFLICT DO NOTHING
+        """,
+        [Vutuv.UUIDv7.generate_at(at), user_id, post_id]
+      )
+    end
+  end
+
+  defp resolve(body, by_handle) do
+    body
+    |> Vutuv.Mentions.local_handles()
+    |> Enum.flat_map(&List.wrap(Map.get(by_handle, &1)))
+    |> Enum.uniq()
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -267,6 +267,17 @@ defmodule Vutuv.Factory do
   """
   def unique_tag_name(base \\ "tag"), do: "#{base}-#{System.unique_integer([:positive])}"
 
+  @doc """
+  A per-call unique username a test can write into a body as `@handle`.
+
+  The `user_factory` sequence mints `user-1`, which is **not** a mentionable
+  handle: the mention grammar is `[A-Za-z0-9_]+`, so `@user-1` parses as the
+  handle `user`. A test about mentions therefore has to set the username
+  itself — and, for the same deadlock reason as `unique_tag_name/1`, must not
+  hardcode a literal that another async module also inserts.
+  """
+  def unique_username(base \\ "member"), do: "#{base}_#{System.unique_integer([:positive])}"
+
   def user_tag_factory do
     %Vutuv.Tags.UserTag{}
   end

--- a/test/vutuv/mention_notifications_test.exs
+++ b/test/vutuv/mention_notifications_test.exs
@@ -1,0 +1,229 @@
+defmodule Vutuv.MentionNotificationsTest do
+  @moduledoc """
+  The `"mention"` notification kind: being named `@handle` in a post is news,
+  wherever that post sits.
+
+  Before this existed, a post that named you notified you only by accident —
+  if it happened to be a direct answer to your own post ("reply") or to land in
+  a thread you had written in ("thread"). A mention in a standalone post, or in
+  a thread you are not part of, reached nobody. Both halves are covered here:
+  the write side (`Vutuv.Posts` reconciling `post_mentions` and pushing live)
+  and the read side (`Vutuv.Activity`'s derived feed, its unread count and the
+  precedence against reply/thread).
+  """
+  use Vutuv.DataCase, async: true
+
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Activity
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostMention
+  alias Vutuv.Social
+
+  # A member whose handle can actually appear as `@handle` in a body (the
+  # factory's default `user-1` is not mentionable, see Factory.unique_username/1).
+  defp mentionable(attrs \\ []) do
+    insert(:activated_user, Keyword.put_new(attrs, :username, unique_username()))
+  end
+
+  defp notifications(user_id), do: Activity.notifications_page(user_id, limit: 50).entries
+
+  defp kinds(user_id), do: user_id |> notifications() |> Enum.frequencies_by(& &1.kind)
+
+  describe "recording mentions" do
+    test "a post naming a member records the mention and pushes it live" do
+      author = mentionable()
+      mentioned = mentionable()
+      Activity.subscribe(mentioned.id)
+
+      post = create_post!(author, %{body: "Ask @#{mentioned.username} about it."})
+      post_id = post.id
+
+      assert_receive {:new_notification, %{kind: "mention", post_id: ^post_id} = n}
+      assert n.actor_param == author.username
+      assert [%PostMention{user_id: user_id}] = Repo.all(PostMention)
+      assert user_id == mentioned.id
+    end
+
+    test "several mentions in one body each get a row, a repeat only one" do
+      author = mentionable()
+      first = mentionable()
+      second = mentionable()
+
+      create_post!(author, %{
+        body: "@#{first.username} and @#{second.username} — again @#{first.username}!"
+      })
+
+      assert Repo.all(PostMention) |> Enum.map(& &1.user_id) |> Enum.sort() ==
+               Enum.sort([first.id, second.id])
+    end
+
+    test "mentioning yourself is not news" do
+      author = mentionable()
+      Activity.subscribe(author.id)
+
+      create_post!(author, %{body: "As @#{author.username} always says…"})
+
+      refute_receive {:new_notification, %{kind: "mention"}}, 50
+      assert Repo.all(PostMention) == []
+      assert kinds(author.id) == %{}
+    end
+
+    test "a handle inside a code span is sample text, not a mention" do
+      author = mentionable()
+      mentioned = mentionable()
+
+      create_post!(author, %{body: "Type `@#{mentioned.username}` to mention them."})
+
+      assert Repo.all(PostMention) == []
+      assert kinds(mentioned.id) == %{}
+    end
+
+    test "an organization handle notifies nobody (organizations have no feed)" do
+      author = mentionable()
+      org = insert(:organization, username: unique_username())
+
+      create_post!(author, %{body: "Now hiring at @#{org.username}."})
+
+      assert Repo.all(PostMention) == []
+    end
+
+    test "an edit that adds a mention notifies the newly named member only" do
+      author = mentionable()
+      first = mentionable()
+      second = mentionable()
+      post = create_post!(author, %{body: "Hello @#{first.username}."})
+
+      # Both topics feed this one mailbox, so a second push would show up here
+      # — which is the point: exactly one member is newly named.
+      Activity.subscribe(first.id)
+      Activity.subscribe(second.id)
+
+      {:ok, _} =
+        Posts.update_post(post, %{body: "Hello @#{first.username} and @#{second.username}."})
+
+      post_id = post.id
+      assert_receive {:new_notification, %{kind: "mention", post_id: ^post_id}}
+      refute_receive {:new_notification, %{kind: "mention"}}, 50
+
+      assert kinds(first.id) == %{"mention" => 1}
+      assert kinds(second.id) == %{"mention" => 1}
+    end
+
+    test "an edit that drops a mention drops the event with it" do
+      author = mentionable()
+      mentioned = mentionable()
+      post = create_post!(author, %{body: "Hello @#{mentioned.username}."})
+      assert kinds(mentioned.id) == %{"mention" => 1}
+
+      {:ok, _} = Posts.update_post(post, %{body: "Hello everyone."})
+
+      assert Repo.all(PostMention) == []
+      assert kinds(mentioned.id) == %{}
+    end
+
+    test "deleting the post takes its mention events with it" do
+      author = mentionable()
+      mentioned = mentionable()
+      post = create_post!(author, %{body: "Hello @#{mentioned.username}."})
+
+      {:ok, _} = Posts.delete_post(post)
+
+      assert Repo.all(PostMention) == []
+      assert kinds(mentioned.id) == %{}
+    end
+  end
+
+  describe "the derived feed" do
+    test "carries the mention with the post that named the member" do
+      author = mentionable(first_name: "Joe", last_name: "Armstrong")
+      mentioned = mentionable()
+      post = create_post!(author, %{body: "Over to @#{mentioned.username}."})
+
+      assert [n] = notifications(mentioned.id)
+      assert n.kind == "mention"
+      assert n.post_id == post.id
+      assert n.actor_name == "Joe Armstrong"
+      assert n.actor_param == author.username
+    end
+
+    test "counts toward the unread badge and clears once read" do
+      author = mentionable()
+      mentioned = mentionable()
+      create_post!(author, %{body: "Hi @#{mentioned.username}."})
+
+      assert Activity.unread_notification_count(mentioned.id) == 1
+      assert Activity.notifications_count(mentioned.id, ["mention"]) == 1
+
+      # The read marker has to know about the kind, or its badge never clears.
+      Activity.mark_notifications_read(mentioned.id)
+      assert Activity.unread_notification_count(mentioned.id) == 0
+    end
+
+    test "is hidden from a member with a block either way to the author" do
+      author = mentionable()
+      mentioned = mentionable()
+      {:ok, _} = Social.block_user(mentioned, author)
+
+      Activity.subscribe(mentioned.id)
+      create_post!(author, %{body: "Hi @#{mentioned.username}."})
+
+      refute_receive {:new_notification, %{kind: "mention"}}, 50
+      assert kinds(mentioned.id) == %{}
+      assert Activity.unread_notification_count(mentioned.id) == 0
+    end
+
+    test "a mention in a post the member may not see stays hidden" do
+      author = mentionable()
+      mentioned = mentionable()
+
+      create_post!(author, %{
+        body: "Hi @#{mentioned.username}.",
+        denials: [%{"denied_user_id" => mentioned.id}]
+      })
+
+      assert kinds(mentioned.id) == %{}
+    end
+  end
+
+  describe "precedence: one event per post" do
+    test "a direct answer that also names you stays a reply, never both" do
+      me = mentionable()
+      other = mentionable()
+      root = create_post!(me, %{body: "root"})
+
+      {:ok, _} = Posts.create_reply(other, root, %{body: "Good point, @#{me.username}!"})
+
+      assert kinds(me.id) == %{"reply" => 1}
+    end
+
+    test "being named in a thread you write in beats the quieter thread event" do
+      me = mentionable()
+      other = mentionable()
+      third = mentionable()
+      root = create_post!(other, %{body: "root"})
+      {:ok, mine} = Posts.create_reply(me, root, %{body: "mine"})
+
+      # `third` answers `other`, not me — normally a "thread" event for me.
+      # Naming me makes it a mention instead: same post, one row, stronger word.
+      {:ok, _} = Posts.create_reply(third, mine, %{body: "what @#{me.username} said"})
+
+      assert kinds(me.id) == %{"reply" => 1}
+
+      {:ok, _} = Posts.create_reply(third, root, %{body: "also, @#{me.username}, look"})
+
+      assert kinds(me.id) == %{"reply" => 1, "mention" => 1}
+    end
+
+    test "a thread reply that names nobody stays a thread event" do
+      me = mentionable()
+      other = mentionable()
+      root = create_post!(other, %{body: "root"})
+      {:ok, _} = Posts.create_reply(me, root, %{body: "mine"})
+
+      {:ok, _} = Posts.create_reply(mentionable(), root, %{body: "no names here"})
+
+      assert kinds(me.id) == %{"thread" => 1}
+    end
+  end
+end

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -14,6 +14,10 @@ defmodule Vutuv.PostsTest do
   # the default test user is.
   defp user(attrs \\ []), do: insert(:activated_user, attrs)
 
+  # `thread_forest/1` reads each post's preloaded `reply_ref`; the structs the
+  # create helpers hand back don't carry one.
+  defp reload(%Post{} = post), do: Repo.preload(post, :reply_ref, force: true)
+
   # Timeline ordering ties at second precision; shift a post into the past so
   # order assertions stay deterministic.
   defp backdate_post!(post, seconds) do
@@ -1927,20 +1931,36 @@ defmodule Vutuv.PostsTest do
 
   describe "list_thread/3" do
     # The permalink page renders the whole conversation (issue #1006): the
-    # thread's root plus every visible reply, oldest first, from ANY post in it.
-    test "returns the whole conversation oldest-first from any post in it" do
+    # thread's root plus every visible reply, in reading order (the reply tree
+    # walked depth-first), from ANY post in it.
+    test "returns the whole conversation in reading order from any post in it" do
       root = create_post!(user(), %{body: "thread root"})
       {:ok, mid} = Posts.create_reply(user(), root, %{body: "mid"})
       {:ok, branch_a} = Posts.create_reply(user(), mid, %{body: "branch a"})
       {:ok, branch_b} = Posts.create_reply(user(), mid, %{body: "branch b"})
       {:ok, leaf} = Posts.create_reply(user(), branch_a, %{body: "leaf"})
 
-      expected = [root.id, mid.id, branch_a.id, branch_b.id, leaf.id]
+      # branch_a's own answer follows branch_a, ahead of the older sibling
+      # branch_b — a conversation is a tree, not a timeline.
+      expected = [root.id, mid.id, branch_a.id, leaf.id, branch_b.id]
 
       for post <- [root, branch_b, leaf] do
         assert %{posts: posts, truncated?: false} = Posts.list_thread(post, nil)
         assert Enum.map(posts, & &1.id) == expected
       end
+    end
+
+    # The production bug behind this: a reply written hours after a busy branch
+    # point landed at the bottom of a chronological list, so the card above it
+    # was a stranger's post and it read as answering that one.
+    test "a reply follows the post it answers, not the newest post before it" do
+      root = create_post!(user(), %{body: "root"})
+      {:ok, early} = Posts.create_reply(user(), root, %{body: "early branch"})
+      {:ok, other} = Posts.create_reply(user(), root, %{body: "other branch"})
+      {:ok, late} = Posts.create_reply(user(), early, %{body: "the late answer"})
+
+      assert %{posts: posts} = Posts.list_thread(late, nil)
+      assert Enum.map(posts, & &1.id) == [root.id, early.id, late.id, other.id]
     end
 
     test "a post with no replies is a one-post thread" do
@@ -1989,6 +2009,42 @@ defmodule Vutuv.PostsTest do
       # The cap keeps the oldest posts; the permalinked post itself is always
       # unioned back in so the page never loses its own subject.
       assert Enum.map(posts, & &1.id) == [root.id, r1.id, r3.id]
+    end
+  end
+
+  describe "thread_forest/1" do
+    test "nests every entry under the entry it answers, siblings oldest first" do
+      root = create_post!(user(), %{body: "root"})
+      {:ok, first} = Posts.create_reply(user(), root, %{body: "first branch"})
+      {:ok, second} = Posts.create_reply(user(), root, %{body: "second branch"})
+      {:ok, deep} = Posts.create_reply(user(), first, %{body: "under the first"})
+
+      entries = for post <- Enum.shuffle([root, first, second, deep]), do: %{post: reload(post)}
+
+      assert [%{post: %Post{id: root_id}, children: children}] = Posts.thread_forest(entries)
+      assert root_id == root.id
+
+      assert [
+               %{
+                 post: %Post{id: first_id},
+                 children: [%{post: %Post{id: deep_id}, children: []}]
+               },
+               %{post: %Post{id: second_id}, children: []}
+             ] = children
+
+      assert [first_id, deep_id, second_id] == [first.id, deep.id, second.id]
+    end
+
+    test "an entry whose parent is not present becomes its own root" do
+      root = create_post!(user(), %{body: "root"})
+      {:ok, orphan} = Posts.create_reply(user(), root, %{body: "parent is off the page"})
+
+      # Only the reply is present (the feed page it renders on never loaded the
+      # parent), so it heads its own tree instead of vanishing.
+      assert [%{post: %Post{id: id}, children: []}] =
+               Posts.thread_forest([%{post: reload(orphan)}])
+
+      assert id == orphan.id
     end
   end
 

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -449,6 +449,38 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert nested_entry["id"] == nested.id
     assert nested_entry["in_reply_to_id"] == focus.id
     refute doc["thread_truncated"]
+
+    # Each entry also carries how deep it hangs, so a reader gets the tree
+    # without walking the parent pointers itself.
+    assert [0, 1, 2] == Enum.map(doc["thread"], & &1["depth"])
+
+    # And the depth is what the human-readable formats indent by: a heading
+    # level per step in Markdown, two spaces per step in plain text.
+    author = nested_entry["author"]
+    assert rendered.md =~ "##### [#{author}]"
+    assert rendered.txt =~ "\n    * #{author} ·"
+  end
+
+  # A thread branches, and the branch has to survive into the agent formats the
+  # same way it does on the page: depth-first, so a reply follows the post it
+  # answers rather than whatever was written last (issue #1027).
+  test "post permalink: a branching conversation reaches every format in reading order", %{
+    user: user,
+    post: post
+  } do
+    {:ok, alpha} = Vutuv.Posts.create_reply(user, post, %{"body" => "The alpha drift branch."})
+    {:ok, beta} = Vutuv.Posts.create_reply(user, post, %{"body" => "The beta drift branch."})
+    {:ok, late} = Vutuv.Posts.create_reply(user, alpha, %{"body" => "The late drift answer."})
+
+    rendered = formats_for("/drift_tester/posts/#{late.id}")
+
+    for fact <- ["The alpha drift branch.", "The beta drift branch.", "The late drift answer."],
+        do: assert_fact_everywhere(rendered, fact)
+
+    doc = Jason.decode!(rendered.json)
+
+    assert [post.id, alpha.id, late.id, beta.id] == Enum.map(doc["thread"], & &1["id"])
+    assert [0, 1, 2, 1] == Enum.map(doc["thread"], & &1["depth"])
   end
 
   test "post permalink: a book review's facts reach every format", %{user: user} do

--- a/test/vutuv_web/controllers/post_controller_test.exs
+++ b/test/vutuv_web/controllers/post_controller_test.exs
@@ -24,6 +24,15 @@ defmodule VutuvWeb.PostControllerTest do
 
   defp pad(int), do: String.pad_leading(Integer.to_string(int), 2, "0")
 
+  # Where `text` first shows up in the rendered page — how the thread tests
+  # assert reading order without parsing the whole card tree.
+  defp position(html, text) do
+    case :binary.match(html, text) do
+      {at, _} -> at
+      :nomatch -> flunk("#{inspect(text)} is not on the page")
+    end
+  end
+
   describe "the review card on the permalink" do
     # Stores a served cover version for `review` under a throwaway uploads
     # tree, so the card renders the <img> (and its source credit) instead of
@@ -626,9 +635,66 @@ defmodule VutuvWeb.PostControllerTest do
       assert html =~ ~s(id="thread-focus")
       assert html =~ "data-thread-scroll"
 
-      # The sibling branch answers the root, not the card right above it, so
-      # its own "Replying to" banner names the real parent.
-      assert html =~ "Replying to"
+      # Every card hangs under the post it answers, so no card needs a
+      # "Replying to" banner to correct the nesting.
+      refute html =~ "Replying to"
+    end
+
+    # The production report behind issue #1027: in a long branching thread the
+    # newest reply was written hours after a busy branch point, so a flat
+    # chronological chain put it under a stranger's post and it read as
+    # answering that one.
+    test "a branching thread nests each reply under the post it answers", %{conn: conn} do
+      author = insert_activated_user()
+      other = insert_activated_user()
+      root = create_post!(author, %{body: "the conversation root"})
+      {:ok, alpha} = Posts.create_reply(other, root, %{body: "alpha branch"})
+      {:ok, beta} = Posts.create_reply(author, root, %{body: "beta branch"})
+      {:ok, _under_beta} = Posts.create_reply(other, beta, %{body: "answer under beta"})
+      {:ok, late} = Posts.create_reply(author, alpha, %{body: "the late answer"})
+
+      # Only the conversation card, so the page's own <meta> excerpt of the
+      # permalinked post cannot pass for its position in the thread.
+      html =
+        conn
+        |> get(Posts.path(late))
+        |> html_response(200)
+        |> String.split(~s(id="post-thread"), parts: 2)
+        |> List.last()
+
+      # Reading order follows the reply tree: the late answer sits right under
+      # the branch it answers, ahead of the whole beta branch it has nothing to
+      # do with — not at the bottom where the clock would have put it.
+      assert position(html, "alpha branch") < position(html, "the late answer")
+      assert position(html, "the late answer") < position(html, "beta branch")
+      assert position(html, "beta branch") < position(html, "answer under beta")
+
+      # The branch point (root answered twice) keeps the spine running past the
+      # first branch's subtree: an earlier sibling draws the full-height line
+      # plus its own tick, only the last one closes with the rounded elbow.
+      assert html =~ "h-full w-0.5 rounded-full bg-slate-200"
+      assert html =~ "rounded-bl-xl"
+    end
+
+    # Past the indent cap every card sits in its parent's column, so nesting
+    # can no longer show who answered whom — the banner takes that job back.
+    test "a branch below the indent cap names the post it answers", %{conn: conn} do
+      author = insert_activated_user()
+      brancher = insert_activated_user(first_name: "Bea", last_name: "Brancher")
+
+      # root(0) → r1(1) → r2(2), both of whose answers render past the cap.
+      root = create_post!(author, %{body: "capped root"})
+      {:ok, r1} = Posts.create_reply(author, root, %{body: "first step"})
+      {:ok, r2} = Posts.create_reply(brancher, r1, %{body: "second step"})
+      {:ok, _first} = Posts.create_reply(author, r2, %{body: "the first answer"})
+      {:ok, second} = Posts.create_reply(author, r2, %{body: "the second answer"})
+
+      html = html_response(get(conn, Posts.path(second)), 200)
+
+      # The first answer follows its parent card directly, so it needs no
+      # banner; the second one follows its sibling instead and names the
+      # author it really answers.
+      assert html =~ "Replying to @#{brancher.username}"
     end
 
     test "the root's permalink shows its thread without the auto-scroll marker", %{conn: conn} do

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -5,6 +5,7 @@ defmodule VutuvWeb.NotificationLiveTest do
   use VutuvWeb.ConnCase
 
   import Phoenix.LiveViewTest
+  import Vutuv.PostsHelpers
 
   alias Vutuv.Prefs
   alias Vutuv.Prefs.Cache
@@ -776,6 +777,42 @@ defmodule VutuvWeb.NotificationLiveTest do
       html = render(live)
       assert html =~ "Grace Hopper"
       assert html =~ ~s(href="/#{follower.username}")
+    end
+  end
+
+  describe "mention rows" do
+    test "a post naming the reader renders a mention row linking that post", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      author = insert(:activated_user, first_name: "Joe", last_name: "Armstrong")
+
+      post =
+        create_post!(author, %{body: "Ask @#{user.username} about the schema, they know it."})
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+      html = render(live)
+
+      assert length(row_ids(html, "mention")) == 1
+      assert html =~ "Joe Armstrong"
+      assert html =~ "mentioned you in a post."
+
+      # The quoted post and the row both open the permalink under the *author*
+      # — it is their post, not the reader's, which is what sets this kind
+      # apart from a reply or a like.
+      assert has_element?(live, ~s([data-post-preview]), "they know it")
+
+      assert has_element?(
+               live,
+               ~s([data-post-preview] a[href="/#{author.username}/posts/#{post.id}"])
+             )
+    end
+
+    test "the posts filter tab keeps mention rows", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      create_post!(insert(:activated_user), %{body: "Hello @#{user.username}."})
+
+      {:ok, live, _html} = live(conn, ~p"/notifications?filter=posts")
+
+      assert length(row_ids(render(live), "mention")) == 1
     end
   end
 

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -13,6 +13,15 @@ defmodule VutuvWeb.PostFeedLiveTest do
 
   defp other_user(attrs \\ []), do: insert(:user, Keyword.merge([email_confirmed?: true], attrs))
 
+  # Where `text` first shows up in the rendered feed — how the thread tests
+  # assert reading order without parsing the whole card tree.
+  defp position(html, text) do
+    case :binary.match(html, text) do
+      {at, _} -> at
+      :nomatch -> flunk("#{inspect(text)} is not on the page")
+    end
+  end
+
   describe "engagement query batching" do
     test "feed engagement queries do not grow with post count", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
@@ -170,6 +179,33 @@ defmodule VutuvWeb.PostFeedLiveTest do
       assert has_element?(live, "#post-actions-post-#{leaf.id}-like")
       assert has_element?(live, "#post-actions-post-#{leaf.id}-parent-#{mid.id}-like")
       assert has_element?(live, "#post-actions-post-#{leaf.id}-parent-#{root.id}-like")
+    end
+
+    test "a branching thread nests each reply under the post it answers", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      friend = other_user()
+      insert(:follow, follower: user, followee: friend)
+
+      # One root answered twice; the newest reply belongs to the *first* branch.
+      {:ok, root} = Posts.create_post(user, %{body: "the branch root"})
+      {:ok, alpha} = Posts.create_reply(friend, root, %{body: "alpha branch"})
+      {:ok, beta} = Posts.create_reply(friend, root, %{body: "beta branch"})
+      {:ok, _} = Posts.create_reply(user, beta, %{body: "answer under beta"})
+      {:ok, _} = Posts.create_reply(user, alpha, %{body: "the late answer"})
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+      feed_html = live |> element("#feed-posts") |> render()
+
+      # The collapsed thread renders as the tree it is, not as a timeline: the
+      # newest reply hangs under the alpha branch it answers, ahead of the whole
+      # beta branch (issue #1027).
+      assert position(feed_html, "alpha branch") < position(feed_html, "the late answer")
+      assert position(feed_html, "the late answer") < position(feed_html, "beta branch")
+      assert position(feed_html, "beta branch") < position(feed_html, "answer under beta")
+
+      # A card whose parent is nested right above it says so by its position;
+      # the redundant "Replying to @handle" banner stays off.
+      refute feed_html =~ "Replying to"
     end
 
     test "a deep thread caps its indentation so it can't scroll a phone sideways", %{conn: conn} do


### PR DESCRIPTION
**TL;DR** Being named `@handle` in a post notified nobody. This adds the `"mention"` notification kind, backed by a new `post_mentions` table.

**Now:** `Vutuv.Mentions` rendered the link, validated the handle exists and rewrote it on rename. Nothing notified. A mention reached you only by accident, as a `"reply"` (it answered your post) or a `"thread"` event (it landed in a thread you had written in). A mention in a standalone post, or in a thread you are not part of, reached nobody.

**Want:** a post that names you tells you, wherever it sits.

I found this on a real post: https://vutuv.de/sebastian_haedr/posts/019f8ec3-0631-7a6a-b755-004b429873f5 names `@wintermeyer`, who got only the weaker "replied in a thread you posted in" row — and says so himself further down that same thread.

### Why it needs a table

Every other feed kind is derived at read time from a table that already exists. A mention is plain text in `posts.body`, so deriving it would mean an ILIKE over every post on **every unread count** — and that count runs on every page render for the shell badge. So `Vutuv.Posts.sync_mentions/1` resolves the body once at save time, through the same `Vutuv.Mentions` grammar the renderer links with, and reconciles one row per named member. Create, reply and every edit re-derive the set; the body stays the source of truth, the table is only a resolved index. Second such table after `handle_change_notifications`.

### Where each exclusion lives

| Dropped | When | Why there |
|---|---|---|
| the author, anyone the post isn't visible to | write time | belongs to the post; the edit that changes it re-derives the set |
| blocks either way, the precedence rule | read time (`mention_events/1`) | changes outside the post, like thread events already do |

Organizations share the handle namespace but have no feed, so `@some_gmbh` records nothing.

### One post, one row

Precedence is `reply` > `mention` > `thread`. An answer to your own post stays a reply even when it names you; a mention supersedes the quieter thread event (`thread_replies/1` gained a `NOT EXISTS` against `post_mentions`).

```
post answers my post ──────────► reply
post names me ─────────────────► mention
post sits in my thread ────────► thread
```

### Notes

- **Migration is additive and backfills**, so the kind is retroactive like the others. Each row's timestamp and UUID v7 id come from its post, not from deploy time, so history lands where it belongs instead of bunching onto deploy day. N-1 safe.
- **In-app only**, like thread replies: no email, no preference. Easy to add later if wanted.
- `mention` shares the `@` glyph with the rare `handle_change` kind. Different filter tabs, and the badge title disambiguates; I left the existing kind's styling alone rather than change it as a side effect.

### Verification

`mix precommit` green (4543 tests). 15 new unit tests + 2 LiveView tests. Also driven in a browser against a copy of the production database: the backfill picked up 10 historical mentions including the one above, and the page renders "Sebastian Hädrich hat Sie in einem Beitrag erwähnt." with the post quoted and the permalink pointing at its own author.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
