### PR TITLE
Cap actual inflation in the LinkedIn import to stop a zip bomb (F5/F19)

### DIFF
--- a/lib/vutuv/imports/linked_in.ex
+++ b/lib/vutuv/imports/linked_in.ex
@@ -79,60 +79,97 @@ defmodule Vutuv.Imports.LinkedIn do
 
   @doc """
   Parses a LinkedIn export ZIP (a binary) into candidate lists. Returns
-  `{:error, :invalid_archive}` for anything that is not a readable ZIP.
+  `{:error, :invalid_archive}` for anything that is not a readable ZIP, and
+  `{:error, :archive_too_large}` for one whose contents blow past the safety
+  caps. `opts` may override those caps (for tests); production uses the
+  defaults in `@default_caps`.
   """
-  def parse(zip_binary) when is_binary(zip_binary) do
-    do_parse(zip_binary)
+  def parse(zip_binary, opts \\ []) when is_binary(zip_binary) do
+    do_parse(zip_binary, opts)
   end
 
   @doc """
   Like `parse/1`, but reads the ZIP from a file on disk (the uploaded temp
-  file), so the archive is never loaded into memory whole — `:zip` only
-  inflates the selected small entries.
+  file). The archive is read into memory whole (its size is already bounded by
+  the controller's upload cap) and only the small, selected entries are
+  inflated — each under a per-entry and cumulative output cap, with a cumulative
+  cap on the compressed bytes fed to the inflater as well.
   """
-  def parse_file(path) when is_binary(path) do
-    do_parse(String.to_charlist(path))
+  def parse_file(path, opts \\ []) when is_binary(path) do
+    case File.read(path) do
+      {:ok, bytes} -> do_parse(bytes, opts)
+      {:error, _} -> {:error, :invalid_archive}
+    end
   end
 
-  # `:zip` accepts both an in-memory binary and a filename charlist.
-  defp do_parse(zip_source) do
-    with {:ok, names} <- safe_entry_names(zip_source),
-         {:ok, files} <- extract(zip_source, names) do
+  defp do_parse(bytes, opts) when is_binary(bytes) do
+    caps = caps(opts)
+
+    with {:ok, entries} <- central_directory(bytes),
+         {:ok, kept} <- select_entries(entries, caps),
+         {:ok, located} <- locate_entries(bytes, kept),
+         :ok <- reject_overlaps(located),
+         {:ok, files} <- inflate_entries(bytes, caps, located) do
       {:ok, build(files)}
     end
   end
 
