### PR TITLE
Scope-aware search tips, kept on the results page (#887, #861)

### DIFF
--- a/lib/vutuv_web/live/search_live.ex
+++ b/lib/vutuv_web/live/search_live.ex
@@ -178,6 +178,89 @@ defmodule VutuvWeb.SearchLive do
   defp scope_label(:tags), do: gettext("Tags")
   defp scope_label(:posts), do: gettext("Posts")
 
+  attr(:scope, :atom, required: true)
+
+  # The scope-aware Search Tips body, rendered by BOTH the empty-query card and
+  # the compact results-page disclosure so #887's scope-awareness applies in
+  # both places (#861). It shows only the operators that actually work in the
+  # active scope: the people operators (first:/last:, city:, status:, @handle)
+  # and the phonetic "similar names" note apply on :all/:people; tag: filters
+  # people AND posts (#946) so it applies on :all/:people/:posts but is dropped
+  # on :tags (which searches tag names directly); the quotes/exact tip is
+  # general. On a scope where a whole class of operators is irrelevant the tips
+  # explain what this tab does instead of listing dead operators (#887 point 2).
+  defp search_tips(assigns) do
+    tips = Enum.filter(operator_tips(), &(assigns.scope in &1.scopes))
+    assigns = assign(assigns, tips: tips, similar_names?: assigns.scope in [:all, :people])
+
+    ~H"""
+    <p class="text-sm text-slate-600 dark:text-slate-300">{tips_intro(@scope)}</p>
+    <p :if={@similar_names?} class="mt-2 text-sm text-slate-600 dark:text-slate-300">
+      {gettext(
+        "Our search will try to match similar names to your search, so don't worry about spelling."
+      )}
+    </p>
+    <%!-- m-0 / font-normal undo the legacy `dl dt`/`dl dd` element defaults
+    from components.css so the grid rows line up. The operator examples are
+    gettext'd too: every operator has a German and an English key (both always
+    work), so each locale shows its own spelling. --%>
+    <dl
+      :if={@tips != []}
+      id="search-syntax"
+      class="mt-4 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-[auto_1fr]"
+    >
+      <%= for tip <- @tips do %>
+        <dt class="m-0 font-mono text-slate-700 dark:text-slate-200">{tip.term}</dt>
+        <dd class="m-0 font-normal text-slate-600 dark:text-slate-400">{tip.desc}</dd>
+      <% end %>
+    </dl>
+    """
+  end
+
+  # The operator rows and the scopes each one works in (derived from
+  # Vutuv.Search's people/tags/posts guards). `search_tips/1` filters this by
+  # the active scope so no tab shows an operator it cannot honor.
+  defp operator_tips do
+    [
+      %{
+        term: gettext("first:stefan"),
+        desc: gettext("searches first names only (last: for last names)"),
+        scopes: [:all, :people]
+      },
+      %{
+        term: "tag:php",
+        desc: gettext("people and posts with this tag, combinable: miller tag:php"),
+        scopes: [:all, :people, :posts]
+      },
+      %{
+        term: gettext("city:koblenz"),
+        desc: gettext("only people with an address in this city"),
+        scopes: [:all, :people]
+      },
+      %{
+        term: "status:looking",
+        desc: gettext("only people open to offers (status:open) or looking (status:looking)"),
+        scopes: [:all, :people]
+      },
+      %{term: "@stefan", desc: gettext("searches usernames"), scopes: [:all, :people]},
+      %{
+        term: ~s("#{gettext("miller")}"),
+        desc: gettext("in quotes: exact matches only, no similar names"),
+        scopes: [:all, :people, :tags, :posts]
+      }
+    ]
+  end
+
+  # One intro sentence describing what the active scope searches. The generic
+  # :all copy is the original two-scope sentence; the narrowed scopes name only
+  # what they actually cover, so the tips stop over-promising (#887).
+  defp tips_intro(:people), do: gettext("Search for people by name, email, or username.")
+  defp tips_intro(:tags), do: gettext("Search for tags by name.")
+  defp tips_intro(:posts), do: gettext("Search for words in public posts.")
+
+  defp tips_intro(_all),
+    do: gettext("You can search for a name, email, or tag, or for words in public posts.")
+
   attr(:id, :string, required: true)
   attr(:patch, :string, required: true)
   attr(:active, :boolean, required: true)
@@ -276,35 +359,39 @@ defmodule VutuvWeb.SearchLive do
         {gettext("Results appear once you have typed at least three letters.")}
       </p>
 
-      <.card :if={@q == ""} class="mt-6">
+      <.card :if={@q == ""} id="search-tips-empty" class="mt-6">
         <.section_title>{gettext("Search Tips")}</.section_title>
-        <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">
-          {gettext("You can search for a name, email, or tag, or for words in public posts.")}
-        </p>
-        <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
-          {gettext("Our search will try to match similar names to your search, so don't worry about spelling.")}
-        </p>
-        <%!-- m-0 / font-normal undo the legacy `dl dt`/`dl dd` element
-        defaults from components.css so the grid rows line up. The operator
-        examples are gettext'd too: every operator has a German and an English
-        key (both always work), so each locale shows its own spelling. --%>
-        <dl id="search-syntax" class="mt-4 grid gap-x-6 gap-y-2 text-sm sm:grid-cols-[auto_1fr]">
-          <dt class="m-0 font-mono text-slate-700 dark:text-slate-200">{gettext("first:stefan")}</dt>
-          <dd class="m-0 font-normal text-slate-600 dark:text-slate-400">{gettext("searches first names only (last: for last names)")}</dd>
-          <dt class="m-0 font-mono text-slate-700 dark:text-slate-200">tag:php</dt>
-          <dd class="m-0 font-normal text-slate-600 dark:text-slate-400">{gettext("people and posts with this tag, combinable: miller tag:php")}</dd>
-          <dt class="m-0 font-mono text-slate-700 dark:text-slate-200">{gettext("city:koblenz")}</dt>
-          <dd class="m-0 font-normal text-slate-600 dark:text-slate-400">{gettext("only people with an address in this city")}</dd>
-          <dt class="m-0 font-mono text-slate-700 dark:text-slate-200">status:looking</dt>
-          <dd class="m-0 font-normal text-slate-600 dark:text-slate-400">{gettext("only people open to offers (status:open) or looking (status:looking)")}</dd>
-          <dt class="m-0 font-mono text-slate-700 dark:text-slate-200">@stefan</dt>
-          <dd class="m-0 font-normal text-slate-600 dark:text-slate-400">{gettext("searches usernames")}</dd>
-          <dt class="m-0 font-mono text-slate-700 dark:text-slate-200">"{gettext("miller")}"</dt>
-          <dd class="m-0 font-normal text-slate-600 dark:text-slate-400">{gettext("in quotes: exact matches only, no similar names")}</dd>
-        </dl>
+        <div class="mt-3">
+          <.search_tips scope={@effective_scope} />
+        </div>
       </.card>
 
       <div :if={@results} class="mt-6 space-y-6">
+        <%!-- Keep the tips reachable while refining a search (#861), but as a
+        collapsed one-line disclosure so they cost almost no real estate. It
+        renders the SAME scope-aware body as the empty-state card. --%>
+        <details
+          id="search-tips-results"
+          class="group rounded-2xl bg-white px-4 py-3 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800"
+        >
+          <summary class="flex cursor-pointer list-none items-center gap-2 text-sm font-semibold text-slate-600 [&::-webkit-details-marker]:hidden dark:text-slate-300">
+            <svg
+              class="h-4 w-4 shrink-0 text-slate-500 transition-transform group-open:rotate-90 dark:text-slate-400"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="m9 5 7 7-7 7" />
+            </svg>
+            {gettext("Search Tips")}
+          </summary>
+          <div class="mt-3">
+            <.search_tips scope={@effective_scope} />
+          </div>
+        </details>
+
         <.save_search_control
           :if={@current_user && @saveable?}
           id="people-save-search"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.143.0",
+      version: "7.144.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -4699,6 +4699,21 @@ msgstr ""
 "Sie können nach Namen (Vor- und Nachname), E-Mail Adressen, Tags oder nach "
 "Wörtern in öffentlichen Beiträgen suchen."
 
+#: lib/vutuv_web/live/search_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "Search for people by name, email, or username."
+msgstr "Suchen Sie Personen nach Name, E-Mail Adresse oder Benutzername."
+
+#: lib/vutuv_web/live/search_live.ex:258
+#, elixir-autogen, elixir-format
+msgid "Search for tags by name."
+msgstr "Suchen Sie Tags nach ihrem Namen."
+
+#: lib/vutuv_web/live/search_live.ex:259
+#, elixir-autogen, elixir-format
+msgid "Search for words in public posts."
+msgstr "Suchen Sie nach Wörtern in öffentlichen Beiträgen."
+
 #: lib/vutuv_web/templates/block/index.html.heex:28
 #: lib/vutuv_web/templates/user/show.html.heex:196
 #, elixir-autogen, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -4526,6 +4526,21 @@ msgstr ""
 msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
 
+#: lib/vutuv_web/live/search_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "Search for people by name, email, or username."
+msgstr ""
+
+#: lib/vutuv_web/live/search_live.ex:258
+#, elixir-autogen, elixir-format
+msgid "Search for tags by name."
+msgstr ""
+
+#: lib/vutuv_web/live/search_live.ex:259
+#, elixir-autogen, elixir-format
+msgid "Search for words in public posts."
+msgstr ""
+
 #: lib/vutuv_web/templates/block/index.html.heex:28
 #: lib/vutuv_web/templates/user/show.html.heex:196
 #, elixir-autogen, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -4524,6 +4524,21 @@ msgstr ""
 msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
 
+#: lib/vutuv_web/live/search_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "Search for people by name, email, or username."
+msgstr ""
+
+#: lib/vutuv_web/live/search_live.ex:258
+#, elixir-autogen, elixir-format
+msgid "Search for tags by name."
+msgstr ""
+
+#: lib/vutuv_web/live/search_live.ex:259
+#, elixir-autogen, elixir-format
+msgid "Search for words in public posts."
+msgstr ""
+
 #: lib/vutuv_web/templates/block/index.html.heex:28
 #: lib/vutuv_web/templates/user/show.html.heex:196
 #, elixir-autogen, elixir-format

--- a/test/vutuv_web/live/search_live_test.exs
+++ b/test/vutuv_web/live/search_live_test.exs
@@ -384,6 +384,89 @@ defmodule VutuvWeb.SearchLiveTest do
     end
   end
 
+  describe "scope-aware search tips (#887)" do
+    test "the empty-state tips card hides people-only operators on the tags scope", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/search?scope=tags")
+
+      # The empty-query tips card is the always-open one, with its operator list.
+      assert has_element?(view, "#search-tips-empty #search-syntax")
+
+      # The people-only operators do not apply to a tag-name search, so their
+      # rows are gone (they would be misleading on this tab, issue #887).
+      refute has_element?(view, "#search-syntax dt", "status:looking")
+      refute has_element?(view, "#search-syntax dt", "city:koblenz")
+      refute has_element?(view, "#search-syntax dt", "first:stefan")
+      refute has_element?(view, "#search-syntax dt", "@stefan")
+      # tag: searches tag NAMES on this tab, so the tag: operator is meaningless here too.
+      refute has_element?(view, "#search-syntax dt", "tag:php")
+    end
+
+    test "the empty-state tips card keeps the people operators on all and people scopes",
+         %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/search")
+      assert has_element?(view, "#search-syntax dt", "status:looking")
+      assert has_element?(view, "#search-syntax dt", "city:koblenz")
+      assert has_element?(view, "#search-syntax dt", "first:stefan")
+      assert has_element?(view, "#search-syntax dt", "@stefan")
+
+      {:ok, view, _html} = live(conn, ~p"/search?scope=people")
+      assert has_element?(view, "#search-syntax dt", "status:looking")
+      assert has_element?(view, "#search-syntax dt", "city:koblenz")
+    end
+
+    test "the posts scope keeps tag: but drops the people-only operators", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/search?scope=posts")
+
+      # tag: filters posts (issue #946), so it applies on the posts tab ...
+      assert has_element?(view, "#search-syntax dt", "tag:php")
+      # ... but the people-only operators do not.
+      refute has_element?(view, "#search-syntax dt", "status:looking")
+      refute has_element?(view, "#search-syntax dt", "city:koblenz")
+    end
+
+    # Locale is a test dimension: the new scope intro strings ship a German
+    # translation, and the German render must stay scope-aware too.
+    test "the German render keeps the tips scope-aware on the tags scope", %{conn: conn} do
+      conn = put_req_header(conn, "accept-language", "de-DE,de")
+
+      {:ok, view, _html} = live(conn, ~p"/search?scope=tags")
+
+      # The German tag-scope intro resolved (not the English fallback) ...
+      assert has_element?(view, "#search-tips-empty", "Suchen Sie Tags")
+      # ... and the people-only operators are still gone.
+      refute has_element?(view, "#search-syntax dt", "status:looking")
+      refute has_element?(view, "#search-syntax dt", "city:koblenz")
+    end
+  end
+
+  describe "compact tips on the results page (#861)" do
+    test "results show a collapsed tips disclosure, not the big empty-state card", %{conn: conn} do
+      searchable_user("Maria", "Meier")
+
+      {:ok, view, _html} = live(conn, ~p"/search?q=meier")
+
+      # Results are showing ...
+      assert has_element?(view, "#search-people")
+      # ... so the compact, collapsed disclosure carries the tips ...
+      assert has_element?(view, "details#search-tips-results")
+      assert has_element?(view, "#search-tips-results #search-syntax")
+      # ... and the always-open empty-state card is not rendered.
+      refute has_element?(view, "#search-tips-empty")
+    end
+
+    test "the results disclosure is scope-aware too", %{conn: conn} do
+      author = insert(:activated_user)
+      create_post!(author, %{body: "Quantum gardening tips for beginners"})
+
+      {:ok, view, _html} = live(conn, ~p"/search?q=quantum gardening&scope=posts")
+
+      assert has_element?(view, "#search-tips-results #search-syntax")
+      # tag: applies on the posts scope, the people-only operators do not.
+      assert has_element?(view, "#search-tips-results #search-syntax dt", "tag:php")
+      refute has_element?(view, "#search-tips-results #search-syntax dt", "status:looking")
+    end
+  end
+
   describe "legacy search URLs" do
     test "a stored-query URL replays as a live search", %{conn: conn} do
       conn = get(conn, "/search/smith")


### PR DESCRIPTION
## What

Two closely related fixes to the `/search` "Search Tips", in one PR.

**#887 - scope-aware tips.** The tips card listed every operator regardless of the active scope chip, so People-only operators (`first:`/`last:`, `city:`, `status:`, `@handle`) and the "similar names" note showed even on the Tags tab, where they do nothing. The tips now depend on `@effective_scope`, derived from `Vutuv.Search`'s people/tags/posts guards:

- People operators + "similar names" -> `:all` / `:people` only
- `tag:` -> `:all` / `:people` / `:posts` (filters people and posts, #946), but **not** `:tags` (that scope searches tag names directly)
- quotes / exact-match tip -> all scopes

Each scope also gets a one-line intro naming only what it actually searches, so a tab with few applicable operators explains itself rather than showing a misleading list (#887 point 2).

**#861 - tips on the results page.** They used to vanish once results appeared. They are back as a compact, collapsed-by-default `<details>` disclosure that costs a single line until opened, and expands to the same scope-aware tips. Following Stefan's note on the issue, it stays a small disclosure (no new JS) rather than the always-open card, to keep the real-estate footprint tiny.

## How

Both the empty-state card and the results disclosure render one shared private component (`search_tips/1`), so #887's scope-awareness applies in both places and can't drift between them. New DOM ids: `#search-tips-empty` (empty-state card) and `#search-tips-results` (results disclosure).

## Out of scope

shaedrich's "clickable chips that insert into the search bar" idea (from #861) is deliberately not built - the collapsible disclosure keeps the footprint small and needs no JS. Easy to add later if wanted.

## Tests

New tests drive the scope via the same URL param the chips use and assert on stable element ids: people-only operators absent on `:tags`, present on `:all`/`:people`, `tag:` kept on `:posts`; the results disclosure present (and the big card absent) once results show, and scope-aware there too; plus a German-locale render so the new scope-intro translations stay green. Full `mix precommit` is green (4754 tests).

Closes #887
Closes #861

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*