### PR TITLE
Fediverse account migration, both directions (#986)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -30,9 +30,17 @@ every endpoint 404s and nothing is delivered.
   A remote server that moves a member's followers *to* vutuv checks this before
   it accepts the move (the destination must name the origin as an alias first).
   Anyone can *claim* an alias, so verifying it is the remote server's job;
-  vutuv only publishes the claim, and the key renders only when non-empty. This
-  is half 1 of migration; emitting `Move` to carry followers *out* is not built
-  (see the v1 limits).
+  vutuv only publishes the claim, and the key renders only when non-empty. A
+  member who instead moves *out* sets **`movedTo`** (`users.moved_to`):
+  `Vutuv.Fediverse.move_out/2` fetches the target actor, confirms it lists this
+  member in *its* `alsoKnownAs` (the same check every remote server makes, so a
+  doomed Move fails fast), stamps `moved_to`/`moved_at`, and broadcasts
+  `Move { actor, object, target }` to every follower inbox. From then on the
+  member's posts stop federating (`moved?/1` gate) while the actor keeps serving
+  the `movedTo` redirect; the vutuv profile is untouched (a redirect, not a
+  deletion). A 30-day cooldown (`move_cooldown_days/0`) stops move-spam, and
+  `cancel_move/1` clears the redirect while keeping `moved_at` so the cooldown
+  still holds.
 - **Discovery**: `GET /.well-known/webfinger?resource=acct:handle@host`
   answers with the actor URL — how Mastodon's search resolves
   `@handle@vutuv.de`. The profile URL itself answers an
@@ -98,13 +106,13 @@ every endpoint 404s and nothing is delivered.
 
 No inbound content (likes/replies/boosts are dropped), no `Announce` for
 reposts, and account deletion sends no actor `Delete` broadcast (rows cascade;
-remote copies age out). Account migration is **half done** (issue #986):
-`alsoKnownAs` lets a member move their followers *in* from another server
-(the actor names the origin as an alias, Mastodon's own tooling drives the
-move), but vutuv never emits a `Move`, so a member leaving for another server
-still has to ask each follower to re-follow by hand. That half is gated on a
-product decision about what becomes of the vutuv account after a move-out. The
-followers
+remote copies age out). Account migration is **both ways** now (issue #986):
+`alsoKnownAs` moves followers *in*, `Move` + `movedTo` moves them *out* (see the
+Actor bullet above). The design choice worth remembering: a move-out is a
+**redirect, never a deletion** — the vutuv account is a full profile, not just a
+Fediverse actor, so moving your Fediverse followers away only pauses outbound
+post federation and publishes the redirect; the profile, CV and everything else
+stay. Deleting an account remains its own separate action. The followers
 collection is count-only (privacy). A follower row whose inbox answers 404/410
 is not pruned either: deliveries go to the sharedInbox where the remote
 declares one, so a per-actor gone signal rarely reaches us and pruning on a

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -24,7 +24,15 @@ every endpoint 404s and nothing is delivered.
   (`Vutuv.Fediverse.Keys`), created lazily on opt-in. The documents are built
   by `VutuvWeb.Fediverse.Docs`; URLs hang off the member so no root slug is
   burned: `/:username/actor` (id), `.../inbox`, `.../followers` and
-  `.../outbox` (count-only collections).
+  `.../outbox` (count-only collections). The actor also carries
+  **`alsoKnownAs`** (issue #986) — the account URIs a member is migrating
+  *from* (`users.also_known_as`, set on `/settings/fediverse`, one per line).
+  A remote server that moves a member's followers *to* vutuv checks this before
+  it accepts the move (the destination must name the origin as an alias first).
+  Anyone can *claim* an alias, so verifying it is the remote server's job;
+  vutuv only publishes the claim, and the key renders only when non-empty. This
+  is half 1 of migration; emitting `Move` to carry followers *out* is not built
+  (see the v1 limits).
 - **Discovery**: `GET /.well-known/webfinger?resource=acct:handle@host`
   answers with the actor URL — how Mastodon's search resolves
   `@handle@vutuv.de`. The profile URL itself answers an
@@ -89,8 +97,14 @@ every endpoint 404s and nothing is delivered.
 ## Deliberate v1 limits
 
 No inbound content (likes/replies/boosts are dropped), no `Announce` for
-reposts, no `Move`/account migration, and account deletion sends no actor
-`Delete` broadcast (rows cascade; remote copies age out). The followers
+reposts, and account deletion sends no actor `Delete` broadcast (rows cascade;
+remote copies age out). Account migration is **half done** (issue #986):
+`alsoKnownAs` lets a member move their followers *in* from another server
+(the actor names the origin as an alias, Mastodon's own tooling drives the
+move), but vutuv never emits a `Move`, so a member leaving for another server
+still has to ask each follower to re-follow by hand. That half is gated on a
+product decision about what becomes of the vutuv account after a move-out. The
+followers
 collection is count-only (privacy). A follower row whose inbox answers 404/410
 is not pruned either: deliveries go to the sharedInbox where the remote
 declares one, so a per-actor gone signal rarely reaches us and pruning on a

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -196,6 +196,16 @@ defmodule Vutuv.Accounts.User do
     # through the virtual `also_known_as_input` textarea, one URI per line.
     field(:also_known_as, {:array, :string}, default: [])
     field(:also_known_as_input, :string, virtual: true)
+    # The Fediverse account the member redirected their followers *to* (issue
+    # #986, half 2). When set, the actor document advertises `movedTo`, remote
+    # servers re-point their follow, and vutuv stops pushing new posts to the
+    # Fediverse (the account is "moved" — a redirect, not a live feed). The
+    # vutuv profile itself is untouched: this is not a deletion or a logout,
+    # only a Fediverse redirect. `moved_at` stamps the last Move broadcast, so a
+    # cooldown can stop a member spamming their followers with moves. Both are
+    # set programmatically by `Vutuv.Fediverse.move_out/2` (never cast).
+    field(:moved_to, :string)
+    field(:moved_at, :naive_datetime)
     # The member-preference fields (the Vutuv.Prefs registry): deliberately
     # WITHOUT schema or DB defaults — nil means "inherit the installation
     # default" (admin-set at /admin/preferences, else the shipped default from

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -181,12 +181,21 @@ defmodule Vutuv.Accounts.User do
     # Codeberg). Default on; the opt-out lives on the Privacy settings page.
     # Off, the accounts still render as plain links on the Social Media card.
     field(:show_code_stats?, :boolean, default: true)
-    # The Fediverse opt-in (Privacy settings, default off). Federation is not
-    # built yet: the flag ships ahead of the feature to measure demand and to
-    # collect the per-member consent any future ActivityPub federation must be
-    # gated on (remote deletion is unenforceable, so opt-in is the only lawful
-    # default). Until federation ships, nothing reads this flag.
+    # The Fediverse opt-in (the /settings/fediverse page, default off). Gates
+    # follow-only ActivityPub federation (Vutuv.Fediverse): with it on, remote
+    # servers can follow the member and receive their public posts. Opt-in
+    # because deleting federated copies on remote servers is unenforceable, so
+    # per-member consent is the only lawful default.
     field(:fediverse_followers?, :boolean, default: false)
+    # The Fediverse account(s) the member is migrating *from* (issue #986,
+    # half 1): actor URIs rendered as `alsoKnownAs` on the actor document. A
+    # remote server (Mastodon) checks this before it moves a member's followers
+    # *to* their vutuv account — the destination has to name the origin as an
+    # alias first. Anyone can *claim* an alias, so the verification is the
+    # remote server's job; vutuv only has to publish the claim honestly. Set
+    # through the virtual `also_known_as_input` textarea, one URI per line.
+    field(:also_known_as, {:array, :string}, default: [])
+    field(:also_known_as_input, :string, virtual: true)
     # The member-preference fields (the Vutuv.Prefs registry): deliberately
     # WITHOUT schema or DB defaults — nil means "inherit the installation
     # default" (admin-set at /admin/preferences, else the shipped default from
@@ -327,7 +336,7 @@ defmodule Vutuv.Accounts.User do
   # :email_confirmed? is NOT here either: it flips only via the login-PIN path
   # (Accounts.activate_user/1, its own narrow cast) — castable, it would let a
   # registration self-activate without ever proving control of an email.
-  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix gender birthdate birthdate_visibility locale tag_list)a
+  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix gender birthdate birthdate_visibility locale tag_list)a
 
   # The job-availability values a member can advertise (issue #870), other
   # than the "not specified" default which is stored as nil. The single source
@@ -338,6 +347,14 @@ defmodule Vutuv.Accounts.User do
   @employment_statuses ~w(open looking)
 
   def employment_statuses, do: @employment_statuses
+
+  # Fediverse aliases (issue #986, half 1): how many origin accounts a member
+  # may list, and the per-URI length ceiling. Real actor URIs are short; the
+  # cap is only there to stop a paste of nonsense reaching the array column.
+  @max_also_known_as 10
+  @max_also_known_as_length 500
+
+  def max_also_known_as, do: @max_also_known_as
 
   # How a job-seeking member wants to work. Deliberately the same three values
   # `Vutuv.Jobs.JobPosting`'s workplace_type uses (kept as literals here rather
@@ -527,6 +544,7 @@ defmodule Vutuv.Accounts.User do
     |> nullify_default_birthdate()
     |> validate_birthdate()
     |> validate_inclusion(:birthdate_visibility, @birthdate_visibilities)
+    |> normalize_also_known_as()
     |> revoke_verification_on_identity_change()
   end
 
@@ -935,6 +953,69 @@ defmodule Vutuv.Accounts.User do
     else
       changeset
     end
+  end
+
+  # The Fediverse aliases (issue #986) come from a textarea, one account URI
+  # per line. Split them, trim, drop blanks and duplicates, then store the
+  # survivors in the real array column. Each entry must be an absolute https
+  # URI (an ActivityPub actor id) and stay within a sane length — Postgres
+  # would not reject an over-long one (the column is text[]), so a field error
+  # is the guard against a member pasting nonsense. A whole-field error names
+  # the first bad entry rather than silently dropping it, so the member can fix
+  # it.
+  #
+  # Keyed off `changeset.params` (string keys after cast), not the cast change:
+  # Ecto turns an empty textarea into nil, and reading `get_change` there would
+  # make clearing the box a no-op — so a member could never *remove* an alias.
+  # A form that omits the field entirely leaves the list untouched.
+  defp normalize_also_known_as(changeset) do
+    case changeset.params do
+      %{"also_known_as_input" => raw} when is_binary(raw) ->
+        put_also_known_as(changeset, raw)
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp put_also_known_as(changeset, raw) do
+    entries =
+      raw
+      |> String.split(~r/[\r\n]+/)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.uniq()
+
+    cond do
+      length(entries) > @max_also_known_as ->
+        add_error(
+          changeset,
+          :also_known_as_input,
+          "Please list at most %{max} accounts.",
+          max: @max_also_known_as
+        )
+
+      bad = Enum.find(entries, &(not valid_actor_uri?(&1))) ->
+        add_error(
+          changeset,
+          :also_known_as_input,
+          "\"%{uri}\" is not a valid https account address.",
+          uri: String.slice(bad, 0, 100)
+        )
+
+      true ->
+        put_change(changeset, :also_known_as, entries)
+    end
+  end
+
+  # An ActivityPub actor id is an absolute https URL with a real host, capped so
+  # nobody stores a novel in the array.
+  defp valid_actor_uri?(uri) do
+    String.length(uri) <= @max_also_known_as_length and
+      match?(
+        %URI{scheme: "https", host: host} when is_binary(host) and host != "",
+        URI.parse(uri)
+      )
   end
 
   # Stamp employment_status_set_at whenever the member changes their

--- a/lib/vutuv/export.ex
+++ b/lib/vutuv/export.ex
@@ -224,6 +224,7 @@ defmodule Vutuv.Export do
       noai: user.noai?,
       fediverse_followers: user.fediverse_followers?,
       also_known_as: user.also_known_as,
+      moved_to: user.moved_to,
       notification_emails: user.notification_emails?,
       email_on_endorsement: user.email_on_endorsement?,
       email_on_follower: user.email_on_follower?,

--- a/lib/vutuv/export.ex
+++ b/lib/vutuv/export.ex
@@ -223,6 +223,7 @@ defmodule Vutuv.Export do
       noindex: user.noindex?,
       noai: user.noai?,
       fediverse_followers: user.fediverse_followers?,
+      also_known_as: user.also_known_as,
       notification_emails: user.notification_emails?,
       email_on_endorsement: user.email_on_endorsement?,
       email_on_follower: user.email_on_follower?,

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -199,6 +199,108 @@ defmodule Vutuv.Fediverse do
     )
   end
 
+  ## Account migration — move out (issue #986, half 2)
+
+  @move_cooldown_days 30
+
+  @doc "How long (days) a member must wait between Move broadcasts."
+  def move_cooldown_days, do: @move_cooldown_days
+
+  @doc "Whether the member has redirected their Fediverse followers elsewhere."
+  def moved?(%User{moved_to: nil}), do: false
+  def moved?(%User{moved_to: moved_to}), do: is_binary(moved_to)
+
+  @doc """
+  Redirects the member's Fediverse followers to another account (`Move`).
+
+  Fetches the target actor and checks it lists this member's vutuv actor in its
+  own `alsoKnownAs` — the same guarantee every remote server demands before it
+  honors a Move, so a move the network would silently ignore fails fast here
+  instead. On success it stamps `moved_to`/`moved_at`, broadcasts
+  `Move { actor, object, target }` to every follower inbox (compliant servers
+  re-point their follow to the target), and from then on the member's new posts
+  stop federating (`moved?/1` gate above) while the actor keeps serving the
+  `movedTo` redirect. The vutuv profile itself is untouched — this is a redirect,
+  not a deletion or a logout.
+
+  Returns `{:ok, user}` or `{:error, reason}` where reason is one of
+  `:not_federated`, `:cooldown`, `:invalid_target`, `:self_target`,
+  `:alias_missing`, `:target_unreachable`.
+  """
+  def move_out(%User{} = user, target_input) do
+    with true <- (enabled?() and federated?(user)) or {:error, :not_federated},
+         :ok <- check_move_cooldown(user),
+         {:ok, target_id} <- resolve_move_target(user, target_input),
+         {:ok, moved} <- store_move(user, target_id) do
+      broadcast_move(moved, target_id)
+      {:ok, moved}
+    end
+  end
+
+  @doc """
+  Cancels a redirect: clears `moved_to` so the member federates new posts again
+  and the actor stops advertising `movedTo`. `moved_at` is deliberately kept, so
+  the re-move cooldown still holds — cancelling must not be a way to spam moves.
+  Followers a remote server already re-pointed do not come back automatically
+  (a Fediverse reality, not something vutuv can reverse).
+  """
+  def cancel_move(%User{} = user) do
+    user |> Ecto.Changeset.change(moved_to: nil) |> Repo.update()
+  end
+
+  # nil moved_at = never moved; otherwise block until the cooldown has elapsed.
+  defp check_move_cooldown(%User{moved_at: nil}), do: :ok
+
+  defp check_move_cooldown(%User{moved_at: moved_at}) do
+    cutoff = NaiveDateTime.add(NaiveDateTime.utc_now(), -@move_cooldown_days * 86_400, :second)
+    if NaiveDateTime.compare(moved_at, cutoff) == :gt, do: {:error, :cooldown}, else: :ok
+  end
+
+  # Resolve the target to its canonical actor id and confirm it names us as an
+  # alias. A bare/non-https string never reaches the network (fetch_remote_actor
+  # would reject it, but a clean :invalid_target message is friendlier).
+  defp resolve_move_target(user, target_input) do
+    my_actor = Docs.actor_url(user)
+
+    with {:input, %URI{scheme: "https", host: h}} when is_binary(h) and h != "" <-
+           {:input, URI.parse(to_string(target_input))},
+         {:fetch, {:ok, remote}} <- {:fetch, fetch_remote_actor(target_input, signer(user))} do
+      cond do
+        remote.id == my_actor -> {:error, :self_target}
+        my_actor in remote.also_known_as -> {:ok, remote.id}
+        true -> {:error, :alias_missing}
+      end
+    else
+      {:input, _} -> {:error, :invalid_target}
+      {:fetch, _} -> {:error, :target_unreachable}
+    end
+  end
+
+  defp store_move(user, target_id) do
+    user
+    |> Ecto.Changeset.change(
+      moved_to: target_id,
+      moved_at: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    )
+    |> Repo.update()
+  end
+
+  defp broadcast_move(user, target_id) do
+    case delivery_inboxes(user) do
+      [] -> :ok
+      inboxes -> enqueue(user, inboxes, Docs.move_activity(user, target_id))
+    end
+  end
+
+  # The member's own key, to sign the target-actor fetch (authorized-fetch
+  # instances reject anonymous GETs). federated?/1 guaranteed the actor exists.
+  defp signer(user) do
+    case get_actor(user) do
+      nil -> nil
+      actor -> {Docs.key_id(user), actor.private_key_pem}
+    end
+  end
+
   ## Federating posts (called from Vutuv.Posts after commit)
 
   @doc "A freshly published post -> Create(Note) to every follower inbox."
@@ -222,6 +324,7 @@ defmodule Vutuv.Fediverse do
     with true <- enabled?(),
          %User{} = user <- Repo.get(User, user_id),
          true <- federated?(user),
+         false <- moved?(user),
          [_ | _] = inboxes <- delivery_inboxes(user) do
       enqueue(user, inboxes, Docs.delete_activity(post_id, user))
     else
@@ -233,6 +336,7 @@ defmodule Vutuv.Fediverse do
     with true <- enabled?(),
          %User{} = user <- Repo.get(User, post.user_id),
          true <- federated?(user),
+         false <- moved?(user),
          false <- Vutuv.Posts.restricted?(post),
          [_ | _] = inboxes <- delivery_inboxes(user) do
       post = Repo.preload(post, [:images, :review, reply_ref: [:parent_author]])
@@ -418,7 +522,12 @@ defmodule Vutuv.Fediverse do
          preferred_username: truncate(doc["preferredUsername"]),
          name: truncate(doc["name"]),
          public_key_id: get_in(doc, ["publicKey", "id"]),
-         public_key_pem: get_in(doc, ["publicKey", "publicKeyPem"])
+         public_key_pem: get_in(doc, ["publicKey", "publicKeyPem"]),
+         # The aliases the remote account claims (issue #986): a Move *to* this
+         # account is only honored once it lists the origin here, so move_out/2
+         # checks our own actor URL is among them. AP allows a bare string or a
+         # list; normalize to a list of strings.
+         also_known_as: normalize_uri_list(doc["alsoKnownAs"])
        }}
     else
       {:parse, _} -> {:error, :https_only}