-  # Zip-bomb defense. The CSVs we need (profile, positions, volunteering,
-  # education, skills, phone) are tiny; a LinkedIn export's bulk (connections,
-  # messages, media) we
-  # don't touch. So we read the ZIP's central directory FIRST (no decompression),
-  # then:
-  #   * skip any single entry that declares more than @max_entry_bytes — the big
-  #     message dumps, and any honest bomb whose header admits its size;
-  #   * refuse the whole archive if it has more than @max_entries members, or if
-  #     the entries we would actually extract already declare more than
-  #     @max_total_bytes uncompressed.
-  # Only the surviving small entries are decompressed, so a classic bomb (e.g.
-  # 42.zip, whose members declare petabytes) is rejected before any inflation.
-  # The compressed upload is also capped in the controller (@max_upload_bytes),
-  # which bounds the worst case for a spoofed-header single stream.
-  @max_entries 2_000
-  @max_entry_bytes 15_000_000
-  @max_total_bytes 40_000_000
+  # Zip-bomb / decompression-DoS defense. The CSVs we need (profile, positions,
+  # volunteering, education, skills, phone) are tiny; a LinkedIn export's bulk
+  # (connections, messages, media) we don't touch. The declared central-directory
+  # sizes are attacker-controlled, so they are only a cheap FIRST filter — the
+  # real caps are enforced against actual inflated output AND compressed input:
+  #
+  #   * @max_entries  — refuse an archive with too many members.
+  #   * @max_entry_bytes  — pre-filter: skip any entry that *declares* more than
+  #     this (a cheap first line), then also abort a single entry that actually
+  #     inflates past it (a spoofed-header stream that lies about its size).
+  #   * @max_total_bytes  — refuse if the kept entries already *declare* more
+  #     than this uncompressed, and abort once the cumulative *actual* output
+  #     crosses it.
+  #   * @max_input_bytes  — a cumulative budget on the compressed bytes fed to
+  #     the inflater across ALL entries. This is what bounds decompression WORK:
+  #     a low-ratio stream (tiny output, huge input) never trips the output caps
+  #     but is stopped here, and duplicated/overlapping streams can never make us
+  #     inflate the same data twice past the budget. A legitimate export inflates
+  #     only its small CSVs, whose combined compressed size is tiny; and the
+  #     non-overlapping entries of a <=50 MB archive hold <=50 MB of compressed
+  #     data total, so 40 MB is generous for real data and fatal to the attack.
+  #   * @max_iterations  — a per-entry backstop on `safeInflate` calls, so a
+  #     truncated stream that keeps asking for input can never spin forever.
+  #
+  # Entries whose local-header data regions OVERLAP (or share an offset) are not
+  # a normal archive — they are the "2000 members all pointing at one 48 MB
+  # stream" attack — and the archive is rejected outright before any inflation.
+  # Only stored (0) and deflate (8) methods are accepted; anything else, or any
+  # malformed local header, degrades to `{:error, :invalid_archive}`.
+  @default_caps %{
+    max_entries: 2_000,
+    max_entry_bytes: 15_000_000,
+    max_total_bytes: 40_000_000,
+    max_input_bytes: 40_000_000,
+    max_iterations: 100_000
+  }
 
-  defp safe_entry_names(zip_source) do
-    case :zip.list_dir(zip_source) do
+  defp caps(opts) do
+    overrides = opts |> Map.new() |> Map.take(Map.keys(@default_caps))
+    Map.merge(@default_caps, overrides)
+  end
+
+  # Read the central directory only (no decompression): name + declared
+  # uncompressed size + local-header offset + compressed size per entry.
+  defp central_directory(bytes) do
+    case :zip.list_dir(bytes) do
       {:ok, table} ->
         entries =
-          for {:zip_file, name, info, _comment, _offset, _comp} <- table,
+          for {:zip_file, name, info, _comment, offset, comp_size} <- table,
               not directory?(name),
-              do: {name, elem(info, 1)}
+              is_integer(offset),
+              is_integer(comp_size),
+              is_integer(elem(info, 1)),
+              do: %{name: name, declared: elem(info, 1), offset: offset, comp_size: comp_size}
 
-        if length(entries) > @max_entries do
-          {:error, :archive_too_large}
-        else
-          select_entries(entries)
-        end
+        {:ok, entries}
 
       {:error, _} ->
         {:error, :invalid_archive}
@@ -141,34 +178,207 @@ defmodule Vutuv.Imports.LinkedIn do
     _ -> {:error, :invalid_archive}
   end
 
-  # Keep only entries small enough to be a real CSV, and refuse if their total
-  # declared uncompressed size is still too big.
-  defp select_entries(entries) do
-    kept = for {name, size} <- entries, size <= @max_entry_bytes, do: {name, size}
-    total = Enum.reduce(kept, 0, fn {_name, size}, acc -> acc + size end)
+  defp directory?(name), do: List.last(name) == ?/
 
-    if total > @max_total_bytes do
+  # Cheap first line: drop entries that DECLARE more than the per-entry cap, and
+  # refuse the whole archive on too many members or too much declared total.
+  defp select_entries(entries, caps) do
+    if length(entries) > caps.max_entries do
       {:error, :archive_too_large}
     else
