### PR TITLE
Personal content filters: mute tags & keywords (#940)

### DIFF
--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -86,3 +86,28 @@ The private list at `/blocks` also unblocks; unblocking restores nothing
 (deliberately unlike a rejected moderation report) but thaws the conversation
 its own block froze, unless a reverse block or an active report severance still
 stands
+
+## Content filters (muted words & tags)
+
+Topic-level muting, the third layer above per-follow mute and the block
+(issue #940): `Vutuv.ContentFilters` is a member's private, viewer-only deny
+list, managed at `/settings/filters` ("Muted words & tags"). Each
+`content_filters` row mutes a **tag** or a **keyword/phrase** (with `*`
+wildcards); keyword rows match the post body **and** its tags/hashtags, tag rows
+match the post's tags only.
+
+Unlike a muted follow (which drops a *person* out of the feed via the query),
+content filters run **after** the feed page is hydrated: the feed compiles the
+viewer's whole list once (`compile_for/1`) and asks `filtered_pattern/2` per post
+which filter, if any, hides it. A match does not vanish — the post collapses to a
+"Show anyway" line (`PostLive.Feed`, `data-filtered-post`), so a filtered post
+never silently shortens the feed or breaks a reply thread; the reveal is
+in-place and survives the midnight restream. The viewer's **own** posts are never
+filtered.
+
+Keyword matching is a compiled, case-insensitive regex (`compile_pattern/2`):
+`*` → "any run of characters", literal segments escaped, word-boundaries by
+default (so `cess` does not hide "success") except on a side opened with `*`.
+The list is owner-only — never public, never in the agent formats — capped
+(`ContentFilters.max_filters/0`), and rides along in the GDPR export. `expires_at`
+is a column reserved for a later "snooze" UI (not honored yet).

--- a/lib/vutuv/content_filters.ex
+++ b/lib/vutuv/content_filters.ex
@@ -1,0 +1,161 @@
+defmodule Vutuv.ContentFilters do
+  @moduledoc """
+  A member's private content filters (issue #940): the owner-only deny list that
+  hides matching posts from their own feed. Each entry mutes a **tag** or a
+  **keyword/phrase** (with `*` wildcards); see `Vutuv.ContentFilters.ContentFilter`.
+
+  The feed compiles a member's whole list once per page (`compile_for/1`) and
+  asks `filtered_pattern/2` per post which filter, if any, hides it — so the
+  post collapses to a "Show anyway" placeholder rather than vanishing (a
+  silently shorter feed confuses and breaks reply threads). It never filters the
+  member's own posts; that guard sits at the call site.
+
+  Nothing here is public: the list is the member's alone, one-directional, never
+  notifies, never reaches the agent formats, and rides along in the GDPR export.
+  """
+
+  import Ecto.Query
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.ContentFilters.ContentFilter
+  alias Vutuv.Repo
+
+  # A member cannot mute the whole world: cap the list so a runaway import (or a
+  # bored user) can't turn every feed page into a compile of hundreds of regexes.
+  @max_filters 200
+
+  @doc "The maximum number of filters one member may keep."
+  def max_filters, do: @max_filters
+
+  @doc "The member's filters, newest first. `[]` for a logged-out visitor."
+  def list_for_user(nil), do: []
+
+  def list_for_user(%User{id: user_id}) do
+    Repo.all(from(f in ContentFilter, where: f.user_id == ^user_id, order_by: [desc: f.id]))
+  end
+
+  @doc "How many filters the member already keeps (for the cap check + UI)."
+  def count_for_user(%User{id: user_id}) do
+    Repo.aggregate(from(f in ContentFilter, where: f.user_id == ^user_id), :count)
+  end
+
+  @doc "A blank changeset for the add form."
+  def change_filter(attrs \\ %{}), do: ContentFilter.changeset(%ContentFilter{}, attrs)
+
+  @doc """
+  Add a filter to `user`'s list. `user_id` is set here, never cast, so a request
+  can only add to its own list. Refuses past the cap.
+  """
+  def create_filter(%User{} = user, attrs) do
+    if count_for_user(user) >= @max_filters do
+      {:error, :too_many}
+    else
+      %ContentFilter{user_id: user.id}
+      |> ContentFilter.changeset(attrs)
+      |> Repo.insert()
+    end
+  end
+
+  @doc "Remove one of `user`'s filters. Scoped to the owner, so it can only drop their own."
+  def delete_filter(%User{id: user_id}, id) do
+    {count, _} =
+      Repo.delete_all(from(f in ContentFilter, where: f.id == ^id and f.user_id == ^user_id))
+
+    if count == 1, do: :ok, else: {:error, :not_found}
+  end
+
+  @doc """
+  Compile `user`'s list into the shape `filtered_pattern/2` matches against:
+
+      %{tags: %{"crypto" => "crypto", ...}, keywords: [{"crypto*", ~r/.../}, ...]}
+
+  Tags are keyed by their normalized (downcased) value so a post tag matches by
+  slug or by name; each maps back to the original pattern the placeholder shows.
+  Keywords carry their compiled regex. Returns the empty shape for a member with
+  no filters (or a logged-out visitor), so the caller can skip the work.
+  """
+  def compile_for(user) do
+    filters = list_for_user(user)
+
+    tags =
+      for %{kind: :tag, pattern: pattern} <- filters, into: %{} do
+        {String.downcase(pattern), pattern}
+      end
+
+    keywords =
+      for %{kind: :keyword, pattern: pattern, whole_word: whole_word} <- filters,
+          re = compile_pattern(pattern, whole_word),
+          re != nil do
+        {pattern, re}
+      end
+
+    %{tags: tags, keywords: keywords}
+  end
+
+  @doc "True when the compiled set has at least one filter."
+  def any?(%{tags: tags, keywords: keywords}), do: map_size(tags) > 0 or keywords != []
+
+  @doc """
+  The pattern of the first filter that hides `post`, or `nil` when none does. A
+  tag filter matches the post's tags; a keyword filter matches its body and
+  tags/hashtags. The caller skips the member's own posts.
+  """
+  def filtered_pattern(_post, %{tags: tags, keywords: keywords})
+      when map_size(tags) == 0 and keywords == [],
+      do: nil
+
+  def filtered_pattern(post, %{tags: tags, keywords: keywords}) do
+    matched_tag(post, tags) || matched_keyword(post, keywords)
+  end
+
+  @doc """
+  Compile one keyword/phrase pattern into a case-insensitive regex.
+
+  `*` becomes "any run of characters"; the literal segments between are escaped,
+  so no user input reaches the regex engine as syntax. With `whole_word` the
+  match is bounded by word boundaries, except on a side the pattern opens with a
+  `*` (that side is deliberately affix/substring). Returns `nil` if the pattern
+  cannot compile (defensive; the changeset already caps the length).
+  """
+  def compile_pattern(pattern, whole_word) do
+    body =
+      pattern
+      |> String.split("*")
+      |> Enum.map_join(".*", &Regex.escape/1)
+
+    left = if whole_word and not String.starts_with?(pattern, "*"), do: "\\b", else: ""
+    right = if whole_word and not String.ends_with?(pattern, "*"), do: "\\b", else: ""
+
+    case Regex.compile(left <> body <> right, "iu") do
+      {:ok, re} -> re
+      _ -> nil
+    end
+  end
+
+  defp matched_tag(_post, tags) when map_size(tags) == 0, do: nil
+
+  defp matched_tag(post, tags) do
+    Enum.find_value(post_tags(post), fn tag ->
+      tags[String.downcase(tag.name)] || tags[tag.slug]
+    end)
+  end
+
+  defp matched_keyword(_post, []), do: nil
+
+  defp matched_keyword(post, keywords) do
+    text = post_text(post)
+    Enum.find_value(keywords, fn {pattern, re} -> Regex.match?(re, text) && pattern end)
+  end
+
+  # A whole-word keyword sees the raw body plus the tag names: `\bcrypto\b`
+  # matches "crypto" inside `**crypto**` or `#crypto` on its own (the `*` / `#`
+  # are word boundaries), so no Markdown stripping is needed here, and matching
+  # the source keeps this in the core layer.
+  defp post_text(post) do
+    tags = post |> post_tags() |> Enum.map_join(" ", & &1.name)
+    (post.body || "") <> " " <> tags
+  end
+
+  defp post_tags(%{tags: tags}) when is_list(tags), do: tags
+  defp post_tags(_post), do: []
+end

--- a/lib/vutuv/content_filters/content_filter.ex
+++ b/lib/vutuv/content_filters/content_filter.ex
@@ -1,0 +1,71 @@
+defmodule Vutuv.ContentFilters.ContentFilter do
+  @moduledoc """
+  One entry in a member's private content filter (issue #940): a **tag** to
+  mute, or a **keyword/phrase** (with `*` wildcards) to hide from their feed.
+
+  It is the member's own, viewer-only deny list — silent and one-directional
+  (it never touches the author or anyone else, never notifies, never appears in
+  the public agent formats). Because it reveals what a member dislikes it is
+  owner-only and rides along in the GDPR export.
+
+  `kind`:
+    * `:tag` — matches a post carrying that tag (by slug or name).
+    * `:keyword` — matches the keyword/phrase in the post's body **and** its
+      tags/hashtags. `whole_word` (default true) keeps `cess` from hiding
+      "su**cess**"; a `*` in the pattern opts into affix/substring matching and
+      overrides the boundary on that side.
+
+  `expires_at` is an optional snooze (`nil` = permanent); the column exists now,
+  the UI for it comes later.
+  """
+
+  use VutuvWeb, :model
+
+  @kinds [:tag, :keyword]
+
+  # A muted tag slug is short; a muted phrase can be a few words. Capped so a
+  # pathological pattern can never build a catastrophic regex (issue #940).
+  @max_pattern 100
+
+  schema "content_filters" do
+    belongs_to(:user, Vutuv.Accounts.User)
+    field(:kind, Ecto.Enum, values: @kinds)
+    field(:pattern, :string)
+    field(:whole_word, :boolean, default: true)
+    field(:expires_at, :utc_datetime)
+
+    timestamps()
+  end
+
+  @doc "The valid filter kinds (`:tag`, `:keyword`)."
+  def kinds, do: @kinds
+
+  @doc "The maximum pattern length."
+  def max_pattern, do: @max_pattern
+
+  @doc """
+  Changeset for a new filter. `user_id` is set by the caller (never cast), so a
+  request can only ever add a filter to its own list.
+  """
+  def changeset(filter, attrs) do
+    filter
+    |> cast(attrs, [:kind, :pattern, :whole_word, :expires_at])
+    |> update_change(:pattern, &normalize_pattern/1)
+    |> validate_required([:kind, :pattern])
+    |> validate_inclusion(:kind, @kinds)
+    |> validate_length(:pattern, min: 1, max: @max_pattern)
+    # A pattern that is only wildcards/whitespace would hide the whole feed.
+    |> validate_format(:pattern, ~r/[^\s*]/,
+      message: "must contain something to match, not only wildcards"
+    )
+    |> unique_constraint([:user_id, :kind, :pattern], message: "you already mute this")
+  end
+
+  # Trim and collapse inner whitespace so "  machine   learning " and
+  # "machine learning" are the same phrase (and the same unique key).
+  defp normalize_pattern(nil), do: nil
+
+  defp normalize_pattern(value) do
+    value |> String.trim() |> String.replace(~r/\s+/u, " ")
+  end
+end

--- a/lib/vutuv/export.ex
+++ b/lib/vutuv/export.ex
@@ -145,6 +145,7 @@ defmodule Vutuv.Export do
       conversations: conversations(user),
       ad_bookings: ad_bookings(user),
       blocked_members: blocks(user),
+      content_filters: content_filters(user),
       saved_members: %{
         bookmarked: saved_users(user, UserBookmark),
         liked: saved_users(user, UserLike)
@@ -158,6 +159,14 @@ defmodule Vutuv.Export do
         liked: saved_jobs(user, JobPostingLike)
       }
     }
+  end
+
+  # The member's private content filters (issue #940): owner-only data, so it
+  # belongs in their GDPR export.
+  defp content_filters(user) do
+    Enum.map(Vutuv.ContentFilters.list_for_user(user), fn f ->
+      %{kind: f.kind, pattern: f.pattern, whole_word: f.whole_word, added_at: f.inserted_at}
+    end)
   end
 
   defp blocks(user) do

--- a/lib/vutuv_web/components/ui.ex
+++ b/lib/vutuv_web/components/ui.ex
@@ -3181,7 +3181,8 @@ defmodule VutuvWeb.UI do
        [
          {gettext("Privacy"), ~p"/settings/privacy", :privacy},
          {gettext("Fediverse"), ~p"/settings/fediverse", :fediverse},
-         {gettext("Notifications"), ~p"/settings/notifications", :notifications}
+         {gettext("Notifications"), ~p"/settings/notifications", :notifications},
+         {gettext("Muted words & tags"), ~p"/settings/filters", :filters}
        ] ++
          followed_tags_rows(user) ++
          saved_search_rows(user) ++

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -30,6 +30,7 @@ defmodule VutuvWeb.SettingsController do
 
   alias Vutuv.Accounts
   alias Vutuv.Accounts.User
+  alias Vutuv.ContentFilters
   alias Vutuv.Credentials
   alias Vutuv.LoginCodes
   alias Vutuv.Organizations
@@ -257,6 +258,59 @@ defmodule VutuvWeb.SettingsController do
       user: user,
       followed_tags: Vutuv.Tags.followed_tags(user),
       page_title: gettext("Tags you follow")
+    )
+  end
+
+  # Muted words & tags (issue #940): the member's private content filter.
+  def filters(conn, _params) do
+    render_filters(conn, ContentFilters.change_filter())
+  end
+
+  def create_filter(conn, %{"content_filter" => params}) do
+    user = conn.assigns[:user]
+
+    case ContentFilters.create_filter(user, params) do
+      {:ok, _filter} ->
+        conn
+        |> put_flash(
+          :info,
+          gettext("Filter added. Matching posts are now hidden from your feed.")
+        )
+        |> redirect(to: ~p"/settings/filters")
+
+      {:error, :too_many} ->
+        conn
+        |> put_flash(
+          :error,
+          gettext("You have reached the maximum of %{count} filters.",
+            count: ContentFilters.max_filters()
+          )
+        )
+        |> redirect(to: ~p"/settings/filters")
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render_filters(changeset)
+    end
+  end
+
+  def delete_filter(conn, %{"id" => id}) do
+    _ = ContentFilters.delete_filter(conn.assigns[:user], id)
+
+    conn
+    |> put_flash(:info, gettext("Filter removed."))
+    |> redirect(to: ~p"/settings/filters")
+  end
+
+  defp render_filters(conn, changeset) do
+    user = conn.assigns[:user]
+
+    render(conn, "filters.html",
+      user: user,
+      filters: ContentFilters.list_for_user(user),
+      form: Phoenix.Component.to_form(changeset),
+      page_title: gettext("Muted words & tags")
     )
   end
 

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -23,6 +23,7 @@ defmodule VutuvWeb.PostLive.Feed do
   # card is a global VutuvWeb.UI component, imported already).
   import VutuvWeb.UserHTML, only: [user_row: 1]
 
