### PR TITLE
Authenticate the three embedded LiveViews by session token, not user_id

### DIFF
--- a/lib/vutuv_web/live/init_assigns.ex
+++ b/lib/vutuv_web/live/init_assigns.ex
@@ -96,31 +96,37 @@ defmodule VutuvWeb.Live.InitAssigns do
     |> assign(:shell_path, session["request_path"])
   end
 
-  # The one place a mount decides who the visitor is, shared by the `:default`
-  # hook and the off-router LiveViews. It resolves the **cookie** session's
-  # `session_token` — LiveView merges the cookie session into the mount session,
-  # so nothing has to pass it along — through the server-side session rows, the
-  # same revocation check `VutuvWeb.Plug.ConfigureSession` runs on every
-  # request, and refuses a suspended or deactivated member. Unlike the plug it
-  # has no side effects: a mount cannot rewrite the cookie, and an unauthorized
-  # socket simply staying anonymous is the right outcome (`:require_login` /
-  # `:require_admin` then redirect).
-  #
-  # There is deliberately **no** fallback to a bare `session["user_id"]`.
-  # `user_id` is not only a cookie value: a controller-curated `live_render`
-  # session map carries it too and is merged *over* the cookie session, and that
-  # map travels in `data-phx-session`, which is signed but not encrypted and
-  # stays valid for days. Honoring `user_id` without a token would therefore let
-  # a captured payload, replayed with a cookie holding no token, authenticate as
-  # the member it names, with no revocation check at all.
-  defp session_user(session) when is_map(session) do
+  @doc """
+  The one place a mount decides who the visitor is, shared by the `:default`
+  hook, the off-router LiveViews assigned through `assign_embedded/2`, and the
+  three embedded live_render children that carry no `:current_user`
+  (`VutuvWeb.ShellLive`, `VutuvWeb.PostLive.Actions`,
+  `VutuvWeb.SectionReorderLive`). Resolves the **cookie** session's
+  `session_token` — LiveView merges the cookie session into the mount session,
+  so nothing has to pass it along — through the server-side session rows, the
+  same revocation check `VutuvWeb.Plug.ConfigureSession` runs on every request,
+  and refuses a suspended or deactivated member. Returns the preloaded
+  `%Vutuv.Accounts.User{}` or `nil`. Unlike the plug it has no side effects: a
+  mount cannot rewrite the cookie, and an unauthorized socket simply staying
+  anonymous is the right outcome (`:require_login` / `:require_admin` then
+  redirect).
+
+  There is deliberately **no** fallback to a bare `session["user_id"]`.
+  `user_id` is not only a cookie value: a controller-curated `live_render`
+  session map carries it too and is merged *over* the cookie session, and that
+  map travels in `data-phx-session`, which is signed but not encrypted and
+  stays valid for days. Honoring `user_id` without a token would therefore let
+  a captured payload, replayed with a cookie holding no token, authenticate as
+  the member it names, with no revocation check at all.
+  """
+  def session_user(session) when is_map(session) do
     case Sessions.active_session(Map.get(session, "session_token")) do
       %{user: %User{} = user} -> if allowed?(user), do: user, else: nil
       _ -> nil
     end
   end
 
-  defp session_user(_session), do: nil
+  def session_user(_session), do: nil
 
   # Mirrors the plug's own gate: a suspension or deactivation must end running
   # sessions, not just block new logins.

--- a/lib/vutuv_web/live/post_live/actions.ex
+++ b/lib/vutuv_web/live/post_live/actions.ex
@@ -16,19 +16,35 @@ defmodule VutuvWeb.PostLive.Actions do
   Logged-out viewers get the same live counters; pressing a button sends them
   to the login page. Mounted outside the `live_session` (embedded), so it
   applies the session locale itself, like `VutuvWeb.ShellLive`.