-      {:ok, Enum.map(kept, fn {name, _size} -> name end)}
+      kept = Enum.filter(entries, &(&1.declared <= caps.max_entry_bytes))
+      total = Enum.reduce(kept, 0, &(&1.declared + &2))
+
+      if total > caps.max_total_bytes, do: {:error, :archive_too_large}, else: {:ok, kept}
     end
   end
 
-  defp directory?(name), do: List.last(name) == ?/
-
-  defp extract(_zip_source, []), do: {:ok, []}
-
-  defp extract(zip_source, names) do
-    case :zip.unzip(zip_source, [:memory, {:file_list, names}]) do
-      {:ok, entries} ->
-        {:ok,
-         Enum.map(entries, fn {name, content} -> {to_string(name), ensure_utf8(content)} end)}
-
-      {:error, _reason} ->
-        {:error, :invalid_archive}
+  # Parse each kept entry's LOCAL header to find where its compressed data
+  # actually starts and how much of it is present in the archive. name_len is at
+  # byte 26 of the local header, extra_len at byte 28, the compression method at
+  # byte 8; the data begins at offset + 30 + name_len + extra_len.
+  defp locate_entries(bytes, kept) do
+    kept
+    |> Enum.reduce_while([], fn entry, acc ->
+      case locate_entry(bytes, entry) do
+        {:ok, located} -> {:cont, [located | acc]}
+        :error -> {:halt, {:error, :invalid_archive}}
+      end
+    end)
+    |> case do
+      {:error, _} = err -> err
+      located -> {:ok, Enum.reverse(located)}
     end