@@ -434,6 +543,12 @@ defmodule Vutuv.Fediverse do
   # column's worth (nil and non-strings pass through as nil).
   defp truncate(value) when is_binary(value), do: String.slice(value, 0, 255)
   defp truncate(_), do: nil
+
+  # `alsoKnownAs` is a single URI string or a list of them; anything else (or
+  # absent) is no aliases. Keep only the strings.
+  defp normalize_uri_list(value) when is_binary(value), do: [value]
+  defp normalize_uri_list(value) when is_list(value), do: Enum.filter(value, &is_binary/1)
+  defp normalize_uri_list(_), do: []
 
   defp ap_get(url, signer) do
     signature_headers =

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -210,6 +210,71 @@ defmodule VutuvWeb.SettingsController do
     )
   end
 
+  # Redirect the member's Fediverse followers to another account (issue #986,
+  # half 2): broadcast a Move. The vutuv profile is untouched — only outbound
+  # federation of new posts stops, and the actor advertises the redirect.
+  def move_fediverse(conn, %{"move" => %{"target" => target}}) do
+    case Vutuv.Fediverse.move_out(conn.assigns[:user], target) do
+      {:ok, _moved} ->
+        conn
+        |> put_flash(
+          :info,
+          gettext(
+            "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
+          )
+        )
+        |> redirect(to: ~p"/settings/fediverse")
+
+      {:error, reason} ->
+        conn
+        |> put_flash(:error, move_error_message(reason))
+        |> redirect(to: ~p"/settings/fediverse")
+    end
+  end
+
+  def move_fediverse(conn, _params) do
+    conn
+    |> put_flash(:error, move_error_message(:invalid_target))
+    |> redirect(to: ~p"/settings/fediverse")
+  end
+
+  # Undo the redirect: the member federates new posts again, the actor stops
+  # advertising the move. The cooldown still holds (Fediverse.cancel_move/1).
+  def cancel_move_fediverse(conn, _params) do
+    {:ok, _} = Vutuv.Fediverse.cancel_move(conn.assigns[:user])
+
+    conn
+    |> put_flash(:info, gettext("Redirect cancelled. Your posts federate from here again."))
+    |> redirect(to: ~p"/settings/fediverse")
+  end
+
+  defp move_error_message(:not_federated),
+    do: gettext("Turn on federation first, then you can redirect your followers.")
+
+  defp move_error_message(:cooldown),
+    do:
+      gettext("You can only move once every %{days} days.",
+        days: Vutuv.Fediverse.move_cooldown_days()
+      )
+
+  defp move_error_message(:invalid_target),
+    do: gettext("Please enter the full https address of the account you are moving to.")
+
+  defp move_error_message(:self_target),
+    do: gettext("That is this account. Enter the account you are moving to.")
+
+  defp move_error_message(:alias_missing),
+    do:
+      gettext(
+        "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
+      )
+
+  defp move_error_message(:target_unreachable),
+    do:
+      gettext(
+        "That account could not be reached. Check the address, and that the other server is online."
+      )
+
   defp fediverse_assigns(user) do
     [
       follower_count: Vutuv.Fediverse.follower_count(user),

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -184,8 +184,17 @@ defmodule VutuvWeb.SettingsController do
       conn,
       "fediverse.html",
       fediverse_assigns(user) ++
-        [user: user, changeset: User.changeset(user), page_title: gettext("Fediverse")]
+        [user: user, changeset: fediverse_changeset(user), page_title: gettext("Fediverse")]
     )