+
+  The viewer is authenticated from the cookie's `session_token` (through the
+  shared `VutuvWeb.Live.InitAssigns.session_user/1` resolver), never a bare
+  `user_id`, so a remotely logged-out device or a suspended member can no longer
+  write a like / bookmark / repost from this bar. That lookup runs **only on
+  connect**: the throwaway dead render does no writes and its engagement flags
+  are the threaded ones the controller already computed for the authenticated
+  request, so deferring the resolution keeps a many-post permalink from paying a
+  session lookup per card on a render that is discarded the moment the socket
+  connects.
   """
   use Phoenix.LiveView
 
   import VutuvWeb.PostComponents, only: [post_actions: 1]
 
+  alias Vutuv.Accounts.User
   alias Vutuv.Posts
+  alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.PostLive.ActionBar
 
   @impl true
   def mount(_params, session, socket) do
     post_id = session["post_id"]
-    viewer_id = session["user_id"]
     VutuvWeb.LiveLocale.put_locale(session)
+
+    # Resolve the viewer from the session token on the connected socket only —
+    # it is the one that subscribes and writes. The dead render stays anonymous
+    # (viewer_id nil) and renders from the threaded engagement.
+    viewer_id = if connected?(socket), do: session_viewer_id(session), else: nil
 
     # The post topic carries everything this bar needs: absolute counts for
     # every viewer, plus — when the actor is the viewer (`:by_user_id`) — the
@@ -46,6 +62,15 @@ defmodule VutuvWeb.PostLive.Actions do
      |> assign(:post_id, post_id)
      |> assign(:viewer_id, viewer_id)
      |> assign(:engagement, engagement)}
+  end
+
+  # The token-resolved viewer id, or nil when the cookie's session token is
+  # missing / revoked / belongs to a suspended member.
+  defp session_viewer_id(session) do
+    case InitAssigns.session_user(session) do
+      %User{id: id} -> id
+      _ -> nil
+    end
   end
 
   @impl true

--- a/lib/vutuv_web/live/section_reorder_live.ex
+++ b/lib/vutuv_web/live/section_reorder_live.ex
@@ -9,12 +9,15 @@ defmodule VutuvWeb.SectionReorderLive do
   One LiveView serves all orderable sections (phone numbers, addresses, social
   media accounts, messengers, email addresses, links and languages — where the
   order additionally means preference, the first language being the member's
-  preferred contact language, issue #894); the `section` (the URL segment) and the owner's
-  `slug` arrive in the embedded session, the
-  authenticated owner in the raw browser session's `user_id` (merged under the
-  curated session by `Phoenix.LiveView.Static`, exactly like `ShellLive`). Every
-  reorder/move is scoped to that `user_id` through `Vutuv.Ordering`, so the
-  signed-in member can only ever renumber their own rows.
+  preferred contact language, issue #894); the `section` (the URL segment) and
+  the owner's `slug` arrive in the embedded session. The authenticated owner is
+  resolved from the cookie's `session_token` through
+  `VutuvWeb.Live.InitAssigns.session_user/1` — the same token-based resolver
+  `VutuvWeb.Plug.ConfigureSession` and the router LiveViews use — never a bare
+  `user_id`, so a remotely logged-out device or a suspended member can no longer
+  renumber rows. Every reorder/move is scoped to that resolved id through
+  `Vutuv.Ordering`, so the signed-in member can only ever renumber their own
+  rows.
 
   Both interactions persist over the socket with no page reload: the up/down
   arrows are `phx-click` events; drag-and-drop is the `Reorder` JS hook
@@ -45,6 +48,7 @@ defmodule VutuvWeb.SectionReorderLive do
   alias Vutuv.Profiles.Messenger
   alias Vutuv.Profiles.SocialMediaAccount
   alias Vutuv.Repo
+  alias VutuvWeb.Live.InitAssigns
 
   # section (= URL segment) => the schema whose rows it orders.
   @schemas %{
@@ -63,13 +67,18 @@ defmodule VutuvWeb.SectionReorderLive do
     # the session locale here or the tool falls back to English.
     VutuvWeb.LiveLocale.put_locale(session)
 
+    # The authenticated owner is resolved from the cookie's session_token (the
+    # same resolver ConfigureSession / Live.InitAssigns use), never a bare
+    # user_id merged from the cookie or handed in through the curated map — so a
+    # revoked device or suspended member can no longer reorder, and the member
+    # can only ever renumber their own rows. Resolved on both renders: the
+    # disconnected one must list the owner's entries with no JavaScript, and the
+    # cookie's token is available there too (Static merges it under the session).
+    user = InitAssigns.session_user(session)
+
     socket =
       socket
-      # The authenticated owner is the raw browser session's user_id (merged
-      # UNDER the curated session), never a value the page handed us — so the
-      # signed-in member can only reorder their own rows. cast_or_nil tolerates
-      # a pre-cutover integer cookie.
-      |> assign(:user_id, Vutuv.UUIDv7.cast_or_nil(session["user_id"]))
+      |> assign(:user_id, user && user.id)
       |> assign(:section, session["section"])
       |> assign(:slug, session["slug"])
       |> assign(:locale, session["locale"])
@@ -78,15 +87,24 @@ defmodule VutuvWeb.SectionReorderLive do
     {:ok, socket}
   end
 
+  # An unauthenticated socket (no resolved owner — a revoked/absent token) never
+  # renders a reorder handle, but a hand-crafted client could still push the
+  # event; ignore it rather than scoping an `Ordering` write to a nil user_id
+  # (which Ecto would raise on anyway).
   @impl true
   def handle_event("reorder", %{"order" => order}, socket) when is_list(order) do
-    Vutuv.Ordering.reorder(schema(socket), socket.assigns.user_id, order)
+    if socket.assigns.user_id,
+      do: Vutuv.Ordering.reorder(schema(socket), socket.assigns.user_id, order)
+
     {:noreply, load_entries(socket)}
   end
 
   def handle_event("move", %{"id" => id, "dir" => dir}, socket) when dir in ["up", "down"] do
-    direction = if dir == "up", do: :up, else: :down
-    Vutuv.Ordering.move(schema(socket), socket.assigns.user_id, id, direction)
+    if socket.assigns.user_id do
+      direction = if dir == "up", do: :up, else: :down
+      Vutuv.Ordering.move(schema(socket), socket.assigns.user_id, id, direction)
+    end
+
     {:noreply, load_entries(socket)}
   end
 

--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -31,28 +31,19 @@ defmodule VutuvWeb.ShellLive do
       presence_dot: 1
     ]
 
+  import VutuvWeb.UserHelpers, only: [full_name: 1]
+
   alias Vutuv.Accounts.MemberCounter
+  alias Vutuv.Accounts.User
   alias Vutuv.Activity
   alias Vutuv.Dashboard
   alias Vutuv.DayClock
   alias Vutuv.Social
+  alias VutuvWeb.Live.InitAssigns
   alias VutuvWeb.Presence
 
   @impl true
   def mount(_params, session, socket) do
-    # LayoutHTML.shell_session/1 (the curated :session) only carries the
-    # profile fields (user_param/name/avatar) for a current, valid user.
-    # Phoenix.LiveView.Static merges the raw browser session UNDER it, so a
-    # cookie pointing at a since-deleted or UUID-re-keyed account (every
-    # pre-cutover session is now one) leaks its bare `user_id` here with no
-    # profile fields. Key "logged in" off `user_param`, which only
-    # shell_session sets, so such a session renders the anonymous shell instead
-    # of the logged-in chrome that would crash on `~p"/#{nil}"`. cast_or_nil
-    # also tolerates the integer ids in cookies from before the UUID cutover.
-    user_param = session["user_param"]
-    user_id = user_param && Vutuv.UUIDv7.cast_or_nil(session["user_id"])
-    if connected?(socket), do: Activity.subscribe(user_id)
-
     # The shell mounts outside the `live_session` (embedded via live_render),
     # so InitAssigns never runs for it — apply the session locale here.
     VutuvWeb.LiveLocale.put_locale(session)
@@ -63,40 +54,110 @@ defmodule VutuvWeb.ShellLive do
     path = session["path"] || ""
 
     socket =
-      socket
-      |> assign(:user_id, user_id)
-      |> assign(:user_name, session["user_name"])
-      # Initials are built from first+last (matching <.avatar>); fall back to the
-      # display name only for sessions built before that key existed.
-      |> assign(:user_initials, session["user_initials"] || name_initials(session["user_name"]))
-      |> assign(:user_param, user_param)
-      |> assign(:user_avatar, session["user_avatar"])
-      |> assign(:user_admin?, session["user_admin?"] == true)
-      |> assign(:self_online?, false)
-      |> assign(:presence_hidden_ids, MapSet.new())
-      # The badge counts are the most expensive query on every page (an 8-way
-      # aggregate for notifications, a COUNT(DISTINCT) join for messages). The
-      # dead (static HTTP) render is thrown away the instant the socket connects,
-      # so computing them there doubles that cost site-wide for no benefit:
-      # start at 0 (count_badge renders nothing at 0) and fill them in on
-      # connect. A real unread count appears within a fraction of a second.
-      |> assign(:messages_count, 0)
-      |> assign(:notifications_count, 0)
-      |> assign(:brand_path, brand_path(user_param, path))
-      # The current path also drives the active-nav highlight (which top/bottom
-      # nav item is the page being viewed). Like brand_path it is the path at
-      # mount; every nav destination is reached by a full-reload `href`, so the
-      # shell remounts with a fresh path on each of those.
-      |> assign(:path, path)
-      # Admins get one more figure: how many sign-ups confirmed so far today.
-      # Zero renders nothing, so it is also the starting value for everyone else.
-      |> assign(:new_members_today, 0)
-      |> maybe_start_counts(user_id, path)
-      |> maybe_start_new_members()
-      |> maybe_start_presence(user_id, session["show_online"] == true)
-      |> push_badge()
+      if connected?(socket) do
+        # The live socket authenticates from the cookie's `session_token` — the
+        # same source of truth ConfigureSession / Live.InitAssigns use — never
+        # the curated shell_session map (signed, not encrypted, so replayable)
+        # nor the bare cookie `user_id` a revoked device still carries. So a
+        # remotely logged-out device or a suspended member drops to the anonymous
+        # shell on reconnect, and a replayed shell_session payload cannot render
+        # another member's chrome or subscribe to their "user:<id>" unread-badge
+        # topic. All identity therefore comes from the resolved user, not the
+        # curated map.
+        mount_authenticated(socket, InitAssigns.session_user(session), path)
+      else
+        # The throwaway dead render, authenticated by the HTTP request that built
+        # shell_session/1 from the validated current_user — so its curated
+        # display fields are safe to show, and the whole render is replaced the
+        # instant the socket connects and re-checks the token. It computes no
+        # counts / presence — those are connected-only anyway.
+        mount_static(socket, session, path)
+      end
 
     {:ok, socket}
+  end
+
+  # The dead render's identity: the curated display fields LayoutHTML.shell_session/1
+  # signs into `data-phx-session`. Phoenix.LiveView.Static merges the raw browser
+  # session UNDER them, so a cookie pointing at a since-deleted or UUID-re-keyed
+  # account (every pre-cutover session is now one) leaks its bare `user_id` here
+  # with no profile fields. Key "logged in" off `user_param`, which only
+  # shell_session sets, so such a session renders the anonymous shell instead of
+  # the logged-in chrome that would crash on `~p"/#{nil}"`. cast_or_nil also
+  # tolerates the integer ids in cookies from before the UUID cutover.
+  defp mount_static(socket, session, path) do
+    user_param = session["user_param"]
+    user_id = user_param && Vutuv.UUIDv7.cast_or_nil(session["user_id"])
+
+    socket
+    |> assign(:user_id, user_id)
+    |> assign(:user_name, session["user_name"])
+    # Initials are built from first+last (matching <.avatar>); fall back to the
+    # display name only for sessions built before that key existed.
+    |> assign(:user_initials, session["user_initials"] || name_initials(session["user_name"]))
+    |> assign(:user_param, user_param)
+    |> assign(:user_avatar, session["user_avatar"])
+    |> assign(:user_admin?, session["user_admin?"] == true)
+    |> assign_shell_defaults(path)
+  end
+
+  # The connected socket, authenticated from the session token. A nil user
+  # (missing / revoked / suspended / deactivated token) is the anonymous shell —
+  # no subscriptions, no counts, no presence.
+  defp mount_authenticated(socket, nil, path) do
+    socket
+    |> assign(:user_id, nil)
+    |> assign(:user_name, nil)
+    |> assign(:user_initials, nil)
+    |> assign(:user_param, nil)
+    |> assign(:user_avatar, nil)
+    |> assign(:user_admin?, false)
+    |> assign_shell_defaults(path)
+  end
+
+  # Everything the chrome shows is derived from the resolved user (recomputed the
+  # same way shell_session/1 builds the curated map), so a replayed curated map
+  # can neither render nor subscribe as another member.
+  defp mount_authenticated(socket, %User{} = user, path) do
+    user_id = user.id
+    Activity.subscribe(user_id)
+
+    socket
+    |> assign(:user_id, user_id)
+    |> assign(:user_name, full_name(user))
+    |> assign(:user_initials, name_initials(user))
+    |> assign(:user_param, Phoenix.Param.to_param(user))
+    |> assign(:user_avatar, Vutuv.Avatar.user_url(user, :thumb))
+    |> assign(:user_admin?, user.admin?)
+    |> assign_shell_defaults(path)
+    |> maybe_start_counts(user_id, path)
+    |> maybe_start_new_members()
+    |> maybe_start_presence(user_id, user.show_online_status?)
+    |> push_badge()
+  end
+
+  # The assigns every render carries, so render/1 never sees a missing key. The
+  # badge counts are the most expensive query on every page (an 8-way aggregate
+  # for notifications, a COUNT(DISTINCT) join for messages), and the dead render
+  # is thrown away the instant the socket connects, so they start at 0
+  # (count_badge renders nothing at 0) and are filled in on connect by
+  # maybe_start_counts/3. A real unread count appears within a fraction of a
+  # second.
+  defp assign_shell_defaults(socket, path) do
+    socket
+    |> assign(:self_online?, false)
+    |> assign(:presence_hidden_ids, MapSet.new())
+    |> assign(:messages_count, 0)
+    |> assign(:notifications_count, 0)
+    |> assign(:brand_path, brand_path(socket.assigns.user_param, path))
+    # The current path also drives the active-nav highlight (which top/bottom
+    # nav item is the page being viewed). Like brand_path it is the path at
+    # mount; every nav destination is reached by a full-reload `href`, so the
+    # shell remounts with a fresh path on each of those.
+    |> assign(:path, path)
+    # Admins get one more figure: how many sign-ups confirmed so far today.
+    # Zero renders nothing, so it is also the starting value for everyone else.
+    |> assign(:new_members_today, 0)
   end
 
   # Site-wide online presence. The shell is the one component on every page, so

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.140.5",
+      version: "7.140.6",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/post_actions_live_test.exs
+++ b/test/vutuv_web/live/post_actions_live_test.exs
@@ -423,6 +423,93 @@ defmodule VutuvWeb.PostActionsLiveTest do
     end
   end
 
+  describe "viewer authentication (issue #1036)" do
+    # The standalone bar backs the dead controller pages, where it authenticates
+    # the viewer itself. It must do so from the cookie's session_token, never a
+    # bare user_id — otherwise a remotely logged-out device (issue #794) or a
+    # suspended member could keep writing likes/bookmarks/reposts from a bar it
+    # still has open.
+    defp bar_session(cookie, post) do
+      Map.merge(cookie, %{
+        "post_id" => post.id,
+        "id" => "post-actions-#{post.id}",
+        "locale" => "en"
+      })
+    end
+
+    test "an active session lets the viewer toggle a like", %{conn: conn} do
+      {conn, viewer} = create_and_login_user(conn)
+      cookie = Plug.Conn.get_session(conn)
+      post = create_post!(other_user(), %{body: "gated"})
+
+      {:ok, bar, _html} =
+        live_isolated(build_conn(), VutuvWeb.PostLive.Actions, session: bar_session(cookie, post))
+
+      bar |> element("#post-actions-#{post.id}-like") |> render_click()
+
+      assert %{likes: 1} = Posts.engagement_counts(post.id)
+      assert Posts.post_engagement(post.id, viewer.id).liked?
+    end
+
+    test "a revoked device cannot toggle", %{conn: conn} do
+      {conn, viewer} = create_and_login_user(conn)
+      cookie = Plug.Conn.get_session(conn)
+      post = create_post!(other_user(), %{body: "locked"})
+
+      [device] = Vutuv.Sessions.list_active(viewer)
+      Vutuv.Sessions.revoke(device)
+
+      {:ok, bar, _html} =
+        live_isolated(build_conn(), VutuvWeb.PostLive.Actions, session: bar_session(cookie, post))
+
+      # No viewer resolves, so the button sends them to login and writes nothing.
+      assert {:error, {:redirect, %{to: "/login"}}} =
+               bar |> element("#post-actions-#{post.id}-like") |> render_click()
+
+      assert %{likes: 0} = Posts.engagement_counts(post.id)
+    end
+
+    test "a suspended member cannot toggle", %{conn: conn} do
+      {conn, viewer} = create_and_login_user(conn)
+      cookie = Plug.Conn.get_session(conn)
+      post = create_post!(other_user(), %{body: "no writes"})
+
+      Repo.update_all(from(u in Vutuv.Accounts.User, where: u.id == ^viewer.id),
+        set: [suspended_until: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 86_400)]
+      )
+
+      {:ok, bar, _html} =
+        live_isolated(build_conn(), VutuvWeb.PostLive.Actions, session: bar_session(cookie, post))
+
+      assert {:error, {:redirect, %{to: "/login"}}} =
+               bar |> element("#post-actions-#{post.id}-like") |> render_click()
+
+      assert %{likes: 0} = Posts.engagement_counts(post.id)
+    end
+
+    test "a bare user_id with no token never authenticates a write" do
+      # The replay a curated session map enables: a real member's id, but no
+      # proof the session was not revoked. The bar must refuse it.
+      viewer = other_user()
+      post = create_post!(other_user(), %{body: "replayed"})
+
+      {:ok, bar, _html} =
+        live_isolated(build_conn(), VutuvWeb.PostLive.Actions,
+          session: %{
+            "post_id" => post.id,
+            "id" => "post-actions-#{post.id}",
+            "locale" => "en",
+            "user_id" => viewer.id
+          }
+        )
+
+      assert {:error, {:redirect, %{to: "/login"}}} =
+               bar |> element("#post-actions-#{post.id}-like") |> render_click()
+
+      assert %{likes: 0} = Posts.engagement_counts(post.id)
+    end
+  end
+
   describe "preloaded engagement" do
     # A list page (the feed) pre-loads engagement once and hands each card its
     # own via the session, so the bar skips its mount query. Prove the bar

--- a/test/vutuv_web/live/section_reorder_live_test.exs
+++ b/test/vutuv_web/live/section_reorder_live_test.exs
@@ -3,8 +3,10 @@ defmodule VutuvWeb.SectionReorderLiveTest do
   The owner's embedded reorder tool (`VutuvWeb.SectionReorderLive`). Both the
   drag-and-drop path (the JS hook pushes a "reorder" event with the new id
   order) and the up/down arrows ("move" phx-click) persist over the socket with
-  no page reload. The authoritative owner is the session `user_id`, so the tool
-  can only ever renumber that member's own rows.
+  no page reload. The authoritative owner is resolved from the cookie's
+  `session_token` (never a bare `user_id`), so a remotely logged-out device or a
+  suspended member can no longer reorder, and the tool can only ever renumber
+  that member's own rows.
   """
   use VutuvWeb.ConnCase, async: true
 
