### PR TITLE
Drop redundant self-like query filters

### DIFF
--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -114,10 +114,12 @@ defmodule Vutuv.Activity do
 
     mention_max = select(mention_events(user_id), [mention: m], %{ts: max(m.inserted_at)})
 
+    # No self-like filter needed: a member cannot like their own post
+    # (enforced in Posts.like_post/2, issue #1030).
     like_max =
       from(l in PostLike,
         join: p in assoc(l, :post),
-        where: p.user_id == ^user_id and l.user_id != ^user_id,
+        where: p.user_id == ^user_id,
         select: %{ts: max(l.inserted_at)}
       )
 
@@ -864,13 +866,14 @@ defmodule Vutuv.Activity do
     )
   end
 
-  # Likes on this user's posts, minus self-likes. Carries the liked post's id
-  # so the notification can link to it.
+  # Likes on this user's posts. Carries the liked post's id so the notification
+  # can link to it. No self-like filter: a member cannot like their own post
+  # (enforced in Posts.like_post/2, issue #1030).
   defp like_items(user_id, limit, cursor) do
     from(l in PostLike,
       join: p in assoc(l, :post),
       join: liker in assoc(l, :user),
-      where: p.user_id == ^user_id and l.user_id != ^user_id,
+      where: p.user_id == ^user_id,
       order_by: [desc: l.inserted_at, desc: l.id],
       limit: ^limit,
       select: {l.id, l.inserted_at, struct(liker, ^User.listing_fields()), p.id}
@@ -1154,10 +1157,12 @@ defmodule Vutuv.Activity do
     |> since(read_at)
   end
 
+  # No self-like filter: a member cannot like their own post (enforced in
+  # Posts.like_post/2, issue #1030).
   defp count_likes(user_id, read_at) do
     from(l in PostLike,
       join: p in assoc(l, :post),
-      where: p.user_id == ^user_id and l.user_id != ^user_id,
+      where: p.user_id == ^user_id,
       select: %{count: count()}
     )
     |> since(read_at)

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1664,14 +1664,15 @@ defmodule Vutuv.Posts do
     |> scope_visible(nil)
   end
 
-  # The like counts the rail ranks on: likes by anyone but the author, rolled
-  # up once for the whole table (likes are far rarer than posts, so this beats
-  # a correlated count per candidate row).
+  # The like counts the rail ranks on, rolled up once for the whole table
+  # (likes are far rarer than posts, so this beats a correlated count per
+  # candidate row). No self-like filter is needed: a member cannot like their
+  # own post (enforced in `like_post/2`, issue #1030), so every like is by
+  # someone other than the author.
   defp discover_like_counts do
     from(l in PostLike,
       join: p in Post,
       on: p.id == l.post_id,
-      where: l.user_id != p.user_id,
       group_by: l.post_id,
       select: %{post_id: l.post_id, likes: count(l.id)}
     )

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.140.5",
+      version: "7.140.6",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
**TL;DR** Follow-up to #1038. A member can no longer like their own post, so the `l.user_id != p.user_id` guards at the read sites are dead code. Remove all four; the write chokepoint owns the invariant now. Pure refactor, no behavior change.

**Why**
`Posts.like_post/2` rejects a self-like at the single insertion path (#1030) and the `PurgeSelfLikes` migration cleared the rows the old bug wrote, so no `post_likes` row can ever have `l.user_id = p.user_id`. Every read-site filter that excluded self-likes is now redundant.

**What changed** (removed the self-like `where` clause, added a comment pointing at the write-time invariant):
- `Vutuv.Posts.discover_like_counts/0` — the discovery rail's like tally.
- `Vutuv.Activity` — `like_max`, `like_items/3`, `count_likes/2` (the notifications subsystem).

`Vutuv.Reports.daily/1` is unchanged: it counts raw like rows for a daily activity metric and never filtered self-likes.

**Tests**: no new tests — behavior is provably identical and already covered (the self-like rejection is asserted in `posts_test`/`activity_test`). Full `mix precommit` green (4584 tests). Bumped to 7.140.6.

An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.

https://claude.ai/code/session_0157Fb6QGGuZUi1V3Eme8kp2