-  rescue
-    _ -> {:error, :invalid_archive}
+  end
+
+  defp locate_entry(bytes, %{offset: offset, comp_size: comp_size, name: name})
+       when is_integer(offset) and offset >= 0 do
+    case bytes do
+      <<_::binary-size(^offset), 0x50, 0x4B, 0x03, 0x04, _::binary-size(4), method::little-16,
+        _::binary-size(16), name_len::little-16, extra_len::little-16, _rest::binary>>
+      when method in [0, 8] ->
+        data_start = offset + 30 + name_len + extra_len
+
+        if data_start <= byte_size(bytes) do
+          available = byte_size(bytes) - data_start
+          feed = min(max(comp_size, 0), available)
+          {:ok, %{name: name, method: method, data_start: data_start, feed: feed}}
+        else
+          :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp locate_entry(_bytes, _entry), do: :error
+
+  # Two kept entries whose compressed-data regions overlap (or share an offset)
+  # cannot happen in a normal archive; it is the "inflate one stream N times"
+  # attack. Reject the whole archive before any inflation.
+  defp reject_overlaps(located) do
+    regions =
+      located
+      |> Enum.map(fn %{data_start: start, feed: feed} -> {start, start + feed} end)
+      |> Enum.sort()
+
+    if overlapping?(regions), do: {:error, :invalid_archive}, else: :ok
+  end
+
+  defp overlapping?([{_start1, end1}, {start2, _end2} = next | rest]) do
+    start2 < end1 or overlapping?([next | rest])
+  end
+
+  defp overlapping?(_), do: false
+
+  # Inflate the located entries in one pass, threading two cumulative budgets:
+  # the actual output produced (@max_total_bytes) and the compressed input fed to
+  # the inflater (@max_input_bytes). The zlib port is opened once and closed in
+  # the `after`; any zlib raise (a corrupt/garbage stream) becomes
+  # `{:error, :invalid_archive}`.
+  defp inflate_entries(_bytes, _caps, []), do: {:ok, []}
+
+  defp inflate_entries(bytes, caps, located) do
+    z = :zlib.open()
+
+    try do
+      :zlib.inflateInit(z, -15)
+
+      result =
+        Enum.reduce_while(located, {[], 0, 0}, fn entry, {files, input_used, output_total} ->
+          case inflate_entry(z, bytes, caps, entry, input_used, output_total) do
+            {:ok, content, input_used2, output_total2} ->
+              {:cont, {[{to_string(entry.name), content} | files], input_used2, output_total2}}
+
+            {:error, _} = err ->
+              {:halt, err}
+          end
+        end)
+
+      case result do
+        {:error, _} = err -> err
+        {files, _input, _output} -> {:ok, Enum.reverse(files)}
+      end
+    rescue
+      _ -> {:error, :invalid_archive}
+    after
+      :zlib.close(z)
+    end
+  end
+
+  # A stored (uncompressed) entry: output is the raw slice, so it is bounded by
+  # the same caps directly.
+  defp inflate_entry(
+         _z,
+         bytes,
+         caps,
+         %{method: 0, data_start: data_start, feed: feed},
+         input_used,
+         output_total
+       ) do
+    new_input = input_used + feed
+
+    cond do
+      new_input > caps.max_input_bytes ->
+        {:error, :archive_too_large}
+
+      feed > caps.max_entry_bytes ->
+        {:error, :archive_too_large}
+
+      output_total + feed > caps.max_total_bytes ->
+        {:error, :archive_too_large}
+
+      true ->
+        {:ok, ensure_utf8(binary_part(bytes, data_start, feed)), new_input, output_total + feed}
+    end
+  end
+
+  # A deflate entry: stream-inflate it, aborting the moment the actual output
+  # crosses a cap. The compressed input is bounded up front by the cumulative
+  # input budget, before a single byte is fed.
+  defp inflate_entry(
+         z,
+         bytes,
+         caps,
+         %{method: 8, data_start: data_start, feed: feed},
+         input_used,
+         output_total
+       ) do
+    new_input = input_used + feed
+
+    if new_input > caps.max_input_bytes do
+      {:error, :archive_too_large}
+    else
+      :zlib.inflateReset(z)
+      data = binary_part(bytes, data_start, feed)
+
+      case drain(z, data, caps, output_total, 0, 0, []) do
+        {:ok, iodata, entry_out} ->
+          {:ok, ensure_utf8(:erlang.iolist_to_binary(iodata)), new_input,
+           output_total + entry_out}
+
+        {:error, _} = err ->
+          err
+      end
+    end
+  end
+
+  # Drain `safeInflate` until the stream finishes, feeding the compressed data on
+  # the first call and `[]` on every continuation. A zero-output `{:continue,
+  # <<>>}` is NORMAL (zlib documents output latency) and never rejected on its
+  # own — the caps and the iteration backstop stop a malicious stream, a zlib
+  # raise stops a garbage one.
+  defp drain(_z, _input, caps, _output_total, _entry_out, iterations, _acc)
+       when iterations > caps.max_iterations do
+    {:error, :archive_too_large}
+  end
+
+  defp drain(z, input, caps, output_total, entry_out, iterations, acc) do
+    case :zlib.safeInflate(z, input) do
+      {:continue, output} ->
+        entry_out2 = entry_out + :erlang.iolist_size(output)
+
+        cond do
+          entry_out2 > caps.max_entry_bytes ->
+            {:error, :archive_too_large}
+
+          output_total + entry_out2 > caps.max_total_bytes ->
+            {:error, :archive_too_large}
+
+          true ->
+            drain(z, [], caps, output_total, entry_out2, iterations + 1, [acc | [output]])
+        end
+
+      {:finished, output} ->
+        entry_out2 = entry_out + :erlang.iolist_size(output)
+
+        cond do
+          entry_out2 > caps.max_entry_bytes -> {:error, :archive_too_large}
+          output_total + entry_out2 > caps.max_total_bytes -> {:error, :archive_too_large}
+          true -> {:ok, [acc | [output]], entry_out2}
+        end
+    end
   end
 
   # LinkedIn writes UTF-8, but a member who opens a CSV in Excel and re-saves

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.144.0",
+      version: "7.144.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/imports/linked_in_test.exs
+++ b/test/vutuv/imports/linked_in_test.exs
@@ -20,6 +20,63 @@ defmodule Vutuv.Imports.LinkedInTest do
 
   defp profile_csv, do: @profile_headers <> "\n" <> @profile_row <> "\n"
 
