### PR TITLE
Bound two unauthenticated resource-exhaustion vectors (CV socket, ReDoS)

### DIFF
--- a/lib/vutuv/web_address.ex
+++ b/lib/vutuv/web_address.ex
@@ -73,6 +73,18 @@ defmodule Vutuv.WebAddress do
       iex> Vutuv.WebAddress.link_only?("???")
       false
   """
+  # ReDoS guard (F20): `strip_addresses/1` runs nine unanchored regexes with
+  # greedy/lazy quantifiers, whose bump-along is O(n²) in the input length, and
+  # `link_only?/1` is reached with length-unvalidated `user[headline]` and
+  # `user[tag_list]` tokens from the unauthenticated POST /new_registration. A
+  # value longer than its varchar(255) column can never be stored, so it is
+  # never a valid "names only a link" value — reject it before the regex battery
+  # runs. The bound is in bytes because it must cap the *regex input*, and a
+  # varchar(255) value holds at most 255 characters, i.e. at most 255 × 4 = 1020
+  # UTF-8 bytes; so >1020 bytes is never a storable value and no legitimate
+  # (≤255-character) input, multi-byte included, changes result.
+  def link_only?(text) when is_binary(text) and byte_size(text) > 255 * 4, do: false
+
   def link_only?(text) when is_binary(text) do
     case String.trim(text) do
       "" ->

--- a/lib/vutuv_web/endpoint.ex
+++ b/lib/vutuv_web/endpoint.ex
@@ -12,7 +12,16 @@ defmodule VutuvWeb.Endpoint do
     max_age: 7_776_000
   ]
 
-  socket("/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]])
+  # Cap a single websocket frame so no client can push an arbitrarily large
+  # payload over the LiveView socket (Phoenix's default is "infinity"). 1 MB
+  # clears every legitimate flow — LiveView uploads chunk at 64 kB, and the
+  # largest composer draft (a 20,000-character post body, worst case ~80 kB of
+  # UTF-8) rides well under it — while bounding a hostile frame. Only a single
+  # frame above 1 MB (an oversized paste far past the 20,000-char post limit, or
+  # a malicious payload) now closes the connection to reconnect.
+  socket("/live", Phoenix.LiveView.Socket,
+    websocket: [connect_info: [session: @session_options], max_frame_size: 1_000_000]
+  )
 
   # In dev, serve static assets with `cache-control: no-cache` so the browser
   # always revalidates against the ETag after a Tailwind rebuild (a 304 when the

--- a/lib/vutuv_web/live/cv_live.ex
+++ b/lib/vutuv_web/live/cv_live.ex
@@ -38,6 +38,8 @@ defmodule VutuvWeb.CVLive do
     # short "CV" from the template.
     name = full_name(user)
 
+    cv = CV.build(user, viewer: current_user, photo: true)
+
     socket =
       socket
       |> assign(:user, user)
@@ -49,21 +51,21 @@ defmodule VutuvWeb.CVLive do
           name: name
         )
       )
-      |> assign(:cv, CV.build(user, viewer: current_user, photo: true))
+      |> assign(:cv, cv)
+      |> assign(:allowed_keys, allowed_keys(cv))
       |> put_hide(MapSet.new())
 
     {:ok, socket}
   end
 
+  # The public `/:slug/cv` socket must never accumulate arbitrary client strings.
+  # A CV offers only a few hundred toggleable keys, so this is generous headroom
+  # while a hard backstop against the hide set growing without bound (F12).
+  @max_hide_keys 500
+
   @impl true
   def handle_event("toggle", %{"key" => key}, socket) do
-    hide = socket.assigns.hide
-
-    hide =
-      if MapSet.member?(hide, key),
-        do: MapSet.delete(hide, key),
-        else: MapSet.put(hide, key)
-
+    hide = apply_toggle(socket.assigns.hide, key, socket.assigns.allowed_keys)
     {:noreply, put_hide(socket, hide)}
   end
 
@@ -75,6 +77,45 @@ defmodule VutuvWeb.CVLive do
   def handle_event("reset", _params, socket) do
     {:noreply, put_hide(socket, MapSet.new())}
   end
+
+  @doc """
+  The include/exclude toggle at the heart of `handle_event("toggle", …)`, kept
+  pure so both belt-and-braces guards are unit-testable without a giant CV: a
+  `key` the current CV does not offer (`allowed_keys`) is ignored, an offered
+  key flips, and the hide set is never grown past `@max_hide_keys` (F12).
+  """
+  def apply_toggle(hide, key, allowed_keys) do
+    cond do
+      not MapSet.member?(allowed_keys, key) -> hide
+      MapSet.member?(hide, key) -> MapSet.delete(hide, key)
+      MapSet.size(hide) >= @max_hide_keys -> hide
+      true -> MapSet.put(hide, key)
+    end
+  end
+
+  # Every key the loaded CV can legitimately toggle, built from the CV itself so
+  # it always matches what the template renders: the identity fields, the section
+  # and card heading keys, and every single entry/skill/link/qualification/
+  # language/social-media id. Any other key is a no-op (F12). The CV is built
+  # once at mount and never rebuilt for the socket's life, so this is computed
+  # once too.
+  defp allowed_keys(cv) do
+    identity = for {key, _field} <- CV.identity_fields(), do: key
+    card_keys = ~w(tags links qualifications languages social_media)
+    section_keys = for section <- cv.sections, do: section.key
+
+    entry_ids =
+      Enum.flat_map(cv.sections, fn section -> Enum.map(section.entries, & &1.id) end) ++
+        ids(cv.skills) ++
+        ids(cv.links) ++
+        ids(cv.qualifications) ++
+        ids(cv.languages) ++
+        ids(cv.social_media)
+
+    MapSet.new(identity ++ card_keys ++ section_keys ++ entry_ids)
+  end
+
+  defp ids(list), do: Enum.map(list, & &1.id)
 
   # Recompute the download query whenever the selection changes, so every
   # link in the render reflects the current include/exclude set.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.142.1",
+      version: "7.142.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/web_address_test.exs
+++ b/test/vutuv/web_address_test.exs
@@ -72,4 +72,42 @@ defmodule Vutuv.WebAddressTest do
       for junk <- ["-", ".", "????????", "!!!"], do: refute(WebAddress.link_only?(junk))
     end
   end
+
+  describe "link_only?/1 caps its input before the regex battery (F20)" do
+    test "a value longer than the varchar(255) column is refused outright" do
+      # A single long URL is link-only when it fits the column, but a value too
+      # long to ever be a stored headline or tag is short-circuited to false —
+      # the guard flips this exact result, so the test fails without it.
+      short_url = "https://example.com/cv"
+      assert WebAddress.link_only?(short_url) == true
+
+      over_limit = "https://example.com/" <> String.duplicate("a", 2_000)
+      assert WebAddress.link_only?(over_limit) == false
+    end
+
+    test "a ~1 MB free-text payload returns false fast, not after an O(n²) scan" do
+      # The pathological ReDoS input the finding describes: length-unvalidated
+      # free text ending in a slash. Without the guard each of the nine
+      # unanchored patterns bump-alongs at O(n²) over ~1 MB; with it the byte
+      # cap returns instantly. Assert both the result and that it is fast.
+      giant = String.duplicate("a", 1_000_000) <> "/"
+
+      {micros, result} = :timer.tc(fn -> WebAddress.link_only?(giant) end)
+
+      assert result == false
+      assert micros < 100_000, "expected a fast short-circuit, took #{micros}µs"
+    end
+
+    test "a storable multi-byte link-only value is still caught, not clipped by the byte cap" do
+      # A value can be ≤255 *characters* (so it fits varchar(255)) yet exceed
+      # 255 *bytes* when it uses multi-byte characters. Such a value is still
+      # storable, so a link-only one must still be refused — the byte cap sits
+      # above any storable value's byte size (255 chars × 4 = 1020) precisely so
+      # it is not clipped. A naive 255-*byte* cap would wrongly accept this.
+      multibyte_url = "https://" <> String.duplicate("ü", 240) <> ".de"
+      assert String.length(multibyte_url) <= 255
+      assert byte_size(multibyte_url) > 255
+      assert WebAddress.link_only?(multibyte_url) == true
+    end
+  end
 end

--- a/test/vutuv_web/live/cv_live_test.exs
+++ b/test/vutuv_web/live/cv_live_test.exs
@@ -10,6 +10,7 @@ defmodule VutuvWeb.CVLiveTest do
 
   alias Vutuv.Profiles.WorkExperience
   alias Vutuv.Repo
+  alias VutuvWeb.CVLive
 
   defp seed(user) do
     insert(:work_experience,
@@ -141,6 +142,72 @@ defmodule VutuvWeb.CVLiveTest do
 
       assert has_element?(view, "#cv-download-docx")
       assert has_element?(view, "#cv-download-json")
+    end
+  end
+
+  # The CV page is public (no login), so a raw phx "toggle" event — bypassing
+  # the rendered checkboxes — must not let a client store arbitrary strings in
+  # the socket's :hide set and re-sort/re-join them into six download hrefs on
+  # every event (F12: an unbounded-accumulation DoS).
+  describe "the toggle event is hardened against arbitrary client keys (F12)" do
+    setup :owner
+
+    test "a toggle for a key the CV does not offer is ignored", %{conn: conn, owner: owner} do
+      {:ok, view, _html} = live(conn, ~p"/#{owner}/cv")
+
+      # Baseline: the full CV downloads carry no ?hide=.
+      assert has_element?(view, "#cv-download-docx[href='/#{owner.username}/cv/download/docx']")
+
+      # A raw phx event carrying an arbitrary multi-KB key is a no-op: nothing is
+      # stored, the query is unchanged, so no download link gains a ?hide=.
+      render_hook(view, "toggle", %{"key" => String.duplicate("x", 5_000)})
+
+      assert has_element?(view, "#cv-download-docx[href='/#{owner.username}/cv/download/docx']")
+      refute has_element?(view, "#cv-download-docx[href*='hide=']")
+    end
+
+    test "a toggle for a real CV key still toggles it", %{conn: conn, owner: owner} do
+      {:ok, view, _html} = live(conn, ~p"/#{owner}/cv")
+
+      render_hook(view, "toggle", %{"key" => "name"})
+      assert has_element?(view, "#cv-download-docx[href*='hide=name']")
+    end
+  end
+
+  describe "apply_toggle/3 (the pure toggle core)" do
+    test "ignores a key the CV does not offer" do
+      allowed = MapSet.new(["name", "photo"])
+      assert CVLive.apply_toggle(MapSet.new(), "bogus", allowed) == MapSet.new()
+    end
+
+    test "flips an offered key on and back off" do
+      allowed = MapSet.new(["name"])
+
+      on = CVLive.apply_toggle(MapSet.new(), "name", allowed)
+      assert MapSet.member?(on, "name")
+
+      off = CVLive.apply_toggle(on, "name", allowed)
+      refute MapSet.member?(off, "name")
+    end
+
+    test "refuses to grow the hide set past the cap" do
+      # 600 legitimate keys on offer, but the set can never hold more than 500.
+      allowed = MapSet.new(for i <- 0..599, do: "k#{i}")
+
+      full =
+        Enum.reduce(0..599, MapSet.new(), fn i, acc ->
+          CVLive.apply_toggle(acc, "k#{i}", allowed)
+        end)
+
+      assert MapSet.size(full) == 500
+
+      # A further offered, not-yet-hidden key is refused once the cap is hit...
+      next = Enum.find(0..599, fn i -> not MapSet.member?(full, "k#{i}") end)
+      assert CVLive.apply_toggle(full, "k#{next}", allowed) == full
+
+      # ...but removing an already-hidden key still works at the cap.
+      [some | _] = MapSet.to_list(full)
+      refute MapSet.member?(CVLive.apply_toggle(full, some, allowed), some)
     end
   end
 end


### PR DESCRIPTION
**TL;DR** Two MEDIUM scan findings, both letting an unauthenticated request drive superlinear CPU or unbounded memory. Batch 2 of the remaining scan mediums. (F15, also in this batch originally, was already closed by #1044's SSRF work.)

**F12 — CV LiveView socket state.** The public `/:slug/cv` view stored the client `toggle` `key` verbatim in a MapSet with no validation or cap, re-sorting/re-joining it into six hrefs on every event. Raw phx events could push distinct multi-KB keys, held for the socket's life → O(N²) CPU, O(N) memory per connection. Now validates `key` against an allow-list derived from the loaded CV, caps the set at 500 (un-hiding always works), and sets an explicit `max_frame_size: 1_000_000` on `/live` (was "infinity") — which clears every legitimate frame (uploads chunk at 64 KB, largest post body ~80 KB).

**F20 — ReDoS in `WebAddress.link_only?/1`.** Nine unanchored regexes ran over length-unvalidated headline/tag text from the unauthenticated `POST /new_registration`; the changeset's length error doesn't stop the pipeline, so ~1 MB of filler reached the regex battery for ~10¹¹ char-steps per pattern. Now short-circuits to `false` for input >1020 bytes (255 chars × max 4 UTF-8 bytes = provably non-clipping for the varchar(255) columns). Every caller has an independent `max: 255` gate, so no stored outcome changes and no spam value slips past.

**Verification:** each fix ships a regression test that fails against the unpatched code; reviewed by an independent verifier and re-challenged by a fresh reviewer of the diff (which confirmed the 1 MB frame cap breaks no upload/composer flow and the length cap opens no spam-filter bypass). `mix precommit` green: Credo clean, 4671 tests.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01Dz1H9S965ie56hT4DQ6Gax