### PR TITLE
Reject liking your own post (#1030)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -657,24 +657,24 @@ defmodule Vutuv.Posts do
   @doc """
   Likes `post` as `user` (idempotent). Only visible posts can be liked, and
   never across a block (a like notifies the author — a harassment vector).
+  A member cannot like their **own** post (`{:error, :self}`): a self-vote
+  inflating your own like count is not a real endorsement (issue #1030).
+  Bookmarking your own post stays fine — that is a private save.
   """
   def like_post(%User{} = user, %Post{} = post) do
-    if blocked?(user, post) do
-      {:error, :blocked}
-    else
-      do_like_post(user, post)
+    cond do
+      author?(post, user) -> {:error, :self}
+      blocked?(user, post) -> {:error, :blocked}
+      true -> do_like_post(user, post)
     end
   end
 
   defp do_like_post(%User{} = user, %Post{} = post) do
     case engage(PostLike, :like, user, post) do
       {:ok, %PostLike{}} ->
-        # A fresh like is news for the author; the idempotent repeat is not,
-        # and neither is liking your own post.
-        if post.user_id != user.id do
-          Vutuv.Activity.notify_like(post.user_id, user, post.id)
-        end
-
+        # A fresh like is news for the author; the idempotent repeat is not.
+        # Self-likes never reach here (`like_post/2` rejects them upstream).
+        Vutuv.Activity.notify_like(post.user_id, user, post.id)
         :ok
 
       {:ok, :noop} ->

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -2000,12 +2000,25 @@ defmodule VutuvWeb.PostComponents do
   attr(:post_id, :any, required: true)
   attr(:engagement, :any, default: nil)
 
+  attr(:viewer_id, :any,
+    default: nil,
+    doc: "the viewer's user id (nil when logged out), to detect their own post"
+  )
+
   attr(:target, :any,
     default: nil,
     doc: "phx-target: the LiveComponent's @myself on a host page, nil on a dead page"
   )
 
   def post_actions(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :own?,
+        assigns.engagement != nil and assigns.viewer_id != nil and
+          assigns.engagement.author_id == assigns.viewer_id
+      )
+
     ~H"""
     <%!-- justify-between spreads the four controls across the column's full
           width (X-style); -mx-2 cancels the outer buttons' px-2 so the first
@@ -2014,17 +2027,13 @@ defmodule VutuvWeb.PostComponents do
       :if={@engagement}
       class="-mx-2 mt-3 flex items-center justify-between gap-2 text-slate-600 dark:text-slate-400"
     >
-      <.action_button
+      <.like_control
         id={"#{@id}-like"}
         target={@target}
-        kind="like"
-        active?={@engagement.liked?}
+        own?={@own?}
+        liked?={@engagement.liked?}
         count={@engagement.likes}
-        label={if @engagement.liked?, do: gettext("Unlike"), else: gettext("Like")}
-        active_class="text-accent"
-      >
-        <:icon><.icon_heart filled?={@engagement.liked?} /></:icon>
-      </.action_button>
+      />
 
       <.reply_link
         id={"#{@id}-reply"}
@@ -2059,6 +2068,44 @@ defmodule VutuvWeb.PostComponents do
         <:icon><.icon_bookmark filled?={@engagement.bookmarked?} /></:icon>
       </.action_button>
     </div>
+    """
+  end
+
+  # The Like control: a real toggle for everyone but the author. On your OWN
+  # post it is a plain, non-interactive count instead of a clickable heart —
+  # a member cannot like their own post (issue #1030), so the toggle would be
+  # a dead control. Same slot and id either way, so the row layout and the
+  # tests that key on `#…-like` don't care which branch renders.
+  attr(:id, :string, required: true)
+  attr(:target, :any, default: nil)
+  attr(:own?, :boolean, required: true)
+  attr(:liked?, :boolean, required: true)
+  attr(:count, :integer, required: true)
+
+  defp like_control(assigns) do
+    ~H"""
+    <.action_button
+      :if={!@own?}
+      id={@id}
+      target={@target}
+      kind="like"
+      active?={@liked?}
+      count={@count}
+      label={if @liked?, do: gettext("Unlike"), else: gettext("Like")}
+      active_class="text-accent"
+    >
+      <:icon><.icon_heart filled?={@liked?} /></:icon>
+    </.action_button>
+    <span
+      :if={@own?}
+      id={@id}
+      title={gettext("You can't like your own post.")}
+      aria-label={gettext("Likes")}
+      class="inline-flex cursor-default items-center gap-1.5 rounded-lg px-2 py-1 text-sm text-slate-600 dark:text-slate-400"
+    >
+      <.icon_heart filled?={false} />
+      <.count_pill count={@count} kind="like" />
+    </span>
     """
   end
 

--- a/lib/vutuv_web/controllers/api_v2/post_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/post_controller.ex
@@ -222,6 +222,13 @@ defmodule VutuvWeb.ApiV2.PostController do
 
   defp post_error(conn, :blocked), do: Problem.blocked(conn)
 
+  defp post_error(conn, :self) do
+    Problem.send_problem(conn, 422, "Cannot like your own post",
+      detail: "A member cannot like their own post.",
+      extra: %{reason: :self}
+    )
+  end
+
   defp post_error(conn, :not_visible), do: Problem.not_found(conn)
 
   defp post_error(conn, reason)

--- a/lib/vutuv_web/live/post_live/actions.ex
+++ b/lib/vutuv_web/live/post_live/actions.ex
@@ -99,7 +99,7 @@ defmodule VutuvWeb.PostLive.Actions do
   @impl true
   def render(assigns) do
     ~H"""
-    <.post_actions id={@id} post_id={@post_id} engagement={@engagement} />
+    <.post_actions id={@id} post_id={@post_id} engagement={@engagement} viewer_id={@viewer_id} />
     """
   end
 end

--- a/lib/vutuv_web/live/post_live/actions_component.ex
+++ b/lib/vutuv_web/live/post_live/actions_component.ex
@@ -51,7 +51,13 @@ defmodule VutuvWeb.PostLive.ActionsComponent do
   def render(assigns) do
     ~H"""
     <div id={@id}>
-      <.post_actions id={@id} post_id={@post_id} engagement={@engagement} target={@myself} />
+      <.post_actions
+        id={@id}
+        post_id={@post_id}
+        engagement={@engagement}
+        viewer_id={@viewer_id}
+        target={@myself}
+      />
     </div>
     """
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.140.3",
+      version: "7.140.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260724060604_purge_self_likes.exs
+++ b/priv/repo/migrations/20260724060604_purge_self_likes.exs
@@ -1,0 +1,18 @@
+defmodule Vutuv.Repo.Migrations.PurgeSelfLikes do
+  use Ecto.Migration
+
+  # A member could like their own post until issue #1030, so `post_likes` holds
+  # self-votes that inflate those posts' public like counts. Delete them once;
+  # `Vutuv.Posts.like_post/2` now rejects the write, so none can reappear.
+  # Irreversible (the removed rows carry no information worth restoring), hence
+  # `up`/`down` rather than a reversible `change`.
+  def up do
+    execute("""
+    DELETE FROM post_likes l
+    USING posts p
+    WHERE l.post_id = p.id AND l.user_id = p.user_id
+    """)
+  end
+
+  def down, do: :ok
+end

--- a/test/vutuv/activity_test.exs
+++ b/test/vutuv/activity_test.exs
@@ -162,7 +162,8 @@ defmodule Vutuv.ActivityTest do
       fan = insert(:user, first_name: "Fanny", last_name: "First")
       post = insert(:post, user: author)
       :ok = Vutuv.Posts.like_post(fan, post)
-      :ok = Vutuv.Posts.like_post(author, post)
+      # A self-like never happens (issue #1030), so it can produce no event.
+      assert {:error, :self} = Vutuv.Posts.like_post(author, post)
 
       assert [%{kind: "like", actor_name: "Fanny First"}] =
                author.id |> recent_notifications() |> Enum.filter(&(&1.kind == "like"))

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -1034,7 +1034,9 @@ defmodule Vutuv.PostsTest do
       author = user()
 
       self_promoted = create_post!(author, %{body: "I like me"})
-      :ok = Posts.like_post(author, self_promoted)
+      # A self-like is refused outright (issue #1030), so the post keeps only
+      # the single stranger's like and stays below the discovery bar.
+      assert {:error, :self} = Posts.like_post(author, self_promoted)
       :ok = Posts.like_post(user(), self_promoted)
 
       earned = liked_post!(user(), %{body: "liked by others"})
@@ -1498,9 +1500,18 @@ defmodule Vutuv.PostsTest do
       :ok = Posts.like_post(fan, post)
       refute_receive {:new_notification, _}, 50
 
-      # Liking your own post is not news.
-      :ok = Posts.like_post(author, post)
+      # You cannot like your own post at all, so there is nothing to notify.
+      assert {:error, :self} = Posts.like_post(author, post)
       refute_receive {:new_notification, _}, 50
+    end
+
+    test "like_post/2 refuses a self-like and writes no row (#1030)" do
+      author = user()
+      post = create_post!(author, %{body: "I like me"})
+
+      assert {:error, :self} = Posts.like_post(author, post)
+      assert %{likes: 0} = Posts.engagement_counts(post.id)
+      refute Posts.post_engagement(post.id, author).liked?
     end
 
     test "unlike_post/2 removes the like" do

--- a/test/vutuv_web/controllers/api_v2/posts_api_test.exs
+++ b/test/vutuv_web/controllers/api_v2/posts_api_test.exs
@@ -205,6 +205,15 @@ defmodule VutuvWeb.ApiV2.PostsApiTest do
       assert json_response(conn3, 200)["liked?"] == false
     end
 
+    test "liking your own post is a 422 (#1030)", %{conn: conn, me: me, token: token} do
+      post = insert(:post, user: me)
+
+      conn = put(authed(conn, token), "/api/2.0/posts/#{post.id}/like")
+      assert conn.status == 422
+      assert Jason.decode!(conn.resp_body)["reason"] == "self"
+      assert %{likes: 0} = Posts.engagement_counts(post.id)
+    end
+
     test "reposting a restricted post is a 409", %{conn: conn, me: me, token: token} do
       {:ok, post} =
         Posts.create_post(me, %{

--- a/test/vutuv_web/live/post_actions_live_test.exs
+++ b/test/vutuv_web/live/post_actions_live_test.exs
@@ -29,7 +29,9 @@ defmodule VutuvWeb.PostActionsLiveTest do
   describe "no nested action LiveView (flash + PubSub fix)" do
     test "the feed renders the action bar inline, not as a child LiveView", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
-      post = create_post!(user, %{body: "inline bar"})
+      friend = other_user()
+      insert(:follow, follower: user, followee: friend)
+      post = create_post!(friend, %{body: "inline bar"})
 
       {:ok, feed, _html} = live(conn, ~p"/feed")
 
@@ -49,7 +51,9 @@ defmodule VutuvWeb.PostActionsLiveTest do
   describe "the action bar on the feed" do
     test "like toggles and counts", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
-      post = create_post!(user, %{body: "likeable"})
+      friend = other_user()
+      insert(:follow, follower: user, followee: friend)
+      post = create_post!(friend, %{body: "likeable"})
       %{view: actions} = feed_actions(conn, post)
 
       html =
@@ -68,6 +72,30 @@ defmodule VutuvWeb.PostActionsLiveTest do
         |> render_click()
 
       refute html =~ ~s(data-count="like")
+      assert %{likes: 0} = Posts.engagement_counts(post.id)
+    end
+
+    # A member cannot like their own post (issue #1030), so on your own card
+    # the heart is a plain, inert count instead of a clickable toggle. The
+    # id stays (the row keeps its four columns), but there is no toggle wiring.
+    test "your own post shows a static like count, not a toggle", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "no self like"})
+      %{view: actions} = feed_actions(conn, post)
+
+      like = "#post-actions-post-#{post.id}-like"
+      assert has_element?(actions, like)
+
+      html = actions |> element(like) |> render()
+      assert html =~ "<span"
+      refute html =~ ~s(phx-click="toggle")
+      refute html =~ "<button"
+
+      # Bookmarking your own post is still fine — a private save, unchanged.
+      assert has_element?(actions, "#post-actions-post-#{post.id}-bookmark[phx-click]")
+
+      # A self-like cannot sneak in through the data layer either.
+      assert {:error, :self} = Posts.like_post(user, post)
       assert %{likes: 0} = Posts.engagement_counts(post.id)
     end
 
@@ -142,7 +170,9 @@ defmodule VutuvWeb.PostActionsLiveTest do
     # active and inactive reposts visually identical (both brand blue).
     test "buttons carry an explicit state color", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
-      post = create_post!(user, %{body: "state colors"})
+      friend = other_user()
+      insert(:follow, follower: user, followee: friend)
+      post = create_post!(friend, %{body: "state colors"})
       %{view: actions} = feed_actions(conn, post)
 
       like = "#post-actions-post-#{post.id}-like"
@@ -162,7 +192,9 @@ defmodule VutuvWeb.PostActionsLiveTest do
     # doesn't shift the neighbouring buttons under the pointer.
     test "zero counters reserve their space", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
-      post = create_post!(user, %{body: "stable row"})
+      friend = other_user()
+      insert(:follow, follower: user, followee: friend)
+      post = create_post!(friend, %{body: "stable row"})
       %{view: actions} = feed_actions(conn, post)
 
       like = "#post-actions-post-#{post.id}-like"
@@ -397,8 +429,11 @@ defmodule VutuvWeb.PostActionsLiveTest do
     # renders exactly what it was handed by passing a like count no query could
     # produce (the post has zero likes).
     test "renders engagement handed in via the session instead of querying" do
-      user = other_user()
-      post = create_post!(user, %{body: "preloaded"})
+      author = other_user()
+      # The viewer is a reader (not the author), so the Like heart stays a live
+      # toggle — an author sees a static count on their own post (issue #1030).
+      reader = other_user()
+      post = create_post!(author, %{body: "preloaded"})
 
       passed = %{
         likes: 999,
@@ -409,7 +444,7 @@ defmodule VutuvWeb.PostActionsLiveTest do
         bookmarked?: false,
         reposted?: false,
         restricted?: false,
-        author_id: user.id,
+        author_id: author.id,
         id: post.id
       }
 
@@ -417,7 +452,7 @@ defmodule VutuvWeb.PostActionsLiveTest do
         live_isolated(build_conn(), VutuvWeb.PostLive.Actions,
           session: %{
             "post_id" => post.id,
-            "user_id" => user.id,
+            "user_id" => reader.id,
             "id" => "post-actions-#{post.id}",
             "locale" => "en",
             "engagement" => passed


### PR DESCRIPTION
**TL;DR** A member could like their own post; now they can't. `Posts.like_post/2` returns `{:error, :self}`, the Like heart is a plain inert count on your own card, and a migration purges the self-likes the bug already wrote.

Fixes #1030.

**What changed**
- `Vutuv.Posts.like_post/2` rejects a self-like with `{:error, :self}` — one rule shared by the LiveView action bar, the standalone dead-page bar, and the API. Bookmarking your own post stays fine (a private save).
- On your own card the Like heart renders as a plain, non-interactive count instead of a clickable toggle (same slot + id, so the row keeps its four columns). Reply / repost / bookmark are untouched.
- API `PUT /posts/:id/like` on your own post answers `422` with `reason: "self"`.
- Migration `PurgeSelfLikes` deletes the `post_likes` rows where the liker is the post's author, so existing public counts drop back to the truth. N-1 safe (row delete only).

**Tests**
- `Posts.like_post/2` refuses a self-like and writes no row; existing self-like / notification / discovery tests updated to expect `{:error, :self}`.
- Feed: your own post shows a static like count (no toggle wiring); the four feed toggle tests now like a followed friend's post.
- API: liking your own post is a 422.

Full `mix precommit` green (4582 tests).

An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.

https://claude.ai/code/session_0157Fb6QGGuZUi1V3Eme8kp2