### PR TITLE
Pin capture browser to a vetted IP to close screenshot SSRF (GHSA-mmjf-8cwc-6vwv)

### DIFF
--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -70,6 +70,36 @@ thread auto-scroll for that agent (issue #1033,
 `Vutuv.SocialFeed.Http.own_agent?/1`). Keep new on-arrival scroll/focus
 behaviour off the capture path for the same reason.
 
+### SSRF egress control (GHSA-mmjf-8cwc-6vwv, CWE-918)
+
+The captured URL is member-supplied, so headless Chromium is a
+server-side-request-forgery risk: left to itself it resolves DNS and follows
+redirects, `<meta http-equiv="refresh">` and JavaScript navigations, and could
+be steered onto `169.254.169.254`, `127.0.0.1:<port>`, or any LAN host and
+publish the rendered result on the attacker's own profile/post card. Validating
+only the seed URL does not help — the browser is what does the fetching.
+
+The guard therefore constrains Chromium itself. `Vutuv.PageScreenshot.capture_framed/2`
+resolves the target host **once** through `Vutuv.Ssrf.vetted_address/1`
+(fail-closed: any resolved internal address refuses the whole capture) and pins
+the browser to that exact IP with `--host-resolver-rules=MAP * <vetted-ip>`.
+Chromium then does no DNS of its own, so every request it makes — the seed page,
+its subresources, and any redirect / meta-refresh / in-page navigation — goes to
+the one vetted public address. This also closes the check-vs-fetch (TOCTOU) DNS
+rebinding window, since there is no second lookup to poison. The real hostname
+still rides in `Host:`/SNI, so the intended page renders; only a *different*
+host is pinned to the wrong address and simply fails to load — an accepted
+fidelity trade for cross-host subresources.
+
+`Vutuv.Moderation.EvidenceScreenshot` calls `capture/3` without a pin, on
+purpose: it shoots this installation's *own* host (a profile/evidence page),
+which may legitimately be internal.
+
+The pre-capture probes (redirect resolution on the profile path, the HTTP-200
+check on the post path) read only the status line and `location` header, and cap
+the response body during receipt with `Vutuv.Http.capped_collector/1` so a
+hostile link cannot stream an unbounded body into memory.
+
 ## AI image moderation (the Ollama scan)
 
 **Every** image that could become visible to anyone but its owner passes