+  end
+
+  # Seed the virtual textarea from the stored aliases so the edit form shows
+  # what is already set (the array column is not the form field). One URI per
+  # line, matching how normalize_also_known_as/1 splits them back.
+  defp fediverse_changeset(user) do
+    user
+    |> User.changeset()
+    |> Ecto.Changeset.put_change(:also_known_as_input, Enum.join(user.also_known_as, "\n"))
   end
 
   def update_fediverse(conn, %{"user" => params}) do

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -62,6 +62,18 @@ defmodule VutuvWeb.Fediverse.Docs do
         "url" => "#{base()}/#{user.username}/avatar.jpg"
       }
     }
+    |> put_also_known_as(user)
+  end
+
+  # The accounts the member is migrating *from* (issue #986). Rendered only
+  # when set: a remote server that moves followers here checks that its origin
+  # account is one of these aliases, so an empty list must be absent, never an
+  # empty array that reads as "claims nothing".
+  defp put_also_known_as(doc, user) do
+    case user.also_known_as do
+      [_ | _] = aliases -> Map.put(doc, "alsoKnownAs", aliases)
+      _ -> doc
+    end
   end
 
   @doc "Create(Note): a freshly published public post."

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -63,6 +63,7 @@ defmodule VutuvWeb.Fediverse.Docs do
       }
     }
     |> put_also_known_as(user)
+    |> put_moved_to(user)
   end
 
   # The accounts the member is migrating *from* (issue #986). Rendered only
@@ -74,6 +75,32 @@ defmodule VutuvWeb.Fediverse.Docs do
       [_ | _] = aliases -> Map.put(doc, "alsoKnownAs", aliases)
       _ -> doc
     end
+  end
+
+  # The account the member redirected their followers *to* (issue #986, half 2).
+  # Present only after a move: remote servers show a "moved to" notice and steer
+  # follows to the target instead of this actor.
+  defp put_moved_to(doc, %{moved_to: uri}) when is_binary(uri), do: Map.put(doc, "movedTo", uri)
+  defp put_moved_to(doc, _user), do: doc
+
+  @doc """
+  Move: the redirect broadcast to every follower inbox (issue #986). Both
+  `object` and `actor` are the member's own actor; `target` is the account they
+  moved to. A compliant server re-points its follow to `target` once that
+  account lists this actor in its `alsoKnownAs`.
+  """
+  def move_activity(user, target) do
+    actor_url = actor_url(user)
+
+    %{
+      "@context" => "https://www.w3.org/ns/activitystreams",
+      "id" => actor_url <> "#moves/" <> Vutuv.UUIDv7.generate(),
+      "type" => "Move",
+      "actor" => actor_url,
+      "object" => actor_url,
+      "target" => target,
+      "to" => [actor_url <> "/followers"]
+    }
   end
 
   @doc "Create(Note): a freshly published public post."

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -822,6 +822,10 @@ defmodule VutuvWeb.Router do
     get("/fediverse", SettingsController, :fediverse)
     put("/fediverse", SettingsController, :update_fediverse)
     patch("/fediverse", SettingsController, :update_fediverse)
