### PR TITLE
Warn operators the bounce webhook trusts unauthenticated DSNs (#1063)

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -112,7 +112,7 @@ Everything else has a default (the vutuv.de production value):
 | `OPERATOR_URL` | `https://wintermeyer-consulting.de` | **Set this.** Linked from the site/email footer |
 | `OPERATOR_ADDRESS` | (vutuv.de's) | **Set this.** One-line postal address in every email footer |
 | `APPEAL_REPLY_TO` | (vutuv.de's) | Reply-To on the account-deactivation (strike 3) email |
-| `BOUNCE_WEBHOOK_TOKEN` | – | Bearer token for `POST /webhooks/bounces`; unset = bounce handling off |
+| `BOUNCE_WEBHOOK_TOKEN` | – | Bearer token for `POST /webhooks/bounces`; unset = the endpoint 404s and webhook bounce handling is off. **Prefer the log watcher (`MAIL_LOG_PATH`) to this webhook:** the webhook acts on the DSN it receives without verifying the installation ever mailed the address, so feeding it a raw local bounce mailbox lets a forged bounce freeze a member ([#1063](https://github.com/wintermeyer/vutuv/issues/1063)). On a watcher-only setup leave this unset |
 | `MAIL_LOG_PATH` | `/var/log/mail.log` | Postfix log the bounce watcher tails; `""` = watcher off |
 | `POST_EDIT_WINDOW_MINUTES` | `30` | How long a post stays editable after publishing. Editing also closes with the first like, repost or reply, whatever this value says (an edit would silently rewrite what somebody else endorsed); deleting is never blocked. Raise it for a closed community where posts get little immediate engagement |
 | `FEDIVERSE_ENABLED` | `true` | `false` turns follow-only ActivityPub federation off entirely (endpoints 404, nothing is delivered) — set it on intranet installations |
@@ -324,8 +324,16 @@ vutuv runs fine without internet access:
 vutuv can detect hard bounces and stop mailing dead addresses: a watcher
 tails the local Postfix log (`MAIL_LOG_PATH`), or an external detector can
 POST to `/webhooks/bounces` (guarded by `BOUNCE_WEBHOOK_TOKEN`). Without
-either, bounce handling is simply off and nothing else breaks. The full
-design, DSN taxonomy and a new-server runbook:
+either, bounce handling is simply off and nothing else breaks.
+
+**Prefer the log watcher.** The webhook acts on the DSN it is handed without
+checking that this installation ever sent to the address, so piping a raw local
+bounce mailbox into it lets anyone forge a bounce and freeze a member
+([#1063](https://github.com/wintermeyer/vutuv/issues/1063)). The watcher has no
+such hole: it only acts on a bounce it can tie back to our own outbound mail. On
+a watcher-only setup, `BOUNCE_WEBHOOK_TOKEN` is not needed and can be left unset.
+
+The full design, DSN taxonomy and a new-server runbook:
 [`production-email-and-bounces.md`](production-email-and-bounces.md).
 
 ## Backups

--- a/docs/production-email-and-bounces.md
+++ b/docs/production-email-and-bounces.md
@@ -164,6 +164,20 @@ Either way it only catches what becomes a DSN, and gives no early signal on
 repeated *soft* failures (needed for the freeze decision, §4.2) until Postfix
 finally expires the message (~5 days).
 
+> **Security caveat: a raw mailbox pipe trusts forged DSNs (issue #1063).**
+> Where Option A *is* wired, `scripts/postfix/vutuv-bounce` forwards whatever
+> lands in the bounce mailbox to `/webhooks/bounces` verbatim, and the webhook
+> acts on the DSN's `Final-Recipient` / `Status` with no check that this
+> installation ever mailed that address. `BOUNCE_WEBHOOK_TOKEN` only proves the
+> message came through the pipe, not that the bounce is genuine. Because that
+> mailbox accepts arbitrary inbound internet mail, anyone can send a forged DSN
+> for an address they know and have it marked undeliverable; enough repeats (or
+> the grace window) then freeze the account and hide the profile (§4). Option B
+> does not have this hole: the log watcher only ever acts on a bounce it can
+> join back to *our own* outbound queue-id (§3.2), which is exactly the
+> sender/recipient correlation the webhook lacks. Prefer Option B, and do not
+> wire the raw mailbox pipe until the webhook grows that correlation (#1063).
+
 ### Option B — read Postfix's delivery log (CHOSEN, implemented)
 
 `Vutuv.Deliverability.Watcher` (a GenServer) tails `/var/log/mail.log`,
@@ -268,7 +282,11 @@ as the liveness check that the watcher is running in the current release.
   release) and let the app tail the log directly. Simplest; reversible.
 - **A tiny root-side shipper** (systemd unit) that tails the log and POSTs
   vutuv-attributed bounces to `POST /webhooks/bounces` with `BOUNCE_WEBHOOK_TOKEN`.
-  Keeps the app unprivileged; reuses the existing endpoint verbatim.
+  Keeps the app unprivileged; reuses the existing endpoint verbatim. The
+  "vutuv-attributed" is load-bearing: the shipper must do the queue-id join
+  itself (§3.2) and forward *only* bounces for our own outbound mail. Forwarding
+  a raw bounce *mailbox* into the webhook instead (Option A, §2) reopens the
+  forged-DSN hole (#1063), because the webhook does no correlation of its own.
 
 ---
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.145.3",
+      version: "7.145.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
**TL;DR** Docs-only. Warn operators that the inbound bounce webhook trusts unauthenticated DSNs, so wiring a raw local bounce mailbox into it lets a forged bounce freeze a member (#1063). vutuv.de production is **not** affected (it uses the log watcher). No code change; patch bump to 7.145.4.

## What
- `docs/production-email-and-bounces.md`: security caveat in §2 (Option A), plus a clarifying note in §3.5 that the root-side shipper must attribute by queue-id and not forward a raw mailbox.
- `docs/ADMINS.md`: warning next to the `BOUNCE_WEBHOOK_TOKEN` env-var row and in the "Email deliverability" section, steering operators to the log watcher and to leave the token unset on a watcher-only setup.

## Why
Tracking issue #1063 (findings F16/F18 from the security scan). `POST /webhooks/bounces` acts on a DSN's `Final-Recipient`/`Status` with no check that this installation ever mailed the named recipient. On the opt-in Option-A pipe (local bounce mailbox → `scripts/postfix/vutuv-bounce` → webhook), that mailbox accepts arbitrary inbound internet mail, so a forged DSN can deactivate a member's address and, after repeats or the grace window, freeze the account and hide the profile. The `BOUNCE_WEBHOOK_TOKEN` only proves the message came through the pipe, not that the bounce is genuine.

The code fix (sender/recipient correlation) stays tracked in #1063. This PR closes the **documentation** gap so operators who wire that pipe are warned in the meantime.

## Not affected
vutuv.de runs the log watcher (Option B), which only acts on a bounce it can join back to our own outbound queue-id, and its bounce address resolves to Google Workspace, so no local pipe feeds the webhook untrusted mail.

## Verification
`mix precommit` green (compile `--warnings-as-errors`, credo `--strict`, format check, 4797 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
