### PR TITLE
Pin an education as the profile headline (#882)

### DIFF
--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -34,6 +34,7 @@ defmodule Vutuv.Accounts do
   alias Vutuv.Ordering
   alias Vutuv.Pages
   alias Vutuv.Profiles.Address
+  alias Vutuv.Profiles.Education
   alias Vutuv.Profiles.WorkExperience
   alias Vutuv.Repo
   alias Vutuv.Social.Block
@@ -1234,7 +1235,10 @@ defmodule Vutuv.Accounts do
         user_id: user_id
       }) do
     user
-    |> Ecto.Changeset.change(profile_work_experience_id: we_id)
+    # The profile headline is EITHER a pinned work experience OR a pinned
+    # education (issue #882), never both, so pinning a job clears any pinned
+    # education in the same write.
+    |> Ecto.Changeset.change(profile_work_experience_id: we_id, profile_education_id: nil)
     # Guards against a race where the experience is deleted between the owner
     # resolution and this write: the FK constraint fails cleanly instead of
     # persisting a dangling pointer.
@@ -1251,6 +1255,42 @@ defmodule Vutuv.Accounts do
   def unpin_profile_work_experience(%User{} = user) do
     user
     |> Ecto.Changeset.change(profile_work_experience_id: nil)
+    |> Repo.update()
+  end
+
+  @doc """
+  Pins `education` as the member's profile headline (issue #882): the
+  "Degree, School" line the profile header, its title, meta description and
+  every agent format lead with, instead of a job title — for a student or
+  someone unemployed who would rather feature a degree or school.
+
+  The headline is EITHER a pinned work experience OR a pinned education, never
+  both, so this clears any pinned work experience in the same write.
+  `education` must belong to `user` (the caller resolves it owner-scoped); a
+  foreign one is rejected rather than pinned. `profile_education_id` is set
+  programmatically here, never cast from a form.
+  """
+  def pin_profile_education(%User{id: user_id} = user, %Education{
+        id: edu_id,
+        user_id: user_id
+      }) do
+    user
+    |> Ecto.Changeset.change(profile_education_id: edu_id, profile_work_experience_id: nil)
+    # Same race guard as the job pin: if the education is deleted between the
+    # owner resolution and this write, the FK constraint fails cleanly.
+    |> Ecto.Changeset.foreign_key_constraint(:profile_education_id)
+    |> Repo.update()
+  end
+
+  def pin_profile_education(%User{}, %Education{}), do: {:error, :not_owner}
+
+  @doc """
+  Clears the member's pinned profile education, so the headline falls back to
+  the automatic job resolution again (issue #882).
+  """
+  def unpin_profile_education(%User{} = user) do
+    user
+    |> Ecto.Changeset.change(profile_education_id: nil)
     |> Repo.update()
   end
 

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -307,6 +307,15 @@ defmodule Vutuv.Accounts.User do
     # experience is deleted (ON DELETE SET NULL), so it can never point at a
     # gone role.
     belongs_to(:profile_work_experience, Vutuv.Profiles.WorkExperience)
+
+    # The education the member pinned as their profile headline (issue #882).
+    # nil = no education pinned, so the header falls back to the work-experience
+    # resolution (UserHelpers.profile_headline/3). Mutually exclusive with
+    # profile_work_experience_id above: pinning one clears the other in
+    # Accounts.pin_profile_education/2 / pin_profile_work_experience/2 (never
+    # cast from a form). Nulled by the DB when the pinned education is deleted
+    # (ON DELETE SET NULL), so it can never point at a gone entry.
+    belongs_to(:profile_education, Vutuv.Profiles.Education)
     has_many(:search_terms, Vutuv.Accounts.SearchTerm, on_replace: :delete)
     has_many(:endorsements, Vutuv.Tags.UserTagEndorsement)
 

--- a/lib/vutuv_web/agent_docs/profile_doc.ex
+++ b/lib/vutuv_web/agent_docs/profile_doc.ex
@@ -54,7 +54,11 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
         user.profile_work_experience_id
       )
 
-    work_info = UserHelpers.work_information_string_for_job(job, 256)
+    # The header line: a pinned education (issue #882) leads with its
+    # "Degree, School", else the job's "Title @ Org" — the same resolution the
+    # HTML header uses, so the doc's description/work_info can never drift from
+    # the page. `user` has :educations preloaded here, so it resolves in memory.
+    work_info = UserHelpers.profile_headline(user, job, 256)
     posts = Vutuv.Posts.profile_posts(user, viewer)
 
     # The #928 base gate AND the #938 exclusion, resolved together (one query):

--- a/lib/vutuv_web/controllers/education_controller.ex
+++ b/lib/vutuv_web/controllers/education_controller.ex
@@ -3,6 +3,7 @@ defmodule VutuvWeb.EducationController do
 
   import Ecto.Query
 
+  alias Vutuv.Accounts
   alias Vutuv.Profiles.CvUpdates
   alias Vutuv.Profiles.Education
   alias Vutuv.Social
@@ -35,6 +36,10 @@ defmodule VutuvWeb.EducationController do
           as_owner?: false,
           user: user,
           education: user.educations,
+          # The pinned profile headline (issue #882), so the shared card_list
+          # never crashes on a missing assign — the chooser itself stays gated
+          # on as_owner? and never renders here.
+          profile_education_id: user.profile_education_id,
           page_title: VutuvWeb.UserHelpers.member_page_title(user, gettext("Education"))
         )
       end,
@@ -42,16 +47,48 @@ defmodule VutuvWeb.EducationController do
     )
   end
 
-  # The owner's editor (GET /settings/educations).
+  # The owner's editor (GET /settings/educations), including the
+  # profile-headline pin chooser (issue #882).
   def manage(conn, _params) do
     user = user_with_educations(conn)
 
     render(conn, "manage.html",
       user: user,
       education: user.educations,
+      profile_education_id: user.profile_education_id,
       as_owner?: true,
       page_title: gettext("Education")
     )
+  end
+
+  # Pin one education as the member's profile headline, or clear the pin back to
+  # the automatic job resolution (issue #882). Owner-only (AuthUser) and
+  # owner-scoped (ResolveOwnedSlug assigns :education from the member's own
+  # rows), so a member can only ever pin their own entry. Pinning also clears a
+  # pinned work experience — the headline is one slot (Accounts).
+  def pin(conn, _params) do
+    user = conn.assigns[:user]
+
+    case Accounts.pin_profile_education(user, conn.assigns[:education]) do
+      {:ok, _user} ->
+        conn
+        |> put_flash(:info, gettext("This education now shows at the top of your profile."))
+        |> redirect(to: ~p"/settings/educations")
+
+      {:error, _} ->
+        conn
+        |> put_flash(:error, gettext("That education could not be pinned."))
+        |> redirect(to: ~p"/settings/educations")
+    end
+  end
+
+  def unpin(conn, _params) do
+    user = conn.assigns[:user]
+    {:ok, _user} = Accounts.unpin_profile_education(user)
+
+    conn
+    |> put_flash(:info, gettext("The top of your profile is chosen automatically again."))
+    |> redirect(to: ~p"/settings/educations")
   end
 
   def new(conn, _params) do

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -593,7 +593,12 @@ defmodule VutuvWeb.UserProfileLive do
     # the owner gets all of theirs (their card marks the lapsed ones).
     |> assign(:qualifications, user.qualifications)
     |> assign(:header_job, header_job)
-    |> assign(:work_info, work_information_string_for_job(header_job, 60))
+    # The header line: a pinned education (issue #882) leads with its
+    # "Degree, School", else the pinned/heuristic job's "Title @ Org". The user
+    # already has :educations preloaded, so profile_headline/3 resolves it in
+    # memory (no extra query). header_job stays the resolved work role for the
+    # JSON-LD Person markup below.
+    |> assign(:work_info, profile_headline(user, header_job, 60))
     |> assign(:completion_steps, steps)
     |> assign(:show_completion?, show_completion?)
     |> assign(:recommended_users, recommended_users)

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -962,6 +962,11 @@ defmodule VutuvWeb.Router do
       as: :settings_work_experience
     )
 