+    # Fediverse account migration, move out (issue #986): broadcast a Move to
+    # redirect followers, or cancel the redirect.
+    post("/fediverse/move", SettingsController, :move_fediverse)
+    delete("/fediverse/move", SettingsController, :cancel_move_fediverse)
     get("/notifications", SettingsController, :notifications)
     put("/notifications", SettingsController, :update_notifications)
     patch("/notifications", SettingsController, :update_notifications)

--- a/lib/vutuv_web/templates/settings/fediverse.html.heex
+++ b/lib/vutuv_web/templates/settings/fediverse.html.heex
@@ -79,6 +79,30 @@ deserves more room than one toggle row. --%>
           )}
         </.setting_toggle>
 
+        <%!-- alsoKnownAs (issue #986): the accounts a member is moving *from*.
+              A remote server checks these before it moves the member's
+              followers here, so listing the old account's address is what makes
+              a move *to* vutuv possible. Empty for almost everyone; only shown
+              once federation is on, where it can take effect. --%>
+        <div :if={Vutuv.Fediverse.federated?(@user)}>
+          <label for="user_also_known_as_input" class="block text-sm font-semibold text-slate-700 dark:text-slate-200">
+            {gettext("Moving to vutuv from another account?")}
+          </label>
+          <%= textarea f, :also_known_as_input,
+            id: "user_also_known_as_input",
+            rows: 3,
+            class: [input_class(f, :also_known_as_input), "mt-1 resize-y font-mono text-xs"],
+            placeholder: "https://mastodon.social/users/yourname",
+            "aria-invalid": f.errors[:also_known_as_input] && "true" %>
+          <%= error_tag f, :also_known_as_input %>
+          <p :if={!f.errors[:also_known_as_input]} class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+            {gettext(
+              "List the full address of each account you are migrating from, one per line (for example %{example}). On the other server, start the move to your vutuv handle; it will only go through once your old account is listed here. Leave empty if you are not moving accounts.",
+              example: "https://mastodon.social/users/yourname"
+            )}
+          </p>
+        </div>
+
         <div class="pt-1">
           <.button type="submit">{gettext("Save")}</.button>
         </div>

--- a/lib/vutuv_web/templates/settings/fediverse.html.heex
+++ b/lib/vutuv_web/templates/settings/fediverse.html.heex
@@ -83,8 +83,9 @@ deserves more room than one toggle row. --%>
               A remote server checks these before it moves the member's
               followers here, so listing the old account's address is what makes
               a move *to* vutuv possible. Empty for almost everyone; only shown
-              once federation is on, where it can take effect. --%>
-        <div :if={Vutuv.Fediverse.federated?(@user)}>
+              once federation is on, where it can take effect. Hidden once the
+              member has moved *out* (moving in and out at once makes no sense). --%>
+        <div :if={Vutuv.Fediverse.federated?(@user) and is_nil(@user.moved_to)}>
           <label for="user_also_known_as_input" class="block text-sm font-semibold text-slate-700 dark:text-slate-200">
             {gettext("Moving to vutuv from another account?")}
           </label>
@@ -107,6 +108,99 @@ deserves more room than one toggle row. --%>
           <.button type="submit">{gettext("Save")}</.button>
         </div>
       </.form>
+    </.card>
+
+    <%!-- Move out (issue #986, half 2): redirect the member's Fediverse
+          followers to another account. Only meaningful while federating. The
+          key reassurance, repeated: this is a redirect, not a deletion — the
+          vutuv profile is untouched. --%>
+    <.card :if={Vutuv.Fediverse.federated?(@user)}>
+      <.section_title>{gettext("Move your followers to another account")}</.section_title>
+
+      <%= if @user.moved_to do %>
+        <div class="mt-3 rounded-lg bg-slate-50 p-4 text-sm dark:bg-slate-800/50">
+          <p class="text-slate-700 dark:text-slate-200">
+            {gettext("You have redirected your Fediverse followers to another account:")}
+          </p>
+          <p class="mt-1">
+            <a
+              href={@user.moved_to}
+              target="_blank"
+              rel="nofollow noopener noreferrer"
+              class="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400"
+            >{@user.moved_to}</a>
+          </p>
+          <p :if={@user.moved_at} class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+            {gettext("Redirected on %{date}",
+              date: Calendar.strftime(@user.moved_at, "%Y-%m-%d")
+            )}
+          </p>
+          <p class="mt-2 text-slate-600 dark:text-slate-400">
+            {gettext(
+              "New posts are no longer federated from here, and your actor points visitors to your new account. Your vutuv profile itself is unchanged."
+            )}
+          </p>
+          <.form
+            :let={_f}
+            for={%{}}
+            as={:cancel}
+            action={~p"/settings/fediverse/move"}
+            method="delete"
+            id="cancel-move-form"
+            class="mt-4"
+          >
+            <.button type="submit" variant="secondary">
+              {gettext("Cancel redirect")}
+            </.button>
+          </.form>
+        </div>
+      <% else %>
+        <p class="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+          {gettext(
+            "Leaving for another Fediverse account? You can send your followers there. They will be asked to follow your new account, and vutuv stops federating your new posts. This is only a redirect: your vutuv profile stays exactly as it is, and nothing is deleted."
+          )}
+        </p>
+        <ol class="mt-3 list-decimal space-y-1 pl-5 text-sm text-slate-600 dark:text-slate-400">
+          <li>
+            {gettext("On your other account, add your vutuv handle")}
+            <code class="select-all rounded bg-slate-100 px-1 py-0.5 text-slate-800 dark:bg-slate-800 dark:text-slate-100">@{@user.username}@{@fediverse_host}</code>
+            {gettext("as an account alias.")}
+          </li>
+          <li>{gettext("Enter that account's address below and redirect.")}</li>
+        </ol>
+        <.form
+          :let={_f}
+          for={%{}}
+          as={:move}
+          action={~p"/settings/fediverse/move"}
+          method="post"
+          id="move-form"
+          class="mt-4 space-y-3"
+        >
+          <div>
+            <label for="move_target" class="sr-only">
+              {gettext("Account you are moving to")}
+            </label>
+            <input
+              type="text"
+              name="move[target]"
+              id="move_target"
+              class={[input_class(), "font-mono text-xs"]}
+              placeholder="https://mastodon.social/users/yourname"
+            />
+          </div>
+          <.button
+            type="submit"
+            data-confirm={
+              gettext(
+                "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
+              )
+            }
+          >
+            {gettext("Redirect my followers")}
+          </.button>
+        </.form>
+      <% end %>
     </.card>
 
     <%!-- The no-federation-needed sibling feature, so members find both. --%>

--- a/lib/vutuv_web/views/error_helpers.ex
+++ b/lib/vutuv_web/views/error_helpers.ex
@@ -70,7 +70,10 @@ defmodule VutuvWeb.ErrorHelpers do
       ),
       # Vutuv.Tags.Tag, a name of punctuation only.
       dgettext_noop("errors", "must not be only punctuation"),
