### PR TITLE
Close three authorization gaps: org handle, member typeahead, report preview

### DIFF
--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -101,11 +101,34 @@ defmodule Vutuv.Moderation do
   report form's `new` action shares with `report_content/3`, so the form never
   previews content (a private message, a restricted post) the reporter has no
   right to see. The owner must exist, and the reporter must currently be able to
-  report it (visibility) or already be tied to it by an open case.
+  report it (visibility) or already be tied to it by an open case they filed a
+  report on.
+
+  The open-case arm must be reporter-specific: a mere *existing* open case is
+  true for everyone, so keying the form on it alone let any logged-in member
+  preview frozen/restricted/private content (whose permalink 404s for them) the
+  moment a case was opened. A bystander with no report on the case falls through
+  to the ordinary visibility check.
   """
   def can_report?(%User{} = reporter, content) do
     owner_id(content) != nil and
-      (open_case_for(content) != nil or reportable_by?(reporter, content))
+      (reporter_on_open_case?(reporter, content) or reportable_by?(reporter, content))
+  end
+
+  # Whether `reporter` already filed a report on `content`'s open case. Being
+  # tied to the case this way keeps the report form reachable (e.g. to file a
+  # follow-up), but a case nobody else can see never opens the form to a
+  # stranger who cannot otherwise view the content.
+  defp reporter_on_open_case?(%User{id: reporter_id}, content) do
+    case open_case_for(content) do
+      nil ->
+        false
+
+      %Case{id: case_id} ->
+        Repo.exists?(
+          from(r in Report, where: r.case_id == ^case_id and r.reporter_id == ^reporter_id)
+        )
+    end
   end
 
   defp open_new_case(reporter, content, attrs) do

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -238,7 +238,7 @@ defmodule Vutuv.Organizations do
       Repo.all(
         from(u in User,
           where:
-            u.id not in ^exclude and
+            u.id not in ^exclude and account_confirmed_row(u) and not account_hidden_row(u) and
               (ilike(u.username, ^like) or ilike(u.first_name, ^like) or ilike(u.last_name, ^like)),
           order_by: [asc: u.username],
           limit: 6

--- a/lib/vutuv_web/live/organization_live/edit.ex
+++ b/lib/vutuv_web/live/organization_live/edit.ex
@@ -125,29 +125,41 @@ defmodule VutuvWeb.OrganizationLive.Edit do
   end
 
   def handle_event("claim_handle", %{"username" => username}, socket) do
-    case Organizations.claim_handle(socket.assigns.organization, %{"username" => username}) do
-      {:ok, organization} ->
-        {:noreply,
-         socket
-         |> assign(:organization, organization)
-         |> assign(:handle_value, organization.username)
-         |> assign(:handle_error, nil)
-         |> put_flash(:info, gettext("Your organization handle is set."))}
+    # The form is owner-gated, but re-check here: an organization admin (not an
+    # owner) can reach the edit page, and claiming the global root handle (in
+    # the shared /:handle namespace) is owner-only.
+    if socket.assigns.owner? do
+      case Organizations.claim_handle(socket.assigns.organization, %{"username" => username}) do
+        {:ok, organization} ->
+          {:noreply,
+           socket
+           |> assign(:organization, organization)
+           |> assign(:handle_value, organization.username)
+           |> assign(:handle_error, nil)
+           |> put_flash(:info, gettext("Your organization handle is set."))}
 
-      {:error, :not_verified} ->
-        {:noreply,
-         socket
-         |> assign(:handle_value, username)
-         |> assign(
-           :handle_error,
-           gettext("Only a verified organization page can claim a handle.")
-         )}
+        {:error, :not_verified} ->
+          {:noreply,
+           socket
+           |> assign(:handle_value, username)
+           |> assign(
+             :handle_error,
+             gettext("Only a verified organization page can claim a handle.")
+           )}
 
-      {:error, changeset} ->
-        {:noreply,
-         socket
-         |> assign(:handle_value, username)
-         |> assign(:handle_error, handle_error_message(changeset))}
+        {:error, changeset} ->
+          {:noreply,
+           socket
+           |> assign(:handle_value, username)
+           |> assign(:handle_error, handle_error_message(changeset))}
+      end
+    else
+      {:noreply,
+       put_flash(
+         socket,
+         :error,
+         gettext("You are not allowed to change this organization's handle.")
+       )}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.142.0",
+      version: "7.142.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/organizations_management_test.exs
+++ b/test/vutuv/organizations_management_test.exs
@@ -44,6 +44,44 @@ defmodule Vutuv.OrganizationsManagementTest do
     end
   end
 
+  describe "suggest_members/2" do
+    # The roles typeahead must honour the same visibility gate as every other
+    # people-search surface: never surface never-activated sign-ups or
+    # moderation-hidden accounts. Usernames/names are hardcoded here, which is
+    # safe because this module is async: false.
+    test "excludes unconfirmed and moderation-hidden accounts" do
+      future = NaiveDateTime.add(NaiveDateTime.utc_now(:second), 7 * 86_400)
+
+      visible = insert(:activated_user, username: "suggestme-visible", first_name: "Suggestme")
+      _unconfirmed = insert(:user, username: "suggestme-unconfirmed", first_name: "Suggestme")
+
+      _frozen =
+        insert(:activated_user,
+          username: "suggestme-frozen",
+          first_name: "Suggestme",
+          frozen_at: NaiveDateTime.utc_now(:second)
+        )
+
+      _suspended =
+        insert(:activated_user,
+          username: "suggestme-suspended",
+          first_name: "Suggestme",
+          suspended_until: future
+        )
+
+      _deactivated =
+        insert(:activated_user,
+          username: "suggestme-deactivated",
+          first_name: "Suggestme",
+          deactivated_at: NaiveDateTime.utc_now(:second)
+        )
+
+      ids = Organizations.suggest_members("suggestme") |> Enum.map(& &1.id)
+
+      assert ids == [visible.id]
+    end
+  end
+
   describe "roles" do
     test "owner powers vs admin vs recruiter" do
       {organization, owner} = active_organization()

--- a/test/vutuv_web/controllers/report_controller_test.exs
+++ b/test/vutuv_web/controllers/report_controller_test.exs
@@ -93,6 +93,49 @@ defmodule VutuvWeb.ReportControllerTest do
       conn = get(conn, ~p"/reports/new?type=post&id=#{Vutuv.UUIDv7.generate()}")
       assert html_response(conn, 404)
     end
+
+    test "a bystander cannot preview frozen content once a case is open, but the author can" do
+      # Log both members in first, so each login PIN is read from the mailbox
+      # before the freeze fires its owner-notification email. Each needs its own
+      # session-initialised conn (see the ConnCase setup).
+      fresh_conn = fn -> Plug.Test.init_test_session(build_conn(), %{}) end
+      {author_conn, author} = create_and_login_user(fresh_conn.())
+      {bystander_conn, _bystander} = create_and_login_user(fresh_conn.())
+
+      post = insert(:post, user: author)
+
+      # A trusted reporter freezes the post and opens a moderation case; the
+      # permalink now 404s for everyone but the author and admins.
+      {:ok, _} = Moderation.report_content(insert_activated_user(), post, %{"category" => "spam"})
+      assert Repo.get!(Vutuv.Posts.Post, post.id).frozen_at
+
+      # F10: a bystander with no tie to the open case must not get the form. The
+      # open case alone used to render the preview to any logged-in member.
+      assert bystander_conn
+             |> get(~p"/reports/new?type=post&id=#{post.id}")
+             |> html_response(404)
+
+      # The author can see their own frozen post, so the gate still admits them.
+      assert author_conn
+             |> get(~p"/reports/new?type=post&id=#{post.id}")
+             |> html_response(200)
+    end
+
+    test "a reporter tied to the open case still reaches the form", %{conn: conn} do
+      {conn, reporter} = create_and_login_user(conn)
+      author = insert_activated_user()
+      post = insert(:post, user: author)
+
+      # Filing the report freezes the post and ties the reporter to the case.
+      {:ok, _} = Moderation.report_content(reporter, post, %{"category" => "spam"})
+      assert Repo.get!(Vutuv.Posts.Post, post.id).frozen_at
+
+      # The frozen post is no longer otherwise visible to them, but their own
+      # report on the open case keeps the form reachable.
+      assert conn
+             |> get(~p"/reports/new?type=post&id=#{post.id}")
+             |> html_response(200)
+    end
   end
 
   describe "create" do

--- a/test/vutuv_web/organization_management_test.exs
+++ b/test/vutuv_web/organization_management_test.exs
@@ -187,6 +187,27 @@ defmodule VutuvWeb.OrganizationManagementTest do
       assert slug_page =~ "/acmehandle"
     end
 
+    test "an organization admin (not an owner) sees no claim form and a forged event is refused",
+         %{conn: conn} do
+      {conn, admin} = create_and_login_user(conn)
+      owner = insert(:activated_user)
+      organization = active_organization_for(owner)
+      {:ok, _} = Organizations.add_role(organization, admin, "admin", owner)
+
+      {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}/edit")
+
+      # The claim form is owner-gated in the template.
+      refute has_element?(view, "#claim-handle-form")
+
+      # A forged socket event must not set the global root handle: an admin is
+      # not an owner, and the handle lives in the shared /:handle namespace.
+      render_click(view, "claim_handle", %{"username" => "adminhandle"})
+
+      assert is_nil(Organizations.get_organization(organization.id).username)
+      # The handle was never registered, so it stays claimable.
+      assert Vutuv.Handles.available?("adminhandle")
+    end
+
     test "owner cannot claim a handle already held by a member", %{conn: conn} do
       {conn, owner} = create_and_login_user(conn)
       organization = active_organization_for(owner)


### PR DESCRIPTION
**TL;DR** Three MEDIUM security-scan findings, each a missing or too-broad authorization check. Batch 1 of the remaining scan mediums.

**F6 — org "admin" could claim the owner-only root handle.** `claim_handle` (`live/organization_live/edit.ex`) called `Organizations.claim_handle/2` with no owner check; an admin sending a raw phx-event (the form is hidden for them, the socket isn't) could seize a word in the shared `/:handle` namespace. Now re-checks `socket.assigns.owner?`, like the `delete_organization` handler.

**F14 — roles typeahead leaked hidden accounts.** `Organizations.suggest_members/2` ran a name/handle substring query with neither the `account_confirmed_row` nor `account_hidden_row` gate, so it returned never-activated and moderation-hidden members, enumerable 2 chars at a time. Added the standard visibility gate.

**F10 — report form previewed hidden content once a case was open.** `Moderation.can_report?/2` admitted any reporter whenever an open case existed, so any logged-in member could `GET /reports/new` for a frozen post, a restricted post, or a private DM and read the first 280 chars. The open-case arm now requires the reporter to already have a report on that case, else falls through to `reportable_by?/2`. Strictly narrower — can only refuse more, never expose more.

**Verification:** each fix ships a regression test that fails against the unpatched code; reviewed by an independent verifier and re-challenged by a fresh reviewer of the diff (which confirmed no legitimate flow — owner, author, or a reporter already tied to the case — regresses). `mix precommit` green: Credo clean, 4634 tests.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01Dz1H9S965ie56hT4DQ6Gax