### PR TITLE
Add a screenshot host blocklist (default: reddit.com)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -71,6 +71,15 @@ config :vutuv, Vutuv.Repo,
 config :vutuv, :generate_screenshots, true
 config :vutuv, :fetch_gravatar, true
 
+# Hosts whose pages are never worth a link-preview screenshot: they answer a
+# headless capture with a login/consent wall or block bots outright, so the
+# shot is always a useless placeholder. Skipping them (in Vutuv.PageScreenshot
+# and the single-link post queue) saves the Chromium run instead of burning it
+# on something that can't work. Matches the apex host and every subdomain
+# (`old.reddit.com`). Override per installation with SCREENSHOT_BLOCKED_HOSTS
+# (comma-separated) in config/runtime.exs.
+config :vutuv, :screenshot_blocked_hosts, ["reddit.com"]
+
 # AI image moderation (Vutuv.Moderation.ImageScans): every image — uploads
 # and machine-generated screenshots alike — is held in owner-only limbo until
 # an Ollama vision model releases it; unsafe images are deleted and the

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -103,6 +103,14 @@ if config_env() == :prod do
     config :vutuv, :post_edit_window_minutes, String.to_integer(minutes)
   end
 
+  # Hosts to never take a link-preview screenshot of (default `reddit.com`; see
+  # config/config.exs). Comma-separated apex hosts; every subdomain is covered.
+  if blocked = System.get_env("SCREENSHOT_BLOCKED_HOSTS") do
+    config :vutuv,
+           :screenshot_blocked_hosts,
+           blocked |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+  end
+
   # Operator identity overrides (defaults in config/config.exs are the
   # vutuv.de values; see the "Operator identity" block there).
   if from_address = System.get_env("MAILER_FROM_ADDRESS") do

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -96,6 +96,7 @@ Everything else has a default (the vutuv.de production value):
 | `POOL_SIZE` | `10` | DB connection pool |
 | `UPLOADS_DIR_PREFIX` | `/srv/legacy-vutuv` | **Set this.** Root directory for uploaded images (avatars, covers, screenshots, post images, private originals) |
 | `CHROMIUM_PATH` | – | Chromium binary, if not on `$PATH` |
+| `SCREENSHOT_BLOCKED_HOSTS` | `reddit.com` | Comma-separated hosts to never take a link-preview screenshot of (profile links **and** single-link posts). Some sites answer a headless capture with a login/consent wall or block bots outright, so the shot is always a useless placeholder — listing the host skips the Chromium run instead of burning it. Each entry matches the apex host and every subdomain (`old.reddit.com`). Set it (replacing the default) to tune the list for your installation |
 | `SMTP_RELAY` | `127.0.0.1` | SMTP server |
 | `SMTP_PORT` | `25` | SMTP port |
 | `SMTP_USERNAME` | – | SMTP auth (empty = no auth) |

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -60,6 +60,14 @@ window frame (`Vutuv.BrowserFrame`); see `Vutuv.PageScreenshot`. Needs a
 `chromium`/`chrome` binary on the host (set `CHROMIUM_PATH` if it is not on
 `$PATH`)
 
+Some hosts never yield a useful shot — they answer a headless capture with a
+login/consent wall or block bots outright — so a **screenshot blocklist**
+(`:screenshot_blocked_hosts`, default `["reddit.com"]`, override with
+`SCREENSHOT_BLOCKED_HOSTS`) short-circuits both paths before any Chromium run:
+`Vutuv.PageScreenshot.host_blocked?/1` matches the apex host and every subdomain,
+`capture_framed/2` returns `:blocked_host`, and the post path skips the job
+entirely at `qualifying_url/1`.
+
 The capture browser sends vutuv's own `User-Agent`
 (`Vutuv.SocialFeed.Http.user_agent/0`), the same string the HTTP preflight
 probe uses, so a site sees one agent for both requests. It also lets our own

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -366,12 +366,20 @@ the save is never slowed. The subsystem is `Vutuv.Posts.Screenshots` with the
 the durable queue and the attachment record**: a `pending`/`capturing`/`failed`
 row is work, a `ready` row carries the stored screenshot.
 
-Two kinds of link are deliberately **not** screenshotted. A link to *this*
-installation's own **`/settings`, `/admin` or `/system`** area is rejected in
+Some links are deliberately **not** screenshotted. Two are caught in
 `qualifying_url/1` (a pure, no-network check on the request path, so no row is
-ever created) — the host is derived from `VutuvWeb.Endpoint.host()`, never a
+ever created): a link to *this* installation's own **`/settings`, `/admin` or
+`/system`** area — the host is derived from `VutuvWeb.Endpoint.host()`, never a
 literal `vutuv.de`, so it holds on any installation, and a shot of those pages