-      dgettext_noop("errors", "\"%{tag}\" is only punctuation, not a tag.")
+      dgettext_noop("errors", "\"%{tag}\" is only punctuation, not a tag."),
+      # Vutuv.Accounts.User, the Fediverse aliases (issue #986, alsoKnownAs).
+      dgettext_noop("errors", "Please list at most %{max} accounts."),
+      dgettext_noop("errors", "\"%{uri}\" is not a valid https account address.")
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.142.2",
+      version: "7.143.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15447,3 +15447,113 @@ msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr "Filter entfernt."
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:182
+#, elixir-autogen, elixir-format
+msgid "Account you are moving to"
+msgstr "Konto, zu dem Sie umziehen"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:153
+#, elixir-autogen, elixir-format
+msgid "Cancel redirect"
+msgstr "Weiterleitung aufheben"
+
+#: lib/vutuv_web/controllers/settings_controller.ex:222
+#, elixir-autogen, elixir-format
+msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
+msgstr "Fertig. Ihre Fediverse-Follower wurden gebeten, Ihrem neuen Konto zu folgen, und neue Beiträge werden von hier nicht mehr föderiert. Ihr vutuv-Profil bleibt unverändert."
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Enter that account's address below and redirect."
+msgstr "Tragen Sie unten die Adresse dieses Kontos ein und leiten Sie weiter."
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
+#, elixir-autogen, elixir-format
+msgid "Leaving for another Fediverse account? You can send your followers there. They will be asked to follow your new account, and vutuv stops federating your new posts. This is only a redirect: your vutuv profile stays exactly as it is, and nothing is deleted."
+msgstr "Wechseln Sie zu einem anderen Fediverse-Konto? Sie können Ihre Follower dorthin mitnehmen. Sie werden gebeten, Ihrem neuen Konto zu folgen, und vutuv föderiert Ihre neuen Beiträge nicht mehr. Das ist nur eine Weiterleitung: Ihr vutuv-Profil bleibt genau wie es ist, und nichts wird gelöscht."
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:100
+#, elixir-autogen, elixir-format
+msgid "List the full address of each account you are migrating from, one per line (for example %{example}). On the other server, start the move to your vutuv handle; it will only go through once your old account is listed here. Leave empty if you are not moving accounts."
+msgstr "Tragen Sie die vollständige Adresse jedes Kontos ein, von dem Sie umziehen, eine pro Zeile (zum Beispiel %{example}). Starten Sie den Umzug auf dem anderen Server zu Ihrem vutuv-Handle; er gelingt erst, wenn Ihr altes Konto hier aufgeführt ist. Lassen Sie das Feld leer, wenn Sie nicht umziehen."
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:118
+#, elixir-autogen, elixir-format
+msgid "Move your followers to another account"
+msgstr "Ihre Follower zu einem anderen Konto mitnehmen"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
+#, elixir-autogen, elixir-format
+msgid "Moving to vutuv from another account?"
+msgstr "Ziehen Sie von einem anderen Konto zu vutuv um?"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:139
+#, elixir-autogen, elixir-format
+msgid "New posts are no longer federated from here, and your actor points visitors to your new account. Your vutuv profile itself is unchanged."
+msgstr "Neue Beiträge werden von hier nicht mehr föderiert, und Ihr Actor verweist Besucher auf Ihr neues Konto. Ihr vutuv-Profil selbst bleibt unverändert."
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:165
+#, elixir-autogen, elixir-format
+msgid "On your other account, add your vutuv handle"
+msgstr "Fügen Sie auf Ihrem anderen Konto Ihr vutuv-Handle"
+
+#: lib/vutuv_web/controllers/settings_controller.ex:261
+#, elixir-autogen, elixir-format
+msgid "Please enter the full https address of the account you are moving to."
+msgstr "Bitte geben Sie die vollständige https-Adresse des Kontos ein, zu dem Sie umziehen."
+
+#: lib/vutuv_web/controllers/settings_controller.ex:247
+#, elixir-autogen, elixir-format
+msgid "Redirect cancelled. Your posts federate from here again."
+msgstr "Weiterleitung aufgehoben. Ihre Beiträge werden wieder von hier föderiert."
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:200
+#, elixir-autogen, elixir-format
+msgid "Redirect my followers"
+msgstr "Meine Follower weiterleiten"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:134
+#, elixir-autogen, elixir-format
+msgid "Redirected on %{date}"
+msgstr "Weitergeleitet am %{date}"
+
+#: lib/vutuv_web/controllers/settings_controller.ex:274
+#, elixir-autogen, elixir-format
+msgid "That account could not be reached. Check the address, and that the other server is online."
+msgstr "Dieses Konto war nicht erreichbar. Prüfen Sie die Adresse und ob der andere Server online ist."
+
+#: lib/vutuv_web/controllers/settings_controller.ex:268
+#, elixir-autogen, elixir-format
+msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
+msgstr "Dieses Konto führt Ihr vutuv-Profil noch nicht als Alias. Fügen Sie dort zuerst die Adresse dieses Profils hinzu und versuchen Sie es dann erneut."
+
+#: lib/vutuv_web/controllers/settings_controller.ex:264
+#, elixir-autogen, elixir-format
+msgid "That is this account. Enter the account you are moving to."
+msgstr "Das ist dieses Konto. Geben Sie das Konto an, zu dem Sie umziehen."
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:195
+#, elixir-autogen, elixir-format
+msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
+msgstr "Damit werden Ihre Fediverse-Follower gebeten, stattdessen Ihrem neuen Konto zu folgen, und Ihre Beiträge werden von hier nicht mehr föderiert. Ihr vutuv-Profil ist nicht betroffen. Fortfahren?"
+
+#: lib/vutuv_web/controllers/settings_controller.ex:252
+#, elixir-autogen, elixir-format
+msgid "Turn on federation first, then you can redirect your followers."
+msgstr "Schalten Sie zuerst die Föderation ein, dann können Sie Ihre Follower weiterleiten."
+
+#: lib/vutuv_web/controllers/settings_controller.ex:256
+#, elixir-autogen, elixir-format
+msgid "You can only move once every %{days} days."
+msgstr "Sie können nur alle %{days} Tage umziehen."
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:123
+#, elixir-autogen, elixir-format
+msgid "You have redirected your Fediverse followers to another account:"
+msgstr "Sie haben Ihre Fediverse-Follower zu einem anderen Konto weitergeleitet:"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:167
+#, elixir-autogen, elixir-format
+msgid "as an account alias."
+msgstr "als Konto-Alias hinzu."

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -226,3 +226,13 @@ msgstr "darf nicht nur aus Satzzeichen bestehen"
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr "„%{tag}“ besteht nur aus Satzzeichen und ist kein Tag."
+
+#: lib/vutuv_web/views/error_helpers.ex:75
+#, elixir-autogen, elixir-format
+msgid "Please list at most %{max} accounts."
+msgstr "Bitte geben Sie höchstens %{max} Konten an."
+
+#: lib/vutuv_web/views/error_helpers.ex:76
+#, elixir-autogen, elixir-format
+msgid "\"%{uri}\" is not a valid https account address."
+msgstr "„%{uri}“ ist keine gültige https-Kontoadresse."

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -227,12 +227,12 @@ msgstr "darf nicht nur aus Satzzeichen bestehen"
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr "„%{tag}“ besteht nur aus Satzzeichen und ist kein Tag."
 
-#: lib/vutuv_web/views/error_helpers.ex:75
-#, elixir-autogen, elixir-format
-msgid "Please list at most %{max} accounts."
-msgstr "Bitte geben Sie höchstens %{max} Konten an."
-
 #: lib/vutuv_web/views/error_helpers.ex:76
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
 msgstr "„%{uri}“ ist keine gültige https-Kontoadresse."
+
+#: lib/vutuv_web/views/error_helpers.ex:75
+#, elixir-autogen, elixir-format
+msgid "Please list at most %{max} accounts."
+msgstr "Bitte geben Sie höchstens %{max} Konten an."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -14574,3 +14574,113 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "unreachable"
 msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:182
+#, elixir-autogen, elixir-format
+msgid "Account you are moving to"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:153
+#, elixir-autogen, elixir-format
+msgid "Cancel redirect"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:222
+#, elixir-autogen, elixir-format
+msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Enter that account's address below and redirect."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
+#, elixir-autogen, elixir-format
+msgid "Leaving for another Fediverse account? You can send your followers there. They will be asked to follow your new account, and vutuv stops federating your new posts. This is only a redirect: your vutuv profile stays exactly as it is, and nothing is deleted."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:100
+#, elixir-autogen, elixir-format
+msgid "List the full address of each account you are migrating from, one per line (for example %{example}). On the other server, start the move to your vutuv handle; it will only go through once your old account is listed here. Leave empty if you are not moving accounts."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:118
+#, elixir-autogen, elixir-format
+msgid "Move your followers to another account"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
+#, elixir-autogen, elixir-format
+msgid "Moving to vutuv from another account?"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:139
+#, elixir-autogen, elixir-format
+msgid "New posts are no longer federated from here, and your actor points visitors to your new account. Your vutuv profile itself is unchanged."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:165
+#, elixir-autogen, elixir-format
+msgid "On your other account, add your vutuv handle"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:261
+#, elixir-autogen, elixir-format
+msgid "Please enter the full https address of the account you are moving to."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:247
+#, elixir-autogen, elixir-format
+msgid "Redirect cancelled. Your posts federate from here again."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:200
+#, elixir-autogen, elixir-format
+msgid "Redirect my followers"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:134
+#, elixir-autogen, elixir-format
+msgid "Redirected on %{date}"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:274
+#, elixir-autogen, elixir-format
+msgid "That account could not be reached. Check the address, and that the other server is online."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:268
+#, elixir-autogen, elixir-format
+msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:264
+#, elixir-autogen, elixir-format
+msgid "That is this account. Enter the account you are moving to."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:195
+#, elixir-autogen, elixir-format
+msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:252
+#, elixir-autogen, elixir-format
+msgid "Turn on federation first, then you can redirect your followers."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:256
+#, elixir-autogen, elixir-format
+msgid "You can only move once every %{days} days."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:123
+#, elixir-autogen, elixir-format
+msgid "You have redirected your Fediverse followers to another account:"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:167
+#, elixir-autogen, elixir-format
+msgid "as an account alias."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -14572,3 +14572,113 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "unreachable"
 msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:182