+  # ── Malicious-archive builders (craft what :zip.create won't) ──
+
+  # Overwrite the 4-byte little-endian field at absolute byte `pos` in `bin`.
+  defp patch_u32(bin, pos, value) do
+    binary_part(bin, 0, pos) <>
+      <<value::little-32>> <> binary_part(bin, pos + 4, byte_size(bin) - pos - 4)
+  end
+
+  # A single real deflate entry whose central-directory *declared* uncompressed
+  # size is overwritten to a small lie, so the cheap declared-size pre-filter
+  # keeps it while the stream actually inflates to `byte_size(actual)`.
+  # (Central-directory file header: uncompressed size is the 4 bytes at +24.)
+  defp bomb_zip(actual, declared_size) do
+    {:ok, {_n, bin}} = :zip.create(~c"bomb.zip", [{~c"Connections.csv", actual}], [:memory])
+    {cd, _} = :binary.match(bin, <<0x50, 0x4B, 0x01, 0x02>>)
+    patch_u32(bin, cd + 24, declared_size)
+  end
+
+  # `count` central-directory records all pointing at ONE local header (offset 0),
+  # i.e. `count` entries that share a single deflate stream — the "inflate one
+  # stream N times" attack. Built by duplicating the single record and rewriting
+  # the end-of-central-directory record's counts/sizes.
+  defp shared_offset_zip(count) do
+    # ~300 KB of real, compressible data at offset 0 — the stream the naive
+    # attack would inflate once per central-directory entry.
+    stream = :binary.copy("data,row,value\n", 20_000)
+    {:ok, {_n, bin}} = :zip.create(~c"s.zip", [{~c"x.csv", stream}], [:memory])
+    {cd_start, _} = :binary.match(bin, <<0x50, 0x4B, 0x01, 0x02>>)
+    {eocd_start, _} = :binary.match(bin, <<0x50, 0x4B, 0x05, 0x06>>)
+    prefix = binary_part(bin, 0, cd_start)
+    # Each copy declares a tiny uncompressed size (+24 in the record), so the
+    # archive clears the declared-size pre-filter and reaches the overlap check —
+    # mirroring an attack whose entries all lie about their size.
+    cdfh = patch_u32(binary_part(bin, cd_start, eocd_start - cd_start), 24, 5_000)
+    eocd = binary_part(bin, eocd_start, byte_size(bin) - eocd_start)
+    new_cd = :binary.copy(cdfh, count)
+
+    <<sig::binary-size(4), disk::binary-size(4), _recs1::little-16, _recs2::little-16,
+      _cd_size::little-32, _cd_off::little-32, rest::binary>> = eocd
+
+    new_eocd =
+      <<sig::binary-size(4), disk::binary-size(4), count::little-16, count::little-16,
+        byte_size(new_cd)::little-32, byte_size(prefix)::little-32, rest::binary>>
+
+    prefix <> new_cd <> new_eocd
+  end
+
+  # Two kept entries whose data regions overlap: entry b's central-directory
+  # local-header offset (+42 in the record) is patched to point at entry a's.
+  defp overlapping_zip do
+    {:ok, {_n, bin}} =
+      :zip.create(~c"o.zip", [{~c"a.csv", "aaaa\n"}, {~c"b.csv", "bbbb\n"}], [:memory])
+
+    [_first, {second, _}] = :binary.matches(bin, <<0x50, 0x4B, 0x01, 0x02>>)
+    patch_u32(bin, second + 42, 0)
+  end
+
   describe "parse/1 errors" do
     test "a non-zip binary is an invalid archive" do
       assert LinkedIn.parse("this is not a zip file") == {:error, :invalid_archive}
