### PR TITLE
Record the decided inbound-federation model and its non-goal

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -119,7 +119,11 @@ every endpoint 404s and nothing is delivered.
 
 ## Deliberate v1 limits
 
-No inbound content (likes/replies/boosts are dropped). Reposts now federate as
+No inbound content (likes/replies/boosts are dropped) — the inbound tier is
+planned in issues #1067–#1071 under an agreed retention model: counts before
+text, a counter row lives as long as its post, stored remote text expires after
+six months, and the operator blocklist ships with the first stored row. Reposts
+now federate as
 `Announce` (issue #910) and account deletion broadcasts an actor `Delete`
 (issue #985) — see the post-lifecycle and account-deletion bullets.
 Account migration is **both ways** now (issue #986):
@@ -132,4 +136,17 @@ stay. Deleting an account remains its own separate action. The followers
 collection is count-only (privacy). A follower row whose inbox answers 404/410
 is not pruned either: deliveries go to the sharedInbox where the remote
 declares one, so a per-actor gone signal rarely reaches us and pruning on a
-shared inbox would drop every follower on that server.
+shared inbox would drop every follower on that server (issue #1072).
+
+## Non-goal: reading other networks inside vutuv
+
+Members following Fediverse accounts and reading their posts in the vutuv feed
+is **not planned** (decided 2026-07-24). It would mean continuously storing the
+post stream of every followed remote account — a large, permanent pile of
+third-party content with the moderation and retention duties that come with it —
+to rebuild what the clients of those networks already do well. vutuv publishes
+outward and (once the inbound tier lands) shows the response to what its members
+published; it is not a reader for other networks. The existing profile feed of a
+member's *own* linked Mastodon/Bluesky accounts (`Vutuv.SocialFeed`) is a
+different thing: it shows the member's own posts, on their own profile, at their
+own request.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.147.0",
+      version: "7.147.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Documentation only, no behaviour change.

`#784` (the Fediverse tracker) and `#911` (the inbound umbrella) are closed and replaced by #1067–#1074. The architecture doc now points at that plan instead of describing inbound as an open question, and records two things that would otherwise live only in an issue thread:

- **The model the split rests on** — counts before text, a counter row lives as long as its post, stored remote text expires after six months, and the operator blocklist ships with the first stored row.
- **The non-goal** — members following remote accounts and reading their posts inside vutuv is not planned. It would mean permanently storing the post stream of every followed account, with the moderation and retention duties that come with it, to rebuild what the clients of those networks already do well. A decision *not* to build something is easy to lose, and a permanently open wish in a tracker reads like an intention.

Also gives the follower-pruning limit its issue number (#1072). Version bumped to 7.147.1; `mix precommit` green.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*