+#, elixir-autogen, elixir-format
+msgid "Account you are moving to"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:153
+#, elixir-autogen, elixir-format
+msgid "Cancel redirect"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:222
+#, elixir-autogen, elixir-format
+msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:169
+#, elixir-autogen, elixir-format
+msgid "Enter that account's address below and redirect."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
+#, elixir-autogen, elixir-format
+msgid "Leaving for another Fediverse account? You can send your followers there. They will be asked to follow your new account, and vutuv stops federating your new posts. This is only a redirect: your vutuv profile stays exactly as it is, and nothing is deleted."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:100
+#, elixir-autogen, elixir-format
+msgid "List the full address of each account you are migrating from, one per line (for example %{example}). On the other server, start the move to your vutuv handle; it will only go through once your old account is listed here. Leave empty if you are not moving accounts."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:118
+#, elixir-autogen, elixir-format
+msgid "Move your followers to another account"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
+#, elixir-autogen, elixir-format
+msgid "Moving to vutuv from another account?"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:139
+#, elixir-autogen, elixir-format
+msgid "New posts are no longer federated from here, and your actor points visitors to your new account. Your vutuv profile itself is unchanged."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:165
+#, elixir-autogen, elixir-format
+msgid "On your other account, add your vutuv handle"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:261
+#, elixir-autogen, elixir-format
+msgid "Please enter the full https address of the account you are moving to."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:247
+#, elixir-autogen, elixir-format
+msgid "Redirect cancelled. Your posts federate from here again."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:200
+#, elixir-autogen, elixir-format
+msgid "Redirect my followers"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:134
+#, elixir-autogen, elixir-format
+msgid "Redirected on %{date}"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:274
+#, elixir-autogen, elixir-format
+msgid "That account could not be reached. Check the address, and that the other server is online."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:268
+#, elixir-autogen, elixir-format
+msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:264
+#, elixir-autogen, elixir-format
+msgid "That is this account. Enter the account you are moving to."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:195
+#, elixir-autogen, elixir-format
+msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:252
+#, elixir-autogen, elixir-format
+msgid "Turn on federation first, then you can redirect your followers."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:256
+#, elixir-autogen, elixir-format
+msgid "You can only move once every %{days} days."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:123
+#, elixir-autogen, elixir-format
+msgid "You have redirected your Fediverse followers to another account:"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:167
+#, elixir-autogen, elixir-format
+msgid "as an account alias."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -224,3 +224,13 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:75
+#, elixir-autogen, elixir-format
+msgid "Please list at most %{max} accounts."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:76
+#, elixir-autogen, elixir-format
+msgid "\"%{uri}\" is not a valid https account address."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -225,12 +225,12 @@ msgstr ""
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:75
-#, elixir-autogen, elixir-format
-msgid "Please list at most %{max} accounts."
-msgstr ""
-
 #: lib/vutuv_web/views/error_helpers.ex:76
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:75
+#, elixir-autogen, elixir-format
+msgid "Please list at most %{max} accounts."
 msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -227,3 +227,13 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:75
+#, elixir-autogen, elixir-format
+msgid "Please list at most %{max} accounts."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:76
+#, elixir-autogen, elixir-format
+msgid "\"%{uri}\" is not a valid https account address."
+msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -228,12 +228,12 @@ msgstr ""
 msgid "\"%{tag}\" is only punctuation, not a tag."
 msgstr ""
 
-#: lib/vutuv_web/views/error_helpers.ex:75
-#, elixir-autogen, elixir-format
-msgid "Please list at most %{max} accounts."
-msgstr ""
-
 #: lib/vutuv_web/views/error_helpers.ex:76
 #, elixir-autogen, elixir-format
 msgid "\"%{uri}\" is not a valid https account address."
+msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:75
+#, elixir-autogen, elixir-format
+msgid "Please list at most %{max} accounts."
 msgstr ""

--- a/priv/repo/migrations/20260724091352_add_also_known_as_to_users.exs
+++ b/priv/repo/migrations/20260724091352_add_also_known_as_to_users.exs
@@ -1,0 +1,14 @@
+defmodule Vutuv.Repo.Migrations.AddAlsoKnownAsToUsers do
+  use Ecto.Migration
+
+  # The Fediverse accounts a member is migrating *from* (issue #986, half 1).
+  # Rendered as `alsoKnownAs` on the actor document, this is what a remote
+  # server (Mastodon) checks before it moves a member's followers *to* their
+  # vutuv account. A text array so a long actor URI can never raise 22001, and
+  # a plain additive column so the migration is N-1 backward compatible.
+  def change do
+    alter table(:users) do
+      add(:also_known_as, {:array, :text}, null: false, default: [])
+    end
+  end
+end

--- a/priv/repo/migrations/20260724095757_add_moved_to_to_users.exs
+++ b/priv/repo/migrations/20260724095757_add_moved_to_to_users.exs
@@ -1,0 +1,15 @@
+defmodule Vutuv.Repo.Migrations.AddMovedToToUsers do
+  use Ecto.Migration
+
+  # Fediverse account migration, half 2 (issue #986): where a member redirected
+  # their Fediverse followers *to*. `moved_to` is the target actor URI rendered
+  # as `movedTo` on the actor document (the redirect a remote server honors);
+  # `moved_at` stamps the last Move broadcast, so a re-move cooldown can hold.
+  # Both nullable and additive, so the migration is N-1 backward compatible.
+  def change do
+    alter table(:users) do
+      add(:moved_to, :text)
+      add(:moved_at, :naive_datetime)
+    end
+  end
+end

--- a/test/vutuv/accounts/user_test.exs
+++ b/test/vutuv/accounts/user_test.exs
@@ -509,4 +509,69 @@ defmodule Vutuv.Accounts.UserTest do
       assert User.changeset(%User{}, %{"first_name" => "first_name"}).valid?
     end
   end
+
+  describe "also_known_as (Fediverse migration, issue #986)" do
+    defp aka_changeset(input) do
+      User.changeset(%User{}, %{"first_name" => "first_name", "also_known_as_input" => input})
+    end
+
+    test "splits a textarea into a trimmed, de-duplicated actor-URI list" do
+      changeset =
+        aka_changeset("""
+          https://mastodon.social/users/alice
+          https://fosstodon.org/users/alice
+          https://mastodon.social/users/alice
+        """)
+
+      assert changeset.valid?
+
+      assert Ecto.Changeset.get_change(changeset, :also_known_as) == [
+               "https://mastodon.social/users/alice",
+               "https://fosstodon.org/users/alice"
+             ]
+    end
+
+    test "an empty textarea leaves the list empty" do
+      changeset = aka_changeset("")
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :also_known_as) == []
+    end
+
+    test "clearing the textarea removes an existing list" do
+      user = %User{also_known_as: ["https://mastodon.social/users/alice"]}
+
+      changeset =
+        User.changeset(user, %{"first_name" => "first_name", "also_known_as_input" => ""})
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :also_known_as) == []
+    end
+
+    test "rejects a non-https entry" do
+      changeset = aka_changeset("http://mastodon.social/users/alice")
+      refute changeset.valid?
+      assert %{also_known_as_input: [_]} = errors_on(changeset)
+    end
+
+    test "rejects an entry that is not a URL at all" do
+      changeset = aka_changeset("@alice@mastodon.social")
+      refute changeset.valid?
+    end
+
+    test "rejects more than the allowed number of accounts" do
+      too_many =
+        1..(User.max_also_known_as() + 1)
+        |> Enum.map_join("\n", &"https://mastodon.social/users/alice#{&1}")
+
+      refute aka_changeset(too_many).valid?
+    end
+
+    test "an untouched form never clears an existing list" do
+      user = %User{also_known_as: ["https://mastodon.social/users/alice"]}
+      changeset = User.changeset(user, %{"first_name" => "first_name"})
+
+      assert changeset.valid?
+      refute Ecto.Changeset.get_change(changeset, :also_known_as)
+    end
+  end
 end

