### PR TITLE
Keep the link screenshot from jumping down the page (#1033)

### DIFF
--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -60,6 +60,16 @@ window frame (`Vutuv.BrowserFrame`); see `Vutuv.PageScreenshot`. Needs a
 `chromium`/`chrome` binary on the host (set `CHROMIUM_PATH` if it is not on
 `$PATH`)
 
+The capture browser sends vutuv's own `User-Agent`
+(`Vutuv.SocialFeed.Http.user_agent/0`), the same string the HTTP preflight
+probe uses, so a site sees one agent for both requests. It also lets our own
+pages recognise a capture: `--screenshot` renders the document **from the
+top**, so a page that scrolls itself on arrival is shot before those tiles are
+painted and stores a blank image — which is why the post permalink drops its
+thread auto-scroll for that agent (issue #1033,
+`Vutuv.SocialFeed.Http.own_agent?/1`). Keep new on-arrival scroll/focus
+behaviour off the capture path for the same reason.
+
 ## AI image moderation (the Ollama scan)
 
 **Every** image that could become visible to anyone but its owner passes

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -269,7 +269,9 @@ once a deleted root has nilified the thread's root links), returns them in
 renders it as one feed-style conversation. The permalinked post is the tinted
 `:full`-mode card (`#thread-focus`; an absolutely positioned `::before` so the
 connector geometry is untouched) and, when it has context above, app.js scrolls
-it into view on arrival (`data-thread-scroll`). A post with no thread renders
+it into view on arrival (`data-thread-scroll`) — for a person, not for the link
+screenshot browser, whose capture that jump left blank (issue #1033; see the
+URL-screenshot section of [images.md](images.md)). A post with no thread renders
 standalone exactly as before. The action bar carries a live reply counter, and
 the parent's author gets a derived "replied to your post" notification
 (self-replies excluded). The agent-format siblings mirror the page: `PostDoc`

--- a/lib/vutuv/page_screenshot.ex
+++ b/lib/vutuv/page_screenshot.ex
@@ -276,6 +276,14 @@ defmodule Vutuv.PageScreenshot do
   `--virtual-time-budget` does *not* bound that under `--headless=new`, so it is
   no substitute; with `--timeout` the load is stopped and whatever has rendered
   is captured, which is what a member sees in their own browser anyway.
+
+  `--user-agent` names the installation the same way the HTTP preflight probe
+  does, so a site sees one agent for both requests instead of a nameless Chrome
+  for the shot — and our own pages can recognise the capture
+  (`Vutuv.SocialFeed.Http.own_agent?/1`) and skip on-arrival behaviour that
+  would spoil it: `--screenshot` renders the document **from the top**, so a
+  page that scrolls itself on arrival is captured before those tiles are
+  painted and stores a blank image (issue #1033).
   """
   def capture_args(url, out_path, opts \\ []) do
     {width, height} = Keyword.get(opts, :window, window_size())
@@ -295,6 +303,7 @@ defmodule Vutuv.PageScreenshot do
       "--force-device-scale-factor=1",
       "--virtual-time-budget=8000",
       "--timeout=#{@page_timeout_seconds * 1000}",
+      "--user-agent=#{Http.user_agent()}",
       "--window-size=#{width},#{height}",
       "--screenshot=#{out_path}",
       url

--- a/lib/vutuv/social_feed/http.ex
+++ b/lib/vutuv/social_feed/http.ex
@@ -109,4 +109,16 @@ defmodule Vutuv.SocialFeed.Http do
 
     "vutuv/#{Application.spec(:vutuv, :vsn)} (+#{String.trim_trailing(public_url, "/")})"
   end
+
+  @doc """
+  True when `user_agent` is a vutuv installation's outbound agent — this one or
+  anybody else's, since only the version and the public URL differ.
+
+  The headless page-capture browser sends it too
+  (`Vutuv.PageScreenshot.capture_args/3`), which is how a page can tell that it
+  is being screenshotted rather than read, and skip on-arrival behaviour that
+  would spoil the shot (the post permalink's scroll jump, issue #1033).
+  """
+  def own_agent?("vutuv/" <> _rest), do: true
+  def own_agent?(_user_agent), do: false
 end

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -736,6 +736,14 @@ defmodule VutuvWeb.PostComponents do
   attr(:focus_id, :string, required: true, doc: "the permalinked post's id")
   attr(:viewer, :any, default: nil)
 
+  attr(:auto_scroll?, :boolean,
+    default: true,
+    doc:
+      "false suppresses the arrival scroll jump: the headless page capture " <>
+        "screenshots from the document top, so a page that scrolls itself is " <>
+        "shot before those tiles are painted and comes out blank (issue #1033)"
+  )
+
   attr(:viewer_follows, :map,
     default: %{},
     doc:
@@ -772,7 +780,7 @@ defmodule VutuvWeb.PostComponents do
         entry_id: nil,
         mode: if(focus?, do: :full, else: :preview),
         focus?: focus?,
-        scroll?: focus? and post.id != top_id
+        scroll?: assigns.auto_scroll? and focus? and post.id != top_id
       }
     end)
     |> Posts.thread_forest()

--- a/lib/vutuv_web/controllers/post_controller.ex
+++ b/lib/vutuv_web/controllers/post_controller.ex
@@ -26,6 +26,7 @@ defmodule VutuvWeb.PostController do
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Social
+  alias Vutuv.SocialFeed.Http
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.PostDoc
   alias VutuvWeb.Fediverse.Docs, as: FediverseDocs
@@ -247,6 +248,7 @@ defmodule VutuvWeb.PostController do
       viewer_follows: viewer_follows,
       thread: thread,
       thread_truncated?: thread_truncated?,
+      auto_scroll?: not page_capture?(conn),
       # The "Other formats" card links to the post's agent siblings — shown only
       # when the anonymous .md/.txt/.json/.xml would actually resolve (the same
       # gate as maybe_put_alternates/2 advertising them in the head).
@@ -256,6 +258,16 @@ defmodule VutuvWeb.PostController do
       page_title:
         "#{VutuvWeb.UserHelpers.full_name(author)} · #{Date.to_iso8601(post.published_on)}"
     )
+  end
+
+  # The link-preview screenshot browser reading this page rather than a person
+  # (`Vutuv.PageScreenshot`, which sends vutuv's own user agent). Headless
+  # Chromium's `--screenshot` renders the document **from the top**, so the
+  # thread's arrival scroll jump moves the compositor away before those tiles
+  # are painted and the stored preview is an empty page (issue #1033). The
+  # capture gets the same conversation, just no jump.
+  defp page_capture?(conn) do
+    conn |> get_req_header("user-agent") |> List.first() |> Http.own_agent?()
   end
 
   defp redirect_query(conn) do

--- a/lib/vutuv_web/templates/post/show.html.heex
+++ b/lib/vutuv_web/templates/post/show.html.heex
@@ -30,6 +30,7 @@
           focus_id={@post.id}
           viewer={@current_user}
           viewer_follows={@viewer_follows}
+          auto_scroll?={@auto_scroll?}
           conn_or_socket={@conn}
         />
       </.card>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.140.1",
+      version: "7.140.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/page_screenshot_test.exs
+++ b/test/vutuv/page_screenshot_test.exs
@@ -11,6 +11,8 @@ defmodule Vutuv.PageScreenshotTest do
 
   import ExUnit.CaptureLog
 
+  alias Vutuv.SocialFeed.Http
+
   setup do
     prev = Application.get_env(:vutuv, :chromium_path)
     prev_resolver = Application.get_env(:vutuv, :ssrf_resolver)
@@ -52,6 +54,18 @@ defmodule Vutuv.PageScreenshotTest do
     # And it has to fire before the OS force-kill, or Chromium never gets to
     # write the file it rendered.
     assert page_timeout_ms < Vutuv.PageScreenshot.capture_seconds() * 1000
+  end
+
+  test "the capture browser identifies itself with vutuv's own user agent" do
+    args = Vutuv.PageScreenshot.capture_args("https://example.com", "/tmp/out.png")
+
+    # Same string the HTTP preflight probes with, so a site sees one agent for
+    # both requests instead of a nameless Chrome for the shot. Our own pages
+    # read it too: the post permalink drops its arrival auto-scroll for it,
+    # because `--screenshot` renders the document from the top and a page that
+    # scrolls itself is captured before those tiles are painted — the empty
+    # preview image of issue #1033.
+    assert "--user-agent=#{Http.user_agent()}" in args
   end
 
   describe "capture_outcome/2 (the file on disk decides)" do

--- a/test/vutuv_web/controllers/post_controller_test.exs
+++ b/test/vutuv_web/controllers/post_controller_test.exs
@@ -11,6 +11,7 @@ defmodule VutuvWeb.PostControllerTest do
   alias Vutuv.Posts
   alias Vutuv.Repo
   alias Vutuv.ReviewCover
+  alias Vutuv.SocialFeed.Http
 
   @other_login_attrs %{
     "emails" => %{"0" => %{"value" => "other@example.com"}},
@@ -710,6 +711,33 @@ defmodule VutuvWeb.PostControllerTest do
       assert html =~ ~s(id="thread-focus")
       # Nothing above the root, so no scroll jump on arrival.
       refute html =~ "data-thread-scroll"
+    end
+
+    # Issue #1033: the link-preview screenshot of a vutuv post permalink came
+    # out as an empty page. Headless Chromium's `--screenshot` renders the
+    # document from the top, but the arrival auto-scroll moves the compositor
+    # away before those tiles are painted, so the shot is blank. Our capture
+    # browser sends vutuv's own user agent, and for it the page must not jump.
+    test "a page capture gets the thread without the arrival auto-scroll", %{conn: conn} do
+      author = insert_activated_user()
+      root = create_post!(author, %{body: "the conversation root"})
+
+      {:ok, focus} =
+        Posts.create_reply(insert_activated_user(), root, %{body: "the focused answer"})
+
+      html =
+        conn
+        |> put_req_header("user-agent", Http.user_agent())
+        |> get(Posts.path(focus))
+        |> html_response(200)
+
+      # The whole conversation still renders, the subject is still tinted.
+      assert html =~ "the conversation root"
+      assert html =~ ~s(id="thread-focus")
+      refute html =~ "data-thread-scroll"
+
+      # A normal browser still jumps to the permalinked post.
+      assert html_response(get(conn, Posts.path(focus)), 200) =~ "data-thread-scroll"
     end
 
     test "a post without replies renders standalone, no thread frame", %{conn: conn} do


### PR DESCRIPTION
Fixes #1033.

**TL;DR** A link to a vutuv post permalink got an empty preview image, because the permalink page scrolls itself on arrival and headless Chromium's `--screenshot` shoots the document from the top, where nothing has been rastered.

### What was happening

The permalink renders the whole conversation, and when the linked post has context above it, `app.js` scrolls it into view (`data-thread-scroll`, issue #1006). Chromium's `--screenshot` renders the document **from the top** while the compositor has only rastered the tiles around the current scroll position, so that jump leaves the captured region unpainted and the stored image is a flat page background.

I reproduced it against production and locally: deterministic, at every window size below the full document height, unchanged by longer timeouts, `--virtual-time-budget` or the usual compositor flags, and gone the moment the scroll marker is dropped. A pasted `#anchor` URL blanks the same way, so this is the capture tool's limit, not something the page can be waited out of.

### The fix

Chromium now sends vutuv's own `User-Agent` for a capture — the same string the HTTP preflight probe already uses, so a site sees one agent for both requests instead of a nameless Chrome for the shot. The permalink page recognises it (`Vutuv.SocialFeed.Http.own_agent?/1`) and renders the same conversation without the arrival jump. People still get the jump.

Verified end to end against a locally seeded 27-post thread through the real `Vutuv.PageScreenshot` code path: 4,716-byte blank image before, 130,037-byte screenshot of the conversation after.

`mix precommit` is green (4,579 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01AqfaFLNL7b6hQBQPAWGBGq