### PR TITLE
Let a member switch thread notifications off (#1025)

### DIFF
--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -159,6 +159,14 @@ defmodule Vutuv.Accounts.User do
     # settings page turns the whole kind off. Off, the events vanish from the
     # feed and the unread count retroactively — the feed is derived, not stored.
     field(:cv_update_notifications?, :boolean, default: true)
+    # The reader's switch for the in-app "someone replied elsewhere in a thread
+    # I wrote in" notification (issue #1025, the "thread" kind from #1010).
+    # Opt-OUT (default true): it is what makes a live discussion reach every
+    # participant, but a busy thread can get loud, so the notification settings
+    # page turns the whole kind off. Off, the events vanish from the feed and
+    # the unread count (derived, not stored) and the live push stops too. Direct
+    # answers to your own post (the "reply" kind) are unaffected and stay on.
+    field(:thread_notifications?, :boolean, default: true)
     # Whether this member's avatar shows the real-time "online" green dot while
     # they have the site open. Default on; opting out (Privacy settings) means
     # VutuvWeb.Presence never tracks them, so they show as online to no one.
@@ -319,7 +327,7 @@ defmodule Vutuv.Accounts.User do
   # :email_confirmed? is NOT here either: it flips only via the login-PIN path
   # (Accounts.activate_user/1, its own narrow cast) — castable, it would let a
   # registration self-activate without ever proving control of an email.
-  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? newsletter_emails? saved_search_emails? cv_update_notifications? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix gender birthdate birthdate_visibility locale tag_list)a
+  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix gender birthdate birthdate_visibility locale tag_list)a
 
   # The job-availability values a member can advertise (issue #870), other
   # than the "not specified" default which is stored as nil. The single source

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -813,6 +813,16 @@ defmodule Vutuv.Activity do
       join: reply in Post,
       on: reply.id == r.post_id,
       as: :reply_post,
+      # The reader's opt-out (issue #1025): with the switch off, this whole
+      # source yields nothing — feed and unread count both build on it. A
+      # constant subquery, so it costs no extra round trip and no caller change.
+      where:
+        exists(
+          from(reader in User,
+            where: reader.id == ^user_id and reader.thread_notifications?,
+            select: 1
+          )
+        ),
       where: not is_nil(r.root_post_id),
       where: reply.user_id != ^user_id,
       where: is_nil(r.parent_author_id) or r.parent_author_id != ^user_id,

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2533,10 +2533,24 @@ defmodule Vutuv.Posts do
         &(is_nil(&1) or &1 == reply.user_id or &1 == parent.user_id or
             Vutuv.Social.blocked_between?(&1, reply.user_id))
       )
+      # Honor the reader's opt-out on the write side too (issue #1025): the feed
+      # query already suppresses the "thread" kind for anyone who turned it off,
+      # so pushing a live badge here would leave them a count with nothing
+      # behind it. One query keeps only the members who still want the push.
+      |> thread_notifiable_ids()
       |> Enum.each(&Vutuv.Activity.notify_thread_reply(&1, reply.user, root_id, reply.id))
     end
 
     :ok
+  end
+
+  # Of the given member ids, the ones who still want thread pushes (issue
+  # #1025). Empty in, empty out — no query for a thread with no other eligible
+  # participant.
+  defp thread_notifiable_ids([]), do: []
+
+  defp thread_notifiable_ids(ids) do
+    Repo.all(from(u in User, where: u.id in ^ids and u.thread_notifications?, select: u.id))
   end
 
   # Reconcile the `post_mentions` rows behind the feed's "mention" kind against

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -230,6 +230,13 @@ defmodule VutuvWeb.NotificationLive.Index do
     end
   end
 
+  # The id of the day's first "thread" group, so its row alone carries the
+  # opt-out hint (issue #1025) - one hint per Berlin-day section, not per row.
+  # nil when the day has no thread row, so nothing is marked.
+  defp first_thread_group_id(groups) do
+    Enum.find_value(groups, fn group -> group.kind == "thread" && group.id end)
+  end
+
   # The rail data (follow-back suggestions + 30-day summary) is skipped on
   # the static mount, like the remaining count, to keep the first paint lean.
   defp assign_rail(socket, false) do
