### PR TITLE
Bound the Markdown autolinker's trailing-punctuation walk

### DIFF
--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -30,6 +30,12 @@ defmodule VutuvWeb.Markdown do
   # `…` included: remote (Mastodon) text is length-capped with a trailing
   # ellipsis that must not become part of a link target.
   @trailing_punct ~w(. , ; : ! ? …)
+  # A single `[^\s<>]+` autolink match longer than this is emitted verbatim
+  # instead of being linked. No real URL comes close (browsers cap around 2K),
+  # so this only ever rejects a pathological unbroken run — a hard ceiling on
+  # the work `split_trailing_punct/1` can be asked to do per match, independent
+  # of that function already being linear.
+  @autolink_max 2_000
   @preview_limit 1000
   # When a whole block would overflow the preview, keep a word-cut of it (so a
   # one-line intro above a long block doesn't leave a one-line preview) — but
@@ -253,36 +259,61 @@ defmodule VutuvWeb.Markdown do
   def render_preview(_, _images, _opts), do: {Phoenix.HTML.raw(""), false}
 
   # Bare URLs become `[truncated-display](url)`. The lookbehind skips URLs that
-  # are already the target of a Markdown link (`](http…`).
+  # are already the target of a Markdown link (`](http…`). A match longer than
+  # `@autolink_max` is left as literal text: no genuine URL is that long, and it
+  # caps the work per match so a pathological unbroken run can never drive the
+  # trailing-punctuation walk (findings F1/F9 — a body of `http://a` plus tens
+  # of thousands of `.`/`)` matched as one token).
   defp autolink_bare_urls(text) do
     Regex.replace(~r{(?<!\]\()(?<![\w/])(https?://[^\s<>]+)}, text, fn _, raw ->
-      {url, trailing} = split_trailing_punct(raw)
-      "[#{truncate_url(url)}](#{url})#{trailing}"
+      if byte_size(raw) > @autolink_max do
+        raw
+      else
+        {url, trailing} = split_trailing_punct(raw)
+        "[#{truncate_url(url)}](#{url})#{trailing}"
+      end
     end)
   end
 
   # "…wiki/Elixir_(programming_language)), see!" — sentence punctuation and any
-  # `)` beyond the balanced ones belong to the sentence, not the URL.
+  # `)` beyond the balanced ones belong to the sentence, not the URL. We strip
+  # that trailing run in one right-to-left pass instead of recursing a character
+  # at a time (each old level re-walked the whole remaining string via
+  # `String.last`/`String.slice`/`String.graphemes`, so a long match cost O(n²)
+  # time and allocation — findings F1/F9). The paren balance is computed once:
+  # a `)` is trailing only while the prefix up to and including it still closes
+  # more parens than it opens, so a balanced `(disambiguation)` stays in the
+  # href while an unbalanced `)` is dropped — the exact rule the recursion had.
   defp split_trailing_punct(url) do
-    last = String.last(url)
+    graphemes = String.graphemes(url)
+    opens = Enum.count(graphemes, &(&1 == "("))
+    closes = Enum.count(graphemes, &(&1 == ")"))
 
-    cond do
-      last in @trailing_punct ->
-        {u, t} = url |> String.slice(0..-2//1) |> split_trailing_punct()
-        {u, t <> last}
+    strip =
+      graphemes
+      |> Enum.reverse()
+      |> count_trailing_to_strip(opens, closes)
 
-      last == ")" and closes_more_than_opens?(url) ->
-        {u, t} = url |> String.slice(0..-2//1) |> split_trailing_punct()
-        {u, t <> last}
-
-      true ->
-        {url, ""}
-    end
+    {kept, trailing} = Enum.split(graphemes, length(graphemes) - strip)
+    {Enum.join(kept), Enum.join(trailing)}
   end
 
-  defp closes_more_than_opens?(url) do
-    graphemes = String.graphemes(url)
-    Enum.count(graphemes, &(&1 == ")")) > Enum.count(graphemes, &(&1 == "("))
+  # How many graphemes to peel off the end, walking the reversed list once. A
+  # `.,;:!?…` char always peels; a `)` peels only while the still-kept prefix
+  # (`closes` shrinks as each closing paren is peeled; `opens` never does, since
+  # a `(` is never trailing) holds an unbalanced close. Stops at the first char
+  # that stays, so it never scans past the trailing run.
+  defp count_trailing_to_strip(reversed_graphemes, opens, closes) do
+    {strip, _closes} =
+      Enum.reduce_while(reversed_graphemes, {0, closes}, fn grapheme, {strip, closes} ->
+        cond do
+          grapheme in @trailing_punct -> {:cont, {strip + 1, closes}}
+          grapheme == ")" and closes > opens -> {:cont, {strip + 1, closes - 1}}
+          true -> {:halt, {strip, closes}}
+        end
+      end)
+
+    strip
   end
 
   # Scheme-less, www-less display text for a bare URL, shortened to the host

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.139.0",
+      version: "7.139.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/markdown_test.exs
+++ b/test/vutuv_web/markdown_test.exs
@@ -53,6 +53,41 @@ defmodule VutuvWeb.MarkdownTest do
     refute html =~ "\\"
   end
 
+  # A balanced `(disambiguation)` inside the URL stays in the href while the
+  # trailing sentence punctuation and the extra unbalanced `)` are re-appended
+  # as literal text after the anchor — the exact split the trailing-punctuation
+  # walk must preserve after being made linear (findings F1/F9).
+  test "keeps balanced parens in the href but leaves trailing punctuation and unbalanced ) out" do
+    url = "https://en.wikipedia.org/wiki/Elixir_(programming_language)"
+    html = render("see #{url}), done")
+
+    # the full URL — including the ")" that balances its own "(" — is the href
+    assert html =~ ~s(href="#{url}")
+    # the extra ")" and the "," land after the anchor as plain text
+    assert html =~ "</a>),"
+  end
+
+  # Findings F1/F9: `http://a` followed by a long unbroken run of trailing
+  # punctuation is matched as one token by `[^\s<>]+`. It must be emitted
+  # verbatim (over the length cap → not autolinked) and, either way, render in a
+  # fraction of a second rather than driving a quadratic loop.
+  test "leaves a pathological over-long autolink candidate as literal text, fast" do
+    body = "http://a" <> String.duplicate(".", 20_000)
+
+    {micros, html} = :timer.tc(fn -> render(body) end)
+
+    refute html =~ "<a "
+    assert html =~ "http://a"
+    assert micros < 1_000_000
+  end
+
+  test "still autolinks a normal long-ish URL under the cap" do
+    url = "https://example.com/" <> String.duplicate("a", 300)
+    html = render("read #{url} please")
+
+    assert html =~ ~s(href="#{url}")
+  end
+
   describe "bare URL display" do
     # The visible text of the first autolinked anchor.
     defp link_text(text) do


### PR DESCRIPTION
**TL;DR** One stored post could pin a scheduler for seconds on every render of a public page; the Markdown autolinker's trailing-punctuation walk was quadratic in an attacker-chosen length. This makes it linear and caps the candidate.

**Where:** `lib/vutuv_web/markdown.ex` — `autolink_bare_urls/1` and `split_trailing_punct/1`

**Now:** every greedy `https?://[^\s<>]+` match was handed to `split_trailing_punct/1`, which recursed once per trailing punctuation character and re-walked the whole remaining string at each level (`String.last/1`, `String.slice(0..-2//1)`, `String.graphemes/1`). A post body of `http://a` plus ~20,000 dots is matched as one URL token, so each render cost seconds of CPU and gigabytes of transient allocation in a single BEAM process. The trigger is an unauthenticated GET: post permalinks are public and listed in the sitemap, `/feed` renders full bodies, and the RSS/XML feeds render up to 20 bodies per request — so one stored post plus a request loop saturates every scheduler. The same path is reached from message threads, job postings and profile work-experience descriptions.

**Want:** the same trailing-punctuation rule at linear cost, with identical link output.

**What changed:**
- `split_trailing_punct/1` strips the trailing run in one right-to-left pass and counts the paren balance once instead of recomputing it per level. A balanced `(disambiguation)` still stays inside the href; sentence punctuation and unbalanced `)` are still re-appended as literal text.
- A match longer than 2,000 bytes is emitted verbatim rather than linked — no real URL comes close, and it caps per-match work independently of the walk now being linear.
- Three regression tests, including a 20,000-character pathological body that must render fast and unlinked.

**Behaviour:** unchanged for every legitimate input. A differential harness comparing the old recursion against the new implementation over 18 crafted cases and 200,000 random paren/punctuation-heavy inputs found 0 mismatches. The only input treated differently is an unbroken `http(s)://` token over 2,000 bytes, which was the exploit vector.

**Provenance:** found by a Claude Security scan of the repository (findings F1 and F9, both confirmed 3/3 by the verification panel), then reviewed by an independent verifier and re-challenged by a fresh reviewer of the bare diff before being applied. `mix precommit` is green locally: Credo clean, format clean, compile clean, 4553 tests passing.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01Dz1H9S965ie56hT4DQ6Gax