+  alias Vutuv.ContentFilters
   alias Vutuv.Posts
   alias Vutuv.Social
   alias VutuvWeb.Live.DayClockRestream
@@ -72,10 +73,15 @@ defmodule VutuvWeb.PostLive.Feed do
       Process.send_after(self(), :refresh_suggestions, @suggestions_refresh)
     end
 
+    # The member's private content filters (issue #940): compiled once, applied
+    # to every page, and the set of posts they chose to reveal anyway.
+    compiled = ContentFilters.compile_for(user)
     page = Posts.feed_page(user, limit: @page_size)
-    entries = with_engagement(page.entries, user)
+    entries = page.entries |> with_engagement(user) |> mark_filtered(compiled, user.id)
 
     socket
+    |> assign(:content_filters, compiled)
+    |> assign(:revealed_filters, MapSet.new())
     |> assign(:page_title, gettext("Feed"))
     |> assign(:more?, page.more?)
     |> assign(:cursor, page.next_cursor)
@@ -180,6 +186,33 @@ defmodule VutuvWeb.PostLive.Feed do
   # each entry carries a `%{post_id => engagement}` submap for those cards' bars.
   # Live-arriving single posts carry `engagement: nil` (falls back to the bar's
   # own query) and get their follow edge in `insert_entry/3`.