--- a/lib/vutuv/page_screenshot.ex
+++ b/lib/vutuv/page_screenshot.ex
@@ -141,25 +141,41 @@ defmodule Vutuv.PageScreenshot do
   `url_value` is an untrusted member-supplied link. The changeset already
   rejected literal internal hosts, but a public hostname can resolve to an
   internal IP (DNS rebinding, issue #777), so resolve at capture time and refuse
-  before handing the URL to Chromium. `Vutuv.Moderation.EvidenceScreenshot`
-  calls `capture/3` directly to shoot the app's own host and is intentionally
-  not gated.
+  before handing the URL to Chromium.
+
+  Resolving is done **once** here, and the vetted IP is *pinned* into Chromium
+  via `--host-resolver-rules` (see `capture_args/3`): the browser never does its
+  own DNS lookup, so it cannot be steered onto an internal host by a redirect, a
+  `<meta http-equiv="refresh">`, in-page JavaScript navigation, or a DNS record
+  that flips between our check and Chromium's fetch — the SSRF-via-capture hole
+  of GHSA-mmjf-8cwc-6vwv (CWE-918). A host that resolves only to internal
+  addresses is a permanent property of the URL (`:internal_target`); one that
+  does not resolve at all right now is transient (`:unresolvable_target`), so the
+  caller retries rather than poisoning the row.
+
+  `Vutuv.Moderation.EvidenceScreenshot` calls `capture/3` directly to shoot the
+  app's own host and is intentionally neither gated nor pinned.
   """
   def capture_framed(url_value, id) when is_binary(url_value) do
-    if Ssrf.resolves_to_internal?(URI.parse(url_value).host) do
-      {:error, :internal_target}
-    else
-      page_path = tmp_path("page", id, "png")
-      framed_path = tmp_path("frame", id, "webp")
+    case Ssrf.vetted_address(URI.parse(url_value).host) do
+      {:ok, pin_ip} ->
+        page_path = tmp_path("page", id, "png")
+        framed_path = tmp_path("frame", id, "webp")
 
-      try do
-        with :ok <- capture(url_value, page_path),
-             {:ok, ^framed_path} <- BrowserFrame.wrap(page_path, url_value, framed_path) do
-          {:ok, framed_path}
+        try do
+          with :ok <- capture(url_value, page_path, pin_ip: pin_ip),
+               {:ok, ^framed_path} <- BrowserFrame.wrap(page_path, url_value, framed_path) do
+            {:ok, framed_path}
+          end
+        after
+          File.rm(page_path)
         end
-      after
-        File.rm(page_path)
-      end
+
+      {:error, :internal} ->
+        {:error, :internal_target}
+
+      {:error, :unresolvable} ->
+        {:error, :unresolvable_target}
     end
   end
 
@@ -205,6 +221,11 @@ defmodule Vutuv.PageScreenshot do
     end
   end
 
+  # We only read the status line and `location` header of the probe, never the
+  # body, so drop it during receipt at a small ceiling: a hostile member link
+  # could otherwise stream an unbounded body into memory (scan finding F15).
+  @probe_max_body_bytes 64 * 1024
+
   # A `redirect: false` GET so we see (and validate) each 3xx hop ourselves.
   defp probe(url) do
     [
@@ -213,7 +234,7 @@ defmodule Vutuv.PageScreenshot do
       connect_options: [timeout: 3_000],
       retry: false,
       redirect: false,
-      decode_body: false,
+      into: Vutuv.Http.capped_collector(@probe_max_body_bytes),
       headers: [{"user-agent", Http.user_agent()}]
     ]
     |> Keyword.merge(Application.get_env(:vutuv, @probe_req_options_key, []))
@@ -284,6 +305,17 @@ defmodule Vutuv.PageScreenshot do
   would spoil it: `--screenshot` renders the document **from the top**, so a
   page that scrolls itself on arrival is captured before those tiles are
   painted and stores a blank image (issue #1033).
+
+  `opts[:pin_ip]` (an `:inet.ip_address/0`) adds
+  `--host-resolver-rules=MAP * <ip>`, which forces **every** name Chromium would
+  resolve during the run — the seed host, its subresources, and any redirect /
+  meta-refresh / JavaScript-navigation target — to the single vetted public IP.
+  That is the SSRF egress control (GHSA-mmjf-8cwc-6vwv): Chromium does no DNS of
+  its own, so it cannot reach an internal address the seed URL was validated
+  against. The real hostname still rides in `Host:`/SNI, so the intended page
+  renders; only a *different* host is pinned to the wrong address and simply
+  fails to load. Omitted (`EvidenceScreenshot` shooting our own host), no rule
+  is added and behaviour is unchanged.
   """
   def capture_args(url, out_path, opts \\ []) do
     {width, height} = Keyword.get(opts, :window, window_size())
@@ -305,9 +337,21 @@ defmodule Vutuv.PageScreenshot do
       "--timeout=#{@page_timeout_seconds * 1000}",
       "--user-agent=#{Http.user_agent()}",
       "--window-size=#{width},#{height}",
-      "--screenshot=#{out_path}",
-      url
-    ]
+      "--screenshot=#{out_path}"
+    ] ++ host_resolver_args(Keyword.get(opts, :pin_ip)) ++ [url]
+  end
+
+  # The SSRF pin: map every resolved name to the one vetted IP, or nothing when
+  # unpinned. `MAP * <ip>` still lets Chromium send the correct `Host:`/SNI, so
+  # the seed page renders normally while nothing can be re-resolved elsewhere.
+  defp host_resolver_args(nil), do: []
+  defp host_resolver_args(pin_ip), do: ["--host-resolver-rules=MAP * #{format_pin(pin_ip)}"]
+
+  # Chromium's resolver-rule replacement wants a bare IPv4 literal, and a
+  # bracketed IPv6 literal so the optional `:port` suffix stays unambiguous.
+  defp format_pin(pin_ip) do
+    addr = pin_ip |> :inet.ntoa() |> to_string()
+    if tuple_size(pin_ip) == 8, do: "[#{addr}]", else: addr
   end
 
   @doc "The OS-level ceiling for one Chromium run, in seconds."

--- a/lib/vutuv/posts/screenshots.ex
+++ b/lib/vutuv/posts/screenshots.ex
@@ -365,6 +365,11 @@ defmodule Vutuv.Posts.Screenshots do
   # Couldn't reach the target to check — transient, retried like a Chromium timeout.
   defp classify(_error), do: {:error, :probe_failed}
 