+    # Pin one education as the profile headline, or clear it back to the
+    # automatic job resolution (issue #882). Before the resources so "pin" is
+    # never read as an education id.
+    put("/educations/:id/pin", EducationController, :pin)
+    delete("/educations/:id/pin", EducationController, :unpin)
     get("/educations", EducationController, :manage)
 
     resources("/educations", EducationController,

--- a/lib/vutuv_web/templates/education/card_list.html.heex
+++ b/lib/vutuv_web/templates/education/card_list.html.heex
@@ -6,7 +6,44 @@ the visitor preview modes, gated on @as_owner?). Entries arrive newest-first
 
 The list is split into the CV categories (issue #849) — Studium,
 Berufsausbildung, Schulbildung — each under its own heading; a degrees-only
-member keeps the single unlabeled list. --%>
+member keeps the single unlabeled list.
+
+The owner also chooses whether a degree or school leads their profile headline
+(issue #882): the "Degree, School" line shown at the top of the profile, under
+the name, INSTEAD of a job title — for a student or someone unemployed. A short
+explainer up top says what fills that line and, when an education is pinned,
+offers the single "Choose automatically instead" revert; each entry below
+carries a "Show at top of profile" pin button, and the chosen one is marked.
+Pinning an education wins over the automatic job resolution and clears any
+pinned job (the headline is one slot). Owner-only, hidden in the public
+showcase. --%>
+<p
+  :if={@as_owner? and @education != []}
+  class="mb-5 flex items-start gap-2 text-sm text-slate-600 dark:text-slate-400"
+>
+  <%= cond do %>
+    <% pinned = pinned_entry(@education, @profile_education_id) -> %>
+      <.pin_star filled class="mt-0.5 h-4 w-4 shrink-0 text-brand-600 dark:text-brand-400" />
+      <span>
+        {gettext("%{job} shows at the top of your profile.", job: education_headline(pinned))}
+        <.link
+          href={~p"/settings/educations/#{pinned}/pin"}
+          method="delete"
+          class="font-semibold text-slate-600 underline hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
+        >
+          {gettext("Choose automatically instead")}
+        </.link>
+      </span>
+    <% true -> %>
+      <.pin_star class="mt-0.5 h-4 w-4 shrink-0 text-slate-600 dark:text-slate-400" />
+      <span>
+        {gettext(
+          "Pick a degree or school below to show it at the top of your profile instead of a job title."
+        )}
+      </span>
+  <% end %>
+</p>
+
 <div :for={{kind, entries} <- group_by_kind(@education)} class="mt-8 first:mt-0">
   <h2
     :if={show_kind_headings?(@education)}
@@ -38,6 +75,24 @@ member keeps the single unlabeled list. --%>
         text={edu.description}
         class="mt-1 text-sm text-slate-600 dark:text-slate-400"
       />
+      <div :if={@as_owner?} class="mt-2">
+        <span
+          :if={@profile_education_id == edu.id}
+          class="inline-flex items-center gap-1 text-xs font-semibold text-brand-700 dark:text-brand-400"
+        >
+          <.pin_star filled class="h-4 w-4" />
+          {gettext("Shown at the top of your profile")}
+        </span>
+        <.link
+          :if={@profile_education_id != edu.id}
+          href={~p"/settings/educations/#{edu}/pin"}
+          method="put"
+          class="inline-flex items-center gap-1 rounded-full border border-brand-600 px-3 py-1 text-xs font-semibold text-brand-600 hover:bg-brand-50 dark:border-brand-400 dark:text-brand-400 dark:hover:bg-brand-900/40"
+        >
+          <.pin_star class="h-4 w-4" />
+          {gettext("Show at top of profile")}
+        </.link>
+      </div>
       <.row_actions
         :if={@as_owner?}
         align={:start}

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -241,7 +241,11 @@ the resulting ~200px rail width. --%>
         >
           {VutuvWeb.Markdown.render(@user.headline)}
         </div>
-        <p :if={@work_info not in [nil, ""]} class="mt-1.5 text-sm text-slate-600 dark:text-slate-400">
+        <p
+          :if={@work_info not in [nil, ""]}
+          id="profile-headline"
+          class="mt-1.5 text-sm text-slate-600 dark:text-slate-400"
+        >
           {@work_info}
         </p>
 

--- a/lib/vutuv_web/views/education_html.ex
+++ b/lib/vutuv_web/views/education_html.ex
@@ -5,11 +5,20 @@ defmodule VutuvWeb.EducationHTML do
   # The month select options and the date-range formatter are identical to a
   # work experience's; reuse them rather than duplicate the logic.
   import VutuvWeb.WorkExperienceHTML,
-    only: [month_options: 0, format_duration: 4, format_duration: 5]
+    only: [month_options: 0, format_duration: 4, format_duration: 5, pin_star: 1]
 
   alias Vutuv.Profiles.Education
 
   defdelegate group_by_kind(educations), to: Education
+
+  @doc """
+  The education a member pinned as their profile headline (issue #882), found in
+  the already-loaded list, or nil when they use the automatic job resolution.
+  `id` is a member's `users.profile_education_id`. The management page's chooser
+  marks this entry and offers the revert.
+  """
+  def pinned_entry(_educations, nil), do: nil
+  def pinned_entry(educations, id), do: Enum.find(educations, &(&1.id == id))
 
   @doc """
   A category's label (issue #849) — one wording for the form's picker, the

--- a/lib/vutuv_web/views/layout_html.ex
+++ b/lib/vutuv_web/views/layout_html.ex
@@ -139,7 +139,9 @@ defmodule VutuvWeb.LayoutHTML do
   end
 
   defp member_title_detail(user, header_job) do
-    case work_information_string_for_job(header_job, 60) do
+    # A pinned education (issue #882) leads the title too, else the job line —
+    # profile_headline/3 folds both, and returns "" when there is neither.
+    case profile_headline(user, header_job, 60) do
       "" -> headline_text(user.headline, 60)
       work -> work
     end

--- a/lib/vutuv_web/views/user_helpers.ex
+++ b/lib/vutuv_web/views/user_helpers.ex
@@ -11,6 +11,7 @@ defmodule VutuvWeb.UserHelpers do
   alias PhoenixHTMLHelpers.Link, as: HTMLLink
   alias Vutuv.Accounts.User
   alias Vutuv.Profiles.Address
+  alias Vutuv.Profiles.Education
   alias Vutuv.Profiles.WorkExperience
   alias Vutuv.Repo
   alias Vutuv.Social.Follow
@@ -232,6 +233,71 @@ defmodule VutuvWeb.UserHelpers do
   defp most_recent_job(job, _), do: job
 
   @doc """
+  The profile header line for `user`: the pinned education's "Degree, School"
+  (issue #882) when they pinned one, else the pinned/heuristic job's
+  "Title @ Organization" (`job` already resolved by the caller). The single
+  seam the profile header, its page title, meta description and agent docs
+  share, so a member who features a degree instead of a job title reads
+  consistently everywhere. Falls through to `work_information_string_for_job/2`
+  (which is `""` when there is no job), so a member with neither reads exactly
+  as before.
+  """
+  def profile_headline(user, job, len \\ 256) do
+    education_headline(pinned_education(user), len) ||
+      work_information_string_for_job(job, len)
+  end
+
+  @doc """
+  The education a member pinned as their profile headline (issue #882), or nil.
+
+  Preload-aware: resolves from an already-loaded `:educations` assoc in memory
+  (the profile LiveView and `ProfileDoc` both preload it), else one indexed
+  query — and no query at all when nothing is pinned, the common case. Re-scoped
+  to the user so a stale pointer to a foreign or deleted row never surfaces.
+  """
+  def pinned_education(%User{profile_education_id: nil}), do: nil
+
+  def pinned_education(%User{profile_education_id: id, id: user_id, educations: educations})
+      when is_binary(id) and is_list(educations) do
+    Enum.find(educations, &(&1.id == id and &1.user_id == user_id))
+  end
+
+  def pinned_education(%User{profile_education_id: id, id: user_id}) when is_binary(id) do
+    Repo.one(from(e in Education, where: e.id == ^id and e.user_id == ^user_id))
+  end
+
+  def pinned_education(_user), do: nil
+
+  @doc """
+  A pinned education as a one-line header string (issue #882): "Degree, School"
+  (e.g. "Doctor of Medicine, St. Mary's University"), the school alone when the
+  entry carries no degree, truncated to `len`. nil for a nil education, so a
+  call site can fall through to the job line.
+  """
+  def education_headline(education, len \\ 256)
+
+  def education_headline(nil, _len), do: nil
+
+  def education_headline(%Education{degree: degree, school: school}, len) do
+    case [degree, school]
+         |> Enum.map(&trimmed/1)
+         |> Enum.reject(&(&1 == ""))
+         |> Enum.join(", ") do
+      "" -> nil
+      line -> truncate_headline(line, len)
+    end
+  end
+
+  defp trimmed(nil), do: ""
+  defp trimmed(value), do: String.trim(value)
+
+  defp truncate_headline(line, len) when len >= 3 do
+    if String.length(line) > len, do: String.slice(line, 0, len - 3) <> "...", else: line
+  end
+
+  defp truncate_headline(line, _len), do: line
+
+  @doc """
   The profile page's meta description: the current work line, optionally
   followed by a `detail` string (the member's follower count).
 
@@ -243,8 +309,8 @@ defmodule VutuvWeb.UserHelpers do
   """
   def meta_description(nil, _detail, _job), do: ""
 
-  def meta_description(_user, detail, job) do
-    case {work_information_string_for_job(job), detail || ""} do
+  def meta_description(user, detail, job) do
+    case {profile_headline(user, job), detail || ""} do
       {"", ""} ->
         []
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.144.3",
+      version: "7.145.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -18,7 +18,7 @@ msgstr "Impressum"
 #: lib/vutuv_web/components/ui.ex:3024
 #: lib/vutuv_web/components/ui.ex:3029
 #: lib/vutuv_web/live/organization_live/domains.ex:235
-#: lib/vutuv_web/live/organization_live/edit.ex:382
+#: lib/vutuv_web/live/organization_live/edit.ex:394
 #: lib/vutuv_web/live/organization_live/roles.ex:202
 #, elixir-autogen
 msgid "Add"
@@ -29,13 +29,13 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/agent_docs/text.ex:197
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
-#: lib/vutuv_web/live/cv_live.ex:110
+#: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/show.ex:350
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1159
+#: lib/vutuv_web/templates/user/show.html.heex:1163
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -98,7 +98,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/agent_docs/markdown.ex:432
 #: lib/vutuv_web/agent_docs/text.ex:428
 #: lib/vutuv_web/agent_docs/text.ex:429
-#: lib/vutuv_web/templates/user/show.html.heex:824
+#: lib/vutuv_web/templates/user/show.html.heex:828
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
@@ -109,7 +109,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
 #: lib/vutuv_web/live/job_posting_live/form.ex:594
-#: lib/vutuv_web/live/organization_live/edit.ex:333
+#: lib/vutuv_web/live/organization_live/edit.ex:345
 #: lib/vutuv_web/live/organization_live/new.ex:173
 #: lib/vutuv_web/templates/ad/new.html.heex:133
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
@@ -142,7 +142,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:13
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:862
+#: lib/vutuv_web/templates/user/show.html.heex:866
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -167,8 +167,8 @@ msgid "Delete"
 msgstr "Löschen"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:481
-#: lib/vutuv_web/live/organization_live/edit.ex:260
-#: lib/vutuv_web/live/organization_live/edit.ex:267
+#: lib/vutuv_web/live/organization_live/edit.ex:272
+#: lib/vutuv_web/live/organization_live/edit.ex:279
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:32
 #: lib/vutuv_web/templates/dev_app/form_content.html.heex:14
@@ -189,9 +189,9 @@ msgstr "Beschreibung"
 msgid "Disable"
 msgstr "Inaktivieren"
 
-#: lib/vutuv_web/live/cv_live.ex:398
+#: lib/vutuv_web/live/cv_live.ex:439
 #: lib/vutuv_web/templates/export/index.html.heex:41
-#: lib/vutuv_web/templates/user/show.html.heex:278
+#: lib/vutuv_web/templates/user/show.html.heex:282
 #: lib/vutuv_web/views/qualification_html.ex:237
 #, elixir-autogen
 msgid "Download"
@@ -220,7 +220,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/url/edit.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:847
+#: lib/vutuv_web/templates/user/show.html.heex:851
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #, elixir-autogen
 msgid "Edit"
@@ -301,7 +301,7 @@ msgstr "Nachname eingeben"
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:494
+#: lib/vutuv_web/templates/user/show.html.heex:498
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:3
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -324,7 +324,7 @@ msgstr "Vorname"
 #: lib/vutuv_web/agent_docs/markdown.ex:443
 #: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/notification_live/index.ex:770
+#: lib/vutuv_web/live/notification_live/index.ex:798
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
 #, elixir-autogen
@@ -342,7 +342,7 @@ msgstr "Follower"
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:772
+#: lib/vutuv_web/templates/user/show.html.heex:776
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
@@ -353,11 +353,11 @@ msgstr "Folge ich"
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
 #: lib/vutuv_web/cv/odt.ex:109
-#: lib/vutuv_web/live/cv_live.ex:113
+#: lib/vutuv_web/live/cv_live.ex:154
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:819
+#: lib/vutuv_web/templates/user/show.html.heex:823
 #, elixir-autogen
 msgid "Gender"
 msgstr "Geschlecht"
@@ -426,7 +426,7 @@ msgstr "Link wurde geändert."
 #: lib/vutuv_web/cv/html.ex:205
 #: lib/vutuv_web/cv/latex.ex:164
 #: lib/vutuv_web/cv/odt.ex:176
-#: lib/vutuv_web/live/cv_live.ex:296
+#: lib/vutuv_web/live/cv_live.ex:337
 #: lib/vutuv_web/templates/import/new.html.heex:12
 #: lib/vutuv_web/templates/import/preview.html.heex:40
 #: lib/vutuv_web/templates/url/edit.html.heex:3
@@ -469,14 +469,14 @@ msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
 #: lib/vutuv_web/components/ui.ex:3180
-#: lib/vutuv_web/live/notification_live/index.ex:694
+#: lib/vutuv_web/live/notification_live/index.ex:722
 #, elixir-autogen
 msgid "More"
 msgstr "Mehr"
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:71
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:590
-#: lib/vutuv_web/live/cv_live.ex:104
+#: lib/vutuv_web/live/cv_live.ex:145
 #: lib/vutuv_web/templates/access_token/new.html.heex:8
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:50
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:17
@@ -486,7 +486,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:497
+#: lib/vutuv_web/live/notification_live/index.ex:525
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/templates/access_token/new.html.heex:1
 #: lib/vutuv_web/templates/ad/new.html.heex:3
@@ -573,7 +573,7 @@ msgstr "Telefonnummern"
 msgid "Phone Numbers Belonging to "
 msgstr "Telefonnummern von "
 
-#: lib/vutuv_web/live/cv_live.ex:109
+#: lib/vutuv_web/live/cv_live.ex:150
 #: lib/vutuv_web/templates/phone_number/card_list.html.heex:6
 #, elixir-autogen
 msgid "Phone number"
@@ -643,11 +643,11 @@ msgstr "Öffentlich"
 msgid "Public (Everyone can view) or Private (Only you can view)"
 msgstr "Öffentlich (für alle sichtbar) oder Privat (nur für Sie sichtbar)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:327
+#: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/live/post_live/composer.ex:818
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:83
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:108
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
@@ -655,16 +655,16 @@ msgstr "Öffentlich (für alle sichtbar) oder Privat (nur für Sie sichtbar)"
 #: lib/vutuv_web/templates/settings/privacy.html.heex:64
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:383
-#: lib/vutuv_web/views/settings_html.ex:131
+#: lib/vutuv_web/views/settings_html.ex:138
 #, elixir-autogen
 msgid "Save"
 msgstr "Speichern"
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:231
-#: lib/vutuv_web/live/job_board_live.ex:314
+#: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:35
-#: lib/vutuv_web/live/search_live.ex:229
+#: lib/vutuv_web/live/search_live.ex:312
 #: lib/vutuv_web/live/shell_live.ex:481
 #: lib/vutuv_web/live/shell_live.ex:637
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
@@ -704,19 +704,19 @@ msgstr "Slug"
 #: lib/vutuv_web/cv/html.ex:226
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
-#: lib/vutuv_web/live/cv_live.ex:370
+#: lib/vutuv_web/live/cv_live.ex:411
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:973
+#: lib/vutuv_web/templates/user/show.html.heex:977
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:975
+#: lib/vutuv_web/templates/user/show.html.heex:979
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -821,7 +821,7 @@ msgstr "User wurde verifiziert."
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
-#: lib/vutuv_web/live/notification_live/index.ex:836
+#: lib/vutuv_web/live/notification_live/index.ex:864
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -866,20 +866,20 @@ msgid "Users"
 msgstr "Benutzer"
 
 #: lib/vutuv_web/components/ui.ex:581
-#: lib/vutuv_web/templates/user/show.html.heex:284
+#: lib/vutuv_web/templates/user/show.html.heex:288
 #, elixir-autogen
 msgid "vCard"
 msgstr "vCard"
 
 #: lib/vutuv_web/components/ui.ex:2987
-#: lib/vutuv_web/templates/user/show.html.heex:766
-#: lib/vutuv_web/templates/user/show.html.heex:786
+#: lib/vutuv_web/templates/user/show.html.heex:770
+#: lib/vutuv_web/templates/user/show.html.heex:790
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:550
-#: lib/vutuv_web/live/organization_live/edit.ex:286
+#: lib/vutuv_web/live/organization_live/edit.ex:298
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #, elixir-autogen
@@ -949,7 +949,7 @@ msgid "You follow back %{name}."
 msgstr "Sie folgen %{name}."
 
 #: lib/vutuv_web/live/init_assigns.ex:52
-#: lib/vutuv_web/live/post_live/feed.ex:58
+#: lib/vutuv_web/live/post_live/feed.ex:59
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1065,14 +1065,14 @@ msgstr "Wählen Sie einen Monat"
 msgid "Select a year"
 msgstr "Wählen Sie ein Jahr"
 
-#: lib/vutuv/accounts/user.ex:884
+#: lib/vutuv/accounts/user.ex:929
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr "Frau"
 
-#: lib/vutuv/accounts/user.ex:883
+#: lib/vutuv/accounts/user.ex:928
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1139,7 +1139,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:808
+#: lib/vutuv_web/templates/user/show.html.heex:812
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1230,12 +1230,13 @@ msgstr "Die URL ist ungültig"
 msgid "Can't find URL"
 msgstr "Die URL kann nicht gefunden werden"
 
-#: lib/vutuv_web/live/search_live.ex:285
+#: lib/vutuv_web/live/search_live.ex:199
 #, elixir-autogen
 msgid "Our search will try to match similar names to your search, so don't worry about spelling."
 msgstr "Die Suche nach Vor- und Nachnamen ist fuzzy (unscharf)."
 
-#: lib/vutuv_web/live/search_live.ex:280
+#: lib/vutuv_web/live/search_live.ex:363
+#: lib/vutuv_web/live/search_live.ex:388
 #, elixir-autogen
 msgid "Search Tips"
 msgstr "Hilfe bei der Suche"
@@ -1325,7 +1326,7 @@ msgstr "Alle Tag-URLs"
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/templates/user/show.html.heex:492
 #, elixir-autogen
 msgid "All tags"
 msgstr "Alle Tags"
@@ -1502,16 +1503,17 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/agent_docs/text.ex:394
 #: lib/vutuv_web/agent_docs/text.ex:571
 #: lib/vutuv_web/components/ui.ex:3170
-#: lib/vutuv_web/controllers/user_tag_controller.ex:39
-#: lib/vutuv_web/controllers/user_tag_controller.ex:56
+#: lib/vutuv_web/controllers/user_tag_controller.ex:43
+#: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
 #: lib/vutuv_web/cv/html.ex:159
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
-#: lib/vutuv_web/live/cv_live.ex:275
+#: lib/vutuv_web/live/cv_live.ex:316
+#: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:509
 #: lib/vutuv_web/live/search_live.ex:178
-#: lib/vutuv_web/live/search_live.ex:361
+#: lib/vutuv_web/live/search_live.ex:448
 #: lib/vutuv_web/live/tag_new_live.ex:35
 #: lib/vutuv_web/live/tag_new_live.ex:45
 #: lib/vutuv_web/live/tag_new_live.ex:54
@@ -1526,7 +1528,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:458
+#: lib/vutuv_web/templates/user/show.html.heex:462
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1658,7 +1660,7 @@ msgstr "Empfehlung zurückgenommen."
 msgid "User tag created successfully."
 msgstr "Tag erfolgreich hinzugefügt."
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:144
+#: lib/vutuv_web/controllers/user_tag_controller.ex:166
 #, elixir-autogen
 msgid "User tag deleted successfully."
 msgstr "Ein Tag wurde gelöscht."
@@ -1688,9 +1690,9 @@ msgstr ""
 "Link."
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
-#: lib/vutuv_web/live/job_board_live.ex:274
+#: lib/vutuv_web/live/job_board_live.ex:360
 #: lib/vutuv_web/live/job_posting_live/form.ex:410
-#: lib/vutuv_web/live/organization_live/edit.ex:282
+#: lib/vutuv_web/live/organization_live/edit.ex:294
 #: lib/vutuv_web/live/organization_live/new.ex:127
 #: lib/vutuv_web/templates/ad/new.html.heex:111
 #: lib/vutuv_web/templates/address/country_input.html.heex:2
@@ -1832,7 +1834,7 @@ msgstr ""
 "Folgen!"
 
 #: lib/vutuv_web/live/shell_live.ex:608
-#: lib/vutuv_web/views/settings_html.ex:218
+#: lib/vutuv_web/views/settings_html.ex:225
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr "Ausloggen"
@@ -1877,14 +1879,14 @@ msgstr "Netzwerk"
 msgid "Nothing here yet."
 msgstr "Hier gibt es noch nichts."
 
-#: lib/vutuv_web/live/notification_live/index.ex:305
+#: lib/vutuv_web/live/notification_live/index.ex:314
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
 #: lib/vutuv_web/components/ui.ex:3184
 #: lib/vutuv_web/live/notification_live/index.ex:103
-#: lib/vutuv_web/live/notification_live/index.ex:268
+#: lib/vutuv_web/live/notification_live/index.ex:275
 #: lib/vutuv_web/live/shell_live.ex:508
 #: lib/vutuv_web/templates/layout/app.html.heex:118
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -1978,8 +1980,8 @@ msgstr ""
 "Wir haben einen PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie ihn "
 "unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1247
+#: lib/vutuv_web/live/post_live/feed.ex:757
+#: lib/vutuv_web/templates/user/show.html.heex:1251
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
@@ -1998,14 +2000,14 @@ msgstr "Ihre Anmeldung ist abgelaufen. Bitte versuchen Sie es erneut."
 
 #: lib/vutuv_web/open_graph.ex:256
 #: lib/vutuv_web/templates/tag/show.html.heex:13
-#: lib/vutuv_web/templates/user/show.html.heex:253
+#: lib/vutuv_web/templates/user/show.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] "Follower"
 msgstr[1] "Follower"
 
-#: lib/vutuv_web/templates/user/show.html.heex:257
+#: lib/vutuv_web/templates/user/show.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr "folgt"
@@ -2015,17 +2017,17 @@ msgstr "folgt"
 msgid "submit a bug report"
 msgstr "einen Fehlerbericht erstellen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:857
+#: lib/vutuv_web/live/notification_live/index.ex:885
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr "hat Sie für %{tag} empfohlen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:852
+#: lib/vutuv_web/live/notification_live/index.ex:880
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr "ist jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:847
+#: lib/vutuv_web/live/notification_live/index.ex:875
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
@@ -2237,8 +2239,8 @@ msgstr "Beschreiben Sie dieses Bild (Alt-Text)"
 msgid "Edit post"
 msgstr "Beitrag bearbeiten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:79
-#: lib/vutuv_web/live/post_live/feed.ex:552
+#: lib/vutuv_web/live/post_live/feed.ex:85
+#: lib/vutuv_web/live/post_live/feed.ex:624
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:116
@@ -2283,7 +2285,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:617
+#: lib/vutuv_web/live/post_live/feed.ex:698
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2323,10 +2325,10 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/controllers/user_controller.ex:73
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/notification_live/index.ex:692
+#: lib/vutuv_web/live/notification_live/index.ex:720
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:179
-#: lib/vutuv_web/live/search_live.ex:375
+#: lib/vutuv_web/live/search_live.ex:462
 #: lib/vutuv_web/templates/settings/preferences.html.heex:118
 #: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
@@ -2347,13 +2349,13 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:209
-#: lib/vutuv_web/live/organization_live/edit.ex:359
+#: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
 #: lib/vutuv_web/live/post_live/composer.ex:888
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:264
+#: lib/vutuv_web/views/settings_html.ex:271
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
@@ -2375,7 +2377,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:581
+#: lib/vutuv_web/live/post_live/feed.ex:653
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2413,11 +2415,11 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:3357
+#: lib/vutuv_web/components/ui.ex:3358
 #: lib/vutuv_web/live/shell_live.ex:551
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:165
+#: lib/vutuv_web/views/settings_html.ex:172
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr "Profil ansehen"
@@ -2458,7 +2460,7 @@ msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:293
+#: lib/vutuv_web/views/settings_html.ex:300
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "unbekannt"
@@ -2483,7 +2485,7 @@ msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
 msgid "Posts by %{name}"
 msgstr "Beiträge von %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:448
+#: lib/vutuv_web/templates/user/show.html.heex:452
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr "Alle %{count} Beiträge ansehen"
@@ -2516,7 +2518,7 @@ msgstr "Lesezeichen"
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2470
-#: lib/vutuv_web/live/notification_live/index.ex:828
+#: lib/vutuv_web/live/notification_live/index.ex:856
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2524,7 +2526,7 @@ msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:833
 #: lib/vutuv_web/components/post_components.ex:2196
-#: lib/vutuv_web/live/notification_live/index.ex:772
+#: lib/vutuv_web/live/notification_live/index.ex:800
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:559
@@ -2585,7 +2587,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1648
-#: lib/vutuv_web/live/post_live/feed.ex:665
+#: lib/vutuv_web/live/post_live/feed.ex:746
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2602,14 +2604,14 @@ msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
 #: lib/vutuv_web/components/post_components.ex:276
-#: lib/vutuv_web/live/notification_live/index.ex:773
+#: lib/vutuv_web/live/notification_live/index.ex:801
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:2219
 #: lib/vutuv_web/components/post_components.ex:2220
-#: lib/vutuv_web/live/notification_live/index.ex:825
+#: lib/vutuv_web/live/notification_live/index.ex:853
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2635,7 +2637,7 @@ msgstr ""
 "Dieser Beitrag wurde repostet oder beantwortet. Er bleibt öffentlich, "
 "solange Reposts oder Antworten existieren; löschen können Sie ihn jederzeit."
 
-#: lib/vutuv_web/live/notification_live/index.ex:966
+#: lib/vutuv_web/live/notification_live/index.ex:994
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
@@ -2824,42 +2826,42 @@ msgid "Use a different email address"
 msgstr "Andere E-Mail-Adresse verwenden"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:698
+#: lib/vutuv_web/templates/user/show.html.heex:702
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:936
+#: lib/vutuv_web/templates/user/show.html.heex:940
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1161
+#: lib/vutuv_web/templates/user/show.html.heex:1165
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:864
+#: lib/vutuv_web/templates/user/show.html.heex:868
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:810
+#: lib/vutuv_web/templates/user/show.html.heex:814
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:497
+#: lib/vutuv_web/templates/user/show.html.heex:501
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
-#: lib/vutuv_web/live/user_profile_live.ex:965
-#: lib/vutuv_web/templates/user/show.html.heex:400
+#: lib/vutuv_web/live/user_profile_live.ex:970
+#: lib/vutuv_web/templates/user/show.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
@@ -2872,25 +2874,25 @@ msgstr "Ersten Beitrag schreiben"
 #: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/templates/user/show.html.heex:492
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:564
-#: lib/vutuv_web/templates/user/show.html.heex:400
+#: lib/vutuv_web/live/post_live/feed.ex:636
+#: lib/vutuv_web/templates/user/show.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr "Beitrag schreiben"
 
-#: lib/vutuv_web/views/user_helpers.ex:117
+#: lib/vutuv_web/views/user_helpers.ex:118
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] "%{count} Tag hinzugefügt."
 msgstr[1] "%{count} Tags hinzugefügt."
 
-#: lib/vutuv_web/views/user_helpers.ex:121
+#: lib/vutuv_web/views/user_helpers.ex:122
 #, elixir-autogen, elixir-format
 msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
 msgstr ""
@@ -2914,7 +2916,7 @@ msgstr[1] "+%{formatted} weitere Tags"
 #: lib/vutuv_web/agent_docs/markdown.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:442
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:771
+#: lib/vutuv_web/live/notification_live/index.ex:799
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2950,7 +2952,7 @@ msgstr "Nur Text"
 msgid "This post is for the connections of %{name}"
 msgstr "Dieser Beitrag ist für die Vernetzungen von %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:266
+#: lib/vutuv_web/templates/user/show.html.heex:270
 #: lib/vutuv_web/views/admin/moderation_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "connection"
@@ -2968,23 +2970,23 @@ msgstr "Personen, mit denen Sie nicht vernetzt sind"
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:837
+#: lib/vutuv_web/live/notification_live/index.ex:865
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:829
+#: lib/vutuv_web/live/notification_live/index.ex:857
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:824
+#: lib/vutuv_web/live/notification_live/index.ex:852
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:823
-#: lib/vutuv_web/templates/user/show.html.heex:753
+#: lib/vutuv_web/live/notification_live/index.ex:851
+#: lib/vutuv_web/templates/user/show.html.heex:757
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2996,7 +2998,7 @@ msgstr[1] "Follower"
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Willkommen bei vutuv, %{name}!"
 
-#: lib/vutuv_web/live/notification_live/index.ex:854
+#: lib/vutuv_web/live/notification_live/index.ex:882
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr "gefällt Ihr Beitrag."
@@ -3028,12 +3030,12 @@ msgstr "(gelöschtes Konto)"
 msgid "(no text)"
 msgstr "(kein Text)"
 
-#: lib/vutuv_web/live/notification_live/index.ex:993
+#: lib/vutuv_web/live/notification_live/index.ex:1021
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde bestätigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:994
+#: lib/vutuv_web/live/notification_live/index.ex:1022
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
@@ -3148,7 +3150,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:830
+#: lib/vutuv_web/live/notification_live/index.ex:858
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3231,8 +3233,8 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:904
-#: lib/vutuv_web/templates/user/show.html.heex:905
+#: lib/vutuv_web/templates/user/show.html.heex:908
+#: lib/vutuv_web/templates/user/show.html.heex:909
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
@@ -3606,12 +3608,12 @@ msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
 
-#: lib/vutuv_web/live/notification_live/index.ex:996
+#: lib/vutuv_web/live/notification_live/index.ex:1024
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt gelöscht; der Fall ist abgeschlossen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:995
+#: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
@@ -3621,7 +3623,7 @@ msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
 msgid "Your content was reported"
 msgstr "Ihr Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/live/notification_live/index.ex:997
+#: lib/vutuv_web/live/notification_live/index.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3823,7 +3825,7 @@ msgstr "Verlauf"
 msgid "Open the profile"
 msgstr "Profil öffnen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3850,7 +3852,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:832
+#: lib/vutuv_web/live/notification_live/index.ex:860
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -3932,7 +3934,7 @@ msgstr "Bestätigt"
 msgid "Waiting for the owner"
 msgstr "Wartet auf den Besitzer"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1026
+#: lib/vutuv_web/live/notification_live/index.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4249,7 +4251,7 @@ msgstr "Für die Buchung ist ein vutuv-Login erforderlich."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:404
-#: lib/vutuv_web/live/organization_live/edit.ex:278
+#: lib/vutuv_web/live/organization_live/edit.ex:290
 #: lib/vutuv_web/live/organization_live/new.ex:123
 #: lib/vutuv_web/templates/ad/new.html.heex:105
 #: lib/vutuv_web/templates/welcome/show.html.heex:74
@@ -4692,7 +4694,7 @@ msgstr ""
 msgid "Undeliverable"
 msgstr "Unzustellbar"
 
-#: lib/vutuv_web/live/search_live.ex:282
+#: lib/vutuv_web/live/search_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
@@ -4776,7 +4778,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:622
+#: lib/vutuv_web/live/post_live/feed.ex:703
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4788,7 +4790,7 @@ msgstr "Mitglieder finden"
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:772
+#: lib/vutuv_web/templates/user/show.html.heex:776
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4820,12 +4822,12 @@ msgstr "Folgt noch niemandem."
 msgid "This area is reserved for administrators."
 msgstr "Dieser Bereich ist Administratoren vorbehalten."
 
-#: lib/vutuv_web/live/search_live.ex:407
+#: lib/vutuv_web/live/search_live.ex:494
 #, elixir-autogen, elixir-format
 msgid "No results for \"%{query}\""
 msgstr "Keine Ergebnisse für \"%{query}\""
 
-#: lib/vutuv_web/live/search_live.ex:344
+#: lib/vutuv_web/live/search_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Not an exact match, but sounds like your search."
 msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
@@ -4833,23 +4835,23 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/agent_docs/markdown.ex:316
 #: lib/vutuv_web/agent_docs/text.ex:342
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:693
+#: lib/vutuv_web/live/notification_live/index.ex:721
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:177
-#: lib/vutuv_web/live/search_live.ex:317
+#: lib/vutuv_web/live/search_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Personen"
 
-#: lib/vutuv_web/live/search_live.ex:276
+#: lib/vutuv_web/live/search_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Results appear once you have typed at least three letters."
 msgstr ""
 "Ergebnisse erscheinen, sobald Sie mindestens drei Buchstaben eingegeben "
 "haben."
 
-#: lib/vutuv_web/live/search_live.ex:341
+#: lib/vutuv_web/live/search_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Similar names"
 msgstr "Ähnliche Namen"
@@ -4857,65 +4859,61 @@ msgstr "Ähnliche Namen"
 #: lib/vutuv_web/components/post_components.ex:273
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:691
+#: lib/vutuv_web/live/notification_live/index.ex:719
 #: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr "Alle"
 
-#: lib/vutuv_web/live/search_live.ex:259
+#: lib/vutuv_web/live/search_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Exact matches only"
 msgstr "Nur exakte Treffer"
 
-#: lib/vutuv_web/live/search_live.ex:303
+#: lib/vutuv_web/live/search_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "in quotes: exact matches only, no similar names"
 msgstr "in Anführungszeichen: nur exakte Treffer, keine ähnlichen Namen"
 
-#: lib/vutuv_web/live/search_live.ex:301
+#: lib/vutuv_web/live/search_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "searches usernames"
 msgstr "sucht Benutzernamen"
 
-#: lib/vutuv_web/live/search_live.ex:297
+#: lib/vutuv_web/live/search_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "only people with an address in this city"
 msgstr "nur Personen mit einer Adresse in diesem Ort (auch stadt: / city:)"
 
-#: lib/vutuv_web/live/search_live.ex:296
+#: lib/vutuv_web/live/search_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "city:koblenz"
 msgstr "ort:koblenz"
 
-#: lib/vutuv_web/live/search_live.ex:292
+#: lib/vutuv_web/live/search_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "first:stefan"
 msgstr "vorname:stefan"
 
-#: lib/vutuv_web/live/search_live.ex:302
+#: lib/vutuv_web/live/search_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "miller"
 msgstr "müller"
 
-#: lib/vutuv_web/live/search_live.ex:293
+#: lib/vutuv_web/live/search_live.ex:227
 #, elixir-autogen, elixir-format
 msgid "searches first names only (last: for last names)"
 msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
-#: lib/vutuv_web/live/user_profile_live.ex:953
-#: lib/vutuv_web/templates/user/show.html.heex:461
+#: lib/vutuv_web/live/job_board_live.ex:388
+#: lib/vutuv_web/live/user_profile_live.ex:958
+#: lib/vutuv_web/templates/user/show.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Tag hinzufügen"
 
-#: lib/vutuv_web/live/job_board_live.ex:314
-#, elixir-autogen, elixir-format
-msgid "Filter by a tag"
-msgstr "Nach einem Tag filtern"
-
-#: lib/vutuv_web/live/search_live.ex:236
+#: lib/vutuv_web/live/search_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, or posts"
 msgstr "Nach Personen, Tags oder Beiträgen suchen"
@@ -5157,8 +5155,8 @@ msgstr "API-Anwendungen"
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:94
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
-#: lib/vutuv_web/views/settings_html.ex:31
-#: lib/vutuv_web/views/settings_html.ex:209
+#: lib/vutuv_web/views/settings_html.ex:38
+#: lib/vutuv_web/views/settings_html.ex:216
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
@@ -5542,8 +5540,8 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:3190
-#: lib/vutuv_web/controllers/settings_controller.ex:129
+#: lib/vutuv_web/components/ui.ex:3191
+#: lib/vutuv_web/controllers/settings_controller.ex:130
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
@@ -5625,10 +5623,10 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:3276
-#: lib/vutuv_web/components/ui.ex:3281
-#: lib/vutuv_web/components/ui.ex:3349
-#: lib/vutuv_web/controllers/settings_controller.ex:51
+#: lib/vutuv_web/components/ui.ex:3277
+#: lib/vutuv_web/components/ui.ex:3282
+#: lib/vutuv_web/components/ui.ex:3350
+#: lib/vutuv_web/controllers/settings_controller.ex:52
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/live/tag_new_live.ex:44
 #: lib/vutuv_web/templates/address/edit.html.heex:2
@@ -5656,7 +5654,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/templates/username/new.html.heex:4
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:2
 #: lib/vutuv_web/templates/work_experience/new.html.heex:2
-#: lib/vutuv_web/views/settings_html.ex:160
+#: lib/vutuv_web/views/settings_html.ex:167
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -5683,17 +5681,17 @@ msgstr "Beitrag schreiben"
 msgid "Your profile"
 msgstr "Ihr Profil"
 
-#: lib/vutuv_web/templates/user/show.html.heex:306
+#: lib/vutuv_web/templates/user/show.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr "Profil vervollständigen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:328
+#: lib/vutuv_web/templates/user/show.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/live/user_profile_live.ex:955
+#: lib/vutuv_web/live/user_profile_live.ex:960
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -5722,8 +5720,8 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:1137
 #: lib/vutuv_web/components/post_components.ex:1191
 #: lib/vutuv_web/components/post_components.ex:1506
-#: lib/vutuv_web/live/notification_live/index.ex:530
-#: lib/vutuv_web/live/post_live/feed.ex:737
+#: lib/vutuv_web/live/notification_live/index.ex:558
+#: lib/vutuv_web/live/post_live/feed.ex:818
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr "Beitrag ansehen"
@@ -5738,7 +5736,7 @@ msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr "Ihre Tags (z.B. JavaScript, Kochen, Origami, Katze)"
 
-#: lib/vutuv/accounts/user.ex:887
+#: lib/vutuv/accounts/user.ex:932
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5786,7 +5784,7 @@ msgstr "Konto"
 msgid "Add, remove or pick your primary address."
 msgstr "Adressen hinzufügen, entfernen oder Ihre Hauptadresse wählen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:429
+#: lib/vutuv_web/live/organization_live/edit.ex:441
 #: lib/vutuv_web/templates/settings/security.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -5809,7 +5807,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr "E-Mail-Adressen"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:227
+#: lib/vutuv_web/controllers/settings_controller.ex:302
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr "Benachrichtigungseinstellungen gespeichert."
@@ -5835,7 +5833,7 @@ msgstr "Fotos"
 msgid "Privacy"
 msgstr "Privatsphäre"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:167
+#: lib/vutuv_web/controllers/settings_controller.ex:168
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr "Datenschutzeinstellungen gespeichert."
@@ -5855,7 +5853,7 @@ msgstr "Ansehen"
 msgid "Your name"
 msgstr "Ihr Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:445
+#: lib/vutuv_web/live/notification_live/index.ex:455
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Ihr Beitrag"
@@ -5890,7 +5888,7 @@ msgstr "Sprache der Oberfläche"
 msgid "Language & region"
 msgstr "Sprache & Region"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:316
+#: lib/vutuv_web/controllers/settings_controller.ex:444
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr "Sprache aktualisiert."
@@ -5944,48 +5942,32 @@ msgstr "@%{slug} hat Sie auf vutuv empfohlen"
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 
-#: lib/vutuv_web/components/ui.ex:3189
+#: lib/vutuv_web/components/ui.ex:3190
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:144
+#: lib/vutuv_web/controllers/settings_controller.ex:145
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr "Apps & API-Zugang"
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:105
-#: lib/vutuv_web/live/notification_live/index.ex:774
+#: lib/vutuv_web/controllers/user_tag_controller.ex:127
+#: lib/vutuv_web/live/notification_live/index.ex:802
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
+#: lib/vutuv_web/templates/user_tag/show.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Endorsements"
 msgstr "Empfehlungen"
 
-#: lib/vutuv_web/templates/user_tag/show.html.heex:34
-#, elixir-autogen, elixir-format
-msgid "All endorsers"
-msgstr "Alle Empfehlenden"
-
-#: lib/vutuv_web/templates/user_tag/show.html.heex:17
-#, elixir-autogen, elixir-format
-msgid "Nobody has endorsed %{name} for this tag yet."
-msgstr "Noch niemand hat %{name} für dieses Tag empfohlen."
-
-#: lib/vutuv_web/templates/user_tag/show.html.heex:22
-#, elixir-autogen, elixir-format
-msgid "%{formatted} endorsement"
-msgid_plural "%{formatted} endorsements"
-msgstr[0] "%{formatted} Empfehlung"
-msgstr[1] "%{formatted} Empfehlungen"
-
-#: lib/vutuv_web/templates/settings/notifications.html.heex:99
+#: lib/vutuv_web/templates/settings/notifications.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Endorsements and new followers"
 msgstr "Empfehlungen und neue Follower"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:93
+#: lib/vutuv_web/templates/settings/notifications.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "In-app notifications"
 msgstr "Benachrichtigungen in der App"
@@ -5995,22 +5977,22 @@ msgstr "Benachrichtigungen in der App"
 msgid "New followers"
 msgstr "Neue Follower"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:217
+#: lib/vutuv_web/controllers/settings_controller.ex:292
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr "Benachrichtigungseinstellungen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:107
+#: lib/vutuv_web/templates/settings/notifications.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Open your notifications"
 msgstr "Benachrichtigungen öffnen"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:138
+#: lib/vutuv_web/controllers/settings_controller.ex:139
 #, elixir-autogen, elixir-format
 msgid "Privacy settings"
 msgstr "Privatsphäre-Einstellungen"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:100
+#: lib/vutuv_web/templates/settings/notifications.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr "Antworten und Likes zu Ihren Beiträgen"
@@ -6025,7 +6007,7 @@ msgstr "Sicherheit"
 msgid "Search engines & AI"
 msgstr "Suchmaschinen & KI"
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:95
+#: lib/vutuv_web/templates/settings/notifications.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "These are always on. You see them under the bell at the top of every page, in real time."
 msgstr ""
@@ -6180,28 +6162,28 @@ msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:174
-#: lib/vutuv_web/views/settings_html.ex:302
+#: lib/vutuv_web/views/settings_html.ex:309
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/views/settings_html.ex:301
+#: lib/vutuv_web/views/settings_html.ex:308
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/views/settings_html.ex:300
+#: lib/vutuv_web/views/settings_html.ex:307
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] "vor %{count} Minute"
 msgstr[1] "vor %{count} Minuten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:411
+#: lib/vutuv_web/controllers/settings_controller.ex:539
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
@@ -6211,7 +6193,7 @@ msgstr "Alle anderen Geräte wurden abgemeldet."
 msgid "Another session was already active on your account."
 msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
 
-#: lib/vutuv_web/views/settings_html.ex:198
+#: lib/vutuv_web/views/settings_html.ex:205
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr "Zuletzt aktiv"
@@ -6226,7 +6208,7 @@ msgstr "Alle anderen Geräte abmelden"
 msgid "Log out of every device except this one?"
 msgstr "Von allen Geräten außer diesem abmelden?"
 
-#: lib/vutuv_web/views/settings_html.ex:215
+#: lib/vutuv_web/views/settings_html.ex:222
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
@@ -6241,7 +6223,7 @@ msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
 msgid "Signed-in devices"
 msgstr "Angemeldete Geräte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:400
+#: lib/vutuv_web/controllers/settings_controller.ex:528
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
@@ -6251,7 +6233,7 @@ msgstr "Dieses Gerät wurde abgemeldet."
 msgid "The location looks different from where you usually sign in."
 msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
 
-#: lib/vutuv_web/views/settings_html.ex:199
+#: lib/vutuv_web/views/settings_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr "Dieses Gerät"
@@ -6263,7 +6245,7 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/views/settings_html.ex:299
+#: lib/vutuv_web/views/settings_html.ex:306
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
@@ -6298,7 +6280,7 @@ msgid "Add a passkey"
 msgstr "Passkey hinzufügen"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/views/settings_html.ex:250
+#: lib/vutuv_web/views/settings_html.ex:257
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr "Hinzugefügt"
@@ -6309,7 +6291,7 @@ msgid "Could not add the passkey. Please try again."
 msgstr ""
 "Der Passkey konnte nicht hinzugefügt werden. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/views/settings_html.ex:253
+#: lib/vutuv_web/views/settings_html.ex:260
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr "Zuletzt verwendet"
@@ -6319,7 +6301,7 @@ msgstr "Zuletzt verwendet"
 msgid "Name (optional)"
 msgstr "Name (optional)"
 
-#: lib/vutuv_web/views/settings_html.ex:247
+#: lib/vutuv_web/views/settings_html.ex:254
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr "Passkey"
@@ -6339,7 +6321,7 @@ msgstr "Passkey entfernt."
 msgid "Passkeys"
 msgstr "Passkeys"
 
-#: lib/vutuv_web/views/settings_html.ex:261
+#: lib/vutuv_web/views/settings_html.ex:268
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr "Diesen Passkey entfernen?"
@@ -6399,12 +6381,12 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/live/user_profile_live.ex:959
+#: lib/vutuv_web/live/user_profile_live.ex:964
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
 
-#: lib/vutuv_web/live/cv_live.ex:107
+#: lib/vutuv_web/live/cv_live.ex:148
 #: lib/vutuv_web/templates/user/edit.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6413,14 +6395,14 @@ msgstr "Kurzbeschreibung"
 #: lib/vutuv_web/components/ui.ex:174
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:696
+#: lib/vutuv_web/templates/user/show.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] "Link"
 msgstr[1] "Links"
 
-#: lib/vutuv_web/templates/user/show.html.heex:381
+#: lib/vutuv_web/templates/user/show.html.heex:385
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6434,7 +6416,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1212
+#: lib/vutuv_web/templates/user/show.html.heex:1216
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6479,8 +6461,8 @@ msgstr "Foto verwenden"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:830
-#: lib/vutuv_web/templates/user/show.html.heex:840
+#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:844
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6522,12 +6504,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:951
+#: lib/vutuv_web/templates/user/show.html.heex:955
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:962
+#: lib/vutuv_web/templates/user/show.html.heex:966
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6569,7 +6551,7 @@ msgstr "Vorheriger Tag"
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:960
+#: lib/vutuv_web/templates/user/show.html.heex:964
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6609,7 +6591,7 @@ msgstr "Empfehlung zurücknehmen"
 msgid "Default map"
 msgstr "Standardkarte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:331
+#: lib/vutuv_web/controllers/settings_controller.ex:459
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr "Karteneinstellungen gespeichert."
@@ -6625,9 +6607,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1198
-#: lib/vutuv_web/templates/user/show.html.heex:1206
-#: lib/vutuv_web/templates/user/show.html.heex:1218
+#: lib/vutuv_web/templates/user/show.html.heex:1202
+#: lib/vutuv_web/templates/user/show.html.heex:1210
+#: lib/vutuv_web/templates/user/show.html.heex:1222
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6664,10 +6646,10 @@ msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
 #: lib/vutuv_web/components/ui.ex:1332
-#: lib/vutuv_web/live/notification_live/index.ex:475
-#: lib/vutuv_web/live/notification_live/index.ex:490
-#: lib/vutuv_web/live/notification_live/index.ex:613
-#: lib/vutuv_web/live/notification_live/index.ex:615
+#: lib/vutuv_web/live/notification_live/index.ex:503
+#: lib/vutuv_web/live/notification_live/index.ex:518
+#: lib/vutuv_web/live/notification_live/index.ex:641
+#: lib/vutuv_web/live/notification_live/index.ex:643
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
@@ -6980,6 +6962,7 @@ msgstr ""
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
 #: lib/vutuv_web/components/ui.ex:1836
+#: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Mute"
@@ -6991,7 +6974,7 @@ msgstr "Stummschalten"
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr "Stummgeschaltet. Die Beiträge erscheinen nicht mehr in Ihrem Feed."
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:98
+#: lib/vutuv_web/templates/settings/notifications.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "New messages and new connections"
 msgstr "Neue Nachrichten und neue Vernetzungen"
@@ -7002,6 +6985,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
 #: lib/vutuv_web/components/ui.ex:1835
+#: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Unmute"
@@ -7244,6 +7228,7 @@ msgstr "Filter"
 #: lib/vutuv_web/agent_docs/text.ex:193
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
+#: lib/vutuv_web/templates/settings/filters.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Kind"
 msgstr "Art"
@@ -7410,7 +7395,7 @@ msgstr "Empfänger"
 msgid "Rendered with your own account data for the variables."
 msgstr "Mit Ihren eigenen Kontodaten für die Variablen dargestellt."
 
-#: lib/vutuv_web/live/cv_live.ex:201
+#: lib/vutuv_web/live/cv_live.ex:242
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:281
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:35
 #, elixir-autogen, elixir-format
@@ -7501,8 +7486,9 @@ msgid "Suppressed (bounced address)"
 msgstr "Unterdrückt (unzustellbare Adresse)"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
-#: lib/vutuv_web/live/job_board_live.ex:205
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
+#: lib/vutuv_web/templates/settings/filters.html.heex:22
+#: lib/vutuv_web/views/settings_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Tag"
 msgstr "Tag"
@@ -8164,13 +8150,13 @@ msgstr "Neue Mitglieder"
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:720
+#: lib/vutuv_web/live/notification_live/index.ex:748
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Heute"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:723
+#: lib/vutuv_web/live/notification_live/index.ex:751
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Gestern"
@@ -8249,42 +8235,42 @@ msgstr "Wie oft"
 msgid "Send the email"
 msgstr "E-Mail senden"
 
-#: lib/vutuv_web/views/settings_html.ex:65
+#: lib/vutuv_web/views/settings_html.ex:72
 #, elixir-autogen
 msgid "As soon as possible"
 msgstr "So bald wie möglich"
 
-#: lib/vutuv_web/views/settings_html.ex:66
+#: lib/vutuv_web/views/settings_html.ex:73
 #, elixir-autogen
 msgid "After 5 minutes"
 msgstr "Nach 5 Minuten"
 
-#: lib/vutuv_web/views/settings_html.ex:67
+#: lib/vutuv_web/views/settings_html.ex:74
 #, elixir-autogen
 msgid "After 15 minutes"
 msgstr "Nach 15 Minuten"
 
-#: lib/vutuv_web/views/settings_html.ex:68
+#: lib/vutuv_web/views/settings_html.ex:75
 #, elixir-autogen
 msgid "After 30 minutes"
 msgstr "Nach 30 Minuten"
 
-#: lib/vutuv_web/views/settings_html.ex:69
+#: lib/vutuv_web/views/settings_html.ex:76
 #, elixir-autogen
 msgid "After 1 hour"
 msgstr "Nach 1 Stunde"
 
-#: lib/vutuv_web/views/settings_html.ex:70
+#: lib/vutuv_web/views/settings_html.ex:77
 #, elixir-autogen
 msgid "After 2 hours"
 msgstr "Nach 2 Stunden"
 
-#: lib/vutuv_web/views/settings_html.ex:49
+#: lib/vutuv_web/views/settings_html.ex:56
 #, elixir-autogen
 msgid "Only the first message"
 msgstr "Nur die erste Nachricht"
 
-#: lib/vutuv_web/views/settings_html.ex:50
+#: lib/vutuv_web/views/settings_html.ex:57
 #, elixir-autogen
 msgid "Every message"
 msgstr "Jede Nachricht"
@@ -8350,7 +8336,7 @@ msgid "Awaiting verification"
 msgstr "Prüfung ausstehend"
 
 #: lib/vutuv_web/live/admin/user_live.ex:196
-#: lib/vutuv_web/live/job_board_live.ex:192
+#: lib/vutuv_web/live/job_board_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr "Filter zurücksetzen"
@@ -8410,8 +8396,8 @@ msgstr "Identität verifiziert. Das Mitglied wurde per E-Mail benachrichtigt."
 msgid "Identity-verified"
 msgstr "Identität verifiziert"
 
-#: lib/vutuv/accounts.ex:922
-#: lib/vutuv/accounts.ex:971
+#: lib/vutuv/accounts.ex:923
+#: lib/vutuv/accounts.ex:972
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8452,7 +8438,7 @@ msgstr "Nicht bestätigt"
 msgid "Open the member browser"
 msgstr "Mitgliederübersicht öffnen"
 
-#: lib/vutuv/accounts.ex:939
+#: lib/vutuv/accounts.ex:940
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8597,7 +8583,7 @@ msgstr[0] "%{count} Berufserfahrung"
 msgstr[1] "%{count} Berufserfahrungen"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:549
+#: lib/vutuv_web/templates/user/show.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Ausbildung hinzufügen"
@@ -8610,9 +8596,9 @@ msgstr "Abschluss"
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
 #: lib/vutuv_web/components/ui.ex:3161
-#: lib/vutuv_web/controllers/education_controller.ex:38
-#: lib/vutuv_web/controllers/education_controller.ex:53
-#: lib/vutuv_web/controllers/education_controller.ex:103
+#: lib/vutuv_web/controllers/education_controller.ex:43
+#: lib/vutuv_web/controllers/education_controller.ex:60
+#: lib/vutuv_web/controllers/education_controller.ex:140
 #: lib/vutuv_web/cv/cv.ex:274
 #: lib/vutuv_web/templates/education/edit.html.heex:3
 #: lib/vutuv_web/templates/education/index.html.heex:5
@@ -8622,17 +8608,17 @@ msgstr "Abschluss"
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:546
+#: lib/vutuv_web/templates/user/show.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr "Ausbildung"
 
-#: lib/vutuv_web/controllers/education_controller.ex:81
+#: lib/vutuv_web/controllers/education_controller.ex:118
 #, elixir-autogen, elixir-format
 msgid "Education created successfully."
 msgstr "Ausbildung erfolgreich erstellt."
 
-#: lib/vutuv_web/controllers/education_controller.ex:134
+#: lib/vutuv_web/controllers/education_controller.ex:171
 #, elixir-autogen, elixir-format
 msgid "Education deleted successfully."
 msgstr "Ausbildung erfolgreich gelöscht."
@@ -8642,7 +8628,7 @@ msgstr "Ausbildung erfolgreich gelöscht."
 msgid "Education of %{name}"
 msgstr "Ausbildung von %{name}"
 
-#: lib/vutuv_web/controllers/education_controller.ex:123
+#: lib/vutuv_web/controllers/education_controller.ex:160
 #, elixir-autogen, elixir-format
 msgid "Education updated successfully."
 msgstr "Ausbildung erfolgreich aktualisiert."
@@ -8677,7 +8663,7 @@ msgstr "Import"
 #: lib/vutuv_web/controllers/import_controller.ex:114
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:369
+#: lib/vutuv_web/templates/user/show.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "Import from LinkedIn"
 msgstr "Von LinkedIn importieren"
@@ -8789,7 +8775,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/live/user_profile_live.ex:978
+#: lib/vutuv_web/live/user_profile_live.ex:983
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr "Zum Beispiel ein Gedanke zu %{tag}."
@@ -8819,7 +8805,7 @@ msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:94
-#: lib/vutuv_web/templates/user/show.html.heex:1065
+#: lib/vutuv_web/templates/user/show.html.heex:1069
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8905,7 +8891,7 @@ msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
 #: lib/vutuv_web/components/ui.ex:3176
-#: lib/vutuv_web/controllers/settings_controller.ex:106
+#: lib/vutuv_web/controllers/settings_controller.ex:107
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
@@ -8917,7 +8903,7 @@ msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
 #: lib/vutuv_web/components/ui.ex:3174
-#: lib/vutuv_web/controllers/settings_controller.ex:89
+#: lib/vutuv_web/controllers/settings_controller.ex:90
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:5
 #: lib/vutuv_web/templates/totp/new.html.heex:5
@@ -8952,13 +8938,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:704
-#: lib/vutuv_web/live/post_live/feed.ex:705
+#: lib/vutuv_web/live/post_live/feed.ex:785
+#: lib/vutuv_web/live/post_live/feed.ex:786
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:699
+#: lib/vutuv_web/live/post_live/feed.ex:780
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -9179,7 +9165,7 @@ msgid "Allow followers from the Fediverse"
 msgstr "Follower aus dem Fediverse erlauben"
 
 #: lib/vutuv_web/components/ui.ex:3183
-#: lib/vutuv_web/controllers/settings_controller.ex:186
+#: lib/vutuv_web/controllers/settings_controller.ex:187
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:288
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:8
@@ -9187,7 +9173,7 @@ msgstr "Follower aus dem Fediverse erlauben"
 msgid "Fediverse"
 msgstr "Fediverse"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:208
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Get verified on Mastodon"
@@ -9215,7 +9201,7 @@ msgstr ""
 "Jeder auf Mastodon kann dieses Handle in die Suche einfügen und Ihnen von "
 "dort folgen."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:196
+#: lib/vutuv_web/controllers/settings_controller.ex:206
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr "Fediverse-Einstellungen gespeichert."
@@ -9225,7 +9211,7 @@ msgstr "Fediverse-Einstellungen gespeichert."
 msgid "Followers from the Fediverse:"
 msgstr "Follower aus dem Fediverse:"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:92
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Independent of federation: your vutuv profile links your listed social media accounts with rel=\"me\", so adding your profile address to your Mastodon profile shows it there as verified."
 msgstr ""
@@ -9233,7 +9219,7 @@ msgstr ""
 "Social-Media-Konten mit rel=\"me\". Tragen Sie Ihre Profiladresse in Ihrem "
 "Mastodon-Profil ein, wird sie dort als bestätigt angezeigt."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:99
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr "Social-Media-Konten verwalten"
@@ -9262,7 +9248,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
 
-#: lib/vutuv/accounts.ex:934
+#: lib/vutuv/accounts.ex:935
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9319,7 +9305,7 @@ msgstr "Berufserfahrung"
 msgid "Volunteering & hobbies"
 msgstr "Ehrenamt, Hobby & Freiwilligenarbeit"
 
-#: lib/vutuv_web/live/search_live.ex:251
+#: lib/vutuv_web/live/search_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr "Nicht verfügbar, solange die Suche einen Personen-Filter verwendet."
@@ -9328,7 +9314,7 @@ msgstr "Nicht verfügbar, solange die Suche einen Personen-Filter verwendet."
 #: lib/vutuv_web/cv/html.ex:58
 #: lib/vutuv_web/cv/latex.ex:45
 #: lib/vutuv_web/cv/latex.ex:46
-#: lib/vutuv_web/live/cv_live.ex:175
+#: lib/vutuv_web/live/cv_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "CV"
 msgstr "Lebenslauf"
@@ -9338,19 +9324,19 @@ msgstr "Lebenslauf"
 msgid "Your profile as a CV"
 msgstr "Ihr Profil als Lebenslauf"
 
-#: lib/vutuv_web/views/education_html.ex:19
+#: lib/vutuv_web/views/education_html.ex:28
 #, elixir-autogen, elixir-format
 msgid "Higher Education"
 msgstr "Studium"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:633
-#: lib/vutuv_web/views/education_html.ex:21
+#: lib/vutuv_web/views/education_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:632
-#: lib/vutuv_web/views/education_html.ex:20
+#: lib/vutuv_web/views/education_html.ex:29
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
 msgstr "Berufsausbildung"
@@ -9390,24 +9376,24 @@ msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
 
-#: lib/vutuv_web/live/cv_live.ex:193
+#: lib/vutuv_web/live/cv_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Anonymize"
 msgstr "Anonymisieren"
 
-#: lib/vutuv_web/live/cv_live.ex:108
+#: lib/vutuv_web/live/cv_live.ex:149
 #: lib/vutuv_web/templates/invitation/new.html.heex:47
 #: lib/vutuv_web/templates/invitation/sent.html.heex:23
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-Mail-Adresse"
 
-#: lib/vutuv_web/live/cv_live.ex:400
+#: lib/vutuv_web/live/cv_live.ex:441
 #, elixir-autogen, elixir-format
 msgid "Every download reflects the parts you selected."
 msgstr "Jeder Download enthält genau die ausgewählten Teile."
 
-#: lib/vutuv_web/live/cv_live.ex:207
+#: lib/vutuv_web/live/cv_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr "Kopfzeile"
@@ -9418,12 +9404,12 @@ msgstr "Kopfzeile"
 msgid "Open CV"
 msgstr "Lebenslauf öffnen"
 
-#: lib/vutuv_web/live/cv_live.ex:105
+#: lib/vutuv_web/live/cv_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr "Foto"
 
-#: lib/vutuv_web/live/cv_live.ex:182
+#: lib/vutuv_web/live/cv_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Pick what to include. Untick single entries or whole sections, or anonymize the CV by hiding the name, photo and contact details."
 msgstr ""
@@ -9431,12 +9417,12 @@ msgstr ""
 "ganze Abschnitte ab, oder anonymisieren Sie den Lebenslauf, indem Sie Name, "
 "Foto und Kontaktdaten ausblenden."
 
-#: lib/vutuv_web/live/cv_live.ex:409
+#: lib/vutuv_web/live/cv_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "Print / Save as PDF"
 msgstr "Drucken / Als PDF speichern"
 
-#: lib/vutuv_web/live/cv_live.ex:111
+#: lib/vutuv_web/live/cv_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "Profile link"
 msgstr "Profillink"
@@ -9466,12 +9452,12 @@ msgstr ""
 "und drucken Sie ihn dann (Als PDF speichern) oder laden Sie ihn als Word, "
 "OpenDocument, HTML, LaTeX oder JSON Resume herunter."
 
-#: lib/vutuv_web/live/cv_live.ex:44
+#: lib/vutuv_web/live/cv_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "CV of %{name}"
 msgstr "Lebenslauf von %{name}"
 
-#: lib/vutuv_web/live/cv_live.ex:47
+#: lib/vutuv_web/live/cv_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
@@ -9492,7 +9478,7 @@ msgstr "Freiberuflich / Selbstständig"
 msgid "Other activities"
 msgstr "Sonstige Tätigkeiten"
 
-#: lib/vutuv_web/live/cv_live.ex:423
+#: lib/vutuv_web/live/cv_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
@@ -9506,21 +9492,25 @@ msgstr ""
 msgid "characters"
 msgstr "Zeichen"
 
+#: lib/vutuv_web/templates/education/card_list.html.heex:28
 #: lib/vutuv_web/templates/work_experience/card_list.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "%{job} shows at the top of your profile."
 msgstr "%{job} wird oben in Ihrem Profil angezeigt."
 
+#: lib/vutuv_web/templates/education/card_list.html.heex:34
 #: lib/vutuv_web/templates/work_experience/card_list.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Choose automatically instead"
 msgstr "Stattdessen automatisch wählen"
 
+#: lib/vutuv_web/templates/education/card_list.html.heex:93
 #: lib/vutuv_web/views/work_experience_html.ex:682
 #, elixir-autogen, elixir-format
 msgid "Show at top of profile"
 msgstr "Oben im Profil anzeigen"
 
+#: lib/vutuv_web/templates/education/card_list.html.heex:84
 #: lib/vutuv_web/views/work_experience_html.ex:673
 #, elixir-autogen, elixir-format
 msgid "Shown at the top of your profile"
@@ -9614,7 +9604,7 @@ msgstr "Dieses Mitglied aus dem Tag entfernen?"
 msgid "Removed @%{handle} from this tag."
 msgstr "@%{handle} aus diesem Tag entfernt."
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:149
+#: lib/vutuv_web/controllers/user_tag_controller.ex:171
 #, elixir-autogen, elixir-format
 msgid "This tag can only be removed by a site admin."
 msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
@@ -9654,7 +9644,7 @@ msgid "A2 (Elementary)"
 msgstr "A2 (Grundkenntnisse)"
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Sprache hinzufügen"
@@ -9873,13 +9863,13 @@ msgstr "Sprache erfolgreich aktualisiert."
 #: lib/vutuv_web/cv/html.ex:188
 #: lib/vutuv_web/cv/latex.ex:149
 #: lib/vutuv_web/cv/odt.ex:163
-#: lib/vutuv_web/live/cv_live.ex:346
+#: lib/vutuv_web/live/cv_live.ex:387
 #: lib/vutuv_web/templates/language/edit.html.heex:3
 #: lib/vutuv_web/templates/language/index.html.heex:10
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:3
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:608
+#: lib/vutuv_web/templates/user/show.html.heex:612
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Sprachen"
@@ -10066,18 +10056,18 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:735
+#: lib/vutuv/accounts/user.ex:780
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
 msgstr "Auf Jobsuche"
 
-#: lib/vutuv_web/views/user_helpers.ex:40
+#: lib/vutuv_web/views/user_helpers.ex:41
 #, elixir-autogen, elixir-format
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:732
+#: lib/vutuv/accounts/user.ex:777
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10170,7 +10160,7 @@ msgstr[0] "%{count} Zertifikat oder Lizenz"
 msgstr[1] "%{count} Zertifikate oder Lizenzen"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:651
+#: lib/vutuv_web/templates/user/show.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
@@ -10211,14 +10201,14 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/cv/html.ex:172
 #: lib/vutuv_web/cv/latex.ex:140
 #: lib/vutuv_web/cv/odt.ex:154
-#: lib/vutuv_web/live/cv_live.ex:321
+#: lib/vutuv_web/live/cv_live.ex:362
 #: lib/vutuv_web/templates/import/preview.html.heex:27
 #: lib/vutuv_web/templates/qualification/edit.html.heex:3
 #: lib/vutuv_web/templates/qualification/index.html.heex:11
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:3
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:648
+#: lib/vutuv_web/templates/user/show.html.heex:652
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr "Zertifikate & Lizenzen"
@@ -10359,8 +10349,8 @@ msgstr "Bevorzugt"
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:926
-#: lib/vutuv_web/templates/user/show.html.heex:927
+#: lib/vutuv_web/templates/user/show.html.heex:930
+#: lib/vutuv_web/templates/user/show.html.heex:931
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10369,7 +10359,7 @@ msgstr "+%{code} ist die Ländervorwahl von %{region}"
 #: lib/vutuv_web/cv/html.ex:84
 #: lib/vutuv_web/cv/latex.ex:69
 #: lib/vutuv_web/cv/odt.ex:109
-#: lib/vutuv_web/live/cv_live.ex:112
+#: lib/vutuv_web/live/cv_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
@@ -10546,8 +10536,8 @@ msgstr "Ihre Einladung ist unterwegs"
 msgid "Permanent profile link"
 msgstr "Dauerhafter Profillink"
 
-#: lib/vutuv_web/templates/user/show.html.heex:317
-#: lib/vutuv_web/templates/user/show.html.heex:318
+#: lib/vutuv_web/templates/user/show.html.heex:321
+#: lib/vutuv_web/templates/user/show.html.heex:322
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr "Schließen"
@@ -11093,7 +11083,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1039
+#: lib/vutuv_web/templates/user/show.html.heex:1043
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -11425,7 +11415,7 @@ msgstr ""
 "Längere Beiträge erhalten einen „Weiterlesen“-Link. Mit 0 (oder leer) wird "
 "nie gekürzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:344
+#: lib/vutuv_web/controllers/settings_controller.ex:472
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
@@ -11484,7 +11474,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr "Standard der Installation (%{value})"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:375
+#: lib/vutuv_web/controllers/settings_controller.ex:503
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr "Karten-Einstellungen auf die Standardwerte zurückgesetzt."
@@ -11503,7 +11493,7 @@ msgstr ""
 "Eigener Wert; leeren Sie das Feld, um zum Standard der Installation "
 "zurückzukehren."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:371
+#: lib/vutuv_web/controllers/settings_controller.ex:499
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -11739,19 +11729,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:773
+#: lib/vutuv/accounts/user.ex:818
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:778
+#: lib/vutuv/accounts/user.ex:823
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:776
+#: lib/vutuv/accounts/user.ex:821
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
@@ -11950,7 +11940,7 @@ msgstr "Ihre Ausschlussliste ist voll (max. %{count})."
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr "Ihre Liste ist leer. Es ist noch niemand ausgeschlossen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/organization_live/edit.ex:326
 #, elixir-autogen, elixir-format
 msgid "AI agents"
 msgstr "KI-Agenten"
@@ -11983,28 +11973,28 @@ msgid "Domain verification is disabled on this installation."
 msgstr "Die Domain-Verifizierung ist auf dieser Installation deaktiviert."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:31
-#: lib/vutuv_web/live/organization_live/edit.ex:228
+#: lib/vutuv_web/live/organization_live/edit.ex:240
 #, elixir-autogen, elixir-format
 msgid "Edit %{name}"
 msgstr "%{name} bearbeiten"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:300
+#: lib/vutuv_web/live/organization_live/edit.ex:312
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
 "Suchmaschinen dürfen diese Seite indexieren und in die Sitemap aufnehmen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:235
+#: lib/vutuv_web/live/organization_live/edit.ex:247
 #, elixir-autogen, elixir-format
 msgid "Logo"
 msgstr "Logo"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:262
+#: lib/vutuv_web/live/organization_live/edit.ex:274
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported"
 msgstr "Markdown wird unterstützt"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:316
+#: lib/vutuv_web/live/organization_live/edit.ex:328
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -12022,7 +12012,7 @@ msgstr "Bitte loggen Sie sich zuerst ein."
 msgid "Prove you control %{domain} to publish this page."
 msgstr "Weisen Sie nach, dass Ihnen %{domain} gehört, um diese Seite zu veröffentlichen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:246
+#: lib/vutuv_web/live/organization_live/edit.ex:258
 #, elixir-autogen, elixir-format
 msgid "Remove logo"
 msgstr "Logo entfernen"
@@ -12032,7 +12022,7 @@ msgstr "Logo entfernen"
 msgid "Search by name or city"
 msgstr "Nach Name oder Stadt suchen"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:298
+#: lib/vutuv_web/live/organization_live/edit.ex:310
 #, elixir-autogen, elixir-format
 msgid "Search engines"
 msgstr "Suchmaschinen"
@@ -12048,23 +12038,23 @@ msgstr "Land auswählen"
 msgid "Serve this file at:"
 msgstr "Stellen Sie diese Datei bereit unter:"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:279
+#: lib/vutuv_web/live/organization_live/edit.ex:291
 #: lib/vutuv_web/live/organization_live/new.ex:124
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr "Bundesland / Region (optional)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:459
+#: lib/vutuv_web/live/organization_live/edit.ex:471
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr "Dieser Dateityp ist nicht erlaubt."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:457
+#: lib/vutuv_web/live/organization_live/edit.ex:469
 #, elixir-autogen, elixir-format
 msgid "The file is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:460
+#: lib/vutuv_web/live/organization_live/edit.ex:472
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr "Der Upload ist fehlgeschlagen."
@@ -12112,7 +12102,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:207
 #: lib/vutuv_web/agent_docs/text.ex:196
-#: lib/vutuv_web/live/organization_live/edit.ex:273
+#: lib/vutuv_web/live/organization_live/edit.ex:285
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
 msgid "Website"
@@ -12131,7 +12121,7 @@ msgstr "Website-Datei"
 msgid "Website file (.well-known)"
 msgstr "Website-Datei (.well-known)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:458
+#: lib/vutuv_web/live/organization_live/edit.ex:470
 #, elixir-autogen, elixir-format
 msgid "You can only upload one logo."
 msgstr "Sie können nur ein Logo hochladen."
@@ -12161,7 +12151,7 @@ msgid "@handle or email"
 msgstr "@handle oder E-Mail"
 
 #: lib/vutuv_web/components/organization_components.ex:252
-#: lib/vutuv_web/live/organization_live/edit.ex:376
+#: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr "Abkürzung"
@@ -12182,7 +12172,7 @@ msgid "Added @%{handle} to the team."
 msgstr "@%{handle} zum Team hinzugefügt."
 
 #: lib/vutuv_web/components/organization_components.ex:253
-#: lib/vutuv_web/live/organization_live/edit.ex:374
+#: lib/vutuv_web/live/organization_live/edit.ex:386
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr "Alias"
@@ -12199,13 +12189,13 @@ msgstr "Alias entfernt."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:308
 #: lib/vutuv_web/agent_docs/text.ex:335
-#: lib/vutuv_web/live/organization_live/edit.ex:339
+#: lib/vutuv_web/live/organization_live/edit.ex:351
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr "Auch bekannt als"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:370
+#: lib/vutuv_web/live/organization_live/edit.ex:382
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr "Alternativer Name"
@@ -12227,7 +12217,7 @@ msgid "Archived"
 msgstr "Archiviert"
 
 #: lib/vutuv_web/components/organization_components.ex:251
-#: lib/vutuv_web/live/organization_live/edit.ex:375
+#: lib/vutuv_web/live/organization_live/edit.ex:387
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr "Marke"
@@ -12382,7 +12372,7 @@ msgstr "Diese Domain entfernen?"
 msgid "Remove this member from the team?"
 msgstr "Dieses Mitglied aus dem Team entfernen?"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:356
+#: lib/vutuv_web/live/organization_live/edit.ex:368
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr "Diesen Namen entfernen?"
@@ -12449,44 +12439,44 @@ msgstr "primär"
 msgid "verified"
 msgstr "verifiziert"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:276
+#: lib/vutuv_web/live/organization_live/edit.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:121
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr "Straße und Hausnummer (optional)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:277
+#: lib/vutuv_web/live/organization_live/edit.ex:289
 #: lib/vutuv_web/live/organization_live/new.ex:122
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr "PLZ (optional)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:429
+#: lib/vutuv_web/live/organization_live/edit.ex:441
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr "Reservieren"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:398
+#: lib/vutuv_web/live/organization_live/edit.ex:410
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr "Erreichbar unter"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:388
+#: lib/vutuv_web/live/organization_live/edit.ex:400
 #, elixir-autogen, elixir-format
 msgid "Root handle"
 msgstr "Handle"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:191
+#: lib/vutuv_web/live/organization_live/edit.ex:203
 #, elixir-autogen, elixir-format
 msgid "That handle is not available."
 msgstr "Dieses Handle ist nicht verfügbar."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:435
+#: lib/vutuv_web/live/organization_live/edit.ex:447
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr "Gefahrenbereich"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:446
+#: lib/vutuv_web/live/organization_live/edit.ex:458
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr "%{name} wirklich löschen? Das kann nicht rückgängig gemacht werden."
@@ -12649,7 +12639,7 @@ msgstr[1] ""
 "%{count} Aliasse stimmen mit anderen verifizierten Organisationen überein und wurden"
 " zur Prüfung markiert. Öffne unten eine Organisation, um sie zu sehen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:341
+#: lib/vutuv_web/live/organization_live/edit.ex:353
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
@@ -12691,7 +12681,7 @@ msgstr ""
 "Domain oder einer Subdomain davon liegt, wird ausgeschlossen. So verbergen "
 "Sie es zuverlässig vor Ihrer ganzen Organisation."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:390
+#: lib/vutuv_web/live/organization_live/edit.ex:402
 #, elixir-autogen, elixir-format
 msgid "Claim a short @handle so this organization has its own root URL, like a member profile. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr "Reservieren Sie ein kurzes @handle, damit diese Organisation wie ein Mitgliedsprofil eine eigene Root-URL bekommt. Buchstaben, Zahlen und Unterstriche, %{min} bis %{max} Zeichen."
@@ -12730,17 +12720,17 @@ msgstr "Der Nachweis ist eine kleine technische Änderung an Ihrer Domain: ein D
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr "Diese Schritte sind technisch. Wenn Sie %{domain} nicht selbst verwalten, kopieren Sie den unten gezeigten Eintrag oder die Datei und senden Sie ihn an Ihre IT-Abteilung oder die Firma, die Ihre Website betreut. Sobald sie ihn hinzugefügt hat, kommen Sie hierher zurück und klicken auf „Jetzt verifizieren“."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:450
+#: lib/vutuv_web/live/organization_live/edit.ex:462
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr "Diese Organisation löschen"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:437
+#: lib/vutuv_web/live/organization_live/edit.ex:449
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr "Das Löschen dieser Organisationsseite ist endgültig. Ihre verifizierten Domains und ihr @handle werden freigegeben und können erneut beansprucht werden."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:256
+#: lib/vutuv_web/live/organization_live/edit.ex:268
 #: lib/vutuv_web/live/organization_live/new.ex:111
 #, elixir-autogen, elixir-format
 msgid "Kind of organization"
@@ -12806,7 +12796,7 @@ msgstr "Organisation"
 msgid "Organization frozen."
 msgstr "Organisation"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:255
+#: lib/vutuv_web/live/organization_live/edit.ex:267
 #: lib/vutuv_web/live/organization_live/new.ex:110
 #, elixir-autogen, elixir-format
 msgid "Organization name"
@@ -12825,7 +12815,7 @@ msgstr "Organisation"
 msgid "Organization pages"
 msgstr "Organisation"
 
-#: lib/vutuv_web/live/notification_live/index.ex:833
+#: lib/vutuv_web/live/notification_live/index.ex:861
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisation"
@@ -12837,7 +12827,7 @@ msgstr "Organisation"
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
 #: lib/vutuv_web/components/ui.ex:3175
-#: lib/vutuv_web/controllers/settings_controller.ex:157
+#: lib/vutuv_web/controllers/settings_controller.ex:158
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
 #: lib/vutuv_web/live/post_live/saved.ex:455
@@ -12885,7 +12875,7 @@ msgstr "Diese Domain gehört bereits zu einer anderen Organisationsseite."
 msgid "That name is already listed for this organization."
 msgstr "Dieser Name ist für diese Organisation bereits eingetragen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:179
+#: lib/vutuv_web/live/organization_live/edit.ex:191
 #, elixir-autogen, elixir-format
 msgid "The organization page was deleted."
 msgstr "Die Organisationsseite wurde gelöscht."
@@ -12916,12 +12906,12 @@ msgstr ""
 "Verifizierte Organisationsseiten: Domains, Team-Rollen, Aliasse und "
 "Umbenennungsverlauf. Seite einfrieren, archivieren oder löschen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:162
+#: lib/vutuv_web/live/organization_live/edit.ex:174
 #, elixir-autogen, elixir-format
 msgid "You are not allowed to delete this organization."
 msgstr "Sie dürfen diese Organisation nicht löschen."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:135
+#: lib/vutuv_web/live/organization_live/edit.ex:139
 #, elixir-autogen, elixir-format
 msgid "Your organization handle is set."
 msgstr "Ihr Organisations-Handle ist gesetzt."
@@ -12936,27 +12926,27 @@ msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
 msgid "Your organization page was updated."
 msgstr "Ihre Organisationsseite wurde aktualisiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:985
+#: lib/vutuv_web/live/notification_live/index.ex:1013
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr "hat dir eine Rolle bei %{company} gegeben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:982
+#: lib/vutuv_web/live/notification_live/index.ex:1010
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr "hat dich zum Recruiter für %{company} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:979
+#: lib/vutuv_web/live/notification_live/index.ex:1007
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr "hat dich zum Administrator von %{company} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:976
+#: lib/vutuv_web/live/notification_live/index.ex:1004
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr "hat dich zum Inhaber von %{company} gemacht."
 
-#: lib/vutuv_web/live/organization_live/edit.ex:419
+#: lib/vutuv_web/live/organization_live/edit.ex:431
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr "ihre_organisation"
@@ -13117,7 +13107,7 @@ msgstr "Name des Arbeitgebers (optional)"
 #: lib/vutuv_web/agent_docs/markdown.ex:354
 #: lib/vutuv_web/agent_docs/text.ex:213
 #: lib/vutuv_web/agent_docs/text.ex:380
-#: lib/vutuv_web/live/job_board_live.ex:281
+#: lib/vutuv_web/live/job_board_live.ex:367
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
 msgid "Employment type"
@@ -13153,7 +13143,7 @@ msgstr "Halten Sie Strg / Cmd gedrückt, um mehrere auszuwählen."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:747
+#: lib/vutuv/accounts/user.ex:792
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -13176,8 +13166,8 @@ msgstr "Stellenbezeichnung"
 
 #: lib/vutuv_web/agent_docs/job_board_doc.ex:19
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:41
-#: lib/vutuv_web/live/job_board_live.ex:146
+#: lib/vutuv_web/live/job_board_live.ex:45
+#: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:458
 #: lib/vutuv_web/live/shell_live.ex:457
 #: lib/vutuv_web/templates/layout/app.html.heex:77
@@ -13273,7 +13263,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:746
+#: lib/vutuv/accounts/user.ex:791
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -13355,7 +13345,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:748
+#: lib/vutuv/accounts/user.ex:793
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
 #: lib/vutuv_web/agent_docs/markdown.ex:339
@@ -13571,12 +13561,12 @@ msgstr "Vertreten Sie ein Unternehmen, einen Verein oder eine andere Gruppe? Fü
 msgid "Browse all organizations"
 msgstr "Alle Organisationen ansehen"
 
-#: lib/vutuv_web/views/settings_html.ex:28
+#: lib/vutuv_web/views/settings_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Under review"
 msgstr "In Prüfung"
 
-#: lib/vutuv_web/views/settings_html.ex:30
+#: lib/vutuv_web/views/settings_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Verification pending"
 msgstr "Verifizierung ausstehend"
@@ -13618,7 +13608,7 @@ msgstr "Legen Sie in Ihren DNS-Einstellungen einen neuen TXT-Eintrag mit diesem 
 msgid "Name (host)"
 msgstr "Name (Host)"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:143
+#: lib/vutuv_web/live/organization_live/edit.ex:147
 #, elixir-autogen, elixir-format
 msgid "Only a verified organization page can claim a handle."
 msgstr "Nur eine verifizierte Organisationsseite kann ein Handle beanspruchen."
@@ -13642,12 +13632,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] "vor %{count} Woche"
 msgstr[1] "vor %{count} Wochen"
 
-#: lib/vutuv_web/live/job_board_live.ex:387
+#: lib/vutuv_web/live/job_board_live.ex:491
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr "%{km} km"
 
-#: lib/vutuv_web/live/job_board_live.ex:275
+#: lib/vutuv_web/live/job_board_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr "Alle Länder"
@@ -13663,42 +13653,42 @@ msgstr "Alle Stellen mit diesem Tag"
 msgid "All jobs with this tag: %{url}"
 msgstr "Alle Stellen mit diesem Tag: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:282
+#: lib/vutuv_web/live/job_board_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr "Alle Anstellungsarten"
 
-#: lib/vutuv_web/live/job_board_live.ex:264
+#: lib/vutuv_web/live/job_board_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr "Stadt oder Postleitzahl"
 
-#: lib/vutuv_web/live/job_board_live.ex:387
+#: lib/vutuv_web/live/job_board_live.ex:491
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr "Genau"
 
-#: lib/vutuv_web/live/job_board_live.ex:184
+#: lib/vutuv_web/live/job_board_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr "Ab meiner Gehaltsvorstellung"
 
-#: lib/vutuv_web/live/job_board_live.ex:176
+#: lib/vutuv_web/live/job_board_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr "Passend zu meinen Tags"
 
-#: lib/vutuv_web/live/job_board_live.ex:357
+#: lib/vutuv_web/live/job_board_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr "Mindestgehalt/Jahr (%{currency})"
 
-#: lib/vutuv_web/live/job_board_live.ex:306
+#: lib/vutuv_web/live/job_board_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr "Mindestgehalt pro Jahr"
 
-#: lib/vutuv_web/live/job_board_live.ex:239
+#: lib/vutuv_web/live/job_board_live.ex:324
 #: lib/vutuv_web/live/organization_live/show.ex:342
 #, elixir-autogen, elixir-format
 msgid "More jobs"
@@ -13714,12 +13704,12 @@ msgstr "Nächste Seite"
 msgid "Next page: %{url}"
 msgstr "Nächste Seite: %{url}"
 
-#: lib/vutuv_web/live/job_board_live.ex:395
+#: lib/vutuv_web/live/job_board_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr "Noch keine Stellenanzeigen."
 
-#: lib/vutuv_web/live/job_board_live.ex:393
+#: lib/vutuv_web/live/job_board_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Keine passenden Stellen. Passe die Filter an."
@@ -13735,27 +13725,27 @@ msgid "Open positions"
 msgstr "Offene Stellen"
 
 #: lib/vutuv_web/agent_docs/job_board_doc.ex:20
-#: lib/vutuv_web/live/job_board_live.ex:148
+#: lib/vutuv_web/live/job_board_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr "Offene Stellen auf vutuv, neueste zuerst."
 
-#: lib/vutuv_web/live/job_board_live.ex:156
+#: lib/vutuv_web/live/job_board_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr "Stelle ausschreiben"
 
-#: lib/vutuv_web/live/job_board_live.ex:221
+#: lib/vutuv_web/live/job_board_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr "Veröffentliche die erste"
 
-#: lib/vutuv_web/live/job_board_live.ex:268
+#: lib/vutuv_web/live/job_board_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr "Umkreis"
 
-#: lib/vutuv_web/live/job_board_live.ex:256
+#: lib/vutuv_web/live/job_board_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr "Jobs durchsuchen"
@@ -13956,7 +13946,7 @@ msgstr[1] "%{count} neue Treffer für deine gespeicherten Suchen"
 msgid "Alert frequency"
 msgstr "Häufigkeit der Benachrichtigung"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:269
+#: lib/vutuv_web/controllers/settings_controller.ex:397
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr "Benachrichtigung aktualisiert."
@@ -14022,13 +14012,13 @@ msgstr "Speichere eine Suche in der Stellenbörse oder in der Personensuche, und
 msgid "Save search"
 msgstr "Suche speichern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:287
+#: lib/vutuv_web/controllers/settings_controller.ex:415
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:3213
-#: lib/vutuv_web/controllers/settings_controller.ex:245
+#: lib/vutuv_web/components/ui.ex:3214
+#: lib/vutuv_web/controllers/settings_controller.ex:320
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14047,8 +14037,8 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr "E-Mail-Benachrichtigungen für deine gespeicherte Suche „%{label}“ stoppen?"
 
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:274
-#: lib/vutuv_web/controllers/settings_controller.ex:292
+#: lib/vutuv_web/controllers/settings_controller.ex:402
+#: lib/vutuv_web/controllers/settings_controller.ex:420
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr "Das hat nicht funktioniert."
@@ -14094,7 +14084,7 @@ msgstr "Stellenbörse"
 msgid "job search"
 msgstr "Jobsuche"
 
-#: lib/vutuv_web/live/search_live.ex:299
+#: lib/vutuv_web/live/search_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "only people open to offers (status:open) or looking (status:looking)"
 msgstr "nur Personen, die offen für Angebote (status:open) oder auf Jobsuche (status:looking) sind"
@@ -14268,7 +14258,7 @@ msgstr "Alias-Markierung entfernt."
 msgid "Reviewed, all fine: clear the flag"
 msgstr "Geprüft, alles in Ordnung: Markierung entfernen"
 
-#: lib/vutuv_web/live/organization_live/edit.ex:169
+#: lib/vutuv_web/live/organization_live/edit.ex:181
 #, elixir-autogen, elixir-format
 msgid "This page has job postings, so it cannot be deleted. Ask an admin to archive it instead."
 msgstr "Diese Seite hat Stellenanzeigen und kann deshalb nicht gelöscht werden. Bitte einen Admin, sie stattdessen zu archivieren."
@@ -14301,7 +14291,7 @@ msgstr "Bild wird geprüft, nur für Sie sichtbar"
 msgid "Image is being reviewed"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/live/notification_live/index.ex:831
+#: lib/vutuv_web/live/notification_live/index.ex:859
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -14342,7 +14332,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:791
+#: lib/vutuv/accounts/user.ex:836
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14353,19 +14343,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:794
+#: lib/vutuv/accounts/user.ex:839
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:797
+#: lib/vutuv/accounts/user.ex:842
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:788
+#: lib/vutuv/accounts/user.ex:833
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14388,7 +14378,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:834
+#: lib/vutuv_web/live/notification_live/index.ex:862
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -14400,7 +14390,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] "Wir haben %{formatted} Beitrag aktualisiert, der Ihren alten Handle erwähnt hat, und dessen Verfasser benachrichtigt."
 msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle erwähnt haben, und deren Verfasser benachrichtigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/notification_live/index.ex:1063
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
@@ -14447,14 +14437,14 @@ msgstr "In den Text einfügen"
 msgid "Posts with this tag"
 msgstr "Beiträge mit diesem Tag"
 
-#: lib/vutuv_web/live/search_live.ex:268
+#: lib/vutuv_web/live/search_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
 "Diese Suche nutzt einen reinen Personenfilter wie city: oder status: und "
 "findet daher nur Personen."
 
-#: lib/vutuv_web/live/search_live.ex:295
+#: lib/vutuv_web/live/search_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "people and posts with this tag, combinable: miller tag:php"
 msgstr "Personen und Beiträge mit diesem Tag, kombinierbar: müller tag:php"
@@ -14494,46 +14484,46 @@ msgstr "Eigene Beiträge"
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr "Beiträge mit einem Tag, dem du folgst, landen in deinem Feed, und passende Personen tauchen in deinen Vorschlägen auf. Einem Tag folgst du auf seiner Seite."
 
-#: lib/vutuv_web/components/ui.ex:3202
-#: lib/vutuv_web/controllers/settings_controller.ex:259
-#: lib/vutuv_web/live/post_live/feed.ex:651
+#: lib/vutuv_web/components/ui.ex:3203
+#: lib/vutuv_web/controllers/settings_controller.ex:334
+#: lib/vutuv_web/live/post_live/feed.ex:732
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen du folgst"
 
-#: lib/vutuv_web/live/post_live/feed.ex:666
+#: lib/vutuv_web/live/post_live/feed.ex:747
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
 
-#: lib/vutuv_web/live/job_board_live.ex:324
+#: lib/vutuv_web/live/job_board_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr "Ein Beruf mit mehreren möglichen Titeln? Trenne sie mit Komma, dann zeigen wir Anzeigen, die zu einem davon passen."
 
-#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/job_board_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr "Suchtipps"
 
-#: lib/vutuv_web/live/job_board_live.ex:378
+#: lib/vutuv_web/live/job_board_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr "einer dieser Titel"
 
-#: lib/vutuv_web/live/job_board_live.ex:380
+#: lib/vutuv_web/live/job_board_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr "genaue Wortfolge"
 
-#: lib/vutuv_web/live/job_board_live.ex:381
+#: lib/vutuv_web/live/job_board_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr "ohne Praktika"
 
-#: lib/vutuv_web/live/job_board_live.ex:379
+#: lib/vutuv_web/live/job_board_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr "Wortanfang: findet auch Entwickler, Entwicklung"
@@ -14544,7 +14534,7 @@ msgid "Signal and WhatsApp accept a phone number or a username; the other messen
 msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzernamen; die anderen Messenger nutzen ihre eigene ID oder ihren Handle (z. B. eine 8-stellige Threema-ID oder eine Matrix-Adresse @du:matrix.org)."
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1005
+#: lib/vutuv_web/templates/user/show.html.heex:1009
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14581,7 +14571,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:3
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1003
+#: lib/vutuv_web/templates/user/show.html.heex:1007
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14613,22 +14603,22 @@ msgstr[1] "Meine %{formatted} Follower darüber informieren"
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:835
+#: lib/vutuv_web/live/notification_live/index.ex:863
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1055
+#: lib/vutuv_web/live/notification_live/index.ex:1083
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr "hat eine neue Station im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1047
+#: lib/vutuv_web/live/notification_live/index.ex:1075
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr "hat eine neue Ausbildung im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1052
+#: lib/vutuv_web/live/notification_live/index.ex:1080
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr "hat ein neues Zertifikat im Lebenslauf: %{entry}"
@@ -14653,37 +14643,7 @@ msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folg
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:100
-#, elixir-autogen, elixir-format
-msgid "Thread replies"
-msgstr "Thread-Antworten"
-
-#: lib/vutuv_web/templates/settings/notifications.html.heex:103
-#, elixir-autogen, elixir-format
-msgid "When someone replies anywhere in a thread you have written in, you hear about it under the bell, so a discussion reaches everyone who took part. Never by email."
-msgstr "Wenn jemand irgendwo in einem Thread antwortet, in dem Sie geschrieben haben, hören Sie es unter der Glocke, damit eine Diskussion alle Beteiligten erreicht. Nie per E-Mail."
-
-#: lib/vutuv_web/templates/settings/notifications.html.heex:108
-#, elixir-autogen, elixir-format
-msgid "Tell me about new replies in threads I take part in"
-msgstr "Über neue Antworten in Threads informieren, an denen ich teilnehme"
-
-#: lib/vutuv_web/templates/settings/notifications.html.heex:110
-#, elixir-autogen, elixir-format
-msgid "When off, you only hear about direct answers to your own posts, never other replies in the thread."
-msgstr "Wenn aus, hören Sie nur von direkten Antworten auf Ihre eigenen Beiträge, nie von anderen Antworten im Thread."
-
-#: lib/vutuv_web/live/notification_live/index.ex:459
-#, elixir-autogen, elixir-format
-msgid "You wrote in this thread."
-msgstr "Sie haben in diesem Thread geschrieben."
-
-#: lib/vutuv_web/live/notification_live/index.ex:463
-#, elixir-autogen, elixir-format
-msgid "Turn off thread notifications"
-msgstr "Thread-Benachrichtigungen abschalten"
-
-#: lib/vutuv_web/live/notification_live/index.ex:1060
+#: lib/vutuv_web/live/notification_live/index.ex:1088
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
@@ -14876,45 +14836,45 @@ msgstr "Mit Qualifikation: %{name}"
 msgid "Publisher:"
 msgstr "Verlag:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:712
+#: lib/vutuv_web/live/notification_live/index.ex:740
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} neue Mitteilung"
 msgstr[1] "%{formatted} neue Mitteilungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:726
+#: lib/vutuv_web/live/notification_live/index.ex:754
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day}. %{month} %{year}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:321
+#: lib/vutuv_web/live/notification_live/index.ex:330
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr "Zurückfolgen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:336
+#: lib/vutuv_web/live/notification_live/index.ex:345
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr "Letzte 30 Tage"
 
-#: lib/vutuv_web/live/notification_live/index.ex:678
-#: lib/vutuv_web/live/notification_live/index.ex:883
+#: lib/vutuv_web/live/notification_live/index.ex:706
+#: lib/vutuv_web/live/notification_live/index.ex:911
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/vutuv_web/live/notification_live/index.ex:850
+#: lib/vutuv_web/live/notification_live/index.ex:878
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "sind jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:845
+#: lib/vutuv_web/live/notification_live/index.ex:873
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "folgen Ihnen jetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:860
+#: lib/vutuv_web/live/notification_live/index.ex:888
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
@@ -15161,7 +15121,7 @@ msgstr "Bevorzugte Arbeitsform"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: lib/vutuv_web/live/notification_live/index.ex:648
+#: lib/vutuv_web/live/notification_live/index.ex:676
 #, elixir-autogen, elixir-format
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
@@ -15173,7 +15133,7 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1009
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
@@ -15181,12 +15141,12 @@ msgstr ""
 "familienfreundlich genug für ein Arbeitsumfeld. Sie kann sich irren, "
 "antworten Sie in dem Fall einfach auf unsere E-Mail."
 
-#: lib/vutuv_web/live/notification_live/index.ex:826
+#: lib/vutuv_web/live/notification_live/index.ex:854
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Thread-Antwort"
 
-#: lib/vutuv_web/live/notification_live/index.ex:870
+#: lib/vutuv_web/live/notification_live/index.ex:898
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -15205,12 +15165,12 @@ msgstr "Unterhaltung"
 msgid "Only part of this long conversation is shown."
 msgstr "Von dieser langen Unterhaltung wird nur ein Teil angezeigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:827
+#: lib/vutuv_web/live/notification_live/index.ex:855
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Erwähnung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:968
+#: lib/vutuv_web/live/notification_live/index.ex:996
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
@@ -15391,78 +15351,6 @@ msgstr "Unbestätigt"
 msgid "unreachable"
 msgstr "Nicht erreichbar"
 
-#: lib/vutuv_web/components/ui.ex:3184
-#: lib/vutuv_web/controllers/settings_controller.ex:308
-#: lib/vutuv_web/templates/settings/filters.html.heex:2
-#, elixir-autogen, elixir-format
-msgid "Muted words & tags"
-msgstr "Stummgeschaltete Wörter & Tags"
-
-#: lib/vutuv_web/templates/settings/filters.html.heex:5
-#, elixir-autogen, elixir-format
-msgid "Hide posts from your feed that carry a tag, or that contain a word or phrase. This list is yours alone: it is never shared, the author is never told, and a hidden post collapses to a line you can still open."
-msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wort bzw. eine Phrase enthalten. Diese Liste gehört nur Ihnen: Sie wird nie geteilt, der Verfasser erfährt nichts davon, und ein ausgeblendeter Beitrag klappt zu einer Zeile zusammen, die Sie weiterhin öffnen können."
-
-#: lib/vutuv_web/templates/settings/filters.html.heex:18
-#, elixir-autogen, elixir-format
-msgid "Word or phrase"
-msgstr "Wort oder Phrase"
-
-#: lib/vutuv_web/views/settings_html.ex:24
-#, elixir-autogen, elixir-format
-msgid "Word or phrase (whole word)"
-msgstr "Wort oder Phrase (ganzes Wort)"
-
-#: lib/vutuv_web/templates/settings/filters.html.heex:34
-#, elixir-autogen, elixir-format
-msgid "e.g. crypto*, \"machine learning\", politics"
-msgstr "z. B. crypto*, \"machine learning\", Politik"
-
-#: lib/vutuv_web/templates/settings/filters.html.heex:37
-#, elixir-autogen, elixir-format
-msgid "Word, phrase or tag to mute"
-msgstr "Wort, Phrase oder Tag zum Stummschalten"
-
-#: lib/vutuv_web/templates/settings/filters.html.heex:47
-#, elixir-autogen, elixir-format
-msgid "Use * as a wildcard (crypto* → cryptobro). Whole-word by default."
-msgstr "Verwenden Sie * als Platzhalter (crypto* → cryptobro). Standardmäßig ganze Wörter."
-
-#: lib/vutuv_web/templates/settings/filters.html.heex:58
-#, elixir-autogen, elixir-format
-msgid "Match whole words only (word/phrase)"
-msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
-
-#: lib/vutuv_web/templates/settings/filters.html.heex:85
-#, elixir-autogen, elixir-format
-msgid "You have not muted anything yet."
-msgstr "Sie haben noch nichts stummgeschaltet."
-
-#: lib/vutuv_web/live/post_live/feed.ex:521
-#, elixir-autogen, elixir-format
-msgid "Hidden: matches your filter"
-msgstr "Ausgeblendet: passt zu Ihrem Filter"
-
-#: lib/vutuv_web/live/post_live/feed.ex:530
-#, elixir-autogen, elixir-format
-msgid "Show anyway"
-msgstr "Trotzdem anzeigen"
-
-#: lib/vutuv_web/controllers/settings_controller.ex:271
-#, elixir-autogen, elixir-format
-msgid "Filter added. Matching posts are now hidden from your feed."
-msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgeblendet."
-
-#: lib/vutuv_web/controllers/settings_controller.ex:279
-#, elixir-autogen, elixir-format
-msgid "You have reached the maximum of %{count} filters."
-msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
-
-#: lib/vutuv_web/controllers/settings_controller.ex:295
-#, elixir-autogen, elixir-format
-msgid "Filter removed."
-msgstr "Filter entfernt."
-
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "Account you are moving to"
@@ -15572,3 +15460,156 @@ msgstr "Sie haben Ihre Fediverse-Follower zu einem anderen Konto weitergeleitet:
 #, elixir-autogen, elixir-format
 msgid "as an account alias."
 msgstr "als Konto-Alias hinzu."
+
+#: lib/vutuv_web/templates/user_tag/show.html.heex:24
+#, elixir-autogen, elixir-format
+msgid "%{formatted} endorsement"
+msgid_plural "%{formatted} endorsements"
+msgstr[0] "%{formatted} Empfehlung"
+msgstr[1] "%{formatted} Empfehlungen"
+
+#: lib/vutuv_web/templates/user_tag/show.html.heex:36
+#, elixir-autogen, elixir-format
+msgid "All endorsers"
+msgstr "Alle Empfehlenden"
+
+#: lib/vutuv_web/controllers/settings_controller.ex:351
+#, elixir-autogen, elixir-format
+msgid "Filter added. Matching posts are now hidden from your feed."
+msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgeblendet."
+
+#: lib/vutuv_web/live/job_board_live.ex:389
+#, elixir-autogen, elixir-format
+msgid "Filter by a tag"
+msgstr "Nach einem Tag filtern"
+
+#: lib/vutuv_web/controllers/settings_controller.ex:376
+#, elixir-autogen, elixir-format
+msgid "Filter removed."
+msgstr "Filter entfernt."
+
+#: lib/vutuv_web/live/post_live/feed.ex:201
+#, elixir-autogen, elixir-format
+msgid "Hidden: matches your filter"
+msgstr "Ausgeblendet: passt zu Ihrem Filter"
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:5
+#, elixir-autogen, elixir-format
+msgid "Hide posts from your feed that carry a tag, or that contain a word or phrase. This list is yours alone: it is never shared, the author is never told, and a hidden post collapses to a line you can still open."
+msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wort bzw. eine Phrase enthalten. Diese Liste gehört nur Ihnen: Sie wird nie geteilt, der Verfasser erfährt nichts davon, und ein ausgeblendeter Beitrag klappt zu einer Zeile zusammen, die Sie weiterhin öffnen können."
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:54
+#, elixir-autogen, elixir-format
+msgid "Match whole words only (word/phrase)"
+msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
+
+#: lib/vutuv_web/components/ui.ex:3185
+#: lib/vutuv_web/controllers/settings_controller.ex:387
+#: lib/vutuv_web/templates/settings/filters.html.heex:1
+#: lib/vutuv_web/templates/settings/filters.html.heex:3
+#, elixir-autogen, elixir-format
+msgid "Muted words & tags"
+msgstr "Stummgeschaltete Wörter & Tags"
+
+#: lib/vutuv_web/templates/user_tag/show.html.heex:20
+#, elixir-autogen, elixir-format
+msgid "Nobody has endorsed %{name} for this tag yet."
+msgstr "Noch niemand hat %{name} für dieses Tag empfohlen."
+
+#: lib/vutuv_web/templates/education/card_list.html.heex:40
+#, elixir-autogen, elixir-format
+msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
+msgstr ""
+"Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
+"Jobtitels oben in Ihrem Profil anzuzeigen."
+
+#: lib/vutuv_web/live/post_live/feed.ex:210
+#, elixir-autogen, elixir-format
+msgid "Show anyway"
+msgstr "Trotzdem anzeigen"
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:105
+#, elixir-autogen, elixir-format
+msgid "Tell me about new replies in threads I take part in"
+msgstr "Über neue Antworten in Threads informieren, an denen ich teilnehme"
+
+#: lib/vutuv_web/controllers/education_controller.ex:80
+#, elixir-autogen, elixir-format
+msgid "That education could not be pinned."
+msgstr "Diese Ausbildung konnte nicht angeheftet werden."
+
+#: lib/vutuv_web/controllers/education_controller.ex:90
+#, elixir-autogen, elixir-format
+msgid "The top of your profile is chosen automatically again."
+msgstr "Der obere Bereich Ihres Profils wird wieder automatisch gewählt."
+
+#: lib/vutuv_web/controllers/education_controller.ex:75
+#, elixir-autogen, elixir-format
+msgid "This education now shows at the top of your profile."
+msgstr "Diese Ausbildung wird jetzt oben in Ihrem Profil angezeigt."
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Thread replies"
+msgstr "Thread-Antworten"
+
+#: lib/vutuv_web/live/notification_live/index.ex:481
+#, elixir-autogen, elixir-format
+msgid "Turn off thread notifications"
+msgstr "Thread-Benachrichtigungen abschalten"
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:43
+#, elixir-autogen, elixir-format
+msgid "Use * as a wildcard (crypto* → cryptobro). Whole-word by default."
+msgstr "Verwenden Sie * als Platzhalter (crypto* → cryptobro). Standardmäßig ganze Wörter."
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:107
+#, elixir-autogen, elixir-format
+msgid "When off, you only hear about direct answers to your own posts, never other replies in the thread."
+msgstr "Wenn aus, hören Sie nur von direkten Antworten auf Ihre eigenen Beiträge, nie von anderen Antworten im Thread."
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:101
+#, elixir-autogen, elixir-format
+msgid "When someone replies anywhere in a thread you have written in, you hear about it under the bell, so a discussion reaches everyone who took part. Never by email."
+msgstr "Wenn jemand irgendwo in einem Thread antwortet, in dem Sie geschrieben haben, hören Sie es unter der Glocke, damit eine Diskussion alle Beteiligten erreicht. Nie per E-Mail."
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:19
+#: lib/vutuv_web/views/settings_html.ex:23
+#, elixir-autogen, elixir-format
+msgid "Word or phrase"
+msgstr "Wort oder Phrase"
+
+#: lib/vutuv_web/views/settings_html.ex:26
+#, elixir-autogen, elixir-format
+msgid "Word or phrase (whole word)"
+msgstr "Wort oder Phrase (ganzes Wort)"
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Word, phrase or tag to mute"
+msgstr "Wort, Phrase oder Tag zum Stummschalten"
+
+#: lib/vutuv_web/live/organization_live/edit.ex:161
+#, elixir-autogen, elixir-format
+msgid "You are not allowed to change this organization's handle."
+msgstr "Sie dürfen den Benutzernamen dieser Organisation nicht ändern."
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:87
+#, elixir-autogen, elixir-format
+msgid "You have not muted anything yet."
+msgstr "Sie haben noch nichts stummgeschaltet."
+
+#: lib/vutuv_web/controllers/settings_controller.ex:359
+#, elixir-autogen, elixir-format
+msgid "You have reached the maximum of %{count} filters."
+msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
+
+#: lib/vutuv_web/live/notification_live/index.ex:476
+#, elixir-autogen, elixir-format
+msgid "You wrote in this thread."
+msgstr "Sie haben in diesem Thread geschrieben."
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:31
+#, elixir-autogen, elixir-format
+msgid "e.g. crypto*, \"machine learning\", politics"
+msgstr "z. B. crypto*, \"machine learning\", Politik"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -20,7 +20,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3024
 #: lib/vutuv_web/components/ui.ex:3029
 #: lib/vutuv_web/live/organization_live/domains.ex:235
-#: lib/vutuv_web/live/organization_live/edit.ex:382
+#: lib/vutuv_web/live/organization_live/edit.ex:394
 #: lib/vutuv_web/live/organization_live/roles.ex:202
 #, elixir-autogen
 msgid "Add"
@@ -31,13 +31,13 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:197
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
-#: lib/vutuv_web/live/cv_live.ex:110
+#: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/show.ex:350
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1159
+#: lib/vutuv_web/templates/user/show.html.heex:1163
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -100,7 +100,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:432
 #: lib/vutuv_web/agent_docs/text.ex:428
 #: lib/vutuv_web/agent_docs/text.ex:429
-#: lib/vutuv_web/templates/user/show.html.heex:824
+#: lib/vutuv_web/templates/user/show.html.heex:828
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -111,7 +111,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
 #: lib/vutuv_web/live/job_posting_live/form.ex:594
-#: lib/vutuv_web/live/organization_live/edit.ex:333
+#: lib/vutuv_web/live/organization_live/edit.ex:345
 #: lib/vutuv_web/live/organization_live/new.ex:173
 #: lib/vutuv_web/templates/ad/new.html.heex:133
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
@@ -142,7 +142,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:13
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:862
+#: lib/vutuv_web/templates/user/show.html.heex:866
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -167,8 +167,8 @@ msgid "Delete"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:481
-#: lib/vutuv_web/live/organization_live/edit.ex:260
-#: lib/vutuv_web/live/organization_live/edit.ex:267
+#: lib/vutuv_web/live/organization_live/edit.ex:272
+#: lib/vutuv_web/live/organization_live/edit.ex:279
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:32
 #: lib/vutuv_web/templates/dev_app/form_content.html.heex:14
@@ -189,9 +189,9 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:398
+#: lib/vutuv_web/live/cv_live.ex:439
 #: lib/vutuv_web/templates/export/index.html.heex:41
-#: lib/vutuv_web/templates/user/show.html.heex:278
+#: lib/vutuv_web/templates/user/show.html.heex:282
 #: lib/vutuv_web/views/qualification_html.ex:237
 #, elixir-autogen
 msgid "Download"
@@ -220,7 +220,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/url/edit.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:847
+#: lib/vutuv_web/templates/user/show.html.heex:851
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #, elixir-autogen
 msgid "Edit"
@@ -301,7 +301,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:494
+#: lib/vutuv_web/templates/user/show.html.heex:498
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:3
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -324,7 +324,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:443
 #: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/notification_live/index.ex:770
+#: lib/vutuv_web/live/notification_live/index.ex:798
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
 #, elixir-autogen
@@ -342,7 +342,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:772
+#: lib/vutuv_web/templates/user/show.html.heex:776
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -353,11 +353,11 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
 #: lib/vutuv_web/cv/odt.ex:109
-#: lib/vutuv_web/live/cv_live.ex:113
+#: lib/vutuv_web/live/cv_live.ex:154
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:819
+#: lib/vutuv_web/templates/user/show.html.heex:823
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -426,7 +426,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:205
 #: lib/vutuv_web/cv/latex.ex:164
 #: lib/vutuv_web/cv/odt.ex:176
-#: lib/vutuv_web/live/cv_live.ex:296
+#: lib/vutuv_web/live/cv_live.ex:337
 #: lib/vutuv_web/templates/import/new.html.heex:12
 #: lib/vutuv_web/templates/import/preview.html.heex:40
 #: lib/vutuv_web/templates/url/edit.html.heex:3
@@ -469,14 +469,14 @@ msgid "Middle Name"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3180
-#: lib/vutuv_web/live/notification_live/index.ex:694
+#: lib/vutuv_web/live/notification_live/index.ex:722
 #, elixir-autogen
 msgid "More"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:71
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:590
-#: lib/vutuv_web/live/cv_live.ex:104
+#: lib/vutuv_web/live/cv_live.ex:145
 #: lib/vutuv_web/templates/access_token/new.html.heex:8
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:50
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:17
@@ -486,7 +486,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:497
+#: lib/vutuv_web/live/notification_live/index.ex:525
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/templates/access_token/new.html.heex:1
 #: lib/vutuv_web/templates/ad/new.html.heex:3
@@ -573,7 +573,7 @@ msgstr ""
 msgid "Phone Numbers Belonging to "
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:109
+#: lib/vutuv_web/live/cv_live.ex:150
 #: lib/vutuv_web/templates/phone_number/card_list.html.heex:6
 #, elixir-autogen
 msgid "Phone number"
@@ -643,11 +643,11 @@ msgstr ""
 msgid "Public (Everyone can view) or Private (Only you can view)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:327
+#: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/live/post_live/composer.ex:818
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:83
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:108
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
@@ -655,16 +655,16 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:64
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:383
-#: lib/vutuv_web/views/settings_html.ex:131
+#: lib/vutuv_web/views/settings_html.ex:138
 #, elixir-autogen
 msgid "Save"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:231
-#: lib/vutuv_web/live/job_board_live.ex:314
+#: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:35
-#: lib/vutuv_web/live/search_live.ex:229
+#: lib/vutuv_web/live/search_live.ex:312
 #: lib/vutuv_web/live/shell_live.ex:481
 #: lib/vutuv_web/live/shell_live.ex:637
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
@@ -704,19 +704,19 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:226
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
-#: lib/vutuv_web/live/cv_live.ex:370
+#: lib/vutuv_web/live/cv_live.ex:411
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:973
+#: lib/vutuv_web/templates/user/show.html.heex:977
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:975
+#: lib/vutuv_web/templates/user/show.html.heex:979
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -818,7 +818,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
-#: lib/vutuv_web/live/notification_live/index.ex:836
+#: lib/vutuv_web/live/notification_live/index.ex:864
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -863,20 +863,20 @@ msgid "Users"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:581
-#: lib/vutuv_web/templates/user/show.html.heex:284
+#: lib/vutuv_web/templates/user/show.html.heex:288
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2987
-#: lib/vutuv_web/templates/user/show.html.heex:766
-#: lib/vutuv_web/templates/user/show.html.heex:786
+#: lib/vutuv_web/templates/user/show.html.heex:770
+#: lib/vutuv_web/templates/user/show.html.heex:790
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:550
-#: lib/vutuv_web/live/organization_live/edit.ex:286
+#: lib/vutuv_web/live/organization_live/edit.ex:298
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #, elixir-autogen
@@ -940,7 +940,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:52
-#: lib/vutuv_web/live/post_live/feed.ex:58
+#: lib/vutuv_web/live/post_live/feed.ex:59
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1049,14 +1049,14 @@ msgstr ""
 msgid "Select a year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:884
+#: lib/vutuv/accounts/user.ex:929
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:883
+#: lib/vutuv/accounts/user.ex:928
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1117,7 +1117,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:808
+#: lib/vutuv_web/templates/user/show.html.heex:812
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1205,12 +1205,13 @@ msgstr ""
 msgid "Can't find URL"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:285
+#: lib/vutuv_web/live/search_live.ex:199
 #, elixir-autogen
 msgid "Our search will try to match similar names to your search, so don't worry about spelling."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:280
+#: lib/vutuv_web/live/search_live.ex:363
+#: lib/vutuv_web/live/search_live.ex:388
 #, elixir-autogen
 msgid "Search Tips"
 msgstr ""
@@ -1300,7 +1301,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/templates/user/show.html.heex:492
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1474,16 +1475,17 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:394
 #: lib/vutuv_web/agent_docs/text.ex:571
 #: lib/vutuv_web/components/ui.ex:3170
-#: lib/vutuv_web/controllers/user_tag_controller.ex:39
-#: lib/vutuv_web/controllers/user_tag_controller.ex:56
+#: lib/vutuv_web/controllers/user_tag_controller.ex:43
+#: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
 #: lib/vutuv_web/cv/html.ex:159
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
-#: lib/vutuv_web/live/cv_live.ex:275
+#: lib/vutuv_web/live/cv_live.ex:316
+#: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:509
 #: lib/vutuv_web/live/search_live.ex:178
-#: lib/vutuv_web/live/search_live.ex:361
+#: lib/vutuv_web/live/search_live.ex:448
 #: lib/vutuv_web/live/tag_new_live.ex:35
 #: lib/vutuv_web/live/tag_new_live.ex:45
 #: lib/vutuv_web/live/tag_new_live.ex:54
@@ -1498,7 +1500,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:458
+#: lib/vutuv_web/templates/user/show.html.heex:462
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1627,7 +1629,7 @@ msgstr ""
 msgid "User tag created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:144
+#: lib/vutuv_web/controllers/user_tag_controller.ex:166
 #, elixir-autogen
 msgid "User tag deleted successfully."
 msgstr ""
@@ -1655,9 +1657,9 @@ msgid "You'll receive an email with a login link."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
-#: lib/vutuv_web/live/job_board_live.ex:274
+#: lib/vutuv_web/live/job_board_live.ex:360
 #: lib/vutuv_web/live/job_posting_live/form.ex:410
-#: lib/vutuv_web/live/organization_live/edit.ex:282
+#: lib/vutuv_web/live/organization_live/edit.ex:294
 #: lib/vutuv_web/live/organization_live/new.ex:127
 #: lib/vutuv_web/templates/ad/new.html.heex:111
 #: lib/vutuv_web/templates/address/country_input.html.heex:2
@@ -1796,7 +1798,7 @@ msgid "It doesn't look like you're following anyone yet. Open the profile of som
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:608
-#: lib/vutuv_web/views/settings_html.ex:218
+#: lib/vutuv_web/views/settings_html.ex:225
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -1841,14 +1843,14 @@ msgstr ""
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:305
+#: lib/vutuv_web/live/notification_live/index.ex:314
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3184
 #: lib/vutuv_web/live/notification_live/index.ex:103
-#: lib/vutuv_web/live/notification_live/index.ex:268
+#: lib/vutuv_web/live/notification_live/index.ex:275
 #: lib/vutuv_web/live/shell_live.ex:508
 #: lib/vutuv_web/templates/layout/app.html.heex:118
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -1936,8 +1938,8 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1247
+#: lib/vutuv_web/live/post_live/feed.ex:757
+#: lib/vutuv_web/templates/user/show.html.heex:1251
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1956,14 +1958,14 @@ msgstr ""
 
 #: lib/vutuv_web/open_graph.ex:256
 #: lib/vutuv_web/templates/tag/show.html.heex:13
-#: lib/vutuv_web/templates/user/show.html.heex:253
+#: lib/vutuv_web/templates/user/show.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:257
+#: lib/vutuv_web/templates/user/show.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr ""
@@ -1973,17 +1975,17 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:857
+#: lib/vutuv_web/live/notification_live/index.ex:885
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:852
+#: lib/vutuv_web/live/notification_live/index.ex:880
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:847
+#: lib/vutuv_web/live/notification_live/index.ex:875
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -2191,8 +2193,8 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:79
-#: lib/vutuv_web/live/post_live/feed.ex:552
+#: lib/vutuv_web/live/post_live/feed.ex:85
+#: lib/vutuv_web/live/post_live/feed.ex:624
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:116
@@ -2237,7 +2239,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:617
+#: lib/vutuv_web/live/post_live/feed.ex:698
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2275,10 +2277,10 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:73
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/notification_live/index.ex:692
+#: lib/vutuv_web/live/notification_live/index.ex:720
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:179
-#: lib/vutuv_web/live/search_live.ex:375
+#: lib/vutuv_web/live/search_live.ex:462
 #: lib/vutuv_web/templates/settings/preferences.html.heex:118
 #: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
@@ -2299,13 +2301,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:209
-#: lib/vutuv_web/live/organization_live/edit.ex:359
+#: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
 #: lib/vutuv_web/live/post_live/composer.ex:888
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:264
+#: lib/vutuv_web/views/settings_html.ex:271
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2325,7 +2327,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:581
+#: lib/vutuv_web/live/post_live/feed.ex:653
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2363,11 +2365,11 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3357
+#: lib/vutuv_web/components/ui.ex:3358
 #: lib/vutuv_web/live/shell_live.ex:551
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:165
+#: lib/vutuv_web/views/settings_html.ex:172
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
@@ -2408,7 +2410,7 @@ msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:293
+#: lib/vutuv_web/views/settings_html.ex:300
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2433,7 +2435,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:448
+#: lib/vutuv_web/templates/user/show.html.heex:452
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2466,7 +2468,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2470
-#: lib/vutuv_web/live/notification_live/index.ex:828
+#: lib/vutuv_web/live/notification_live/index.ex:856
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2474,7 +2476,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:833
 #: lib/vutuv_web/components/post_components.ex:2196
-#: lib/vutuv_web/live/notification_live/index.ex:772
+#: lib/vutuv_web/live/notification_live/index.ex:800
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:559
@@ -2535,7 +2537,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1648
-#: lib/vutuv_web/live/post_live/feed.ex:665
+#: lib/vutuv_web/live/post_live/feed.ex:746
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2552,14 +2554,14 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:276
-#: lib/vutuv_web/live/notification_live/index.ex:773
+#: lib/vutuv_web/live/notification_live/index.ex:801
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2219
 #: lib/vutuv_web/components/post_components.ex:2220
-#: lib/vutuv_web/live/notification_live/index.ex:825
+#: lib/vutuv_web/live/notification_live/index.ex:853
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2581,7 +2583,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:966
+#: lib/vutuv_web/live/notification_live/index.ex:994
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2766,42 +2768,42 @@ msgid "Use a different email address"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:698
+#: lib/vutuv_web/templates/user/show.html.heex:702
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:936
+#: lib/vutuv_web/templates/user/show.html.heex:940
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1161
+#: lib/vutuv_web/templates/user/show.html.heex:1165
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:864
+#: lib/vutuv_web/templates/user/show.html.heex:868
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:810
+#: lib/vutuv_web/templates/user/show.html.heex:814
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:497
+#: lib/vutuv_web/templates/user/show.html.heex:501
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:965
-#: lib/vutuv_web/templates/user/show.html.heex:400
+#: lib/vutuv_web/live/user_profile_live.ex:970
+#: lib/vutuv_web/templates/user/show.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
@@ -2814,25 +2816,25 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/templates/user/show.html.heex:492
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:564
-#: lib/vutuv_web/templates/user/show.html.heex:400
+#: lib/vutuv_web/live/post_live/feed.ex:636
+#: lib/vutuv_web/templates/user/show.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:117
+#: lib/vutuv_web/views/user_helpers.ex:118
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_helpers.ex:121
+#: lib/vutuv_web/views/user_helpers.ex:122
 #, elixir-autogen, elixir-format
 msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
 msgstr ""
@@ -2854,7 +2856,7 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:442
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:771
+#: lib/vutuv_web/live/notification_live/index.ex:799
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2890,7 +2892,7 @@ msgstr ""
 msgid "This post is for the connections of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:266
+#: lib/vutuv_web/templates/user/show.html.heex:270
 #: lib/vutuv_web/views/admin/moderation_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "connection"
@@ -2908,23 +2910,23 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:837
+#: lib/vutuv_web/live/notification_live/index.ex:865
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:829
+#: lib/vutuv_web/live/notification_live/index.ex:857
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:824
+#: lib/vutuv_web/live/notification_live/index.ex:852
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:823
-#: lib/vutuv_web/templates/user/show.html.heex:753
+#: lib/vutuv_web/live/notification_live/index.ex:851
+#: lib/vutuv_web/templates/user/show.html.heex:757
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2936,7 +2938,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:854
+#: lib/vutuv_web/live/notification_live/index.ex:882
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2968,12 +2970,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:993
+#: lib/vutuv_web/live/notification_live/index.ex:1021
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:994
+#: lib/vutuv_web/live/notification_live/index.ex:1022
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3079,7 +3081,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:830
+#: lib/vutuv_web/live/notification_live/index.ex:858
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3153,8 +3155,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:904
-#: lib/vutuv_web/templates/user/show.html.heex:905
+#: lib/vutuv_web/templates/user/show.html.heex:908
+#: lib/vutuv_web/templates/user/show.html.heex:909
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -3499,12 +3501,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:996
+#: lib/vutuv_web/live/notification_live/index.ex:1024
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:995
+#: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3514,7 +3516,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:997
+#: lib/vutuv_web/live/notification_live/index.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3703,7 +3705,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3728,7 +3730,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:832
+#: lib/vutuv_web/live/notification_live/index.ex:860
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3803,7 +3805,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1026
+#: lib/vutuv_web/live/notification_live/index.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4106,7 +4108,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:404
-#: lib/vutuv_web/live/organization_live/edit.ex:278
+#: lib/vutuv_web/live/organization_live/edit.ex:290
 #: lib/vutuv_web/live/organization_live/new.ex:123
 #: lib/vutuv_web/templates/ad/new.html.heex:105
 #: lib/vutuv_web/templates/welcome/show.html.heex:74
@@ -4521,7 +4523,7 @@ msgstr ""
 msgid "Undeliverable"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:282
+#: lib/vutuv_web/live/search_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
@@ -4592,7 +4594,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:622
+#: lib/vutuv_web/live/post_live/feed.ex:703
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4604,7 +4606,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:772
+#: lib/vutuv_web/templates/user/show.html.heex:776
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4634,12 +4636,12 @@ msgstr ""
 msgid "This area is reserved for administrators."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:407
+#: lib/vutuv_web/live/search_live.ex:494
 #, elixir-autogen, elixir-format
 msgid "No results for \"%{query}\""
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:344
+#: lib/vutuv_web/live/search_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
@@ -4647,21 +4649,21 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:316
 #: lib/vutuv_web/agent_docs/text.ex:342
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:693
+#: lib/vutuv_web/live/notification_live/index.ex:721
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:177
-#: lib/vutuv_web/live/search_live.ex:317
+#: lib/vutuv_web/live/search_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:276
+#: lib/vutuv_web/live/search_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Results appear once you have typed at least three letters."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:341
+#: lib/vutuv_web/live/search_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Similar names"
 msgstr ""
@@ -4669,60 +4671,61 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:273
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:691
+#: lib/vutuv_web/live/notification_live/index.ex:719
 #: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:259
+#: lib/vutuv_web/live/search_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Exact matches only"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:303
+#: lib/vutuv_web/live/search_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "in quotes: exact matches only, no similar names"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:301
+#: lib/vutuv_web/live/search_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "searches usernames"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:297
+#: lib/vutuv_web/live/search_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "only people with an address in this city"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:296
+#: lib/vutuv_web/live/search_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "city:koblenz"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:292
+#: lib/vutuv_web/live/search_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "first:stefan"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:302
+#: lib/vutuv_web/live/search_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "miller"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:293
+#: lib/vutuv_web/live/search_live.ex:227
 #, elixir-autogen, elixir-format
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:953
-#: lib/vutuv_web/templates/user/show.html.heex:461
+#: lib/vutuv_web/live/job_board_live.ex:388
+#: lib/vutuv_web/live/user_profile_live.ex:958
+#: lib/vutuv_web/templates/user/show.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:236
+#: lib/vutuv_web/live/search_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, or posts"
 msgstr ""
@@ -4947,8 +4950,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:94
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
-#: lib/vutuv_web/views/settings_html.ex:31
-#: lib/vutuv_web/views/settings_html.ex:209
+#: lib/vutuv_web/views/settings_html.ex:38
+#: lib/vutuv_web/views/settings_html.ex:216
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -5304,8 +5307,8 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3190
-#: lib/vutuv_web/controllers/settings_controller.ex:129
+#: lib/vutuv_web/components/ui.ex:3191
+#: lib/vutuv_web/controllers/settings_controller.ex:130
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
@@ -5382,10 +5385,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3276
-#: lib/vutuv_web/components/ui.ex:3281
-#: lib/vutuv_web/components/ui.ex:3349
-#: lib/vutuv_web/controllers/settings_controller.ex:51
+#: lib/vutuv_web/components/ui.ex:3277
+#: lib/vutuv_web/components/ui.ex:3282
+#: lib/vutuv_web/components/ui.ex:3350
+#: lib/vutuv_web/controllers/settings_controller.ex:52
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/live/tag_new_live.ex:44
 #: lib/vutuv_web/templates/address/edit.html.heex:2
@@ -5413,7 +5416,7 @@ msgstr ""
 #: lib/vutuv_web/templates/username/new.html.heex:4
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:2
 #: lib/vutuv_web/templates/work_experience/new.html.heex:2
-#: lib/vutuv_web/views/settings_html.ex:160
+#: lib/vutuv_web/views/settings_html.ex:167
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5438,17 +5441,17 @@ msgstr ""
 msgid "Your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:306
+#: lib/vutuv_web/templates/user/show.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:328
+#: lib/vutuv_web/templates/user/show.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:955
+#: lib/vutuv_web/live/user_profile_live.ex:960
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5477,8 +5480,8 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1137
 #: lib/vutuv_web/components/post_components.ex:1191
 #: lib/vutuv_web/components/post_components.ex:1506
-#: lib/vutuv_web/live/notification_live/index.ex:530
-#: lib/vutuv_web/live/post_live/feed.ex:737
+#: lib/vutuv_web/live/notification_live/index.ex:558
+#: lib/vutuv_web/live/post_live/feed.ex:818
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr ""
@@ -5493,7 +5496,7 @@ msgstr ""
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:887
+#: lib/vutuv/accounts/user.ex:932
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5541,7 +5544,7 @@ msgstr ""
 msgid "Add, remove or pick your primary address."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:429
+#: lib/vutuv_web/live/organization_live/edit.ex:441
 #: lib/vutuv_web/templates/settings/security.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -5563,7 +5566,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:227
+#: lib/vutuv_web/controllers/settings_controller.ex:302
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr ""
@@ -5589,7 +5592,7 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:167
+#: lib/vutuv_web/controllers/settings_controller.ex:168
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr ""
@@ -5609,7 +5612,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:445
+#: lib/vutuv_web/live/notification_live/index.ex:455
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5644,7 +5647,7 @@ msgstr ""
 msgid "Language & region"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:316
+#: lib/vutuv_web/controllers/settings_controller.ex:444
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr ""
@@ -5696,31 +5699,32 @@ msgstr ""
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3189
+#: lib/vutuv_web/components/ui.ex:3190
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:144
+#: lib/vutuv_web/controllers/settings_controller.ex:145
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:105
-#: lib/vutuv_web/live/notification_live/index.ex:774
+#: lib/vutuv_web/controllers/user_tag_controller.ex:127
+#: lib/vutuv_web/live/notification_live/index.ex:802
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
+#: lib/vutuv_web/templates/user_tag/show.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Endorsements"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:99
+#: lib/vutuv_web/templates/settings/notifications.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Endorsements and new followers"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:93
+#: lib/vutuv_web/templates/settings/notifications.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "In-app notifications"
 msgstr ""
@@ -5730,22 +5734,22 @@ msgstr ""
 msgid "New followers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:217
+#: lib/vutuv_web/controllers/settings_controller.ex:292
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:107
+#: lib/vutuv_web/templates/settings/notifications.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Open your notifications"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:138
+#: lib/vutuv_web/controllers/settings_controller.ex:139
 #, elixir-autogen, elixir-format
 msgid "Privacy settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:100
+#: lib/vutuv_web/templates/settings/notifications.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr ""
@@ -5760,7 +5764,7 @@ msgstr ""
 msgid "Search engines & AI"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:95
+#: lib/vutuv_web/templates/settings/notifications.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "These are always on. You see them under the bell at the top of every page, in real time."
 msgstr ""
@@ -5911,28 +5915,28 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:174
-#: lib/vutuv_web/views/settings_html.ex:302
+#: lib/vutuv_web/views/settings_html.ex:309
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:301
+#: lib/vutuv_web/views/settings_html.ex:308
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:300
+#: lib/vutuv_web/views/settings_html.ex:307
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:411
+#: lib/vutuv_web/controllers/settings_controller.ex:539
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5942,7 +5946,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:198
+#: lib/vutuv_web/views/settings_html.ex:205
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5957,7 +5961,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:215
+#: lib/vutuv_web/views/settings_html.ex:222
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5972,7 +5976,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:400
+#: lib/vutuv_web/controllers/settings_controller.ex:528
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5982,7 +5986,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:199
+#: lib/vutuv_web/views/settings_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5992,7 +5996,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:299
+#: lib/vutuv_web/views/settings_html.ex:306
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -6023,7 +6027,7 @@ msgid "Add a passkey"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/views/settings_html.ex:250
+#: lib/vutuv_web/views/settings_html.ex:257
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -6033,7 +6037,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:253
+#: lib/vutuv_web/views/settings_html.ex:260
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -6043,7 +6047,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:247
+#: lib/vutuv_web/views/settings_html.ex:254
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -6063,7 +6067,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:261
+#: lib/vutuv_web/views/settings_html.ex:268
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6118,12 +6122,12 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:959
+#: lib/vutuv_web/live/user_profile_live.ex:964
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:107
+#: lib/vutuv_web/live/cv_live.ex:148
 #: lib/vutuv_web/templates/user/edit.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6132,14 +6136,14 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:174
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:696
+#: lib/vutuv_web/templates/user/show.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:381
+#: lib/vutuv_web/templates/user/show.html.heex:385
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6153,7 +6157,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1212
+#: lib/vutuv_web/templates/user/show.html.heex:1216
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6196,8 +6200,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:830
-#: lib/vutuv_web/templates/user/show.html.heex:840
+#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:844
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6237,12 +6241,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:951
+#: lib/vutuv_web/templates/user/show.html.heex:955
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:962
+#: lib/vutuv_web/templates/user/show.html.heex:966
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6284,7 +6288,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:960
+#: lib/vutuv_web/templates/user/show.html.heex:964
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6322,7 +6326,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:331
+#: lib/vutuv_web/controllers/settings_controller.ex:459
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -6338,9 +6342,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1198
-#: lib/vutuv_web/templates/user/show.html.heex:1206
-#: lib/vutuv_web/templates/user/show.html.heex:1218
+#: lib/vutuv_web/templates/user/show.html.heex:1202
+#: lib/vutuv_web/templates/user/show.html.heex:1210
+#: lib/vutuv_web/templates/user/show.html.heex:1222
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6373,10 +6377,10 @@ msgid "No endorsements yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1332
-#: lib/vutuv_web/live/notification_live/index.ex:475
-#: lib/vutuv_web/live/notification_live/index.ex:490
-#: lib/vutuv_web/live/notification_live/index.ex:613
-#: lib/vutuv_web/live/notification_live/index.ex:615
+#: lib/vutuv_web/live/notification_live/index.ex:503
+#: lib/vutuv_web/live/notification_live/index.ex:518
+#: lib/vutuv_web/live/notification_live/index.ex:641
+#: lib/vutuv_web/live/notification_live/index.ex:643
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -6661,6 +6665,7 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1836
+#: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Mute"
@@ -6672,7 +6677,7 @@ msgstr ""
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:98
+#: lib/vutuv_web/templates/settings/notifications.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "New messages and new connections"
 msgstr ""
@@ -6683,6 +6688,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1835
+#: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Unmute"
@@ -6913,6 +6919,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:193
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
+#: lib/vutuv_web/templates/settings/filters.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Kind"
 msgstr ""
@@ -7077,7 +7084,7 @@ msgstr ""
 msgid "Rendered with your own account data for the variables."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:201
+#: lib/vutuv_web/live/cv_live.ex:242
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:281
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:35
 #, elixir-autogen, elixir-format
@@ -7166,8 +7173,9 @@ msgid "Suppressed (bounced address)"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
-#: lib/vutuv_web/live/job_board_live.ex:205
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
+#: lib/vutuv_web/templates/settings/filters.html.heex:22
+#: lib/vutuv_web/views/settings_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Tag"
 msgstr ""
@@ -7784,13 +7792,13 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:720
+#: lib/vutuv_web/live/notification_live/index.ex:748
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:723
+#: lib/vutuv_web/live/notification_live/index.ex:751
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7865,42 +7873,42 @@ msgstr ""
 msgid "Send the email"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:65
+#: lib/vutuv_web/views/settings_html.ex:72
 #, elixir-autogen
 msgid "As soon as possible"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:66
+#: lib/vutuv_web/views/settings_html.ex:73
 #, elixir-autogen
 msgid "After 5 minutes"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:67
+#: lib/vutuv_web/views/settings_html.ex:74
 #, elixir-autogen
 msgid "After 15 minutes"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:68
+#: lib/vutuv_web/views/settings_html.ex:75
 #, elixir-autogen
 msgid "After 30 minutes"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:69
+#: lib/vutuv_web/views/settings_html.ex:76
 #, elixir-autogen
 msgid "After 1 hour"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:70
+#: lib/vutuv_web/views/settings_html.ex:77
 #, elixir-autogen
 msgid "After 2 hours"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:49
+#: lib/vutuv_web/views/settings_html.ex:56
 #, elixir-autogen
 msgid "Only the first message"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:50
+#: lib/vutuv_web/views/settings_html.ex:57
 #, elixir-autogen
 msgid "Every message"
 msgstr ""
@@ -7956,7 +7964,7 @@ msgid "Awaiting verification"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:196
-#: lib/vutuv_web/live/job_board_live.ex:192
+#: lib/vutuv_web/live/job_board_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -8009,8 +8017,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:922
-#: lib/vutuv/accounts.ex:971
+#: lib/vutuv/accounts.ex:923
+#: lib/vutuv/accounts.ex:972
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8049,7 +8057,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:939
+#: lib/vutuv/accounts.ex:940
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8180,7 +8188,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:549
+#: lib/vutuv_web/templates/user/show.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8193,9 +8201,9 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
 #: lib/vutuv_web/components/ui.ex:3161
-#: lib/vutuv_web/controllers/education_controller.ex:38
-#: lib/vutuv_web/controllers/education_controller.ex:53
-#: lib/vutuv_web/controllers/education_controller.ex:103
+#: lib/vutuv_web/controllers/education_controller.ex:43
+#: lib/vutuv_web/controllers/education_controller.ex:60
+#: lib/vutuv_web/controllers/education_controller.ex:140
 #: lib/vutuv_web/cv/cv.ex:274
 #: lib/vutuv_web/templates/education/edit.html.heex:3
 #: lib/vutuv_web/templates/education/index.html.heex:5
@@ -8205,17 +8213,17 @@ msgstr ""
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:546
+#: lib/vutuv_web/templates/user/show.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
 
-#: lib/vutuv_web/controllers/education_controller.ex:81
+#: lib/vutuv_web/controllers/education_controller.ex:118
 #, elixir-autogen, elixir-format
 msgid "Education created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/education_controller.ex:134
+#: lib/vutuv_web/controllers/education_controller.ex:171
 #, elixir-autogen, elixir-format
 msgid "Education deleted successfully."
 msgstr ""
@@ -8225,7 +8233,7 @@ msgstr ""
 msgid "Education of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/education_controller.ex:123
+#: lib/vutuv_web/controllers/education_controller.ex:160
 #, elixir-autogen, elixir-format
 msgid "Education updated successfully."
 msgstr ""
@@ -8255,7 +8263,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/import_controller.ex:114
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:369
+#: lib/vutuv_web/templates/user/show.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "Import from LinkedIn"
 msgstr ""
@@ -8364,7 +8372,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:978
+#: lib/vutuv_web/live/user_profile_live.ex:983
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
@@ -8390,7 +8398,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:94
-#: lib/vutuv_web/templates/user/show.html.heex:1065
+#: lib/vutuv_web/templates/user/show.html.heex:1069
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8457,7 +8465,7 @@ msgid "Basics & photos"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3176
-#: lib/vutuv_web/controllers/settings_controller.ex:106
+#: lib/vutuv_web/controllers/settings_controller.ex:107
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
@@ -8469,7 +8477,7 @@ msgid "More profile sections"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3174
-#: lib/vutuv_web/controllers/settings_controller.ex:89
+#: lib/vutuv_web/controllers/settings_controller.ex:90
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:5
 #: lib/vutuv_web/templates/totp/new.html.heex:5
@@ -8499,13 +8507,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:704
-#: lib/vutuv_web/live/post_live/feed.ex:705
+#: lib/vutuv_web/live/post_live/feed.ex:785
+#: lib/vutuv_web/live/post_live/feed.ex:786
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:699
+#: lib/vutuv_web/live/post_live/feed.ex:780
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8702,7 +8710,7 @@ msgid "Allow followers from the Fediverse"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3183
-#: lib/vutuv_web/controllers/settings_controller.ex:186
+#: lib/vutuv_web/controllers/settings_controller.ex:187
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:288
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:8
@@ -8710,7 +8718,7 @@ msgstr ""
 msgid "Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:208
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Get verified on Mastodon"
@@ -8731,7 +8739,7 @@ msgstr ""
 msgid "Anyone on Mastodon can paste this handle into their search and follow you from there."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:196
+#: lib/vutuv_web/controllers/settings_controller.ex:206
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr ""
@@ -8741,12 +8749,12 @@ msgstr ""
 msgid "Followers from the Fediverse:"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:92
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Independent of federation: your vutuv profile links your listed social media accounts with rel=\"me\", so adding your profile address to your Mastodon profile shows it there as verified."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:99
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr ""
@@ -8766,7 +8774,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:934
+#: lib/vutuv/accounts.ex:935
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8819,7 +8827,7 @@ msgstr ""
 msgid "Volunteering & hobbies"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:251
+#: lib/vutuv_web/live/search_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr ""
@@ -8828,7 +8836,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:58
 #: lib/vutuv_web/cv/latex.ex:45
 #: lib/vutuv_web/cv/latex.ex:46
-#: lib/vutuv_web/live/cv_live.ex:175
+#: lib/vutuv_web/live/cv_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "CV"
 msgstr ""
@@ -8838,19 +8846,19 @@ msgstr ""
 msgid "Your profile as a CV"
 msgstr ""
 
-#: lib/vutuv_web/views/education_html.ex:19
+#: lib/vutuv_web/views/education_html.ex:28
 #, elixir-autogen, elixir-format
 msgid "Higher Education"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:633
-#: lib/vutuv_web/views/education_html.ex:21
+#: lib/vutuv_web/views/education_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:632
-#: lib/vutuv_web/views/education_html.ex:20
+#: lib/vutuv_web/views/education_html.ex:29
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
 msgstr ""
@@ -8887,24 +8895,24 @@ msgstr[1] ""
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:193
+#: lib/vutuv_web/live/cv_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Anonymize"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:108
+#: lib/vutuv_web/live/cv_live.ex:149
 #: lib/vutuv_web/templates/invitation/new.html.heex:47
 #: lib/vutuv_web/templates/invitation/sent.html.heex:23
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:400
+#: lib/vutuv_web/live/cv_live.ex:441
 #, elixir-autogen, elixir-format
 msgid "Every download reflects the parts you selected."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:207
+#: lib/vutuv_web/live/cv_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
@@ -8915,22 +8923,22 @@ msgstr ""
 msgid "Open CV"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:105
+#: lib/vutuv_web/live/cv_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:182
+#: lib/vutuv_web/live/cv_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Pick what to include. Untick single entries or whole sections, or anonymize the CV by hiding the name, photo and contact details."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:409
+#: lib/vutuv_web/live/cv_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "Print / Save as PDF"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:111
+#: lib/vutuv_web/live/cv_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "Profile link"
 msgstr ""
@@ -8950,12 +8958,12 @@ msgstr ""
 msgid "Turn your profile into a formatted CV for a job application: pick what to include, anonymize it, then print (Save as PDF) or download it as Word, OpenDocument, HTML, LaTeX or JSON Resume."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:44
+#: lib/vutuv_web/live/cv_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "CV of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:47
+#: lib/vutuv_web/live/cv_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
@@ -8974,7 +8982,7 @@ msgstr ""
 msgid "Other activities"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:423
+#: lib/vutuv_web/live/cv_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
@@ -8984,21 +8992,25 @@ msgstr ""
 msgid "characters"
 msgstr ""
 
+#: lib/vutuv_web/templates/education/card_list.html.heex:28
 #: lib/vutuv_web/templates/work_experience/card_list.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "%{job} shows at the top of your profile."
 msgstr ""
 
+#: lib/vutuv_web/templates/education/card_list.html.heex:34
 #: lib/vutuv_web/templates/work_experience/card_list.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Choose automatically instead"
 msgstr ""
 
+#: lib/vutuv_web/templates/education/card_list.html.heex:93
 #: lib/vutuv_web/views/work_experience_html.ex:682
 #, elixir-autogen, elixir-format
 msgid "Show at top of profile"
 msgstr ""
 
+#: lib/vutuv_web/templates/education/card_list.html.heex:84
 #: lib/vutuv_web/views/work_experience_html.ex:673
 #, elixir-autogen, elixir-format
 msgid "Shown at the top of your profile"
@@ -9084,7 +9096,7 @@ msgstr ""
 msgid "Removed @%{handle} from this tag."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:149
+#: lib/vutuv_web/controllers/user_tag_controller.ex:171
 #, elixir-autogen, elixir-format
 msgid "This tag can only be removed by a site admin."
 msgstr ""
@@ -9124,7 +9136,7 @@ msgid "A2 (Elementary)"
 msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9343,13 +9355,13 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:188
 #: lib/vutuv_web/cv/latex.ex:149
 #: lib/vutuv_web/cv/odt.ex:163
-#: lib/vutuv_web/live/cv_live.ex:346
+#: lib/vutuv_web/live/cv_live.ex:387
 #: lib/vutuv_web/templates/language/edit.html.heex:3
 #: lib/vutuv_web/templates/language/index.html.heex:10
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:3
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:608
+#: lib/vutuv_web/templates/user/show.html.heex:612
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9536,18 +9548,18 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:735
+#: lib/vutuv/accounts/user.ex:780
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:40
+#: lib/vutuv_web/views/user_helpers.ex:41
 #, elixir-autogen, elixir-format
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:732
+#: lib/vutuv/accounts/user.ex:777
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9629,7 +9641,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:651
+#: lib/vutuv_web/templates/user/show.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9670,14 +9682,14 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:172
 #: lib/vutuv_web/cv/latex.ex:140
 #: lib/vutuv_web/cv/odt.ex:154
-#: lib/vutuv_web/live/cv_live.ex:321
+#: lib/vutuv_web/live/cv_live.ex:362
 #: lib/vutuv_web/templates/import/preview.html.heex:27
 #: lib/vutuv_web/templates/qualification/edit.html.heex:3
 #: lib/vutuv_web/templates/qualification/index.html.heex:11
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:3
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:648
+#: lib/vutuv_web/templates/user/show.html.heex:652
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr ""
@@ -9813,8 +9825,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:926
-#: lib/vutuv_web/templates/user/show.html.heex:927
+#: lib/vutuv_web/templates/user/show.html.heex:930
+#: lib/vutuv_web/templates/user/show.html.heex:931
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9823,7 +9835,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:84
 #: lib/vutuv_web/cv/latex.ex:69
 #: lib/vutuv_web/cv/odt.ex:109
-#: lib/vutuv_web/live/cv_live.ex:112
+#: lib/vutuv_web/live/cv_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
@@ -9987,8 +9999,8 @@ msgstr ""
 msgid "Permanent profile link"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:317
-#: lib/vutuv_web/templates/user/show.html.heex:318
+#: lib/vutuv_web/templates/user/show.html.heex:321
+#: lib/vutuv_web/templates/user/show.html.heex:322
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
@@ -10485,7 +10497,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1039
+#: lib/vutuv_web/templates/user/show.html.heex:1043
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10786,7 +10798,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:344
+#: lib/vutuv_web/controllers/settings_controller.ex:472
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10835,7 +10847,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:375
+#: lib/vutuv_web/controllers/settings_controller.ex:503
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10850,7 +10862,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:371
+#: lib/vutuv_web/controllers/settings_controller.ex:499
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -11066,19 +11078,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:773
+#: lib/vutuv/accounts/user.ex:818
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:778
+#: lib/vutuv/accounts/user.ex:823
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:776
+#: lib/vutuv/accounts/user.ex:821
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
@@ -11262,7 +11274,7 @@ msgstr ""
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/organization_live/edit.ex:326
 #, elixir-autogen, elixir-format
 msgid "AI agents"
 msgstr ""
@@ -11295,27 +11307,27 @@ msgid "Domain verification is disabled on this installation."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:31
-#: lib/vutuv_web/live/organization_live/edit.ex:228
+#: lib/vutuv_web/live/organization_live/edit.ex:240
 #, elixir-autogen, elixir-format
 msgid "Edit %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:300
+#: lib/vutuv_web/live/organization_live/edit.ex:312
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:235
+#: lib/vutuv_web/live/organization_live/edit.ex:247
 #, elixir-autogen, elixir-format
 msgid "Logo"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:262
+#: lib/vutuv_web/live/organization_live/edit.ex:274
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:316
+#: lib/vutuv_web/live/organization_live/edit.ex:328
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -11331,7 +11343,7 @@ msgstr ""
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:246
+#: lib/vutuv_web/live/organization_live/edit.ex:258
 #, elixir-autogen, elixir-format
 msgid "Remove logo"
 msgstr ""
@@ -11341,7 +11353,7 @@ msgstr ""
 msgid "Search by name or city"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:298
+#: lib/vutuv_web/live/organization_live/edit.ex:310
 #, elixir-autogen, elixir-format
 msgid "Search engines"
 msgstr ""
@@ -11357,23 +11369,23 @@ msgstr ""
 msgid "Serve this file at:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:279
+#: lib/vutuv_web/live/organization_live/edit.ex:291
 #: lib/vutuv_web/live/organization_live/new.ex:124
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:459
+#: lib/vutuv_web/live/organization_live/edit.ex:471
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:457
+#: lib/vutuv_web/live/organization_live/edit.ex:469
 #, elixir-autogen, elixir-format
 msgid "The file is too large."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:460
+#: lib/vutuv_web/live/organization_live/edit.ex:472
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11419,7 +11431,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:207
 #: lib/vutuv_web/agent_docs/text.ex:196
-#: lib/vutuv_web/live/organization_live/edit.ex:273
+#: lib/vutuv_web/live/organization_live/edit.ex:285
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
 msgid "Website"
@@ -11438,7 +11450,7 @@ msgstr ""
 msgid "Website file (.well-known)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:458
+#: lib/vutuv_web/live/organization_live/edit.ex:470
 #, elixir-autogen, elixir-format
 msgid "You can only upload one logo."
 msgstr ""
@@ -11466,7 +11478,7 @@ msgid "@handle or email"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:252
-#: lib/vutuv_web/live/organization_live/edit.ex:376
+#: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr ""
@@ -11487,7 +11499,7 @@ msgid "Added @%{handle} to the team."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:253
-#: lib/vutuv_web/live/organization_live/edit.ex:374
+#: lib/vutuv_web/live/organization_live/edit.ex:386
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr ""
@@ -11504,13 +11516,13 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:308
 #: lib/vutuv_web/agent_docs/text.ex:335
-#: lib/vutuv_web/live/organization_live/edit.ex:339
+#: lib/vutuv_web/live/organization_live/edit.ex:351
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:370
+#: lib/vutuv_web/live/organization_live/edit.ex:382
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr ""
@@ -11532,7 +11544,7 @@ msgid "Archived"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:251
-#: lib/vutuv_web/live/organization_live/edit.ex:375
+#: lib/vutuv_web/live/organization_live/edit.ex:387
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr ""
@@ -11678,7 +11690,7 @@ msgstr ""
 msgid "Remove this member from the team?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:356
+#: lib/vutuv_web/live/organization_live/edit.ex:368
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr ""
@@ -11745,44 +11757,44 @@ msgstr ""
 msgid "verified"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:276
+#: lib/vutuv_web/live/organization_live/edit.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:121
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:277
+#: lib/vutuv_web/live/organization_live/edit.ex:289
 #: lib/vutuv_web/live/organization_live/new.ex:122
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:429
+#: lib/vutuv_web/live/organization_live/edit.ex:441
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:398
+#: lib/vutuv_web/live/organization_live/edit.ex:410
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:388
+#: lib/vutuv_web/live/organization_live/edit.ex:400
 #, elixir-autogen, elixir-format
 msgid "Root handle"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:191
+#: lib/vutuv_web/live/organization_live/edit.ex:203
 #, elixir-autogen, elixir-format
 msgid "That handle is not available."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:435
+#: lib/vutuv_web/live/organization_live/edit.ex:447
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:446
+#: lib/vutuv_web/live/organization_live/edit.ex:458
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr ""
@@ -11929,7 +11941,7 @@ msgid_plural "%{count} aliases match another verified organization and are flagg
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:341
+#: lib/vutuv_web/live/organization_live/edit.ex:353
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
@@ -11959,7 +11971,7 @@ msgstr ""
 msgid "Any signed-in member whose confirmed email is at this domain, or a subdomain of it, is excluded. This is the reliable way to hide from your whole organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:390
+#: lib/vutuv_web/live/organization_live/edit.ex:402
 #, elixir-autogen, elixir-format
 msgid "Claim a short @handle so this organization has its own root URL, like a member profile. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr ""
@@ -11998,17 +12010,17 @@ msgstr ""
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:450
+#: lib/vutuv_web/live/organization_live/edit.ex:462
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:437
+#: lib/vutuv_web/live/organization_live/edit.ex:449
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:256
+#: lib/vutuv_web/live/organization_live/edit.ex:268
 #: lib/vutuv_web/live/organization_live/new.ex:111
 #, elixir-autogen, elixir-format
 msgid "Kind of organization"
@@ -12074,7 +12086,7 @@ msgstr ""
 msgid "Organization frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:255
+#: lib/vutuv_web/live/organization_live/edit.ex:267
 #: lib/vutuv_web/live/organization_live/new.ex:110
 #, elixir-autogen, elixir-format
 msgid "Organization name"
@@ -12093,7 +12105,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:833
+#: lib/vutuv_web/live/notification_live/index.ex:861
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12105,7 +12117,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
 #: lib/vutuv_web/components/ui.ex:3175
-#: lib/vutuv_web/controllers/settings_controller.ex:157
+#: lib/vutuv_web/controllers/settings_controller.ex:158
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
 #: lib/vutuv_web/live/post_live/saved.ex:455
@@ -12151,7 +12163,7 @@ msgstr ""
 msgid "That name is already listed for this organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:179
+#: lib/vutuv_web/live/organization_live/edit.ex:191
 #, elixir-autogen, elixir-format
 msgid "The organization page was deleted."
 msgstr ""
@@ -12176,12 +12188,12 @@ msgstr ""
 msgid "Verified organization pages: domains, team roles, aliases and rename history. Freeze, archive or delete a page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:162
+#: lib/vutuv_web/live/organization_live/edit.ex:174
 #, elixir-autogen, elixir-format
 msgid "You are not allowed to delete this organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:135
+#: lib/vutuv_web/live/organization_live/edit.ex:139
 #, elixir-autogen, elixir-format
 msgid "Your organization handle is set."
 msgstr ""
@@ -12196,27 +12208,27 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:985
+#: lib/vutuv_web/live/notification_live/index.ex:1013
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:982
+#: lib/vutuv_web/live/notification_live/index.ex:1010
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:979
+#: lib/vutuv_web/live/notification_live/index.ex:1007
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:976
+#: lib/vutuv_web/live/notification_live/index.ex:1004
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:419
+#: lib/vutuv_web/live/organization_live/edit.ex:431
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr ""
@@ -12372,7 +12384,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:354
 #: lib/vutuv_web/agent_docs/text.ex:213
 #: lib/vutuv_web/agent_docs/text.ex:380
-#: lib/vutuv_web/live/job_board_live.ex:281
+#: lib/vutuv_web/live/job_board_live.ex:367
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
 msgid "Employment type"
@@ -12408,7 +12420,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:747
+#: lib/vutuv/accounts/user.ex:792
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12431,8 +12443,8 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/job_board_doc.ex:19
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:41
-#: lib/vutuv_web/live/job_board_live.ex:146
+#: lib/vutuv_web/live/job_board_live.ex:45
+#: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:458
 #: lib/vutuv_web/live/shell_live.ex:457
 #: lib/vutuv_web/templates/layout/app.html.heex:77
@@ -12528,7 +12540,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:746
+#: lib/vutuv/accounts/user.ex:791
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12610,7 +12622,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:748
+#: lib/vutuv/accounts/user.ex:793
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
 #: lib/vutuv_web/agent_docs/markdown.ex:339
@@ -12826,12 +12838,12 @@ msgstr ""
 msgid "Browse all organizations"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:28
+#: lib/vutuv_web/views/settings_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Under review"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:30
+#: lib/vutuv_web/views/settings_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Verification pending"
 msgstr ""
@@ -12873,7 +12885,7 @@ msgstr ""
 msgid "Name (host)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:143
+#: lib/vutuv_web/live/organization_live/edit.ex:147
 #, elixir-autogen, elixir-format
 msgid "Only a verified organization page can claim a handle."
 msgstr ""
@@ -12897,12 +12909,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_board_live.ex:387
+#: lib/vutuv_web/live/job_board_live.ex:491
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:275
+#: lib/vutuv_web/live/job_board_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr ""
@@ -12918,42 +12930,42 @@ msgstr ""
 msgid "All jobs with this tag: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:282
+#: lib/vutuv_web/live/job_board_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:264
+#: lib/vutuv_web/live/job_board_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:387
+#: lib/vutuv_web/live/job_board_live.ex:491
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:184
+#: lib/vutuv_web/live/job_board_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:176
+#: lib/vutuv_web/live/job_board_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:357
+#: lib/vutuv_web/live/job_board_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:306
+#: lib/vutuv_web/live/job_board_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:239
+#: lib/vutuv_web/live/job_board_live.ex:324
 #: lib/vutuv_web/live/organization_live/show.ex:342
 #, elixir-autogen, elixir-format
 msgid "More jobs"
@@ -12969,12 +12981,12 @@ msgstr ""
 msgid "Next page: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:395
+#: lib/vutuv_web/live/job_board_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:393
+#: lib/vutuv_web/live/job_board_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
@@ -12990,27 +13002,27 @@ msgid "Open positions"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/job_board_doc.ex:20
-#: lib/vutuv_web/live/job_board_live.ex:148
+#: lib/vutuv_web/live/job_board_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:156
+#: lib/vutuv_web/live/job_board_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:221
+#: lib/vutuv_web/live/job_board_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:268
+#: lib/vutuv_web/live/job_board_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:256
+#: lib/vutuv_web/live/job_board_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr ""
@@ -13211,7 +13223,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:269
+#: lib/vutuv_web/controllers/settings_controller.ex:397
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -13277,13 +13289,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:287
+#: lib/vutuv_web/controllers/settings_controller.ex:415
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3213
-#: lib/vutuv_web/controllers/settings_controller.ex:245
+#: lib/vutuv_web/components/ui.ex:3214
+#: lib/vutuv_web/controllers/settings_controller.ex:320
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13302,8 +13314,8 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:274
-#: lib/vutuv_web/controllers/settings_controller.ex:292
+#: lib/vutuv_web/controllers/settings_controller.ex:402
+#: lib/vutuv_web/controllers/settings_controller.ex:420
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -13349,7 +13361,7 @@ msgstr ""
 msgid "job search"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:299
+#: lib/vutuv_web/live/search_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "only people open to offers (status:open) or looking (status:looking)"
 msgstr ""
@@ -13523,7 +13535,7 @@ msgstr ""
 msgid "Reviewed, all fine: clear the flag"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:169
+#: lib/vutuv_web/live/organization_live/edit.ex:181
 #, elixir-autogen, elixir-format
 msgid "This page has job postings, so it cannot be deleted. Ask an admin to archive it instead."
 msgstr ""
@@ -13556,7 +13568,7 @@ msgstr ""
 msgid "Image is being reviewed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:831
+#: lib/vutuv_web/live/notification_live/index.ex:859
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13597,7 +13609,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:791
+#: lib/vutuv/accounts/user.ex:836
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13608,19 +13620,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:794
+#: lib/vutuv/accounts/user.ex:839
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:797
+#: lib/vutuv/accounts/user.ex:842
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:788
+#: lib/vutuv/accounts/user.ex:833
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13643,7 +13655,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:834
+#: lib/vutuv_web/live/notification_live/index.ex:862
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13655,7 +13667,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/notification_live/index.ex:1063
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13702,12 +13714,12 @@ msgstr ""
 msgid "Posts with this tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:268
+#: lib/vutuv_web/live/search_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:295
+#: lib/vutuv_web/live/search_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "people and posts with this tag, combinable: miller tag:php"
 msgstr ""
@@ -13747,46 +13759,46 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3202
-#: lib/vutuv_web/controllers/settings_controller.ex:259
-#: lib/vutuv_web/live/post_live/feed.ex:651
+#: lib/vutuv_web/components/ui.ex:3203
+#: lib/vutuv_web/controllers/settings_controller.ex:334
+#: lib/vutuv_web/live/post_live/feed.ex:732
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:666
+#: lib/vutuv_web/live/post_live/feed.ex:747
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:324
+#: lib/vutuv_web/live/job_board_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/job_board_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:378
+#: lib/vutuv_web/live/job_board_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:380
+#: lib/vutuv_web/live/job_board_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:381
+#: lib/vutuv_web/live/job_board_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:379
+#: lib/vutuv_web/live/job_board_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr ""
@@ -13797,7 +13809,7 @@ msgid "Signal and WhatsApp accept a phone number or a username; the other messen
 msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1005
+#: lib/vutuv_web/templates/user/show.html.heex:1009
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13834,7 +13846,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:3
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1003
+#: lib/vutuv_web/templates/user/show.html.heex:1007
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13866,22 +13878,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:835
+#: lib/vutuv_web/live/notification_live/index.ex:863
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1055
+#: lib/vutuv_web/live/notification_live/index.ex:1083
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1047
+#: lib/vutuv_web/live/notification_live/index.ex:1075
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1052
+#: lib/vutuv_web/live/notification_live/index.ex:1080
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13906,7 +13918,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1060
+#: lib/vutuv_web/live/notification_live/index.ex:1088
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -14099,45 +14111,45 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:712
+#: lib/vutuv_web/live/notification_live/index.ex:740
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:726
+#: lib/vutuv_web/live/notification_live/index.ex:754
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:321
+#: lib/vutuv_web/live/notification_live/index.ex:330
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:336
+#: lib/vutuv_web/live/notification_live/index.ex:345
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:678
-#: lib/vutuv_web/live/notification_live/index.ex:883
+#: lib/vutuv_web/live/notification_live/index.ex:706
+#: lib/vutuv_web/live/notification_live/index.ex:911
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:850
+#: lib/vutuv_web/live/notification_live/index.ex:878
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:845
+#: lib/vutuv_web/live/notification_live/index.ex:873
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:860
+#: lib/vutuv_web/live/notification_live/index.ex:888
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -14372,7 +14384,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:648
+#: lib/vutuv_web/live/notification_live/index.ex:676
 #, elixir-autogen, elixir-format
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
@@ -14382,17 +14394,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1009
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:826
+#: lib/vutuv_web/live/notification_live/index.ex:854
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:870
+#: lib/vutuv_web/live/notification_live/index.ex:898
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14411,12 +14423,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:827
+#: lib/vutuv_web/live/notification_live/index.ex:855
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:968
+#: lib/vutuv_web/live/notification_live/index.ex:996
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -14698,4 +14710,155 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "as an account alias."
+msgstr ""
+
+#: lib/vutuv_web/templates/user_tag/show.html.heex:24
+#, elixir-autogen, elixir-format
+msgid "%{formatted} endorsement"
+msgid_plural "%{formatted} endorsements"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/templates/user_tag/show.html.heex:36
+#, elixir-autogen, elixir-format
+msgid "All endorsers"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:351
+#, elixir-autogen, elixir-format
+msgid "Filter added. Matching posts are now hidden from your feed."
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:389
+#, elixir-autogen, elixir-format
+msgid "Filter by a tag"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:376
+#, elixir-autogen, elixir-format
+msgid "Filter removed."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/feed.ex:201
+#, elixir-autogen, elixir-format
+msgid "Hidden: matches your filter"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:5
+#, elixir-autogen, elixir-format
+msgid "Hide posts from your feed that carry a tag, or that contain a word or phrase. This list is yours alone: it is never shared, the author is never told, and a hidden post collapses to a line you can still open."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:54
+#, elixir-autogen, elixir-format
+msgid "Match whole words only (word/phrase)"
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:3185
+#: lib/vutuv_web/controllers/settings_controller.ex:387
+#: lib/vutuv_web/templates/settings/filters.html.heex:1
+#: lib/vutuv_web/templates/settings/filters.html.heex:3
+#, elixir-autogen, elixir-format
+msgid "Muted words & tags"
+msgstr ""
+
+#: lib/vutuv_web/templates/user_tag/show.html.heex:20
+#, elixir-autogen, elixir-format
+msgid "Nobody has endorsed %{name} for this tag yet."
+msgstr ""
+
+#: lib/vutuv_web/templates/education/card_list.html.heex:40
+#, elixir-autogen, elixir-format
+msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/feed.ex:210
+#, elixir-autogen, elixir-format
+msgid "Show anyway"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:105
+#, elixir-autogen, elixir-format
+msgid "Tell me about new replies in threads I take part in"
+msgstr ""
+
+#: lib/vutuv_web/controllers/education_controller.ex:80
+#, elixir-autogen, elixir-format
+msgid "That education could not be pinned."
+msgstr ""
+
+#: lib/vutuv_web/controllers/education_controller.ex:90
+#, elixir-autogen, elixir-format
+msgid "The top of your profile is chosen automatically again."
+msgstr ""
+
+#: lib/vutuv_web/controllers/education_controller.ex:75
+#, elixir-autogen, elixir-format
+msgid "This education now shows at the top of your profile."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:99
+#, elixir-autogen, elixir-format
+msgid "Thread replies"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:481
+#, elixir-autogen, elixir-format
+msgid "Turn off thread notifications"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:43
+#, elixir-autogen, elixir-format
+msgid "Use * as a wildcard (crypto* → cryptobro). Whole-word by default."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:107
+#, elixir-autogen, elixir-format
+msgid "When off, you only hear about direct answers to your own posts, never other replies in the thread."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:101
+#, elixir-autogen, elixir-format
+msgid "When someone replies anywhere in a thread you have written in, you hear about it under the bell, so a discussion reaches everyone who took part. Never by email."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:19
+#: lib/vutuv_web/views/settings_html.ex:23
+#, elixir-autogen, elixir-format
+msgid "Word or phrase"
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:26
+#, elixir-autogen, elixir-format
+msgid "Word or phrase (whole word)"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Word, phrase or tag to mute"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/edit.ex:161
+#, elixir-autogen, elixir-format
+msgid "You are not allowed to change this organization's handle."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:87
+#, elixir-autogen, elixir-format
+msgid "You have not muted anything yet."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:359
+#, elixir-autogen, elixir-format
+msgid "You have reached the maximum of %{count} filters."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:476
+#, elixir-autogen, elixir-format
+msgid "You wrote in this thread."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:31
+#, elixir-autogen, elixir-format
+msgid "e.g. crypto*, \"machine learning\", politics"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -18,7 +18,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3024
 #: lib/vutuv_web/components/ui.ex:3029
 #: lib/vutuv_web/live/organization_live/domains.ex:235
-#: lib/vutuv_web/live/organization_live/edit.ex:382
+#: lib/vutuv_web/live/organization_live/edit.ex:394
 #: lib/vutuv_web/live/organization_live/roles.ex:202
 #, elixir-autogen
 msgid "Add"
@@ -29,13 +29,13 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:197
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
-#: lib/vutuv_web/live/cv_live.ex:110
+#: lib/vutuv_web/live/cv_live.ex:151
 #: lib/vutuv_web/live/organization_live/show.ex:350
 #: lib/vutuv_web/templates/address/card_list.html.heex:6
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1159
+#: lib/vutuv_web/templates/user/show.html.heex:1163
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -98,7 +98,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:432
 #: lib/vutuv_web/agent_docs/text.ex:428
 #: lib/vutuv_web/agent_docs/text.ex:429
-#: lib/vutuv_web/templates/user/show.html.heex:824
+#: lib/vutuv_web/templates/user/show.html.heex:828
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -109,7 +109,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
 #: lib/vutuv_web/live/job_posting_live/form.ex:594
-#: lib/vutuv_web/live/organization_live/edit.ex:333
+#: lib/vutuv_web/live/organization_live/edit.ex:345
 #: lib/vutuv_web/live/organization_live/new.ex:173
 #: lib/vutuv_web/templates/ad/new.html.heex:133
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
@@ -140,7 +140,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:13
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:862
+#: lib/vutuv_web/templates/user/show.html.heex:866
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -165,8 +165,8 @@ msgid "Delete"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:481
-#: lib/vutuv_web/live/organization_live/edit.ex:260
-#: lib/vutuv_web/live/organization_live/edit.ex:267
+#: lib/vutuv_web/live/organization_live/edit.ex:272
+#: lib/vutuv_web/live/organization_live/edit.ex:279
 #: lib/vutuv_web/templates/address/card_list.html.heex:5
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:32
 #: lib/vutuv_web/templates/dev_app/form_content.html.heex:14
@@ -187,9 +187,9 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:398
+#: lib/vutuv_web/live/cv_live.ex:439
 #: lib/vutuv_web/templates/export/index.html.heex:41
-#: lib/vutuv_web/templates/user/show.html.heex:278
+#: lib/vutuv_web/templates/user/show.html.heex:282
 #: lib/vutuv_web/views/qualification_html.ex:237
 #, elixir-autogen
 msgid "Download"
@@ -218,7 +218,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/edit.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:4
 #: lib/vutuv_web/templates/url/edit.html.heex:4
-#: lib/vutuv_web/templates/user/show.html.heex:847
+#: lib/vutuv_web/templates/user/show.html.heex:851
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #, elixir-autogen
 msgid "Edit"
@@ -299,7 +299,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:494
+#: lib/vutuv_web/templates/user/show.html.heex:498
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:3
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -322,7 +322,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:443
 #: lib/vutuv_web/agent_docs/text.ex:440
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/notification_live/index.ex:770
+#: lib/vutuv_web/live/notification_live/index.ex:798
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
 #, elixir-autogen
@@ -340,7 +340,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:772
+#: lib/vutuv_web/templates/user/show.html.heex:776
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -351,11 +351,11 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
 #: lib/vutuv_web/cv/odt.ex:109
-#: lib/vutuv_web/live/cv_live.ex:113
+#: lib/vutuv_web/live/cv_live.ex:154
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:819
+#: lib/vutuv_web/templates/user/show.html.heex:823
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -424,7 +424,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:205
 #: lib/vutuv_web/cv/latex.ex:164
 #: lib/vutuv_web/cv/odt.ex:176
-#: lib/vutuv_web/live/cv_live.ex:296
+#: lib/vutuv_web/live/cv_live.ex:337
 #: lib/vutuv_web/templates/import/new.html.heex:12
 #: lib/vutuv_web/templates/import/preview.html.heex:40
 #: lib/vutuv_web/templates/url/edit.html.heex:3
@@ -467,14 +467,14 @@ msgid "Middle Name"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3180
-#: lib/vutuv_web/live/notification_live/index.ex:694
+#: lib/vutuv_web/live/notification_live/index.ex:722
 #, elixir-autogen
 msgid "More"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:71
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:590
-#: lib/vutuv_web/live/cv_live.ex:104
+#: lib/vutuv_web/live/cv_live.ex:145
 #: lib/vutuv_web/templates/access_token/new.html.heex:8
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:50
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:17
@@ -484,7 +484,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:497
+#: lib/vutuv_web/live/notification_live/index.ex:525
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/templates/access_token/new.html.heex:1
 #: lib/vutuv_web/templates/ad/new.html.heex:3
@@ -571,7 +571,7 @@ msgstr ""
 msgid "Phone Numbers Belonging to "
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:109
+#: lib/vutuv_web/live/cv_live.ex:150
 #: lib/vutuv_web/templates/phone_number/card_list.html.heex:6
 #, elixir-autogen
 msgid "Phone number"
@@ -641,11 +641,11 @@ msgstr ""
 msgid "Public (Everyone can view) or Private (Only you can view)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:327
+#: lib/vutuv_web/live/organization_live/edit.ex:339
 #: lib/vutuv_web/live/post_live/composer.ex:818
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:83
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:108
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
@@ -653,16 +653,16 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:64
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:383
-#: lib/vutuv_web/views/settings_html.ex:131
+#: lib/vutuv_web/views/settings_html.ex:138
 #, elixir-autogen
 msgid "Save"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:231
-#: lib/vutuv_web/live/job_board_live.ex:314
+#: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:35
-#: lib/vutuv_web/live/search_live.ex:229
+#: lib/vutuv_web/live/search_live.ex:312
 #: lib/vutuv_web/live/shell_live.ex:481
 #: lib/vutuv_web/live/shell_live.ex:637
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
@@ -702,19 +702,19 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:226
 #: lib/vutuv_web/cv/latex.ex:179
 #: lib/vutuv_web/cv/odt.ex:185
-#: lib/vutuv_web/live/cv_live.ex:370
+#: lib/vutuv_web/live/cv_live.ex:411
 #: lib/vutuv_web/templates/social_media_account/edit.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/index.html.heex:10
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:3
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:973
+#: lib/vutuv_web/templates/user/show.html.heex:977
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:975
+#: lib/vutuv_web/templates/user/show.html.heex:979
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -816,7 +816,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
-#: lib/vutuv_web/live/notification_live/index.ex:836
+#: lib/vutuv_web/live/notification_live/index.ex:864
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -861,20 +861,20 @@ msgid "Users"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:581
-#: lib/vutuv_web/templates/user/show.html.heex:284
+#: lib/vutuv_web/templates/user/show.html.heex:288
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2987
-#: lib/vutuv_web/templates/user/show.html.heex:766
-#: lib/vutuv_web/templates/user/show.html.heex:786
+#: lib/vutuv_web/templates/user/show.html.heex:770
+#: lib/vutuv_web/templates/user/show.html.heex:790
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:550
-#: lib/vutuv_web/live/organization_live/edit.ex:286
+#: lib/vutuv_web/live/organization_live/edit.ex:298
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
 #, elixir-autogen
@@ -938,7 +938,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:52
-#: lib/vutuv_web/live/post_live/feed.ex:58
+#: lib/vutuv_web/live/post_live/feed.ex:59
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1047,14 +1047,14 @@ msgstr ""
 msgid "Select a year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:884
+#: lib/vutuv/accounts/user.ex:929
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:883
+#: lib/vutuv/accounts/user.ex:928
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1115,7 +1115,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:808
+#: lib/vutuv_web/templates/user/show.html.heex:812
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1203,12 +1203,13 @@ msgstr ""
 msgid "Can't find URL"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:285
+#: lib/vutuv_web/live/search_live.ex:199
 #, elixir-autogen
 msgid "Our search will try to match similar names to your search, so don't worry about spelling."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:280
+#: lib/vutuv_web/live/search_live.ex:363
+#: lib/vutuv_web/live/search_live.ex:388
 #, elixir-autogen
 msgid "Search Tips"
 msgstr ""
@@ -1298,7 +1299,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/templates/user/show.html.heex:492
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1472,16 +1473,17 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:394
 #: lib/vutuv_web/agent_docs/text.ex:571
 #: lib/vutuv_web/components/ui.ex:3170
-#: lib/vutuv_web/controllers/user_tag_controller.ex:39
-#: lib/vutuv_web/controllers/user_tag_controller.ex:56
+#: lib/vutuv_web/controllers/user_tag_controller.ex:43
+#: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
 #: lib/vutuv_web/cv/html.ex:159
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
-#: lib/vutuv_web/live/cv_live.ex:275
+#: lib/vutuv_web/live/cv_live.ex:316
+#: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:509
 #: lib/vutuv_web/live/search_live.ex:178
-#: lib/vutuv_web/live/search_live.ex:361
+#: lib/vutuv_web/live/search_live.ex:448
 #: lib/vutuv_web/live/tag_new_live.ex:35
 #: lib/vutuv_web/live/tag_new_live.ex:45
 #: lib/vutuv_web/live/tag_new_live.ex:54
@@ -1496,7 +1498,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:458
+#: lib/vutuv_web/templates/user/show.html.heex:462
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1625,7 +1627,7 @@ msgstr ""
 msgid "User tag created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:144
+#: lib/vutuv_web/controllers/user_tag_controller.ex:166
 #, elixir-autogen
 msgid "User tag deleted successfully."
 msgstr ""
@@ -1653,9 +1655,9 @@ msgid "You'll receive an email with a login link."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
-#: lib/vutuv_web/live/job_board_live.ex:274
+#: lib/vutuv_web/live/job_board_live.ex:360
 #: lib/vutuv_web/live/job_posting_live/form.ex:410
-#: lib/vutuv_web/live/organization_live/edit.ex:282
+#: lib/vutuv_web/live/organization_live/edit.ex:294
 #: lib/vutuv_web/live/organization_live/new.ex:127
 #: lib/vutuv_web/templates/ad/new.html.heex:111
 #: lib/vutuv_web/templates/address/country_input.html.heex:2
@@ -1794,7 +1796,7 @@ msgid "It doesn't look like you're following anyone yet. Open the profile of som
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:608
-#: lib/vutuv_web/views/settings_html.ex:218
+#: lib/vutuv_web/views/settings_html.ex:225
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -1839,14 +1841,14 @@ msgstr ""
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:305
+#: lib/vutuv_web/live/notification_live/index.ex:314
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3184
 #: lib/vutuv_web/live/notification_live/index.ex:103
-#: lib/vutuv_web/live/notification_live/index.ex:268
+#: lib/vutuv_web/live/notification_live/index.ex:275
 #: lib/vutuv_web/live/shell_live.ex:508
 #: lib/vutuv_web/templates/layout/app.html.heex:118
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
@@ -1934,8 +1936,8 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:676
-#: lib/vutuv_web/templates/user/show.html.heex:1247
+#: lib/vutuv_web/live/post_live/feed.ex:757
+#: lib/vutuv_web/templates/user/show.html.heex:1251
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -1954,14 +1956,14 @@ msgstr ""
 
 #: lib/vutuv_web/open_graph.ex:256
 #: lib/vutuv_web/templates/tag/show.html.heex:13
-#: lib/vutuv_web/templates/user/show.html.heex:253
+#: lib/vutuv_web/templates/user/show.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "follower"
 msgid_plural "followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:257
+#: lib/vutuv_web/templates/user/show.html.heex:261
 #, elixir-autogen, elixir-format
 msgid "following"
 msgstr ""
@@ -1971,17 +1973,17 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:857
+#: lib/vutuv_web/live/notification_live/index.ex:885
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:852
+#: lib/vutuv_web/live/notification_live/index.ex:880
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:847
+#: lib/vutuv_web/live/notification_live/index.ex:875
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -2189,8 +2191,8 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:79
-#: lib/vutuv_web/live/post_live/feed.ex:552
+#: lib/vutuv_web/live/post_live/feed.ex:85
+#: lib/vutuv_web/live/post_live/feed.ex:624
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:116
@@ -2235,7 +2237,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:617
+#: lib/vutuv_web/live/post_live/feed.ex:698
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2273,10 +2275,10 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:73
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/notification_live/index.ex:692
+#: lib/vutuv_web/live/notification_live/index.ex:720
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:179
-#: lib/vutuv_web/live/search_live.ex:375
+#: lib/vutuv_web/live/search_live.ex:462
 #: lib/vutuv_web/templates/settings/preferences.html.heex:118
 #: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
@@ -2297,13 +2299,13 @@ msgstr ""
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:209
-#: lib/vutuv_web/live/organization_live/edit.ex:359
+#: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
 #: lib/vutuv_web/live/post_live/composer.ex:888
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
-#: lib/vutuv_web/views/settings_html.ex:264
+#: lib/vutuv_web/views/settings_html.ex:271
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2323,7 +2325,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:581
+#: lib/vutuv_web/live/post_live/feed.ex:653
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2361,11 +2363,11 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3357
+#: lib/vutuv_web/components/ui.ex:3358
 #: lib/vutuv_web/live/shell_live.ex:551
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
-#: lib/vutuv_web/views/settings_html.ex:165
+#: lib/vutuv_web/views/settings_html.ex:172
 #, elixir-autogen, elixir-format
 msgid "View profile"
 msgstr ""
@@ -2406,7 +2408,7 @@ msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:293
+#: lib/vutuv_web/views/settings_html.ex:300
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2431,7 +2433,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:448
+#: lib/vutuv_web/templates/user/show.html.heex:452
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2464,7 +2466,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2470
-#: lib/vutuv_web/live/notification_live/index.ex:828
+#: lib/vutuv_web/live/notification_live/index.ex:856
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2472,7 +2474,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:833
 #: lib/vutuv_web/components/post_components.ex:2196
-#: lib/vutuv_web/live/notification_live/index.ex:772
+#: lib/vutuv_web/live/notification_live/index.ex:800
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:559
@@ -2533,7 +2535,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1648
-#: lib/vutuv_web/live/post_live/feed.ex:665
+#: lib/vutuv_web/live/post_live/feed.ex:746
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2550,14 +2552,14 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:276
-#: lib/vutuv_web/live/notification_live/index.ex:773
+#: lib/vutuv_web/live/notification_live/index.ex:801
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2219
 #: lib/vutuv_web/components/post_components.ex:2220
-#: lib/vutuv_web/live/notification_live/index.ex:825
+#: lib/vutuv_web/live/notification_live/index.ex:853
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
@@ -2579,7 +2581,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:966
+#: lib/vutuv_web/live/notification_live/index.ex:994
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2764,42 +2766,42 @@ msgid "Use a different email address"
 msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:698
+#: lib/vutuv_web/templates/user/show.html.heex:702
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:936
+#: lib/vutuv_web/templates/user/show.html.heex:940
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1161
+#: lib/vutuv_web/templates/user/show.html.heex:1165
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:864
+#: lib/vutuv_web/templates/user/show.html.heex:868
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:810
+#: lib/vutuv_web/templates/user/show.html.heex:814
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:497
+#: lib/vutuv_web/templates/user/show.html.heex:501
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:965
-#: lib/vutuv_web/templates/user/show.html.heex:400
+#: lib/vutuv_web/live/user_profile_live.ex:970
+#: lib/vutuv_web/templates/user/show.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
@@ -2812,25 +2814,25 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:133
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:175
-#: lib/vutuv_web/templates/user/show.html.heex:488
+#: lib/vutuv_web/templates/user/show.html.heex:492
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:564
-#: lib/vutuv_web/templates/user/show.html.heex:400
+#: lib/vutuv_web/live/post_live/feed.ex:636
+#: lib/vutuv_web/templates/user/show.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:117
+#: lib/vutuv_web/views/user_helpers.ex:118
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_helpers.ex:121
+#: lib/vutuv_web/views/user_helpers.ex:122
 #, elixir-autogen, elixir-format
 msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
 msgstr ""
@@ -2852,7 +2854,7 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:445
 #: lib/vutuv_web/agent_docs/text.ex:442
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:771
+#: lib/vutuv_web/live/notification_live/index.ex:799
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2888,7 +2890,7 @@ msgstr ""
 msgid "This post is for the connections of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:266
+#: lib/vutuv_web/templates/user/show.html.heex:270
 #: lib/vutuv_web/views/admin/moderation_html.ex:81
 #, elixir-autogen, elixir-format
 msgid "connection"
@@ -2906,23 +2908,23 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:837
+#: lib/vutuv_web/live/notification_live/index.ex:865
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:829
+#: lib/vutuv_web/live/notification_live/index.ex:857
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:824
+#: lib/vutuv_web/live/notification_live/index.ex:852
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:823
-#: lib/vutuv_web/templates/user/show.html.heex:753
+#: lib/vutuv_web/live/notification_live/index.ex:851
+#: lib/vutuv_web/templates/user/show.html.heex:757
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -2934,7 +2936,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:854
+#: lib/vutuv_web/live/notification_live/index.ex:882
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2966,12 +2968,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:993
+#: lib/vutuv_web/live/notification_live/index.ex:1021
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:994
+#: lib/vutuv_web/live/notification_live/index.ex:1022
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3077,7 +3079,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:830
+#: lib/vutuv_web/live/notification_live/index.ex:858
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3151,8 +3153,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:904
-#: lib/vutuv_web/templates/user/show.html.heex:905
+#: lib/vutuv_web/templates/user/show.html.heex:908
+#: lib/vutuv_web/templates/user/show.html.heex:909
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -3497,12 +3499,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:996
+#: lib/vutuv_web/live/notification_live/index.ex:1024
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:995
+#: lib/vutuv_web/live/notification_live/index.ex:1023
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3512,7 +3514,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:997
+#: lib/vutuv_web/live/notification_live/index.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3701,7 +3703,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3726,7 +3728,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:832
+#: lib/vutuv_web/live/notification_live/index.ex:860
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3801,7 +3803,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1026
+#: lib/vutuv_web/live/notification_live/index.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4104,7 +4106,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/organization_live.ex:245
 #: lib/vutuv_web/live/job_posting_live/form.ex:404
-#: lib/vutuv_web/live/organization_live/edit.ex:278
+#: lib/vutuv_web/live/organization_live/edit.ex:290
 #: lib/vutuv_web/live/organization_live/new.ex:123
 #: lib/vutuv_web/templates/ad/new.html.heex:105
 #: lib/vutuv_web/templates/welcome/show.html.heex:74
@@ -4519,7 +4521,7 @@ msgstr ""
 msgid "Undeliverable"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:282
+#: lib/vutuv_web/live/search_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
@@ -4590,7 +4592,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:622
+#: lib/vutuv_web/live/post_live/feed.ex:703
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4602,7 +4604,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:772
+#: lib/vutuv_web/templates/user/show.html.heex:776
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4632,12 +4634,12 @@ msgstr ""
 msgid "This area is reserved for administrators."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:407
+#: lib/vutuv_web/live/search_live.ex:494
 #, elixir-autogen, elixir-format
 msgid "No results for \"%{query}\""
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:344
+#: lib/vutuv_web/live/search_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
@@ -4645,21 +4647,21 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:316
 #: lib/vutuv_web/agent_docs/text.ex:342
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:693
+#: lib/vutuv_web/live/notification_live/index.ex:721
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:177
-#: lib/vutuv_web/live/search_live.ex:317
+#: lib/vutuv_web/live/search_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:276
+#: lib/vutuv_web/live/search_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Results appear once you have typed at least three letters."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:341
+#: lib/vutuv_web/live/search_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Similar names"
 msgstr ""
@@ -4667,60 +4669,61 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:273
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:691
+#: lib/vutuv_web/live/notification_live/index.ex:719
 #: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:259
+#: lib/vutuv_web/live/search_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Exact matches only"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:303
+#: lib/vutuv_web/live/search_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "in quotes: exact matches only, no similar names"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:301
+#: lib/vutuv_web/live/search_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "searches usernames"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:297
+#: lib/vutuv_web/live/search_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "only people with an address in this city"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:296
+#: lib/vutuv_web/live/search_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "city:koblenz"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:292
+#: lib/vutuv_web/live/search_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "first:stefan"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:302
+#: lib/vutuv_web/live/search_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "miller"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:293
+#: lib/vutuv_web/live/search_live.ex:227
 #, elixir-autogen, elixir-format
 msgid "searches first names only (last: for last names)"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:953
-#: lib/vutuv_web/templates/user/show.html.heex:461
+#: lib/vutuv_web/live/job_board_live.ex:388
+#: lib/vutuv_web/live/user_profile_live.ex:958
+#: lib/vutuv_web/templates/user/show.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:236
+#: lib/vutuv_web/live/search_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Search for people, tags, or posts"
 msgstr ""
@@ -4945,8 +4948,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:94
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:181
-#: lib/vutuv_web/views/settings_html.ex:31
-#: lib/vutuv_web/views/settings_html.ex:209
+#: lib/vutuv_web/views/settings_html.ex:38
+#: lib/vutuv_web/views/settings_html.ex:216
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -5302,8 +5305,8 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3190
-#: lib/vutuv_web/controllers/settings_controller.ex:129
+#: lib/vutuv_web/components/ui.ex:3191
+#: lib/vutuv_web/controllers/settings_controller.ex:130
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
@@ -5380,10 +5383,10 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3276
-#: lib/vutuv_web/components/ui.ex:3281
-#: lib/vutuv_web/components/ui.ex:3349
-#: lib/vutuv_web/controllers/settings_controller.ex:51
+#: lib/vutuv_web/components/ui.ex:3277
+#: lib/vutuv_web/components/ui.ex:3282
+#: lib/vutuv_web/components/ui.ex:3350
+#: lib/vutuv_web/controllers/settings_controller.ex:52
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/live/tag_new_live.ex:44
 #: lib/vutuv_web/templates/address/edit.html.heex:2
@@ -5411,7 +5414,7 @@ msgstr ""
 #: lib/vutuv_web/templates/username/new.html.heex:4
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:2
 #: lib/vutuv_web/templates/work_experience/new.html.heex:2
-#: lib/vutuv_web/views/settings_html.ex:160
+#: lib/vutuv_web/views/settings_html.ex:167
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -5436,17 +5439,17 @@ msgstr ""
 msgid "Your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:306
+#: lib/vutuv_web/templates/user/show.html.heex:310
 #, elixir-autogen, elixir-format
 msgid "Complete your profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:328
+#: lib/vutuv_web/templates/user/show.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:955
+#: lib/vutuv_web/live/user_profile_live.ex:960
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5475,8 +5478,8 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1137
 #: lib/vutuv_web/components/post_components.ex:1191
 #: lib/vutuv_web/components/post_components.ex:1506
-#: lib/vutuv_web/live/notification_live/index.ex:530
-#: lib/vutuv_web/live/post_live/feed.ex:737
+#: lib/vutuv_web/live/notification_live/index.ex:558
+#: lib/vutuv_web/live/post_live/feed.ex:818
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr ""
@@ -5491,7 +5494,7 @@ msgstr ""
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:887
+#: lib/vutuv/accounts/user.ex:932
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5539,7 +5542,7 @@ msgstr ""
 msgid "Add, remove or pick your primary address."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:429
+#: lib/vutuv_web/live/organization_live/edit.ex:441
 #: lib/vutuv_web/templates/settings/security.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -5561,7 +5564,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:227
+#: lib/vutuv_web/controllers/settings_controller.ex:302
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr ""
@@ -5587,7 +5590,7 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:167
+#: lib/vutuv_web/controllers/settings_controller.ex:168
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr ""
@@ -5607,7 +5610,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:445
+#: lib/vutuv_web/live/notification_live/index.ex:455
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5642,7 +5645,7 @@ msgstr ""
 msgid "Language & region"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:316
+#: lib/vutuv_web/controllers/settings_controller.ex:444
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr ""
@@ -5694,31 +5697,32 @@ msgstr ""
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3189
+#: lib/vutuv_web/components/ui.ex:3190
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:144
+#: lib/vutuv_web/controllers/settings_controller.ex:145
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:105
-#: lib/vutuv_web/live/notification_live/index.ex:774
+#: lib/vutuv_web/controllers/user_tag_controller.ex:127
+#: lib/vutuv_web/live/notification_live/index.ex:802
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
+#: lib/vutuv_web/templates/user_tag/show.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Endorsements"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:99
+#: lib/vutuv_web/templates/settings/notifications.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Endorsements and new followers"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:93
+#: lib/vutuv_web/templates/settings/notifications.html.heex:116
 #, elixir-autogen, elixir-format
 msgid "In-app notifications"
 msgstr ""
@@ -5728,22 +5732,22 @@ msgstr ""
 msgid "New followers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:217
+#: lib/vutuv_web/controllers/settings_controller.ex:292
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:107
+#: lib/vutuv_web/templates/settings/notifications.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Open your notifications"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:138
+#: lib/vutuv_web/controllers/settings_controller.ex:139
 #, elixir-autogen, elixir-format
 msgid "Privacy settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:100
+#: lib/vutuv_web/templates/settings/notifications.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr ""
@@ -5758,7 +5762,7 @@ msgstr ""
 msgid "Search engines & AI"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:95
+#: lib/vutuv_web/templates/settings/notifications.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "These are always on. You see them under the bell at the top of every page, in real time."
 msgstr ""
@@ -5909,28 +5913,28 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:174
-#: lib/vutuv_web/views/settings_html.ex:302
+#: lib/vutuv_web/views/settings_html.ex:309
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:301
+#: lib/vutuv_web/views/settings_html.ex:308
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:300
+#: lib/vutuv_web/views/settings_html.ex:307
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:411
+#: lib/vutuv_web/controllers/settings_controller.ex:539
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5940,7 +5944,7 @@ msgstr ""
 msgid "Another session was already active on your account."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:198
+#: lib/vutuv_web/views/settings_html.ex:205
 #, elixir-autogen, elixir-format
 msgid "Last active"
 msgstr ""
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "Log out of every device except this one?"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:215
+#: lib/vutuv_web/views/settings_html.ex:222
 #, elixir-autogen, elixir-format
 msgid "Log this device out of your account?"
 msgstr ""
@@ -5970,7 +5974,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:400
+#: lib/vutuv_web/controllers/settings_controller.ex:528
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5980,7 +5984,7 @@ msgstr ""
 msgid "The location looks different from where you usually sign in."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:199
+#: lib/vutuv_web/views/settings_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "This device"
 msgstr ""
@@ -5990,7 +5994,7 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:299
+#: lib/vutuv_web/views/settings_html.ex:306
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -6021,7 +6025,7 @@ msgid "Add a passkey"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/views/settings_html.ex:250
+#: lib/vutuv_web/views/settings_html.ex:257
 #, elixir-autogen, elixir-format
 msgid "Added"
 msgstr ""
@@ -6031,7 +6035,7 @@ msgstr ""
 msgid "Could not add the passkey. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:253
+#: lib/vutuv_web/views/settings_html.ex:260
 #, elixir-autogen, elixir-format
 msgid "Last used"
 msgstr ""
@@ -6041,7 +6045,7 @@ msgstr ""
 msgid "Name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:247
+#: lib/vutuv_web/views/settings_html.ex:254
 #, elixir-autogen, elixir-format
 msgid "Passkey"
 msgstr ""
@@ -6061,7 +6065,7 @@ msgstr ""
 msgid "Passkeys"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:261
+#: lib/vutuv_web/views/settings_html.ex:268
 #, elixir-autogen, elixir-format
 msgid "Remove this passkey?"
 msgstr ""
@@ -6116,12 +6120,12 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:959
+#: lib/vutuv_web/live/user_profile_live.ex:964
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:107
+#: lib/vutuv_web/live/cv_live.ex:148
 #: lib/vutuv_web/templates/user/edit.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Tagline"
@@ -6130,14 +6134,14 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:174
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:696
+#: lib/vutuv_web/templates/user/show.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:381
+#: lib/vutuv_web/templates/user/show.html.heex:385
 #, elixir-autogen, elixir-format
 msgctxt "profile"
 msgid "Post"
@@ -6151,7 +6155,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1212
+#: lib/vutuv_web/templates/user/show.html.heex:1216
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6194,8 +6198,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:830
-#: lib/vutuv_web/templates/user/show.html.heex:840
+#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:844
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6235,12 +6239,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:951
+#: lib/vutuv_web/templates/user/show.html.heex:955
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:962
+#: lib/vutuv_web/templates/user/show.html.heex:966
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6282,7 +6286,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:960
+#: lib/vutuv_web/templates/user/show.html.heex:964
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6320,7 +6324,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:331
+#: lib/vutuv_web/controllers/settings_controller.ex:459
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -6336,9 +6340,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1198
-#: lib/vutuv_web/templates/user/show.html.heex:1206
-#: lib/vutuv_web/templates/user/show.html.heex:1218
+#: lib/vutuv_web/templates/user/show.html.heex:1202
+#: lib/vutuv_web/templates/user/show.html.heex:1210
+#: lib/vutuv_web/templates/user/show.html.heex:1222
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6371,10 +6375,10 @@ msgid "No endorsements yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1332
-#: lib/vutuv_web/live/notification_live/index.ex:475
-#: lib/vutuv_web/live/notification_live/index.ex:490
-#: lib/vutuv_web/live/notification_live/index.ex:613
-#: lib/vutuv_web/live/notification_live/index.ex:615
+#: lib/vutuv_web/live/notification_live/index.ex:503
+#: lib/vutuv_web/live/notification_live/index.ex:518
+#: lib/vutuv_web/live/notification_live/index.ex:641
+#: lib/vutuv_web/live/notification_live/index.ex:643
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -6659,6 +6663,7 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1836
+#: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Mute"
@@ -6670,7 +6675,7 @@ msgstr ""
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/notifications.html.heex:98
+#: lib/vutuv_web/templates/settings/notifications.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "New messages and new connections"
 msgstr ""
@@ -6681,6 +6686,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1835
+#: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "Unmute"
@@ -6911,6 +6917,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:193
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
+#: lib/vutuv_web/templates/settings/filters.html.heex:17
 #, elixir-autogen, elixir-format
 msgid "Kind"
 msgstr ""
@@ -7075,7 +7082,7 @@ msgstr ""
 msgid "Rendered with your own account data for the variables."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:201
+#: lib/vutuv_web/live/cv_live.ex:242
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:281
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:35
 #, elixir-autogen, elixir-format
@@ -7164,8 +7171,9 @@ msgid "Suppressed (bounced address)"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:816
-#: lib/vutuv_web/live/job_board_live.ex:205
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:44
+#: lib/vutuv_web/templates/settings/filters.html.heex:22
+#: lib/vutuv_web/views/settings_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Tag"
 msgstr ""
@@ -7782,13 +7790,13 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:720
+#: lib/vutuv_web/live/notification_live/index.ex:748
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:723
+#: lib/vutuv_web/live/notification_live/index.ex:751
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7863,42 +7871,42 @@ msgstr ""
 msgid "Send the email"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:65
+#: lib/vutuv_web/views/settings_html.ex:72
 #, elixir-autogen
 msgid "As soon as possible"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:66
+#: lib/vutuv_web/views/settings_html.ex:73
 #, elixir-autogen
 msgid "After 5 minutes"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:67
+#: lib/vutuv_web/views/settings_html.ex:74
 #, elixir-autogen
 msgid "After 15 minutes"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:68
+#: lib/vutuv_web/views/settings_html.ex:75
 #, elixir-autogen
 msgid "After 30 minutes"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:69
+#: lib/vutuv_web/views/settings_html.ex:76
 #, elixir-autogen
 msgid "After 1 hour"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:70
+#: lib/vutuv_web/views/settings_html.ex:77
 #, elixir-autogen
 msgid "After 2 hours"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:49
+#: lib/vutuv_web/views/settings_html.ex:56
 #, elixir-autogen
 msgid "Only the first message"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:50
+#: lib/vutuv_web/views/settings_html.ex:57
 #, elixir-autogen
 msgid "Every message"
 msgstr ""
@@ -7954,7 +7962,7 @@ msgid "Awaiting verification"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_live.ex:196
-#: lib/vutuv_web/live/job_board_live.ex:192
+#: lib/vutuv_web/live/job_board_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -8007,8 +8015,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:922
-#: lib/vutuv/accounts.ex:971
+#: lib/vutuv/accounts.ex:923
+#: lib/vutuv/accounts.ex:972
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8047,7 +8055,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:939
+#: lib/vutuv/accounts.ex:940
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8178,7 +8186,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:549
+#: lib/vutuv_web/templates/user/show.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8191,9 +8199,9 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
 #: lib/vutuv_web/components/ui.ex:3161
-#: lib/vutuv_web/controllers/education_controller.ex:38
-#: lib/vutuv_web/controllers/education_controller.ex:53
-#: lib/vutuv_web/controllers/education_controller.ex:103
+#: lib/vutuv_web/controllers/education_controller.ex:43
+#: lib/vutuv_web/controllers/education_controller.ex:60
+#: lib/vutuv_web/controllers/education_controller.ex:140
 #: lib/vutuv_web/cv/cv.ex:274
 #: lib/vutuv_web/templates/education/edit.html.heex:3
 #: lib/vutuv_web/templates/education/index.html.heex:5
@@ -8203,17 +8211,17 @@ msgstr ""
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:546
+#: lib/vutuv_web/templates/user/show.html.heex:550
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
 
-#: lib/vutuv_web/controllers/education_controller.ex:81
+#: lib/vutuv_web/controllers/education_controller.ex:118
 #, elixir-autogen, elixir-format
 msgid "Education created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/education_controller.ex:134
+#: lib/vutuv_web/controllers/education_controller.ex:171
 #, elixir-autogen, elixir-format
 msgid "Education deleted successfully."
 msgstr ""
@@ -8223,7 +8231,7 @@ msgstr ""
 msgid "Education of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/education_controller.ex:123
+#: lib/vutuv_web/controllers/education_controller.ex:160
 #, elixir-autogen, elixir-format
 msgid "Education updated successfully."
 msgstr ""
@@ -8253,7 +8261,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/import_controller.ex:114
 #: lib/vutuv_web/templates/import/new.html.heex:1
 #: lib/vutuv_web/templates/import/preview.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:369
+#: lib/vutuv_web/templates/user/show.html.heex:373
 #, elixir-autogen, elixir-format
 msgid "Import from LinkedIn"
 msgstr ""
@@ -8362,7 +8370,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:978
+#: lib/vutuv_web/live/user_profile_live.ex:983
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
@@ -8388,7 +8396,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:94
-#: lib/vutuv_web/templates/user/show.html.heex:1065
+#: lib/vutuv_web/templates/user/show.html.heex:1069
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8455,7 +8463,7 @@ msgid "Basics & photos"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3176
-#: lib/vutuv_web/controllers/settings_controller.ex:106
+#: lib/vutuv_web/controllers/settings_controller.ex:107
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
@@ -8467,7 +8475,7 @@ msgid "More profile sections"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3174
-#: lib/vutuv_web/controllers/settings_controller.ex:89
+#: lib/vutuv_web/controllers/settings_controller.ex:90
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:5
 #: lib/vutuv_web/templates/totp/new.html.heex:5
@@ -8497,13 +8505,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:704
-#: lib/vutuv_web/live/post_live/feed.ex:705
+#: lib/vutuv_web/live/post_live/feed.ex:785
+#: lib/vutuv_web/live/post_live/feed.ex:786
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:699
+#: lib/vutuv_web/live/post_live/feed.ex:780
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8700,7 +8708,7 @@ msgid "Allow followers from the Fediverse"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3183
-#: lib/vutuv_web/controllers/settings_controller.ex:186
+#: lib/vutuv_web/controllers/settings_controller.ex:187
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:288
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:5
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:8
@@ -8708,7 +8716,7 @@ msgstr ""
 msgid "Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:208
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Get verified on Mastodon"
@@ -8729,7 +8737,7 @@ msgstr ""
 msgid "Anyone on Mastodon can paste this handle into their search and follow you from there."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:196
+#: lib/vutuv_web/controllers/settings_controller.ex:206
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr ""
@@ -8739,12 +8747,12 @@ msgstr ""
 msgid "Followers from the Fediverse:"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:92
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Independent of federation: your vutuv profile links your listed social media accounts with rel=\"me\", so adding your profile address to your Mastodon profile shows it there as verified."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:99
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr ""
@@ -8764,7 +8772,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:934
+#: lib/vutuv/accounts.ex:935
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8817,7 +8825,7 @@ msgstr ""
 msgid "Volunteering & hobbies"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:251
+#: lib/vutuv_web/live/search_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Not available while the search uses a people filter."
 msgstr ""
@@ -8826,7 +8834,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:58
 #: lib/vutuv_web/cv/latex.ex:45
 #: lib/vutuv_web/cv/latex.ex:46
-#: lib/vutuv_web/live/cv_live.ex:175
+#: lib/vutuv_web/live/cv_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "CV"
 msgstr ""
@@ -8836,19 +8844,19 @@ msgstr ""
 msgid "Your profile as a CV"
 msgstr ""
 
-#: lib/vutuv_web/views/education_html.ex:19
+#: lib/vutuv_web/views/education_html.ex:28
 #, elixir-autogen, elixir-format
 msgid "Higher Education"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:633
-#: lib/vutuv_web/views/education_html.ex:21
+#: lib/vutuv_web/views/education_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:632
-#: lib/vutuv_web/views/education_html.ex:20
+#: lib/vutuv_web/views/education_html.ex:29
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
 msgstr ""
@@ -8885,24 +8893,24 @@ msgstr[1] ""
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:193
+#: lib/vutuv_web/live/cv_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Anonymize"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:108
+#: lib/vutuv_web/live/cv_live.ex:149
 #: lib/vutuv_web/templates/invitation/new.html.heex:47
 #: lib/vutuv_web/templates/invitation/sent.html.heex:23
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:400
+#: lib/vutuv_web/live/cv_live.ex:441
 #, elixir-autogen, elixir-format
 msgid "Every download reflects the parts you selected."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:207
+#: lib/vutuv_web/live/cv_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
@@ -8913,22 +8921,22 @@ msgstr ""
 msgid "Open CV"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:105
+#: lib/vutuv_web/live/cv_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:182
+#: lib/vutuv_web/live/cv_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Pick what to include. Untick single entries or whole sections, or anonymize the CV by hiding the name, photo and contact details."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:409
+#: lib/vutuv_web/live/cv_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "Print / Save as PDF"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:111
+#: lib/vutuv_web/live/cv_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "Profile link"
 msgstr ""
@@ -8948,12 +8956,12 @@ msgstr ""
 msgid "Turn your profile into a formatted CV for a job application: pick what to include, anonymize it, then print (Save as PDF) or download it as Word, OpenDocument, HTML, LaTeX or JSON Resume."
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:44
+#: lib/vutuv_web/live/cv_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "CV of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:47
+#: lib/vutuv_web/live/cv_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
@@ -8972,7 +8980,7 @@ msgstr ""
 msgid "Other activities"
 msgstr ""
 
-#: lib/vutuv_web/live/cv_live.ex:423
+#: lib/vutuv_web/live/cv_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "For a PDF, open the print view and choose \"Save as PDF\" in your browser's print dialog. Word and OpenDocument are editable; LaTeX is the typesetting source; JSON Resume is the open %{link} format."
 msgstr ""
@@ -8982,21 +8990,25 @@ msgstr ""
 msgid "characters"
 msgstr ""
 
+#: lib/vutuv_web/templates/education/card_list.html.heex:28
 #: lib/vutuv_web/templates/work_experience/card_list.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "%{job} shows at the top of your profile."
 msgstr ""
 
+#: lib/vutuv_web/templates/education/card_list.html.heex:34
 #: lib/vutuv_web/templates/work_experience/card_list.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Choose automatically instead"
 msgstr ""
 
+#: lib/vutuv_web/templates/education/card_list.html.heex:93
 #: lib/vutuv_web/views/work_experience_html.ex:682
 #, elixir-autogen, elixir-format
 msgid "Show at top of profile"
 msgstr ""
 
+#: lib/vutuv_web/templates/education/card_list.html.heex:84
 #: lib/vutuv_web/views/work_experience_html.ex:673
 #, elixir-autogen, elixir-format
 msgid "Shown at the top of your profile"
@@ -9082,7 +9094,7 @@ msgstr ""
 msgid "Removed @%{handle} from this tag."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_tag_controller.ex:149
+#: lib/vutuv_web/controllers/user_tag_controller.ex:171
 #, elixir-autogen, elixir-format
 msgid "This tag can only be removed by a site admin."
 msgstr ""
@@ -9122,7 +9134,7 @@ msgid "A2 (Elementary)"
 msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9341,13 +9353,13 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:188
 #: lib/vutuv_web/cv/latex.ex:149
 #: lib/vutuv_web/cv/odt.ex:163
-#: lib/vutuv_web/live/cv_live.ex:346
+#: lib/vutuv_web/live/cv_live.ex:387
 #: lib/vutuv_web/templates/language/edit.html.heex:3
 #: lib/vutuv_web/templates/language/index.html.heex:10
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:3
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:608
+#: lib/vutuv_web/templates/user/show.html.heex:612
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9534,18 +9546,18 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:735
+#: lib/vutuv/accounts/user.ex:780
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:40
+#: lib/vutuv_web/views/user_helpers.ex:41
 #, elixir-autogen, elixir-format
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:732
+#: lib/vutuv/accounts/user.ex:777
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9627,7 +9639,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:651
+#: lib/vutuv_web/templates/user/show.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9668,14 +9680,14 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:172
 #: lib/vutuv_web/cv/latex.ex:140
 #: lib/vutuv_web/cv/odt.ex:154
-#: lib/vutuv_web/live/cv_live.ex:321
+#: lib/vutuv_web/live/cv_live.ex:362
 #: lib/vutuv_web/templates/import/preview.html.heex:27
 #: lib/vutuv_web/templates/qualification/edit.html.heex:3
 #: lib/vutuv_web/templates/qualification/index.html.heex:11
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:3
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:648
+#: lib/vutuv_web/templates/user/show.html.heex:652
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr ""
@@ -9811,8 +9823,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:926
-#: lib/vutuv_web/templates/user/show.html.heex:927
+#: lib/vutuv_web/templates/user/show.html.heex:930
+#: lib/vutuv_web/templates/user/show.html.heex:931
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9821,7 +9833,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:84
 #: lib/vutuv_web/cv/latex.ex:69
 #: lib/vutuv_web/cv/odt.ex:109
-#: lib/vutuv_web/live/cv_live.ex:112
+#: lib/vutuv_web/live/cv_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
@@ -9985,8 +9997,8 @@ msgstr ""
 msgid "Permanent profile link"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:317
-#: lib/vutuv_web/templates/user/show.html.heex:318
+#: lib/vutuv_web/templates/user/show.html.heex:321
+#: lib/vutuv_web/templates/user/show.html.heex:322
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
@@ -10483,7 +10495,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1039
+#: lib/vutuv_web/templates/user/show.html.heex:1043
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10784,7 +10796,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:344
+#: lib/vutuv_web/controllers/settings_controller.ex:472
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10833,7 +10845,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:375
+#: lib/vutuv_web/controllers/settings_controller.ex:503
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10848,7 +10860,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:371
+#: lib/vutuv_web/controllers/settings_controller.ex:499
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -11064,19 +11076,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:773
+#: lib/vutuv/accounts/user.ex:818
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:778
+#: lib/vutuv/accounts/user.ex:823
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:776
+#: lib/vutuv/accounts/user.ex:821
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
@@ -11260,7 +11272,7 @@ msgstr ""
 msgid "Your list is empty. Nobody is excluded yet."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:314
+#: lib/vutuv_web/live/organization_live/edit.ex:326
 #, elixir-autogen, elixir-format
 msgid "AI agents"
 msgstr ""
@@ -11293,27 +11305,27 @@ msgid "Domain verification is disabled on this installation."
 msgstr ""
 
 #: lib/vutuv_web/live/organization_live/edit.ex:31
-#: lib/vutuv_web/live/organization_live/edit.ex:228
+#: lib/vutuv_web/live/organization_live/edit.ex:240
 #, elixir-autogen, elixir-format
 msgid "Edit %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:300
+#: lib/vutuv_web/live/organization_live/edit.ex:312
 #, elixir-autogen, elixir-format
 msgid "Let search engines index this page and include it in the sitemap."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:235
+#: lib/vutuv_web/live/organization_live/edit.ex:247
 #, elixir-autogen, elixir-format
 msgid "Logo"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:262
+#: lib/vutuv_web/live/organization_live/edit.ex:274
 #, elixir-autogen, elixir-format
 msgid "Markdown is supported"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:316
+#: lib/vutuv_web/live/organization_live/edit.ex:328
 #, elixir-autogen, elixir-format
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) and list them for AI agents."
 msgstr ""
@@ -11329,7 +11341,7 @@ msgstr ""
 msgid "Prove you control %{domain} to publish this page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:246
+#: lib/vutuv_web/live/organization_live/edit.ex:258
 #, elixir-autogen, elixir-format
 msgid "Remove logo"
 msgstr ""
@@ -11339,7 +11351,7 @@ msgstr ""
 msgid "Search by name or city"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:298
+#: lib/vutuv_web/live/organization_live/edit.ex:310
 #, elixir-autogen, elixir-format
 msgid "Search engines"
 msgstr ""
@@ -11355,23 +11367,23 @@ msgstr ""
 msgid "Serve this file at:"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:279
+#: lib/vutuv_web/live/organization_live/edit.ex:291
 #: lib/vutuv_web/live/organization_live/new.ex:124
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:459
+#: lib/vutuv_web/live/organization_live/edit.ex:471
 #, elixir-autogen, elixir-format
 msgid "That file type is not allowed."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:457
+#: lib/vutuv_web/live/organization_live/edit.ex:469
 #, elixir-autogen, elixir-format
 msgid "The file is too large."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:460
+#: lib/vutuv_web/live/organization_live/edit.ex:472
 #, elixir-autogen, elixir-format
 msgid "The upload failed."
 msgstr ""
@@ -11417,7 +11429,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:207
 #: lib/vutuv_web/agent_docs/text.ex:196
-#: lib/vutuv_web/live/organization_live/edit.ex:273
+#: lib/vutuv_web/live/organization_live/edit.ex:285
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
 msgid "Website"
@@ -11436,7 +11448,7 @@ msgstr ""
 msgid "Website file (.well-known)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:458
+#: lib/vutuv_web/live/organization_live/edit.ex:470
 #, elixir-autogen, elixir-format
 msgid "You can only upload one logo."
 msgstr ""
@@ -11464,7 +11476,7 @@ msgid "@handle or email"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:252
-#: lib/vutuv_web/live/organization_live/edit.ex:376
+#: lib/vutuv_web/live/organization_live/edit.ex:388
 #, elixir-autogen, elixir-format
 msgid "Abbreviation"
 msgstr ""
@@ -11485,7 +11497,7 @@ msgid "Added @%{handle} to the team."
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:253
-#: lib/vutuv_web/live/organization_live/edit.ex:374
+#: lib/vutuv_web/live/organization_live/edit.ex:386
 #, elixir-autogen, elixir-format
 msgid "Alias"
 msgstr ""
@@ -11502,13 +11514,13 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:308
 #: lib/vutuv_web/agent_docs/text.ex:335
-#: lib/vutuv_web/live/organization_live/edit.ex:339
+#: lib/vutuv_web/live/organization_live/edit.ex:351
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:370
+#: lib/vutuv_web/live/organization_live/edit.ex:382
 #, elixir-autogen, elixir-format
 msgid "Alternative name"
 msgstr ""
@@ -11530,7 +11542,7 @@ msgid "Archived"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:251
-#: lib/vutuv_web/live/organization_live/edit.ex:375
+#: lib/vutuv_web/live/organization_live/edit.ex:387
 #, elixir-autogen, elixir-format
 msgid "Brand"
 msgstr ""
@@ -11676,7 +11688,7 @@ msgstr ""
 msgid "Remove this member from the team?"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:356
+#: lib/vutuv_web/live/organization_live/edit.ex:368
 #, elixir-autogen, elixir-format
 msgid "Remove this name?"
 msgstr ""
@@ -11743,44 +11755,44 @@ msgstr ""
 msgid "verified"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:276
+#: lib/vutuv_web/live/organization_live/edit.ex:288
 #: lib/vutuv_web/live/organization_live/new.ex:121
 #, elixir-autogen, elixir-format
 msgid "Street address (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:277
+#: lib/vutuv_web/live/organization_live/edit.ex:289
 #: lib/vutuv_web/live/organization_live/new.ex:122
 #, elixir-autogen, elixir-format
 msgid "ZIP / postal code (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:429
+#: lib/vutuv_web/live/organization_live/edit.ex:441
 #, elixir-autogen, elixir-format
 msgid "Claim"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:398
+#: lib/vutuv_web/live/organization_live/edit.ex:410
 #, elixir-autogen, elixir-format
 msgid "Reachable at"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:388
+#: lib/vutuv_web/live/organization_live/edit.ex:400
 #, elixir-autogen, elixir-format
 msgid "Root handle"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:191
+#: lib/vutuv_web/live/organization_live/edit.ex:203
 #, elixir-autogen, elixir-format
 msgid "That handle is not available."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:435
+#: lib/vutuv_web/live/organization_live/edit.ex:447
 #, elixir-autogen, elixir-format
 msgid "Danger zone"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:446
+#: lib/vutuv_web/live/organization_live/edit.ex:458
 #, elixir-autogen, elixir-format
 msgid "Really delete %{name}? This cannot be undone."
 msgstr ""
@@ -11927,7 +11939,7 @@ msgid_plural "%{count} aliases match another verified organization and are flagg
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:341
+#: lib/vutuv_web/live/organization_live/edit.ex:353
 #, elixir-autogen, elixir-format
 msgid "Alternative names, brands or abbreviations this organization is findable under. A rename keeps the old name here automatically."
 msgstr ""
@@ -11957,7 +11969,7 @@ msgstr ""
 msgid "Any signed-in member whose confirmed email is at this domain, or a subdomain of it, is excluded. This is the reliable way to hide from your whole organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:390
+#: lib/vutuv_web/live/organization_live/edit.ex:402
 #, elixir-autogen, elixir-format
 msgid "Claim a short @handle so this organization has its own root URL, like a member profile. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr ""
@@ -11996,17 +12008,17 @@ msgstr ""
 msgid "These steps are technical. If you don't manage %{domain} yourself, copy the record or file shown below and send it to your IT team or whoever runs your website. Once they have added it, come back here and press Verify now."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:450
+#: lib/vutuv_web/live/organization_live/edit.ex:462
 #, elixir-autogen, elixir-format
 msgid "Delete this organization"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:437
+#: lib/vutuv_web/live/organization_live/edit.ex:449
 #, elixir-autogen, elixir-format
 msgid "Deleting this organization page is permanent. Its verified domains and its @handle are freed and can be claimed again."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:256
+#: lib/vutuv_web/live/organization_live/edit.ex:268
 #: lib/vutuv_web/live/organization_live/new.ex:111
 #, elixir-autogen, elixir-format
 msgid "Kind of organization"
@@ -12072,7 +12084,7 @@ msgstr ""
 msgid "Organization frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:255
+#: lib/vutuv_web/live/organization_live/edit.ex:267
 #: lib/vutuv_web/live/organization_live/new.ex:110
 #, elixir-autogen, elixir-format
 msgid "Organization name"
@@ -12091,7 +12103,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:833
+#: lib/vutuv_web/live/notification_live/index.ex:861
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12103,7 +12115,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
 #: lib/vutuv_web/components/ui.ex:3175
-#: lib/vutuv_web/controllers/settings_controller.ex:157
+#: lib/vutuv_web/controllers/settings_controller.ex:158
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
 #: lib/vutuv_web/live/post_live/saved.ex:455
@@ -12149,7 +12161,7 @@ msgstr ""
 msgid "That name is already listed for this organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:179
+#: lib/vutuv_web/live/organization_live/edit.ex:191
 #, elixir-autogen, elixir-format
 msgid "The organization page was deleted."
 msgstr ""
@@ -12174,12 +12186,12 @@ msgstr ""
 msgid "Verified organization pages: domains, team roles, aliases and rename history. Freeze, archive or delete a page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:162
+#: lib/vutuv_web/live/organization_live/edit.ex:174
 #, elixir-autogen, elixir-format
 msgid "You are not allowed to delete this organization."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:135
+#: lib/vutuv_web/live/organization_live/edit.ex:139
 #, elixir-autogen, elixir-format
 msgid "Your organization handle is set."
 msgstr ""
@@ -12194,27 +12206,27 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:985
+#: lib/vutuv_web/live/notification_live/index.ex:1013
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:982
+#: lib/vutuv_web/live/notification_live/index.ex:1010
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:979
+#: lib/vutuv_web/live/notification_live/index.ex:1007
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:976
+#: lib/vutuv_web/live/notification_live/index.ex:1004
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:419
+#: lib/vutuv_web/live/organization_live/edit.ex:431
 #, elixir-autogen, elixir-format
 msgid "your_organization"
 msgstr ""
@@ -12370,7 +12382,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:354
 #: lib/vutuv_web/agent_docs/text.ex:213
 #: lib/vutuv_web/agent_docs/text.ex:380
-#: lib/vutuv_web/live/job_board_live.ex:281
+#: lib/vutuv_web/live/job_board_live.ex:367
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
 msgid "Employment type"
@@ -12406,7 +12418,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:747
+#: lib/vutuv/accounts/user.ex:792
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12429,8 +12441,8 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/job_board_doc.ex:19
 #: lib/vutuv_web/components/saved_search_components.ex:56
-#: lib/vutuv_web/live/job_board_live.ex:41
-#: lib/vutuv_web/live/job_board_live.ex:146
+#: lib/vutuv_web/live/job_board_live.ex:45
+#: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:458
 #: lib/vutuv_web/live/shell_live.ex:457
 #: lib/vutuv_web/templates/layout/app.html.heex:77
@@ -12526,7 +12538,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:746
+#: lib/vutuv/accounts/user.ex:791
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12608,7 +12620,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:748
+#: lib/vutuv/accounts/user.ex:793
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
 #: lib/vutuv_web/agent_docs/markdown.ex:339
@@ -12824,12 +12836,12 @@ msgstr ""
 msgid "Browse all organizations"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:28
+#: lib/vutuv_web/views/settings_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Under review"
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:30
+#: lib/vutuv_web/views/settings_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Verification pending"
 msgstr ""
@@ -12871,7 +12883,7 @@ msgstr ""
 msgid "Name (host)"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:143
+#: lib/vutuv_web/live/organization_live/edit.ex:147
 #, elixir-autogen, elixir-format
 msgid "Only a verified organization page can claim a handle."
 msgstr ""
@@ -12895,12 +12907,12 @@ msgid_plural "%{count} weeks ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/job_board_live.ex:387
+#: lib/vutuv_web/live/job_board_live.ex:491
 #, elixir-autogen, elixir-format
 msgid "%{km} km"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:275
+#: lib/vutuv_web/live/job_board_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "All countries"
 msgstr ""
@@ -12916,42 +12928,42 @@ msgstr ""
 msgid "All jobs with this tag: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:282
+#: lib/vutuv_web/live/job_board_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Any employment type"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:264
+#: lib/vutuv_web/live/job_board_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "City or zip code"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:387
+#: lib/vutuv_web/live/job_board_live.ex:491
 #, elixir-autogen, elixir-format
 msgid "Exact"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:184
+#: lib/vutuv_web/live/job_board_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "From my salary expectation"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:176
+#: lib/vutuv_web/live/job_board_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Matches my tags"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:357
+#: lib/vutuv_web/live/job_board_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "Min. salary/year (%{currency})"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:306
+#: lib/vutuv_web/live/job_board_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Minimum yearly salary"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:239
+#: lib/vutuv_web/live/job_board_live.ex:324
 #: lib/vutuv_web/live/organization_live/show.ex:342
 #, elixir-autogen, elixir-format
 msgid "More jobs"
@@ -12967,12 +12979,12 @@ msgstr ""
 msgid "Next page: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:395
+#: lib/vutuv_web/live/job_board_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "No job postings yet."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:393
+#: lib/vutuv_web/live/job_board_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
@@ -12988,27 +13000,27 @@ msgid "Open positions"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/job_board_doc.ex:20
-#: lib/vutuv_web/live/job_board_live.ex:148
+#: lib/vutuv_web/live/job_board_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Open positions on vutuv, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:156
+#: lib/vutuv_web/live/job_board_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Post a job"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:221
+#: lib/vutuv_web/live/job_board_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:268
+#: lib/vutuv_web/live/job_board_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "Radius"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:256
+#: lib/vutuv_web/live/job_board_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Search jobs"
 msgstr ""
@@ -13209,7 +13221,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:269
+#: lib/vutuv_web/controllers/settings_controller.ex:397
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -13275,13 +13287,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:287
+#: lib/vutuv_web/controllers/settings_controller.ex:415
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3213
-#: lib/vutuv_web/controllers/settings_controller.ex:245
+#: lib/vutuv_web/components/ui.ex:3214
+#: lib/vutuv_web/controllers/settings_controller.ex:320
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13300,8 +13312,8 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:274
-#: lib/vutuv_web/controllers/settings_controller.ex:292
+#: lib/vutuv_web/controllers/settings_controller.ex:402
+#: lib/vutuv_web/controllers/settings_controller.ex:420
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -13347,7 +13359,7 @@ msgstr ""
 msgid "job search"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:299
+#: lib/vutuv_web/live/search_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "only people open to offers (status:open) or looking (status:looking)"
 msgstr ""
@@ -13521,7 +13533,7 @@ msgstr ""
 msgid "Reviewed, all fine: clear the flag"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/edit.ex:169
+#: lib/vutuv_web/live/organization_live/edit.ex:181
 #, elixir-autogen, elixir-format
 msgid "This page has job postings, so it cannot be deleted. Ask an admin to archive it instead."
 msgstr ""
@@ -13554,7 +13566,7 @@ msgstr ""
 msgid "Image is being reviewed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:831
+#: lib/vutuv_web/live/notification_live/index.ex:859
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13595,7 +13607,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:791
+#: lib/vutuv/accounts/user.ex:836
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13606,19 +13618,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:794
+#: lib/vutuv/accounts/user.ex:839
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:797
+#: lib/vutuv/accounts/user.ex:842
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:788
+#: lib/vutuv/accounts/user.ex:833
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13641,7 +13653,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:834
+#: lib/vutuv_web/live/notification_live/index.ex:862
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13653,7 +13665,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1035
+#: lib/vutuv_web/live/notification_live/index.ex:1063
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13700,12 +13712,12 @@ msgstr ""
 msgid "Posts with this tag"
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:268
+#: lib/vutuv_web/live/search_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Your search uses a people-only filter such as city: or status:, so it only finds people."
 msgstr ""
 
-#: lib/vutuv_web/live/search_live.ex:295
+#: lib/vutuv_web/live/search_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "people and posts with this tag, combinable: miller tag:php"
 msgstr ""
@@ -13745,46 +13757,46 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3202
-#: lib/vutuv_web/controllers/settings_controller.ex:259
-#: lib/vutuv_web/live/post_live/feed.ex:651
+#: lib/vutuv_web/components/ui.ex:3203
+#: lib/vutuv_web/controllers/settings_controller.ex:334
+#: lib/vutuv_web/live/post_live/feed.ex:732
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:666
+#: lib/vutuv_web/live/post_live/feed.ex:747
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:324
+#: lib/vutuv_web/live/job_board_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:320
+#: lib/vutuv_web/live/job_board_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "Search tips"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:378
+#: lib/vutuv_web/live/job_board_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "any of these titles"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:380
+#: lib/vutuv_web/live/job_board_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "exact wording"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:381
+#: lib/vutuv_web/live/job_board_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "without internships"
 msgstr ""
 
-#: lib/vutuv_web/live/job_board_live.ex:379
+#: lib/vutuv_web/live/job_board_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "word start: also finds Entwickler, Entwicklung"
 msgstr ""
@@ -13795,7 +13807,7 @@ msgid "Signal and WhatsApp accept a phone number or a username; the other messen
 msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1005
+#: lib/vutuv_web/templates/user/show.html.heex:1009
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13832,7 +13844,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:3
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1003
+#: lib/vutuv_web/templates/user/show.html.heex:1007
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13864,22 +13876,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:835
+#: lib/vutuv_web/live/notification_live/index.ex:863
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1055
+#: lib/vutuv_web/live/notification_live/index.ex:1083
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1047
+#: lib/vutuv_web/live/notification_live/index.ex:1075
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1052
+#: lib/vutuv_web/live/notification_live/index.ex:1080
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13904,7 +13916,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1060
+#: lib/vutuv_web/live/notification_live/index.ex:1088
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -14097,45 +14109,45 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:712
+#: lib/vutuv_web/live/notification_live/index.ex:740
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:726
+#: lib/vutuv_web/live/notification_live/index.ex:754
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:321
+#: lib/vutuv_web/live/notification_live/index.ex:330
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:336
+#: lib/vutuv_web/live/notification_live/index.ex:345
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:678
-#: lib/vutuv_web/live/notification_live/index.ex:883
+#: lib/vutuv_web/live/notification_live/index.ex:706
+#: lib/vutuv_web/live/notification_live/index.ex:911
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:850
+#: lib/vutuv_web/live/notification_live/index.ex:878
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:845
+#: lib/vutuv_web/live/notification_live/index.ex:873
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:860
+#: lib/vutuv_web/live/notification_live/index.ex:888
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -14370,7 +14382,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:648
+#: lib/vutuv_web/live/notification_live/index.ex:676
 #, elixir-autogen, elixir-format
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
@@ -14380,17 +14392,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1009
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:826
+#: lib/vutuv_web/live/notification_live/index.ex:854
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:870
+#: lib/vutuv_web/live/notification_live/index.ex:898
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14409,12 +14421,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:827
+#: lib/vutuv_web/live/notification_live/index.ex:855
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:968
+#: lib/vutuv_web/live/notification_live/index.ex:996
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -14696,4 +14708,155 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "as an account alias."
+msgstr ""
+
+#: lib/vutuv_web/templates/user_tag/show.html.heex:24
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{formatted} endorsement"
+msgid_plural "%{formatted} endorsements"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/templates/user_tag/show.html.heex:36
+#, elixir-autogen, elixir-format
+msgid "All endorsers"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:351
+#, elixir-autogen, elixir-format
+msgid "Filter added. Matching posts are now hidden from your feed."
+msgstr ""
+
+#: lib/vutuv_web/live/job_board_live.ex:389
+#, elixir-autogen, elixir-format
+msgid "Filter by a tag"
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:376
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Filter removed."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/feed.ex:201
+#, elixir-autogen, elixir-format
+msgid "Hidden: matches your filter"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:5
+#, elixir-autogen, elixir-format
+msgid "Hide posts from your feed that carry a tag, or that contain a word or phrase. This list is yours alone: it is never shared, the author is never told, and a hidden post collapses to a line you can still open."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:54
+#, elixir-autogen, elixir-format
+msgid "Match whole words only (word/phrase)"
+msgstr ""
+
+#: lib/vutuv_web/components/ui.ex:3185
+#: lib/vutuv_web/controllers/settings_controller.ex:387
+#: lib/vutuv_web/templates/settings/filters.html.heex:1
+#: lib/vutuv_web/templates/settings/filters.html.heex:3
+#, elixir-autogen, elixir-format
+msgid "Muted words & tags"
+msgstr ""
+
+#: lib/vutuv_web/templates/user_tag/show.html.heex:20
+#, elixir-autogen, elixir-format
+msgid "Nobody has endorsed %{name} for this tag yet."
+msgstr ""
+
+#: lib/vutuv_web/templates/education/card_list.html.heex:40
+#, elixir-autogen, elixir-format
+msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/feed.ex:210
+#, elixir-autogen, elixir-format
+msgid "Show anyway"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:105
+#, elixir-autogen, elixir-format
+msgid "Tell me about new replies in threads I take part in"
+msgstr ""
+
+#: lib/vutuv_web/controllers/education_controller.ex:80
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That education could not be pinned."
+msgstr ""
+
+#: lib/vutuv_web/controllers/education_controller.ex:90
+#, elixir-autogen, elixir-format
+msgid "The top of your profile is chosen automatically again."
+msgstr ""
+
+#: lib/vutuv_web/controllers/education_controller.ex:75
+#, elixir-autogen, elixir-format, fuzzy
+msgid "This education now shows at the top of your profile."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:99
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Thread replies"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:481
+#, elixir-autogen, elixir-format
+msgid "Turn off thread notifications"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:43
+#, elixir-autogen, elixir-format
+msgid "Use * as a wildcard (crypto* → cryptobro). Whole-word by default."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:107
+#, elixir-autogen, elixir-format
+msgid "When off, you only hear about direct answers to your own posts, never other replies in the thread."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/notifications.html.heex:101
+#, elixir-autogen, elixir-format
+msgid "When someone replies anywhere in a thread you have written in, you hear about it under the bell, so a discussion reaches everyone who took part. Never by email."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:19
+#: lib/vutuv_web/views/settings_html.ex:23
+#, elixir-autogen, elixir-format
+msgid "Word or phrase"
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:26
+#, elixir-autogen, elixir-format
+msgid "Word or phrase (whole word)"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "Word, phrase or tag to mute"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/edit.ex:161
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You are not allowed to change this organization's handle."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:87
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You have not muted anything yet."
+msgstr ""
+
+#: lib/vutuv_web/controllers/settings_controller.ex:359
+#, elixir-autogen, elixir-format
+msgid "You have reached the maximum of %{count} filters."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:476
+#, elixir-autogen, elixir-format
+msgid "You wrote in this thread."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/filters.html.heex:31
+#, elixir-autogen, elixir-format
+msgid "e.g. crypto*, \"machine learning\", politics"
 msgstr ""

--- a/priv/repo/migrations/20260724120215_add_profile_education_id_to_users.exs
+++ b/priv/repo/migrations/20260724120215_add_profile_education_id_to_users.exs
@@ -1,0 +1,24 @@
+defmodule Vutuv.Repo.Migrations.AddProfileEducationIdToUsers do
+  use Ecto.Migration
+
+  # The education a member pinned as their profile headline (issue #882): the
+  # "Degree, School" line that leads the profile instead of a job title, for a
+  # student or someone unemployed who wants to feature a school over a role.
+  # NULL = no education pinned (today's behaviour, the header falls back to the
+  # work-experience resolution), so this is a plain, backward-compatible
+  # addition the currently deployed release simply ignores. It is the education
+  # twin of profile_work_experience_id (issue #833); the two are mutually
+  # exclusive in the pin-setting code, not the schema. ON DELETE SET NULL means
+  # deleting the pinned entry clears the pointer, so the header can never point
+  # at a gone education. The index keeps that SET NULL cascade (and any lookup)
+  # off a users seq scan.
+  def change do
+    alter table(:users) do
+      add(:profile_education_id,
+        references(:educations, on_delete: :nilify_all, type: :binary_id)
+      )
+    end
+
+    create(index(:users, [:profile_education_id]))
+  end
+end

--- a/test/vutuv_web/controllers/education_pin_test.exs
+++ b/test/vutuv_web/controllers/education_pin_test.exs
@@ -1,0 +1,224 @@
+defmodule VutuvWeb.EducationPinTest do
+  @moduledoc """
+  The profile-headline chooser for education (issue #882): the owner may pin an
+  education entry as the "Degree, School" line at the top of their profile,
+  instead of a job title, for a student or someone unemployed. The headline is
+  EITHER a pinned work experience OR a pinned education, never both, so pinning
+  one clears the other. Clearing falls back to the automatic job heuristic, and
+  only the owner may pin their own entry.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Accounts
+  alias Vutuv.Accounts.User
+  alias VutuvWeb.AgentDocs.ProfileDoc
+
+  @headline "Doctor of Medicine, St. Mary's University"
+  # The apostrophe in the school name is HTML-escaped to &#39; in rendered
+  # pages, so raw-HTML string assertions match on the part before it; the
+  # LiveView `has_element?` text filter and the raw ProfileDoc struct keep the
+  # full string.
+  @headline_html "Doctor of Medicine, St. Mary"
+
+  setup %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+
+    # An open-ended role the automatic heuristic leads with while nothing is
+    # pinned — so a switch to the pinned education is observable.
+    job =
+      insert(:work_experience,
+        user: user,
+        title: "Current Role",
+        organization: "NowCo",
+        start_month: 3,
+        start_year: 2021,
+        end_month: nil,
+        end_year: nil
+      )
+
+    degree =
+      insert(:education,
+        user: user,
+        degree: "Doctor of Medicine",
+        school: "St. Mary's University",
+        field_of_study: "Medicine"
+      )
+
+    school =
+      insert(:education,
+        user: user,
+        degree: nil,
+        school: "Old Grammar School",
+        kind: "school"
+      )
+
+    %{conn: conn, user: user, job: job, degree: degree, school: school}
+  end
+
+  defp meta_description(html) do
+    [_, description] = Regex.run(~r/<meta name="description" content="([^"]*)"/, html)
+    description
+  end
+
+  # ── The context: mutual exclusion + authorization ──
+
+  describe "Accounts.pin_profile_education/2 (mutual exclusion + ownership)" do
+    test "pinning an education sets the pointer and clears a pinned work experience", ctx do
+      %{user: user, job: job, degree: degree} = ctx
+
+      {:ok, user} = Accounts.pin_profile_work_experience(user, job)
+      assert user.profile_work_experience_id == job.id
+
+      {:ok, user} = Accounts.pin_profile_education(user, degree)
+
+      assert user.profile_education_id == degree.id
+      assert is_nil(user.profile_work_experience_id)
+    end
+
+    test "pinning a work experience clears a pinned education", ctx do
+      %{user: user, job: job, degree: degree} = ctx
+
+      {:ok, user} = Accounts.pin_profile_education(user, degree)
+      assert user.profile_education_id == degree.id
+
+      {:ok, user} = Accounts.pin_profile_work_experience(user, job)
+
+      assert user.profile_work_experience_id == job.id
+      assert is_nil(user.profile_education_id)
+    end
+
+    test "unpinning clears only the education pointer", ctx do
+      %{user: user, degree: degree} = ctx
+
+      {:ok, user} = Accounts.pin_profile_education(user, degree)
+      {:ok, user} = Accounts.unpin_profile_education(user)
+
+      assert is_nil(user.profile_education_id)
+    end
+
+    test "a member cannot pin another user's education", %{user: user} do
+      other = insert_activated_user()
+      foreign = insert(:education, user: other, degree: "Foreign Degree", school: "TheirSchool")
+
+      assert {:error, :not_owner} = Accounts.pin_profile_education(user, foreign)
+      assert is_nil(Repo.get!(User, user.id).profile_education_id)
+    end
+  end
+
+  # ── The controller flow ──
+
+  test "by default the header leads with the heuristic job", %{conn: conn, user: user} do
+    html = conn |> get(~p"/#{user}") |> html_response(200)
+    assert meta_description(html) =~ "Current Role @ NowCo"
+    refute meta_description(html) =~ @headline
+  end
+
+  test "the owner pins an education and the profile header follows", ctx do
+    %{conn: conn, user: user, degree: degree} = ctx
+
+    conn = put(conn, ~p"/settings/educations/#{degree}/pin")
+    assert redirected_to(conn) == ~p"/settings/educations"
+    assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "at the top of your profile"
+
+    assert Repo.get!(User, user.id).profile_education_id == degree.id
+
+    html = conn |> get(~p"/#{user}") |> html_response(200)
+    assert meta_description(html) =~ @headline_html
+    refute meta_description(html) =~ "Current Role"
+  end
+
+  test "the connected profile renders the pinned education as the headline line", ctx do
+    %{conn: conn, user: user, degree: degree} = ctx
+
+    {:ok, _user} = Accounts.pin_profile_education(user, degree)
+
+    {:ok, view, _html} = live(conn, ~p"/#{user}")
+
+    assert has_element?(view, "#profile-headline", @headline)
+    refute has_element?(view, "#profile-headline", "Current Role")
+  end
+
+  test "clearing the pin falls back to the automatic job heuristic", ctx do
+    %{conn: conn, user: user, degree: degree} = ctx
+
+    conn = put(conn, ~p"/settings/educations/#{degree}/pin")
+    assert Repo.get!(User, user.id).profile_education_id == degree.id
+
+    conn = delete(conn, ~p"/settings/educations/#{degree}/pin")
+    assert redirected_to(conn) == ~p"/settings/educations"
+    assert is_nil(Repo.get!(User, user.id).profile_education_id)
+
+    html = conn |> get(~p"/#{user}") |> html_response(200)
+    assert meta_description(html) =~ "Current Role @ NowCo"
+  end
+
+  test "the /settings editor offers the chooser to the owner", ctx do
+    %{conn: conn, degree: degree, school: school} = ctx
+
+    html = conn |> get(~p"/settings/educations") |> html_response(200)
+
+    assert html =~ ~p"/settings/educations/#{degree}/pin"
+    assert html =~ ~p"/settings/educations/#{school}/pin"
+    assert html =~ "Show at top of profile"
+    refute html =~ "Choose automatically instead"
+  end
+
+  test "with an education pinned the editor names it and offers a clear revert", ctx do
+    %{conn: conn, user: user, degree: degree} = ctx
+
+    conn = put(conn, ~p"/settings/educations/#{degree}/pin")
+    assert Repo.get!(User, user.id).profile_education_id == degree.id
+
+    html = conn |> get(~p"/settings/educations") |> html_response(200)
+
+    assert html =~ @headline_html
+    assert html =~ "shows at the top of your profile"
+    assert html =~ "Choose automatically instead"
+    assert html =~ "Shown at the top of your profile"
+  end
+
+  test "the public educations page never shows the chooser", %{user: user, degree: degree} do
+    html = build_conn() |> get(~p"/#{user}/educations") |> html_response(200)
+    refute html =~ ~p"/settings/educations/#{degree}/pin"
+    refute html =~ "Show at top of profile"
+  end
+
+  test "a logged-out request cannot pin", %{user: user, degree: degree} do
+    conn = put(build_conn(), ~p"/settings/educations/#{degree}/pin")
+    assert redirected_to(conn) == "/"
+    assert is_nil(Repo.get!(User, user.id).profile_education_id)
+  end
+
+  # ── Agent docs (ProfileDoc) reflect the pinned education ──
+
+  test "the profile doc's headline reflects a pinned education", ctx do
+    %{user: user, degree: degree} = ctx
+
+    {:ok, _user} = Accounts.pin_profile_education(user, degree)
+
+    # Build from a fresh struct, the way the controller passes the plug-resolved
+    # user (ProfileDoc.build owns all preloading); the setup user carries a
+    # partial user_tags preload that would shadow it.
+    doc = ProfileDoc.build(Repo.get!(User, user.id))
+    assert doc.work_info == @headline
+    assert doc.description == @headline
+  end
+
+  # The German UI must stay translated (issue #882 copy). Runtime Gettext lookups
+  # so the extractor ignores them.
+  test "the chooser copy is translated into German" do
+    backend = VutuvWeb.Gettext
+    Gettext.put_locale(backend, "de")
+
+    assert Gettext.gettext(backend, "This education now shows at the top of your profile.") ==
+             "Diese Ausbildung wird jetzt oben in Ihrem Profil angezeigt."
+
+    assert Gettext.gettext(
+             backend,
+             "Pick a degree or school below to show it at the top of your profile instead of a job title."
+           ) ==
+             "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines Jobtitels oben in Ihrem Profil anzuzeigen."
+  end
+end

--- a/test/vutuv_web/views/user_helpers_test.exs
+++ b/test/vutuv_web/views/user_helpers_test.exs
@@ -177,6 +177,41 @@ defmodule VutuvWeb.UserHelpersTest do
     end
   end
 
+  describe "a pinned education is the profile headline (issue #882)" do
+    test "education_headline/1 reads as 'Degree, School'" do
+      edu = build(:education, degree: "Doctor of Medicine", school: "St. Mary's University")
+      assert UserHelpers.education_headline(edu) == "Doctor of Medicine, St. Mary's University"
+    end
+
+    test "education_headline/1 falls back to the school alone when there is no degree" do
+      edu = build(:education, degree: nil, school: "Old Grammar School")
+      assert UserHelpers.education_headline(edu) == "Old Grammar School"
+    end
+
+    test "education_headline/1 is nil for a nil education, so a caller can fall through" do
+      assert UserHelpers.education_headline(nil) == nil
+    end
+
+    test "profile_headline/3 prefers the pinned education over the job line" do
+      user = insert(:user)
+      we(user, title: "Job Title", organization: "JobCo", end_month: nil, end_year: nil)
+      degree = insert(:education, user: user, degree: "PhD", school: "Uni")
+      {:ok, user} = Vutuv.Accounts.pin_profile_education(user, degree)
+
+      job = UserHelpers.current_job(user)
+      assert UserHelpers.profile_headline(user, job) == "PhD, Uni"
+    end
+
+    test "profile_headline/3 uses the job line when no education is pinned" do
+      user = insert(:user)
+      we(user, title: "Job Title", organization: "JobCo", end_month: nil, end_year: nil)
+      insert(:education, user: user, degree: "PhD", school: "Uni")
+
+      job = UserHelpers.current_job(user)
+      assert UserHelpers.profile_headline(user, job) == "Job Title @ JobCo"
+    end
+  end
+
   describe "work_information_string_for_job/2 matches work_information_string/2" do
     test "current job with title and organization" do
       user = insert(:user)


### PR DESCRIPTION
Closes #882

## What

Members can now pin an **education** entry as their profile "headline" (the line under their name), the same way an Experience can already be pinned (#833). The headline is **either** a pinned work experience **or** a pinned education, never both. Use case: a student or someone unemployed who would rather feature a degree/school than a job title.

## How

- **Migration**: new nullable `users.profile_education_id` (`references(:educations, on_delete: :nilify_all)`), the education twin of `profile_work_experience_id`. Plain additive column, N-1 safe, single deploy.
- **Mutual exclusion**: pinning an education clears any pinned work experience and vice versa, in the same `Accounts` write. Both setters are owner-scoped (`{:error, :not_owner}` for a foreign entry).
- **One resolution seam** `UserHelpers.profile_headline/3`: pinned education's "Degree, School" (e.g. "Doctor of Medicine, St. Mary's University") wins, else the pinned/heuristic job line, else the existing tagline path is untouched. It feeds the profile header, the page title, the meta/OpenGraph description and `ProfileDoc`, so all four stay consistent. Preload-aware, so it runs no extra query when nothing is pinned (the common case).
- **Chooser UI**: `/settings/educations` gains the same "Show at top of profile" pin control Experience has (per-entry pin button, the pinned one marked, one revert to automatic), mirroring its CSRF + Direction-A pattern. Hidden on the public showcase.
- **Agent docs**: `ProfileDoc`'s `work_info`/`description` reflect a pinned education; drift test stays green.

## Listing rows

**Left as-is.** Search / follower / who-to-follow rows still show the job line (via `work_information_map/2`), which the issue explicitly permits. Reflecting a pinned education there would need a second batched educations query, which is out of scope for this change; the required surfaces (profile header + agent docs) are covered.

## Incidental

While syncing gettext, the extractor surfaced one pre-existing untranslated German string ("You are not allowed to change this organization's handle.") and gave it a wrong fuzzy guess; I translated it correctly rather than leave it broken.

## Tests (all new/extended, test-first)

- `test/vutuv_web/controllers/education_pin_test.exs` — context (pin sets pointer + clears the work pin, and vice versa; unpin; **cannot pin another user's education**), controller flow (pin/unpin routes, header + meta follow the pin, logged-out cannot pin, public page hides the chooser), the connected `UserProfileLive` header via `#profile-headline`, `ProfileDoc` reflects the pinned education, German copy.
- `test/vutuv_web/views/user_helpers_test.exs` — `education_headline/1` (degree+school, school-only, nil) and `profile_headline/3` precedence.

`mix precommit` is fully green. Version bumped 7.144.0 → 7.145.0.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
