### PR TITLE
Mark the session and login cookies Secure over https; document HSTS (F8)

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -187,6 +187,14 @@ everything to it. LiveView needs websocket upgrades:
 server {
     server_name example.com;
 
+    # HSTS: tell the browser to only ever reach this host over https, so it
+    # never sends the login-session cookie (`_vutuv_key`) over cleartext http —
+    # closing the very first-request window that the cookie's own `Secure` flag
+    # cannot cover. Only add this on a TLS (https) vhost; an intranet install
+    # served over plain http must NOT set it. `includeSubDomains` covers every
+    # subdomain; drop it if any subdomain is intentionally http-only.
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+
     location / {
         proxy_pass http://127.0.0.1:4003;
         proxy_http_version 1.1;
@@ -200,6 +208,12 @@ server {
     client_max_body_size 64m;
 }
 ```
+
+The app itself does **not** send `Strict-Transport-Security` and does **not**
+enable `Plug.SSL`/`force_ssl`: the blue/green deploy's health gate curls
+`http://127.0.0.1:$PORT/health` on loopback with no `X-Forwarded-Proto`, which
+`Plug.SSL` would redirect and break the deploy. HSTS therefore belongs here in
+the nginx TLS terminator, which every internet install already runs.
 
 ### Uploaded images
 

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -417,8 +417,22 @@ defmodule Vutuv.Accounts do
     payload = Phoenix.Token.sign(@token_context, pin_cookie_salt(), email)
 
     conn
-    |> Conn.delete_resp_cookie(@pin_cookie, max_age: @pin_cookie_max_age)
-    |> Conn.put_resp_cookie(@pin_cookie, payload, max_age: @pin_cookie_max_age)
+    |> Conn.delete_resp_cookie(@pin_cookie, pin_cookie_opts())
+    |> Conn.put_resp_cookie(@pin_cookie, payload, pin_cookie_opts())
+  end
+
+  # Cookie attributes for the login-identity cookie. `Secure` is gated on the
+  # endpoint's public scheme exactly like the session cookie (only over https,
+  # so a plain-HTTP intranet install and dev/test can still set and read it), and
+  # `SameSite=Lax` is set on every scheme. `put_resp_cookie/4` already defaults
+  # `http_only: true`, which we keep. The signed payload holds the pending login
+  # identity, so an on-path attacker must never be able to lift it over http.
+  defp pin_cookie_opts do
+    [
+      max_age: @pin_cookie_max_age,
+      same_site: "Lax",
+      secure: VutuvWeb.Endpoint.secure_cookies?()
+    ]
   end
 
   @doc """
@@ -438,7 +452,7 @@ defmodule Vutuv.Accounts do
 
   @doc "Drops the login-identity cookie (after a successful login or lockout)."
   def delete_pin_cookie(conn) do
-    Conn.delete_resp_cookie(conn, @pin_cookie, max_age: @pin_cookie_max_age)
+    Conn.delete_resp_cookie(conn, @pin_cookie, pin_cookie_opts())
   end
 
   defp pin_cookie_salt do

--- a/lib/vutuv_web/endpoint.ex
+++ b/lib/vutuv_web/endpoint.ex
@@ -115,7 +115,19 @@ defmodule VutuvWeb.Endpoint do
   # /stefan.wintermeyer.md matches the /:slug route; see VutuvWeb.AgentDocs.
   plug(VutuvWeb.Plug.AgentFormat)
 
-  plug(Plug.Session, @session_options)
+  # The login-session cookie (`_vutuv_key`, which carries the `session_token`
+  # `VutuvWeb.Plug.ConfigureSession` trusts) must be marked `Secure` +
+  # `SameSite=Lax` over https, so an on-path attacker on a plain-HTTP request can
+  # never observe or replay it. But whether the cookie may be `Secure` depends on
+  # the endpoint's PUBLIC scheme, which is set at RUNTIME (config/runtime.exs):
+  # https on the internet, http on an intranet install and in dev/test. An
+  # unconditional `secure: true` would make the cookie unusable over plain HTTP.
+  # `@session_options` is a compile-time attribute, so the scheme-dependent flags
+  # are added per request here; the LiveView socket above keeps the plain
+  # `@session_options` (it only DECODES the cookie, so `secure`/`same_site` are
+  # irrelevant there — and must not change, or the key/signing_salt drift and
+  # everyone is logged out).
+  plug(:secure_session)
 
   plug(VutuvWeb.Router)
 
@@ -125,4 +137,27 @@ defmodule VutuvWeb.Endpoint do
   request, where `url/0` is not available.
   """
   def public_url, do: config(:public_url)
+
+  @doc """
+  Whether cookies this endpoint sets may carry the `Secure` flag: true only when
+  the public scheme is https. False on a plain-HTTP (intranet) install and in
+  dev/test, where a `Secure` cookie would never be sent back over http and would
+  break login. Read here by `Plug.Session` and by the login-identity PIN cookie
+  in `Vutuv.Accounts.put_pin_cookie/2`.
+  """
+  def secure_cookies?, do: config(:url)[:scheme] == "https"
+
+  # The `Plug.Session` options with the scheme-dependent `secure` flag and
+  # `SameSite=Lax` added onto the compile-time `@session_options`. Its
+  # `key`/`signing_salt`/`max_age` are `@session_options` unchanged, so existing
+  # cookies keep decoding. Public (`@doc false`) as a test seam: the session
+  # test builds it for an https and an http scheme without mutating global config.
+  @doc false
+  def session_options(secure?) do
+    @session_options ++ [secure: secure?, same_site: "Lax"]
+  end
+
+  defp secure_session(conn, _opts) do
+    Plug.Session.call(conn, Plug.Session.init(session_options(secure_cookies?())))
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.145.1",
+      version: "7.145.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/session_cookie_test.exs
+++ b/test/vutuv_web/session_cookie_test.exs
@@ -1,0 +1,132 @@
+defmodule VutuvWeb.SessionCookieTest do
+  @moduledoc """
+  The login-session cookie (`_vutuv_key`, which carries the `session_token`
+  `VutuvWeb.Plug.ConfigureSession` trusts) and the login-identity PIN cookie
+  (`_vutuv_login_pin`) must be marked `Secure` + `SameSite=Lax` over https, so an
+  on-path attacker on a plain-HTTP request can neither observe nor replay them —
+  while staying usable over plain http on an intranet install (and in dev/test),
+  where a `Secure` cookie would never be sent back and would break login.
+
+  `async: false`: the https cases temporarily override the shared, ETS-backed
+  `VutuvWeb.Endpoint` `:url` scheme (process/node-global config every generated
+  URL reads). ExUnit runs sync modules only after all async modules finish, and
+  runs them serially, so no other module can observe the override; each case
+  restores the original `:url` in an `after` regardless of outcome.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  alias Plug.Conn
+  alias Vutuv.Accounts
+  alias VutuvWeb.Endpoint
+
+  @session_cookie "_vutuv_key"
+  @pin_cookie "_vutuv_login_pin"
+
+  # Run `fun` with the endpoint's public URL scheme forced to `scheme`, then
+  # restore the original `:url` config. `Endpoint.config/1` reads
+  # `:ets.lookup(Endpoint, :url)` directly, so overwriting just that one key is
+  # the minimal, self-contained way to flip the scheme the cookie gate reads.
+  defp with_scheme(scheme, fun) do
+    original = Endpoint.config(:url)
+
+    try do
+      :ets.insert(Endpoint, {:url, Keyword.put(original, :scheme, scheme)})
+      fun.()
+    after
+      :ets.insert(Endpoint, {:url, original})
+    end
+  end
+
+  # The `set-cookie` header string a browser would actually receive for `name`.
+  defp set_cookie(conn, name) do
+    conn
+    |> Conn.get_resp_header("set-cookie")
+    |> Enum.find(&String.starts_with?(&1, name <> "="))
+  end
+
+  describe "Endpoint.secure_cookies?/0 gate" do
+    test "is false when the public scheme is http (the default test env)" do
+      refute Endpoint.secure_cookies?()
+    end
+
+    test "is true only when the public scheme is https" do
+      with_scheme("https", fn -> assert Endpoint.secure_cookies?() end)
+    end
+  end
+
+  describe "session_options/1 builder" do
+    test "adds Secure + SameSite=Lax over https, keeping key/signing_salt/max_age" do
+      opts = Endpoint.session_options(true)
+
+      assert opts[:secure] == true
+      assert opts[:same_site] == "Lax"
+      # The cookie identity must not drift, or every existing session is logged out.
+      assert opts[:key] == "_vutuv_key"
+      assert opts[:signing_salt] == "UOTk6kQ0"
+      assert opts[:max_age] == 7_776_000
+    end
+
+    test "leaves Secure off over http so a plain-HTTP install still works" do
+      opts = Endpoint.session_options(false)
+
+      assert opts[:secure] == false
+      assert opts[:same_site] == "Lax"
+    end
+  end
+
+  describe "the session cookie (_vutuv_key) on a real request" do
+    test "is HttpOnly + SameSite=Lax and NOT Secure over http (login works over http)" do
+      # The Locale plug writes the session on every browser request, so the
+      # landing page emits a fresh session cookie we can inspect.
+      conn = get(build_conn(), "/")
+      cookie = set_cookie(conn, @session_cookie)
+
+      assert cookie, "expected the session write to set #{@session_cookie}"
+      assert cookie =~ "; SameSite=Lax"
+      assert cookie =~ "; HttpOnly"
+      refute cookie =~ "; secure"
+    end
+
+    test "is Secure + SameSite=Lax + HttpOnly when the public scheme is https" do
+      with_scheme("https", fn ->
+        conn = get(build_conn(), "/")
+        cookie = set_cookie(conn, @session_cookie)
+
+        assert cookie =~ "; secure"
+        assert cookie =~ "; SameSite=Lax"
+        assert cookie =~ "; HttpOnly"
+      end)
+    end
+  end
+
+  describe "the login-identity PIN cookie (_vutuv_login_pin)" do
+    test "is HttpOnly + SameSite=Lax and NOT Secure over http", %{conn: conn} do
+      user = insert(:user, email_confirmed?: true)
+      insert(:email, value: "pin-http@example.com", user: user)
+
+      {:ok, returned} = Accounts.login_by_email(conn, "pin-http@example.com")
+      cookie = returned |> Conn.send_resp(200, "") |> set_cookie(@pin_cookie)
+
+      assert cookie
+      assert cookie =~ "; HttpOnly"
+      assert cookie =~ "; SameSite=Lax"
+      refute cookie =~ "; secure"
+    end
+
+    test "is Secure (still HttpOnly + SameSite=Lax) when the public scheme is https", %{
+      conn: conn
+    } do
+      user = insert(:user, email_confirmed?: true)
+      insert(:email, value: "pin-https@example.com", user: user)
+
+      with_scheme("https", fn ->
+        {:ok, returned} = Accounts.login_by_email(conn, "pin-https@example.com")
+        cookie = returned |> Conn.send_resp(200, "") |> set_cookie(@pin_cookie)
+
+        assert cookie =~ "; secure"
+        assert cookie =~ "; SameSite=Lax"
+        assert cookie =~ "; HttpOnly"
+      end)
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** The 90-day session cookie and the login-identity PIN cookie were set without `Secure`, and the app emitted no HSTS, so one cleartext `http://` request to the host leaks `_vutuv_key` for a full-account takeover. Both cookies now get `Secure`+`SameSite=Lax` on https installs; HSTS goes in the nginx reference config. Batch 5 of the remaining scan mediums.

**Where:** `lib/vutuv_web/endpoint.ex` (`@session_options`), `lib/vutuv/accounts.ex` (`put_pin_cookie/2`)

**Now:** neither cookie carried `Secure`/`SameSite`, and nothing sent HSTS. An on-path attacker who observes or induces one `http://` request captures `_vutuv_key` and replays it for its `max_age` (F8).

**What changed:**
- Both cookies now carry **`Secure` + `SameSite=Lax` when the public scheme is https**, and neither when it's http — gated by the new `Endpoint.secure_cookies?/0`, which reads the runtime url scheme (`PHX_SCHEME`, https by default; intranet sets http). So a deliberately TLS-less intranet install and the http dev/test envs still set and read the cookie, while every internet install gets `Secure`. Because the scheme is runtime but `@session_options` is compile-time, the endpoint builds the session opts in a small per-request plug; the LiveView socket keeps decoding the plain options. `key`/`signing_salt`/`max_age` unchanged → no session invalidated.
- **HSTS** is added to the reference nginx TLS block in `docs/ADMINS.md`, not enabled as app-level `force_ssl` — the blue/green deploy's `/health` gate curls `http://127.0.0.1:PORT/health` on loopback with no `X-Forwarded-Proto`, so `Plug.SSL` would redirect that probe. nginx (the TLS terminator) is the right place for the header.

**Verification:** a regression test asserts both cookies carry `Secure`+`SameSite=Lax` under https and neither under http (so http installs still log in); it fails against the unpatched wiring. Reviewed by an independent verifier and re-challenged by a fresh reviewer of the diff, which confirmed the gate fails safe (http never locks out), `SameSite=Lax` breaks none of the OAuth/fediverse/passkey flows, and the signing identity doesn't drift. `mix precommit` green: Credo clean, 4795 tests.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01Dz1H9S965ie56hT4DQ6Gax