+  # Only the status line is read, never the body, so drop it during receipt at a
+  # small ceiling: a hostile member link could otherwise stream an unbounded
+  # body into memory (scan finding F15).
+  @probe_max_body_bytes 64 * 1024
+
   defp probe(url) do
     [
       url: url,
@@ -372,7 +377,7 @@ defmodule Vutuv.Posts.Screenshots do
       connect_options: [timeout: 3_000],
       retry: false,
       redirect: false,
-      decode_body: false,
+      into: Vutuv.Http.capped_collector(@probe_max_body_bytes),
       headers: [{"user-agent", Http.user_agent()}]
     ]
     |> Keyword.merge(Application.get_env(:vutuv, @probe_req_options_key, []))

--- a/lib/vutuv/ssrf.ex
+++ b/lib/vutuv/ssrf.ex
@@ -16,9 +16,16 @@ defmodule Vutuv.Ssrf do
       if it is a literal internal host **or** any resolved address is internal.
       Run at fetch time to defeat DNS rebinding (a public hostname whose record
       points at an internal IP), which the literal check cannot catch (issues
-      #775 / #777). There is still a TOCTOU residual (the resolver could answer
-      differently between this check and the fetcher's own lookup); closing it
-      fully needs connect-time peer-address validation.
+      #775 / #777). On its own it leaves a TOCTOU residual: it only *checks*, and
+      a fetcher that then re-resolves the host could get a different, internal
+      answer.
+    * `vetted_address/1` — resolves once and returns the exact public IP to pin
+      the fetcher to, so there is no second lookup to poison. This closes the
+      TOCTOU for the one fetcher that re-resolved on its own, the headless-capture
+      browser: it is handed the vetted IP via `--host-resolver-rules`
+      (`Vutuv.PageScreenshot`, GHSA-mmjf-8cwc-6vwv / CWE-918) rather than the
+      hostname, and every redirect / `<meta refresh>` / in-page navigation it
+      then makes is pinned to that same address too.
 
   The resolver is injectable via `config :vutuv, :ssrf_resolver` (a
   `fun(charlist, :inet | :inet6) -> {:ok, [ip]} | {:error, term}`) so tests can
@@ -67,6 +74,47 @@ defmodule Vutuv.Ssrf do
   end
 
   def resolves_to_internal?(_), do: true
+
+  @doc """
+  Resolves `host` to a single **vetted public IP** so a downstream fetcher can be
+  pinned to exactly that address instead of re-resolving the hostname itself.
+
+  This is what `resolves_to_internal?/1` cannot do on its own: that predicate only
+  *checks* the host, and the fetcher then looked it up again — a second lookup that
+  could answer with an internal address (DNS rebinding), the TOCTOU acknowledged in
+  the moduledoc. Handing the fetcher the exact IP we validated (the headless-capture
+  browser gets it via `--host-resolver-rules`) removes that second lookup, so there
+  is no window for the answer to change.
+
+    * `{:ok, ip}` — a public IP literal (returns itself, no lookup), or a hostname
+      whose resolved addresses are **all** public (returns the first, to pin on).
+    * `{:error, :internal}` — a literal internal host, or a hostname where **any**
+      resolved address is internal (fail closed: one internal answer blocks).
+    * `{:error, :unresolvable}` — nothing resolved, or a hostless value; there is no
+      address to pin, so the caller must refuse rather than let the fetcher resolve.
+  """
+  def vetted_address(host) when is_binary(host) do
+    bare = bare_host(host)
+
+    cond do
+      internal_host?(host) -> {:error, :internal}
+      literal_ip?(bare) -> {:ok, parse_ip!(bare)}
+      true -> vet_resolved(resolved_addresses(bare))
+    end
+  end
+
+  def vetted_address(_), do: {:error, :unresolvable}
+
+  defp vet_resolved([]), do: {:error, :unresolvable}
+
+  defp vet_resolved([first | _] = addrs) do
+    if Enum.any?(addrs, &internal_ip?/1), do: {:error, :internal}, else: {:ok, first}
+  end
+
+  defp parse_ip!(bare) do
+    {:ok, addr} = :inet.parse_address(to_charlist(bare))
+    addr
+  end
 
   defp bare_host(host), do: host |> String.trim_leading("[") |> String.trim_trailing("]")
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.141.1",
+      version: "7.141.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/page_screenshot_test.exs
+++ b/test/vutuv/page_screenshot_test.exs
@@ -35,6 +35,17 @@ defmodule Vutuv.PageScreenshotTest do
     Application.put_env(:vutuv, :page_screenshot_probe_req_options, plug: fun)
   end
 
+  # A stand-in "Chromium" that records its argv (one element per line, so the
+  # space-carrying `--host-resolver-rules=MAP * <ip>` stays one line) and writes
+  # no screenshot. Lets a test assert the exact command line without a browser.
+  defp fake_chromium(args_file) do
+    path = Path.join(System.tmp_dir!(), "fake-chromium-#{System.unique_integer([:positive])}")
+    File.write!(path, "#!/bin/sh\nprintf '%s\\n' \"$@\" > #{args_file}\n")
+    File.chmod!(path, 0o755)
+    on_exit(fn -> File.rm(path) end)
+    path
+  end
+
   test "the command line bounds the page load, so a hanging page still yields a shot" do
     args = Vutuv.PageScreenshot.capture_args("https://example.com", "/tmp/out.png")
 
@@ -66,6 +77,81 @@ defmodule Vutuv.PageScreenshotTest do
     # scrolls itself is captured before those tiles are painted — the empty
     # preview image of issue #1033.
     assert "--user-agent=#{Http.user_agent()}" in args
+  end
+
+  describe "capture_args/3 host-resolver pinning (SSRF egress control)" do
+    test "no pin IP means no --host-resolver-rules flag (unchanged behaviour)" do
+      args = Vutuv.PageScreenshot.capture_args("https://example.com", "/tmp/out.png")
+      refute Enum.any?(args, &String.starts_with?(&1, "--host-resolver-rules"))
+    end
+
+    test "a pin IP maps EVERY host Chromium resolves to that one vetted address" do
+      args =
+        Vutuv.PageScreenshot.capture_args("https://example.com", "/tmp/out.png",
+          pin_ip: {93, 184, 216, 34}
+        )
+
+      # `MAP * <ip>` pins the seed host, its subresources, and any redirect /
+      # <meta refresh> / JS navigation to the single public IP we already
+      # vetted, so Chromium cannot be steered onto an internal host after the
+      # seed URL passed the guard (GHSA-mmjf-8cwc-6vwv).
+      assert "--host-resolver-rules=MAP * 93.184.216.34" in args
+    end
+
+    test "the URL stays the final positional argument, after the pin flag" do
+      args =
+        Vutuv.PageScreenshot.capture_args("https://example.com/page", "/tmp/out.png",
+          pin_ip: {93, 184, 216, 34}
+        )
+
+      assert List.last(args) == "https://example.com/page"
+    end
+
+    test "an IPv6 pin address is bracketed for the resolver rule" do
+      args =
+        Vutuv.PageScreenshot.capture_args("https://example.com", "/tmp/out.png",
+          pin_ip: {0x2606, 0x2800, 0x220, 1, 0x248, 0x1893, 0x25C8, 0x1946}
+        )
+
+      assert "--host-resolver-rules=MAP * [2606:2800:220:1:248:1893:25c8:1946]" in args
+    end
+  end
+
+  test "capture_framed pins Chromium to the host's vetted IP (resolve-once, no re-lookup)" do
+    # A public-looking host that resolves to a public IP: capture_framed must
+    # resolve it ONCE and hand Chromium that exact address, so the browser never
+    # does its own lookup that DNS rebinding could flip to an internal IP.
+    Application.put_env(:vutuv, :ssrf_resolver, fn _host, _family ->
+      {:ok, [{93, 184, 216, 34}]}
+    end)
+
+    args_file =
+      Path.join(System.tmp_dir!(), "chromium-args-#{System.unique_integer([:positive])}")
+
+    on_exit(fn -> File.rm(args_file) end)
+    Application.put_env(:vutuv, :chromium_path, fake_chromium(args_file))
+
+    # The fake binary records argv and writes no image, so framing fails and
+    # capture_framed returns an error — but the recorded args are what we assert.
+    _ = Vutuv.PageScreenshot.capture_framed("https://public.example/page", "cap1")
+
+    assert File.read!(args_file) =~ "--host-resolver-rules=MAP * 93.184.216.34"
+  end
+
+  test "capture_framed refuses a host that resolves to an internal IP before launching Chromium" do
+    Application.put_env(:vutuv, :ssrf_resolver, fn _host, _family -> {:ok, [{10, 0, 0, 5}]} end)
+
+    args_file =
+      Path.join(System.tmp_dir!(), "chromium-args-#{System.unique_integer([:positive])}")
+
+    on_exit(fn -> File.rm(args_file) end)
+    Application.put_env(:vutuv, :chromium_path, fake_chromium(args_file))
+
+    assert {:error, :internal_target} =
+             Vutuv.PageScreenshot.capture_framed("https://rebind.example/page", "cap2")
+
+    # Chromium was never spawned, so no argv was recorded.
+    refute File.exists?(args_file)
   end
 
   describe "capture_outcome/2 (the file on disk decides)" do

--- a/test/vutuv/ssrf_test.exs
+++ b/test/vutuv/ssrf_test.exs
@@ -87,4 +87,36 @@ defmodule Vutuv.SsrfTest do
       assert Ssrf.resolves_to_internal?(nil)
     end
   end
+
+  describe "vetted_address/1 (resolve once, return a pinnable public IP)" do
+    test "a public IP literal returns itself without any lookup" do
+      Application.put_env(:vutuv, :ssrf_resolver, fn _h, _f -> raise "must not resolve" end)
+      assert Ssrf.vetted_address("93.184.216.34") == {:ok, {93, 184, 216, 34}}
+    end
+
+    test "a literal internal host is refused without any lookup" do
+      Application.put_env(:vutuv, :ssrf_resolver, fn _h, _f -> raise "must not resolve" end)
+      assert Ssrf.vetted_address("169.254.169.254") == {:error, :internal}
+      assert Ssrf.vetted_address("localhost") == {:error, :internal}
+    end
+
+    test "an all-public hostname returns its first resolved address (to pin on)" do
+      stub_resolver(%{"public.example" => [{93, 184, 216, 34}]})
+      assert Ssrf.vetted_address("public.example") == {:ok, {93, 184, 216, 34}}
+    end
+
+    test "one internal address among public ones fails closed" do
+      stub_resolver(%{"rebind.example" => [{93, 184, 216, 34}, {10, 0, 0, 5}]})
+      assert Ssrf.vetted_address("rebind.example") == {:error, :internal}
+    end
+
+    test "a host that resolves to nothing is unresolvable (never handed to a fetcher)" do
+      stub_resolver(%{})
+      assert Ssrf.vetted_address("nxdomain.example") == {:error, :unresolvable}
+    end
+
+    test "a nil / hostless value is unresolvable" do
+      assert Ssrf.vetted_address(nil) == {:error, :unresolvable}
+    end
+  end
 end


### PR DESCRIPTION
## What

Fixes the read-SSRF in the URL screenshot feature, [GHSA-mmjf-8cwc-6vwv](https://github.com/wintermeyer/vutuv/security/advisories/GHSA-mmjf-8cwc-6vwv) (CWE-918, HIGH).

A member-supplied link (a profile Link row, or the sole URL in a post) is screenshotted by headless Chromium. Only the **seed** URL's host was checked against the SSRF guard; Chromium then resolved DNS and followed redirects, `<meta http-equiv="refresh">` and JavaScript navigations on its own. A public seed that redirected / DNS-rebound / served a Chrome-only 302 to `169.254.169.254`, `127.0.0.1:<port>` or a LAN host got fetched, and the render was published on the attacker's own profile Links card or post card.

## Fix

Constrain Chromium itself instead of only the seed URL:

- `Vutuv.Ssrf.vetted_address/1` resolves the host **once** and returns the exact public IP to pin on (fail-closed: any resolved internal address refuses the whole capture).
- `capture_framed/2` passes that IP to Chromium as `--host-resolver-rules="MAP * <vetted-ip>"`. Chromium does no DNS of its own, so the seed page, its subresources, and every redirect / meta-refresh / in-page navigation all go to the one vetted public address — nothing internal is reachable.
- This also closes the check-vs-fetch DNS-rebinding **TOCTOU** the `ssrf.ex` comment acknowledged: there is no second lookup to poison.

The real hostname still rides in `Host:`/SNI, so the intended page renders; only a *different* host is pinned to the wrong address and fails to load (accepted fidelity trade for cross-host subresources). `Vutuv.Moderation.EvidenceScreenshot` stays unpinned on purpose — it shoots this installation's own (possibly internal) host.

Also caps the pre-capture probe bodies with `Vutuv.Http.capped_collector/1` (scan finding **F15**): both probes read only the status line and `location` header, so a hostile link can no longer stream an unbounded body into memory.

## Note on Chromium build

The scan flagged that exact flag behaviour should be confirmed against the deployed Chromium. A test (`fake_chromium`) proves `--host-resolver-rules=MAP * <vetted-ip>` reaches Chromium's argv; the runtime effect is the long-standing documented behaviour of that flag. For defense-in-depth an operator can additionally network-isolate the capture process (the advisory's fallback).

## Tests

- `Vutuv.Ssrf.vetted_address/1`: public literal, internal literal, all-public host, one-internal-among-public (blocks), unresolvable, hostless.
- `capture_args/3`: pin flag present/absent, IPv6 bracketing, URL stays last.
- `capture_framed/2`: pins the vetted IP into the real command line, and refuses an internal-resolving host before launching Chromium.

`mix precommit` green (4642 tests).

---

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01EM3jdQXQXJJQZgZJCDBQSt
