### PR TITLE
Show how many people on other networks reacted to a post (#1068)

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -477,6 +477,16 @@ is not a vetted party. Your levers live at **`/admin` → Fediverse**
   biggest first, and the dashboard card names the busiest one. That is the list
   a block decision is made from.
 
+**What is stored from other servers.** Exactly one thing: a bare counter row per
+remote person per post per kind (favourite / re-share), holding only that
+person's account address, the kind and the time. No name, no picture, no text.
+Members see the tally as a "reactions from other networks" line under their post
+and can switch it off on `/settings/fediverse`, which deletes what is stored. A
+row is deleted when the remote side withdraws it, when the post goes, or when
+the account goes. **Your installation's privacy page has to say so** — it is
+per-installation content, edited at `/admin` → Legal pages, not shipped in the
+code.
+
 ## Moderation & spam
 
 Members report posts, messages and whole profiles from the quiet "Report"

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1,9 +1,11 @@
 # Fediverse (follow-only ActivityPub federation)
 
 People on Mastodon and other ActivityPub servers can follow an opted-in
-member and receive their **public** posts. Federation is outbound-only by
-design: no remote posts, likes or replies are stored — the inbox only
-processes `Follow`, `Undo(Follow)` and the remote actor's own lifecycle
+member and receive their **public** posts. Federation is outbound-first by
+design: no remote posts or reply text is stored. The one thing that does come
+back is a **count** (issue #1068) — how many people out there favourited or
+re-shared a post — and even that is a bare counter row. The inbox otherwise
+processes only `Follow`, `Undo(Follow)` and the remote actor's own lifecycle
 (`Update` / `Delete`); everything else is acknowledged (202) and dropped.
 Everything lives in `Vutuv.Fediverse`.
 
@@ -69,6 +71,32 @@ every endpoint 404s and nothing is delivered.
   it lands during the window where the account is suspended but still served.
   Deliveries to a gone inbox are dropped by the queue on 404/410 but do not
   yet prune the follower row (see the v1 limits).
+- **Reactions from other networks** (issue #1068, the one inbound thing that is
+  stored): a `Like` or `Announce` naming a member's public Note becomes one row
+  in `fediverse_reactions` (`Vutuv.Fediverse.Reaction`) — `post_id`,
+  `actor_uri`, `kind`, `received_at` and **nothing else**. No display name, no
+  avatar, no text: vutuv can never obtain consent from a stranger on another
+  server, so what makes this lawful is storing almost nothing about them plus a
+  deletion path that really works. The actor URI earns its place twice over:
+  each person counts once (unique on `(post_id, actor_uri, kind)`) and an
+  upstream `Undo` can find its row. `record_reaction/4` holds every gate in
+  order — the installation switch, the member federates and has not switched
+  the counts off (`users.fediverse_reactions?`, on by default, `/settings/
+  fediverse`; switching it off calls `drop_reactions/1`), the object really is
+  one of *their* public Note URLs, and the sender is within its inbound cap —
+  and the inbox answers the same 202 whatever it decides, so a misdirected
+  activity learns nothing. `remove_reaction/4` is deliberately **un**gated: an
+  upstream withdrawal is the deletion path, so it must not depend on a switch
+  still being on. Rows live exactly as long as the post (FK cascade, so a post
+  delete and an account delete both take them), like a vutuv like; there is no
+  separate expiry. The count rides the existing engagement select
+  (`Vutuv.Posts.engagement_count_select/1` → `:fediverse_reactions`), so it is
+  batched with the other counters, ticks live through `{:post_counters, …}`
+  (`broadcast_post_counters/1`) and reaches `VutuvWeb.AgentDocs.PostDoc` as
+  `fediverse_reaction_count`. It renders as its **own** labelled line under the
+  vutuv counters, never folded into them: a hostile server can then inflate
+  only its own line, and the reader sees which world answered. Public and
+  hidden at zero.
 - **The operator's safety floor** (issue #1067): anyone can run an ActivityPub
   server, so before anything a remote sends is stored, two independent levers
   sit in front of it. The **blocklist**
@@ -141,12 +169,13 @@ every endpoint 404s and nothing is delivered.
 
 ## Deliberate v1 limits
 
-No inbound content (likes/replies/boosts are dropped) — the inbound tier is
-planned in issues #1068–#1071 under an agreed retention model: counts before
-text, a counter row lives as long as its post, stored remote text expires after
-six months. The operator blocklist and the inbound caps that were the condition
-for storing anything have landed (issue #1067, see the safety-floor bullet
-above). Reposts
+No inbound **content** — remote reply text, names, avatars and boost rosters are
+all still dropped. Only the reaction *count* is stored (issue #1068, above); the
+rest of the inbound tier is planned in issues #1069–#1071 under the agreed
+retention model: counts before text, a counter row lives as long as its post,
+stored remote text expires after six months. The operator blocklist and the
+inbound caps that were the condition for storing anything shipped alongside it
+(issue #1067, see the safety-floor bullet above). Reposts
 now federate as
 `Announce` (issue #910) and account deletion broadcasts an actor `Delete`
 (issue #985) — see the post-lifecycle and account-deletion bullets.

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -187,6 +187,14 @@ defmodule Vutuv.Accounts.User do
     # because deleting federated copies on remote servers is unenforceable, so
     # per-member consent is the only lawful default.
     field(:fediverse_followers?, :boolean, default: false)
+    # Whether favourites and re-shares that come back from other networks are
+    # counted under the member's posts (issue #1068). On by default, because a
+    # member who already federates is publishing outward and this is only the
+    # answer coming back; no second consent box, since consent is not the legal
+    # basis for a third party's data anyway (data minimisation plus a working
+    # deletion path is) and a switch nobody finds helps nobody. Switching it off
+    # drops every stored row (`Vutuv.Fediverse.drop_reactions/1`).
+    field(:fediverse_reactions?, :boolean, default: true)
     # The Fediverse account(s) the member is migrating *from* (issue #986,
     # half 1): actor URIs rendered as `alsoKnownAs` on the actor document. A
     # remote server (Mastodon) checks this before it moves a member's followers
@@ -355,7 +363,7 @@ defmodule Vutuv.Accounts.User do
   # :email_confirmed? is NOT here either: it flips only via the login-PIN path
   # (Accounts.activate_user/1, its own narrow cast) — castable, it would let a
   # registration self-activate without ever proving control of an email.
-  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix gender birthdate birthdate_visibility locale tag_list)a
+  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? fediverse_reactions? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix gender birthdate birthdate_visibility locale tag_list)a
 
   # The job-availability values a member can advertise (issue #870), other
   # than the "not specified" default which is stored as nil. The single source

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -36,11 +36,14 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.Follower
   alias Vutuv.Fediverse.HttpSignature
   alias Vutuv.Fediverse.Keys
+  alias Vutuv.Fediverse.Reaction
+  alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostDenial
   alias Vutuv.RateLimiter
   alias Vutuv.Repo
   alias Vutuv.SocialFeed.Http
+  alias Vutuv.UUIDv7
   alias VutuvWeb.Fediverse.Docs
 
   @max_attempts 8
@@ -356,6 +359,112 @@ defmodule Vutuv.Fediverse do
 
   defp check_inbound_cap(_), do: :ok
 
+  ## Inbound reactions (issue #1068)
+
+  @doc """
+  Records what somebody on another network did with a member's post: a `Like`
+  (they favourited it) or an `Announce` (they re-shared it). Idempotent per
+  remote person per post per kind, so a repeat activity never double-counts.
+
+  Every gate that must hold before a third party's row is stored, in order: the
+  installation switch, the member federates and has not switched the counts off,
+  the object really is one of *their* public posts (a Note URL we serve), the
+  post is public, and the sending server is within its inbound cap. Anything
+  else is `:skip` — the inbox acknowledges and drops it either way, so a
+  misdirected activity never tells the sender what happened.
+
+  Broadcasts the post's counters afterwards, so an open action bar ticks over
+  without a reload.
+  """
+  def record_reaction(%User{} = user, object, kind, actor_uri) when kind in ~w(like announce) do
+    with true <- enabled?(),
+         true <- federated?(user),
+         true <- user.fediverse_reactions?,
+         %Post{} = post <- resolve_own_note(user, object),
+         false <- Posts.restricted?(post),
+         :ok <- check_inbound_cap(actor_uri),
+         {:ok, _} <- insert_reaction(post, actor_uri, kind) do
+      Posts.broadcast_post_counters(post.id)
+      :ok
+    else
+      _ -> :skip
+    end
+  end
+
+  @doc """
+  Removes a reaction the remote side took back (`Undo(Like)` / `Undo(Announce)`).
+  Honoured at once and unconditionally — an upstream withdrawal is the deletion
+  path that makes storing the row defensible, so it must not depend on any
+  switch still being on.
+  """
+  def remove_reaction(%User{} = user, object, kind, actor_uri) when kind in ~w(like announce) do
+    with %Post{} = post <- resolve_own_note(user, object) do
+      {count, _} =
+        Repo.delete_all(
+          from(r in Reaction,
+            where: r.post_id == ^post.id and r.actor_uri == ^actor_uri and r.kind == ^kind
+          )
+        )
+
+      if count > 0, do: Posts.broadcast_post_counters(post.id)
+    end
+
+    :ok
+  end
+
+  @doc "How many people on other networks reacted to this post."
+  def reaction_count(post_id) do
+    Repo.aggregate(from(r in Reaction, where: r.post_id == ^post_id), :count)
+  end
+
+  @doc """
+  Drops every reaction stored for a member's posts — what switching the counts
+  off means. Nothing is kept "just in case": the switch is the member's
+  deletion lever over third-party data they never asked for.
+  """
+  def drop_reactions(%User{id: user_id}) do
+    {count, _} =
+      Repo.delete_all(
+        from(r in Reaction,
+          where:
+            r.post_id in subquery(from(p in Post, where: p.user_id == ^user_id, select: p.id))
+        )
+      )
+
+    count
+  end
+
+  defp insert_reaction(post, actor_uri, kind) do
+    %Reaction{post_id: post.id}
+    |> Reaction.changeset(%{
+      actor_uri: actor_uri,
+      kind: kind,
+      received_at: DateTime.utc_now(:second)
+    })
+    |> Repo.insert(on_conflict: :nothing, conflict_target: [:post_id, :actor_uri, :kind])
+  end
+
+  # The post behind an activity's `object`, but only when it is a Note URL we
+  # serve for *this* member. A URL naming somebody else's post, a foreign host,
+  # or a malformed id is a miss (nil), never a raise.
+  defp resolve_own_note(user, object) do
+    prefix = Docs.note_url(user, "")
+
+    with uri when is_binary(uri) <- activity_object_id(object),
+         post_id when post_id != uri <- String.replace_prefix(uri, prefix, ""),
+         %Post{user_id: user_id} = post when user_id == user.id <-
+           UUIDv7.with_cast(post_id, &Repo.get(Post, &1)) do
+      post
+    else
+      _ -> nil
+    end
+  end
+
+  # An activity's object is either an embedded document or a bare id URI.
+  defp activity_object_id(%{"id" => id}) when is_binary(id), do: id
+  defp activity_object_id(id) when is_binary(id), do: id
+  defp activity_object_id(_), do: nil
+
   ## Account migration — move out (issue #986, half 2)
 
   @move_cooldown_days 30
@@ -469,7 +578,7 @@ defmodule Vutuv.Fediverse do
   deletion is advisory by protocol).
   """
   def federate_post_update(%Post{} = post) do
-    if Vutuv.Posts.restricted?(post) do
+    if Posts.restricted?(post) do
       federate_post_delete(post)
     else
       maybe_federate(post, &Docs.update_activity/2)
@@ -494,7 +603,7 @@ defmodule Vutuv.Fediverse do
          %User{} = user <- Repo.get(User, post.user_id),
          true <- federated?(user),
          false <- moved?(user),
-         false <- Vutuv.Posts.restricted?(post),
+         false <- Posts.restricted?(post),
          [_ | _] = inboxes <- delivery_inboxes(user) do
       post = Repo.preload(post, [:images, :review, reply_ref: [:parent_author]])
       enqueue(user, inboxes, builder.(post, user))
@@ -522,7 +631,7 @@ defmodule Vutuv.Fediverse do
     with true <- enabled?(),
          true <- federated?(reposter),
          false <- moved?(reposter),
-         false <- Vutuv.Posts.restricted?(post),
+         false <- Posts.restricted?(post),
          %User{} = author <- Repo.get(User, post.user_id),
          true <- federated?(author),
          [_ | _] = inboxes <- delivery_inboxes(reposter) do

--- a/lib/vutuv/fediverse/reaction.ex
+++ b/lib/vutuv/fediverse/reaction.ex
@@ -1,0 +1,46 @@
+defmodule Vutuv.Fediverse.Reaction do
+  @moduledoc """
+  One remote reaction to a member's post (issue #1068): somebody on another
+  network favourited (`like`) or re-shared (`announce`) it.
+
+  **Counts only.** No display name, no avatar, no text — the actor URI is stored
+  for exactly two reasons: so each remote person counts once, and so an upstream
+  `Undo` can find its row. That minimalism is the point: vutuv can never obtain
+  consent from a stranger on another server, so what makes this lawful is
+  storing almost nothing about them and deleting it the moment they, the post or
+  the account go.
+
+  The row's lifetime is the post's lifetime (the FK cascades), exactly like a
+  vutuv like. There is no separate expiry.
+  """
+
+  use VutuvWeb, :model
+
+  @kinds ~w(like announce)
+
+  # A remote URI is unbounded in theory. Cap it in **bytes**, because the row is
+  # part of a btree unique index whose key has a hard size limit — a hostile
+  # multi-kilobyte actor id must fail the changeset, never the index insert
+  # (which would be a 500 out of the inbox).
+  @max_uri_bytes 2_048
+
+  @doc "The reaction kinds vutuv counts."
+  def kinds, do: @kinds
+
+  schema "fediverse_reactions" do
+    field(:actor_uri, :string)
+    field(:kind, :string)
+    field(:received_at, :utc_datetime)
+
+    belongs_to(:post, Vutuv.Posts.Post)
+  end
+
+  def changeset(%__MODULE__{} = reaction, attrs) do
+    reaction
+    |> cast(attrs, [:actor_uri, :kind, :received_at])
+    |> validate_required([:actor_uri, :kind, :received_at])
+    |> validate_inclusion(:kind, @kinds)
+    |> validate_length(:actor_uri, max: @max_uri_bytes, count: :bytes)
+    |> unique_constraint([:post_id, :actor_uri, :kind])
+  end
+end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -901,6 +901,16 @@ defmodule Vutuv.Posts do
                                     OR mu.suspended_until > (NOW() AT TIME ZONE 'utc'))))
             """,
             unquote(post).id
+          ),
+        # What OTHER networks did with this post (issue #1068): favourites and
+        # re-shares that arrived over ActivityPub. Deliberately a separate
+        # figure, never folded into the vutuv counters above — a hostile remote
+        # server can then only inflate its own line, and the member can see
+        # which world answered.
+        fediverse_reactions:
+          fragment(
+            "(SELECT count(*) FROM fediverse_reactions fr WHERE fr.post_id = ?)",
+            unquote(post).id
           )
       }
     end
@@ -912,7 +922,8 @@ defmodule Vutuv.Posts do
       from(p in Post, where: p.id == ^post_id)
       |> select([p], engagement_count_select(p))
 
-    Repo.one(query) || %{likes: 0, bookmarks: 0, reposts: 0, replies: 0}
+    Repo.one(query) ||
+      %{likes: 0, bookmarks: 0, reposts: 0, replies: 0, fediverse_reactions: 0}
   end
 
   @doc """
@@ -1005,6 +1016,13 @@ defmodule Vutuv.Posts do
   end
 
   defp post_topic(post_id), do: "post:#{post_id}"
+
+  @doc """
+  Re-broadcasts a post's counters to every open action bar. The Fediverse inbox
+  calls it when a remote reaction lands or is withdrawn (issue #1068), so the
+  "reactions from other networks" line ticks over with no reload.
+  """
+  def broadcast_post_counters(post_id), do: broadcast_counters(post_id)
 
   defp broadcast_counters(post_id, extra \\ %{}) do
     payload = engagement_counts(post_id) |> Map.put(:post_id, post_id) |> Map.merge(extra)

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -827,11 +827,23 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   defp tags_line([]), do: nil
   defp tags_line(tags), do: "Tags: " <> Enum.map_join(tags, ", ", &"##{&1}")
 
-  # The public engagement counters, mirroring the HTML action bar.
+  # The public engagement counters, mirroring the HTML action bar — including
+  # the separate "from other networks" figure it shows on its own line
+  # (issue #1068), which is omitted here at zero exactly as the HTML omits it.
   @doc false
   def engagement_line(doc) do
-    "#{gettext("Likes")}: #{doc.like_count} · #{gettext("Reposts")}: #{doc.repost_count} · " <>
-      "#{gettext("Bookmarks")}: #{doc.bookmark_count}"
+    vutuv_counts =
+      "#{gettext("Likes")}: #{doc.like_count} · #{gettext("Reposts")}: #{doc.repost_count} · " <>
+        "#{gettext("Bookmarks")}: #{doc.bookmark_count}"
+
+    case doc.fediverse_reaction_count do
+      0 ->
+        vutuv_counts
+
+      count ->
+        vutuv_counts <>
+          " · " <> gettext("Reactions from other networks") <> ": #{count}"
+    end
   end
 
   @doc """

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -72,7 +72,10 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # The public engagement counters the HTML action bar shows to everyone.
       like_count: engagement.likes,
       repost_count: engagement.reposts,
-      bookmark_count: engagement.bookmarks
+      bookmark_count: engagement.bookmarks,
+      # Favourites and re-shares from OTHER networks (issue #1068), the same
+      # separate figure the HTML shows on its own line under the vutuv counters.
+      fediverse_reaction_count: engagement.fediverse_reactions
     })
   end
 

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -2161,8 +2161,38 @@ defmodule VutuvWeb.PostComponents do
         <:icon><.icon_bookmark filled?={@engagement.bookmarked?} /></:icon>
       </.action_button>
     </div>