+  # The one-line stand-in for a content-filtered post (issue #940): says which
+  # filter hid it and offers to show it anyway, in place.
+  attr(:pattern, :string, required: true)
+  attr(:post_id, :string, required: true)
+
+  defp filtered_placeholder(assigns) do
+    ~H"""
+    <div
+      data-filtered-post={@pattern}
+      class="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-2xl bg-slate-50 px-4 py-3 text-sm text-slate-600 ring-1 ring-slate-200 dark:bg-slate-900/50 dark:text-slate-400 dark:ring-slate-800"
+    >
+      <span>
+        {gettext("Hidden: matches your filter")}
+        <code class="rounded bg-slate-200 px-1.5 py-0.5 font-mono text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200">{@pattern}</code>
+      </span>
+      <button
+        type="button"
+        phx-click="reveal_filter"
+        phx-value-id={@post_id}
+        class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+      >
+        {gettext("Show anyway")}
+      </button>
+    </div>
+    """
+  end
+
   defp with_engagement(entries, user) do
     ancestor_ids = fn entry -> Enum.map(entry[:ancestors] || [], & &1.id) end
 
@@ -218,7 +251,11 @@ defmodule VutuvWeb.PostLive.Feed do
     # nothing. Filter before the engagement batch so it queries only survivors.
     shown = shown_post_ids(socket.assigns.entries)
     fresh = Enum.reject(page.entries, &MapSet.member?(shown, &1.post.id))