@@ -14,10 +16,19 @@ defmodule VutuvWeb.SectionReorderLiveTest do
   alias Vutuv.Profiles.Language
   alias Vutuv.Profiles.PhoneNumber
   alias Vutuv.Profiles.Url
+  alias Vutuv.Sessions
+
+  # A real active session for the owner: the tool authenticates from the
+  # cookie's session_token the way the embedded child sees it at mount, not a
+  # page-supplied user_id.
+  defp session_for(conn, user, extra) do
+    {token, _session} = Sessions.start_session(user, conn, alert: false)
+    Map.merge(%{"session_token" => token}, extra)
+  end
 
   defp mount_tool(conn, user, section) do
     live_isolated(conn, VutuvWeb.SectionReorderLive,
-      session: %{"user_id" => user.id, "section" => section, "slug" => user.username}
+      session: session_for(conn, user, %{"section" => section, "slug" => user.username})
     )
   end
 
@@ -165,6 +176,73 @@ defmodule VutuvWeb.SectionReorderLiveTest do
       {:ok, _view, html} = mount_tool(conn, user, "languages")
 
       refute html =~ "Preferred contact language"
+    end
+  end
+
+  describe "authentication (issue #1036)" do
+    # The tool must resolve its owner through the session token, so a device
+    # that was remotely logged out (issue #794) or a suspended member cannot
+    # keep reordering by reconnecting with the same cookie.
+    test "a revoked device can no longer reorder", %{conn: conn} do
+      user = insert_activated_user()
+      a = insert(:url, user: user, position: 1)
+      b = insert(:url, user: user, position: 2)
+
+      {token, session} = Sessions.start_session(user, conn, alert: false)
+      Sessions.revoke(session)
+
+      {:ok, view, html} =
+        live_isolated(conn, VutuvWeb.SectionReorderLive,
+          session: %{"session_token" => token, "section" => "links", "slug" => user.username}
+        )
+
+      # No owner resolved, so nothing is listed and a forced reorder event is a
+      # no-op: the positions stay put.
+      refute html =~ "reorder-item-"
+      render_hook(view, "reorder", %{"order" => [b.id, a.id]})
+
+      assert Repo.get(Url, a.id).position == 1
+      assert Repo.get(Url, b.id).position == 2
+    end
+
+    test "a suspended member can no longer reorder", %{conn: conn} do
+      user = insert_activated_user()
+      a = insert(:url, user: user, position: 1)
+      b = insert(:url, user: user, position: 2)
+
+      session = session_for(conn, user, %{"section" => "links", "slug" => user.username})
+
+      Repo.update_all(from(u in Vutuv.Accounts.User, where: u.id == ^user.id),
+        set: [suspended_until: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 86_400)]
+      )
+
+      {:ok, view, html} =
+        live_isolated(conn, VutuvWeb.SectionReorderLive, session: session)
+
+      refute html =~ "reorder-item-"
+      render_hook(view, "reorder", %{"order" => [b.id, a.id]})
+
+      assert Repo.get(Url, a.id).position == 1
+      assert Repo.get(Url, b.id).position == 2
+    end
+
+    test "a page-supplied user_id alone never authenticates", %{conn: conn} do
+      # The replay: no token in the cookie, just a bare user_id the way the old
+      # code trusted it. The tool must refuse it.
+      user = insert_activated_user()
+      a = insert(:url, user: user, position: 1)
+      b = insert(:url, user: user, position: 2)
+
+      {:ok, view, html} =
+        live_isolated(conn, VutuvWeb.SectionReorderLive,
+          session: %{"user_id" => user.id, "section" => "links", "slug" => user.username}
+        )
+
+      refute html =~ "reorder-item-"
+      render_hook(view, "reorder", %{"order" => [b.id, a.id]})
+
+      assert Repo.get(Url, a.id).position == 1
+      assert Repo.get(Url, b.id).position == 2
     end
   end
 end