+
+    <.fediverse_reaction_line :if={@engagement} count={@engagement.fediverse_reactions} />
     """
   end
+
+  # What other networks did with this post (issue #1068): a labelled count on
+  # its OWN line under the vutuv counters, never folded into them. A member who
+  # publishes outward otherwise gets no feedback at all, and keeping the figure
+  # separate means a hostile remote server can inflate only its own line — and
+  # the reader can see which world answered. Public, because it is an aggregate
+  # with no identity attached. Renders nothing at zero, so a post nobody out
+  # there touched stays clean.
+  attr(:count, :integer, required: true)
+
+  defp fediverse_reaction_line(%{count: count} = assigns) when count > 0 do
+    ~H"""
+    <div
+      class="mt-2 border-t border-slate-100 pt-2 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-400"
+      data-fediverse-reactions={@count}
+    >
+      <span aria-hidden="true" class="mr-1">🌐</span>
+      {ngettext(
+        "%{formatted} reaction from other networks",
+        "%{formatted} reactions from other networks",
+        @count,
+        formatted: compact_count(@count)
+      )}
+    </div>
+    """
+  end
+
+  defp fediverse_reaction_line(assigns), do: ~H""
 
   # The Like control: a real toggle for everyone but the author. On your OWN
   # post it is a plain, non-interactive count instead of a clickable heart —

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -161,6 +161,31 @@ defmodule VutuvWeb.FediverseController do
     send_resp(conn, 202, "")
   end
 
+  # Somebody on another network favourited (`Like`) or re-shared (`Announce`)
+  # one of the member's public posts (issue #1068). Stored as a bare counter
+  # row — no name, no text, no picture — so the member sees that their post
+  # travelled. Every gate lives in `Fediverse.record_reaction/4`; whatever it
+  # decides, the answer is the same 202, so a misdirected activity never tells
+  # the sender which of the conditions it failed.
+  defp perform(conn, user, %{"type" => type, "object" => object}, remote)
+       when type in ["Like", "Announce"] do
+    Fediverse.record_reaction(user, object, reaction_kind(type), remote.id)
+    send_resp(conn, 202, "")
+  end
+
+  # The remote side took its reaction back. Honoured at once: an upstream
+  # withdrawal is the deletion path that makes storing the row defensible.
+  defp perform(
+         conn,
+         user,
+         %{"type" => "Undo", "object" => %{"type" => type} = undone},
+         remote
+       )
+       when type in ["Like", "Announce"] do
+    Fediverse.remove_reaction(user, undone["object"], reaction_kind(type), remote.id)
+    send_resp(conn, 202, "")
+  end
+
   # A remote actor that renamed or moved its inbox broadcasts an `Update` of
   # itself to everyone following it. Re-sync from the actor document we just
   # fetched: the row is both a delivery target and what the member sees on
@@ -194,6 +219,9 @@ defmodule VutuvWeb.FediverseController do
   # Outbound-only federation: likes, replies, announces etc. are acknowledged
   # (so well-behaved servers stop retrying) and dropped.
   defp perform(conn, _user, _activity, _remote), do: send_resp(conn, 202, "")
+
+  defp reaction_kind("Like"), do: "like"
+  defp reaction_kind("Announce"), do: "announce"
 
   defp follower_attrs(remote) do
     %{

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -206,6 +206,11 @@ defmodule VutuvWeb.SettingsController do
       gettext("Fediverse settings saved."),
       fn saved ->
         if saved.fediverse_followers?, do: Vutuv.Fediverse.ensure_actor(saved)
+
+        # Switching the counts off is a deletion, not just a "stop counting"
+        # (issue #1068): what is already stored about people on other networks
+        # goes with it, since that is the whole reason storing it is defensible.
+        unless saved.fediverse_reactions?, do: Vutuv.Fediverse.drop_reactions(saved)
       end
     )
   end

--- a/lib/vutuv_web/live/post_live/action_bar.ex
+++ b/lib/vutuv_web/live/post_live/action_bar.ex
@@ -94,7 +94,10 @@ defmodule VutuvWeb.PostLive.ActionBar do
             | likes: likes,
               bookmarks: bookmarks,
               reposts: reposts,
-              replies: replies
+              replies: replies,
+              # Issue #1068: a reaction from another network arrives without any
+              # viewer of ours acting, so this is the only path that updates it.
+              fediverse_reactions: payload.fediverse_reactions
           })
         end
     end

--- a/lib/vutuv_web/templates/settings/fediverse.html.heex
+++ b/lib/vutuv_web/templates/settings/fediverse.html.heex
@@ -79,6 +79,22 @@ deserves more room than one toggle row. --%>
           )}
         </.setting_toggle>
 
+        <%!-- Reaction counts (issue #1068): what other networks did with the
+              member's posts, as a plain number under each post. On by default
+              for anyone who already federates, because they are publishing
+              outward and this is only the answer coming back; the switch is
+              here so it can be turned off, and turning it off deletes what is
+              stored. Only shown once federation is on, where it can apply. --%>
+        <.setting_toggle
+          :if={Vutuv.Fediverse.federated?(@user)}
+          label={gettext("Count reactions from other networks")}
+        >
+          <:checkbox><%= checkbox f, :fediverse_reactions?, class: checkbox_class() %></:checkbox>
+          {gettext(
+            "Under each of your posts, show how many people on Mastodon & Co. liked or shared it. Just a number, visible to everyone who sees the post. We store no names, no pictures and no text for it. Switch it off and everything stored for it is deleted."
+          )}
+        </.setting_toggle>
+
         <%!-- alsoKnownAs (issue #986): the accounts a member is moving *from*.
               A remote server checks these before it moves the member's
               followers here, so listing the old account's address is what makes

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.148.0",
+      version: "7.149.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15738,3 +15738,25 @@ msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
 #, elixir-autogen, elixir-format
 msgid "none yet"
 msgstr "noch keiner"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:845
+#, elixir-autogen, elixir-format
+msgid "Reactions from other networks"
+msgstr "Reaktionen aus anderen Netzwerken"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
+#, elixir-autogen, elixir-format
+msgid "Count reactions from other networks"
+msgstr "Reaktionen aus anderen Netzwerken zählen"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:93
+#, elixir-autogen, elixir-format
+msgid "Under each of your posts, show how many people on Mastodon & Co. liked or shared it. Just a number, visible to everyone who sees the post. We store no names, no pictures and no text for it. Switch it off and everything stored for it is deleted."
+msgstr "Zeigen Sie unter jedem Ihrer Beiträge, wie viele Menschen bei Mastodon & Co. ihn geliked oder geteilt haben. Nur eine Zahl, sichtbar für alle, die den Beitrag sehen. Namen, Bilder oder Texte speichern wir dafür nicht. Schalten Sie es aus, wird alles dafür Gespeicherte gelöscht."
+
+#: lib/vutuv_web/components/post_components.ex:2170
+#, elixir-autogen, elixir-format
+msgid "%{formatted} reaction from other networks"
+msgid_plural "%{formatted} reactions from other networks"
+msgstr[0] "%{formatted} Reaktion aus anderen Netzwerken"
+msgstr[1] "%{formatted} Reaktionen aus anderen Netzwerken"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -14987,3 +14987,25 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "none yet"
 msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:845
+#, elixir-autogen, elixir-format
+msgid "Reactions from other networks"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
+#, elixir-autogen, elixir-format
+msgid "Count reactions from other networks"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:93
+#, elixir-autogen, elixir-format
+msgid "Under each of your posts, show how many people on Mastodon & Co. liked or shared it. Just a number, visible to everyone who sees the post. We store no names, no pictures and no text for it. Switch it off and everything stored for it is deleted."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:2170
+#, elixir-autogen, elixir-format
+msgid "%{formatted} reaction from other networks"
+msgid_plural "%{formatted} reactions from other networks"
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -14985,3 +14985,25 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "none yet"
 msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:845
+#, elixir-autogen, elixir-format
+msgid "Reactions from other networks"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
+#, elixir-autogen, elixir-format
+msgid "Count reactions from other networks"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:93
+#, elixir-autogen, elixir-format
+msgid "Under each of your posts, show how many people on Mastodon & Co. liked or shared it. Just a number, visible to everyone who sees the post. We store no names, no pictures and no text for it. Switch it off and everything stored for it is deleted."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:2170
+#, elixir-autogen, elixir-format
+msgid "%{formatted} reaction from other networks"
+msgid_plural "%{formatted} reactions from other networks"
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/repo/migrations/20260724212449_create_fediverse_reactions.exs
+++ b/priv/repo/migrations/20260724212449_create_fediverse_reactions.exs
@@ -1,0 +1,41 @@
+defmodule Vutuv.Repo.Migrations.CreateFediverseReactions do
+  use Ecto.Migration
+
+  # What other networks did with a member's post (issue #1068): one minimal row
+  # per remote person per post per kind, so the member can be shown a count.
+  #
+  # Deliberately counts only. No display name, no avatar, no text — the actor
+  # URI is here for exactly two reasons: each person counts once, and an
+  # upstream Undo can find its row. Nothing else about a third party is stored,
+  # which is what makes data minimisation plus a working deletion path the legal
+  # footing rather than a consent we could never obtain from them.
+  #
+  # A row lives exactly as long as the post it belongs to (the FK cascade), the
+  # way a vutuv like does; there is no separate expiry.
+  #
+  # Plus the member's off-switch: on by default for anyone who already
+  # federates, since they are already publishing outward and this is only the
+  # answer coming back. Turning it off drops the rows.
+  #
+  # New table + new column with a default -> N-1 safe for the blue/green window.
+  def change do
+    create table(:fediverse_reactions) do
+      add(:post_id, references(:posts, type: :binary_id, on_delete: :delete_all), null: false)
+      # The remote actor's id URI. `text`, because remote URIs are unbounded in
+      # theory; the schema caps the length before anything is written.
+      add(:actor_uri, :text, null: false)
+      # like | announce (a favourite, or a re-share).
+      add(:kind, :string, null: false)
+      add(:received_at, :utc_datetime, null: false)
+    end
+
+    # One row per (post, person, kind): a repeat Like is an upsert, never a
+    # second vote, and an Undo finds its row on this index. It is also the index
+    # the per-post count reads.
+    create(unique_index(:fediverse_reactions, [:post_id, :actor_uri, :kind]))
+
+    alter table(:users) do
+      add(:fediverse_reactions?, :boolean, null: false, default: true)
+    end
+  end
+end

--- a/test/vutuv/fediverse_reactions_test.exs
+++ b/test/vutuv/fediverse_reactions_test.exs
@@ -1,0 +1,217 @@
+defmodule Vutuv.FediverseReactionsTest do
+  @moduledoc """
+  What other networks did with a member's post (issue #1068): the counter rows
+  behind the "reactions from other networks" line.
+
+  async: false — the inbound caps (issue #1067) live in the shared
+  `Vutuv.RateLimiter` ETS table, which the SQL sandbox does not roll back.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Accounts
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Reaction
+  alias Vutuv.Posts
+  alias VutuvWeb.Fediverse.Docs
+
+  @actor "https://social.example/users/alice"
+  @other_actor "https://social.example/users/bob"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    user = insert(:activated_user, fediverse_followers?: true)
+    post = create_post!(user, %{"body" => "Federated far and wide."})
+    {:ok, user: user, post: post, note: Docs.note_url(user, post.id)}
+  end
+
+  describe "record_reaction/4" do
+    test "counts a Like once per remote person", %{user: user, post: post, note: note} do
+      assert :ok = Fediverse.record_reaction(user, note, "like", @actor)
+      assert :ok = Fediverse.record_reaction(user, note, "like", @actor)
+      assert Fediverse.reaction_count(post.id) == 1
+
+      assert :ok = Fediverse.record_reaction(user, note, "like", @other_actor)
+      assert Fediverse.reaction_count(post.id) == 2
+    end
+
+    test "a Like and an Announce from the same person are two reactions", %{
+      user: user,
+      post: post,
+      note: note
+    } do
+      assert :ok = Fediverse.record_reaction(user, note, "like", @actor)
+      assert :ok = Fediverse.record_reaction(user, note, "announce", @actor)
+
+      assert Fediverse.reaction_count(post.id) == 2
+    end
+
+    test "accepts an embedded object as well as a bare URL", %{user: user, post: post, note: note} do
+      assert :ok = Fediverse.record_reaction(user, %{"id" => note}, "like", @actor)
+      assert Fediverse.reaction_count(post.id) == 1
+    end
+
+    test "stores nothing but the actor, the kind and when it arrived", %{
+      user: user,
+      post: post,
+      note: note
+    } do
+      :ok = Fediverse.record_reaction(user, note, "like", @actor)
+
+      assert [%Reaction{} = row] = Repo.all(Reaction)
+      assert row.post_id == post.id
+      assert row.actor_uri == @actor
+      assert row.kind == "like"
+      assert row.received_at
+      # The whole schema: no name, no avatar, no text about a third party.
+      assert Reaction.__schema__(:fields) == [:id, :actor_uri, :kind, :received_at, :post_id]
+    end
+
+    test "ignores a post that is not the addressed member's", %{note: note} do
+      stranger = insert(:activated_user, fediverse_followers?: true)
+
+      assert :skip = Fediverse.record_reaction(stranger, note, "like", @actor)
+      assert Repo.aggregate(Reaction, :count) == 0
+    end
+
+    test "ignores anything that is not one of our Note URLs", %{user: user} do
+      for object <- [
+            "https://social.example/users/alice/statuses/1",
+            "#{VutuvWeb.Endpoint.url()}/#{user.username}/posts/not-a-uuid",
+            "#{VutuvWeb.Endpoint.url()}/#{user.username}",
+            nil,
+            42
+          ] do
+        assert :skip = Fediverse.record_reaction(user, object, "like", @actor)
+      end
+
+      assert Repo.aggregate(Reaction, :count) == 0
+    end
+
+    test "ignores a non-public post", %{user: user} do
+      restricted =
+        create_post!(user, %{
+          body: "Just for some.",
+          denials: [%{"wildcard" => "logged_out"}]
+        })
+
+      assert :skip =
+               Fediverse.record_reaction(
+                 user,
+                 Docs.note_url(user, restricted.id),
+                 "like",
+                 @actor
+               )
+
+      assert Repo.aggregate(Reaction, :count) == 0
+    end
+
+    test "ignores a member who does not federate", %{note: note} do
+      plain = insert(:activated_user)
+
+      assert :skip = Fediverse.record_reaction(plain, note, "like", @actor)
+      assert Repo.aggregate(Reaction, :count) == 0
+    end
+
+    test "ignores a member who switched the counts off", %{user: user, note: note} do
+      {:ok, user} = Accounts.update_user(user, %{"fediverse_reactions?" => false})
+
+      assert :skip = Fediverse.record_reaction(user, note, "like", @actor)
+      assert Repo.aggregate(Reaction, :count) == 0
+    end
+
+    test "stores nothing while federation is switched off installation-wide", %{
+      user: user,
+      note: note
+    } do
+      Application.put_env(:vutuv, :fediverse_enabled, false)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_enabled) end)
+
+      assert :skip = Fediverse.record_reaction(user, note, "like", @actor)
+      assert Repo.aggregate(Reaction, :count) == 0
+    end
+
+    test "is subject to the inbound caps (#1067)", %{user: user, note: note} do
+      Application.put_env(:vutuv, :fediverse_inbound_caps, {1, 1})
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_inbound_caps) end)
+
+      assert :ok = Fediverse.record_reaction(user, note, "like", @actor)
+      assert :skip = Fediverse.record_reaction(user, note, "announce", @other_actor)
+    end
+  end
+
+  describe "remove_reaction/4" do
+    test "an Undo takes exactly that reaction back", %{user: user, post: post, note: note} do
+      :ok = Fediverse.record_reaction(user, note, "like", @actor)
+      :ok = Fediverse.record_reaction(user, note, "announce", @actor)
+
+      assert :ok = Fediverse.remove_reaction(user, note, "like", @actor)
+
+      assert [%Reaction{kind: "announce"}] = Repo.all(Reaction)
+      assert Fediverse.reaction_count(post.id) == 1
+    end
+
+    test "is honoured even after the member switched the counts off", %{
+      user: user,
+      post: post,
+      note: note
+    } do
+      :ok = Fediverse.record_reaction(user, note, "like", @actor)
+      {:ok, user} = Accounts.update_user(user, %{"fediverse_reactions?" => false})
+
+      assert :ok = Fediverse.remove_reaction(user, note, "like", @actor)
+      assert Fediverse.reaction_count(post.id) == 0
+    end
+  end
+
+  describe "cascades" do
+    test "deleting the post takes its reactions", %{user: user, post: post, note: note} do
+      :ok = Fediverse.record_reaction(user, note, "like", @actor)
+
+      {:ok, _} = Posts.delete_post(post)
+
+      assert Repo.aggregate(Reaction, :count) == 0
+    end
+
+    test "deleting the account takes them too", %{user: user, note: note} do
+      :ok = Fediverse.record_reaction(user, note, "like", @actor)
+
+      {:ok, _} = Accounts.delete_user(user)
+
+      assert Repo.aggregate(Reaction, :count) == 0
+    end
+
+    test "switching the counts off drops what is stored", %{user: user, note: note} do
+      :ok = Fediverse.record_reaction(user, note, "like", @actor)
+
+      assert Fediverse.drop_reactions(user) == 1
+      assert Repo.aggregate(Reaction, :count) == 0
+    end
+  end
+
+  describe "the count reaches the action bar" do
+    test "engagement_counts/1 carries it beside the vutuv counters", %{
+      user: user,
+      post: post,
+      note: note
+    } do
+      assert Posts.engagement_counts(post.id).fediverse_reactions == 0
+
+      :ok = Fediverse.record_reaction(user, note, "like", @actor)
+
+      counts = Posts.engagement_counts(post.id)
+      assert counts.fediverse_reactions == 1
+      # Never folded into the vutuv figures: a hostile remote server may only
+      # inflate its own line.
+      assert counts.likes == 0
+      assert counts.reposts == 0
+    end
+
+    test "post_engagement/2 carries it too", %{user: user, post: post, note: note} do
+      :ok = Fediverse.record_reaction(user, note, "like", @actor)
+
+      assert Posts.post_engagement(post.id, nil).fediverse_reactions == 1
+    end
+  end
+end

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -405,6 +405,17 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     :ok = Vutuv.Posts.repost_post(fan, post)
     :ok = Vutuv.Posts.bookmark_post(fan, post)
 
