### PR TITLE
Bound the bounce-report amplification (recipient count and stored body) (F17)

### DIFF
--- a/lib/vutuv/deliverability.ex
+++ b/lib/vutuv/deliverability.ex
@@ -72,7 +72,11 @@ defmodule Vutuv.Deliverability do
       email_value: address,
       action: "failed",
       status: dsn,
-      raw: String.slice(raw || "", 0, 100_000)
+      # A DSN diagnostic never needs 100 KB kept for forensics; bounding the
+      # stored copy caps per-row storage so one report can't write a giant row
+      # per recipient. The watcher's `raw` is a single short log line, well under
+      # this, so it is unaffected.
+      raw: String.slice(raw || "", 0, 16_000)
     })
 
     {transitioned, _} =

--- a/lib/vutuv/notifications/bounces.ex
+++ b/lib/vutuv/notifications/bounces.ex
@@ -35,6 +35,15 @@ defmodule Vutuv.Notifications.Bounces do
   alias Vutuv.Deliverability.MailLog
   alias Vutuv.Repo
 
+  # A real vutuv DSN names exactly one recipient (vutuv sends single-recipient
+  # mail; see the moduledoc), so ten is already generous - a report naming far
+  # more is malformed or abuse. Each acted-on recipient writes its own bounce
+  # ledger row (with a slice of the raw body) synchronously in the request, so
+  # an uncapped list lets one 1 MB body packed with tens of thousands of
+  # distinct `Final-Recipient:` lines amplify into tens of thousands of rows and
+  # queries. Capping here bounds the rows/queries a single report can trigger.
+  @max_recipients 10
+
   @doc """
   Records one raw DSN message. Returns `{:ok, :failed}` when a recipient
   failure was recorded (address deactivated), `{:ok, :ignored}` for a
@@ -132,6 +141,7 @@ defmodule Vutuv.Notifications.Bounces do
       |> List.flatten()
       |> Enum.map(&String.downcase/1)
       |> Enum.uniq()
+      |> cap_recipients()
 
     action =
       case Regex.run(~r/^Action:\s*(\w+)/im, raw, capture: :all_but_first) do
@@ -147,4 +157,21 @@ defmodule Vutuv.Notifications.Bounces do
 
     if recipients != [] and action, do: {recipients, action, status}, else: :error
   end
+
+  # Bounds the amplification: act on at most `@max_recipients` addresses from one
+  # report. The capped list flows unchanged through every `record/1` branch, so a
+  # normal single-recipient DSN is untouched. Log the counts (never the dropped
+  # addresses) so an oversized report is visible in ops without leaking data.
+  defp cap_recipients(recipients) when length(recipients) > @max_recipients do
+    dropped = length(recipients) - @max_recipients
+
+    Logger.warning(
+      "Email bounce: report named #{length(recipients)} recipients; acting on the first " <>
+        "#{@max_recipients} and dropping #{dropped}"
+    )
+
+    Enum.take(recipients, @max_recipients)
+  end
+
+  defp cap_recipients(recipients), do: recipients
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.145.2",
+      version: "7.145.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/notifications/bounces_test.exs
+++ b/test/vutuv/notifications/bounces_test.exs
@@ -208,6 +208,60 @@ defmodule Vutuv.Notifications.BouncesTest do
     test "garbage is rejected" do
       assert {:error, :unparseable} = Bounces.record("To: whatever\n\nnot a DSN")
     end
+
+    test "a report packed with far more recipients than the cap records at most the cap" do
+      # A single 1 MB body can name tens of thousands of distinct recipients;
+      # uncapped, record_hard_bounces/3 would insert one ledger row (with a
+      # slice of the whole body) per recipient - the amplification this fix
+      # bounds. A real vutuv DSN has exactly one recipient.
+      recipient_lines =
+        1..150
+        |> Enum.map_join("\n", &"Final-Recipient: rfc822; dead#{&1}@example.com")
+
+      raw = """
+      From: MAILER-DAEMON@mail.example.com (Mail Delivery System)
+      Content-Type: multipart/report; report-type=delivery-status; boundary="ABC"
+
+      --ABC
+      Content-Type: message/delivery-status
+
+      #{recipient_lines}
+      Action: failed
+      Status: 5.1.1
+      Diagnostic-Code: smtp; 550 5.1.1 User unknown
+
+      --ABC--
+      """
+
+      assert {:ok, :failed} = Bounces.record(raw)
+
+      # 150 distinct recipients, but the report acts on at most @max_recipients
+      # (10) of them - not one row per recipient.
+      assert Repo.aggregate(EmailBounce, :count) == 10
+    end
+
+    test "the stored raw is bounded to the new cap even for a huge body" do
+      padding = String.duplicate("x", 200_000)
+
+      raw = """
+      From: MAILER-DAEMON@mail.example.com (Mail Delivery System)
+      Content-Type: multipart/report; report-type=delivery-status; boundary="ABC"
+
+      --ABC
+      Content-Type: message/delivery-status
+
+      Final-Recipient: rfc822; dead@example.com
+      Action: failed
+      Status: 5.1.1
+      Diagnostic-Code: smtp; 550 5.1.1 User unknown #{padding}
+
+      --ABC--
+      """
+
+      assert {:ok, :failed} = Bounces.record(raw)
+      assert [bounce] = Repo.all(EmailBounce)
+      assert String.length(bounce.raw) <= 16_000
+    end
   end
 
   describe "suppression in Emailer.deliver/1" do


### PR DESCRIPTION
**TL;DR** A DSN posted to the bounce webhook was parsed for every `Final-Recipient:` line with no cap, and each recipient stored a 100 KB copy of the body → a 1 MB message with ~30k recipient lines wrote ~3 GB in one request. Now capped. Batch 6 (final) of the remaining scan mediums.

**Where:** `lib/vutuv/notifications/bounces.ex` (`parse/1`), `lib/vutuv/deliverability.ex` (`record_hard_bounce/3`)

**Now:** `parse/1` scanned unbounded recipients and `record_hard_bounces/3` looped, each writing an `EmailBounce` row with `String.slice(raw, 0, 100_000)` — 100 KB per recipient (F17).

**What changed:**
- `parse/1` caps the recipient list at **10** (a real vutuv DSN names exactly one recipient — every message leaves with a single envelope recipient — so 10 is generous headroom; excess is dropped with a **count-only** `Logger.warning`, never addresses).
- The per-row stored `raw` shrinks **100 KB → 16 KB**, which a DSN's classification fields sit well within. Worst case per report drops from gigabytes to ~160 KB.
- Classification is unchanged: the record-time decision reads the **full untruncated body** (`diagnostic_text` runs before the row is stored), so a `5.0.x` whose text confirms a dead recipient is still vetted correctly. The production log-watcher path is unaffected (a single short log line, far under either cap).

**Scope note:** the forged-bounce authenticity problem (F16/F18) is deliberately **not** touched here — it's a separate design decision tracked in a follow-up issue.

**Verification:** regression tests fail against the unpatched code (150 recipient lines → 10 rows not 150; oversized body → 16 KB raw); a single-recipient hard bounce still deactivates its one address. Reviewed by an independent verifier and re-challenged by a fresh reviewer of the diff, which confirmed no misclassification from the truncation and no legitimate recipient dropped. `mix precommit` green: Credo clean, 4797 tests.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01Dz1H9S965ie56hT4DQ6Gax