### PR TITLE
Let the operator block a remote server and cap what one server can send (#1067)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -150,6 +150,17 @@ if config_env() == :prod do
     config :vutuv, :fediverse_enabled, false
   end
 
+  # How much any single remote server (and any single remote account) may store
+  # here per hour, as "host,actor" (issue #1067). The safety floor under the
+  # operator's blocklist: it bounds servers nobody has thought to block yet.
+  # A busier installation raises it, a cautious one lowers it.
+  if caps = System.get_env("FEDIVERSE_INBOUND_CAPS") do
+    [host_cap, actor_cap] =
+      caps |> String.split(",", parts: 2) |> Enum.map(&String.to_integer(String.trim(&1)))
+
+    config :vutuv, :fediverse_inbound_caps, {host_cap, actor_cap}
+  end
+
   # Book metadata + covers for post reviews come keyless from Open Library.
   # FETCH_BOOK_METADATA=false turns every such fetch off (intranets); the
   # review panel then has no lookup button and covers stay empty.

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -116,6 +116,7 @@ Everything else has a default (the vutuv.de production value):
 | `MAIL_LOG_PATH` | `/var/log/mail.log` | Postfix log the bounce watcher tails; `""` = watcher off |
 | `POST_EDIT_WINDOW_MINUTES` | `30` | How long a post stays editable after publishing. Editing also closes with the first like, repost or reply, whatever this value says (an edit would silently rewrite what somebody else endorsed); deleting is never blocked. Raise it for a closed community where posts get little immediate engagement |
 | `FEDIVERSE_ENABLED` | `true` | `false` turns follow-only ActivityPub federation off entirely (endpoints 404, nothing is delivered) — set it on intranet installations |
+| `FEDIVERSE_INBOUND_CAPS` | `600,60` | `host,actor`: how many rows one remote server, and one remote account, may store here per hour. Anything past the budget is dropped for that hour. The floor under the operator blocklist at `/admin/fediverse`, since it also bounds servers nobody has blocked yet |
 | `FETCH_BOOK_METADATA` | `true` | `false` turns the catalogue lookups behind post **book reviews** off (the composer's ISBN → title/author/year prefill, the cover image, page count and publisher from Open Library, and an audiobook's running time). The review feature itself keeps working — members type the fields by hand and the card renders without a cover or those details. Set it on installations that must not call out (intranets) |
 | `DNB_SRU_URL` | `https://services.dnb.de/sru/dnb` | Where an **audiobook's running time** is looked up by ISBN: an SRU endpoint answering MARC21-xml (the Deutsche Nationalbibliothek by default — Open Library records no durations). Point it at another catalogue's SRU endpoint, or set it **empty** (`DNB_SRU_URL=`) to switch that one lookup off while the rest of the book metadata keeps working |
 | `AMAZON_DOMAIN` | `www.amazon.de` | The store a book review card's shop link points at (`https://<domain>/dp/<isbn10>`). Set your regional store (`www.amazon.com`, …) — or an **empty** value (`AMAZON_DOMAIN=`) to remove the shop link entirely |
@@ -449,6 +450,32 @@ The badge shows on the member's profile (and its `.md`/`.json`/… siblings) wit
 small "honor tag" marker. Reserve honor for **new** tag names: flipping a
 tag that members already hold makes them keep it but blocks them from removing it
 themselves.
+
+## Federation: blocking a remote server
+
+vutuv can copy a member's public posts to other social websites — independent
+servers speaking ActivityPub (Mastodon is the best known), which talk to each
+other the way mail servers do. Anyone can run one, so a server that talks to you
+is not a vetted party. Your levers live at **`/admin` → Fediverse**
+(`/admin/fediverse`); the whole screen is gone on an installation with
+`FEDIVERSE_ENABLED=false`.
+
+- **Blocklist.** Enter a server name (`mastodon.example` — a full address or an
+  `@user@server` handle works too, only the server part is kept). From then on
+  everything that server sends is dropped **before** its signature is checked
+  and before any of its documents are fetched, and it is answered with a plain
+  `202` rather than a refusal, so the list cannot be probed from outside.
+  Blocking also **deletes what that server already stored here** (its remote
+  followers, its queued deliveries) and stops your members' posts from going
+  there. Lifting a block later does not bring any of that back — the server has
+  to follow again.
+- **Caps.** Independent of the list, one remote server may store at most 600
+  rows per hour here, and one remote account at most 60. This bounds servers
+  nobody has thought to block yet; anything past the budget is dropped for that
+  hour. Set `FEDIVERSE_INBOUND_CAPS` to change it (see the configuration table).
+- **Inbound volume.** The same page lists what each server has stored here,
+  biggest first, and the dashboard card names the busiest one. That is the list
+  a block decision is made from.
 
 ## Moderation & spam
 

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -69,6 +69,25 @@ every endpoint 404s and nothing is delivered.
   it lands during the window where the account is suspended but still served.
   Deliveries to a gone inbox are dropped by the queue on 404/410 but do not
   yet prune the follower row (see the v1 limits).
+- **The operator's safety floor** (issue #1067): anyone can run an ActivityPub
+  server, so before anything a remote sends is stored, two independent levers
+  sit in front of it. The **blocklist**
+  (`Vutuv.Fediverse.BlockedInstance`, `fediverse_blocked_instances`, admin UI at
+  `/admin/fediverse`) shuts one named host out: the inbox checks it **first** —
+  before the signature is verified and before the remote actor document is
+  fetched, against *both* the signature's `keyId` and the activity's claimed
+  `actor`, since neither is verified yet — and answers `202` rather than `403`,
+  so the list is not enumerable from outside. Blocking is also a purge
+  (`purge_instance/1`: that host's follower rows and its queued deliveries) and
+  a mouth-shut: `deliver_due/0` drops a queued delivery to a blocked host, and
+  since the follower rows are the delivery targets, the member's posts stop
+  going there. Unblocking resurrects nothing. The **caps**
+  (`check_inbound_cap/1`, `Vutuv.RateLimiter`, `FEDIVERSE_INBOUND_CAPS`, default
+  600 rows/hour per host and 60 per remote actor, host bucket hit first so a
+  flooder cannot also plant one bucket per forged actor) bound the servers
+  nobody has thought to block yet; a capped write returns
+  `{:error, :inbound_capped}` and the inbox drops it silently. Both are behind
+  `:fediverse_enabled`, so an intranet installation has neither screen nor rows.
 - **Deliveries** (`Vutuv.Fediverse.Delivery` + `Deliverer`): the same
   DB-backed queue shape as webhooks — rows per activity × distinct inbox
   (sharedInbox dedupes per server), drained every 15s or on nudge, POSTs
@@ -111,18 +130,23 @@ every endpoint 404s and nothing is delivered.
   never under `/:slug`.
 - **The operator** sees federation health on `/admin`: `Fediverse.stats/0`
   reports federating members (the SQL mirror of `federated?/1`), total remote
-  followers, delivery-queue depth and how many rows are stuck (carry a
-  `last_error`); the "Fediverse" dashboard card flags `attention` when a
-  delivery run is stuck, and hides itself when `:fediverse_enabled` is off. The
-  nightly Tagesbericht (`Vutuv.Reports`) counts new remote followers per Berlin
-  day.
+  followers, delivery-queue depth, how many rows are stuck (carry a
+  `last_error`) and how many servers are blocked; the "Fediverse" dashboard card
+  flags `attention` when a delivery run is stuck, names the busiest inbound host
+  and links to `/admin/fediverse`, and hides itself when `:fediverse_enabled` is
+  off. That page is the blocklist plus `inbound_hosts/1` — what each remote
+  server has stored here, biggest first, which is what a block decision is made
+  from. The nightly Tagesbericht (`Vutuv.Reports`) counts new remote followers
+  per Berlin day.
 
 ## Deliberate v1 limits
 
 No inbound content (likes/replies/boosts are dropped) — the inbound tier is
-planned in issues #1067–#1071 under an agreed retention model: counts before
+planned in issues #1068–#1071 under an agreed retention model: counts before
 text, a counter row lives as long as its post, stored remote text expires after
-six months, and the operator blocklist ships with the first stored row. Reposts
+six months. The operator blocklist and the inbound caps that were the condition
+for storing anything have landed (issue #1067, see the safety-floor bullet
+above). Reposts
 now federate as
 `Announce` (issue #910) and account deletion broadcasts an actor `Delete`
 (issue #985) — see the post-lifecycle and account-deletion bullets.

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -30,6 +30,7 @@ defmodule Vutuv.Fediverse do
 
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse.Actor
+  alias Vutuv.Fediverse.BlockedInstance
   alias Vutuv.Fediverse.Deliverer
   alias Vutuv.Fediverse.Delivery
   alias Vutuv.Fediverse.Follower
@@ -37,6 +38,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.Keys
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostDenial
+  alias Vutuv.RateLimiter
   alias Vutuv.Repo
   alias Vutuv.SocialFeed.Http
   alias VutuvWeb.Fediverse.Docs
@@ -88,14 +90,20 @@ defmodule Vutuv.Fediverse do
   Records a remote follower (idempotent per remote actor). A repeat Follow
   re-syncs every cached field from the actor document, the display ones
   included — a remote who renamed must not stay listed under the old handle.
+
+  Subject to the inbound caps (issue #1067): a follower row is a stored inbound
+  row, so a server trying to plant thousands of them in an hour is throttled
+  with `{:error, :inbound_capped}`.
   """
   def add_follower(%User{} = user, attrs) do
-    %Follower{user_id: user.id}
-    |> Follower.changeset(attrs)
-    |> Repo.insert(
-      on_conflict: {:replace, [:inbox_uri, :shared_inbox_uri, :handle, :name, :updated_at]},
-      conflict_target: [:user_id, :actor_uri]
-    )
+    with :ok <- check_inbound_cap(attrs[:actor_uri] || attrs["actor_uri"]) do
+      %Follower{user_id: user.id}
+      |> Follower.changeset(attrs)
+      |> Repo.insert(
+        on_conflict: {:replace, [:inbox_uri, :shared_inbox_uri, :handle, :name, :updated_at]},
+        conflict_target: [:user_id, :actor_uri]
+      )
+    end
   end
 
   @doc """
@@ -145,7 +153,8 @@ defmodule Vutuv.Fediverse do
   Installation-wide federation figures for the admin dashboard (issue #843):
   how many members federate, how many remote followers they have between them,
   the outbound delivery-queue depth and how many of those rows are stuck
-  (carry a `last_error`), so a broken delivery run is visible at a glance.
+  (carry a `last_error`), so a broken delivery run is visible at a glance, plus
+  how many remote servers the operator has shut out (issue #1067).
   """
   def stats do
     %{
@@ -153,7 +162,8 @@ defmodule Vutuv.Fediverse do
       remote_followers: Repo.aggregate(Follower, :count),
       queue_depth: Repo.aggregate(Delivery, :count),
       stuck_deliveries:
-        Repo.aggregate(from(d in Delivery, where: not is_nil(d.last_error)), :count)
+        Repo.aggregate(from(d in Delivery, where: not is_nil(d.last_error)), :count),
+      blocked_instances: blocked_instance_count()
     }
   end
 
@@ -198,6 +208,153 @@ defmodule Vutuv.Fediverse do
       )
     )
   end
+
+  ## Blocked instances and inbound caps (issue #1067)
+
+  # The operator's safety floor under everything inbound. Two independent
+  # levers, because they answer different abuse: the **blocklist** shuts one
+  # named server out for good, the **caps** bound how much any single server (or
+  # single remote person) can push in an hour, including servers nobody has
+  # thought to block yet.
+  #
+  # Stored inbound rows per hour, per remote host and per remote actor. Generous
+  # on purpose: a big instance legitimately sends a burst when a post travels,
+  # and a cap that bites honest traffic gets turned off. Overridable via
+  # `config :vutuv, :fediverse_inbound_caps, {host_limit, actor_limit}`.
+  @inbound_host_limit 600
+  @inbound_actor_limit 60
+  @inbound_window_ms :timer.hours(1)
+
+  # The host of an actor / inbox URI, as SQL: lowercased, scheme and path and
+  # port stripped, so it can be compared with a `fediverse_blocked_instances`
+  # row. Kept as one macro because three deletes and the admin volume list all
+  # need the same expression. NOTE: an Ecto `fragment/1` string may not contain
+  # a literal `?` (it is the parameter marker), which is why the pattern uses
+  # no non-capturing groups.
+  defmacrop uri_host(uri) do
+    quote do
+      fragment("lower(substring(? from '^[a-z]+://([^/:#]+)'))", unquote(uri))
+    end
+  end
+
+  @doc "Every blocked remote server, newest first, with who blocked it."
+  def list_blocked_instances do
+    Repo.all(from(b in BlockedInstance, order_by: [desc: b.id], preload: [:blocked_by]))
+  end
+
+  @doc "How many remote servers the operator has shut out."
+  def blocked_instance_count, do: Repo.aggregate(BlockedInstance, :count)
+
+  @doc """
+  Whether anything from `uri` (an actor id, a `keyId`, a bare host) must be
+  dropped. Called by the inbox **before** the signature is verified and before
+  the remote actor is fetched, so a blocked server costs us neither an outbound
+  request nor a write. A `nil`/unparseable host is not blocked — the request
+  fails the signature check moments later anyway.
+  """
+  def instance_blocked?(uri) do
+    case BlockedInstance.normalize_host(uri) do
+      nil -> false
+      host -> Repo.exists?(from(b in BlockedInstance, where: b.host == ^host))
+    end
+  end
+
+  @doc """
+  Blocks a remote server and purges everything already stored from it.
+
+  Blocking is not just "stop listening": the follower rows from that host are
+  also the delivery targets for the member's future posts, so leaving them would
+  keep federating *to* a server we refuse to hear from. So the block and the
+  purge are one action — see `purge_instance/1` for what goes.
+
+  Returns `{:ok, {blocked, purged}}` where `purged` is the per-table row count,
+  or `{:error, changeset}`.
+  """
+  def block_instance(attrs, %User{} = admin) do
+    changeset =
+      %BlockedInstance{blocked_by_id: admin.id}
+      |> BlockedInstance.changeset(attrs)
+
+    case Repo.insert(changeset) do
+      {:ok, blocked} -> {:ok, {blocked, purge_instance(blocked.host)}}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  @doc """
+  Lifts a block. Deliberately does **not** resurrect anything: the purged rows
+  are gone, and a remote that wants to follow again simply sends a new Follow.
+  """
+  def unblock_instance(id) do
+    case Repo.get(BlockedInstance, id) do
+      nil -> {:error, :not_found}
+      blocked -> Repo.delete(blocked)
+    end
+  end
+
+  @doc """
+  Deletes everything stored from `host`: its remote followers, and the outbound
+  deliveries still queued for it. Returns `%{followers: n, deliveries: n}`.
+  """
+  def purge_instance(host) when is_binary(host) do
+    {followers, _} =
+      Repo.delete_all(from(f in Follower, where: uri_host(f.actor_uri) == ^host))
+
+    {deliveries, _} =
+      Repo.delete_all(from(d in Delivery, where: uri_host(d.inbox_uri) == ^host))
+
+    %{followers: followers, deliveries: deliveries}
+  end
+
+  @doc """
+  What each remote server has stored here, biggest first — the operator's "who
+  is sending us the most" list on `/admin/fediverse`, and what a block decision
+  is made from. Capped at `limit` hosts.
+  """
+  def inbound_hosts(limit \\ 20) do
+    Repo.all(
+      from(f in Follower,
+        group_by: uri_host(f.actor_uri),
+        order_by: [desc: count(f.id)],
+        limit: ^limit,
+        select: %{host: uri_host(f.actor_uri), followers: count(f.id)}
+      )
+    )
+  end
+
+  @doc """
+  The inbound caps as `{host_limit, actor_limit}` per hour, for the admin
+  screen to state what it is enforcing.
+  """
+  def inbound_caps do
+    Application.get_env(:vutuv, :fediverse_inbound_caps, {
+      @inbound_host_limit,
+      @inbound_actor_limit
+    })
+  end
+
+  # One hourly budget per remote host and one per remote actor, checked right
+  # before a row is stored. The host bucket is hit FIRST and short-circuits, so
+  # a flooding server cannot also plant one actor bucket per forged actor id
+  # after its own budget is spent (the same rule `VutuvWeb.RateLimit` follows).
+  defp check_inbound_cap(actor_uri) when is_binary(actor_uri) do
+    {host_limit, actor_limit} = inbound_caps()
+    host = BlockedInstance.normalize_host(actor_uri) || actor_uri
+
+    with :ok <- RateLimiter.hit({:fediverse_inbound, :host, host}, host_limit, @inbound_window_ms),
+         :ok <-
+           RateLimiter.hit(
+             {:fediverse_inbound, :actor, actor_uri},
+             actor_limit,
+             @inbound_window_ms
+           ) do
+      :ok
+    else
+      _ -> {:error, :inbound_capped}
+    end
+  end
+
+  defp check_inbound_cap(_), do: :ok
 
   ## Account migration — move out (issue #986, half 2)
 
@@ -516,11 +673,14 @@ defmodule Vutuv.Fediverse do
   defp attempt(%Delivery{user: %User{} = user} = delivery, actor) do
     with %Actor{} = actor <- actor,
          %URI{scheme: "https", host: host} <- URI.parse(delivery.inbox_uri),
-         false <- Vutuv.Ssrf.resolves_to_internal?(host) do
+         false <- Vutuv.Ssrf.resolves_to_internal?(host),
+         # A server the operator blocked while this row waited in the queue must
+         # not be delivered to either — a block is both ears and mouth shut.
+         false <- instance_blocked?(delivery.inbox_uri) do
       post_activity(delivery, user, actor)
     else
-      # No key, a non-https inbox or an internal target: undeliverable for
-      # good, so the row goes instead of clogging the queue.
+      # No key, a non-https inbox, an internal target or a blocked server:
+      # undeliverable for good, so the row goes instead of clogging the queue.
       _ -> Repo.delete(delivery)
     end
   end

--- a/lib/vutuv/fediverse/blocked_instance.ex
+++ b/lib/vutuv/fediverse/blocked_instance.ex
@@ -1,0 +1,74 @@
+defmodule Vutuv.Fediverse.BlockedInstance do
+  @moduledoc """
+  A remote server the operator has shut out (issue #1067).
+
+  Anyone can run an ActivityPub server, so a server that talks to us is not a
+  vetted party. A row here means: drop everything that host sends before it is
+  verified or stored, and keep nothing of what it sent before. The blocklist is
+  per-installation content, edited at `/admin/fediverse` — never a source edit.
+
+  `host` is stored as a bare, lowercased hostname. Admins paste all sorts of
+  things (`https://mastodon.example/users/bob`, `@bob@Mastodon.Example`), so
+  `normalize_host/1` is the one place that turns any of them — and every actor
+  URI the inbox checks — into the hostname the two are compared on.
+  """
+
+  use VutuvWeb, :model
+
+  # Hostnames max out at 253 characters; the column is the usual varchar(255).
+  @max_host 253
+  @max_reason 255
+
+  # A real server name: dot-separated labels of letters, digits and hyphens.
+  # Deliberately strict — a blocklist entry that can never match anything (an
+  # IP literal, "localhost", a typo with a slash left in) is worse than an
+  # error, because it reads as protection that isn't there.
+  @host_format ~r/\A[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)+\z/
+
+  schema "fediverse_blocked_instances" do
+    field(:host, :string)
+    field(:reason, :string)
+
+    belongs_to(:blocked_by, Vutuv.Accounts.User)
+
+    timestamps()
+  end
+
+  def changeset(%__MODULE__{} = blocked, attrs) do
+    blocked
+    |> cast(attrs, [:host, :reason])
+    |> update_change(:host, &normalize_host/1)
+    |> validate_required([:host])
+    |> validate_length(:host, max: @max_host)
+    |> validate_length(:reason, max: @max_reason)
+    |> validate_format(:host, @host_format, message: "is not a server name")
+    |> unique_constraint(:host)
+  end
+
+  @doc """
+  The bare, lowercased hostname behind whatever is offered: a full actor URL, a
+  `@user@host` handle, a host with a port, or the plain hostname. Returns `nil`
+  when nothing host-shaped is left, so callers can treat "unparseable" and
+  "absent" the same way.
+  """
+  def normalize_host(value) when is_binary(value) do
+    trimmed = value |> String.trim() |> String.downcase()
+
+    # URI.parse only finds an authority behind a scheme, so give a bare host or
+    # a handle one. It then does the rest: strips userinfo, port, path, query.
+    candidate = if String.contains?(trimmed, "://"), do: trimmed, else: "https://" <> trimmed
+
+    case URI.parse(candidate) do
+      %URI{host: host} when is_binary(host) ->
+        host |> String.trim_trailing(".") |> nil_if_empty()
+
+      _ ->
+        nil
+    end
+  end
+
+  def normalize_host(_), do: nil
+
+  defp nil_if_empty(""), do: nil
+  defp nil_if_empty(value), do: value
+end

--- a/lib/vutuv_web/controllers/admin/admin_controller.ex
+++ b/lib/vutuv_web/controllers/admin/admin_controller.ex
@@ -2,6 +2,7 @@ defmodule VutuvWeb.Admin.AdminController do
   use VutuvWeb, :controller
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
   alias Vutuv.Geo
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Tags.Tag
@@ -35,11 +36,21 @@ defmodule VutuvWeb.Admin.AdminController do
       pref_overrides_count: map_size(Vutuv.Prefs.list_default_rows()),
       frozen_accounts_count: Vutuv.Deliverability.frozen_count(),
       moderation_frozen_count: Vutuv.Moderation.frozen_accounts_count(),
-      fediverse_enabled: Vutuv.Fediverse.enabled?(),
-      # Only the four COUNTs when the card will actually show them; an
-      # air-gapped install (FEDIVERSE_ENABLED=false) hides the card, mirroring
-      # the ads line above.
-      fediverse_stats: if(Vutuv.Fediverse.enabled?(), do: Vutuv.Fediverse.stats())
+      fediverse_enabled: Fediverse.enabled?(),
+      # Only the COUNTs when the card will actually show them; an air-gapped
+      # install (FEDIVERSE_ENABLED=false) hides the card, mirroring the ads line
+      # above.
+      fediverse_stats: if(Fediverse.enabled?(), do: Fediverse.stats()),
+      fediverse_top_host: if(Fediverse.enabled?(), do: top_inbound_host())
     )
+  end
+
+  # The one server sending us the most, for the dashboard card's inbound line
+  # (issue #1067); nil while nothing has arrived.
+  defp top_inbound_host do
+    case Fediverse.inbound_hosts(1) do
+      [%{host: host} | _] -> host
+      [] -> nil
+    end
   end
 end

--- a/lib/vutuv_web/controllers/admin/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/admin/fediverse_controller.ex
@@ -1,0 +1,82 @@
+defmodule VutuvWeb.Admin.FediverseController do
+  @moduledoc """
+  The operator's Fediverse screen (`/admin/fediverse`, issue #1067): the
+  blocklist of remote servers, what each server has stored here, and the
+  inbound caps currently in force.
+
+  Anyone can run an ActivityPub server, so "a server we federate with" is not a
+  vetted party. This is the kill switch: block a host and everything it sent is
+  dropped and everything already stored from it is deleted. Which servers an
+  installation refuses is per-installation content, so it lives in data with an
+  admin screen, never in a source edit.
+  """
+  use VutuvWeb, :controller
+
+  alias Vutuv.Fediverse
+  alias VutuvWeb.ControllerHelpers
+  alias VutuvWeb.UI
+
+  # Everything Fediverse 404s while the installation-wide switch is off, so an
+  # intranet installation has no blocklist screen either.
+  plug(:require_fediverse)
+
+  def index(conn, _params) do
+    render(conn, "index.html",
+      blocked: Fediverse.list_blocked_instances(),
+      inbound_hosts: Fediverse.inbound_hosts(),
+      stats: Fediverse.stats(),
+      caps: Fediverse.inbound_caps(),
+      page_title: gettext("Fediverse")
+    )
+  end
+
+  def create(conn, %{"blocked_instance" => attrs}) do
+    case Fediverse.block_instance(attrs, conn.assigns.current_user) do
+      {:ok, {blocked, purged}} ->
+        conn
+        |> put_flash(:info, blocked_message(blocked, purged))
+        |> redirect(to: ~p"/admin/fediverse")
+
+      {:error, _changeset} ->
+        conn
+        |> put_flash(
+          :error,
+          gettext("Enter the server name on its own, for example mastodon.example.")
+        )
+        |> redirect(to: ~p"/admin/fediverse")
+    end
+  end
+
+  def create(conn, _params), do: redirect(conn, to: ~p"/admin/fediverse")
+
+  def delete(conn, %{"id" => id}) do
+    case Fediverse.unblock_instance(id) do
+      {:ok, blocked} ->
+        conn
+        |> put_flash(
+          :info,
+          gettext(
+            "%{host} is no longer blocked. What was deleted stays deleted; the server has to follow again.",
+            host: blocked.host
+          )
+        )
+        |> redirect(to: ~p"/admin/fediverse")
+
+      {:error, _} ->
+        redirect(conn, to: ~p"/admin/fediverse")
+    end
+  end
+
+  defp blocked_message(blocked, %{followers: followers, deliveries: deliveries}) do
+    gettext(
+      "%{host} is blocked. Removed: %{followers} remote followers and %{deliveries} queued deliveries.",
+      host: blocked.host,
+      followers: UI.delimited_count(followers),
+      deliveries: UI.delimited_count(deliveries)
+    )
+  end
+
+  defp require_fediverse(conn, _opts) do
+    if Fediverse.enabled?(), do: conn, else: ControllerHelpers.render_error(conn, 404)
+  end
+end

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -79,14 +79,41 @@ defmodule VutuvWeb.FediverseController do
 
   def inbox(conn, %{"slug" => slug}) do
     with_federated_user(conn, slug, fn user ->
-      case VutuvWeb.RateLimit.check(conn, :fediverse_inbox, nil,
-             limit: 300,
-             window_ms: :timer.hours(1)
-           ) do
-        :ok -> verify_and_perform(conn, user)
-        :rate_limited -> send_resp(conn, 429, "")
+      cond do
+        # The operator's kill switch (issue #1067), checked FIRST: before the
+        # signature is verified, before the remote actor document is fetched
+        # (an outbound request to a host we refuse to talk to) and before any
+        # write. Answered 202 like every other dropped activity, never 403, so
+        # the blocklist cannot be enumerated from outside.
+        blocked_sender?(conn) ->
+          send_resp(conn, 202, "")
+
+        VutuvWeb.RateLimit.check(conn, :fediverse_inbox, nil,
+          limit: 300,
+          window_ms: :timer.hours(1)
+        ) == :rate_limited ->
+          send_resp(conn, 429, "")
+
+        true ->
+          verify_and_perform(conn, user)
       end
     end)
+  end
+
+  # Both names the request offers for its sender: the signature's `keyId` (whose
+  # host we would otherwise fetch the actor document from) and the activity's
+  # claimed `actor`. Neither is verified yet, so a match on *either* is enough —
+  # a blocked server must not be able to talk its way in by lying about one.
+  defp blocked_sender?(conn) do
+    key_id =
+      case signature_key_id(conn) do
+        {:ok, key_id} -> key_id
+        _ -> nil
+      end
+
+    [key_id, conn.body_params["actor"]]
+    |> Enum.filter(&is_binary/1)
+    |> Enum.any?(&Fediverse.instance_blocked?/1)
   end
 
   # The signature names the sender (keyId -> actor document -> public key).

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -554,6 +554,13 @@ defmodule VutuvWeb.Router do
     post("/deliverability/users/:id/thaw", DeliverabilityController, :thaw)
     post("/deliverability/emails/:id/clear", DeliverabilityController, :clear_address)
 
+    # The Fediverse screen (issue #1067): the operator's blocklist of remote
+    # servers, what each has stored here, and the inbound caps. Blocking is a
+    # POST (it deletes rows), unblocking a CSRF DELETE.
+    get("/fediverse", FediverseController, :index)
+    post("/fediverse", FediverseController, :create)
+    delete("/fediverse/:id", FediverseController, :delete)
+
     # The installation's legal pages (Impressum, Datenschutzerklärung,
     # Nutzungsbedingungen): per-installation trusted Markdown, edited here,
     # rendered by the public PageController routes. The set of pages is fixed,

--- a/lib/vutuv_web/templates/admin/admin/index.html.heex
+++ b/lib/vutuv_web/templates/admin/admin/index.html.heex
@@ -288,9 +288,9 @@ per-IP rate limiter and the security email only ever see the proxy hop. --%>
       title={gettext("Fediverse")}
       count={@fediverse_stats.federating_members}
       attention={@fediverse_stats.stuck_deliveries > 0}
-      href={~p"/admin/reports"}
+      href={~p"/admin/fediverse"}
       id="admin-fediverse-link"
-      cta={gettext("See the daily trend")}
+      cta={gettext("Block servers and see inbound volume")}
     >
       <%= if @fediverse_stats.stuck_deliveries > 0 do %>
         {gettext("Attention:")} {compact_count(@fediverse_stats.stuck_deliveries)} {ngettext(
@@ -304,6 +304,12 @@ per-IP rate limiter and the security email only ever see the proxy hop. --%>
       {gettext("%{followers} remote followers, %{queue} queued for delivery.",
         followers: compact_count(@fediverse_stats.remote_followers),
         queue: compact_count(@fediverse_stats.queue_depth)
+      )}
+      <%!-- Issue #1067: the operator's kill switch is only useful if its state
+            is visible from the dashboard, not just on its own page. --%>
+      {gettext("%{blocked} servers blocked, busiest inbound: %{host}.",
+        blocked: compact_count(@fediverse_stats.blocked_instances),
+        host: @fediverse_top_host || gettext("none yet")
       )}
     </.admin_card>
 

--- a/lib/vutuv_web/templates/admin/fediverse/index.html.heex
+++ b/lib/vutuv_web/templates/admin/fediverse/index.html.heex
@@ -1,0 +1,149 @@
+<%!-- The operator's Fediverse screen (issue #1067): the blocklist of remote
+servers, what each server has stored here, and the inbound caps in force.
+Classic admin page, so it uses the shared card/table/editform classes. --%>
+<.page_header
+  title={gettext("Fediverse")}
+  crumbs={[
+    {gettext("Admin"), ~p"/admin"},
+    gettext("Fediverse")
+  ]}
+/>
+
+<div class="card-list">
+  <section class="card">
+    <h2 class="card__label">{gettext("At a glance")}</h2>
+    <p>
+      {gettext(
+        "%{members} members federate, %{followers} remote followers between them, %{queue} activities queued for delivery, %{blocked} servers blocked.",
+        members: delimited_count(@stats.federating_members),
+        followers: delimited_count(@stats.remote_followers),
+        queue: delimited_count(@stats.queue_depth),
+        blocked: delimited_count(@stats.blocked_instances)
+      )}
+    </p>
+    <p class="editform__hint">
+      {gettext(
+        "Anyone can run a server in this network, so a server that talks to us is not a vetted party. Per hour, one server may store at most %{host_cap} rows here and one remote account at most %{actor_cap}; anything beyond that is dropped.",
+        host_cap: delimited_count(elem(@caps, 0)),
+        actor_cap: delimited_count(elem(@caps, 1))
+      )}
+    </p>
+  </section>
+</div>
+
+<div class="card-list">
+  <section class="card">
+    <h2 class="card__label">{gettext("Block a server")}</h2>
+    <p class="editform__hint">
+      {gettext(
+        "Blocking drops everything that server sends before it is even checked, deletes its followers and its queued deliveries, and stops our members' posts from going there. Lifting the block later does not bring any of it back."
+      )}
+    </p>
+
+    <.form for={%{}} action={~p"/admin/fediverse"} class="editform" id="block-instance-form">
+      <div class="editform__field">
+        <label for="blocked-instance-host">{gettext("Server name")}</label>
+        <input
+          type="text"
+          id="blocked-instance-host"
+          name="blocked_instance[host]"
+          autocomplete="off"
+          placeholder="mastodon.example"
+        />
+        <p class="editform__hint">
+          {gettext("A full address or an @user@server handle works too; we keep the server part.")}
+        </p>
+      </div>
+      <div class="editform__field">
+        <label for="blocked-instance-reason">{gettext("Note (optional)")}</label>
+        <input
+          type="text"
+          id="blocked-instance-reason"
+          name="blocked_instance[reason]"
+          autocomplete="off"
+          placeholder={gettext("Why this server is blocked")}
+        />
+      </div>
+      <div class="editform__actions">
+        <button class="button" type="submit">{gettext("Block this server")}</button>
+      </div>
+    </.form>
+  </section>
+</div>
+
+<div class="card-list">
+  <section class="card">
+    <h2 class="card__label">{gettext("Blocked servers")}</h2>
+    <%= if @blocked == [] do %>
+      <p class="card__empty">{gettext("No server is blocked.")}</p>
+    <% else %>
+      <div class="card__tablewrap">
+        <table>
+          <thead>
+            <tr>
+              <th>{gettext("Server")}</th>
+              <th>{gettext("Note")}</th>
+              <th>{gettext("Blocked by")}</th>
+              <th>{gettext("Since")}</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={entry <- @blocked} data-blocked-host={entry.host}>
+              <td class="breakwrap">{entry.host}</td>
+              <td class="breakwrap">{entry.reason}</td>
+              <td>
+                <%= if entry.blocked_by do %>
+                  <.link navigate={~p"/#{entry.blocked_by.username}"}>
+                    {member_name(entry.blocked_by)}
+                  </.link>
+                <% end %>
+              </td>
+              <td><.local_time at={entry.inserted_at} format="%Y-%m-%d" /></td>
+              <td class="text-right">
+                <.row_actions
+                  delete_to={~p"/admin/fediverse/#{entry.id}"}
+                  confirm={
+                    gettext(
+                      "Unblock %{host}? Nothing that was deleted comes back; the server simply may talk to us again.",
+                      host: entry.host
+                    )
+                  }
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+  </section>
+</div>
+
+<div class="card-list">
+  <section class="card">
+    <h2 class="card__label">{gettext("Inbound volume per server")}</h2>
+    <%= if @inbound_hosts == [] do %>
+      <p class="card__empty">{gettext("No server has sent us anything yet.")}</p>
+    <% else %>
+      <p class="editform__hint">
+        {gettext("How much each server has stored here. Use it to decide what to block.")}
+      </p>
+      <div class="card__tablewrap">
+        <table>
+          <thead>
+            <tr>
+              <th>{gettext("Server")}</th>
+              <th>{gettext("Followers")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={row <- @inbound_hosts} data-inbound-host={row.host}>
+              <td class="breakwrap">{row.host}</td>
+              <td>{delimited_count(row.followers)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/lib/vutuv_web/views/admin/fediverse_html.ex
+++ b/lib/vutuv_web/views/admin/fediverse_html.ex
@@ -1,0 +1,8 @@
+defmodule VutuvWeb.Admin.FediverseHTML do
+  @moduledoc false
+  use VutuvWeb, :html
+
+  import VutuvWeb.UserHelpers, only: [member_name: 1]
+
+  embed_templates("../../templates/admin/fediverse/*")
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.147.1",
+      version: "7.148.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15613,3 +15613,128 @@ msgstr "Sie haben in diesem Thread geschrieben."
 #, elixir-autogen, elixir-format
 msgid "e.g. crypto*, \"machine learning\", politics"
 msgstr "z. B. crypto*, \"machine learning\", Politik"
+
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:43
+#, elixir-autogen, elixir-format
+msgid "Enter the server name on its own, for example mastodon.example."
+msgstr "Geben Sie nur den Servernamen ein, zum Beispiel mastodon.example."
+
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:57
+#, elixir-autogen, elixir-format
+msgid "%{host} is no longer blocked. What was deleted stays deleted; the server has to follow again."
+msgstr "%{host} ist nicht mehr blockiert. Gelöschtes bleibt gelöscht; der Server muss erneut folgen."
+
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:70
+#, elixir-autogen, elixir-format
+msgid "%{host} is blocked. Removed: %{followers} remote followers and %{deliveries} queued deliveries."
+msgstr "%{host} ist blockiert. Entfernt: %{followers} entfernte Follower und %{deliveries} wartende Zustellungen."
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:15
+#, elixir-autogen, elixir-format
+msgid "At a glance"
+msgstr "Auf einen Blick"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:17
+#, elixir-autogen, elixir-format
+msgid "%{members} members federate, %{followers} remote followers between them, %{queue} activities queued for delivery, %{blocked} servers blocked."
+msgstr "%{members} Mitglieder föderieren, zusammen %{followers} entfernte Follower, %{queue} Aktivitäten warten auf Zustellung, %{blocked} Server blockiert."
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "Anyone can run a server in this network, so a server that talks to us is not a vetted party. Per hour, one server may store at most %{host_cap} rows here and one remote account at most %{actor_cap}; anything beyond that is dropped."
+msgstr "Jede und jeder kann in diesem Netzwerk einen Server betreiben, ein Server, der mit uns spricht, ist also keine geprüfte Stelle. Pro Stunde darf ein Server hier höchstens %{host_cap} Einträge speichern und ein entferntes Konto höchstens %{actor_cap}; alles darüber wird verworfen."
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "Block a server"
+msgstr "Server blockieren"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:39
+#, elixir-autogen, elixir-format
+msgid "Blocking drops everything that server sends before it is even checked, deletes its followers and its queued deliveries, and stops our members' posts from going there. Lifting the block later does not bring any of it back."
+msgstr "Blockieren verwirft alles, was dieser Server sendet, noch bevor es geprüft wird, löscht seine Follower und seine wartenden Zustellungen und stoppt die Beiträge unserer Mitglieder dorthin. Ein späteres Aufheben holt nichts davon zurück."
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:47
+#, elixir-autogen, elixir-format
+msgid "Server name"
+msgstr "Servername"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:56
+#, elixir-autogen, elixir-format
+msgid "A full address or an @user@server handle works too; we keep the server part."
+msgstr "Eine vollständige Adresse oder ein Handle der Form @name@server geht auch; wir behalten den Serverteil."
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:60
+#, elixir-autogen, elixir-format
+msgid "Note (optional)"
+msgstr "Notiz (optional)"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:66
+#, elixir-autogen, elixir-format
+msgid "Why this server is blocked"
+msgstr "Warum dieser Server blockiert ist"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:70
+#, elixir-autogen, elixir-format
+msgid "Block this server"
+msgstr "Diesen Server blockieren"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Blocked servers"
+msgstr "Blockierte Server"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:79
+#, elixir-autogen, elixir-format
+msgid "No server is blocked."
+msgstr "Kein Server ist blockiert."
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "Server"
+msgstr "Server"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Note"
+msgstr "Notiz"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:87
+#, elixir-autogen, elixir-format
+msgid "Blocked by"
+msgstr "Blockiert von"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:105
+#, elixir-autogen, elixir-format
+msgid "Unblock %{host}? Nothing that was deleted comes back; the server simply may talk to us again."
+msgstr "%{host} freigeben? Gelöschtes kommt nicht zurück; der Server darf lediglich wieder mit uns sprechen."
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:122
+#, elixir-autogen, elixir-format
+msgid "Inbound volume per server"
+msgstr "Eingehendes Volumen pro Server"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:124
+#, elixir-autogen, elixir-format
+msgid "No server has sent us anything yet."
+msgstr "Bisher hat uns kein Server etwas geschickt."
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:127
+#, elixir-autogen, elixir-format
+msgid "How much each server has stored here. Use it to decide what to block."
+msgstr "Wie viel jeder Server hier gespeichert hat. Danach entscheiden Sie, was Sie blockieren."
+
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:293
+#, elixir-autogen, elixir-format
+msgid "Block servers and see inbound volume"
+msgstr "Server blockieren und eingehendes Volumen ansehen"
+
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:311
+#, elixir-autogen, elixir-format
+msgid "%{blocked} servers blocked, busiest inbound: %{host}."
+msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
+
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:313
+#, elixir-autogen, elixir-format
+msgid "none yet"
+msgstr "noch keiner"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -14862,3 +14862,128 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "e.g. crypto*, \"machine learning\", politics"
 msgstr ""
+
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:43
+#, elixir-autogen, elixir-format
+msgid "Enter the server name on its own, for example mastodon.example."
+msgstr ""
+
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:57
+#, elixir-autogen, elixir-format
+msgid "%{host} is no longer blocked. What was deleted stays deleted; the server has to follow again."
+msgstr ""
+
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:70
+#, elixir-autogen, elixir-format
+msgid "%{host} is blocked. Removed: %{followers} remote followers and %{deliveries} queued deliveries."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:15
+#, elixir-autogen, elixir-format
+msgid "At a glance"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:17
+#, elixir-autogen, elixir-format
+msgid "%{members} members federate, %{followers} remote followers between them, %{queue} activities queued for delivery, %{blocked} servers blocked."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "Anyone can run a server in this network, so a server that talks to us is not a vetted party. Per hour, one server may store at most %{host_cap} rows here and one remote account at most %{actor_cap}; anything beyond that is dropped."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "Block a server"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:39
+#, elixir-autogen, elixir-format
+msgid "Blocking drops everything that server sends before it is even checked, deletes its followers and its queued deliveries, and stops our members' posts from going there. Lifting the block later does not bring any of it back."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:47
+#, elixir-autogen, elixir-format
+msgid "Server name"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:56
+#, elixir-autogen, elixir-format
+msgid "A full address or an @user@server handle works too; we keep the server part."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:60
+#, elixir-autogen, elixir-format
+msgid "Note (optional)"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:66
+#, elixir-autogen, elixir-format
+msgid "Why this server is blocked"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:70
+#, elixir-autogen, elixir-format
+msgid "Block this server"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Blocked servers"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:79
+#, elixir-autogen, elixir-format
+msgid "No server is blocked."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "Server"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Note"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:87
+#, elixir-autogen, elixir-format
+msgid "Blocked by"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:105
+#, elixir-autogen, elixir-format
+msgid "Unblock %{host}? Nothing that was deleted comes back; the server simply may talk to us again."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:122
+#, elixir-autogen, elixir-format
+msgid "Inbound volume per server"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:124
+#, elixir-autogen, elixir-format
+msgid "No server has sent us anything yet."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:127
+#, elixir-autogen, elixir-format
+msgid "How much each server has stored here. Use it to decide what to block."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:293
+#, elixir-autogen, elixir-format
+msgid "Block servers and see inbound volume"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:311
+#, elixir-autogen, elixir-format
+msgid "%{blocked} servers blocked, busiest inbound: %{host}."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:313
+#, elixir-autogen, elixir-format
+msgid "none yet"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -14860,3 +14860,128 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "e.g. crypto*, \"machine learning\", politics"
 msgstr ""
+
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:43
+#, elixir-autogen, elixir-format
+msgid "Enter the server name on its own, for example mastodon.example."
+msgstr ""
+
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:57
+#, elixir-autogen, elixir-format
+msgid "%{host} is no longer blocked. What was deleted stays deleted; the server has to follow again."
+msgstr ""
+
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:70
+#, elixir-autogen, elixir-format
+msgid "%{host} is blocked. Removed: %{followers} remote followers and %{deliveries} queued deliveries."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:15
+#, elixir-autogen, elixir-format
+msgid "At a glance"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:17
+#, elixir-autogen, elixir-format
+msgid "%{members} members federate, %{followers} remote followers between them, %{queue} activities queued for delivery, %{blocked} servers blocked."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:26
+#, elixir-autogen, elixir-format
+msgid "Anyone can run a server in this network, so a server that talks to us is not a vetted party. Per hour, one server may store at most %{host_cap} rows here and one remote account at most %{actor_cap}; anything beyond that is dropped."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:37
+#, elixir-autogen, elixir-format
+msgid "Block a server"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:39
+#, elixir-autogen, elixir-format
+msgid "Blocking drops everything that server sends before it is even checked, deletes its followers and its queued deliveries, and stops our members' posts from going there. Lifting the block later does not bring any of it back."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:47
+#, elixir-autogen, elixir-format
+msgid "Server name"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:56
+#, elixir-autogen, elixir-format
+msgid "A full address or an @user@server handle works too; we keep the server part."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:60
+#, elixir-autogen, elixir-format
+msgid "Note (optional)"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:66
+#, elixir-autogen, elixir-format
+msgid "Why this server is blocked"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:70
+#, elixir-autogen, elixir-format
+msgid "Block this server"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Blocked servers"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:79
+#, elixir-autogen, elixir-format
+msgid "No server is blocked."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:85
+#, elixir-autogen, elixir-format
+msgid "Server"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Note"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:87
+#, elixir-autogen, elixir-format
+msgid "Blocked by"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:105
+#, elixir-autogen, elixir-format
+msgid "Unblock %{host}? Nothing that was deleted comes back; the server simply may talk to us again."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:122
+#, elixir-autogen, elixir-format
+msgid "Inbound volume per server"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:124
+#, elixir-autogen, elixir-format
+msgid "No server has sent us anything yet."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:127
+#, elixir-autogen, elixir-format
+msgid "How much each server has stored here. Use it to decide what to block."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:293
+#, elixir-autogen, elixir-format
+msgid "Block servers and see inbound volume"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:311
+#, elixir-autogen, elixir-format
+msgid "%{blocked} servers blocked, busiest inbound: %{host}."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:313
+#, elixir-autogen, elixir-format
+msgid "none yet"
+msgstr ""

--- a/priv/repo/migrations/20260724210809_create_fediverse_blocked_instances.exs
+++ b/priv/repo/migrations/20260724210809_create_fediverse_blocked_instances.exs
@@ -1,0 +1,29 @@
+defmodule Vutuv.Repo.Migrations.CreateFediverseBlockedInstances do
+  use Ecto.Migration
+
+  # The operator's kill switch per remote server (issue #1067). Anyone can run
+  # an ActivityPub server, so "a server we federate with" is not a vetted party;
+  # before vutuv stores anything a remote sends us, the operator needs a way to
+  # shut one out. Per-installation content, so it is data plus an admin screen
+  # (/admin/fediverse), never a source edit.
+  #
+  # New table, plain addition -> N-1 safe for the blue/green window.
+  def change do
+    create table(:fediverse_blocked_instances) do
+      # The bare, lowercased hostname ("mastodon.example"), never a URL: the
+      # inbox compares it against the host of the sender's actor id.
+      add(:host, :string, null: false)
+      # Free-text note for the next operator ("spam wave 2026-07"), optional.
+      add(:reason, :string)
+      # Who blocked it. The row outlives the admin account (nilify), because a
+      # block must not lapse just because the admin who set it left.
+      add(:blocked_by_id, references(:users, type: :binary_id, on_delete: :nilify_all))
+
+      timestamps()
+    end
+
+    # One row per host; re-blocking is a no-op, not a duplicate. Also the index
+    # the inbox's per-request "is this host blocked?" lookup reads.
+    create(unique_index(:fediverse_blocked_instances, [:host]))
+  end
+end

--- a/test/vutuv/fediverse_blocklist_test.exs
+++ b/test/vutuv/fediverse_blocklist_test.exs
@@ -1,0 +1,262 @@
+defmodule Vutuv.FediverseBlocklistTest do
+  @moduledoc """
+  The operator's blocklist and the inbound caps (issue #1067): the safety floor
+  under everything a remote server sends us.
+
+  async: false — the inbound caps live in the shared `Vutuv.RateLimiter` ETS
+  table, which the SQL sandbox does not roll back, so a parallel module hitting
+  the same host bucket would make these counts drift.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.BlockedInstance
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Fediverse.Follower
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp admin, do: insert(:activated_user, admin?: true)
+
+  defp federating_member do
+    insert(:activated_user, fediverse_followers?: true)
+  end
+
+  describe "normalize_host/1" do
+    test "reduces every shape an admin (or an actor URI) offers to the hostname" do
+      for value <- [
+            "mastodon.example",
+            "Mastodon.Example",
+            "  mastodon.example  ",
+            "https://mastodon.example",
+            "https://mastodon.example/users/bob",
+            "https://mastodon.example:8443/users/bob",
+            "@bob@mastodon.example",
+            "bob@mastodon.example",
+            "mastodon.example."
+          ] do
+        assert BlockedInstance.normalize_host(value) == "mastodon.example",
+               "expected #{inspect(value)} to normalize to mastodon.example"
+      end
+    end
+
+    test "returns nil for nothing host-shaped" do
+      assert BlockedInstance.normalize_host("") == nil
+      assert BlockedInstance.normalize_host("   ") == nil
+      assert BlockedInstance.normalize_host(nil) == nil
+      assert BlockedInstance.normalize_host(42) == nil
+    end
+  end
+
+  describe "block_instance/2" do
+    test "stores the bare host and marks who blocked it" do
+      operator = admin()
+
+      assert {:ok, {blocked, _purged}} =
+               Fediverse.block_instance(
+                 %{"host" => "https://Spam.Example/users/bot", "reason" => "spam wave"},
+                 operator
+               )
+
+      assert blocked.host == "spam.example"
+      assert blocked.reason == "spam wave"
+      assert blocked.blocked_by_id == operator.id
+      assert Fediverse.blocked_instance_count() == 1
+    end
+
+    test "rejects anything that is not a server name" do
+      operator = admin()
+
+      for host <- ["", "not a host", "localhost", "-bad-.example", "spam..example"] do
+        assert {:error, %Ecto.Changeset{}} =
+                 Fediverse.block_instance(%{"host" => host}, operator),
+               "expected #{inspect(host)} to be rejected"
+      end
+    end
+
+    test "blocking the same server twice is an error, not a duplicate row" do
+      operator = admin()
+
+      assert {:ok, _} = Fediverse.block_instance(%{"host" => "spam.example"}, operator)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Fediverse.block_instance(%{"host" => "spam.example"}, operator)
+
+      assert Fediverse.blocked_instance_count() == 1
+    end
+  end
+
+  describe "instance_blocked?/1" do
+    test "matches the host of an actor id, a keyId and a bare host" do
+      {:ok, _} = Fediverse.block_instance(%{"host" => "spam.example"}, admin())
+
+      assert Fediverse.instance_blocked?("https://spam.example/users/bot")
+      assert Fediverse.instance_blocked?("https://spam.example/users/bot#main-key")
+      assert Fediverse.instance_blocked?("spam.example")
+      # A different server, and a host that merely ends in the blocked one.
+      refute Fediverse.instance_blocked?("https://social.example/users/alice")
+      refute Fediverse.instance_blocked?("https://notspam.example/users/bot")
+      refute Fediverse.instance_blocked?(nil)
+    end
+  end
+
+  describe "blocking purges what is already stored" do
+    test "removes that server's followers and queued deliveries, and no other server's" do
+      member = federating_member()
+
+      {:ok, _} =
+        Fediverse.add_follower(member, %{
+          actor_uri: "https://spam.example/users/bot",
+          inbox_uri: "https://spam.example/inbox"
+        })
+
+      {:ok, _} =
+        Fediverse.add_follower(member, %{
+          actor_uri: "https://social.example/users/alice",
+          inbox_uri: "https://social.example/inbox"
+        })
+
+      Repo.insert!(%Delivery{
+        user_id: member.id,
+        inbox_uri: "https://spam.example/inbox",
+        activity_json: "{}",
+        attempts: 0,
+        next_attempt_at: DateTime.utc_now(:second)
+      })
+
+      Repo.insert!(%Delivery{
+        user_id: member.id,
+        inbox_uri: "https://social.example/inbox",
+        activity_json: "{}",
+        attempts: 0,
+        next_attempt_at: DateTime.utc_now(:second)
+      })
+
+      assert {:ok, {_blocked, purged}} =
+               Fediverse.block_instance(%{"host" => "spam.example"}, admin())
+
+      assert purged == %{followers: 1, deliveries: 1}
+      assert [%Follower{actor_uri: "https://social.example/users/alice"}] = Repo.all(Follower)
+      assert [%Delivery{inbox_uri: "https://social.example/inbox"}] = Repo.all(Delivery)
+    end
+
+    test "unblocking does not resurrect anything" do
+      member = federating_member()
+
+      {:ok, _} =
+        Fediverse.add_follower(member, %{
+          actor_uri: "https://spam.example/users/bot",
+          inbox_uri: "https://spam.example/inbox"
+        })
+
+      {:ok, {blocked, _}} = Fediverse.block_instance(%{"host" => "spam.example"}, admin())
+      assert Repo.aggregate(Follower, :count) == 0
+
+      assert {:ok, _} = Fediverse.unblock_instance(blocked.id)
+      assert Fediverse.blocked_instance_count() == 0
+      assert Repo.aggregate(Follower, :count) == 0
+      refute Fediverse.instance_blocked?("https://spam.example/users/bot")
+    end
+  end
+
+  describe "inbound caps" do
+    test "a server over its hourly cap is throttled while other servers are unaffected" do
+      # Tiny budgets so the test states the rule instead of writing 600 rows.
+      Application.put_env(:vutuv, :fediverse_inbound_caps, {2, 2})
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_inbound_caps) end)
+
+      member = federating_member()
+
+      for n <- 1..2 do
+        assert {:ok, _} =
+                 Fediverse.add_follower(member, %{
+                   actor_uri: "https://flood.example/users/bot#{n}",
+                   inbox_uri: "https://flood.example/inbox"
+                 })
+      end
+
+      assert {:error, :inbound_capped} =
+               Fediverse.add_follower(member, %{
+                 actor_uri: "https://flood.example/users/bot3",
+                 inbox_uri: "https://flood.example/inbox"
+               })
+
+      # A different server still gets through: the budget is per host.
+      assert {:ok, _} =
+               Fediverse.add_follower(member, %{
+                 actor_uri: "https://social.example/users/alice",
+                 inbox_uri: "https://social.example/inbox"
+               })
+
+      assert Repo.aggregate(Follower, :count) == 3
+    end
+
+    test "one remote account cannot spend the whole host budget" do
+      # Room for 10 rows from the host, but only 1 from any single actor.
+      Application.put_env(:vutuv, :fediverse_inbound_caps, {10, 1})
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_inbound_caps) end)
+
+      member = federating_member()
+      other = federating_member()
+
+      attrs = %{
+        actor_uri: "https://social.example/users/alice",
+        inbox_uri: "https://social.example/inbox"
+      }
+
+      assert {:ok, _} = Fediverse.add_follower(member, attrs)
+      assert {:error, :inbound_capped} = Fediverse.add_follower(other, attrs)
+    end
+  end
+
+  describe "inbound_hosts/1" do
+    test "counts what each server stores here, biggest first" do
+      member = federating_member()
+
+      for n <- 1..2 do
+        {:ok, _} =
+          Fediverse.add_follower(member, %{
+            actor_uri: "https://busy.example/users/u#{n}",
+            inbox_uri: "https://busy.example/inbox"
+          })
+      end
+
+      {:ok, _} =
+        Fediverse.add_follower(member, %{
+          actor_uri: "https://quiet.example/users/u1",
+          inbox_uri: "https://quiet.example/inbox"
+        })
+
+      assert [
+               %{host: "busy.example", followers: 2},
+               %{host: "quiet.example", followers: 1}
+             ] = Fediverse.inbound_hosts()
+    end
+  end
+
+  describe "outbound deliveries to a blocked server" do
+    test "are dropped instead of sent" do
+      member = federating_member()
+      {:ok, _actor} = Fediverse.ensure_actor(member)
+
+      delivery =
+        Repo.insert!(%Delivery{
+          user_id: member.id,
+          inbox_uri: "https://spam.example/inbox",
+          activity_json: "{}",
+          attempts: 0,
+          next_attempt_at: DateTime.utc_now(:second)
+        })
+
+      # Blocked *after* the row was queued, so the purge did not catch it: the
+      # deliverer must refuse it too. Insert the block directly to skip the purge.
+      Repo.insert!(%BlockedInstance{host: "spam.example"})
+
+      assert Fediverse.deliver_due() == 1
+      refute Repo.get(Delivery, delivery.id)
+    end
+  end
+end

--- a/test/vutuv/fediverse_test.exs
+++ b/test/vutuv/fediverse_test.exs
@@ -531,7 +531,8 @@ defmodule Vutuv.FediverseTest do
                federating_members: 2,
                remote_followers: 2,
                queue_depth: 2,
-               stuck_deliveries: 1
+               stuck_deliveries: 1,
+               blocked_instances: 0
              }
     end
   end

--- a/test/vutuv_web/controllers/admin/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/admin/fediverse_controller_test.exs
@@ -1,0 +1,93 @@
+defmodule VutuvWeb.Admin.FediverseControllerTest do
+  @moduledoc """
+  The operator's Fediverse screen (`/admin/fediverse`, issue #1067): block a
+  remote server, see what each server stores here, lift a block.
+
+  async: false — the tests flip `:fediverse_enabled`, an application-env switch
+  the SQL sandbox does not roll back.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follower
+
+  defp login_admin(conn) do
+    {conn, admin} = create_and_login_admin(conn)
+    {conn, admin}
+  end
+
+  test "lists the blocked servers and the inbound volume", %{conn: conn} do
+    {conn, admin} = login_admin(conn)
+    member = insert(:activated_user, fediverse_followers?: true)
+
+    {:ok, _} =
+      Fediverse.add_follower(member, %{
+        actor_uri: "https://social.example/users/alice",
+        inbox_uri: "https://social.example/inbox"
+      })
+
+    {:ok, {blocked, _}} =
+      Fediverse.block_instance(%{"host" => "spam.example", "reason" => "bots"}, admin)
+
+    html = conn |> get(~p"/admin/fediverse") |> html_response(200)
+
+    assert html =~ ~s(data-blocked-host="spam.example")
+    assert html =~ "bots"
+    assert html =~ ~s(data-inbound-host="social.example")
+    # The rendered form/unblock targets, not a route we know exists: a hand-built
+    # path in a test would not catch a form posting somewhere retired.
+    assert html =~ ~s(action="/admin/fediverse")
+    assert html =~ ~s(href="/admin/fediverse/#{blocked.id}")
+  end
+
+  test "blocking a server purges what it already stored", %{conn: conn} do
+    {conn, _admin} = login_admin(conn)
+    member = insert(:activated_user, fediverse_followers?: true)
+
+    {:ok, _} =
+      Fediverse.add_follower(member, %{
+        actor_uri: "https://spam.example/users/bot",
+        inbox_uri: "https://spam.example/inbox"
+      })
+
+    conn = post(conn, ~p"/admin/fediverse", blocked_instance: %{host: "https://spam.example/"})
+
+    assert redirected_to(conn) == ~p"/admin/fediverse"
+    assert Fediverse.instance_blocked?("https://spam.example/users/bot")
+    assert Repo.aggregate(Follower, :count) == 0
+  end
+
+  test "a malformed server name is refused with a flash, not a 500", %{conn: conn} do
+    {conn, _admin} = login_admin(conn)
+
+    conn = post(conn, ~p"/admin/fediverse", blocked_instance: %{host: "not a host"})
+
+    assert redirected_to(conn) == ~p"/admin/fediverse"
+    assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "mastodon.example"
+    assert Fediverse.blocked_instance_count() == 0
+  end
+
+  test "unblocking removes the row without resurrecting anything", %{conn: conn} do
+    {conn, admin} = login_admin(conn)
+    {:ok, {blocked, _}} = Fediverse.block_instance(%{"host" => "spam.example"}, admin)
+
+    conn = delete(conn, ~p"/admin/fediverse/#{blocked.id}")
+
+    assert redirected_to(conn) == ~p"/admin/fediverse"
+    assert Fediverse.blocked_instance_count() == 0
+  end
+
+  test "the page 404s on an installation with federation switched off", %{conn: conn} do
+    {conn, _admin} = login_admin(conn)
+    Application.put_env(:vutuv, :fediverse_enabled, false)
+    on_exit(fn -> Application.delete_env(:vutuv, :fediverse_enabled) end)
+
+    assert conn |> get(~p"/admin/fediverse") |> html_response(404)
+  end
+
+  test "a non-admin cannot reach it", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+
+    assert conn |> get(~p"/admin/fediverse") |> html_response(403)
+  end
+end

--- a/test/vutuv_web/controllers/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/fediverse_controller_test.exs
@@ -308,6 +308,56 @@ defmodule VutuvWeb.FediverseControllerTest do
     end
   end
 
+  describe "POST /:slug/actor/inbox — blocked servers (#1067)" do
+    setup do
+      admin = insert(:activated_user, admin?: true)
+      {:ok, {_blocked, _purged}} = Fediverse.block_instance(%{"host" => "social.example"}, admin)
+      :ok
+    end
+
+    test "a blocked server is dropped before the signature is even checked", %{conn: conn} do
+      user = federated_user()
+
+      # No stub, no signature: if the blocklist did not cut in first, this would
+      # be a 401. It is answered 202 and dropped, so the blocklist cannot be
+      # enumerated from outside, and no remote actor document is fetched.
+      conn =
+        conn
+        |> put_req_header("content-type", "application/activity+json")
+        |> post("/#{user.username}/actor/inbox", Jason.encode!(follow_activity(user)))
+
+      assert conn.status == 202
+      assert Fediverse.follower_count(user) == 0
+      assert Repo.aggregate(Delivery, :count) == 0
+    end
+
+    test "a correctly signed Follow from a blocked server still writes no row", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = federated_user()
+
+      conn = signed_post(conn, user, follow_activity(user), priv)
+
+      assert conn.status == 202
+      assert Fediverse.follower_count(user) == 0
+      assert Repo.aggregate(Delivery, :count) == 0
+    end
+
+    test "an unblocked server is unaffected", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = federated_user()
+
+      [blocked] = Fediverse.list_blocked_instances()
+      {:ok, _} = Fediverse.unblock_instance(blocked.id)
+
+      conn = signed_post(conn, user, follow_activity(user), priv)
+
+      assert conn.status == 202
+      assert Fediverse.follower_count(user) == 1
+    end
+  end
+
   describe "POST /:slug/actor/inbox — remote actor lifecycle" do
     test "Update of the actor re-syncs the stored handle, name and inboxes", %{conn: conn} do
       {priv, pub} = Keys.generate()


### PR DESCRIPTION
Closes #1067.

The safety floor under everything inbound, so that the first stored remote row (#1068) does not land without it.

**Blocklist** (`fediverse_blocked_instances`, admin UI at `/admin/fediverse`)
- The inbox checks the sender's host **first**: before the HTTP signature is verified and before the remote actor document is fetched, against **both** the signature's `keyId` and the activity's claimed `actor` (neither is verified at that point, so a match on either is enough).
- Answers `202` and drops, never `403`, so the list cannot be enumerated from outside.
- Blocking **purges** what that host already stored (its follower rows, its queued deliveries) and stops our members' posts from going there. Unblocking resurrects nothing.
- A queued delivery to a host blocked after it was enqueued is dropped by the deliverer too.

**Caps** (`FEDIVERSE_INBOUND_CAPS`, default `600,60`)
- 600 stored rows per remote host per hour, 60 per remote actor, on the existing `Vutuv.RateLimiter`. The host bucket is hit first and short-circuits, so a flooder cannot also plant one actor bucket per forged actor id after its own budget is spent.
- Bounds the servers nobody has thought to block yet.

**Admin**
- `/admin/fediverse`: blocklist (add / remove), inbound volume per server, and the caps in force.
- The `/admin` Fediverse card names the busiest inbound host and the blocked count, and links here.
- Everything behind `:fediverse_enabled`, so an intranet installation has neither screen nor rows.

**One decision worth naming:** blocking deletes a server's followers rather than merely muting it. An operator who blocks a server wants no relationship with it, and leaving the rows would keep federating outward to a server we refuse to hear from. The admin copy says so before you press the button.

**Tests** cover every acceptance point: a blocked host gets `202` and writes no row (proved with an *unsigned* request, which would otherwise be a 401 — that is how we know the check runs before verification); blocking removes rows already stored; unblocking does not resurrect them; a host over its hourly cap is throttled while other hosts are unaffected; one actor cannot spend the host budget; `:fediverse_enabled=false` 404s the screen.

`mix precommit` green (4827 tests). Docs: `docs/architecture/fediverse.md` + the `docs/ADMINS.md` env table and a new "Federation: blocking a remote server" section.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01UX4B9CkgK8jqB5b2pULtRp