--- a/test/vutuv_web/live/shell_live_presence_test.exs
+++ b/test/vutuv_web/live/shell_live_presence_test.exs
@@ -13,18 +13,16 @@ defmodule VutuvWeb.ShellLivePresenceTest do
 
   import Phoenix.LiveViewTest
 
+  alias Vutuv.Sessions
   alias VutuvWeb.Presence
 
+  # The shell authenticates the live socket from the cookie's session_token
+  # (issue #1036) and reads "Show when I'm online" off the resolved user, not a
+  # curated key — so a test drives it with a real active session and sets the
+  # member's `show_online_status?` field to control tracking.
   defp session_for(user, extra \\ %{}) do
-    Map.merge(
-      %{
-        "user_id" => user.id,
-        "user_name" => "Greta Tester",
-        "user_param" => user.username,
-        "show_online" => true
-      },
-      extra
-    )
+    {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
+    Map.merge(%{"session_token" => token}, extra)
   end
 
   test "tracks the member online and pushes them in the online set", %{conn: conn} do
@@ -44,12 +42,10 @@ defmodule VutuvWeb.ShellLivePresenceTest do
   end
 
   test "a member who turned online status off is never tracked or dotted", %{conn: conn} do
-    user = insert(:user)
+    user = insert(:user, show_online_status?: false)
 
     {:ok, view, _html} =
-      live_isolated(conn, VutuvWeb.ShellLive,
-        session: session_for(user, %{"show_online" => false})
-      )
+      live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
 
     refute Presence.online?(Presence.online_ids(), user.id)
     # No dot on their own avatar either.
@@ -124,12 +120,10 @@ defmodule VutuvWeb.ShellLivePresenceTest do
   end
 
   test "a live opt-in tracks the member and shows their dot", %{conn: conn} do
-    user = insert(:user)
+    user = insert(:user, show_online_status?: false)
 
     {:ok, view, _html} =
-      live_isolated(conn, VutuvWeb.ShellLive,
-        session: session_for(user, %{"show_online" => false})
-      )
+      live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
 
     refute Presence.online?(Presence.online_ids(), user.id)
 

--- a/test/vutuv_web/live/shell_live_test.exs
+++ b/test/vutuv_web/live/shell_live_test.exs
@@ -3,17 +3,28 @@ defmodule VutuvWeb.ShellLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Vutuv.Sessions
+
   @bell_badge ~s(a[title="Notifications"] span.bg-accent)
   @mail_badge ~s(a[title="Messages"] span.bg-accent)
 
+  # The shell authenticates the live socket from the cookie's session_token
+  # (issue #1036), so a test drives it with a real active session and reads the
+  # chrome back from the resolved user, not a curated map. `extra` still carries
+  # the non-identity keys the shell reads straight from the session (`path`,
+  # `locale`); any leftover curated identity key is simply ignored now.
   defp session_for(user, extra \\ %{}) do
-    Map.merge(
-      %{
-        "user_id" => user.id,
-        "user_name" => "Stefan Wintermeyer",
-        "user_param" => "stefan"
-      },
-      extra
+    {token, _session} = Sessions.start_session(user, build_conn(), alert: false)
+    Map.merge(%{"session_token" => token}, extra)
+  end
+
+  # The member whose name/handle the chrome assertions below expect. This module
+  # is synchronous, so the fixed "stefan" handle is safe (no async file mints it
+  # at the same time).
+  defp stefan(attrs \\ []) do
+    insert(
+      :user,
+      Keyword.merge([first_name: "Stefan", last_name: "Wintermeyer", username: "stefan"], attrs)
     )
   end
 
@@ -134,7 +145,7 @@ defmodule VutuvWeb.ShellLiveTest do
     test "points to the member's own profile on the feed", %{conn: conn} do
       # On /feed the logo would only round-trip through "/" back to the feed,
       # so there it deep-links to the member's own profile instead.
-      user = insert(:user)
+      user = stefan()
       session = session_for(user, %{"path" => "/feed"})
       {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session)
 
@@ -174,16 +185,15 @@ defmodule VutuvWeb.ShellLiveTest do
   end
 
   test "shows the user's avatar in the top bar when they have one", %{conn: conn} do
-    user = insert(:user)
-    session = session_for(user, %{"user_avatar" => "/avatars/#{user.id}/Stefan%20W_thumb.jpg"})
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session)
+    user = stefan(avatar: "me.jpg")
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
 
     assert has_element?(view, ~s(summary[title="Stefan Wintermeyer"] img))
     refute has_element?(view, ~s(summary[title="Stefan Wintermeyer"]), "SW")
   end
 
   test "falls back to initials when the user has no avatar", %{conn: conn} do
-    user = insert(:user)
+    user = stefan()
     {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
 
     assert has_element?(view, ~s(summary[title="Stefan Wintermeyer"]), "SW")
@@ -192,16 +202,22 @@ defmodule VutuvWeb.ShellLiveTest do
 
   test "the top-bar monogram uses the first+last initials, not the honorific title", %{conn: conn} do
     # Regression: "Dr. Anna Schmidt" showed "DA" in the shell instead of "AS".
-    user = insert(:user)
-    session = session_for(user, %{"user_name" => "Dr. Anna Schmidt", "user_initials" => "AS"})
-    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session)
+    user =
+      insert(:user,
+        honorific_prefix: "Dr.",
+        first_name: "Anna",
+        last_name: "Schmidt",
+        username: "anna-schmidt"
+      )
+
+    {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
 
     assert has_element?(view, ~s(summary[title="Dr. Anna Schmidt"]), "AS")
     refute has_element?(view, ~s(summary[title="Dr. Anna Schmidt"]), "DA")
   end
 
   test "the avatar opens an account menu linking to every account area", %{conn: conn} do
-    user = insert(:user)
+    user = stefan()
     {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
 
     menu = "details[data-account-menu]"
@@ -275,7 +291,7 @@ defmodule VutuvWeb.ShellLiveTest do
       # The logo already deep-links to the profile on /feed, but that is not
       # obvious; a named "Profile" nav item makes the member's own profile a
       # first-class, discoverable destination.
-      user = insert(:user)
+      user = stefan()
       {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
 
       assert has_element?(view, ~s(nav a[data-nav-profile][href="/stefan"]), "Profile")
@@ -284,7 +300,7 @@ defmodule VutuvWeb.ShellLiveTest do
     test "the mobile tab bar carries a Profile tab to the member's profile", %{conn: conn} do
       # Desktop is not the only surface: the bottom tab bar gets a Profile tab
       # too, so phone visitors can reach their profile without hunting for it.
-      user = insert(:user)
+      user = stefan()
       {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
 
       assert has_element?(view, ~s(nav a[data-mobile-profile][href="/stefan"]), "Profile")
@@ -320,7 +336,7 @@ defmodule VutuvWeb.ShellLiveTest do
     test "the Profile item is active on the member's own profile (and its subpages)", %{
       conn: conn
     } do
-      user = insert(:user)
+      user = stefan()
 
       for path <- ["/stefan", "/stefan/tags"] do
         {:ok, view, _html} =
@@ -419,6 +435,62 @@ defmodule VutuvWeb.ShellLiveTest do
     assert has_element?(view, "a", "Log in")
     refute has_element?(view, ~s(a[title] img))
     refute has_element?(view, "span.bg-accent")
+  end
+
+  # The socket authenticates from the cookie's session_token, exactly like a
+  # request (issue #1036). So a remotely logged-out device (issue #794) and a
+  # suspended member drop the logged-in chrome on reconnect, and a captured,
+  # signed shell_session map (which carries a bare user_id) can never be replayed
+  # to render another member's chrome or leak their unread badge counts over the
+  # "user:<id>" PubSub topic.
+  describe "socket authentication (issue #1036)" do
+    test "a revoked device drops to the anonymous shell with no badge", %{conn: conn} do
+      user = user_with_unread_notification()
+      {token, session} = Sessions.start_session(user, build_conn(), alert: false)
+      Sessions.revoke(session)
+
+      {:ok, view, _html} =
+        live_isolated(conn, VutuvWeb.ShellLive, session: %{"session_token" => token})
+
+      # No account menu, and crucially no unread badge: the shell never
+      # subscribed to or counted this member's activity.
+      assert has_element?(view, "a", "Log in")
+      refute has_element?(view, "details[data-account-menu]")
+      refute has_element?(view, @bell_badge)
+    end
+
+    test "a suspended member drops to the anonymous shell", %{conn: conn} do
+      user = user_with_unread_notification()
+
+      Repo.update_all(from(u in Vutuv.Accounts.User, where: u.id == ^user.id),
+        set: [suspended_until: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 86_400)]
+      )
+
+      {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session_for(user))
+
+      assert has_element?(view, "a", "Log in")
+      refute has_element?(view, @bell_badge)
+    end
+
+    test "a replayed curated user_id without a token never authenticates", %{conn: conn} do
+      # The core leak: a captured, signed shell_session map replayed alongside an
+      # anonymous cookie must not render the member's chrome or leak their unread
+      # badge counts.
+      user = user_with_unread_notification()
+
+      {:ok, view, _html} =
+        live_isolated(conn, VutuvWeb.ShellLive,
+          session: %{
+            "user_id" => user.id,
+            "user_name" => "Stefan Wintermeyer",
+            "user_param" => "stefan"
+          }
+        )
+
+      assert has_element?(view, "a", "Log in")
+      refute has_element?(view, "details[data-account-menu]")
+      refute has_element?(view, @bell_badge)
+    end
   end
 
   test "a new-notification event recomputes the bell badge from the source of truth", %{
@@ -556,7 +628,11 @@ defmodule VutuvWeb.ShellLiveTest do
   describe "new members today" do
     @pill "#new-members-today"
 
-    defp admin_session(user), do: session_for(user, %{"user_admin?" => true})
+    # The admin pill is now gated on the resolved user's own admin flag (issue
+    # #1036), not a curated session key, so the socket must resolve a real admin.
+    defp admin_session(user), do: session_for(user)
+
+    defp admin, do: insert(:user, admin?: true)
 
     defp joined_today(count) do
       {day_start, _} = Vutuv.BerlinTime.day_bounds_utc(Vutuv.BerlinTime.today())
@@ -569,7 +645,7 @@ defmodule VutuvWeb.ShellLiveTest do
       joined_today(2)
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(insert(:user)))
+        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(admin()))
 
       assert has_element?(view, @pill, "2")
     end
@@ -588,14 +664,14 @@ defmodule VutuvWeb.ShellLiveTest do
       insert(:activated_user, inserted_at: day_start, updated_at: day_start)
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(insert(:user)))
+        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(admin()))
 
       refute has_element?(view, @pill)
     end
 
     test "appears and counts up when a registration confirms", %{conn: conn} do
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(insert(:user)))
+        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(admin()))
 
       refute has_element?(view, @pill)
 
