### PR TITLE
Admin account freezer + honest HTTP status for withheld profiles (#812)

### DIFF
--- a/docs/architecture/admin.md
+++ b/docs/architecture/admin.md
@@ -212,6 +212,29 @@ ends in account deactivation — the "freeze the HR account" lever.
 An open-case count surfaces both on this page and as the coral "attention" badge on
 the `/admin` job-postings card.
 
+## Freeze an account (`/admin/accounts`)
+
+A focused, admins-only **classic controller** page for putting any account into
+the moderation freezer without waiting for a report (issue #812).
+
+**Search** by name, `@handle` or email address (the same matcher as the member
+browser), then hit **Freeze** (or **Unfreeze**) on a row. Freezing goes through
+the public, audited `Vutuv.Moderation.admin_freeze_user/3` (not the private
+`set_user_moderation!/2`): it sets `frozen_at` — which hides the profile and
+everything it owns from everyone but the member and admins — and records a
+caseless audit row in `moderation_admin_actions`. A freeze does **not** block
+login (that is suspension/deactivation); a frozen member can still sign in and
+sees their own amber banner. Freeze/unfreeze are **CSRF-protected POSTs** through
+the `:browser` pipeline.
+
+`/admin/accounts/frozen` is the paginated list of every currently-frozen account
+(newest freeze first, `<.pager>`, 250/page) with a **Source** column (admin vs
+report — an account frozen by an open report is labelled "report") and an
+Unfreeze control. See `moderation.md` for the freeze machinery and the honest
+403/410 HTTP status a withheld profile now returns (was a blanket 404).
+
+Admins-only via the `:admin` pipeline (`Plugs.RequireLogin` + `Plugs.AuthAdmin`).
+
 ## Delete account (`/admin/users/delete`)
 
 A focused, admins-only **LiveView** for permanently removing an account.

--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -83,3 +83,44 @@ Every case carries an **audit log** (`moderation_events`: reports, freezes,
 severances, owner self-service, escalations, rulings, strikes, `owner_removed`)
 rendered as the History timeline on the admin case page, and the urgent admin
 email names the profile, category and reporter's note instead of just a link.
+
+## Admin-initiated freeze (`/admin/accounts`, issue #812)
+
+Freezing an account no longer only happens reactively as a report side effect.
+The **admin account tool** at `/admin/accounts` (see `admin.md`) lets an admin
+search any account (by name, `@handle` or email) and freeze / unfreeze it
+directly, with a paginated moderation-freezer list at `/admin/accounts/frozen`.
+The public, audited entry points are `Moderation.admin_freeze_user/3` and
+`admin_unfreeze_user/2` (never the private `set_user_moderation!/2`): they set /
+clear `frozen_at` and record a **caseless** audit row in `moderation_admin_actions`
+(`Vutuv.Moderation.AdminAction`, mirroring the deliverability ledger — an
+immutable, FK-free record of who froze whom, when, and an optional reason). A
+freeze sets `frozen_at` only, so it hides the profile everywhere but does **not**
+block login (that is what suspension/deactivation do). The frozen list derives
+each row's **Source** (admin vs report) from `report_frozen_ids/1`: an account
+with an open user `Case` was frozen by a report, everything else by an admin. An
+admin thaw clears `frozen_at` even for a report-frozen account (a deliberate
+override); the case stays in the queue and its later ruling clears an
+already-nil `frozen_at` as a no-op.
+
+## The HTTP status of a withheld profile (issue #812)
+
+`VutuvWeb.Plug.EnsureActivated` no longer returns a blanket 404 for every hidden
+profile — a 404 ("does not exist") lied about an account that exists and is
+merely withheld. `Moderation.withheld_status/1` classifies the reason once
+`profile_visible_to?/2` has said no:
+
+- a **never-activated** registration keeps **404** — it must stay
+  indistinguishable from a non-existent account (anti-enumeration), and that
+  wins first even when the row is also frozen;
+- a **reversible hold** (frozen / suspended / unreachable) returns **403
+  Forbidden** — the account exists and is withheld;
+- a **permanently deactivated** account returns **410 Gone**.
+
+The owner/admin HTML bypass (200) is unchanged, and HTML and the agent-format
+siblings (`.md`/`.json`/`.xml`/`.vcf`) share the plug, so they always report the
+same status. 403/410 render a profile-specific "This profile is currently
+unavailable" page (`VutuvWeb.ErrorHTML`, `profile_unavailable.html`) that does
+not reveal *why*. The separate `/api/2.0` JSON API keeps its own 404 for hidden
+accounts — it is not an agent-format sibling and follows problem+json
+conventions.

--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -32,8 +32,20 @@ defmodule Vutuv.Moderation do
   alias Vutuv.Accounts.User
   alias Vutuv.Chat.{Message, Participant}
   alias Vutuv.Jobs.JobPosting
-  alias Vutuv.Moderation.{Case, Event, EvidenceScreenshot, Notifier, Report, Severance, Strike}
+
+  alias Vutuv.Moderation.{
+    AdminAction,
+    Case,
+    Event,
+    EvidenceScreenshot,
+    Notifier,
+    Report,
+    Severance,
+    Strike
+  }
+
   alias Vutuv.Organizations.Organization
+  alias Vutuv.Pages
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Repo
@@ -1147,6 +1159,33 @@ defmodule Vutuv.Moderation do
     email_confirmed?(user) and (not account_hidden?(user) or bypass?(user, viewer))
   end
 
+  @doc """
+  The HTTP status a withheld profile should return to a viewer who cannot see
+  it (issue #812). Call it only once `profile_visible_to?/2` has already said
+  no; it decides *why* the profile is withheld:
+
+    * `404` — a never-activated registration (the anti-spam gate). These must
+      stay indistinguishable from a non-existent account: you must not be able
+      to probe whether an email is registered, so this is not negotiable.
+    * `410` Gone — a permanently deactivated account (`deactivated_at`). It
+      existed and is gone for good.
+    * `403` Forbidden — a reversible hold: frozen pending review, currently
+      suspended, or frozen for unreachability. The account exists and is
+      withheld, which is what 403 says (and what the old blanket 404 lied
+      about).
+
+  A confirmed but deactivated account still reports 410 even though its owner
+  never confirmed a second address, etc.; the `email_confirmed?` gate wins
+  first so an unconfirmed row can never leak its existence through a 403/410.
+  """
+  def withheld_status(%User{} = user) do
+    cond do
+      not email_confirmed?(user) -> 404
+      user.deactivated_at != nil -> 410
+      true -> 403
+    end
+  end
+
   # nil counts as activated: rows from before the activation gate existed.
   defp email_confirmed?(%User{email_confirmed?: false}), do: false
   defp email_confirmed?(%User{}), do: true
@@ -1154,6 +1193,107 @@ defmodule Vutuv.Moderation do
   defp bypass?(%User{id: id}, %User{id: id}), do: true
   defp bypass?(_user, %User{admin?: true}), do: true
   defp bypass?(_user, _viewer), do: false
+
+  ## Admin account freeze (issue #812)
+
+  @doc """
+  Admin-initiated freeze of an account (no report, no case): hides the profile
+  and everything it owns from everyone but the owner and admins, exactly like a
+  report-driven freeze (`account_hidden?/1` flips, `profile_visible_to?/2`
+  hides it, the owner sees their `frozen_banner`). It sets `frozen_at` only, so
+  it does **not** block login (`login_block/1` fires on suspension/deactivation,
+  not a freeze); a frozen member can still sign in and see their own banner.
+
+  Records a caseless `AdminAction` audit row (who froze whom, when, why). The
+  public, audited entry point the admin account tool uses instead of the
+  private `set_user_moderation!/2`.
+
+  Returns `{:ok, :frozen}`, or `{:ok, :noop}` if the account was already frozen.
+  """
+  def admin_freeze_user(user, admin, reason \\ nil)
+
+  def admin_freeze_user(%User{frozen_at: %NaiveDateTime{}}, %User{admin?: true}, _reason),
+    do: {:ok, :noop}
+
+  def admin_freeze_user(%User{} = user, %User{admin?: true} = admin, reason) do
+    set_user_moderation!(user.id, frozen_at: NaiveDateTime.utc_now(:second))
+    log_admin_action(user, admin, "account_frozen", reason)
+    {:ok, :frozen}
+  end
+
+  @doc """
+  Admin-initiated thaw: lifts a `frozen_at` hold, whatever set it (an admin
+  freeze or a report). Clearing a report-driven freeze un-hides the profile
+  while the case stays open in the queue — a deliberate admin override ("I have
+  looked, un-hide it"); the case ruling later clears an already-nil `frozen_at`
+  as a no-op. Records a caseless `AdminAction` audit row.
+
+  Returns `{:ok, :unfrozen}`, or `{:ok, :noop}` if it was not frozen.
+  """
+  def admin_unfreeze_user(user, admin, reason \\ nil)
+
+  def admin_unfreeze_user(%User{frozen_at: nil}, %User{admin?: true}, _reason),
+    do: {:ok, :noop}
+
+  def admin_unfreeze_user(%User{} = user, %User{admin?: true} = admin, reason) do
+    set_user_moderation!(user.id, frozen_at: nil)
+    log_admin_action(user, admin, "account_unfrozen", reason)
+    {:ok, :unfrozen}
+  end
+
+  defp log_admin_action(%User{} = user, %User{} = admin, action, reason) do
+    Repo.insert!(%AdminAction{
+      user_id: user.id,
+      actor_id: admin.id,
+      action: action,
+      reason: presence(reason)
+    })
+
+    :ok
+  end
+
+  defp presence(nil), do: nil
+
+  defp presence(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  @doc "How many accounts are currently in the moderation freezer (`frozen_at` set)."
+  def frozen_accounts_count do
+    Repo.aggregate(from(u in User, where: not is_nil(u.frozen_at)), :count)
+  end
+
+  @doc """
+  One page of currently-frozen accounts, newest freeze first, paginated like
+  the admin member browser (`Vutuv.Pages.paginate/4`). `opts` may carry
+  `:total` (skip the recount) and `:per_page`.
+  """
+  def list_frozen_accounts(params \\ %{}, opts \\ []) do
+    per_page = Keyword.get(opts, :per_page, 250)
+    total = Keyword.get(opts, :total) || frozen_accounts_count()
+
+    from(u in User, where: not is_nil(u.frozen_at), order_by: [desc: u.frozen_at, desc: u.id])
+    |> Pages.paginate(params, total, per_page)
+    |> Repo.all()
+  end
+
+  @doc """
+  Of the given account ids, the set currently frozen by an open report (a user
+  `Case` in an open status). Drives the frozen list's "Source" column: an id in
+  the set was frozen by a report, everything else by an admin. One query, no
+  per-row lookups.
+  """
+  def report_frozen_ids(user_ids) when is_list(user_ids) do
+    from(c in Case,
+      where: c.content_type == "user" and c.owner_id in ^user_ids and c.status in ^@open_statuses,
+      select: c.owner_id
+    )
+    |> Repo.all()
+    |> MapSet.new()
+  end
 
   ## Content plumbing
 

--- a/lib/vutuv/moderation/admin_action.ex
+++ b/lib/vutuv/moderation/admin_action.ex
@@ -1,0 +1,30 @@
+defmodule Vutuv.Moderation.AdminAction do
+  @moduledoc """
+  One admin-initiated moderation action on an account (issue #812): the account
+  was frozen or unfrozen directly from the admin account tool, without a report
+  or a `Vutuv.Moderation.Case`. The audit trail behind the caseless admin
+  freeze, mirroring `Vutuv.Deliverability.Event` and `Vutuv.Moderation.Event`.
+
+  `actor_id` is the admin who acted. `user_id` / `actor_id` are plain values,
+  not associations: like the deliverability ledger this is an immutable record
+  that must stay readable after the rows it references are gone. Rows are
+  inserted by `Vutuv.Moderation` only, never built from user params.
+  """
+
+  use VutuvWeb, :model
+
+  @actions ~w(account_frozen account_unfrozen)
+
+  schema "moderation_admin_actions" do
+    field(:user_id, :binary_id)
+    field(:actor_id, :binary_id)
+    field(:action, :string)
+    field(:reason, :string)
+    field(:detail, :map, default: %{})
+
+    timestamps(updated_at: false)
+  end
+
+  @doc "The closed set of `action` values this ledger records."
+  def actions, do: @actions
+end

--- a/lib/vutuv_web/controllers/admin/account_controller.ex
+++ b/lib/vutuv_web/controllers/admin/account_controller.ex
@@ -1,0 +1,110 @@
+defmodule VutuvWeb.Admin.AccountController do
+  @moduledoc """
+  The admin account freezer (issue #812). Search for any account by name,
+  @handle or email and freeze / unfreeze it directly, without waiting for a
+  report, plus a paginated list of every account currently in the moderation
+  freezer.
+
+  Freezing goes through the public, audited `Vutuv.Moderation.admin_freeze_user/3`
+  (not the private `set_user_moderation!/2`): it sets `frozen_at`, which hides
+  the profile and everything it owns from everyone but the owner and admins, and
+  records a caseless audit row. It does **not** block login — a freeze is a
+  profile hold, not a suspension.
+
+  Freeze/unfreeze are `POST`s through the `:browser` pipeline, so they are
+  CSRF-protected (the forms carry the token); the classic controller mirrors
+  the report-queue POST fallbacks rather than a LiveView because the acceptance
+  criteria call for a CSRF-protected form submit.
+  """
+
+  use VutuvWeb, :controller
+
+  alias Vutuv.Accounts
+  alias Vutuv.Moderation
+  alias VutuvWeb.ControllerHelpers
+
+  # Most matches shown for a search. An admin narrows the query rather than
+  # scrolling; the account they want is reachable by name, @handle or email.
+  @results_limit 50
+
+  def index(conn, params) do
+    filters = Accounts.admin_user_filters(%{"q" => params["q"], "reg" => "all", "flag" => "all"})
+
+    results =
+      if filters.q,
+        do: Accounts.list_admin_users(filters, %{}, per_page: @results_limit),
+        else: []
+
+    render(conn, "index.html",
+      page_title: gettext("Freeze an account"),
+      q: to_string(params["q"]),
+      searched?: filters.q != nil,
+      results: results
+    )
+  end
+
+  def frozen(conn, params) do
+    total = Moderation.frozen_accounts_count()
+    accounts = Moderation.list_frozen_accounts(params, total: total)
+    report_frozen = Moderation.report_frozen_ids(Enum.map(accounts, & &1.id))
+
+    render(conn, "frozen.html",
+      page_title: gettext("Frozen accounts"),
+      accounts: accounts,
+      report_frozen: report_frozen,
+      row_count: total,
+      params: params
+    )
+  end
+
+  def freeze(conn, params), do: toggle(conn, params, :freeze)
+  def unfreeze(conn, params), do: toggle(conn, params, :unfreeze)
+
+  defp toggle(conn, %{"id" => id} = params, action) do
+    back = safe_return(params["return_to"])
+
+    case ControllerHelpers.get_user(id) do
+      nil ->
+        conn
+        |> put_flash(:error, gettext("That account no longer exists."))
+        |> redirect(to: back)
+
+      user ->
+        {result, _} = apply_action(action, user, conn.assigns.current_user, params["reason"])
+
+        conn
+        |> put_flash(:info, flash_message(action, result, user))
+        |> redirect(to: back)
+    end
+  end
+
+  defp apply_action(:freeze, user, admin, reason),
+    do: {elem(Moderation.admin_freeze_user(user, admin, reason), 1), user}
+
+  defp apply_action(:unfreeze, user, admin, reason),
+    do: {elem(Moderation.admin_unfreeze_user(user, admin, reason), 1), user}
+
+  defp flash_message(:freeze, :frozen, user),
+    do: gettext("@%{username} was frozen.", username: user.username)
+
+  defp flash_message(:freeze, :noop, user),
+    do: gettext("@%{username} was already frozen.", username: user.username)
+
+  defp flash_message(:unfreeze, :unfrozen, user),
+    do: gettext("@%{username} was unfrozen.", username: user.username)
+
+  defp flash_message(:unfreeze, :noop, user),
+    do: gettext("@%{username} was not frozen.", username: user.username)
+
+  # Only ever redirect back inside the admin area. A caller-supplied return_to
+  # that is not a local /admin/ path (a full URL, a scheme-relative //host, a
+  # different scope) falls back to the frozen list, so the hidden field can
+  # never be turned into an open redirect.
+  defp safe_return("/admin/" <> _ = path) do
+    if String.starts_with?(path, "/admin//"), do: default_return(), else: path
+  end
+
+  defp safe_return(_other), do: default_return()
+
+  defp default_return, do: ~p"/admin/accounts/frozen"
+end

--- a/lib/vutuv_web/controllers/admin/admin_controller.ex
+++ b/lib/vutuv_web/controllers/admin/admin_controller.ex
@@ -34,6 +34,7 @@ defmodule VutuvWeb.Admin.AdminController do
       jobs_open_cases_count: jobs_counts.open_cases,
       pref_overrides_count: map_size(Vutuv.Prefs.list_default_rows()),
       frozen_accounts_count: Vutuv.Deliverability.frozen_count(),
+      moderation_frozen_count: Vutuv.Moderation.frozen_accounts_count(),
       fediverse_enabled: Vutuv.Fediverse.enabled?(),
       # Only the four COUNTs when the card will actually show them; an
       # air-gapped install (FEDIVERSE_ENABLED=false) hides the card, mirroring

--- a/lib/vutuv_web/controllers/controller_helpers.ex
+++ b/lib/vutuv_web/controllers/controller_helpers.ex
@@ -106,6 +106,22 @@ defmodule VutuvWeb.ControllerHelpers do
   end
 
   @doc """
+  Renders the "this profile is currently unavailable" page and halts with the
+  given status (issue #812): `403` for a reversible hold (frozen / suspended /
+  unreachable), `410` for a permanently deactivated account. Unlike
+  `render_error/2`'s generic 403 ("you are not allowed to view this page"), this
+  gives a profile-specific body that owns up to "exists, withheld" without
+  revealing *why*. `VutuvWeb.Plug.EnsureActivated` is the one caller.
+  """
+  def render_withheld_profile(%Conn{} = conn, status) when status in [403, 410] do
+    conn
+    |> Conn.put_status(status)
+    |> Phoenix.Controller.put_view(html: VutuvWeb.ErrorHTML)
+    |> Phoenix.Controller.render("profile_unavailable.html", code: status)
+    |> Conn.halt()
+  end
+
+  @doc """
   Looks up a member by a caller-supplied id, returning `nil` for a missing
   *or malformed* id — a garbage (non-UUID) id is a no-op, never an
   `Ecto.CastError` 500. The safe lookup the block/connection/save create paths

--- a/lib/vutuv_web/plugs/ensure_activated.ex
+++ b/lib/vutuv_web/plugs/ensure_activated.ex
@@ -1,17 +1,27 @@
 defmodule VutuvWeb.Plug.EnsureActivated do
   @moduledoc """
-  404s the slug-routed pages of accounts that must not be publicly visible:
-  never-activated registrations (the anti-spam gate) and accounts hidden by
-  moderation (frozen pending review, suspended, deactivated). The owner and
-  admins still reach a frozen profile's **HTML** — the owner needs their
-  banner and the case page, admins their review — but the agent-format
-  siblings (`.md`/`.txt`/`.json`/`.vcf`, see `VutuvWeb.AgentDocs`) are the
-  cache-safe anonymous view, so the bypass does not apply to them: a hidden
-  account's docs 404 for everyone, or an owner/admin fetch could prime a
-  shared cache with a hidden profile.
+  Withholds the slug-routed pages of accounts that must not be publicly visible,
+  with an honest HTTP status per reason (issue #812):
+
+    * a never-activated registration (the anti-spam gate) → **404**: it must
+      stay indistinguishable from a non-existent account, so you cannot probe
+      whether an email is registered;
+    * a reversible moderation/deliverability hold (frozen pending review,
+      suspended, unreachable) → **403 Forbidden**: the account exists and is
+      withheld;
+    * a permanently deactivated account → **410 Gone**.
+
+  The owner and admins still reach a frozen profile's **HTML** (200) — the owner
+  needs their banner and the case page, admins their review — but the
+  agent-format siblings (`.md`/`.txt`/`.json`/`.vcf`, see `VutuvWeb.AgentDocs`)
+  are the cache-safe anonymous view, so the bypass does not apply to them: a
+  hidden account's docs carry the same withheld status for everyone, or an
+  owner/admin fetch could prime a shared cache with a hidden profile. HTML and
+  the siblings therefore always report the same status.
   """
 
   alias Vutuv.Accounts.User
+  alias VutuvWeb.ControllerHelpers
   alias VutuvWeb.Plug.AgentFormat
 
   def init(opts) do
@@ -29,11 +39,16 @@ defmodule VutuvWeb.Plug.EnsureActivated do
         if Vutuv.Moderation.profile_visible_to?(user, viewer) do
           conn
         else
-          VutuvWeb.ControllerHelpers.render_error(conn, 404)
+          withhold(conn, Vutuv.Moderation.withheld_status(user))
         end
 
       _missing ->
-        VutuvWeb.ControllerHelpers.render_error(conn, 404)
+        ControllerHelpers.render_error(conn, 404)
     end
   end
+
+  # A never-activated account keeps the anti-enumeration 404; a real-but-hidden
+  # account gets the profile-unavailable page at its honest 403/410 status.
+  defp withhold(conn, 404), do: ControllerHelpers.render_error(conn, 404)
+  defp withhold(conn, status), do: ControllerHelpers.render_withheld_profile(conn, status)
 end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -512,6 +512,18 @@ defmodule VutuvWeb.Router do
     # legacy POST both use.
     post("/users", UserController, :update)
 
+    # The admin account freezer (issue #812): search any account (by name,
+    # @handle or email) and freeze / unfreeze it directly — no report needed —
+    # plus a paginated list of every account currently in the moderation
+    # freezer. Freeze/unfreeze are CSRF-protected POSTs through a public,
+    # audited Moderation entry point. /accounts/frozen is defined before the
+    # /:id actions so the literal segment wins (same ordering as
+    # /moderation/reporters above).
+    get("/accounts", AccountController, :index)
+    get("/accounts/frozen", AccountController, :frozen)
+    post("/accounts/:id/freeze", AccountController, :freeze)
+    post("/accounts/:id/unfreeze", AccountController, :unfreeze)
+
     # The Honor tags overview: the discoverable home for the admin-granted
     # badges (mint one in a step, see holder counts, jump to each roster).
     # Defined before the tag catalog so `/admin/honor_tags` is a distinct path,

--- a/lib/vutuv_web/templates/admin/account/frozen.html.heex
+++ b/lib/vutuv_web/templates/admin/account/frozen.html.heex
@@ -1,0 +1,72 @@
+<.page_header
+  title={gettext("Frozen accounts")}
+  crumbs={[{gettext("Admin"), ~p"/admin"}, gettext("Frozen accounts")]}
+/>
+
+<div class="card-list">
+  <section class="card">
+    <h1>{gettext("Frozen accounts")}</h1>
+    <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+      {ngettext(
+        "%{formatted} account is currently in the moderation freezer, newest freeze first.",
+        "%{formatted} accounts are currently in the moderation freezer, newest freeze first.",
+        @row_count,
+        formatted: delimited_count(@row_count)
+      )}
+    </p>
+
+    <p class="mt-2 text-sm">
+      <.link navigate={~p"/admin/accounts"} class="font-semibold text-brand-600 hover:text-brand-700">
+        {gettext("Search for an account to freeze")} →
+      </.link>
+    </p>
+
+    <p :if={@accounts == []} class="card__empty">
+      {gettext("No accounts are currently frozen.")}
+    </p>
+
+    <div :if={@accounts != []} class="mt-4 card__tablewrap">
+      <table class="pure-table">
+        <thead>
+          <tr>
+            <th>{gettext("Member")}</th>
+            <th>{gettext("Username")}</th>
+            <th>{gettext("Frozen since")}</th>
+            <th>{gettext("Source")}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody id="frozen-accounts">
+          <tr :for={user <- @accounts} id={"frozen-#{user.id}"}>
+            <td>
+              <.link navigate={~p"/#{user}"} class="flex items-center gap-2">
+                <.avatar user={user} size="xs" />
+                <span class="breakwrap font-medium">{member_name(user)}</span>
+              </.link>
+            </td>
+            <td class="breakwrap">
+              <.link navigate={~p"/#{user}"} class="text-brand-600 hover:text-brand-700">
+                @{user.username}
+              </.link>
+            </td>
+            <td class="whitespace-nowrap text-slate-600 dark:text-slate-400">
+              <.local_time at={user.frozen_at} id={"frozen-since-#{user.id}"} format="%Y-%m-%d" />
+            </td>
+            <td class="text-slate-600 dark:text-slate-400">
+              {freeze_source_label(MapSet.member?(@report_frozen, user.id))}
+            </td>
+            <td class="text-right">
+              <.freeze_toggle
+                user={user}
+                frozen?={true}
+                return_to={~p"/admin/accounts/frozen?#{Map.take(@params, ["page"])}"}
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <.pager params={@params} total={@row_count} />
+  </section>
+</div>

--- a/lib/vutuv_web/templates/admin/account/index.html.heex
+++ b/lib/vutuv_web/templates/admin/account/index.html.heex
@@ -1,0 +1,87 @@
+<.page_header
+  title={gettext("Freeze an account")}
+  crumbs={[{gettext("Admin"), ~p"/admin"}, gettext("Freeze an account")]}
+/>
+
+<div class="card-list">
+  <section class="card">
+    <h1>{gettext("Freeze an account")}</h1>
+    <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+      {gettext(
+        "Find a member by name, @handle or email, then freeze or unfreeze the account. A freeze hides the profile and everything it owns from everyone but the member and admins; it does not block the member from signing in. Freezing is reversible."
+      )}
+    </p>
+
+    <p class="mt-2 text-sm">
+      <.link navigate={~p"/admin/accounts/frozen"} class="font-semibold text-brand-600 hover:text-brand-700">
+        {gettext("See all frozen accounts")} →
+      </.link>
+    </p>
+
+    <form id="account-search" method="get" action={~p"/admin/accounts"} class="mt-4">
+      <label for="search-q" class="block text-sm font-semibold text-slate-700 dark:text-slate-200">
+        {gettext("Search")}
+      </label>
+      <div class="mt-1 flex gap-2">
+        <input
+          type="search"
+          name="q"
+          id="search-q"
+          value={@q}
+          autocomplete="off"
+          placeholder={gettext("name, @handle or email")}
+          class={input_class()}
+        />
+        <button
+          type="submit"
+          class="shrink-0 rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
+        >
+          {gettext("Search")}
+        </button>
+      </div>
+    </form>
+
+    <p :if={not @searched?} class="card__empty">
+      {gettext("Type a name, @handle or email to find an account to freeze.")}
+    </p>
+    <p :if={@searched? and @results == []} class="card__empty">
+      {gettext("No accounts match your search.")}
+    </p>
+
+    <div :if={@results != []} class="mt-4 card__tablewrap">
+      <table class="pure-table">
+        <thead>
+          <tr>
+            <th>{gettext("Member")}</th>
+            <th>{gettext("Username")}</th>
+            <th>{gettext("Status")}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody id="account-results">
+          <tr :for={user <- @results} id={"account-#{user.id}"}>
+            <td>
+              <.link navigate={~p"/#{user}"} class="flex items-center gap-2">
+                <.avatar user={user} size="xs" />
+                <span class="breakwrap font-medium">{member_name(user)}</span>
+              </.link>
+            </td>
+            <td class="breakwrap">
+              <.link navigate={~p"/#{user}"} class="text-brand-600 hover:text-brand-700">
+                @{user.username}
+              </.link>
+            </td>
+            <td><.account_status user={user} /></td>
+            <td class="text-right">
+              <.freeze_toggle
+                user={user}
+                frozen?={user.frozen_at != nil}
+                return_to={~p"/admin/accounts?#{[q: @q]}"}
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>

--- a/lib/vutuv_web/templates/admin/admin/index.html.heex
+++ b/lib/vutuv_web/templates/admin/admin/index.html.heex
@@ -97,6 +97,29 @@ per-IP rate limiter and the security email only ever see the proxy hop. --%>
     </.admin_card>
 
     <.admin_card
+      icon="shield"
+      title={gettext("Freeze an account")}
+      count={@moderation_frozen_count}
+      attention={@moderation_frozen_count > 0}
+      href={~p"/admin/accounts"}
+      id="admin-accounts-link"
+      cta={gettext("Search and freeze")}
+    >
+      <%= if @moderation_frozen_count == 0 do %>
+        {gettext(
+          "Find an account by name, @handle or email and freeze or unfreeze it directly, without waiting for a report. The frozen-accounts list is here too."
+        )}
+      <% else %>
+        {ngettext(
+          "%{formatted} account is in the moderation freezer.",
+          "%{formatted} accounts are in the moderation freezer.",
+          @moderation_frozen_count,
+          formatted: compact_count(@moderation_frozen_count)
+        )}
+      <% end %>
+    </.admin_card>
+
+    <.admin_card
       icon="trash"
       title={gettext("Delete account")}
       href={~p"/admin/users/delete"}

--- a/lib/vutuv_web/views/admin/account_html.ex
+++ b/lib/vutuv_web/views/admin/account_html.ex
@@ -1,0 +1,110 @@
+defmodule VutuvWeb.Admin.AccountHTML do
+  @moduledoc """
+  Renders the admin account freezer pages (issue #812): the search + freeze
+  page and the paginated frozen-accounts list.
+  """
+
+  use VutuvWeb, :html
+
+  import VutuvWeb.UserHelpers, only: [member_name: 1]
+
+  embed_templates("../../templates/admin/account/*")
+
+  @doc """
+  The freeze / unfreeze form for one account row: a CSRF-protected POST to the
+  matching admin route. Renders "Unfreeze" for an already-frozen account and
+  "Freeze" otherwise. `return_to` rides along so the redirect lands back on the
+  page the admin acted from.
+  """
+  attr(:user, :any, required: true)
+  attr(:frozen?, :boolean, required: true)
+  attr(:return_to, :string, required: true)
+
+  def freeze_toggle(%{frozen?: true} = assigns) do
+    ~H"""
+    <.form for={%{}} action={~p"/admin/accounts/#{@user.id}/unfreeze"} class="inline">
+      <input type="hidden" name="return_to" value={@return_to} />
+      <button
+        type="submit"
+        class="rounded-lg bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+      >
+        {gettext("Unfreeze")}
+      </button>
+    </.form>
+    """
+  end
+
+  def freeze_toggle(assigns) do
+    ~H"""
+    <.form for={%{}} action={~p"/admin/accounts/#{@user.id}/freeze"} class="inline">
+      <input type="hidden" name="return_to" value={@return_to} />
+      <button
+        type="submit"
+        class="rounded-lg bg-brand-600 px-3 py-1 text-xs font-semibold text-white hover:bg-brand-700"
+      >
+        {gettext("Freeze")}
+      </button>
+    </.form>
+    """
+  end
+
+  @doc """
+  A small status pill for an account: the most severe moderation/deliverability
+  state the row carries (deactivated > suspended > frozen > unreachable >
+  unconfirmed), or a calm "active" when none applies.
+  """
+  attr(:user, :any, required: true)
+
+  def account_status(assigns) do
+    assigns = assign(assigns, :state, account_state(assigns.user))
+
+    ~H"""
+    <span class={[
+      "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+      status_classes(@state)
+    ]}>
+      {status_label(@state)}
+    </span>
+    """
+  end
+
+  # The most severe state first — a row can carry several flags at once.
+  defp account_state(user) do
+    cond do
+      user.deactivated_at != nil -> :deactivated
+      suspended?(user) -> :suspended
+      user.frozen_at != nil -> :frozen
+      user.unreachable_at != nil -> :unreachable
+      user.email_confirmed? == false -> :unconfirmed
+      true -> :active
+    end
+  end
+
+  defp suspended?(%{suspended_until: nil}), do: false
+
+  defp suspended?(%{suspended_until: until}),
+    do: NaiveDateTime.compare(until, NaiveDateTime.utc_now()) == :gt
+
+  defp status_label(:deactivated), do: gettext("deactivated")
+  defp status_label(:suspended), do: gettext("suspended")
+  defp status_label(:frozen), do: gettext("frozen")
+  defp status_label(:unreachable), do: gettext("unreachable")
+  defp status_label(:unconfirmed), do: gettext("unconfirmed")
+  defp status_label(:active), do: gettext("active")
+
+  defp status_classes(:active),
+    do: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200"
+
+  defp status_classes(:unconfirmed),
+    do: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+
+  defp status_classes(_hold),
+    do: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
+
+  @doc """
+  The frozen list's "Source" label: an account currently frozen by an open
+  report shows "report", one frozen by an admin shows "admin".
+  """
+  def freeze_source_label(true), do: gettext("report")
+  def freeze_source_label(false), do: gettext("admin")
+end

--- a/lib/vutuv_web/views/error_html.ex
+++ b/lib/vutuv_web/views/error_html.ex
@@ -37,11 +37,38 @@ defmodule VutuvWeb.ErrorHTML do
     |> error_page()
   end
 
+  def render("410.html", assigns) do
+    assigns
+    |> Map.new()
+    |> Map.merge(%{code: 410, message: gettext("This page is no longer available.")})
+    |> error_page()
+  end
+
   def render("500.html", assigns) do
     assigns
     |> Map.new()
     |> Map.merge(%{code: 500, message: gettext("Pardon us! Something went wrong.")})
     |> error_page()
+  end
+
+  # A withheld profile (issue #812): the account exists but is currently hidden
+  # (frozen / suspended → 403, permanently deactivated → 410). Deliberately
+  # vague — it does not reveal *why* — and distinct from the generic 403
+  # ("you are not allowed to view this page"), which is about the viewer's
+  # permissions, not the resource's state. `@code` is the status the caller
+  # (`EnsureActivated`) chose.
+  def render("profile_unavailable.html", assigns) do
+    assigns = assigns |> Map.new() |> Map.put_new(:code, 403)
+
+    ~H"""
+    <div class="error-page">
+      <p class="error-page__code">{@code}</p>
+      <h1 class="error-page__title">{gettext("This profile is currently unavailable.")}</h1>
+      <p class="error-page__actions">
+        <a href="/" class="button">{gettext("Back to the start page")}</a>
+      </p>
+    </div>
+    """
   end
 
   # An upload beyond Plug.Parsers' multipart cap raises before any controller

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.140.6",
+      version: "7.141.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260724060502_add_moderation_admin_actions.exs
+++ b/priv/repo/migrations/20260724060502_add_moderation_admin_actions.exs
@@ -1,0 +1,29 @@
+defmodule Vutuv.Repo.Migrations.AddModerationAdminActions do
+  use Ecto.Migration
+
+  def change do
+    # The admin-initiated moderation audit trail (issue #812): one row per
+    # caseless admin action on an account — freezing or unfreezing it directly
+    # from the admin account tool, without a report/case. Mirrors the
+    # deliverability_events and moderation_events ledgers. actor_id is the admin
+    # who acted; user_id / actor_id are plain binary_id columns, not FKs,
+    # because this is an immutable ledger that must outlive the rows it
+    # references (a departed member's freeze history stays readable) and keeping
+    # it FK-free means account deletion needs no extra cascade step.
+    create table(:moderation_admin_actions) do
+      add(:user_id, :binary_id)
+      add(:actor_id, :binary_id)
+      add(:action, :string, null: false)
+      add(:reason, :string)
+      add(:detail, :map, null: false, default: %{})
+
+      timestamps(updated_at: false)
+    end
+
+    create(index(:moderation_admin_actions, [:user_id]))
+    create(index(:moderation_admin_actions, [:inserted_at]))
+
+    # All additive and N-1 safe: the currently deployed release never reads the
+    # new table.
+  end
+end

--- a/test/vutuv/directory_test.exs
+++ b/test/vutuv/directory_test.exs
@@ -68,10 +68,10 @@ defmodule Vutuv.DirectoryTest do
     assert Enum.map(users, & &1.last_name) == ["Visible"]
   end
 
-  test "unreachable (every-email-bounced) members are excluded, like the profile 404s" do
+  test "unreachable (every-email-bounced) members are excluded, like the withheld profile" do
     # unreachable_at hides the profile (Moderation.account_hidden?/1); the
     # crawlable set must agree, or a zombie account leaks into the directory and
-    # sitemap while its profile 404s.
+    # sitemap while its profile is withheld (a 403 since issue #812).
     insert_activated_user(last_name: "Reachable")
     insert_activated_user(last_name: "Unreachable", unreachable_at: ~N[2026-01-01 00:00:00])
 

--- a/test/vutuv/moderation_admin_freeze_test.exs
+++ b/test/vutuv/moderation_admin_freeze_test.exs
@@ -1,0 +1,176 @@
+defmodule Vutuv.ModerationAdminFreezeTest do
+  @moduledoc """
+  The admin-initiated account freezer (issue #812): the public, audited
+  `admin_freeze_user/3` / `admin_unfreeze_user/2` entry points, the frozen-list
+  reads, and the withheld-status classifier that drives the honest 403/410.
+  """
+  use Vutuv.DataCase, async: true
+
+  import Ecto.Query
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Moderation
+  alias Vutuv.Moderation.{AdminAction, Case}
+  alias Vutuv.Repo
+
+  defp admin, do: insert(:activated_user, admin?: true)
+
+  defp reload(%User{id: id}), do: Repo.get!(User, id)
+
+  defp actions_for(%User{id: id}),
+    do: Repo.all(from(a in AdminAction, where: a.user_id == ^id, order_by: [asc: a.inserted_at]))
+
+  describe "admin_freeze_user/3" do
+    test "freezes an active account and records an audit row" do
+      user = insert(:activated_user)
+      admin = admin()
+
+      assert {:ok, :frozen} = Moderation.admin_freeze_user(user, admin, "spam ring")
+
+      assert reload(user).frozen_at
+
+      assert [%AdminAction{action: "account_frozen", actor_id: actor, reason: "spam ring"}] =
+               actions_for(user)
+
+      assert actor == admin.id
+    end
+
+    test "is a no-op (no second audit row) when already frozen" do
+      user = insert(:activated_user, frozen_at: NaiveDateTime.utc_now(:second))
+      admin = admin()
+
+      assert {:ok, :noop} = Moderation.admin_freeze_user(user, admin)
+      assert actions_for(user) == []
+    end
+
+    test "a blank reason is stored as nil" do
+      user = insert(:activated_user)
+
+      assert {:ok, :frozen} = Moderation.admin_freeze_user(user, admin(), "   ")
+      assert [%AdminAction{reason: nil}] = actions_for(user)
+    end
+
+    test "hides the profile from other members once frozen" do
+      user = insert(:activated_user)
+      other = insert(:activated_user)
+      refute Moderation.account_hidden?(reload(user))
+
+      {:ok, :frozen} = Moderation.admin_freeze_user(user, admin())
+
+      frozen = reload(user)
+      assert Moderation.account_hidden?(frozen)
+      refute Moderation.profile_visible_to?(frozen, other)
+      # Owner and admins still see it.
+      assert Moderation.profile_visible_to?(frozen, frozen)
+    end
+
+    test "does not block login (frozen_at only, no suspension/deactivation)" do
+      user = insert(:activated_user)
+      {:ok, :frozen} = Moderation.admin_freeze_user(user, admin())
+
+      frozen = reload(user)
+      assert is_nil(Moderation.login_block(frozen))
+      assert is_nil(frozen.suspended_until)
+      assert is_nil(frozen.deactivated_at)
+    end
+  end
+
+  describe "admin_unfreeze_user/2" do
+    test "lifts a freeze and records an audit row" do
+      user = insert(:activated_user, frozen_at: NaiveDateTime.utc_now(:second))
+      admin = admin()
+
+      assert {:ok, :unfrozen} = Moderation.admin_unfreeze_user(user, admin)
+      refute reload(user).frozen_at
+      assert [%AdminAction{action: "account_unfrozen", actor_id: actor}] = actions_for(user)
+      assert actor == admin.id
+    end
+
+    test "is a no-op when the account was not frozen" do
+      user = insert(:activated_user)
+
+      assert {:ok, :noop} = Moderation.admin_unfreeze_user(user, admin())
+      assert actions_for(user) == []
+    end
+  end
+
+  describe "frozen-list reads" do
+    test "frozen_accounts_count/0 counts only frozen_at accounts" do
+      insert(:activated_user, frozen_at: NaiveDateTime.utc_now(:second))
+      insert(:activated_user, deactivated_at: NaiveDateTime.utc_now(:second))
+      insert(:activated_user)
+
+      assert Moderation.frozen_accounts_count() == 1
+    end
+
+    test "list_frozen_accounts/2 returns frozen accounts newest freeze first" do
+      now = NaiveDateTime.utc_now(:second)
+      older = insert(:activated_user, frozen_at: NaiveDateTime.add(now, -100))
+      newer = insert(:activated_user, frozen_at: now)
+      _active = insert(:activated_user)
+
+      ids = Moderation.list_frozen_accounts() |> Enum.map(& &1.id)
+      assert ids == [newer.id, older.id]
+    end
+
+    test "list_frozen_accounts/2 paginates" do
+      now = NaiveDateTime.utc_now(:second)
+
+      for i <- 1..3,
+          do: insert(:activated_user, frozen_at: NaiveDateTime.add(now, -i))
+
+      page1 = Moderation.list_frozen_accounts(%{"page" => "1"}, per_page: 2)
+      page2 = Moderation.list_frozen_accounts(%{"page" => "2"}, per_page: 2)
+
+      assert length(page1) == 2
+      assert length(page2) == 1
+    end
+
+    test "report_frozen_ids/1 sets apart report-frozen from admin-frozen accounts" do
+      reported = insert(:activated_user, frozen_at: NaiveDateTime.utc_now(:second))
+      admin_frozen = insert(:activated_user, frozen_at: NaiveDateTime.utc_now(:second))
+
+      Repo.insert!(%Case{
+        content_type: "user",
+        content_id: reported.id,
+        owner_id: reported.id,
+        status: "escalated"
+      })
+
+      set = Moderation.report_frozen_ids([reported.id, admin_frozen.id])
+
+      assert MapSet.member?(set, reported.id)
+      refute MapSet.member?(set, admin_frozen.id)
+    end
+  end
+
+  describe "withheld_status/1" do
+    test "404 for a never-activated account" do
+      assert Moderation.withheld_status(build(:user, email_confirmed?: false)) == 404
+    end
+
+    test "404 for a never-activated account even when frozen (anti-enumeration)" do
+      user = build(:user, email_confirmed?: false, frozen_at: NaiveDateTime.utc_now(:second))
+      assert Moderation.withheld_status(user) == 404
+    end
+
+    test "410 for a deactivated account" do
+      user = build(:activated_user, deactivated_at: NaiveDateTime.utc_now(:second))
+      assert Moderation.withheld_status(user) == 410
+    end
+
+    test "403 for a frozen, suspended, or unreachable account" do
+      future = NaiveDateTime.add(NaiveDateTime.utc_now(:second), 7 * 86_400)
+
+      assert Moderation.withheld_status(
+               build(:activated_user, frozen_at: NaiveDateTime.utc_now(:second))
+             ) == 403
+
+      assert Moderation.withheld_status(build(:activated_user, suspended_until: future)) == 403
+
+      assert Moderation.withheld_status(
+               build(:activated_user, unreachable_at: NaiveDateTime.utc_now(:second))
+             ) == 403
+    end
+  end
+end

--- a/test/vutuv_web/agent_docs/agent_format_test.exs
+++ b/test/vutuv_web/agent_docs/agent_format_test.exs
@@ -241,10 +241,12 @@ defmodule VutuvWeb.AgentFormatTest do
       )
 
       # The owner still reaches their own frozen HTML profile (banner/review),
-      # but the agent formats are the anonymous view and must 404 like everyone.
+      # but the agent formats are the anonymous view and carry the same withheld
+      # status as everyone gets — a 403 since issue #812 (was a blanket 404) —
+      # never the owner-bypass profile content, so no cache is primed with it.
       assert html_response(get(conn, "/#{me.username}"), 200)
-      assert get(conn, "/#{me.username}.md").status == 404
-      assert get(conn, "/#{me.username}.json").status == 404
+      assert get(conn, "/#{me.username}.md").status == 403
+      assert get(conn, "/#{me.username}.json").status == 403
     end
 
     test "a private email's show page advertises no agent-format alternates", %{conn: conn} do

--- a/test/vutuv_web/controllers/admin/account_controller_test.exs
+++ b/test/vutuv_web/controllers/admin/account_controller_test.exs
@@ -1,0 +1,200 @@
+defmodule VutuvWeb.Admin.AccountControllerTest do
+  @moduledoc """
+  The admin account freezer (issue #812): admins-only search for any account
+  and a CSRF-protected freeze / unfreeze, plus a paginated frozen-accounts list.
+
+  The freeze/unfreeze POSTs are driven through `submit_with_csrf/3` (see
+  ConnCase), not a bare `post/3`, so the rendered form's CSRF token is actually
+  exercised — the CSRF rule in CLAUDE.md.
+  """
+  use VutuvWeb.ConnCase
+
+  import Ecto.Query
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Moderation.{AdminAction, Case}
+  alias Vutuv.Repo
+
+  defp frozen_actions(user_id),
+    do: Repo.all(from(a in AdminAction, where: a.user_id == ^user_id))
+
+  describe "authorization" do
+    test "non-admins are locked out of the search page", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      assert html_response(get(conn, ~p"/admin/accounts"), 403)
+    end
+
+    test "non-admins are locked out of the frozen list", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      assert html_response(get(conn, ~p"/admin/accounts/frozen"), 403)
+    end
+  end
+
+  describe "index (search)" do
+    setup %{conn: conn} do
+      {conn, admin} = create_and_login_admin(conn)
+      %{conn: conn, admin: admin}
+    end
+
+    test "shows a prompt before searching", %{conn: conn} do
+      response = html_response(get(conn, ~p"/admin/accounts"), 200)
+      assert response =~ "Type a name, @handle or email"
+    end
+
+    test "finds an account by name, @handle and email", %{conn: conn} do
+      user = insert(:activated_user, first_name: "Zaphod", username: "zaphod")
+      insert(:email, user: user, value: "beeblebrox@example.com")
+
+      by_name = html_response(get(conn, ~p"/admin/accounts?q=Zaphod"), 200)
+      assert by_name =~ "@zaphod"
+
+      by_handle = html_response(get(conn, ~p"/admin/accounts?q=@zaphod"), 200)
+      assert by_handle =~ "@zaphod"
+
+      by_email = html_response(get(conn, ~p"/admin/accounts?q=beeblebrox@example.com"), 200)
+      assert by_email =~ "@zaphod"
+    end
+
+    test "reports no matches for an empty result", %{conn: conn} do
+      response = html_response(get(conn, ~p"/admin/accounts?q=nobodyhere-xyz"), 200)
+      assert response =~ "No accounts match your search"
+    end
+  end
+
+  describe "freeze / unfreeze" do
+    setup %{conn: conn} do
+      {conn, admin} = create_and_login_admin(conn)
+      %{conn: conn, admin: admin}
+    end
+
+    test "freezes an account through a CSRF-protected POST and audits it", %{
+      conn: conn,
+      admin: admin
+    } do
+      user = insert(:activated_user, first_name: "Freezeme", username: "freezeme")
+
+      # Render the page so the freeze form's CSRF token is available, and assert
+      # the rendered form actually posts to the freeze route (the "assert the
+      # rendered action=" rule — a bare post/3 to a route I know exists would not
+      # catch a form pointing at the wrong URL).
+      conn = get(conn, ~p"/admin/accounts?q=freezeme")
+      assert html_response(conn, 200) =~ ~s(action="/admin/accounts/#{user.id}/freeze")
+
+      conn =
+        submit_with_csrf(conn, ~p"/admin/accounts/#{user.id}/freeze", %{
+          "return_to" => "/admin/accounts?q=freezeme"
+        })
+
+      assert redirected_to(conn) == "/admin/accounts?q=freezeme"
+      assert Repo.get!(User, user.id).frozen_at
+
+      assert [%AdminAction{action: "account_frozen", actor_id: actor}] = frozen_actions(user.id)
+      assert actor == admin.id
+    end
+
+    test "a freeze hides the profile from anonymous visitors (403)", %{conn: conn} do
+      user = insert(:activated_user, first_name: "Hideme", username: "hideme")
+      conn = get(conn, ~p"/admin/accounts?q=hideme")
+
+      submit_with_csrf(conn, ~p"/admin/accounts/#{user.id}/freeze", %{
+        "return_to" => "/admin/accounts"
+      })
+
+      assert get(build_conn(), "/hideme").status == 403
+    end
+
+    test "unfreezes a frozen account through a CSRF-protected POST", %{conn: conn} do
+      user =
+        insert(:activated_user,
+          username: "thawme",
+          frozen_at: NaiveDateTime.utc_now(:second)
+        )
+
+      conn = get(conn, ~p"/admin/accounts/frozen")
+      assert html_response(conn, 200) =~ ~s(action="/admin/accounts/#{user.id}/unfreeze")
+
+      conn =
+        submit_with_csrf(conn, ~p"/admin/accounts/#{user.id}/unfreeze", %{
+          "return_to" => "/admin/accounts/frozen"
+        })
+
+      assert redirected_to(conn) == "/admin/accounts/frozen"
+      refute Repo.get!(User, user.id).frozen_at
+      assert [%AdminAction{action: "account_unfrozen"}] = frozen_actions(user.id)
+    end
+
+    test "freezing an unknown account flashes an error instead of 500ing", %{conn: conn} do
+      # A search result renders a freeze form, which carries the CSRF token.
+      insert(:activated_user, username: "tokenholder1")
+      conn = get(conn, ~p"/admin/accounts?q=tokenholder1")
+
+      conn =
+        submit_with_csrf(conn, ~p"/admin/accounts/#{Vutuv.UUIDv7.generate()}/freeze", %{
+          "return_to" => "/admin/accounts"
+        })
+
+      assert redirected_to(conn) == "/admin/accounts"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "no longer exists"
+    end
+
+    test "a malformed account id does not raise", %{conn: conn} do
+      insert(:activated_user, username: "tokenholder2")
+      conn = get(conn, ~p"/admin/accounts?q=tokenholder2")
+
+      conn =
+        submit_with_csrf(conn, ~p"/admin/accounts/not-a-uuid/freeze", %{
+          "return_to" => "/admin/accounts"
+        })
+
+      assert redirected_to(conn) == "/admin/accounts"
+    end
+
+    test "an off-site return_to falls back to the frozen list (no open redirect)", %{conn: conn} do
+      user = insert(:activated_user, username: "redirectme")
+      conn = get(conn, ~p"/admin/accounts?q=redirectme")
+
+      conn =
+        submit_with_csrf(conn, ~p"/admin/accounts/#{user.id}/freeze", %{
+          "return_to" => "https://evil.example/phish"
+        })
+
+      assert redirected_to(conn) == ~p"/admin/accounts/frozen"
+    end
+  end
+
+  describe "frozen list" do
+    setup %{conn: conn} do
+      {conn, admin} = create_and_login_admin(conn)
+      %{conn: conn, admin: admin}
+    end
+
+    test "lists currently frozen accounts with an Unfreeze control", %{conn: conn} do
+      insert(:activated_user,
+        username: "inthefreezer",
+        frozen_at: NaiveDateTime.utc_now(:second)
+      )
+
+      response = html_response(get(conn, ~p"/admin/accounts/frozen"), 200)
+      assert response =~ "@inthefreezer"
+      assert response =~ "Unfreeze"
+    end
+
+    test "labels the source of a report-driven freeze", %{conn: conn} do
+      reported =
+        insert(:activated_user,
+          username: "reportedfreeze",
+          frozen_at: NaiveDateTime.utc_now(:second)
+        )
+
+      Repo.insert!(%Case{
+        content_type: "user",
+        content_id: reported.id,
+        owner_id: reported.id,
+        status: "escalated"
+      })
+
+      response = html_response(get(conn, ~p"/admin/accounts/frozen"), 200)
+      assert response =~ "report"
+    end
+  end
+end

--- a/test/vutuv_web/controllers/moderation_gates_test.exs
+++ b/test/vutuv_web/controllers/moderation_gates_test.exs
@@ -14,15 +14,17 @@ defmodule VutuvWeb.ModerationGatesTest do
       {:ok, %{conn: conn, owner: owner}}
     end
 
-    test "404s for visitors", %{conn: conn, owner: owner} do
+    # Issue #812: a frozen account exists but is withheld, so it returns 403,
+    # not the misleading 404 it used to.
+    test "403s for visitors", %{conn: conn, owner: owner} do
       conn = get(conn, ~p"/#{owner}")
-      assert html_response(conn, 404)
+      assert html_response(conn, 403)
     end
 
-    test "404s for other logged-in members", %{conn: conn, owner: owner} do
+    test "403s for other logged-in members", %{conn: conn, owner: owner} do
       {conn, _user} = create_and_login_user(conn)
       conn = get(conn, ~p"/#{owner}")
-      assert html_response(conn, 404)
+      assert html_response(conn, 403)
     end
 
     test "stays reachable for the owner", %{conn: conn} do

--- a/test/vutuv_web/plugs/ensure_activated_test.exs
+++ b/test/vutuv_web/plugs/ensure_activated_test.exs
@@ -13,4 +13,99 @@ defmodule VutuvWeb.Plug.EnsureActivatedTest do
     assert conn.status == 404
     assert conn.resp_body =~ ~r/not found/i
   end
+
+  # Issue #812: a real-but-withheld account must not masquerade as 404. A
+  # reversible hold (frozen / suspended / unreachable) is 403 Forbidden; a
+  # permanent deactivation is 410 Gone; only a never-activated registration
+  # keeps the anti-enumeration 404.
+  describe "withheld status per moderation state" do
+    test "a frozen profile returns 403 to an anonymous viewer" do
+      insert(:activated_user,
+        username: "held-account",
+        frozen_at: NaiveDateTime.utc_now(:second)
+      )
+
+      conn = get(build_conn(), "/held-account")
+
+      assert conn.status == 403
+      assert conn.resp_body =~ "currently unavailable"
+      # Must not reveal *why* it is unavailable.
+      refute conn.resp_body =~ ~r/frozen|suspended|deactivated/i
+    end
+
+    test "a suspended profile returns 403" do
+      future = NaiveDateTime.add(NaiveDateTime.utc_now(:second), 7 * 86_400)
+      insert(:activated_user, username: "suspended-user", suspended_until: future)
+
+      conn = get(build_conn(), "/suspended-user")
+
+      assert conn.status == 403
+    end
+
+    test "an unreachable profile returns 403" do
+      insert(:activated_user,
+        username: "unreachable-user",
+        unreachable_at: NaiveDateTime.utc_now(:second)
+      )
+
+      conn = get(build_conn(), "/unreachable-user")
+
+      assert conn.status == 403
+    end
+
+    test "a deactivated profile returns 410 Gone" do
+      insert(:activated_user,
+        username: "deactivated-user",
+        deactivated_at: NaiveDateTime.utc_now(:second)
+      )
+
+      conn = get(build_conn(), "/deactivated-user")
+
+      assert conn.status == 410
+      assert conn.resp_body =~ "currently unavailable"
+    end
+
+    test "a never-activated account that is also frozen still returns 404 (anti-enumeration wins)" do
+      insert(:user,
+        username: "unconfirmed-frozen",
+        email_confirmed?: false,
+        frozen_at: NaiveDateTime.utc_now(:second)
+      )
+
+      conn = get(build_conn(), "/unconfirmed-frozen")
+
+      assert conn.status == 404
+    end
+
+    test "an active profile still renders (200)" do
+      insert(:activated_user, username: "active-user")
+
+      conn = get(build_conn(), "/active-user")
+
+      assert conn.status == 200
+    end
+  end
+
+  # The agent-format siblings share EnsureActivated and must report the *same*
+  # status as the HTML page, so HTML and .md/.json/.vcf stay consistent.
+  describe "agent-format siblings carry the same status" do
+    test "a frozen profile's .json and .md return 403" do
+      insert(:activated_user,
+        username: "frozen-sibling",
+        frozen_at: NaiveDateTime.utc_now(:second)
+      )
+
+      assert get(build_conn(), "/frozen-sibling.json").status == 403
+      assert get(build_conn(), "/frozen-sibling.md").status == 403
+    end
+
+    test "a deactivated profile's .json returns 410" do
+      insert(:activated_user,
+        username: "gone-sibling",
+        deactivated_at: NaiveDateTime.utc_now(:second)
+      )
+
+      assert get(build_conn(), "/gone-sibling.json").status == 410
+    end
+  end
 end


### PR DESCRIPTION
Closes #812.

Gives admins a proactive way to **find any account and freeze/unfreeze it directly**, a **paginated frozen-accounts list**, and replaces the misleading **404** a withheld profile returned with a status that tells the truth about the account's state. Freezing previously only happened reactively, as a side effect of the report→case flow.

## Part 1 & 2 — admin account tool (`/admin/accounts`)

- **Search** any account by name, `@handle` or email (reuses the member-browser matcher), each row with a **Freeze / Unfreeze** button.
- **`/admin/accounts/frozen`** — paginated list of the moderation freezer, newest freeze first (`<.pager>`, 250/page), with a **Source** column (admin vs report) and an Unfreeze control.
- Public, **audited** entry points `Moderation.admin_freeze_user/3` + `admin_unfreeze_user/2` replace the private `set_user_moderation!/2`. **Design decision (option a from the issue):** a caseless `moderation_admin_actions` audit ledger (mirroring the deliverability ledger) rather than a synthetic `Case` — an audit trail without faking a report.
- A freeze sets `frozen_at` only, so it hides the profile everywhere but does **not** block login (the issue's default; not silently changed).
- Freeze/unfreeze are **CSRF-protected POSTs**; a dashboard tile links to the tool with the live frozen count.

## Part 3 — honest HTTP status (`EnsureActivated`)

Decision resolved as the issue proposed:

| State | Status |
|---|---|
| never-activated (spam gate) | **404** (unchanged — must stay indistinguishable from non-existent; wins first even when also frozen) |
| frozen / suspended / unreachable (reversible hold) | **403 Forbidden** |
| deactivated (permanent) | **410 Gone** |
| owner / admin (HTML) | **200** (unchanged) |

HTML and the agent-format siblings (`.md`/`.json`/`.xml`/`.vcf`) share the plug, so they always report the same status. 403/410 render a profile-specific "This profile is currently unavailable" page that does not reveal *why*.

**Out of scope, called out:** the `/api/2.0` JSON API keeps its 404 for hidden accounts — it is a separate authenticated API with problem+json conventions, not an agent-format sibling. And freezing does not block login; making it also lock the member out (`suspended_until`) is a separate decision, not taken here.

## Migration

New additive, N-1-safe `moderation_admin_actions` table (immutable, FK-free ledger, like `deliverability_events`). No column/table drops.

## Testing

- `mix precommit` green: **4584 tests pass**, `credo --strict` clean, formatted, compiles `--warnings-as-errors`.
- Tests-first: moderation context (freeze/unfreeze/audit/frozen-list/`withheld_status`), `EnsureActivated` status per state **including agent-format parity**, and a **CSRF-protected controller test via `submit_with_csrf/3`** that also asserts the **rendered `action=`** matches the route.
- Updated the pre-existing tests that asserted a frozen profile 404s (they now assert 403) and the agent-format hidden-account test (owner's siblings now carry the 403 withheld status, never the profile content — no cache poisoning).
- No live browser smoke test: these are **classic JS-free form pages** (no LiveView/client enhancement → no "assets-404 → no-JS" fallback risk), the CSRF token and rendered `action=` are exercised through the real rendered form, and no email path is involved — so the production-only hazards the smoke-test rule guards against are either covered by tests or structurally absent here.

Docs updated: `docs/architecture/admin.md` + `moderation.md`.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01D768iohpuW53NrhQPrkJya