-would only ever be a login redirect or an internal page.
+would only ever be a login redirect or an internal page — and a link to a
+**screenshot-blocklisted host** (`Vutuv.PageScreenshot.host_blocked?/1`, the
+`:screenshot_blocked_hosts` config, default `reddit.com`, override with
+`SCREENSHOT_BLOCKED_HOSTS`). Those sites answer a headless capture with a
+login/consent wall or block bots outright, so the shot is always a useless
+placeholder; skipping them (matched on the apex host and every subdomain)
+spends no Chromium run at all. The same blocklist gates the profile-link
+previews inside `capture_framed/2` (returning `:blocked_host`, a permanent
+outcome).
 
 A link that does **not answer a plain HTTP 200** is rejected at capture time by
 `ensure_http_ok/1`, a `redirect: false` GET probe the worker runs before Chromium

--- a/lib/vutuv/page_screenshot.ex
+++ b/lib/vutuv/page_screenshot.ex
@@ -98,10 +98,11 @@ defmodule Vutuv.PageScreenshot do
         File.rm(framed_path)
         :ok
 
-      {:error, :internal_target = reason} ->
-        # A permanent property of this URL (SSRF guard, issue #777) and an
-        # expected policy outcome: flag it so the bulk task never retries it,
-        # and log quietly.
+      {:error, reason} when reason in [:internal_target, :blocked_host] ->
+        # A permanent property of this URL and an expected policy outcome — an
+        # SSRF-refused internal host (issue #777) or a blocklisted host that
+        # never screenshots (a login/consent wall). Flag it so the bulk task
+        # never retries it, and log quietly.
         Logger.warning(failure_message(url, reason))
         set_broken(url, true)
         :error
@@ -157,6 +158,14 @@ defmodule Vutuv.PageScreenshot do
   app's own host and is intentionally neither gated nor pinned.
   """
   def capture_framed(url_value, id) when is_binary(url_value) do
+    if host_blocked?(url_value) do
+      {:error, :blocked_host}
+    else
+      capture_vetted(url_value, id)
+    end
+  end
+
+  defp capture_vetted(url_value, id) do
     case Ssrf.vetted_address(URI.parse(url_value).host) do
       {:ok, pin_ip} ->
         page_path = tmp_path("page", id, "png")
@@ -177,6 +186,36 @@ defmodule Vutuv.PageScreenshot do
       {:error, :unresolvable} ->
         {:error, :unresolvable_target}
     end
+  end
+
+  @doc """
+  True when `url`'s host is on the screenshot blocklist
+  (`:screenshot_blocked_hosts`, default `["reddit.com"]`, override via
+  `SCREENSHOT_BLOCKED_HOSTS`). Those sites answer a headless capture with a
+  login / consent wall or block bots outright, so the shot is never useful
+  preview content — the caller skips the capture instead of spending a Chromium
+  run on it. Matches the apex host and any subdomain (`old.reddit.com`), so one
+  entry covers a site's mirrors.
+  """
+  def host_blocked?(url) when is_binary(url) do
+    case URI.parse(url).host do
+      nil -> false
+      host -> host_on_blocklist?(String.downcase(host))
+    end
+  end
+
+  def host_blocked?(_url), do: false
+
+  defp host_on_blocklist?(host) do
+    Enum.any?(blocked_hosts(), fn blocked ->
+      host == blocked or String.ends_with?(host, "." <> blocked)
+    end)
+  end
+
+  defp blocked_hosts do
+    :vutuv
+    |> Application.get_env(:screenshot_blocked_hosts, [])
+    |> Enum.map(&String.downcase/1)
   end
 
   # Resolve a member link to the final PUBLIC URL Chromium should shoot,

--- a/lib/vutuv/posts/screenshots.ex
+++ b/lib/vutuv/posts/screenshots.ex
@@ -85,7 +85,9 @@ defmodule Vutuv.Posts.Screenshots do
   The single URL a post should be screenshotted for, or `:none`. Qualifies only
   with **no image attachment** and **exactly one** distinct `http(s)` URL in the
   body (surrounding text is fine). A URL pointing at this installation's own
-  `/settings`, `/admin` or `/system` area does **not** qualify.
+  `/settings`, `/admin` or `/system` area, or at a screenshot-blocklisted host
+  (`Vutuv.PageScreenshot.host_blocked?/1`, e.g. `reddit.com`), does **not**
+  qualify — a blocklisted page never screenshots, so no job is even enqueued.
   """
   def qualifying_url(%Post{images: [], body: body}), do: sole_url_target(body)
   def qualifying_url(%Post{images: images}) when is_list(images), do: :none