--- a/test/vutuv/fediverse_test.exs
+++ b/test/vutuv/fediverse_test.exs
@@ -203,6 +203,126 @@ defmodule Vutuv.FediverseTest do
       assert :skip == Fediverse.federate_new_post(restricted)
       assert Repo.aggregate(Delivery, :count) == 0
     end
+
+    test "does nothing once the member has moved out" do
+      user = federated_user(moved_to: "https://mastodon.example/users/newme")
+      {:ok, _} = Fediverse.ensure_actor(user)
+
+      {:ok, _} =
+        Fediverse.add_follower(user, %{
+          actor_uri: "https://social.example/users/a",
+          inbox_uri: "https://social.example/inbox"
+        })
+
+      assert :skip == Fediverse.federate_new_post(insert(:post, user: user))
+      assert Repo.aggregate(Delivery, :count) == 0
+    end
+  end
+
+  describe "move_out/2 (issue #986, half 2)" do
+    @target "https://mastodon.example/users/newme"
+
+    # A target actor whose alsoKnownAs is whatever the test needs, or whose id
+    # can be forced (for the self-move check).
+    defp stub_target(also_known_as, id \\ @target) do
+      stub_remote(fn conn ->
+        doc =
+          Jason.encode!(%{
+            "id" => id,
+            "type" => "Person",
+            "inbox" => id <> "/inbox",
+            "alsoKnownAs" => also_known_as
+          })
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/activity+json")
+        |> Plug.Conn.send_resp(200, doc)
+      end)
+    end
+
+    defp with_follower(user) do
+      {:ok, _} = Fediverse.ensure_actor(user)
+
+      {:ok, _} =
+        Fediverse.add_follower(user, %{
+          actor_uri: "https://social.example/users/a",
+          inbox_uri: "https://social.example/inbox"
+        })
+
+      user
+    end
+
+    test "broadcasts a Move and stamps moved_to when the target lists us as an alias" do
+      user = with_follower(federated_user())
+      stub_target([Docs.actor_url(user)])
+
+      assert {:ok, moved} = Fediverse.move_out(user, @target)
+      assert moved.moved_to == @target
+      assert moved.moved_at
+
+      delivery = Repo.one(Delivery)
+      assert delivery.activity_json =~ ~s("type":"Move")
+      assert delivery.activity_json =~ @target
+    end
+
+    test "rejects a target that does not list us as an alias, storing nothing" do
+      user = with_follower(federated_user())
+      stub_target(["https://someone.else/actor"])
+
+      assert {:error, :alias_missing} = Fediverse.move_out(user, @target)
+      assert Repo.aggregate(Delivery, :count) == 0
+      assert Repo.reload(user).moved_to == nil
+    end
+
+    test "refuses to move to this same account" do
+      user = with_follower(federated_user())
+      # The fetched target's id IS our own actor URL.
+      stub_target([Docs.actor_url(user)], Docs.actor_url(user))
+
+      assert {:error, :self_target} = Fediverse.move_out(user, @target)
+    end
+
+    test "rejects a non-https target without reaching the network" do
+      user = with_follower(federated_user())
+      assert {:error, :invalid_target} = Fediverse.move_out(user, "not-a-url")
+    end
+
+    test "requires federation" do
+      assert {:error, :not_federated} = Fediverse.move_out(insert(:activated_user), @target)
+    end
+
+    test "holds within the cooldown window, then allows a move after it" do
+      recent =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(-5 * 86_400, :second)
+        |> NaiveDateTime.truncate(:second)
+
+      user = with_follower(federated_user(moved_at: recent))
+      stub_target([Docs.actor_url(user)])
+
+      assert {:error, :cooldown} = Fediverse.move_out(user, @target)
+
+      long_ago = NaiveDateTime.add(recent, -40 * 86_400, :second)
+      {:ok, aged} = user |> Ecto.Changeset.change(moved_at: long_ago) |> Repo.update()
+      assert {:ok, _} = Fediverse.move_out(aged, @target)
+    end
+  end
+
+  describe "cancel_move/1 and moved?/1" do
+    test "moved?/1 reflects the redirect" do
+      refute Fediverse.moved?(federated_user())
+      assert Fediverse.moved?(federated_user(moved_to: @target))
+    end
+
+    test "cancel clears moved_to but keeps moved_at (the cooldown must hold)" do
+      at = ~N[2026-07-20 10:00:00]
+      user = federated_user(moved_to: @target, moved_at: at)
+
+      {:ok, cancelled} = Fediverse.cancel_move(user)
+
+      assert cancelled.moved_to == nil
+      assert cancelled.moved_at == at
+    end
   end
 
   describe "deliver_due/0" do

--- a/test/vutuv_web/controllers/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/fediverse_controller_test.exs
@@ -176,6 +176,15 @@ defmodule VutuvWeb.FediverseControllerTest do
       assert body["alsoKnownAs"] == [@remote_actor]
     end
 
+    test "a moved account still serves its actor, now advertising movedTo (#986)", %{conn: conn} do
+      user = insert(:activated_user, fediverse_followers?: true, moved_to: @remote_actor)
+      {:ok, _actor} = Fediverse.ensure_actor(user)
+
+      body = conn |> get("/#{user.username}/actor") |> Map.fetch!(:resp_body) |> Jason.decode!()
+
+      assert body["movedTo"] == @remote_actor
+    end
+
     test "followers and outbox are count-only collections", %{conn: conn} do
       user = federated_user()
 

--- a/test/vutuv_web/controllers/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/fediverse_controller_test.exs
@@ -167,6 +167,15 @@ defmodule VutuvWeb.FediverseControllerTest do
       assert conn |> get("/#{user.username}/actor") |> Map.fetch!(:status) == 404
     end
 
+    test "renders the member's alsoKnownAs aliases (#986)", %{conn: conn} do
+      user = insert(:activated_user, fediverse_followers?: true, also_known_as: [@remote_actor])
+      {:ok, _actor} = Fediverse.ensure_actor(user)
+
+      body = conn |> get("/#{user.username}/actor") |> Map.fetch!(:resp_body) |> Jason.decode!()
+
+      assert body["alsoKnownAs"] == [@remote_actor]
+    end
+
     test "followers and outbox are count-only collections", %{conn: conn} do
       user = federated_user()
 

--- a/test/vutuv_web/controllers/settings_controller_test.exs
+++ b/test/vutuv_web/controllers/settings_controller_test.exs
@@ -349,6 +349,46 @@ defmodule VutuvWeb.SettingsControllerTest do
       assert html_response(conn, 422) =~ "not a valid https account address"
       assert Repo.get(User, user.id).also_known_as == ["https://mastodon.social/users/alice"]
     end
+
+    # Move-out rendering + cancel only (no HTTP stub, so this async module never
+    # touches :fediverse_req_options). The Move broadcast itself is covered by
+    # Vutuv.FediverseTest (async: false).
+    test "the move-out form points at the move route while not moved", %{conn: conn} do
+      html = conn |> get(~p"/settings/fediverse") |> html_response(200)
+
+      assert html =~ ~s(id="move-form")
+      assert html =~ ~s(action="#{~p"/settings/fediverse/move"}")
+      # No redirect banner while the member has not moved.
+      refute html =~ "cancel-move-form"
+    end
+
+    test "once moved, the page shows the redirect and a cancel control, not the move-in field",
+         %{conn: conn, user: user} do
+      {:ok, _} =
+        user
+        |> Ecto.Changeset.change(moved_to: "https://mastodon.social/users/gone")
+        |> Repo.update()
+
+      html = conn |> get(~p"/settings/fediverse") |> html_response(200)
+
+      assert html =~ "https://mastodon.social/users/gone"
+      assert html =~ ~s(id="cancel-move-form")
+      # The "moving in" field is hidden once you have moved out.
+      refute html =~ ~s(id="user_also_known_as_input")
+      refute html =~ ~s(id="move-form")
+    end
+
+    test "cancelling the move clears the redirect", %{conn: conn, user: user} do
+      {:ok, _} =
+        user
+        |> Ecto.Changeset.change(moved_to: "https://mastodon.social/users/gone")
+        |> Repo.update()
+
+      conn = delete(conn, ~p"/settings/fediverse/move")
+
+      assert redirected_to(conn) == ~p"/settings/fediverse"
+      assert Repo.get(User, user.id).moved_to == nil
+    end
   end
 
   describe "notifications: granular email toggles" do

