### PR TITLE
Authenticate LiveView mounts by session token, not user_id

### DIFF
--- a/lib/vutuv_web/live/init_assigns.ex
+++ b/lib/vutuv_web/live/init_assigns.ex
@@ -1,10 +1,12 @@
 defmodule VutuvWeb.Live.InitAssigns do
   @moduledoc """
   LiveView `on_mount` hook that mirrors `VutuvWeb.Plug.ConfigureSession` for the
-  socket: it reads `:user_id` from the session and assigns `:current_user`, so
-  LiveViews and the shared `app` layout can render the logged-in chrome the same
-  way classic controller pages do. It also mirrors `VutuvWeb.Plug.Locale`, so
-  gettext speaks the visitor's language in the LiveView process too.
+  socket: it resolves the session's `session_token` against the server-side
+  session rows (so a revoked device and a suspended account lose the socket the
+  same way they lose a request) and assigns `:current_user`, so LiveViews and
+  the shared `app` layout can render the logged-in chrome the same way classic
+  controller pages do. It also mirrors `VutuvWeb.Plug.Locale`, so gettext speaks
+  the visitor's language in the LiveView process too.
 
   The `:require_login` stage mirrors `VutuvWeb.Plug.RequireLogin` for LiveViews:
   declare it module-level (`on_mount {VutuvWeb.Live.InitAssigns, :require_login}`)
@@ -21,10 +23,11 @@ defmodule VutuvWeb.Live.InitAssigns do
     statics: ~w(assets fonts images favicon.ico robots.txt)
 
   alias Vutuv.Accounts.User
-  alias Vutuv.Repo
+  alias Vutuv.Moderation
+  alias Vutuv.Sessions
 
   def on_mount(:default, _params, session, socket) do
-    user = session |> Map.get("user_id") |> load_user()
+    user = session_user(session)
     VutuvWeb.LiveLocale.put_locale(user, session)
 
     # Mirror `conn.request_path` for live pages: the shared layout hands the
@@ -73,8 +76,8 @@ defmodule VutuvWeb.Live.InitAssigns do
 
   @doc """
   The shared `mount/3` preamble for the **off-router** LiveViews (embedded by
-  a controller via `live_render`, so no `on_mount` hook runs): loads the
-  current user from the session, applies the visitor's locale
+  a controller via `live_render`, so no `on_mount` hook runs): resolves the
+  current user from the session token, applies the visitor's locale
   (`VutuvWeb.LiveLocale`), and assigns the keys every embedded page and the
   shared `app` layout read — `:current_user`, `:current_user_id`, `:locale`
   (the "Other formats" `?lang=` suffix) and `:shell_path` (so the embedded
@@ -83,7 +86,7 @@ defmodule VutuvWeb.Live.InitAssigns do
   `socket.assigns.current_user`.
   """
   def assign_embedded(socket, session) do
-    user = load_user(session["user_id"])
+    user = session_user(session)
     VutuvWeb.LiveLocale.put_locale(user, session)
 
     socket
@@ -93,17 +96,33 @@ defmodule VutuvWeb.Live.InitAssigns do
     |> assign(:shell_path, session["request_path"])
   end
 
-  @doc """
-  Load the current user from a session `user_id`, or nil. Shared with the
-  off-router LiveViews (via `assign_embedded/2`), which can't use this module
-  as an on_mount hook but need the same resolution. cast_or_nil:
-  pre-UUID-cutover cookies hold integer ids — anonymous, not a CastError
-  (mirrors `VutuvWeb.Plug.ConfigureSession`).
-  """
-  def load_user(user_id) do
-    case Vutuv.UUIDv7.cast_or_nil(user_id) do
-      nil -> nil
-      user_id -> Repo.get(User, user_id)
+  # The one place a mount decides who the visitor is, shared by the `:default`
+  # hook and the off-router LiveViews. It resolves the **cookie** session's
+  # `session_token` — LiveView merges the cookie session into the mount session,
+  # so nothing has to pass it along — through the server-side session rows, the
+  # same revocation check `VutuvWeb.Plug.ConfigureSession` runs on every
+  # request, and refuses a suspended or deactivated member. Unlike the plug it
+  # has no side effects: a mount cannot rewrite the cookie, and an unauthorized
+  # socket simply staying anonymous is the right outcome (`:require_login` /
+  # `:require_admin` then redirect).
+  #
+  # There is deliberately **no** fallback to a bare `session["user_id"]`.
+  # `user_id` is not only a cookie value: a controller-curated `live_render`
+  # session map carries it too and is merged *over* the cookie session, and that
+  # map travels in `data-phx-session`, which is signed but not encrypted and
+  # stays valid for days. Honoring `user_id` without a token would therefore let
+  # a captured payload, replayed with a cookie holding no token, authenticate as
+  # the member it names, with no revocation check at all.
+  defp session_user(session) when is_map(session) do
+    case Sessions.active_session(Map.get(session, "session_token")) do
+      %{user: %User{} = user} -> if allowed?(user), do: user, else: nil
+      _ -> nil
     end
   end
+
+  defp session_user(_session), do: nil
+
+  # Mirrors the plug's own gate: a suspension or deactivation must end running
+  # sessions, not just block new logins.
+  defp allowed?(%User{} = user), do: is_nil(Moderation.login_block(user))
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.140.0",
+      version: "7.140.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/init_assigns_test.exs
+++ b/test/vutuv_web/live/init_assigns_test.exs
@@ -1,0 +1,144 @@
+defmodule VutuvWeb.Live.InitAssignsTest do
+  @moduledoc """
+  The LiveView mount must authenticate exactly like `VutuvWeb.Plug.Configure
+  Session` does for a request: through the cookie's `session_token`, so a
+  remotely logged-out device and a suspended or deactivated member lose the
+  socket too, and never through a bare `user_id` — that key also arrives from
+  the controller-curated `live_render` session map, which is signed but not
+  encrypted and can therefore be captured and replayed.
+
+  The sessions here are the real thing: the cookie session read off a conn that
+  went through the actual PIN login, optionally merged with a curated map the
+  way `Phoenix.LiveView` merges one over the cookie session at mount.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  alias Phoenix.LiveView.Lifecycle
+  alias Phoenix.LiveView.Socket
+  alias Vutuv.Accounts.User
+  alias Vutuv.Sessions
+  alias VutuvWeb.Live.InitAssigns
+
+  setup %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    {:ok, conn: conn, user: user, session: Plug.Conn.get_session(conn)}
+  end
+
+  defp set_user!(user, fields) do
+    Repo.update_all(from(u in User, where: u.id == ^user.id), set: fields)
+    Repo.get!(User, user.id)
+  end
+
+  # A socket as it reaches an `on_mount` hook: mounted at the router (the
+  # `:default` stage attaches a `:handle_params` hook) with an empty lifecycle.
+  defp mount_socket do
+    %Socket{
+      router: VutuvWeb.Router,
+      endpoint: VutuvWeb.Endpoint,
+      private: %{live_temp: %{}, lifecycle: %Lifecycle{}}
+    }
+  end
+
+  defp mounted_user(session) do
+    assert {:cont, socket} = InitAssigns.on_mount(:default, %{}, session, mount_socket())
+    socket.assigns.current_user
+  end
+
+  defp embedded_user(session) do
+    InitAssigns.assign_embedded(%Socket{}, session).assigns.current_user
+  end
+
+  describe "an active session token" do
+    test "authenticates the on_mount hook", %{session: session, user: user} do
+      assert %User{id: id} = mounted_user(session)
+      assert id == user.id
+    end
+
+    test "authenticates an embedded LiveView", %{session: session, user: user} do
+      socket = InitAssigns.assign_embedded(%Socket{}, session)
+
+      assert socket.assigns.current_user.id == user.id
+      assert socket.assigns.current_user_id == user.id
+    end
+  end
+
+  describe "a token the server no longer honors" do
+    test "a revoked session mounts anonymous", %{session: session, user: user} do
+      assert [device] = Sessions.list_active(user)
+      Sessions.revoke(device)
+
+      refute mounted_user(session)
+      refute embedded_user(session)
+    end
+
+    test "a suspended member mounts anonymous", %{session: session, user: user} do
+      set_user!(user, suspended_until: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 86_400))
+
+      refute mounted_user(session)
+      refute embedded_user(session)
+    end
+
+    test "a deactivated member mounts anonymous", %{session: session, user: user} do
+      set_user!(user, deactivated_at: NaiveDateTime.utc_now(:second))
+
+      refute mounted_user(session)
+      refute embedded_user(session)
+    end
+
+    test "an unknown token mounts anonymous", %{session: session} do
+      session = Map.put(session, "session_token", "not-a-real-token")
+
+      refute mounted_user(session)
+      refute embedded_user(session)
+    end
+  end
+
+  describe "a session with no token" do
+    test "a valid user_id alone never authenticates", %{session: session, user: user} do
+      session = Map.delete(session, "session_token")
+
+      # The identity the cookie still names is a real, active member — and it
+      # is still refused, because nothing proves the session was not revoked.
+      assert session["user_id"] == user.id
+      refute mounted_user(session)
+      refute embedded_user(session)
+    end
+
+    test "an embedded mount ignores a page-supplied user_id", %{conn: conn, user: user} do
+      # The replay: an anonymous visitor's own cookie session (no token) with a
+      # captured `data-phx-session` curated map merged over it, exactly the way
+      # `VutuvWeb.ControllerHelpers.live_render_session/1` builds one.
+      anonymous_session =
+        build_conn() |> Plug.Test.init_test_session(%{}) |> Plug.Conn.get_session()
+
+      curated = %{
+        "user_id" => user.id,
+        "locale" => "de",
+        "request_path" => "/#{user.username}"
+      }
+
+      session = Map.merge(anonymous_session, curated)
+
+      refute embedded_user(session)
+      refute mounted_user(session)
+
+      # The legitimate visitor keeps their own session: the same curated map
+      # over a logged-in cookie session still resolves through the token.
+      logged_in = Map.merge(Plug.Conn.get_session(conn), curated)
+      assert embedded_user(logged_in).id == user.id
+    end
+  end
+
+  describe "no session at all" do
+    test "an anonymous session mounts anonymous" do
+      refute mounted_user(%{})
+      refute embedded_user(%{})
+    end
+
+    test "a malformed session mounts anonymous" do
+      refute mounted_user(%{"session_token" => 12_345})
+      refute embedded_user(%{"session_token" => %{"nested" => true}})
+      refute embedded_user(nil)
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** Remote logout (#794) and moderation suspensions were not enforced on the LiveView socket: the mount authenticated from a bare session `user_id`, so a revoked device or suspended member kept full access by reconnecting. Both mounts now resolve the session token instead.

**Where:** `lib/vutuv_web/live/init_assigns.ex` — `on_mount(:default, …)` and `assign_embedded/2`

**Now:** `VutuvWeb.Plug.ConfigureSession` resolves the cookie's `session_token` via `Sessions.active_session/1` (server-side revocation) and applies `Moderation.login_block/1` on every HTTP request. The LiveView mount did neither — it read `session["user_id"]` and called `Repo.get(User, user_id)`.

**Want:** the socket authenticated from the same source of truth as the request.

**Why it mattered:** revoking a device dropped its open socket, then the browser reconnected with the same cookie and was authenticated again — the cookie is only rewritten on a full HTTP request, and live navigation makes none. A suspended member's open `/messages` tab kept working for the same reason. Both features *looked* enforced because each broadcasts a disconnect, but dropping a connection is not revoking a credential, and nothing re-checked on reconnect. Exposed surface: `/messages` (private DMs), `/notifications`, the feed, the composer, `/jobs/new`, and the `/admin` live_session.

**What changed:**
- One shared resolver reads `session["session_token"]` (LiveView merges the cookie session into the mount session, so nothing needs to pass it along), resolves it through `Sessions.active_session/1`, requires a preloaded user, and refuses one whose `login_block/1` is set. It mirrors the plug's checks and omits only its side effects, since a mount cannot rewrite a cookie.
- The legacy bare-`user_id` fallback and the now-unused public `load_user/1` are deleted.
- A regression test file covering revoked / suspended / deactivated / unknown-token / no-token, both entry points.

**Why the fallback had to go, not just be bypassed:** `user_id` is not only a cookie value — the controller-curated `live_render` session map carries it too, and LiveView merges that map *over* the cookie session. That map travels in `data-phx-session`, which is signed but **not** encrypted and stays valid for days, so honouring `user_id` without a token would let a captured payload, replayed alongside a cookie holding no token, authenticate as the member it names with no revocation check. Deleting it is safe because every LiveView-rendering route pipes through `:browser`, whose `ConfigureSession.lazily_upgrade/2` mints a token in the same request that renders the page — verified by probe: a legacy `user_id`-only cookie still renders `/notifications` and `/feed` logged in.

**Verification:** the new tests fail **6 of 10** against the unpatched module, including one that reproduces the replay end to end (anonymous cookie + captured curated map is refused, while the same map over a logged-in cookie still authenticates). `mix precommit` green locally: Credo clean, format clean, compile clean, 4577 tests.

**Still open (separate issue):** `ShellLive` (`shell_live.ex:53`), `PostLive.Actions` (`actions.ex:30`) and `SectionReorderLive` (`section_reorder_live.ex:72`) still read `session["user_id"]`. `ShellLive` is the notable one — it is replayable via `shell_session/1` and leaks unread badge counts over PubSub. They are excluded here because converting them costs a DB round-trip per mount on the hottest paths (the shell renders on every page, the action bar once per post card), which deserves its own design decision.

**Provenance:** found by a Claude Security scan (findings F4 and F7). Two earlier fixes were rejected in review before this one: the first embedded the token in `data-phx-session`, which would have moved a bearer credential out of the HttpOnly cookie into readable DOM; the second kept the fallback and left the replay path open.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01Dz1H9S965ie56hT4DQ6Gax