-    entries = with_engagement(fresh, socket.assigns.current_user)
+
+    entries =
+      fresh
+      |> with_engagement(socket.assigns.current_user)
+      |> mark_filtered(socket.assigns.content_filters, socket.assigns.current_user.id)
 
     {:noreply,
      socket
@@ -235,6 +272,22 @@ defmodule VutuvWeb.PostLive.Feed do
   # The composer's corner ✕ (feed compose only) bubbles up here to collapse it.
   def handle_event("close-composer", _params, socket) do
     {:noreply, assign(socket, :composer_open?, false)}
+  end
+
+  # "Show anyway" on a content-filtered post (issue #940): reveal it in place,
+  # no reload. The reveal set survives a midnight restream, so the post stays
+  # open. Re-stream just this one entry so its placeholder swaps to the card.
+  def handle_event("reveal_filter", %{"id" => post_id}, socket) do
+    case Enum.find(socket.assigns.entries, &(&1.post.id == post_id)) do
+      nil ->
+        {:noreply, socket}
+
+      entry ->
+        {:noreply,
+         socket
+         |> update(:revealed_filters, &MapSet.put(&1, post_id))
+         |> stream_insert(:posts, entry, update_only: true)}
+    end
   end
 
   # The rail's "Follow" button (user_row live?): follow with no reload, then
@@ -423,7 +476,7 @@ defmodule VutuvWeb.PostLive.Feed do
 
     cond do
       actor_id == user.id ->
-        decorated = decorate(entry, user)
+        decorated = decorate(entry, user, socket)
 
         {:noreply,
          socket
@@ -441,7 +494,7 @@ defmodule VutuvWeb.PostLive.Feed do
         {:noreply, socket}
 
       Posts.visible_to?(entry.post, user) ->
-        {:noreply, update(socket, :pending_posts, &[decorate(entry, user) | &1])}
+        {:noreply, update(socket, :pending_posts, &[decorate(entry, user, socket) | &1])}
 
       true ->
         {:noreply, socket}
@@ -477,10 +530,29 @@ defmodule VutuvWeb.PostLive.Feed do
   # dropped before either query runs. A live-arrived reply nests only its direct
   # parent (one level, whose bar self-loads); the full visible chain reassembles
   # on the next reload / "Load more" (which run through `collapse_threads/1`).
-  defp decorate(entry, user) do
+  defp decorate(entry, user, socket) do
     entry
     |> Map.put(:viewer_follow, Social.follow_edge(user.id, entry.post.user_id))
     |> Map.put(:engagement, Posts.post_engagement(entry.post.id, user.id))
+    |> mark_one(socket.assigns.content_filters, user.id)
+  end
+
+  # Content filters (issue #940): stamp each entry with the pattern that hides it
+  # (`:filtered_by`), or leave it clear. Never the viewer's own posts. A no-op
+  # for the vast majority who mute nothing, so the feed pays for it only when a
+  # filter exists.
+  defp mark_filtered(entries, compiled, viewer_id) do
+    if ContentFilters.any?(compiled),
+      do: Enum.map(entries, &mark_one(&1, compiled, viewer_id)),
+      else: entries
+  end
+
+  defp mark_one(entry, compiled, viewer_id) do
+    pattern =
+      if entry.post.user_id != viewer_id,
+        do: ContentFilters.filtered_pattern(entry.post, compiled)
+
+    Map.put(entry, :filtered_by, pattern)
   end
 
   # Every post id currently represented on screen — each streamed entry's own
@@ -597,7 +669,16 @@ defmodule VutuvWeb.PostLive.Feed do
           content. --%>
           <.post_list :if={!@empty?} id="feed-posts" phx-update="stream" data-post-list>
             <div :for={{dom_id, entry} <- @streams.posts} id={dom_id} class={post_row_class()}>
+              <%!-- A content-filtered post (issue #940) collapses to a line the
+              reader can still open, instead of vanishing (a silently shorter
+              feed confuses and breaks reply threads). --%>
+              <.filtered_placeholder
+                :if={entry[:filtered_by] && entry.post.id not in @revealed_filters}
+                pattern={entry.filtered_by}
+                post_id={entry.post.id}
+              />
               <.post_thread_entry
+                :if={!entry[:filtered_by] || entry.post.id in @revealed_filters}
                 post={entry.post}
                 viewer={@current_user}
                 viewer_follow={entry[:viewer_follow]}

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -836,6 +836,12 @@ defmodule VutuvWeb.Router do
     # subscriptions. Following happens on the tag page; unfollowing here (and in
     # the feed rail) posts to DELETE /tag_follows/:tag_id.
     get("/followed_tags", SettingsController, :followed_tags)
+
+    # Muted words & tags (issue #940): the member's private content filter. Add
+    # a tag or a keyword/phrase to hide matching posts from your own feed.
+    get("/filters", SettingsController, :filters)
+    post("/filters", SettingsController, :create_filter)
+    delete("/filters/:id", SettingsController, :delete_filter)
     # The member's "Your organizations" hub: the organization pages they own or
     # help run, the explainer of how organizations work, and the add call to
     # action. The public browse directory stays at /organizations.

--- a/lib/vutuv_web/templates/settings/filters.html.heex
+++ b/lib/vutuv_web/templates/settings/filters.html.heex
@@ -1,0 +1,90 @@
+<.settings_shell user={@user} active={:filters} title={gettext("Muted words & tags")}>
+  <.card>
+    <.section_title>{gettext("Muted words & tags")}</.section_title>
+    <p class="mt-3 text-sm text-slate-600 dark:text-slate-400">
+      {gettext(
+        "Hide posts from your feed that carry a tag, or that contain a word or phrase. This list is yours alone: it is never shared, the author is never told, and a hidden post collapses to a line you can still open."
+      )}
+    </p>
+
+    <.form
+      for={@form}
+      action={~p"/settings/filters"}
+      method="post"
+      id="content-filter-form"
+      class="mt-5 flex flex-col gap-3 sm:flex-row sm:items-start"
+    >
+      <select name={@form[:kind].name} class={[input_class(), "sm:w-40"]} aria-label={gettext("Kind")}>
+        <option value="keyword" selected={@form[:kind].value in [nil, "keyword", :keyword]}>
+          {gettext("Word or phrase")}
+        </option>
+        <option value="tag" selected={@form[:kind].value in ["tag", :tag]}>
+          {gettext("Tag")}
+        </option>
+      </select>
+
+      <div class="min-w-0 flex-1">
+        <input
+          type="text"
+          name={@form[:pattern].name}
+          value={Phoenix.HTML.Form.normalize_value("text", @form[:pattern].value)}
+          placeholder={gettext("e.g. crypto*, \"machine learning\", politics")}
+          class={input_class(@form[:pattern].errors != [])}
+          aria-label={gettext("Word, phrase or tag to mute")}
+          aria-invalid={@form[:pattern].errors != [] && "true"}
+        />
+        <p
+          :for={{msg, _} <- @form[:pattern].errors}
+          class="mt-1 text-sm font-medium text-red-600 dark:text-red-400"
+        >
+          {msg}
+        </p>
+        <p :if={@form[:pattern].errors == []} class="mt-1 text-xs text-slate-600 dark:text-slate-400">
+          {gettext("Use * as a wildcard (crypto* → cryptobro). Whole-word by default.")}
+        </p>
+        <label class="mt-2 inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+          <input type="hidden" name={@form[:whole_word].name} value="false" />
+          <input
+            type="checkbox"
+            name={@form[:whole_word].name}
+            value="true"
+            checked={@form[:whole_word].value in [nil, true, "true"]}
+            class={checkbox_class()}
+          />
+          {gettext("Match whole words only (word/phrase)")}
+        </label>
+      </div>
+
+      <.button type="submit">{gettext("Mute")}</.button>
+    </.form>
+
+    <ul id="content-filter-list" class="mt-6 divide-y divide-slate-100 dark:divide-slate-800">
+      <li
+        :for={filter <- @filters}
+        id={"content-filter-#{filter.id}"}
+        class="flex items-center justify-between gap-3 py-3 first:pt-0 last:pb-0"
+        data-content-filter={filter.pattern}
+      >
+        <div class="min-w-0">
+          <code class="font-mono text-sm font-semibold text-slate-900 dark:text-slate-100">
+            {filter.pattern}
+          </code>
+          <span class="ml-2 text-xs text-slate-600 dark:text-slate-400">
+            {filter_kind_label(filter)}
+          </span>
+        </div>
+        <.link
+          href={~p"/settings/filters/#{filter.id}"}
+          method="delete"
+          class="flex-shrink-0 rounded-lg px-3 py-1.5 text-sm font-semibold text-rose-600 hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-950/40"
+        >
+          {gettext("Unmute")}
+        </.link>
+      </li>
+    </ul>
+
+    <p :if={@filters == []} class="mt-6 text-sm text-slate-600 dark:text-slate-400">
+      {gettext("You have not muted anything yet.")}
+    </p>
+  </.card>
+</.settings_shell>

--- a/lib/vutuv_web/views/settings_html.ex
+++ b/lib/vutuv_web/views/settings_html.ex
@@ -18,6 +18,13 @@ defmodule VutuvWeb.SettingsHTML do
 
   embed_templates("../templates/settings/*")
 
+  @doc "The human, localized label for a content filter's kind (issue #940)."
+  def filter_kind_label(%{kind: :tag}), do: gettext("Tag")
+  def filter_kind_label(%{kind: :keyword, whole_word: false}), do: gettext("Word or phrase")
+
+  def filter_kind_label(%{kind: :keyword}),
+    do: gettext("Word or phrase (whole word)")
+
   @doc """
   The human, localized status of one of the member's organization pages, derived
   the same way the public site decides visibility: a page under moderation

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15323,3 +15323,75 @@ msgstr "Unbestätigt"
 #, elixir-autogen, elixir-format
 msgid "unreachable"
 msgstr "Nicht erreichbar"
+
+#: lib/vutuv_web/components/ui.ex:3184
+#: lib/vutuv_web/controllers/settings_controller.ex:308
+#: lib/vutuv_web/templates/settings/filters.html.heex:2
+#, elixir-autogen, elixir-format
+msgid "Muted words & tags"
+msgstr "Stummgeschaltete Wörter & Tags"
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:5
+#, elixir-autogen, elixir-format
+msgid "Hide posts from your feed that carry a tag, or that contain a word or phrase. This list is yours alone: it is never shared, the author is never told, and a hidden post collapses to a line you can still open."
+msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wort bzw. eine Phrase enthalten. Diese Liste gehört nur Ihnen: Sie wird nie geteilt, der Verfasser erfährt nichts davon, und ein ausgeblendeter Beitrag klappt zu einer Zeile zusammen, die Sie weiterhin öffnen können."
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:18
+#, elixir-autogen, elixir-format
+msgid "Word or phrase"
+msgstr "Wort oder Phrase"
+
+#: lib/vutuv_web/views/settings_html.ex:24
+#, elixir-autogen, elixir-format
+msgid "Word or phrase (whole word)"
+msgstr "Wort oder Phrase (ganzes Wort)"
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:34
+#, elixir-autogen, elixir-format
+msgid "e.g. crypto*, \"machine learning\", politics"
+msgstr "z. B. crypto*, \"machine learning\", Politik"
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "Word, phrase or tag to mute"
+msgstr "Wort, Phrase oder Tag zum Stummschalten"
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:47
+#, elixir-autogen, elixir-format
+msgid "Use * as a wildcard (crypto* → cryptobro). Whole-word by default."
+msgstr "Verwenden Sie * als Platzhalter (crypto* → cryptobro). Standardmäßig ganze Wörter."
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:58
+#, elixir-autogen, elixir-format
+msgid "Match whole words only (word/phrase)"
+msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "You have not muted anything yet."
+msgstr "Sie haben noch nichts stummgeschaltet."
+
+#: lib/vutuv_web/live/post_live/feed.ex:521
+#, elixir-autogen, elixir-format
+msgid "Hidden: matches your filter"
+msgstr "Ausgeblendet: passt zu Ihrem Filter"
+
+#: lib/vutuv_web/live/post_live/feed.ex:530
+#, elixir-autogen, elixir-format
+msgid "Show anyway"
+msgstr "Trotzdem anzeigen"
+
+#: lib/vutuv_web/controllers/settings_controller.ex:271
+#, elixir-autogen, elixir-format
+msgid "Filter added. Matching posts are now hidden from your feed."
+msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgeblendet."
+
+#: lib/vutuv_web/controllers/settings_controller.ex:279
+#, elixir-autogen, elixir-format
+msgid "You have reached the maximum of %{count} filters."
+msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
+
+#: lib/vutuv_web/controllers/settings_controller.ex:295
+#, elixir-autogen, elixir-format
+msgid "Filter removed."
+msgstr "Filter entfernt."

--- a/priv/repo/migrations/20260724102812_create_content_filters.exs
+++ b/priv/repo/migrations/20260724102812_create_content_filters.exs
@@ -1,0 +1,36 @@
+defmodule Vutuv.Repo.Migrations.CreateContentFilters do
+  use Ecto.Migration
+
+  # Personal content filters (issue #940): a member's private, viewer-only deny
+  # list. Each row mutes a tag or a keyword/phrase (with `*` wildcards) and
+  # hides matching posts from that member's own feed. It reveals what a member
+  # dislikes, so it is strictly owner-only (never public, never in the agent
+  # formats) and belongs in the GDPR export.
+  #
+  # New table, plain addition -> N-1 safe for the blue/green window.
+  def change do
+    create table(:content_filters) do
+      add(:user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false)
+      # tag | keyword. A tag entry matches a post's tags; a keyword entry
+      # matches the post's body and tags/hashtags.
+      add(:kind, :string, null: false)
+      # A tag slug/name, or a keyword/phrase with `*` wildcards.
+      add(:pattern, :string, null: false)
+      # Keyword only: whole-word match by default (so "cess" does not hide
+      # "success"); a `*` overrides it locally. Irrelevant for tag rows.
+      add(:whole_word, :boolean, null: false, default: true)
+      # Optional "snooze": null = permanent. (Column now, UI later.)
+      add(:expires_at, :utc_datetime)
+
+      timestamps()
+    end
+
+    # The feed compiles a member's whole list on every page, so read them by
+    # owner in one shot.
+    create(index(:content_filters, [:user_id]))
+
+    # One row per (owner, kind, pattern): re-muting the same thing is a no-op,
+    # not a duplicate.
+    create(unique_index(:content_filters, [:user_id, :kind, :pattern]))
+  end
+end

--- a/test/vutuv/content_filters_test.exs
+++ b/test/vutuv/content_filters_test.exs
@@ -1,0 +1,164 @@
+defmodule Vutuv.ContentFiltersTest do
+  @moduledoc """
+  Personal content filters (issue #940): the keyword/tag matching engine and the
+  owner-scoped CRUD.
+  """
+  use Vutuv.DataCase, async: true
+
+  import Vutuv.Factory
+
+  alias Vutuv.ContentFilters
+  alias Vutuv.ContentFilters.ContentFilter
+  alias Vutuv.Posts.Post
+  alias Vutuv.Tags.Tag
+
+  # A bare in-memory post (body + preloaded tags), enough for the matcher.
+  defp post(body, tags \\ []) do
+    %Post{body: body, tags: Enum.map(tags, fn {name, slug} -> %Tag{name: name, slug: slug} end)}
+  end
+
+  # Compile a hand-written filter list without touching the DB.
+  defp compile(filters) do
+    tags = for {:tag, p} <- filters, into: %{}, do: {String.downcase(p), p}
+
+    keywords =
+      for {:keyword, p, ww} <- filters, do: {p, ContentFilters.compile_pattern(p, ww)}
+
+    %{tags: tags, keywords: keywords}
+  end
+
+  defp hidden_by(post, filters), do: ContentFilters.filtered_pattern(post, compile(filters))
+
+  describe "keyword matching" do
+    test "a whole word matches only that word, not a longer one" do
+      filters = [{:keyword, "crypto", true}]
+
+      assert hidden_by(post("I love crypto really"), filters) == "crypto"
+      # The classic false-positive trap: "cess" must not hide "success".
+      refute hidden_by(post("this is a big success"), [{:keyword, "cess", true}])
+      # "cryptocurrency" is a different word, so a whole-word "crypto" leaves it.
+      refute hidden_by(post("cryptocurrency is here"), filters)
+    end
+
+    test "case-insensitive" do
+      assert hidden_by(post("CRYPTO news"), [{:keyword, "crypto", true}]) == "crypto"
+    end
+
+    test "a trailing * matches prefixes" do
+      filters = [{:keyword, "crypto*", true}]
+      assert hidden_by(post("cryptocurrency rocks"), filters) == "crypto*"
+      assert hidden_by(post("a cryptobro appears"), filters) == "crypto*"
+    end
+
+    test "a leading * matches suffixes" do
+      filters = [{:keyword, "*coin", true}]
+      assert hidden_by(post("buy bitcoin now"), filters) == "*coin"
+      assert hidden_by(post("altcoin season"), filters) == "*coin"
+    end
+
+    test "*x* matches anywhere" do
+      assert hidden_by(post("a bitcoinmaximalist ranting"), [{:keyword, "*maxi*", true}]) ==
+               "*maxi*"
+    end
+
+    test "a phrase matches the words adjacent and in order" do
+      filters = [{:keyword, "machine learning", true}]
+      assert hidden_by(post("I do machine learning daily"), filters) == "machine learning"
+      # Reversed order is not the phrase.
+      refute hidden_by(post("a learning machine"), filters)
+    end
+
+    test "matches a keyword inside markdown emphasis and a hashtag" do
+      # `**crypto**` and `#crypto` both surround "crypto" with non-word chars,
+      # so a whole-word match still reaches them (no Markdown stripping needed).
+      assert hidden_by(post("this is **crypto** stuff"), [{:keyword, "crypto", true}]) == "crypto"
+      assert hidden_by(post("gm #crypto folks"), [{:keyword, "crypto", true}]) == "crypto"
+    end
+
+    test "a keyword also matches the post's tag names" do
+      p = post("a neutral body", [{"Crypto", "crypto"}])
+      assert hidden_by(p, [{:keyword, "crypto", true}]) == "crypto"
+    end
+  end
+
+  describe "tag matching" do
+    test "a tag filter hides a post carrying that tag, by name or slug" do
+      p = post("nothing to see", [{"Bitcoin", "bitcoin"}])
+      assert hidden_by(p, [{:tag, "bitcoin"}]) == "bitcoin"
+      # Case-insensitive against the tag name too.
+      assert hidden_by(p, [{:tag, "BITCOIN"}]) == "BITCOIN"
+    end
+
+    test "a tag filter does not match the same word only in the body" do
+      # A Tag entry matches the tag only, not free body text (that's a keyword).
+      refute hidden_by(post("I talked about bitcoin today"), [{:tag, "bitcoin"}])
+    end
+  end
+
+  test "no filters hides nothing" do
+    refute hidden_by(post("anything at all"), [])
+  end
+
+  describe "owner-scoped CRUD" do
+    setup do
+      %{user: insert(:user), other: insert(:user)}
+    end
+
+    test "create, list newest-first and delete", %{user: user} do
+      {:ok, _} = ContentFilters.create_filter(user, %{"kind" => "keyword", "pattern" => "crypto"})
+      {:ok, f2} = ContentFilters.create_filter(user, %{"kind" => "tag", "pattern" => "politics"})
+
+      assert [%{pattern: "politics"}, %{pattern: "crypto"}] = ContentFilters.list_for_user(user)
+
+      assert :ok = ContentFilters.delete_filter(user, f2.id)
+      assert [%{pattern: "crypto"}] = ContentFilters.list_for_user(user)
+    end
+
+    test "a member cannot delete someone else's filter", %{user: user, other: other} do
+      {:ok, f} = ContentFilters.create_filter(user, %{"kind" => "keyword", "pattern" => "crypto"})
+
+      assert {:error, :not_found} = ContentFilters.delete_filter(other, f.id)
+      assert [%{pattern: "crypto"}] = ContentFilters.list_for_user(user)
+    end
+
+    test "the same pattern cannot be added twice", %{user: user} do
+      {:ok, _} = ContentFilters.create_filter(user, %{"kind" => "keyword", "pattern" => "crypto"})
+
+      assert {:error, %Ecto.Changeset{}} =
+               ContentFilters.create_filter(user, %{"kind" => "keyword", "pattern" => "crypto"})
+    end
+
+    test "a wildcard-only pattern is rejected", %{user: user} do
+      assert {:error, changeset} =
+               ContentFilters.create_filter(user, %{"kind" => "keyword", "pattern" => "***"})
+
+      assert %{pattern: [_]} = errors_on(changeset)
+    end
+
+    test "the whole list compiles to the matcher shape", %{user: user} do
+      {:ok, _} = ContentFilters.create_filter(user, %{"kind" => "tag", "pattern" => "Crypto"})
+      {:ok, _} = ContentFilters.create_filter(user, %{"kind" => "keyword", "pattern" => "web3*"})
+
+      compiled = ContentFilters.compile_for(user)
+      assert ContentFilters.any?(compiled)
+      assert compiled.tags["crypto"] == "Crypto"
+      assert [{"web3*", _re}] = compiled.keywords
+    end
+  end
+
+  test "an inserted filter belongs to the user, not a cast user_id" do
+    user = insert(:user)
+    other = insert(:user)
+
+    {:ok, filter} =
+      ContentFilters.create_filter(user, %{
+        "kind" => "keyword",
+        "pattern" => "crypto",
+        "user_id" => other.id
+      })
+
+    # user_id is set by the context, never cast, so the injected one is ignored.
+    assert filter.user_id == user.id
+    assert %ContentFilter{} = filter
+  end
+end

--- a/test/vutuv/export_test.exs
+++ b/test/vutuv/export_test.exs
@@ -34,10 +34,16 @@ defmodule Vutuv.ExportTest do
     Vutuv.Social.block_user(user, blocked)
     Vutuv.Social.bookmark_user(user, saved_member)
 
+    {:ok, _} =
+      Vutuv.ContentFilters.create_filter(user, %{"kind" => "keyword", "pattern" => "crypto"})
+
     data = Export.build(user)
 
     assert data.schema_version == 4
     assert Enum.any?(data.blocked_members, &(&1.member == blocked.username))
+    # The private content filters (issue #940) are owner-only, so they ride
+    # along in the member's own GDPR export.
+    assert Enum.any?(data.content_filters, &(&1.pattern == "crypto"))
     assert Enum.any?(data.saved_members.bookmarked, &(&1.member == saved_member.username))
     # The keys exist even when empty, so the export shape stays stable.
     assert Map.has_key?(data.saved_organizations, :liked)

--- a/test/vutuv_web/controllers/settings_controller_test.exs
+++ b/test/vutuv_web/controllers/settings_controller_test.exs
@@ -593,4 +593,62 @@ defmodule VutuvWeb.SettingsControllerTest do
       assert Repo.get(User, user.id).default_map_service == nil
     end
   end
+
+  # Muted words & tags (issue #940): the member's private content filter.
+  describe "content filters (#940)" do
+    test "the page lists the member's filters and offers the add form", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      {:ok, _} =
+        Vutuv.ContentFilters.create_filter(user, %{"kind" => "keyword", "pattern" => "crypto"})
+
+      html = conn |> get(~p"/settings/filters") |> html_response(200)
+
+      assert html =~ "crypto"
+      assert html =~ ~s(id="content-filter-form")
+    end
+
+    test "adding a filter persists it and stays on the page", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      conn =
+        post(conn, ~p"/settings/filters",
+          content_filter: %{"kind" => "keyword", "pattern" => "crypto*", "whole_word" => "false"}
+        )
+
+      assert redirected_to(conn) == ~p"/settings/filters"
+      assert [%{pattern: "crypto*", whole_word: false}] = Vutuv.ContentFilters.list_for_user(user)
+    end
+
+    test "a wildcard-only pattern is rejected with a 422", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      conn =
+        post(conn, ~p"/settings/filters",
+          content_filter: %{"kind" => "keyword", "pattern" => "***"}
+        )
+
+      assert html_response(conn, 422)
+      assert Vutuv.ContentFilters.list_for_user(user) == []
+    end
+
+    test "deleting removes the filter", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      {:ok, filter} =
+        Vutuv.ContentFilters.create_filter(user, %{"kind" => "tag", "pattern" => "politics"})
+
+      conn = delete(conn, ~p"/settings/filters/#{filter.id}")
+
+      assert redirected_to(conn) == ~p"/settings/filters"
+      assert Vutuv.ContentFilters.list_for_user(user) == []
+    end
+
+    test "the filters row is on the settings hub", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      html = conn |> get(~p"/settings") |> html_response(200)
+
+      assert html =~ ~s(href="#{~p"/settings/filters"}")
+    end
+  end
 end

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -1290,4 +1290,78 @@ defmodule VutuvWeb.PostFeedLiveTest do
       assert feed_html =~ "sm:grid-cols-2"
     end
   end
+
+  # Personal content filters (issue #940): a matching post collapses to a
+  # "Show anyway" line instead of vanishing, and the viewer's own posts are
+  # never filtered.
+  describe "content filters" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      friend = other_user()
+      insert(:follow, follower: user, followee: friend)
+      %{conn: conn, user: user, friend: friend}
+    end
+
+    test "a muted keyword collapses a matching post to a placeholder", %{
+      conn: conn,
+      user: user,
+      friend: friend
+    } do
+      {:ok, _} =
+        Vutuv.ContentFilters.create_filter(user, %{"kind" => "keyword", "pattern" => "crypto"})
+
+      {:ok, _} = Posts.create_post(friend, %{body: "buy crypto now"})
+
+      {:ok, live, html} = live(conn, ~p"/feed")
+
+      assert has_element?(live, "[data-filtered-post='crypto']")
+      # The body itself is not on the page until revealed.
+      refute html =~ "buy crypto now"
+    end
+
+    test "'Show anyway' reveals the post in place", %{conn: conn, user: user, friend: friend} do
+      {:ok, _} =
+        Vutuv.ContentFilters.create_filter(user, %{"kind" => "keyword", "pattern" => "crypto"})
+
+      {:ok, post} = Posts.create_post(friend, %{body: "buy crypto now"})
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      revealed =
+        live
+        |> element("button[phx-click='reveal_filter'][phx-value-id='#{post.id}']")
+        |> render_click()
+
+      assert revealed =~ "buy crypto now"
+    end
+
+    test "the viewer's own matching post is never filtered", %{conn: conn, user: user} do
+      {:ok, _} =
+        Vutuv.ContentFilters.create_filter(user, %{"kind" => "keyword", "pattern" => "crypto"})
+
+      {:ok, _} = Posts.create_post(user, %{body: "my own crypto thoughts"})
+
+      {:ok, _live, html} = live(conn, ~p"/feed")
+
+      # Own post shows in full; no placeholder swallows it.
+      assert html =~ "my own crypto thoughts"
+      refute html =~ "data-filtered-post"
+    end
+
+    test "a muted tag collapses a post carrying that tag", %{
+      conn: conn,
+      user: user,
+      friend: friend
+    } do
+      {:ok, _} =
+        Vutuv.ContentFilters.create_filter(user, %{"kind" => "tag", "pattern" => "crypto"})
+
+      {:ok, _} = Posts.create_post(friend, %{body: "a neutral looking body", tags: "crypto"})
+
+      {:ok, live, html} = live(conn, ~p"/feed")
+
+      assert has_element?(live, "[data-filtered-post='crypto']")
+      refute html =~ "a neutral looking body"
+    end
+  end
 end


### PR DESCRIPTION
Closes #940 (v1). Follow-up to #872.

A member can now hide posts from their own feed that carry a tag, or that contain a word or phrase (with `*` wildcards) — a private, viewer-only content filter, the topic-level sibling of per-follow mute and the block.

## Data + engine (`Vutuv.ContentFilters`)
- New `content_filters` table (owner, `kind` tag|keyword, `pattern`, `whole_word`, `expires_at`) with a unique `(user, kind, pattern)` index; cascades on user delete. N-1 safe.
- `compile_for/1` turns a member's list into a matcher; `filtered_pattern/2` returns the pattern that hides a post, or `nil`. A **tag** entry matches the post's tags; a **keyword** entry matches the body **and** its tags/hashtags.
- `compile_pattern/2` builds a case-insensitive regex: `*` → "any run of characters", literal segments escaped (no user input reaches the engine as syntax), **whole-word by default** (so `cess` does not hide "success") except on a side opened with `*`. Pattern length and list size are capped, so a pathological pattern can't build a catastrophic regex.

## Feed (`PostLive.Feed`)
- After the page is hydrated, each entry is stamped with the filter that hides it. A match **does not vanish** — it collapses to a **"Show anyway"** line (`data-filtered-post`), so the feed never silently shortens or breaks a reply thread. The reveal is in-place and survives the midnight restream. **The viewer's own posts are never filtered.**

## Management + privacy
- **`/settings/filters`** ("Muted words & tags"): list, add (tag/keyword + whole-word toggle), remove — owner-scoped end to end.
- The list is **owner-only** (never public, never in the agent formats) and rides along in the **GDPR export**.

## Scope
This is a **v1** covering the core (data model, matching engine, feed hiding, settings management, export). Deferred to follow-ups, clearly out of this PR: filtering the "who to follow" recommendations and search, negative search operators, the tag-page / post-⋯-menu entry points, and the snooze UI (the `expires_at` column is reserved but **not yet honored**).

## Tests
- Engine: whole-word / wildcard prefix-suffix-anywhere / phrase / case-insensitive / markdown-emphasis / hashtag / tag-name matching; tag-vs-keyword scoping; owner-scoped CRUD, dedup, wildcard-only rejection, `user_id` never cast.
- Feed: a muted keyword or tag collapses a matching post; "Show anyway" reveals it; own posts exempt.
- Settings page CRUD + hub row; GDPR export includes the filters.
- `docs/architecture/social-graph.md` updated; German copy added. `mix precommit` green (4696 passed).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_014VdhLKS68PKfE4NBcW1KD7