### PR TITLE
Job board: filter by several individual tags (#951)

### DIFF
--- a/docs/architecture/jobs.md
+++ b/docs/architecture/jobs.md
@@ -152,10 +152,21 @@ and the crawl path — the board is a shared-footer + top-bar nav link). PubSub
   keyset-paginated (`%{entries:, more?:, cursor:}`; the web layer signs the
   `{first_published_at, id}` cursor with `VutuvWeb.ApiV2`).
 - **Filters** (all URL params): `q` (Postgres full-text over title +
-  description; see the search grammar below), `tag` (slug), `workplace`, `employment`,
+  description; see the search grammar below), `tag`, `workplace`, `employment`,
   `salary_min` (+ currency — same-currency only, the posting's yearly-normalised
   `salary_max` must reach the floor), `near` + `radius` + `country` (location),
   and the signed-in-member chip `my_tags` ("Passend zu meinen Tags").
+- **Tag filter, multi-select (issue #951).** `tag` is a **comma-separated list
+  of slugs** (`?tag=elixir,phoenix`); a single slug is the degenerate case, so
+  old `?tag=elixir` links and the tag-page/card links still work. Semantics are
+  **OR** (`filter_tags/2`: a posting matches when it carries *any* selected
+  tag), so adding a tag broadens — the standard board facet, consistent with the
+  `my_tags` chip. The board renders each active tag as a removable pill and
+  offers the current results' other tags as one-tap `+` suggestions; a free-text
+  `add_tag` field (native `<datalist>` typeahead) resolves a typed name to its
+  canonical slug (`Tag.find_by_value/1`) and folds it into `tag` in `mount` (an
+  unknown name is dropped — only existing tags can filter). The transient
+  `add_tag` never reaches a link.
 - **Salary filter, two ways in (issue #953).** A `salary_min` number field
   ("Mindestgehalt/Jahr", `#job-salary-min`) is open to **every** viewer —
   logged out, or a member with no #928 expectation — and files a bare yearly

--- a/lib/vutuv/jobs.ex
+++ b/lib/vutuv/jobs.ex
@@ -965,7 +965,7 @@ defmodule Vutuv.Jobs do
   def board_filters(raw, viewer) when is_map(raw) do
     %{
       q: presence(raw["q"]),
-      tag: presence(raw["tag"]),
+      tags: parse_board_tags(raw["tag"]),
       workplace: parse_workplace(raw["workplace"]),
       employment: parse_employment(raw["employment"]),
       near: presence(raw["near"]),
@@ -994,6 +994,20 @@ defmodule Vutuv.Jobs do
   end
 
   defp put_filter_salary(filters, _value, _user), do: filters
+
+  # The board's `tag` param is a comma-separated list of tag slugs (issue #951):
+  # one slug is the common shareable link (`?tag=elixir`), several the
+  # multiselect filter (`?tag=elixir,phoenix`). Split, trim, drop blanks and
+  # dedupe into the OR list `filter_tags/2` applies. `nil`/blank -> [].
+  defp parse_board_tags(value) when is_binary(value) do
+    value
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  defp parse_board_tags(_value), do: []
 
   defp parse_workplace(value) when value in ["onsite", "hybrid", "remote"],
     do: String.to_existing_atom(value)
@@ -1055,7 +1069,7 @@ defmodule Vutuv.Jobs do
   defp apply_board_filters(query, filters, viewer) do
     query
     |> filter_q(filters[:q])
-    |> filter_tag(filters[:tag])
+    |> filter_tags(filters[:tags])
     |> filter_workplace(filters[:workplace])
     |> filter_employment(filters[:employment])
     |> filter_location(filters[:near], filters[:radius], filters[:country])
@@ -1088,18 +1102,22 @@ defmodule Vutuv.Jobs do
 
   defp filter_q(query, _q), do: query
 
-  defp filter_tag(query, slug) when is_binary(slug) and slug != "" do
+  # OR semantics (issue #951): a posting matches when it carries **any** of the
+  # selected tag slugs, so adding a tag broadens the results (the standard
+  # job-board multiselect facet, and consistent with the "matches my tags"
+  # chip). A single slug is the degenerate one-element list.
+  defp filter_tags(query, slugs) when is_list(slugs) and slugs != [] do
     tagged =
       from(jpt in JobPostingTag,
         join: t in assoc(jpt, :tag),
-        where: t.slug == ^slug,
+        where: t.slug in ^slugs,
         select: jpt.job_posting_id
       )
 
     where(query, [p], p.id in subquery(tagged))
   end
 
-  defp filter_tag(query, _slug), do: query
+  defp filter_tags(query, _slugs), do: query
 
   defp filter_workplace(query, type) when type in [:onsite, :hybrid, :remote],
     do: where(query, [p], p.workplace_type == ^type)

--- a/lib/vutuv_web/live/job_board_live.ex
+++ b/lib/vutuv_web/live/job_board_live.ex
@@ -24,6 +24,7 @@ defmodule VutuvWeb.JobBoardLive do
   alias Vutuv.Jobs
   alias Vutuv.Jobs.JobPosting
   alias Vutuv.Salary
+  alias Vutuv.Tags.Tag
   alias VutuvWeb.ApiV2
   alias VutuvWeb.Live.InitAssigns
 
@@ -34,7 +35,10 @@ defmodule VutuvWeb.JobBoardLive do
 
     if connected?(socket), do: Jobs.subscribe_board()
 
-    raw = session["params"] || %{}
+    # Fold a submitted free-text tag (issue #951) into the canonical comma
+    # list before anything reads it, so the filter and the shareable link both
+    # see one `tag` param and the transient `add_tag` never lingers in links.
+    raw = fold_add_tag(session["params"] || %{})
 
     {:ok,
      socket
@@ -58,6 +62,26 @@ defmodule VutuvWeb.JobBoardLive do
     |> assign(:engagement, Jobs.board_engagement_map(page.entries, user))
     |> assign(:more?, page.more?)
     |> assign(:next_cursor, page.cursor && ApiV2.encode_cursor(page.cursor))
+    |> assign_tag_suggestions(page.entries)
+  end
+
+  # Tags to offer as one-tap additions to the filter (issue #951), drawn from
+  # the tags on the current results and minus the ones already selected. In
+  # memory off the preloaded postings, so no extra query; capped so the row
+  # stays a hint, not a wall.
+  @tag_suggestion_limit 10
+
+  defp assign_tag_suggestions(socket, postings) do
+    selected = MapSet.new(tag_slugs(socket.assigns.params))
+
+    suggestions =
+      postings
+      |> Enum.flat_map(&tag_list/1)
+      |> Enum.uniq_by(& &1.slug)
+      |> Enum.reject(&MapSet.member?(selected, &1.slug))
+      |> Enum.take(@tag_suggestion_limit)
+
+    assign(socket, :tag_suggestions, suggestions)
   end
 
   # --- events ---------------------------------------------------------------
@@ -135,6 +159,47 @@ defmodule VutuvWeb.JobBoardLive do
   defp active?(params, key, value), do: params[key] == value
   defp any_filters?(params), do: params != %{}
 
+  # --- multi-tag filter (issue #951) ----------------------------------------
+
+  # The active tag slugs: the board's `tag` param is a comma-separated list.
+  defp tag_slugs(params) do
+    case params["tag"] do
+      value when is_binary(value) -> String.split(value, ",", trim: true)
+      _ -> []
+    end
+  end
+
+  # Params with `slug` appended to the tag list (a suggestion chip) or removed
+  # from it (a pill's ✕).
+  defp add_tag(params, slug), do: put_tags(params, tag_slugs(params) ++ [slug])
+  defp drop_tag(params, slug), do: put_tags(params, tag_slugs(params) -- [slug])
+
+  # Write the tag list back as a canonical comma param, or drop it when empty.
+  defp put_tags(params, slugs) do
+    case slugs |> Enum.reject(&(&1 == "")) |> Enum.uniq() do
+      [] -> Map.delete(params, "tag")
+      list -> Map.put(params, "tag", Enum.join(list, ","))
+    end
+  end
+
+  # Fold a submitted free-text `add_tag` (a tag name or slug) into the `tag`
+  # list. Only tags that actually exist can filter, so an unknown value is
+  # dropped; a match is stored by its canonical slug. Runs once in mount so the
+  # transient param never reaches a link.
+  defp fold_add_tag(raw) do
+    typed = raw["add_tag"]
+    raw = Map.drop(raw, ["add_tag"])
+
+    case is_binary(typed) && String.trim(typed) do
+      "" -> raw
+      false -> raw
+      value -> add_typed_tag(raw, Tag.find_by_value(value))
+    end
+  end
+
+  defp add_typed_tag(raw, %{slug: slug}), do: add_tag(raw, slug)
+  defp add_typed_tag(raw, _), do: raw
+
   # --- render ---------------------------------------------------------------
 
   @impl true
@@ -157,7 +222,7 @@ defmodule VutuvWeb.JobBoardLive do
         </.link>
       </div>
 
-      <.search_form params={@params} filters={@filters} />
+      <.search_form params={@params} filters={@filters} suggestions={@tag_suggestions} />
 
       <div id="job-filter-chips" class="mt-3 -mx-4 flex gap-2 overflow-x-auto px-4 pb-1 [scrollbar-width:none]">
         <.link
@@ -201,15 +266,35 @@ defmodule VutuvWeb.JobBoardLive do
         class="mt-3"
       />
 
-      <p :if={@params["tag"]} class="mt-3 text-sm text-slate-600 dark:text-slate-400">
-        {gettext("Tag")}:
+      <%!-- Active tag filters as removable pills, and one-tap suggestions drawn
+      from the current results (issue #951). Each pill's ✕ drops just that tag;
+      the whole `tag` param is comma-separated and shareable. --%>
+      <div
+        :if={tag_slugs(@params) != [] or @tag_suggestions != []}
+        id="job-tag-filters"
+        class="mt-3 flex flex-wrap items-center gap-2 text-sm text-slate-600 dark:text-slate-400"
+      >
+        <span :if={tag_slugs(@params) != []} class="font-medium">{gettext("Tags")}:</span>
         <.link
-          navigate={~p"/jobs?#{Map.delete(@params, "tag")}"}
+          :for={slug <- tag_slugs(@params)}
+          navigate={~p"/jobs?#{drop_tag(@params, slug)}"}
+          data-active-tag={slug}
           class="inline-flex items-center gap-1 rounded-lg bg-brand-50 px-2.5 py-1 font-medium text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
         >
-          {@params["tag"]} <span aria-hidden="true">✕</span>
+          {slug} <span aria-hidden="true">✕</span>
         </.link>
-      </p>
+
+        <span :if={tag_slugs(@params) != [] and @tag_suggestions != []} class="text-slate-400">·</span>
+
+        <.link
+          :for={tag <- @tag_suggestions}
+          navigate={~p"/jobs?#{add_tag(@params, tag.slug)}"}
+          data-suggest-tag={tag.slug}
+          class="inline-flex items-center gap-1 rounded-lg px-2.5 py-1 font-medium text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50 hover:text-slate-800 dark:text-slate-300 dark:ring-slate-700 dark:hover:bg-slate-800"
+        >
+          <span aria-hidden="true">+</span> {tag.name}
+        </.link>
+      </div>
 
       <div :if={@postings == []} class="mt-6 rounded-2xl bg-white p-8 text-center shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
         <p class="text-sm text-slate-600 dark:text-slate-400">{empty_line(@params)}</p>
@@ -245,6 +330,7 @@ defmodule VutuvWeb.JobBoardLive do
 
   attr(:params, :map, required: true)
   attr(:filters, :map, required: true)
+  attr(:suggestions, :list, default: [])
 
   defp search_form(assigns) do
     ~H"""
@@ -288,6 +374,24 @@ defmodule VutuvWeb.JobBoardLive do
           {label}
         </option>
       </select>
+
+      <%!-- Free-text tag filter (issue #951): type a tag to add it to the
+            comma-separated `tag` list on submit. Starts blank (an "add" field,
+            not a stored value); the datalist offers the current results' tags
+            as native typeahead, no JS. Only existing tags filter, so an unknown
+            value is silently dropped server-side. --%>
+      <input
+        type="text"
+        name="add_tag"
+        list="job-tag-options"
+        value=""
+        placeholder={gettext("Add a tag")}
+        aria-label={gettext("Filter by a tag")}
+        class={input_class()}
+      />
+      <datalist :if={@suggestions != []} id="job-tag-options">
+        <option :for={tag <- @suggestions} value={tag.name}></option>
+      </datalist>
 
       <%!-- Free minimum-salary filter, open to everyone (issue #953). While the
             "from my expectation" chip drives it, the field is disabled and a

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -4895,6 +4895,11 @@ msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 msgid "Add a tag"
 msgstr "Tag hinzufügen"
 
+#: lib/vutuv_web/live/job_board_live.ex:314
+#, elixir-autogen, elixir-format
+msgid "Filter by a tag"
+msgstr "Nach einem Tag filtern"
+
 #: lib/vutuv_web/live/search_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, or posts"

--- a/test/vutuv/jobs_board_test.exs
+++ b/test/vutuv/jobs_board_test.exs
@@ -112,7 +112,28 @@ defmodule Vutuv.JobsBoardTest do
     end
 
     test "tag filters to postings carrying the slug", %{elixir: elixir} do
-      assert ids(Jobs.board_page(nil, %{tag: "phoenix"})) == [elixir.id]
+      assert ids(Jobs.board_page(nil, %{tags: ["phoenix"]})) == [elixir.id]
+    end
+
+    # Issue #951: the tag filter takes several slugs now, OR between them (a
+    # posting matches when it carries ANY of them), so adding a tag broadens.
+    test "several tags OR: a posting carrying any of them matches", %{elixir: elixir, java: java} do
+      both = Jobs.board_page(nil, %{tags: ["phoenix", "java"]}) |> ids() |> Enum.sort()
+      assert both == Enum.sort([elixir.id, java.id])
+    end
+
+    test "board_filters parses a comma-separated tag param into the OR list", %{
+      elixir: elixir,
+      java: java
+    } do
+      # A shareable ?tag=phoenix,java URL.
+      filters = Jobs.board_filters(%{"tag" => "phoenix,java"}, nil)
+      both = Jobs.board_page(nil, filters) |> ids() |> Enum.sort()
+      assert both == Enum.sort([elixir.id, java.id])
+
+      # A single ?tag=phoenix still works (backward compatible).
+      single = Jobs.board_filters(%{"tag" => "phoenix"}, nil)
+      assert ids(Jobs.board_page(nil, single)) == [elixir.id]
     end
 
     test "workplace and employment type filter", %{elixir: elixir, java: java} do

--- a/test/vutuv_web/live/job_board_live_test.exs
+++ b/test/vutuv_web/live/job_board_live_test.exs
@@ -104,6 +104,69 @@ defmodule VutuvWeb.JobBoardLiveTest do
     assert render(view) =~ "Just appeared"
   end
 
+  describe "tag filter (issue #951)" do
+    setup do
+      poster = poster_fixture()
+
+      elixir =
+        publish_job!(poster, %{"title" => "Elixir Engineer", "required_tags" => "Elixir, Phoenix"})
+
+      java = publish_job!(poster, %{"title" => "Java Developer", "required_tags" => "Java"})
+      %{elixir: elixir, java: java}
+    end
+
+    test "several tags OR: shows postings carrying any of them, each a removable pill", %{
+      conn: conn
+    } do
+      {:ok, view, html} = live(conn, ~p"/jobs?#{[tag: "elixir,java"]}")
+
+      assert html =~ "Elixir Engineer"
+      assert html =~ "Java Developer"
+      assert has_element?(view, "[data-active-tag='elixir']")
+      assert has_element?(view, "[data-active-tag='java']")
+    end
+
+    test "a single ?tag= still works (backward compatible)", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/jobs?#{[tag: "elixir"]}")
+
+      assert html =~ "Elixir Engineer"
+      refute html =~ "Java Developer"
+    end
+
+    test "the free-text add_tag field folds a typed name into the tag list", %{conn: conn} do
+      # On Elixir already; add "Java" by name -> both match, both pills show.
+      {:ok, view, html} = live(conn, ~p"/jobs?#{[tag: "elixir", add_tag: "Java"]}")
+
+      assert html =~ "Elixir Engineer"
+      assert html =~ "Java Developer"
+      assert has_element?(view, "[data-active-tag='java']")
+    end
+
+    test "an unknown add_tag value is dropped, not applied", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/jobs?#{[add_tag: "does-not-exist-xyz"]}")
+
+      # No filter applied -> both postings still show.
+      assert html =~ "Elixir Engineer"
+      assert html =~ "Java Developer"
+    end
+
+    test "offers unselected result tags as one-tap suggestions", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/jobs")
+
+      assert has_element?(view, "[data-suggest-tag='elixir']")
+      assert has_element?(view, "[data-suggest-tag='java']")
+    end
+
+    test "a selected tag drops out of the suggestions", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/jobs?#{[tag: "elixir"]}")
+
+      # Elixir is selected (so it is not suggested), Phoenix co-occurs on the
+      # one matching posting and is offered as a refinement.
+      refute has_element?(view, "[data-suggest-tag='elixir']")
+      assert has_element?(view, "[data-suggest-tag='phoenix']")
+    end
+  end
+
   describe "salary field (#953)" do
     test "everyone gets a minimum-salary input, even logged out", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/jobs")


### PR DESCRIPTION
Closes #951. Follow-up to #933.

The board's tag filter took a single slug (`?tag=elixir`); you could not narrow to a set of individual tags that may or may not be on your profile. This makes it a **multi-select**.

## What
- **`tag` is now a comma-separated list of slugs** (`?tag=elixir,phoenix`). **OR** semantics (`filter_tags/2`): a posting matches when it carries **any** selected tag, so adding a tag broadens — the standard board facet, and consistent with the existing "Matches my tags" chip. (Chosen over AND after a quick check with Stefan.)
- A single `?tag=elixir` is the degenerate one-element case, so **old links and the tag-page / card links keep working**.
- **UI** (all URL-driven and shareable — the board is off-router, filter state lives in the URL):
  - each active tag is a **removable pill** (its ✕ drops just that tag),
  - the current results' other tags are offered as one-tap **`+` suggestions**,
  - a free-text **`add_tag`** field with a native `<datalist>` typeahead (no JS) resolves a typed name to its canonical slug (`Tag.find_by_value/1`) and folds it into `tag` in `mount`; an unknown name is dropped (only existing tags can filter), and the transient `add_tag` never lingers in a link.

## Scope note
Card tag chips stay a single-tag "jump to this tag" (unchanged), so `job_card` needs no board-params threading; the board's own pills + suggestions are the multi-select surface. The saved-search sweeper and the `/api/2.0` job list inherit the multi-tag parsing through the shared `board_filters/2` automatically.

## Tests
- OR over several tags; single-tag backward compatibility; the `add_tag` fold (typed name → slug); unknown `add_tag` dropped; suggestions shown/hidden per selection.
- `docs/architecture/jobs.md` updated. German copy added. `mix precommit` green (4671 passed).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_014VdhLKS68PKfE4NBcW1KD7