@@ -291,12 +298,14 @@ defmodule VutuvWeb.NotificationLive.Index do
             >
               {day_label(section.day, @today)}
             </h2>
+            <% first_thread_id = first_thread_group_id(section.groups) %>
             <div class="mt-2 divide-y divide-slate-100 overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-slate-200 dark:divide-slate-800 dark:bg-slate-900 dark:ring-slate-800">
               <.notification_row
                 :for={group <- section.groups}
                 group={group}
                 current_user={@current_user}
                 quote_lines={@quote_lines}
+                thread_hint={group.kind == "thread" and group.id == first_thread_id}
               />
             </div>
           </section>
@@ -374,6 +383,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   attr(:group, :map, required: true)
   attr(:current_user, :any, required: true)
   attr(:quote_lines, :integer, required: true)
+  attr(:thread_hint, :boolean, default: false)
 
   defp notification_row(assigns) do
     assigns = assign(assigns, :n, assigns.group.item)
@@ -453,6 +463,24 @@ defmodule VutuvWeb.NotificationLive.Index do
             quote_lines={@quote_lines}
           />
         </div>
+
+        <%!-- The day's first thread row says why it is here and links to the
+        switch that stops it (issue #1025), once per day so it stays a hint and
+        not a banner. It shows only when thread events reach this reader, which
+        is exactly when the switch is still on. --%>
+        <p
+          :if={@thread_hint}
+          data-thread-hint
+          class="mb-0 mt-1.5 text-xs text-slate-500 dark:text-slate-400"
+        >
+          {gettext("You wrote in this thread.")}
+          <.link
+            href={~p"/settings/notifications"}
+            class="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+          >
+            {gettext("Turn this off")} ›
+          </.link>
+        </p>
 
         <%!-- A CV update covering several entries names them, each linking to
         its own page (issue #980). A single entry is named in the line itself. --%>

--- a/lib/vutuv_web/templates/settings/notifications.html.heex
+++ b/lib/vutuv_web/templates/settings/notifications.html.heex
@@ -87,6 +87,29 @@ heading. --%>
       hint={gettext("When off, you never see this kind of notification, whoever sends it.")}
     />
 
+    <%!-- Thread replies (issue #1025): the second in-app kind a member can
+          switch off. It is what lets a live discussion reach everyone who wrote
+          in the thread, but a busy thread gets loud. Direct answers to your own
+          post (the "reply" kind) are unaffected and stay on. Never emailed. --%>
+    <.toggle_form_card
+      changeset={@changeset}
+      field={:thread_notifications?}
+      form_id="thread-notifications-form"
+      action={~p"/settings/notifications"}
+      title={gettext("Thread replies")}
+      intro={
+        gettext(
+          "When someone replies anywhere in a thread you have written in, you hear about it under the bell, so a discussion reaches everyone who took part. Never by email."
+        )
+      }
+      label={gettext("Tell me about new replies in threads I take part in")}
+      hint={
+        gettext(
+          "When off, you only hear about direct answers to your own posts, never other replies in the thread."
+        )
+      }
+    />
+
     <%!-- The remaining in-app notifications are not configurable (they are the
           product), so this card just explains them and links to the bell. --%>
     <.card>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -14593,6 +14593,36 @@ msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folg
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
 
+#: lib/vutuv_web/templates/settings/notifications.html.heex:100
+#, elixir-autogen, elixir-format
+msgid "Thread replies"
+msgstr "Thread-Antworten"
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:103
+#, elixir-autogen, elixir-format
+msgid "When someone replies anywhere in a thread you have written in, you hear about it under the bell, so a discussion reaches everyone who took part. Never by email."
+msgstr "Wenn jemand irgendwo in einem Thread antwortet, in dem Sie geschrieben haben, hören Sie es unter der Glocke, damit eine Diskussion alle Beteiligten erreicht. Nie per E-Mail."
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:108
+#, elixir-autogen, elixir-format
+msgid "Tell me about new replies in threads I take part in"
+msgstr "Über neue Antworten in Threads informieren, an denen ich teilnehme"
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:110
+#, elixir-autogen, elixir-format
+msgid "When off, you only hear about direct answers to your own posts, never other replies in the thread."
+msgstr "Wenn aus, hören Sie nur von direkten Antworten auf Ihre eigenen Beiträge, nie von anderen Antworten im Thread."
+
+#: lib/vutuv_web/live/notification_live/index.ex:459
+#, elixir-autogen, elixir-format
+msgid "You wrote in this thread."
+msgstr "Sie haben in diesem Thread geschrieben."
+
+#: lib/vutuv_web/live/notification_live/index.ex:463
+#, elixir-autogen, elixir-format
+msgid "Turn this off"
+msgstr "Das abschalten"
+
 #: lib/vutuv_web/live/notification_live/index.ex:1060
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"

--- a/priv/repo/migrations/20260724094239_add_thread_notifications.exs
+++ b/priv/repo/migrations/20260724094239_add_thread_notifications.exs
@@ -1,0 +1,21 @@
+defmodule Vutuv.Repo.Migrations.AddThreadNotifications do
+  use Ecto.Migration
+
+  # Thread notifications opt-out (issue #1025). Since #1010 a reply anywhere in
+  # a thread a member wrote in reaches every participant (the feed's "thread"
+  # kind). It is the point of a live discussion, but a busy thread can get
+  # loud, so this gives each member one switch to turn it off — shaped exactly
+  # like `cv_update_notifications?` (#980), the only other in-app kind a member
+  # can silence.
+  #
+  # Default true: an opt-out, not an opt-in. The `reply` kind (a direct answer
+  # to your own post) is unaffected and stays always-on.
+  #
+  # Plain additive column with a default, so the previous release keeps working
+  # untouched during the blue/green window (N-1 safe).
+  def change do
+    alter table(:users) do
+      add(:thread_notifications?, :boolean, null: false, default: true)
+    end
+  end
+end

--- a/test/vutuv/activity_test.exs
+++ b/test/vutuv/activity_test.exs
@@ -453,6 +453,28 @@ defmodule Vutuv.ActivityTest do
 
       assert Activity.unread_notification_count(me.id) == 1
     end
+
+    test "a member who switched thread notifications off sees no thread events, and they do not count" do
+      # Same shape as "thread events count as unread", but the reader opted out
+      # (issue #1025): the direct reply to their own post still surfaces and
+      # counts, the thread event is gone from both the feed and the tally.
+      me = insert(:user, thread_notifications?: false)
+      first_replier = insert(:user)
+      root = insert(:post, user: me)
+      first = insert(:post, user: first_replier)
+      insert(:post_reply, post: first, parent_post: root, parent_author: me, root_post: root)
+      nested = insert(:post, user: insert(:user))
+
+      insert(:post_reply,
+        post: nested,
+        parent_post: first,
+        parent_author: first_replier,
+        root_post: root
+      )
+
+      assert Enum.frequencies_by(recent_notifications(me.id), & &1.kind) == %{"reply" => 1}
+      assert Activity.unread_notification_count(me.id) == 1
+    end
   end
 
   describe "notifications_page/2" do

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -1861,6 +1861,27 @@ defmodule Vutuv.PostsTest do
       {:ok, _} = Posts.create_reply(replier, first, %{body: "second"})
       refute_receive {:new_notification, %{kind: "thread"}}, 50
     end
+
+    test "a participant who switched thread notifications off gets no live push (issue #1025)" do
+      # The root author opted out, so the thread event must not reach them —
+      # not even the live badge push, or they would carry an unread count with
+      # nothing behind it. The directly answered author still gets their reply.
+      root_author = user(thread_notifications?: false)
+      first_replier = user()
+      second_replier = user()
+      root = create_post!(root_author, %{body: "root"})
+      {:ok, first} = Posts.create_reply(first_replier, root, %{body: "first"})
+
+      Vutuv.Activity.subscribe(root_author.id)
+      Vutuv.Activity.subscribe(first_replier.id)
+
+      {:ok, _second} = Posts.create_reply(second_replier, first, %{body: "second"})
+
+      # first_replier was answered directly -> still gets the "reply" event.
+      assert_receive {:new_notification, %{kind: "reply"}}
+      # root_author opted out -> no "thread" push at all.
+      refute_receive {:new_notification, %{kind: "thread"}}, 50
+    end
   end
 
   describe "reply tombstones" do

--- a/test/vutuv_web/controllers/settings_controller_test.exs
+++ b/test/vutuv_web/controllers/settings_controller_test.exs
@@ -318,6 +318,19 @@ defmodule VutuvWeb.SettingsControllerTest do
       assert html =~ "dm_email_each_message?"
       assert html =~ "dm_email_delay_minutes"
       assert html =~ ~s(href="#{~p"/notifications"}")
+      # The two in-app opt-outs (issue #980 CV updates, issue #1025 threads).
+      assert html =~ "cv_update_notifications?"
+      assert html =~ "thread_notifications?"
+    end
+
+    test "switching thread notifications off persists (issue #1025)", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      conn =
+        put(conn, ~p"/settings/notifications", user: %{"thread_notifications?" => "false"})
+
+      assert redirected_to(conn) == ~p"/settings/notifications"
+      assert %User{thread_notifications?: false} = Repo.get(User, user.id)
     end
 
     test "saving the message-email frequency and delay persists them", %{conn: conn} do

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -481,6 +481,25 @@ defmodule VutuvWeb.NotificationLiveTest do
       assert length(row_ids(html, "reply")) == 1
     end
 
+    test "only the day's first thread row carries the opt-out hint (issue #1025)", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      # Two separate threads the member rooted, each answered by a third party
+      # to the first replier - two distinct thread rows on the same day.
+      for body <- ["Thread one", "Thread two"] do
+        root = insert(:post, user: user, body: body)
+        {:ok, first} = Vutuv.Posts.create_reply(insert(:user), root, %{body: "First answer"})
+        {:ok, _} = Vutuv.Posts.create_reply(insert(:user), first, %{body: "Third-party answer"})
+      end
+
+      {:ok, live, html} = live(conn, ~p"/notifications")
+
+      assert length(row_ids(html, "thread")) == 2
+      # Exactly one hint for the day, linking to the notification settings.
+      assert length(Regex.scan(~r/data-thread-hint/, html)) == 1
+      assert has_element?(live, ~s([data-thread-hint] a[href="/settings/notifications"]))
+    end
+
     test "the posts filter tab keeps thread rows", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 


### PR DESCRIPTION
Closes #1025.

Adds a per-member opt-out for the "thread" notification kind (#1010): a reply anywhere in a thread you wrote in. It is what makes a live discussion reach every participant, but a busy thread gets loud, so this gives each member one switch to turn it off.

## What
- **New field** `users.thread_notifications?` (boolean, default true) — an opt-out shaped exactly like `cv_update_notifications?` (#980), the only other in-app kind a member can silence. Cast list + a `<.toggle_form_card>` on `/settings/notifications`.
- **Read side:** an `exists` gate on the reader's flag inside `Vutuv.Activity.thread_replies/1`, which both `thread_items/3` (feed) and `count_thread_replies/2` (unread count) build on — one place, no extra round trip. Off → the events vanish from the feed and the tally.
- **Write side:** `Vutuv.Posts.notify_thread_participants/2` filters recipients by the flag before the live badge push, so a member who switched it off never gets a badge with nothing behind it.
- **Hint row:** on `/notifications` the day's first thread row carries a quiet one-line hint ("You wrote in this thread. Turn this off ›") linking to the setting — once per Berlin-day section, so it stays a hint and not a banner.
- Direct answers to your own post (the `reply` kind) are unaffected and stay always-on.
- German copy added in Sie-form, no em-dashes.

## Migration
Additive column with a default → N-1 safe for the blue/green window.

## Tests
- Read side: an opted-out member sees no thread events and they don't count (feed + unread count).
- Write side: an opted-out participant gets no live push, while the directly-answered author still gets their reply.
- UI: only the day's first thread row carries the opt-out hint; the settings toggle persists.
- `mix precommit` green (4646 passed).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_014VdhLKS68PKfE4NBcW1KD7