### PR TITLE
Show endorsers on the tag detail page (#1008)

### DIFF
--- a/lib/vutuv_web/agent_docs/section_docs.ex
+++ b/lib/vutuv_web/agent_docs/section_docs.ex
@@ -75,7 +75,7 @@ defmodule VutuvWeb.AgentDocs.SectionDocs do
   def build_show(user, section, record) when is_map_key(@sections, section) do
     segment = Atom.to_string(section)
     path = "/#{user.username}/#{segment}/#{Phoenix.Param.to_param(record)}"
-    entry = entry(section, record, user)
+    entry = section |> entry(record, user) |> maybe_add_endorsers(section, record)
 
     AgentDocs.doc_meta(@sections[section], path, noindex: true, noai: true)
     |> Map.merge(%{
@@ -151,6 +151,13 @@ defmodule VutuvWeb.AgentDocs.SectionDocs do
   # the member's slug); every other section's vocabulary stays user-less.
   defp entry(:qualifications, record, user), do: qualification_entry(record, user)
   defp entry(section, record, _user), do: entry(section, record)
+
+  # The tag detail page names its endorsers now (issue #1008), so its doc
+  # sibling carries them too - the same list the index doc adds per row.
+  defp maybe_add_endorsers(entry, :tags, record),
+    do: Map.put(entry, :endorsers, endorsers(record))
+
+  defp maybe_add_endorsers(entry, _section, _record), do: entry
 
   # As many endorsers as the page's avatar stack shows, newest first (a UUID v7
   # endorsement id sorts by creation). `[]` when the association was not

--- a/lib/vutuv_web/controllers/user_tag_controller.ex
+++ b/lib/vutuv_web/controllers/user_tag_controller.ex
@@ -19,6 +19,10 @@ defmodule VutuvWeb.UserTagController do
   alias VutuvWeb.AgentDocs.SectionDocs
   alias VutuvWeb.UserHelpers
 
+  # How many endorsers the tag detail page names inline (issue #1008); the rest
+  # live on the paginated endorsers page, one link away.
+  @endorsers_preview 12
+
   # Index and show are also served as Markdown / text / JSON via
   # VutuvWeb.AgentDocs.SectionDocs (see agent_docs_drift_test.exs). The
   # shared preload carries the endorsements the docs count and keeps the
@@ -58,16 +62,34 @@ defmodule VutuvWeb.UserTagController do
   end
 
   def show(conn, %{"id" => _id}) do
-    # Count only visible endorsers (issue #783); the agent doc derives the
-    # endorsement count from length(endorsements) on this plain preload.
+    # Load the endorsers themselves, not just their count (issue #1008): the
+    # detail page names who endorsed this member for this tag. Still only the
+    # visible ones (issue #783), so length(endorsements) stays the right count.
     user_tag =
       conn.assigns[:user_tag]
-      |> Repo.preload([:tag, endorsements: UserTagEndorsement.visible()])
+      |> Repo.preload([:tag, endorsements: UserTagEndorsement.visible_with_endorser()])
+
+    # Newest first (a UUID v7 endorsement id sorts by creation), so the detail
+    # page and the agent-doc sibling name the same people in the same order.
+    endorsers =
+      user_tag.endorsements
+      |> Enum.sort_by(& &1.id, :desc)
+      |> Enum.map(& &1.user)
+
+    # Show a capped preview as a normal people list; the rest lives on the
+    # existing paginated endorsers page, one link away. Batch the per-row
+    # work-info / follow lookups (one query each), like the listing pages.
+    preview = Enum.take(endorsers, @endorsers_preview)
 
     AgentDocs.respond(conn,
       html:
         &render(&1, "show.html",
           user_tag: user_tag,
+          endorsers: preview,
+          endorsement_count: length(endorsers),
+          work_info_by_id: UserHelpers.work_information_map(preview, 45),
+          following_by_id: UserHelpers.following_map(conn.assigns[:current_user], preview),
+          work_string_length: 45,
           page_title: UserHelpers.member_page_title(conn.assigns[:user], UserTag.name(user_tag))
         ),
       doc: fn -> SectionDocs.build_show(conn.assigns[:user], :tags, user_tag) end

--- a/lib/vutuv_web/templates/user_tag/show.html.heex
+++ b/lib/vutuv_web/templates/user_tag/show.html.heex
@@ -10,6 +10,35 @@
 
 <div class="card-list">
 
+  <%!-- Who endorsed THIS member for THIS tag (issue #1008): the endorsements
+  are the point of this page, so they lead, above the global "people with this
+  tag" card. A capped people list plus a link to the full paginated list. --%>
+  <section class="card">
+    <h2 class="card__label">{gettext("Endorsements")}</h2>
+    <%= if @endorsement_count == 0 do %>
+      <p class="card__empty">
+        {gettext("Nobody has endorsed %{name} for this tag yet.", name: full_name(@user))}
+      </p>
+    <% else %>
+      <p>
+        {ngettext("%{formatted} endorsement", "%{formatted} endorsements", @endorsement_count,
+          formatted: delimited_count(@endorsement_count)
+        )}
+      </p>
+
+      {VutuvWeb.UserHTML.card_list(Map.put(assigns, :users, @endorsers))}
+
+      <p class="card__morelink">
+        <.link
+          href={~p"/#{@user}/tags/#{@user_tag.tag.slug}/endorsers"}
+          class="text-sm font-semibold text-brand-600 hover:text-brand-700"
+        >
+          {gettext("All endorsers")} ›
+        </.link>
+      </p>
+    <% end %>
+  </section>
+
   {VutuvWeb.TagHTML.single_card(Map.put(assigns, :tag, @user_tag.tag))}
 
 </div>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -5943,6 +5943,23 @@ msgstr "Apps & API-Zugang"
 msgid "Endorsements"
 msgstr "Empfehlungen"
 
+#: lib/vutuv_web/templates/user_tag/show.html.heex:34
+#, elixir-autogen, elixir-format
+msgid "All endorsers"
+msgstr "Alle Empfehlenden"
+
+#: lib/vutuv_web/templates/user_tag/show.html.heex:17
+#, elixir-autogen, elixir-format
+msgid "Nobody has endorsed %{name} for this tag yet."
+msgstr "Noch niemand hat %{name} für dieses Tag empfohlen."
+
+#: lib/vutuv_web/templates/user_tag/show.html.heex:22
+#, elixir-autogen, elixir-format
+msgid "%{formatted} endorsement"
+msgid_plural "%{formatted} endorsements"
+msgstr[0] "%{formatted} Empfehlung"
+msgstr[1] "%{formatted} Empfehlungen"
+
 #: lib/vutuv_web/templates/settings/notifications.html.heex:99
 #, elixir-autogen, elixir-format
 msgid "Endorsements and new followers"

--- a/test/vutuv_web/controllers/user_tag_controller_test.exs
+++ b/test/vutuv_web/controllers/user_tag_controller_test.exs
@@ -252,6 +252,68 @@ defmodule VutuvWeb.UserTagControllerTest do
     end
   end
 
+  # The person's tag detail page shows who endorsed THEM for this tag (issue
+  # #1008): the member-specific endorsements, not only the global "people with
+  # this tag" card that used to be all this page carried.
+  describe "show" do
+    setup do
+      owner = insert_activated_user(username: "tag_detail_owner")
+      tag = insert(:tag)
+      user_tag = insert(:user_tag, user: owner, tag: tag)
+      {:ok, owner: owner, tag: tag, user_tag: user_tag}
+    end
+
+    test "names the endorsers and links to the full endorser list", %{
+      conn: conn,
+      owner: owner,
+      tag: tag,
+      user_tag: user_tag
+    } do
+      insert(:user_tag_endorsement,
+        user_tag: user_tag,
+        user: insert_activated_user(first_name: "Rick", last_name: "Sanchez")
+      )
+
+      html = conn |> get(~p"/#{owner}/tags/#{tag.slug}") |> html_response(200)
+
+      assert html =~ "Rick Sanchez"
+      assert html =~ ~p"/#{owner}/tags/#{tag.slug}/endorsers"
+    end
+
+    test "a tag nobody endorsed renders an empty-endorsements line, no crash", %{
+      conn: conn,
+      owner: owner,
+      tag: tag
+    } do
+      html = conn |> get(~p"/#{owner}/tags/#{tag.slug}") |> html_response(200)
+
+      assert html =~ tag.name
+      refute html =~ "Rick Sanchez"
+    end
+
+    test "drops hidden / unconfirmed endorsers from the detail page (issue #783)", %{
+      conn: conn,
+      owner: owner,
+      tag: tag,
+      user_tag: user_tag
+    } do
+      insert(:user_tag_endorsement,
+        user_tag: user_tag,
+        user: insert_activated_user(first_name: "Visible", last_name: "Voter")
+      )
+
+      insert(:user_tag_endorsement,
+        user_tag: user_tag,
+        user: insert(:user, first_name: "Hidden", last_name: "Voter")
+      )
+
+      html = conn |> get(~p"/#{owner}/tags/#{tag.slug}") |> html_response(200)
+
+      assert html =~ "Visible Voter"
+      refute html =~ "Hidden Voter"
+    end
+  end
+
   # The public endorser list behind the profile Tags popover's "and N more"
   # link: everyone who currently endorses this member for this tag.
   describe "endorsers" do


### PR DESCRIPTION
Closes #1008.

The person's tag detail page (`/:slug/tags/:tag`) showed only the global "people with this tag" card and never named who endorsed **this** member for **this** tag. That is the most useful information the page could carry, and it was hidden behind the profile Tags popover or the separate endorsers page.

## What
- The detail page now **leads** with an **Endorsements** card: the endorsement count, a capped people list of the endorsers (rendered with the same `card_list` the rest of the page uses, so it carries avatars, work info and a follow control), and an "All endorsers ›" link to the existing full paginated list for the rest.
- Only **visible** endorsers are counted and shown (issue #783), **newest first**.
- Empty state: a plain "Nobody has endorsed <name> for this tag yet." line.

## Agent formats
The tag **show** doc now carries `:endorsers` exactly like the **index** doc already did, so the Markdown/text siblings list the same names and JSON/XML the same refs. `agent_docs_drift_test` stays green.

## Tests
- The detail page names the endorsers and links to the full list.
- A tag nobody endorsed renders the empty line without crashing.
- Hidden / unconfirmed endorsers are dropped (issue #783).
- `mix precommit` green (4666 passed).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_014VdhLKS68PKfE4NBcW1KD7