### PR TITLE
Name the thread notification opt-out link

### DIFF
--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -478,7 +478,7 @@ defmodule VutuvWeb.NotificationLive.Index do
             href={~p"/settings/notifications"}
             class="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
           >
-            {gettext("Turn this off")} ›
+            {gettext("Turn off thread notifications")} ›
           </.link>
         </p>
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.144.2",
+      version: "7.144.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -14680,8 +14680,8 @@ msgstr "Sie haben in diesem Thread geschrieben."
 
 #: lib/vutuv_web/live/notification_live/index.ex:463
 #, elixir-autogen, elixir-format
-msgid "Turn this off"
-msgstr "Das abschalten"
+msgid "Turn off thread notifications"
+msgstr "Thread-Benachrichtigungen abschalten"
 
 #: lib/vutuv_web/live/notification_live/index.ex:1060
 #, elixir-autogen, elixir-format

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -498,6 +498,12 @@ defmodule VutuvWeb.NotificationLiveTest do
       # Exactly one hint for the day, linking to the notification settings.
       assert length(Regex.scan(~r/data-thread-hint/, html)) == 1
       assert has_element?(live, ~s([data-thread-hint] a[href="/settings/notifications"]))
+      # The link names what it switches off, not a vague "turn this off".
+      assert has_element?(
+               live,
+               ~s([data-thread-hint] a[href="/settings/notifications"]),
+               "Turn off thread notifications"
+             )
     end
 
     test "the posts filter tab keeps thread rows", %{conn: conn} do


### PR DESCRIPTION
**TL;DR** On `/notifications` the thread hint's opt-out link read "Das abschalten" ("turn that off"), which never says *what* it turns off. It now names the setting: "Thread-Benachrichtigungen abschalten".

**Where:** `lib/vutuv_web/live/notification_live/index.ex` (the per-day thread hint) + `priv/gettext/de/LC_MESSAGES/default.po`
**Now:** the hint reads "Sie haben in diesem Thread geschrieben. **Das abschalten ›**" — ambiguous next to a sentence about a thread.
**Want:** "Sie haben in diesem Thread geschrieben. **Thread-Benachrichtigungen abschalten ›**", matching the "Thread-Antworten" section it links to.

Copy-only change to the LiveView (no auth/form/email surface). The existing hint test now also asserts the link text so a vague label can't creep back. `mix precommit` green (4765 passed); version bumped 7.144.2 → 7.144.3.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*