@@ -98,7 +100,9 @@ defmodule Vutuv.Posts.Screenshots do
   end
 
   defp qualify(url) do
-    if own_internal_url?(url), do: :none, else: {:ok, url}
+    if own_internal_url?(url) or Vutuv.PageScreenshot.host_blocked?(url),
+      do: :none,
+      else: {:ok, url}
   end
 
   @doc "Every distinct bare `http(s)` URL in `body`, trailing punctuation trimmed."
@@ -292,11 +296,13 @@ defmodule Vutuv.Posts.Screenshots do
   end
 
   # A property of the target that won't change on retry: an SSRF-refused internal
-  # host, a link that redirects (`:redirect`), or a `4xx` non-200 answer
+  # host, a blocklisted host (`:blocked_host`, a login-walled site we never shoot),
+  # a link that redirects (`:redirect`), or a `4xx` non-200 answer
   # (`{:bad_status, _}`). Everything else — a `5xx` server error, an unreachable
   # probe, a missing/crashed/timed-out Chromium — is transient and retries with
   # backoff until the cap.
   defp permanent_failure?(:internal_target), do: true
+  defp permanent_failure?(:blocked_host), do: true
   defp permanent_failure?(:redirect), do: true
   defp permanent_failure?({:bad_status, _status}), do: true
   defp permanent_failure?(_reason), do: false

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.142.1",
+      version: "7.142.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/page_screenshot_test.exs
+++ b/test/vutuv/page_screenshot_test.exs
@@ -138,6 +138,45 @@ defmodule Vutuv.PageScreenshotTest do
     assert File.read!(args_file) =~ "--host-resolver-rules=MAP * 93.184.216.34"
   end
 
+  describe "host_blocked?/1 (screenshot blocklist)" do
+    test "matches the apex host and every subdomain of a blocklisted host" do
+      # config/config.exs ships reddit.com on the list.
+      assert Vutuv.PageScreenshot.host_blocked?("https://reddit.com/r/elixir")
+      assert Vutuv.PageScreenshot.host_blocked?("https://www.reddit.com/r/elixir")
+      assert Vutuv.PageScreenshot.host_blocked?("http://old.reddit.com/r/programming")
+    end
+
+    test "a host that is not on the list is not blocked" do
+      refute Vutuv.PageScreenshot.host_blocked?("https://example.com/page")
+      # A host that merely ends with the letters but is a different domain.
+      refute Vutuv.PageScreenshot.host_blocked?("https://notreddit.com/page")
+      refute Vutuv.PageScreenshot.host_blocked?("garbage-not-a-url")
+    end
+
+    test "the list is config-driven (a per-installation override is honoured)" do
+      previous = Application.get_env(:vutuv, :screenshot_blocked_hosts)
+      on_exit(fn -> Application.put_env(:vutuv, :screenshot_blocked_hosts, previous) end)
+      Application.put_env(:vutuv, :screenshot_blocked_hosts, ["blocked.example"])
+
+      assert Vutuv.PageScreenshot.host_blocked?("https://blocked.example/x")
+      refute Vutuv.PageScreenshot.host_blocked?("https://reddit.com/r/elixir")
+    end
+  end
+
+  test "capture_framed refuses a blocklisted host before resolving or launching Chromium" do
+    args_file =
+      Path.join(System.tmp_dir!(), "chromium-args-#{System.unique_integer([:positive])}")
+
+    on_exit(fn -> File.rm(args_file) end)
+    Application.put_env(:vutuv, :chromium_path, fake_chromium(args_file))
+
+    assert {:error, :blocked_host} =
+             Vutuv.PageScreenshot.capture_framed("https://reddit.com/r/elixir", "cap3")
+
+    # No DNS resolve, no Chromium spawn — the whole point is spending nothing.
+    refute File.exists?(args_file)
+  end
+
   test "capture_framed refuses a host that resolves to an internal IP before launching Chromium" do
     Application.put_env(:vutuv, :ssrf_resolver, fn _host, _family -> {:ok, [{10, 0, 0, 5}]} end)
 

--- a/test/vutuv/posts/screenshots_test.exs
+++ b/test/vutuv/posts/screenshots_test.exs
@@ -107,6 +107,37 @@ defmodule Vutuv.Posts.ScreenshotsTest do
       url = own_url("/some-profile")
       assert Screenshots.qualifying_url(%Posts.Post{images: [], body: url}) == {:ok, url}
     end