@@ -612,7 +688,7 @@ defmodule VutuvWeb.ShellLiveTest do
 
     test "names the exact figure in the viewer's language", %{conn: conn} do
       joined_today(1)
-      session = admin_session(insert(:user))
+      session = admin_session(admin())
 
       {:ok, view, _html} = live_isolated(conn, VutuvWeb.ShellLive, session: session)
       assert has_element?(view, ~s(#{@pill}[title="1 new member today"]))
@@ -627,7 +703,7 @@ defmodule VutuvWeb.ShellLiveTest do
       joined_today(1)
 
       {:ok, view, _html} =
-        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(insert(:user)))
+        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(admin()))
 
       assert has_element?(view, @pill, "1")
 


### PR DESCRIPTION
**TL;DR** `ShellLive`, `PostLive.Actions` and `SectionReorderLive` still authenticated from a bare session `user_id`; they now resolve the viewer through the same session-token resolver PR #1034 introduced, so remote logout (#794) and moderation suspensions reach them too. Closes #1036.

**Where:** `lib/vutuv_web/live/shell_live.ex`, `.../post_live/actions.ex`, `.../section_reorder_live.ex`; shared resolver `InitAssigns.session_user/1` (made public).

**Now → Want:** each read `session["user_id"]` and trusted it as the viewer's identity. That key also arrives from the controller-curated `live_render` map, which is signed but **not** encrypted and valid for days, and it never re-checked server-side revocation. All three now resolve the cookie's `session_token` through `Sessions.active_session/1` plus the `Moderation.login_block/1` gate.

**What changed:**
- **ShellLive** (the notable one): the connected socket derives *every* identity assign from the token-resolved user, so a replayed `shell_session` map can neither render another member's chrome nor subscribe to their `"user:<id>"` unread-badge topic. The dead render keeps its curated fields (authenticated by the HTTP request that built them, discarded on connect), so the hot per-page path pays no extra query on the throwaway render.
- **PostLive.Actions**: resolves the viewer on connect only, so a many-post permalink pays no session lookup per card on the discarded dead render; a revoked device can no longer write a like / bookmark / repost.
- **SectionReorderLive**: resolves the owner from the token on both renders; its reorder/move handlers now no-op for an unresolved owner instead of scoping an `Ordering` write to a `nil` id (which Ecto raises on).

**Tests:** revoked / suspended / bare-`user_id`-replay regressions for all three (including that a replayed curated map leaks no unread badge). The existing shell / actions / reorder tests were migrated to drive real session tokens. `mix precommit` green locally (4594 tests).

**Provenance:** found by a Claude Security scan, the follow-up to #1034's F4/F7.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_017jXQwTdpxTjvrzMYLU74KP
