### PR TITLE
Reflow soft-wrapped post bodies instead of breaking every line

### DIFF
--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -10,8 +10,10 @@ defmodule VutuvWeb.Markdown do
   meaningful unit is two segments deep (long URLs would wreck chat bubbles);
   trailing sentence punctuation and unbalanced `)` stay outside the
   link. Earmark renders the Markdown (bold, italics, links, inline code, lists,
-  quotes; newlines become `<br>`), HtmlSanitizeEx strips anything dangerous as a
-  second line of defence (`javascript:` hrefs etc.), and links open in a new tab.
+  quotes; a single newline becomes a `<br>` in chat/messages, but **posts**
+  reflow soft-wrapped lines instead — see `render_pipeline/2`'s `breaks:` note),
+  HtmlSanitizeEx strips anything dangerous as a second line of defence
+  (`javascript:` hrefs etc.), and links open in a new tab.
 
   **Images**: only a post may embed pictures, and only its **own uploaded
   attachments** (`render_post/2`'s whitelist) — a hotlinked remote image would
@@ -96,7 +98,7 @@ defmodule VutuvWeb.Markdown do
     {prepared, replacements} = extract_inline_images(text, images)
 
     prepared
-    |> render_pipeline()
+    |> render_pipeline(breaks: false)
     |> open_links_in_new_tab()
     |> linkify_entities()
     |> inject_inline_images(replacements)
@@ -194,12 +196,23 @@ defmodule VutuvWeb.Markdown do
   # emits its `<img>`. The one legitimate image path — a post's own uploaded
   # attachments — bypasses the pipeline entirely via `render_post/2`'s
   # plain-text markers and is injected afterwards from known-safe parts.
-  defp render_pipeline(text) do
+  #
+  # `breaks:` (default `true`) decides whether a single newline is a `<br>`.
+  # Chat, remote Mastodon text, newsletters and legal address blocks want that
+  # (a lone Enter is a deliberate break), so they keep the default. **Posts**
+  # pass `breaks: false`: a post body is prose, and Milkdown (the composer)
+  # never emits a lone soft-wrap newline — it serializes a real break as a
+  # trailing backslash and a paragraph as a blank line, both of which render the
+  # same either way. The only bodies with lone newlines are ones hard-wrapped in
+  # an external editor or pasted in source mode, where `breaks: true` turned
+  # every ~80-column wrap into a visible break (a wall of stray `<br>`s next to
+  # long links); `breaks: false` reflows them into flowing paragraphs.
+  defp render_pipeline(text, opts \\ []) do
     text
     |> strip_break_artifacts()
     |> String.replace("<", "&lt;")
     |> autolink_bare_urls()
-    |> Earmark.as_html!(breaks: true, pure_links: false)
+    |> Earmark.as_html!(breaks: Keyword.get(opts, :breaks, true), pure_links: false)
     # Earmark escapes the ampersand of our pre-escaped `&lt;` — undo the double.
     |> String.replace("&amp;lt;", "&lt;")
     |> HtmlSanitizeEx.markdown_html()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.144.1",
+      version: "7.144.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/markdown_test.exs
+++ b/test/vutuv_web/markdown_test.exs
@@ -155,6 +155,46 @@ defmodule VutuvWeb.MarkdownTest do
     assert render("line one\nline two") =~ "<br"
   end
 
+  describe "post line breaks (breaks: false)" do
+    defp post(text), do: text |> Markdown.render_post([]) |> Phoenix.HTML.safe_to_string()
+
+    test "a soft-wrapped paragraph reflows instead of breaking at every source line" do
+      # A post whose source was hard-wrapped at ~80 columns (an editor's
+      # fill-paragraph, or pasted prose) must read as one flowing paragraph, not
+      # a break at every wrap. `render/1` (chat) keeps single newlines as `<br>`;
+      # `render_post/2` (prose) does not. Regression for the "Diese Woche auf
+      # vutuv" announcement, which broke at every soft wrap next to its links.
+      source =
+        "auch wenn sie\nzeitlich durcheinander kamen ([#1006](https://ex.com),\n[#1027](https://ex.com)). Lange Threads"
+
+      html = post(source)
+
+      refute html =~ "<br"
+      assert html =~ "auch wenn sie"
+      assert html =~ "Lange Threads"
+    end
+
+    test "an intentional hard break (trailing backslash from Milkdown) still breaks" do
+      # Milkdown serializes a real in-paragraph break as a trailing backslash, so
+      # a post written with a deliberate line break keeps it even with breaks off.
+      assert post("line one\\\nline two") =~ "<br"
+    end
+
+    test "a blank line still starts a new paragraph" do
+      html = post("para one\n\npara two")
+
+      assert html =~ "para one"
+      assert html =~ "para two"
+      assert html =~ ~r{para one</p>\s*<p[^>]*>\s*para two}
+    end
+
+    test "a chat message keeps single newlines as breaks (unchanged)" do
+      # Guard that fixing posts did not touch the chat/message renderer, whose
+      # single-newline-as-break behavior is relied on (address blocks, DMs).
+      assert render("line one\nline two") =~ "<br"
+    end
+  end
+
   test "drops the editor's empty-paragraph <br /> artifacts instead of showing them" do
     # The Milkdown editor serializes each blank line the writer adds as a
     # standalone `<br />` block. Because the pipeline escapes `<`, those would


### PR DESCRIPTION
**TL;DR** A post whose Markdown was hard-wrapped at ~80 columns showed a `<br>` at every wrap (a wall of stray breaks next to its links). Posts now reflow; chat/messages are unchanged.

**Where:** `VutuvWeb.Markdown.render_post/2` + `render_pipeline/2` (`lib/vutuv_web/markdown.ex`)
**Now:** the shared pipeline renders with `Earmark.as_html!(breaks: true)`, so every single newline becomes a `<br>`. A body wrapped at 80 columns (external editor fill-paragraph, or a source-mode paste) breaks at every line. The [announcement post](https://vutuv.de/wintermeyer/posts/019f93fb-1ab3-72ac-a9f8-1da34e584641) showed this; it *looked* link-related only because the long `github.com/.../issues/NNNN` URLs forced the source to wrap next to them.
**Want:** posts read as flowing paragraphs.

**Fix:** `render_post/2` passes `breaks: false`. Milkdown (the composer) never emits a lone soft-wrap newline — it serializes a real break as a trailing backslash and a paragraph as a blank line, both of which render identically with `breaks: false`. So Milkdown-authored posts are unchanged, and only bodies with lone newlines reflow. Messages, remote Mastodon text, newsletters and legal address blocks keep the default `breaks: true` (a lone Enter there is a deliberate break).

**Verified:** rendered the real announcement body end to end → 0 `<br>`, paragraphs flow. Started with tests (reflow, preserved backslash hard break, blank-line paragraphs, and a guard that the chat renderer still breaks on single newlines). Full `mix precommit` green (4759 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*