### PR TITLE
Bound the login rate limiter's ETS table against a giant email key (F11/F13)

### DIFF
--- a/lib/vutuv_web/rate_limit.ex
+++ b/lib/vutuv_web/rate_limit.ex
@@ -47,14 +47,28 @@ defmodule VutuvWeb.RateLimit do
     if enabled?() do
       lim = Keyword.get(opts, :limit, limit())
       win = Keyword.get(opts, :window_ms, window_ms())
-      keys = [{event, :ip, ip(conn)} | identity_keys(event, extra)]
 
-      results = Enum.map(keys, fn key -> RateLimiter.hit(key, lim, win) end)
-
-      if Enum.all?(results, &(&1 == :ok)), do: :ok, else: :rate_limited
+      # Hit the per-IP bucket FIRST and stop the moment it is exhausted, before
+      # touching (and thus creating) any per-identity bucket. This bounds the
+      # number of identity buckets one IP can plant to its own per-window budget;
+      # without it a rate-limited client kept writing a fresh identity bucket per
+      # distinct email even after its IP budget was spent (F13). `and` short-
+      # circuits, so `identities_ok?/4` never runs once the IP key is over.
+      if RateLimiter.hit({event, :ip, ip(conn)}, lim, win) == :ok and
+           identities_ok?(event, extra, lim, win) do
+        :ok
+      else
+        :rate_limited
+      end
     else
       :ok
     end