+
+    test "does not qualify: a screenshot-blocklisted host (reddit.com + subdomains)" do
+      # config/config.exs ships reddit.com on :screenshot_blocked_hosts; a
+      # single-URL post pointing at it must not enqueue a job — the capture would
+      # only ever be reddit's login/consent wall.
+      for url <- ~w(
+            https://reddit.com/r/elixir
+            https://www.reddit.com/r/elixir/comments/abc
+            https://old.reddit.com/r/programming
+          ) do
+        assert Screenshots.qualifying_url(%Posts.Post{images: [], body: url}) == :none,
+               "expected #{url} to be excluded from screenshotting"
+      end
+    end
+
+    test "the blocklist is config-driven and honours a per-installation override" do
+      previous = Application.get_env(:vutuv, :screenshot_blocked_hosts)
+      on_exit(fn -> Application.put_env(:vutuv, :screenshot_blocked_hosts, previous) end)
+      Application.put_env(:vutuv, :screenshot_blocked_hosts, ["example.com"])
+
+      assert Screenshots.qualifying_url(%Posts.Post{
+               images: [],
+               body: "https://example.com/page"
+             }) == :none
+
+      # A host no longer on the (overridden) list qualifies again.
+      assert Screenshots.qualifying_url(%Posts.Post{
+               images: [],
+               body: "https://reddit.com/r/elixir"
+             }) == {:ok, "https://reddit.com/r/elixir"}
+    end
   end
 
   describe "ensure_http_ok/1 (HTTP-200 probe)" do
@@ -293,6 +324,18 @@ defmodule Vutuv.Posts.ScreenshotsTest do
       {:ok, _job} = Screenshots.reconcile(post)
 
       Screenshots.deliver_due(force: true, capture: fn _ -> {:error, :internal_target} end)
+
+      assert Repo.get_by!(PostScreenshot, post_id: post.id).status == "failed"
+    end
+
+    test "a blocklisted-host refusal fails permanently (a stale row is never retried)" do
+      # `qualify/1` keeps a blocklisted URL from ever enqueuing, but a row queued
+      # before the host was blocklisted could still reach capture — it must die
+      # at once, not burn five retries on a shot that can't work.
+      post = url_post(user())
+      {:ok, _job} = Screenshots.reconcile(post)
+
+      Screenshots.deliver_due(force: true, capture: fn _ -> {:error, :blocked_host} end)
 
       assert Repo.get_by!(PostScreenshot, post_id: post.id).status == "failed"
     end


### PR DESCRIPTION
**TL;DR** A single reddit.com/r/… link in a post queued an auto-screenshot, but reddit serves a login/consent wall to headless capture — the shot is always a useless placeholder. A `:screenshot_blocked_hosts` blocklist (default `["reddit.com"]`) now skips such hosts before any Chromium run, in both screenshot subsystems.

**Where:** `Vutuv.PageScreenshot` (profile links) + `Vutuv.Posts.Screenshots` (single-link posts); config in `config/config.exs` + `config/runtime.exs`.

**Now:** a reddit post burns a Chromium run, an HTTP probe and up to five retries capturing a login wall.

**Want:** blocklisted hosts are skipped with zero compute.

### How
- `Vutuv.PageScreenshot.host_blocked?/1` matches the apex host **and** every subdomain, so one entry covers `old.`/`www.`/`np.reddit.com`. `capture_framed/2` refuses a blocklisted host with `:blocked_host` before resolving DNS or launching Chromium; the profile-link path flags the URL `broken?` so the bulk task never retries.
- The post path skips the job entirely at `qualifying_url/1` (pure request-path check, so no row is even created) and treats `:blocked_host` as a permanent failure, so a row queued before a host was blocklisted dies at once.

### Config
- `:screenshot_blocked_hosts`, default `["reddit.com"]`.
- Runtime override `SCREENSHOT_BLOCKED_HOSTS` (comma-separated) so third-party installations tune it without a source edit. Documented in `docs/ADMINS.md` + the `images.md` / `posts-and-feed.md` architecture docs.

### Tests
Detection, config-override, subdomain match, suffix non-match (`notreddit.com`), unparseable-string non-match, "no Chromium spawn for a blocked host", and "stale blocklisted row fails permanently" — added to `screenshots_test.exs` and `page_screenshot_test.exs`. Full `mix precommit` green (4670 tests).

Motivating post: https://vutuv.de/nikolaus_schuel/posts/019f9311-2794-7e87-bb52-e8034e546670

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*