+    # A favourite from another network (issue #1068): its own figure, so the
+    # `.json` sibling must carry the same number the HTML line shows. Written
+    # straight to the table — the inbox rules that put it there are the
+    # Fediverse tests' business, this one is about what the formats render.
+    Vutuv.Repo.insert!(%Vutuv.Fediverse.Reaction{
+      post_id: post.id,
+      actor_uri: "https://social.example/users/alice",
+      kind: "like",
+      received_at: DateTime.utc_now(:second)
+    })
+
     rendered = formats_for("/drift_tester/posts/#{post.id}")
 
     for fact <- [
@@ -421,9 +432,12 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert doc["like_count"] == 1
     assert doc["repost_count"] == 1
     assert doc["bookmark_count"] == 1
+    assert doc["fediverse_reaction_count"] == 1
 
     assert rendered.md =~ "Likes: 1"
     assert rendered.txt =~ "Likes: 1"
+    assert rendered.md =~ "Reactions from other networks: 1"
+    assert rendered.txt =~ "Reactions from other networks: 1"
   end
 
   test "post permalink: the whole conversation reaches every format (issue #1006)", %{

--- a/test/vutuv_web/controllers/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/fediverse_controller_test.exs
@@ -308,6 +308,79 @@ defmodule VutuvWeb.FediverseControllerTest do
     end
   end
 
+  describe "POST /:slug/actor/inbox — reactions from other networks (#1068)" do
+    defp reaction_activity(type, object) do
+      %{
+        "@context" => "https://www.w3.org/ns/activitystreams",
+        "id" => "https://social.example/activities/#{type}",
+        "type" => type,
+        "actor" => @remote_actor,
+        "object" => object
+      }
+    end
+
+    test "a signed Like on a public post is counted, and only once", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = federated_user()
+      post = create_post!(user, %{body: "Reachable from anywhere."})
+      note = Docs.note_url(user, post.id)
+
+      conn = signed_post(conn, user, reaction_activity("Like", note), priv)
+      assert conn.status == 202
+      assert Fediverse.reaction_count(post.id) == 1
+
+      conn = signed_post(recycle(conn), user, reaction_activity("Like", note), priv)
+      assert conn.status == 202
+      assert Fediverse.reaction_count(post.id) == 1
+    end
+
+    test "an Announce counts beside the Like from the same account", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = federated_user()
+      post = create_post!(user, %{body: "Worth re-sharing."})
+      note = Docs.note_url(user, post.id)
+
+      signed_post(conn, user, reaction_activity("Like", note), priv)
+      signed_post(recycle(conn), user, reaction_activity("Announce", note), priv)
+
+      assert Fediverse.reaction_count(post.id) == 2
+    end
+
+    test "Undo(Like) removes it again", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = federated_user()
+      post = create_post!(user, %{body: "Briefly applauded."})
+      note = Docs.note_url(user, post.id)
+
+      signed_post(conn, user, reaction_activity("Like", note), priv)
+      assert Fediverse.reaction_count(post.id) == 1
+
+      undo = reaction_activity("Undo", reaction_activity("Like", note))
+      conn = signed_post(recycle(conn), user, undo, priv)
+
+      assert conn.status == 202
+      assert Fediverse.reaction_count(post.id) == 0
+    end
+
+    test "a reaction to a non-public post is acknowledged and dropped", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = federated_user()
+
+      post =
+        create_post!(user, %{body: "Members only.", denials: [%{"wildcard" => "logged_out"}]})
+
+      conn =
+        signed_post(conn, user, reaction_activity("Like", Docs.note_url(user, post.id)), priv)
+
+      assert conn.status == 202
+      assert Fediverse.reaction_count(post.id) == 0
+    end
+  end
+
   describe "POST /:slug/actor/inbox — blocked servers (#1067)" do
     setup do
       admin = insert(:activated_user, admin?: true)

--- a/test/vutuv_web/controllers/post_controller_test.exs
+++ b/test/vutuv_web/controllers/post_controller_test.exs
@@ -985,6 +985,30 @@ defmodule VutuvWeb.PostControllerTest do
       assert html =~ ~s(id="post-actions-#{post.id}-like")
       assert html =~ ~r/data-count="like">\s*2\s*</
       assert html =~ ~r/data-count="repost">\s*1\s*</
+      # Nothing from other networks, so no line at all (issue #1068).
+      refute html =~ "data-fediverse-reactions"
+    end
+
+    test "reactions from other networks show as their own labelled line (#1068)", %{conn: conn} do
+      user = insert_activated_user()
+      post = create_post!(user, %{body: "travelled"})
+
+      for actor <- ["alice", "bob"] do
+        Repo.insert!(%Vutuv.Fediverse.Reaction{
+          post_id: post.id,
+          actor_uri: "https://social.example/users/#{actor}",
+          kind: "like",
+          received_at: DateTime.utc_now(:second)
+        })
+      end
+
+      html = html_response(get(conn, Posts.path(post)), 200)
+
+      assert html =~ ~s(data-fediverse-reactions="2")
+      assert html =~ "reactions from other networks"
+      # Its own line, never folded into the vutuv counters: nobody here liked
+      # or reposted, so those counters must show no 2 of their own.
+      refute html =~ ~r/data-count="(like|repost)">\s*2\s*</
     end
 
     test "the archive lists the author's reposts with the reposted-by line", %{conn: conn} do

--- a/test/vutuv_web/controllers/settings_controller_test.exs
+++ b/test/vutuv_web/controllers/settings_controller_test.exs
@@ -290,6 +290,54 @@ defmodule VutuvWeb.SettingsControllerTest do
              ~s(id="user_also_known_as_input")
   end
 
+  describe "fediverse: reaction counts from other networks (#1068)" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, user} = Accounts.update_user(user, %{"fediverse_followers?" => "true"})
+      %{conn: conn, user: user}
+    end
+
+    test "the switch shows once federation is on, and is on by default", %{
+      conn: conn,
+      user: user
+    } do
+      assert user.fediverse_reactions?
+
+      html = conn |> get(~p"/settings/fediverse") |> html_response(200)
+
+      assert html =~ ~s(name="user[fediverse_reactions?]")
+      assert html =~ "Count reactions from other networks"
+    end
+
+    test "the switch is hidden until the member federates", %{conn: conn, user: user} do
+      {:ok, _} = Accounts.update_user(user, %{"fediverse_followers?" => "false"})
+
+      html = conn |> get(~p"/settings/fediverse") |> html_response(200)
+
+      refute html =~ ~s(name="user[fediverse_reactions?]")
+    end
+
+    test "switching it off deletes what is already stored", %{conn: conn, user: user} do
+      post = Vutuv.PostsHelpers.create_post!(user, %{body: "Travelled far."})
+
+      Repo.insert!(%Vutuv.Fediverse.Reaction{
+        post_id: post.id,
+        actor_uri: "https://social.example/users/alice",
+        kind: "like",
+        received_at: DateTime.utc_now(:second)
+      })
+
+      conn =
+        put(conn, ~p"/settings/fediverse",
+          user: %{"fediverse_followers?" => "true", "fediverse_reactions?" => "false"}
+        )
+
+      assert redirected_to(conn) == ~p"/settings/fediverse"
+      refute Repo.get(User, user.id).fediverse_reactions?
+      assert Repo.aggregate(Vutuv.Fediverse.Reaction, :count) == 0
+    end
+  end
+
   describe "fediverse: alsoKnownAs account migration (#986)" do
     setup %{conn: conn} do
       {conn, user} = create_and_login_user(conn)

--- a/test/vutuv_web/live/post_actions_live_test.exs
+++ b/test/vutuv_web/live/post_actions_live_test.exs
@@ -527,6 +527,7 @@ defmodule VutuvWeb.PostActionsLiveTest do
         bookmarks: 0,
         reposts: 0,
         replies: 0,
+        fediverse_reactions: 0,
         liked?: true,
         bookmarked?: false,
         reposted?: false,


### PR DESCRIPTION
Closes #1068. Ships on top of #1076 (#1067), which is the safety floor it required.

A member who publishes outward got **zero** feedback back: every applause and re-share arrived at the inbox, was acknowledged and dropped. Now a `Like` or `Announce` naming one of their public posts becomes one minimal row, shown as a labelled count under the post.

```
┌───────────────────────────────────────┐
│ Stefan Wintermeyer · vor 2 Std        │
│ Wir haben v7.147 ausgeliefert …       │
│                                       │
│  ♥ 8    ⟳ 2    💬 3                   │
│  ───────────────────────────────────  │
│  🌐 14 Reaktionen aus anderen         │
│     Netzwerken                        │
└───────────────────────────────────────┘
```

**Counts only, and the row says so.** `fediverse_reactions`: `post_id`, `actor_uri`, `kind`, `received_at`. No display name, no avatar, no text. vutuv can never obtain consent from a stranger on another server, so what makes this lawful is storing almost nothing about them **plus** a deletion path that really works:
- an upstream `Undo` deletes at once, and `remove_reaction/4` is deliberately **un**gated — it must not depend on any switch still being on;
- deleting the post and deleting the account both cascade;
- the member's off-switch deletes what is stored.

The actor URI earns its place twice over: each person counts once (unique on `(post_id, actor_uri, kind)`) and an `Undo` can find its row.

**Its own line, never folded into the vutuv counters.** A hostile remote server can then inflate only its own line, never a vutuv like count, and the member sees which world answered. Public (an aggregate with no identity attached, and it shows visitors that vutuv posts have reach beyond vutuv), hidden at zero.

**On for members who already federate**, with a visible off-switch on `/settings/fediverse`. No second opt-in checkbox, per the product call on the issue.

**Plumbing.** The count rides the existing engagement select, so it is batched with the other counters, ticks live over the post topic (`broadcast_post_counters/1`), and reaches the `.md`/`.txt`/`.json`/`.xml` siblings from the same doc builder as `fediverse_reaction_count`. Everything behind `:fediverse_enabled` and behind `Fediverse.record_reaction/4`'s gate chain; the inbox answers the same `202` whatever that chain decides, so a misdirected activity learns nothing.

**Tests** cover every acceptance point: a signed `Like` increments the line, a second from the same actor does not, `Like` + `Announce` from one actor are two, `Undo` removes it, a reaction to a non-public post / a non-federating member / somebody else's post is ignored, post and account deletion cascade, the off-switch stops storage and deletes what is there, `:fediverse_enabled=false` stores nothing, and the `.json` sibling carries the same number as the HTML (the drift test).

`mix precommit` green (4853 tests). Docs: `docs/architecture/fediverse.md` + `docs/ADMINS.md`.

⚠️ **Operator action, not in this PR:** the privacy page is per-installation content edited at `/admin/legal`, so its Fediverse paragraph needs a sentence about the counter rows. I can draft and apply that on request.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01UX4B9CkgK8jqB5b2pULtRp