+  end
+
+  defp identities_ok?(event, extra, lim, win) do
+    event
+    |> identity_keys(extra)
+    |> Enum.all?(fn key -> RateLimiter.hit(key, lim, win) == :ok end)
   end
 
   @doc """
@@ -79,10 +93,48 @@ defmodule VutuvWeb.RateLimit do
   end
 
   defp identity_keys(_event, nil), do: []
-  defp identity_keys(event, extra), do: [{event, :id, normalize(extra)}]
+  defp identity_keys(event, extra), do: [{event, :id, hash_identity(extra)}]
 
-  defp normalize(value) when is_binary(value), do: String.downcase(value)
-  defp normalize(value), do: value
+  # Longest byte prefix of an identity value that is ever downcased/hashed. Real
+  # identities are tiny (an email is <= 254 chars, a UUID id 36 bytes), so this
+  # never truncates a legitimate value into a collision; it only caps the CPU an
+  # attacker's oversized `session[email]` (up to Plug's body limit) can spend
+  # before we discard the excess.
+  @max_identity_bytes 1024
+
+  # The `extra` for the email-keyed events is the RAW, length-unvalidated email
+  # from unauthenticated public endpoints (POST /login etc.). Using it verbatim
+  # as part of an ETS bucket key let an attacker plant a multi-MB row per distinct
+  # value for the whole window (unbounded-growth DoS, F11), and — per the project
+  # hashing rule — a bare hash of a low-entropy email is enumerable from an
+  # in-memory table read. So collapse every identity to a FIXED-SIZE, keyed HMAC:
+  # cap the length first (bounds CPU), downcase (case-insensitive bucketing), then
+  # HMAC with a server-secret pepper (32-byte digest, and a table read alone can't
+  # recover which emails hit the limiter). Applied uniformly to the `linkedin_import`
+  # user id too — already fixed size, so hashing it is harmless and keeps one path.
+  defp hash_identity(value) do
+    normalized =
+      value
+      |> to_string()
+      |> cap_length()
+      |> String.downcase()
+
+    :crypto.mac(:hmac, :sha256, pepper(), normalized)
+  end
+
+  defp cap_length(binary) when byte_size(binary) <= @max_identity_bytes, do: binary
+  defp cap_length(binary), do: binary_part(binary, 0, @max_identity_bytes)
+
+  # Dedicated pepper derived from `secret_key_base` with its OWN domain-separation
+  # string (so it never equals the raw secret nor the login-PIN pepper), held
+  # outside any persisted store — mirrors `Vutuv.Accounts`' login-PIN pepper.
+  defp pepper do
+    :crypto.hash(:sha256, "vutuv/rate_limit/pepper/v1" <> secret_key_base())
+  end
+
+  defp secret_key_base do
+    Application.fetch_env!(:vutuv, VutuvWeb.Endpoint)[:secret_key_base]
+  end
 
   # The real client address (resolved by the endpoint's RemoteIp plug from
   # X-Forwarded-For), not the loopback proxy hop.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.145.0",
+      version: "7.145.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/rate_limit_test.exs
+++ b/test/vutuv_web/rate_limit_test.exs
@@ -1,16 +1,29 @@
 defmodule VutuvWeb.RateLimitTest do
   use ExUnit.Case, async: false
 
+  alias Vutuv.RateLimiter
   alias VutuvWeb.RateLimit
 
   setup do
-    Vutuv.RateLimiter.reset()
+    RateLimiter.reset()
     previous = Application.get_env(:vutuv, :rate_limit)
     on_exit(fn -> Application.put_env(:vutuv, :rate_limit, previous) end)
     :ok
   end
 
   defp conn(ip), do: %Plug.Conn{remote_ip: ip}
+
+  # Largest serialized size of any bucket key currently in the limiter table. The
+  # bucket is `{key, window}`; we measure just the caller `key` (the tuple the
+  # RateLimit module builds), which is what an attacker's input would inflate.
+  defp largest_bucket_key_bytes do
+    RateLimiter
+    |> :ets.tab2list()
+    |> Enum.map(fn {{key, _window}, _count, _window_end} ->
+      byte_size(:erlang.term_to_binary(key))
+    end)
+    |> Enum.max()
+  end
 
   test "is a no-op when disabled (the test-env default)" do
     Application.put_env(:vutuv, :rate_limit, enabled: false)
@@ -65,5 +78,51 @@ defmodule VutuvWeb.RateLimitTest do
 
     for _ <- 1..5, do: assert(RateLimit.check_login_resend(c, "x@y.com") == :ok)
     assert RateLimit.check_login_resend(c, "x@y.com") == :rate_limited
+  end
+
+  # F11: the raw email `extra` from the unauthenticated POST /login is length-
+  # unvalidated, so used verbatim it becomes a multi-MB ETS bucket key retained
+  # for the whole window. The keyed HMAC makes the identity component fixed-size.
+  test "the per-identity bucket key stays fixed-size no matter how large the input" do
+    Application.put_env(:vutuv, :rate_limit, enabled: true, limit: 5, window_ms: 60_000)
+
+    giant = String.duplicate("x", 100_000)
+    assert RateLimit.check(conn({10, 0, 0, 21}), :login_email, giant) == :ok
+
+    # Every stored bucket key is small (a 32-byte digest + a couple of atoms),
+    # not a ~100 KB copy of the attacker's input.
+    assert largest_bucket_key_bytes() < 1_000
+  end
+
+  # F13: once the per-IP budget is spent, the limiter must refuse before touching
+  # the per-identity key, so an abusive client cannot keep planting a fresh
+  # identity bucket per distinct email after its IP counter is already exceeded.
+  test "an IP-limited client cannot plant a new identity bucket (short-circuit)" do
+    Application.put_env(:vutuv, :rate_limit, enabled: true, limit: 2, window_ms: 60_000)
+    c = conn({10, 0, 0, 30})
+
+    # Spend the per-IP budget of 2 on two distinct emails (each opens one identity
+    # bucket while the IP is still within budget).
+    assert RateLimit.check(c, :login_email, "one@x.com") == :ok
+    assert RateLimit.check(c, :login_email, "two@x.com") == :ok
+
+    buckets_before = :ets.info(RateLimiter, :size)
+
+    # The IP is now exhausted, so a third request with a brand-new email must be
+    # throttled WITHOUT ever creating that email's identity bucket.
+    assert RateLimit.check(c, :login_email, "three@x.com") == :rate_limited
+
+    assert :ets.info(RateLimiter, :size) == buckets_before
+  end
+
+  # Hashing must not lose the case-insensitive bucketing the raw downcase gave us.
+  test "identity bucketing stays case-insensitive after hashing" do
+    Application.put_env(:vutuv, :rate_limit, enabled: true, limit: 2, window_ms: 60_000)
+
+    # The same address in three cases, from three different IPs, must share one
+    # identity bucket, so the third (over the identity limit of 2) is throttled.
+    assert RateLimit.check(conn({10, 0, 0, 41}), :login_email, "Foo@Example.com") == :ok
+    assert RateLimit.check(conn({10, 0, 0, 42}), :login_email, "foo@example.com") == :ok
+    assert RateLimit.check(conn({10, 0, 0, 43}), :login_email, "FOO@EXAMPLE.COM") == :rate_limited
   end
 end


### PR DESCRIPTION
**TL;DR** The login rate limiter keyed its ETS buckets on the raw, unvalidated email from unauthenticated `POST /login`, so a ~8 MB `session[email]` per request planted a multi-MB row for 3 hours → memory-exhaustion DoS. And it wrote the giant bucket even once the IP was already rate-limited. Batch 4 of the remaining scan mediums.

**Where:** `lib/vutuv_web/rate_limit.ex`

**Now:** `identity_keys/2` used `String.downcase(raw_email)` as part of the ETS `{key, window}` tuple (F11 — unbounded key size), and `check/4` recorded every key with `Enum.map` before deciding, so the per-email bucket was written even when the per-IP counter was already exhausted (F13 — the limiter couldn't throttle its own table).

**What changed (both in `VutuvWeb.RateLimit`):**
- **Fixed-size keyed identity.** The identity component is now `crypto.mac(:hmac, :sha256, pepper, first_1024_bytes_downcased)` — a constant 32 bytes for any input. The pepper is derived from `secret_key_base` with domain separation (`"vutuv/rate_limit/pepper/v1"`), mirroring the login-PIN pepper: an email is low-entropy, so a bare hash a table-reader could dump would still confirm `hash(guess)`; keying it means a read reveals nothing. Case-insensitive bucketing preserved; 1024-byte cap never truncates a real address (≤254 chars).
- **Short-circuit.** `check/4` hits the per-IP key first and only touches the identity key when the IP is within budget — so no identity bucket is written once the IP is rate-limited. This bounds the identity buckets one client can plant to its per-IP budget per window, and stops a single IP from inflating a victim's per-email counter after its own limit is spent.

`Vutuv.RateLimiter` and the API token limiter (already keyed on a fixed-size id) are untouched.

**Verification:** regression tests fail against the unpatched code (a 100 KB email keeps every stored key <1 KB; a fresh email doesn't grow the table once the IP is limited). Reviewed by an independent verifier and re-challenged by a fresh reviewer of the diff, which confirmed the short-circuit preserves per-email throttling in the distributed many-IP/one-victim case. `mix precommit` green: Credo clean, 4768 tests.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01Dz1H9S965ie56hT4DQ6Gax