@@ -376,6 +433,103 @@ defmodule Vutuv.Imports.LinkedInTest do
     test "refuses an archive with too many entries" do
       files = for i <- 1..2001, do: {"f#{i}.csv", "Name\n"}
       assert {:error, :archive_too_large} = LinkedIn.parse(zip(files))
+    end
+
+    # The original finding: a spoofed central-directory header declares a small
+    # uncompressed size (so the cheap pre-filter keeps the entry) while the real
+    # deflate stream inflates far past the per-entry cap. The unpatched code fed
+    # the whole stream to `:zip.unzip` with no output cap and OOMed; now the
+    # streaming inflater aborts once the actual output crosses the cap.
+    test "rejects a declared-small but actually-huge single entry (spoofed header)" do
+      # 16 MB of zeros compresses to a few KB; declared as 5 KB it sails past the
+      # declared-size pre-filter, then trips the 15 MB per-entry OUTPUT cap.
+      archive = bomb_zip(:binary.copy(<<0>>, 16_000_000), 5_000)
+
+      assert {:error, :archive_too_large} = LinkedIn.parse(archive)
+    end
+
+    # Objection 1(a): many central-directory entries whose offsets all point at
+    # the SAME deflate stream. Detected as overlapping data regions and rejected
+    # BEFORE any inflation, so the shared stream is never inflated N times.
+    test "rejects an archive whose entries share one offset, promptly" do
+      archive = shared_offset_zip(500)
+
+      {micros, result} = :timer.tc(fn -> LinkedIn.parse(archive) end)
+
+      # Overlapping data regions are not a normal archive: rejected outright,
+      # before the shared stream is inflated even once.
+      assert {:error, :invalid_archive} = result
+      # No gigabytes inflated: rejection is a cheap header/interval check.
+      assert micros < 1_000_000
+    end
+
+    # The two-entry form of the same defect: entry b's data region is patched to
+    # overlap entry a's. A normal archive never overlaps.
+    test "rejects an archive with two overlapping data regions" do
+      assert {:error, :invalid_archive} = LinkedIn.parse(overlapping_zip())
+    end
+
+    # Objection 1(b): a stream can consume far more compressed INPUT (and CPU)
+    # than it produces OUTPUT, so the output caps alone don't bound the work. The
+    # cumulative-input budget is the primary fix. Caps are overridable so the
+    # test stays small; production keeps 15 MB / 40 MB / 40 MB.
+    test "rejects when the cumulative compressed input exceeds the input budget" do
+      # Two incompressible entries (~1.5 KB each). Their declared sizes are tiny
+      # so the per-entry OUTPUT caps never fire; only the cumulative INPUT budget
+      # (set here to 2 KB) stops them — the second entry pushes the total over.
+      a = :crypto.strong_rand_bytes(1_500)
+      b = :crypto.strong_rand_bytes(1_500)
+      archive = zip([{"a.csv", a}, {"b.csv", b}])
+
+      assert {:error, :archive_too_large} =
+               LinkedIn.parse(archive, max_input_bytes: 2_000)
+
+      # With a budget generous enough for both, the same archive is accepted.
+      assert {:ok, _} = LinkedIn.parse(archive, max_input_bytes: 40_000_000)
+    end
+
+    # Objection 2: a genuinely corrupt/garbage deflate stream must still
+    # terminate with an error (a zlib raise, caught and converted) — never hang.
+    test "rejects a corrupt deflate stream instead of hanging" do
+      {:ok, {_n, bin}} =
+        :zip.create(
+          ~c"g.zip",
+          [{~c"Positions.csv", :binary.copy("Company Name,Title\nA,B\n", 500)}],
+          [:memory]
+        )
+
+      {:ok, [_comment, {:zip_file, _name, _info, _cm, offset, _comp}]} = :zip.list_dir(bin)
+
+      <<_::binary-size(^offset), _::binary-size(26), name_len::little-16, extra_len::little-16,
+        _::binary>> = bin
+
+      data_start = offset + 30 + name_len + extra_len
+      # Overwrite the first deflate byte with an invalid block type (BTYPE = 11,
+      # reserved), so the very first inflate step raises `:data_error`.
+      <<pre::binary-size(^data_start), _first, post::binary>> = bin
+      corrupt = pre <> <<0x07>> <> post
+
+      assert {:error, _} = LinkedIn.parse(corrupt)
+    end
+
+    # A large but valid entry (well under the caps) must inflate fully across many
+    # `safeInflate` iterations — proving zero-output continuations are drained,
+    # not mistaken for corruption (objection 2's availability half).
+    test "imports a large valid entry that drains over many inflate iterations" do
+      header = "Company Name,Title,Description,Location,Started On,Finished On\n"
+
+      body =
+        Enum.map_join(1..40_000, "", fn i -> "Org#{i},Engineer #{i},desc,Berlin,2020,\n" end)
+
+      {:ok, result} = LinkedIn.parse(zip([{"Positions.csv", header <> body}]))
+
+      # The final row (end of a ~1.5 MB stream, many `safeInflate` iterations
+      # deep) is present, proving the whole stream drained rather than being cut
+      # off early or rejected on a zero-output continuation.
+      assert Enum.any?(result.positions, &(&1.params["organization"] == "Org40000"))
+      # phash2 candidate ids collide a handful of times across 40k rows, so allow
+      # for a few merges rather than asserting an exact count.
+      assert length(result.positions) > 39_900
     end
   end
 


