### PR TITLE
Federate reposts as Announce (#910)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -79,7 +79,11 @@ every endpoint 404s and nothing is delivered.
   public post enqueues `Create(Note)`, editing `Update`, deleting
   `Delete(Tombstone)`; an edit that closes the audience federates a `Delete`
   too. Replies federate with `inReplyTo` only when the parent's author also
-  federates (else the id would not resolve). Reposts do not federate (v1).
+  federates (else the id would not resolve). A **repost** of a public post
+  enqueues an `Announce` to the reposter's own followers, un-reposting the
+  matching `Undo(Announce)` (stable id `<note-url>#announce-<reposter>`); both
+  fire only when the reposter federates and the **original author** federates
+  too, since the `Announce` object is that author's Note id (issue #910).
   The Note carries the member-rendered HTML with absolutized links, and image
   attachments via the public post-image proxy URLs. A public post's permalink
   answers an AP Accept with the Note (remote servers dereference ids).
@@ -104,9 +108,10 @@ every endpoint 404s and nothing is delivered.
 
 ## Deliberate v1 limits
 
-No inbound content (likes/replies/boosts are dropped), no `Announce` for
-reposts, and account deletion sends no actor `Delete` broadcast (rows cascade;
-remote copies age out). Account migration is **both ways** now (issue #986):
+No inbound content (likes/replies/boosts are dropped), and account deletion
+sends no actor `Delete` broadcast (rows cascade; remote copies age out).
+Reposts now federate as `Announce` (issue #910, see the post-lifecycle bullet).
+Account migration is **both ways** now (issue #986):
 `alsoKnownAs` moves followers *in*, `Move` + `movedTo` moves them *out* (see the
 Actor bullet above). The design choice worth remembering: a move-out is a
 **redirect, never a deletion** — the vutuv account is a full profile, not just a

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -346,6 +346,35 @@ defmodule Vutuv.Fediverse do
     end
   end
 
+  @doc """
+  A member reposts another member's public post -> `Announce` to the reposter's
+  Fediverse followers (issue #910). Enqueues only when all three hold: the
+  reposter federates and has not moved out, the post is public, and the
+  **original author** federates too (the `Announce` object is that author's Note
+  id, which a non-federating author does not serve). Best effort like every
+  other outbound activity.
+  """
+  def federate_repost(%Post{} = post, %User{} = reposter),
+    do: maybe_federate_repost(post, reposter, &Docs.announce_activity/3)
+
+  @doc "The member un-reposts -> `Undo(Announce)` with the matching id."
+  def federate_unrepost(%Post{} = post, %User{} = reposter),
+    do: maybe_federate_repost(post, reposter, &Docs.undo_announce_activity/3)
+
+  defp maybe_federate_repost(%Post{} = post, %User{} = reposter, builder) do
+    with true <- enabled?(),
+         true <- federated?(reposter),
+         false <- moved?(reposter),
+         false <- Vutuv.Posts.restricted?(post),
+         %User{} = author <- Repo.get(User, post.user_id),
+         true <- federated?(author),
+         [_ | _] = inboxes <- delivery_inboxes(reposter) do
+      enqueue(reposter, inboxes, builder.(post, author, reposter))
+    else
+      _ -> :skip
+    end
+  end
+
   @doc "Answers a Follow with Accept, straight to the follower's own inbox."
   def accept_follow(%User{} = user, follow_object, inbox_uri) do
     enqueue(user, [inbox_uri], Docs.accept_activity(user, follow_object))

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -732,16 +732,30 @@ defmodule Vutuv.Posts do
 
       true ->
         case engage(PostRepost, :repost, user, post) do
-          {:ok, %PostRepost{} = repost} -> broadcast_new_repost(repost)
-          {:ok, :noop} -> :ok
-          {:error, _} = error -> error
+          {:ok, %PostRepost{} = repost} ->
+            Vutuv.Fediverse.federate_repost(post, user)
+            broadcast_new_repost(repost)
+
+          {:ok, :noop} ->
+            :ok
+
+          {:error, _} = error ->
+            error
         end
     end
   end
 
   @doc "Removes `user`'s repost (idempotent). The last one lifts the audience lock."
-  def unrepost_post(%User{} = user, %Post{} = post),
-    do: disengage(PostRepost, :repost, user, post)
+  def unrepost_post(%User{} = user, %Post{} = post) do
+    # Only federate the Undo when there really was a repost to undo, so an
+    # idempotent unrepost of a post the member never boosted stays silent.
+    reposted? =
+      Repo.exists?(from(r in PostRepost, where: r.post_id == ^post.id and r.user_id == ^user.id))
+
+    :ok = disengage(PostRepost, :repost, user, post)
+    if reposted?, do: Vutuv.Fediverse.federate_unrepost(post, user)
+    :ok
+  end
 
   @doc "Whether any reposts of this post exist (the audience lock)."
   def has_reposts?(%Post{id: id}), do: has_reposts?(id)

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -129,6 +129,37 @@ defmodule VutuvWeb.Fediverse.Docs do
     })
   end
 
+  @doc """
+  Announce: `reposter` boosts `author`'s public Note to the reposter's own
+  followers (issue #910). The object is a bare Note id — a URI string — which
+  is why the reposted author must federate too: a non-federating author serves
+  no Note at that URL, so a remote server could not render the boost.
+  """
+  def announce_activity(%Post{} = post, author, reposter) do
+    envelope(reposter, "Announce", announce_id(post, author, reposter), note_url(author, post.id))
+  end
+
+  @doc """
+  Undo(Announce): `reposter` takes their boost back. The wrapped Announce
+  carries the same stable id the original Announce had, so a remote server can
+  match and drop it.
+  """
+  def undo_announce_activity(%Post{} = post, author, reposter) do
+    reposter_actor = actor_url(reposter)
+
+    envelope(reposter, "Undo", announce_id(post, author, reposter) <> "#undo", %{
+      "id" => announce_id(post, author, reposter),
+      "type" => "Announce",
+      "actor" => reposter_actor,
+      "object" => note_url(author, post.id)
+    })
+  end
+
+  # Stable per (reposted note, reposter), so the Undo references the same
+  # Announce the repost sent.
+  defp announce_id(%Post{id: post_id}, author, reposter),
+    do: note_url(author, post_id) <> "#announce-" <> reposter.username
+
   @doc "Accept(Follow): the answer that seals a remote follow."
   def accept_activity(user, follow_object) do
     id = actor_url(user) <> "#accepts/" <> Vutuv.UUIDv7.generate()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.145.4",
+      version: "7.146.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/posts_federation_test.exs
+++ b/test/vutuv/posts_federation_test.exs
@@ -24,11 +24,25 @@ defmodule Vutuv.PostsFederationTest do
     user
   end
 
+  # Federates (opt-in + confirmed + actor) but has no remote followers, so their
+  # own posts enqueue nothing — the right shape for the *reposted* author, whose
+  # Note the Announce points at.
+  defp federating_author do
+    user = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _} = Fediverse.ensure_actor(user)
+    user
+  end
+
   defp activities do
     Delivery
     |> Repo.all()
     |> Enum.map(&Jason.decode!(&1.activity_json)["type"])
     |> Enum.sort()
+  end
+
+  defp only_activity do
+    [delivery] = Repo.all(Delivery)
+    Jason.decode!(delivery.activity_json)
   end
 
   test "publishing a public post federates a Create" do
@@ -77,6 +91,71 @@ defmodule Vutuv.PostsFederationTest do
 
     plain = insert(:activated_user)
     create_post!(plain, %{body: "öffentlich, aber kein Opt-in"})
+
+    assert activities() == []
+  end
+
+  test "reposting a federating author's public post federates an Announce" do
+    reposter = author_with_follower()
+    author = federating_author()
+    post = create_post!(author, %{body: "boost mich"})
+    Repo.delete_all(Delivery)
+
+    :ok = Posts.repost_post(reposter, post)
+
+    announce = only_activity()
+    assert announce["type"] == "Announce"
+    assert announce["actor"] =~ "/#{reposter.username}/actor"
+    assert announce["object"] == "#{VutuvWeb.Endpoint.url()}/#{author.username}/posts/#{post.id}"
+  end
+
+  test "un-reposting federates an Undo referencing the same Announce id" do
+    reposter = author_with_follower()
+    author = federating_author()
+    post = create_post!(author, %{body: "boost mich"})
+    Repo.delete_all(Delivery)
+
+    :ok = Posts.repost_post(reposter, post)
+    announce_id = only_activity()["id"]
+    Repo.delete_all(Delivery)
+
+    :ok = Posts.unrepost_post(reposter, post)
+
+    undo = only_activity()
+    assert undo["type"] == "Undo"
+    assert undo["object"]["type"] == "Announce"
+    assert undo["object"]["id"] == announce_id
+  end
+
+  test "reposting a non-federating author's post enqueues nothing" do
+    reposter = author_with_follower()
+    plain = insert(:activated_user)
+    post = create_post!(plain, %{body: "öffentlich, aber kein Opt-in"})
+    Repo.delete_all(Delivery)
+
+    :ok = Posts.repost_post(reposter, post)
+
+    assert activities() == []
+  end
+
+  test "reposting by a non-federating member enqueues nothing" do
+    plain = insert(:activated_user)
+    author = federating_author()
+    post = create_post!(author, %{body: "boost mich"})
+    Repo.delete_all(Delivery)
+
+    :ok = Posts.repost_post(plain, post)
+
+    assert activities() == []
+  end
+
+  test "an idempotent un-repost with nothing to undo enqueues nothing" do
+    reposter = author_with_follower()
+    author = federating_author()
+    post = create_post!(author, %{body: "boost mich"})
+    Repo.delete_all(Delivery)
+
+    :ok = Posts.unrepost_post(reposter, post)
 
     assert activities() == []
   end


### PR DESCRIPTION
Closes #910.

## What

A repost (boost) by a federating member was invisible to their Fediverse followers — `repost_post/2` had no federation hook, unlike Create/Update/Delete. This adds one.

- **Repost** of a public post → `Announce` to the reposter's own followers.
- **Un-repost** → the matching `Undo(Announce)`, with a stable id so remote servers can match and drop it.

Both fire only when all three hold: the reposter federates (and has not moved out), the post is public, and the **original author** federates too — the `Announce` object is that author's Note id (`https://host/<author>/posts/<id>`), which a non-federating author does not serve. Activity ids are stable (`<note-url>#announce-<reposter>`) so the `Undo` references the same `Announce`. The un-repost path only sends an `Undo` when a repost really existed, so an idempotent unrepost stays silent.

## Where

- `Vutuv.Posts.repost_post/2` + `unrepost_post/2` — the new hooks.
- `Vutuv.Fediverse.federate_repost/2` + `federate_unrepost/2` — the gates + enqueue.
- `VutuvWeb.Fediverse.Docs.announce_activity/3` + `undo_announce_activity/3` — the activity builders.
- `docs/architecture/fediverse.md` — updated (reposts no longer a v1 limit).

## Tests

Five new cases in `test/vutuv/posts_federation_test.exs`: Announce on repost, matching-id Undo on un-repost, nothing for a non-federating author, nothing for a non-federating reposter, nothing for an idempotent no-op un-repost. `mix precommit` green (4802 tests, credo --strict clean, formatted).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_014FZATDx2BDaPW2gNcESAgD