--- a/test/vutuv_web/controllers/settings_controller_test.exs
+++ b/test/vutuv_web/controllers/settings_controller_test.exs
@@ -283,6 +283,74 @@ defmodule VutuvWeb.SettingsControllerTest do
     end
   end
 
+  test "fediverse: the origin-account field is hidden until the member opts in", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+
+    refute conn |> get(~p"/settings/fediverse") |> html_response(200) =~
+             ~s(id="user_also_known_as_input")
+  end
+
+  describe "fediverse: alsoKnownAs account migration (#986)" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, user} = Accounts.update_user(user, %{"fediverse_followers?" => "true"})
+      %{conn: conn, user: user}
+    end
+
+    test "the origin-account field shows once federation is on", %{conn: conn} do
+      html = conn |> get(~p"/settings/fediverse") |> html_response(200)
+
+      assert html =~ ~s(id="user_also_known_as_input")
+    end
+
+    test "saving records the listed accounts, one per line", %{conn: conn, user: user} do
+      conn =
+        put(conn, ~p"/settings/fediverse",
+          user: %{
+            "fediverse_followers?" => "true",
+            "also_known_as_input" =>
+              "https://mastodon.social/users/alice\nhttps://fosstodon.org/users/alice\n"
+          }
+        )
+
+      assert redirected_to(conn) == ~p"/settings/fediverse"
+
+      assert Repo.get(User, user.id).also_known_as == [
+               "https://mastodon.social/users/alice",
+               "https://fosstodon.org/users/alice"
+             ]
+    end
+
+    test "the stored accounts are seeded back into the textarea", %{conn: conn, user: user} do
+      {:ok, _} =
+        Accounts.update_user(user, %{
+          "also_known_as_input" => "https://mastodon.social/users/alice"
+        })
+
+      html = conn |> get(~p"/settings/fediverse") |> html_response(200)
+
+      assert html =~ "https://mastodon.social/users/alice"
+    end
+
+    test "a non-https entry is rejected without changing the stored list", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, _} =
+        Accounts.update_user(user, %{
+          "also_known_as_input" => "https://mastodon.social/users/alice"
+        })
+
+      conn =
+        put(conn, ~p"/settings/fediverse",
+          user: %{"fediverse_followers?" => "true", "also_known_as_input" => "not-a-url"}
+        )
+
+      assert html_response(conn, 422) =~ "not a valid https account address"
+      assert Repo.get(User, user.id).also_known_as == ["https://mastodon.social/users/alice"]
+    end
+  end
+
   describe "notifications: granular email toggles" do
     test "saving the per-type toggles persists each one and stays on the page", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)

--- a/test/vutuv_web/fediverse/docs_test.exs
+++ b/test/vutuv_web/fediverse/docs_test.exs
@@ -30,6 +30,30 @@ defmodule VutuvWeb.Fediverse.DocsTest do
       # The avatar rides as the scraper-friendly square JPEG.
       assert doc["icon"]["url"] == "#{base()}/#{user.username}/avatar.jpg"
     end
+
+    test "renders alsoKnownAs only when the member listed origin accounts (#986)" do
+      user =
+        insert(:activated_user,
+          also_known_as: [
+            "https://mastodon.social/users/alice",
+            "https://fosstodon.org/users/alice"
+          ]
+        )
+
+      {:ok, actor} = Fediverse.ensure_actor(user)
+
+      assert Docs.actor(user, actor)["alsoKnownAs"] == [
+               "https://mastodon.social/users/alice",
+               "https://fosstodon.org/users/alice"
+             ]
+    end
+
+    test "omits alsoKnownAs entirely when empty (absent, never an empty array)" do
+      user = insert(:activated_user, also_known_as: [])
+      {:ok, actor} = Fediverse.ensure_actor(user)
+
+      refute Map.has_key?(Docs.actor(user, actor), "alsoKnownAs")
+    end
   end
 
   describe "create_activity/2 (public post -> Create(Note))" do

--- a/test/vutuv_web/fediverse/docs_test.exs
+++ b/test/vutuv_web/fediverse/docs_test.exs
@@ -54,6 +54,31 @@ defmodule VutuvWeb.Fediverse.DocsTest do
 
       refute Map.has_key?(Docs.actor(user, actor), "alsoKnownAs")
     end
+
+    test "renders movedTo only after a move-out (#986 half 2)" do
+      moved = insert(:activated_user, moved_to: "https://mastodon.social/users/gone")
+      staying = insert(:activated_user)
+      {:ok, ma} = Fediverse.ensure_actor(moved)
+      {:ok, sa} = Fediverse.ensure_actor(staying)
+
+      assert Docs.actor(moved, ma)["movedTo"] == "https://mastodon.social/users/gone"
+      refute Map.has_key?(Docs.actor(staying, sa), "movedTo")
+    end
+  end
+
+  describe "move_activity/2 (#986 half 2)" do
+    test "the Move names the member as actor and object, the target as target" do
+      user = insert(:activated_user)
+      target = "https://mastodon.social/users/gone"
+
+      activity = Docs.move_activity(user, target)
+
+      assert activity["type"] == "Move"
+      assert activity["actor"] == "#{base()}/#{user.username}/actor"
+      assert activity["object"] == activity["actor"]
+      assert activity["target"] == target
+      assert activity["to"] == ["#{base()}/#{user.username}/actor/followers"]
+    end
   end
 
   describe "create_activity/2 (public post -> Create(Note))" do


### PR DESCRIPTION
Closes #986. Fediverse account migration, **both halves**, in one feature.

## Half 1 — move followers *in* (`alsoKnownAs`)
A member migrating from another Fediverse account lists the account(s) they are moving **from** on `/settings/fediverse`. Those actor URIs render as `alsoKnownAs` on `/:username/actor`, which a remote server checks before it moves a member's followers **to** their vutuv account. Mastodon's own tooling drives the move.

## Half 2 — move followers *out* (`Move` + `movedTo`)
A member leaving for another Fediverse account redirects their followers. They enter the account they are moving **to**; vutuv fetches that actor, confirms it lists this profile in *its* `alsoKnownAs` (the check every remote server makes, so a doomed Move fails fast), then broadcasts `Move { actor, object, target }` to every follower inbox. Compliant servers re-point their follow.

### The design decision (the product call in the issue)
A move-out is a **redirect, never a deletion**. A vutuv account is a full profile (CV, work history, connections), not just a Fediverse actor, so moving your Fediverse followers away only:
- pauses outbound post federation (`moved?/1` gate), and
- publishes `movedTo` on the actor (the actor keeps being served so the redirect resolves).

The profile and everything else stay exactly as they are, and the settings copy says so at every step. Deleting an account remains its own separate action. A 30-day cooldown stops move-spam; cancelling clears the redirect but keeps the cooldown.

## How
- Additive columns (all N-1 safe): `users.also_known_as` (`text[]`), `users.moved_to` (`text`), `users.moved_at`.
- `Vutuv.Fediverse.move_out/2` / `cancel_move/1` / `moved?/1`; `VutuvWeb.Fediverse.Docs` renders `alsoKnownAs` + `movedTo` and builds the `Move`.
- Settings UI: move-in field (hidden once moved out), move-out card with alias instructions + a confirm, and a moved-state banner with cancel. Full de/en translations. GDPR export carries both fields.

## Verified
- Unit + controller + doc tests (verify/broadcast/cooldown/cancel, federation suppression when moved, `movedTo`, actor endpoint, form wiring). `mix precommit` green (4693 tests).
- Browser end to end: both halves. Move-in saves and the live actor doc carries the alias; move-out shows the reassurance copy, an invalid target shows the German error, the moved banner + cancel work, and cancel keeps the cooldown.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*