### PR DESCRIPTION
**TL;DR** The LinkedIn-import zip-bomb guard trusted the archive's self-declared sizes, so `:zip.unzip([:memory])` could inflate a declared-small entry to tens of GB and OOM the node. Now inflation is bounded by actual output AND by decompression work.

**Where:** `lib/vutuv/imports/linked_in.ex`

**Now:** the guard filtered entries by their central-directory *declared* uncompressed size (uploader-controlled), then `:zip.unzip([:memory])` inflated the real deflate stream with no output cap. A declared-500-byte / actually-40-GB entry passed the filter and OOM-killed the node; the `rescue` can't catch an allocator abort (findings F5, F19).

**Want:** inflation bounded by *real* bytes, not declared ones, and total decompression work bounded too.

**What changed:**
- Replaced `:zip.unzip` with self-managed inflation: read the archive (already ≤50 MB via the upload gate), keep the cheap declared-size pre-filter, then parse each kept entry's local file header to locate its deflate stream and inflate it with `:zlib.safeInflate` in a chunked loop that aborts the moment actual output crosses `@max_entry_bytes` (15 MB) / `@max_total_bytes` (40 MB). The cap reads real inflated bytes, so a lying central directory can't bypass it.
- Because output caps don't bound *work*, added a cumulative **input budget** (`@max_input_bytes`, 40 MB) charged before feeding each entry (kills a low-output-ratio stream), and **`reject_overlaps`** which refuses an archive whose kept entries share/overlap a deflate region (the "2000 entries → one 48 MB stream" shape) before any inflation. A per-entry iteration backstop guarantees termination. Worst-case decompression per request drops from ~50 GB to ~40 MB (on top of the 10/hour rate limit).
- Only stored/deflate accepted; malformed/truncated/ZIP64 → clean error.

**Verification:** regression tests (declared-small bomb, shared-offset, overlapping regions, cumulative-input overflow) fail against the unpatched code; a legitimate archive still imports and transcodes Latin-1. Reviewed by an independent verifier and, across **one revision that closed a work-exhaustion hole the first attempt introduced**, re-challenged twice by a fresh reviewer of the diff. `mix precommit` green: Credo clean, 4761 tests.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01Dz1H9S965ie56hT4DQ6Gax