### PR TITLE
Drop remote followers whose account no longer exists

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -127,6 +127,13 @@ config :vutuv, :ads_enabled, false
 # either way (users.fediverse_followers?).
 config :vutuv, :fediverse_enabled, true
 
+# Whether the hourly GenServer that re-checks remote followers runs (off in
+# tests, where it would touch the SQL sandbox from outside; tests call
+# Vutuv.Fediverse.prune_due_followers/1 directly). It drops a follower row
+# whose remote account answers 404/410 — the accounts that vanished without
+# an Undo or a Delete. A no-op anyway while :fediverse_enabled is off.
+config :vutuv, :fediverse_follower_pruning, true
+
 # The site-wide AI-crawler stance (see VutuvWeb.ContentPolicy): :permissive
 # welcomes search, live AI input AND model training; :block_training keeps
 # retrieval but declares ai-train=no and blocks the training crawlers in

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,6 +26,10 @@ config :vutuv, :prune_search_history, false
 # outside. Vutuv.Webhooks.Deliverer.nudge/0 casts into the void then.
 config :vutuv, :webhook_deliverer, false
 config :vutuv, :fediverse_deliverer, false
+# The hourly remote-follower re-check would likewise touch the sandbox from
+# outside; tests call Vutuv.Fediverse.prune_due_followers/1 directly with a
+# stubbed HTTP layer.
+config :vutuv, :fediverse_follower_pruning, false
 # Post link-screenshots drain via a polling GenServer that would touch the
 # sandbox from outside; tests call Vutuv.Posts.Screenshots.deliver_due/1 directly
 # with a stubbed capture. ScreenshotWorker.nudge/0 casts into the void then.

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -477,6 +477,20 @@ is not a vetted party. Your levers live at **`/admin` → Fediverse**
   biggest first, and the dashboard card names the busiest one. That is the list
   a block decision is made from.
 
+**Followers who leave without saying so.** Somebody on another server who
+unfollows, or who deletes their account and whose server announces it, disappears
+from a member's follower list at once. Not every departure is announced, so once
+an hour vutuv re-asks a small handful of remote servers whether a follower's
+account still exists, and drops the row when the server answers "no such account"
+(HTTP 404) or "gone" (410). Nothing else drops a follower: a server that is slow,
+down, overloaded or rate-limiting you is having a bad day, not losing a person.
+Each row is re-asked at most once a month and no more than ten accounts per
+server per run, so even a huge server sees a few plain requests an hour. The
+nightly report counts the removals ("Entfernte Fediverse-Follower"), which is
+where you would notice a whole server dropping out at once. This keeps your
+members' follower counts honest and stops the installation from holding the
+address of somebody who deleted their account.
+
 **What is stored from other servers.** Exactly one thing: a bare counter row per
 remote person per post per kind (favourite / re-share), holding only that
 person's account address, the kind and the time. No name, no picture, no text.

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -69,8 +69,30 @@ every endpoint 404s and nothing is delivered.
   protocol — a server that already purged the account answers our actor fetch
   with 410, so the signature cannot be verified and the activity is rejected;
   it lands during the window where the account is suspended but still served.
-  Deliveries to a gone inbox are dropped by the queue on 404/410 but do not
-  yet prune the follower row (see the v1 limits).
+  Deliveries to a gone inbox are dropped by the queue on 404/410; the follower
+  row behind them is dropped by the pruner below.
+- **Pruning followers who left silently** (issue #1072,
+  `Vutuv.Fediverse.FollowerPruner` + `prune_due_followers/1`): an `Undo(Follow)`
+  or the remote's own `Delete` removes a follower at once, but a server that
+  simply stops answering for one account tells us nothing — deliveries go to its
+  *shared* inbox, which keeps working for everybody else there, so pruning on a
+  failed delivery would wrongly drop that whole server. Instead each follower row
+  is re-fetched on a slow rotation with the SSRF-guarded, size-capped, signed
+  `fetch_remote_actor/2` and removed **only** on `404` or `410` (what the common
+  implementations answer for a deleted account). A timeout, a connection error, a
+  `5xx`, a `429` or a redirect leaves the row alone and only stamps
+  `fediverse_followers.last_checked_at` — the server is having a bad day, not a
+  person leaving. Bounded three ways so a big server is never hammered: one row
+  is re-checked at most every `prune_recheck_days/0` (30), a run takes at most
+  `prune_batch/0` (50) rows and at most 10 of them from any one host, and the run
+  is hourly. Each removal appends one row to `fediverse_follower_prunes`
+  (`Vutuv.Fediverse.FollowerPrune`) carrying the member, the **host** and the
+  status — deliberately *not* the remote actor URI, since not holding an
+  identifier of somebody who deleted their account is the entire point. The
+  nightly Tagesbericht counts them (`Vutuv.Reports`, "Entfernte
+  Fediverse-Follower"), so a mass-prune is visible the next morning rather than
+  silent. Gated by `:fediverse_follower_pruning` (off in tests) on top of
+  `:fediverse_enabled`.
 - **Reactions from other networks** (issue #1068, the one inbound thing that is
   stored): a `Like` or `Announce` naming a member's public Note becomes one row
   in `fediverse_reactions` (`Vutuv.Fediverse.Reaction`) — `post_id`,
@@ -199,10 +221,10 @@ Actor bullet above). The design choice worth remembering: a move-out is a
 Fediverse actor, so moving your Fediverse followers away only pauses outbound
 post federation and publishes the redirect; the profile, CV and everything else
 stay. Deleting an account remains its own separate action. The followers
-collection is count-only (privacy). A follower row whose inbox answers 404/410
-is not pruned either: deliveries go to the sharedInbox where the remote
-declares one, so a per-actor gone signal rarely reaches us and pruning on a
-shared inbox would drop every follower on that server (issue #1072).
+collection is count-only (privacy). Followers who leave without saying so are
+found now (issue #1072) — the hourly re-check above prunes a row only on a
+`404`/`410` from the actor document itself, never on a failed delivery to a
+shared inbox.
 
 ## Non-goal: reading other networks inside vutuv
 

--- a/lib/vutuv/application.ex
+++ b/lib/vutuv/application.ex
@@ -79,6 +79,7 @@ defmodule Vutuv.Application do
         optional_child(:prune_search_history, Vutuv.Search.HistorySweeper) ++
         optional_child(:webhook_deliverer, Vutuv.Webhooks.Deliverer) ++
         optional_child(:fediverse_deliverer, Vutuv.Fediverse.Deliverer) ++
+        optional_child(:fediverse_follower_pruning, Vutuv.Fediverse.FollowerPruner) ++
         optional_child(:post_screenshot_worker, Vutuv.Posts.ScreenshotWorker) ++
         optional_child(:image_scan_worker, Vutuv.Moderation.ImageScanWorker) ++
         optional_child(:daily_report_email, Vutuv.Reports.DailyReporter) ++

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -12,7 +12,9 @@ defmodule Vutuv.Fediverse do
       lazily on opt-in; `VutuvWeb.Fediverse.Docs` renders the documents.
     * followers — remote actors following a member
       (`Vutuv.Fediverse.Follower`), written by the inbox on Follow/Undo and
-      kept in step with the remote's own Update/Delete.
+      kept in step with the remote's own Update/Delete; the ones who leave
+      without saying so are found by the slow re-check
+      (`Vutuv.Fediverse.FollowerPruner`).
     * deliveries — a DB-backed outbound queue (`Vutuv.Fediverse.Delivery`)
       drained by `Vutuv.Fediverse.Deliverer` with signed POSTs
       (`Vutuv.Fediverse.HttpSignature`), mirroring the webhooks queue.
@@ -34,6 +36,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.Deliverer
   alias Vutuv.Fediverse.Delivery
   alias Vutuv.Fediverse.Follower
+  alias Vutuv.Fediverse.FollowerPrune
   alias Vutuv.Fediverse.HttpSignature
   alias Vutuv.Fediverse.Keys
   alias Vutuv.Fediverse.Reaction
@@ -211,6 +214,141 @@ defmodule Vutuv.Fediverse do
       )
     )
   end
+
+  ## Pruning followers whose account is gone (issue #1072)
+
+  # Not every departure is announced. An `Undo(Follow)` or the remote actor's
+  # own `Delete` removes a follower at once, but a server that simply stops
+  # answering for one account tells us nothing — deliveries go to its shared
+  # inbox, which keeps working for everybody else on that server. So each
+  # follower row is re-fetched on a slow rotation and dropped only on the two
+  # answers that mean the account itself is gone.
+  #
+  # Slow and bounded on purpose: one row is re-checked at most every
+  # @prune_recheck_days, a run takes at most @prune_batch rows and at most
+  # @prune_per_host of them from any one server, and the run is hourly
+  # (`Vutuv.Fediverse.FollowerPruner`). A big server therefore sees a handful
+  # of plain GETs an hour, never a sweep of its whole roster.
+  @prune_recheck_days 30
+  @prune_batch 50
+  @prune_per_host 10
+
+  # 404 (no such actor) and 410 (Gone — what the common server implementations
+  # answer for a deleted account) are the only answers that prune. A timeout, a
+  # connection error, a 5xx, a 429 rate limit or a redirect all mean the server
+  # is having a bad day, not that a person left, so the row stays.
+  @gone_statuses [404, 410]
+
+  @doc "How long (days) before one follower row is re-checked again."
+  def prune_recheck_days, do: @prune_recheck_days
+
+  @doc "How many follower rows one pruning run checks at most."
+  def prune_batch, do: @prune_batch
+
+  @doc """
+  Re-checks the follower rows that are due and drops the ones whose remote
+  account is gone, recording each removal in the prune ledger
+  (`Vutuv.Fediverse.FollowerPrune`) for the nightly Tagesbericht. Returns how
+  many rows were pruned. A no-op — and no outbound request at all — when the
+  installation-wide switch is off.
+
+  Called by `Vutuv.Fediverse.FollowerPruner`; tests call it directly.
+  """
+  def prune_due_followers(now \\ NaiveDateTime.utc_now()) do
+    now = NaiveDateTime.truncate(now, :second)
+
+    if enabled?(), do: do_prune_due_followers(now), else: 0
+  end
+
+  defp do_prune_due_followers(now) do
+    due = followers_due_for_prune(now)
+    actors = actors_by_user_id(due)
+
+    # Each check is one blocking HTTPS round trip (no DB connection held during
+    # it), so run a few at a time instead of summing every remote's latency.
+    due
+    |> Task.async_stream(&check_follower(&1, actors[&1.user_id], now),
+      max_concurrency: 5,
+      timeout: 30_000,
+      on_timeout: :kill_task
+    )
+    |> Enum.count(&(&1 == {:ok, :pruned}))
+  end
+
+  @doc """
+  The follower rows due for a re-check: never checked, or last checked longer
+  than `prune_recheck_days/0` ago. Oldest first, capped at `prune_batch/0` rows
+  and at `@prune_per_host` rows per remote server.
+  """
+  def followers_due_for_prune(now \\ NaiveDateTime.utc_now()) do
+    cutoff =
+      NaiveDateTime.add(NaiveDateTime.truncate(now, :second), -@prune_recheck_days * 86_400)
+
+    from(f in Follower,
+      where: is_nil(f.last_checked_at) or f.last_checked_at < ^cutoff,
+      order_by: [asc_nulls_first: f.last_checked_at, asc: f.id],
+      # Read a wider window than one batch: a server with thousands of stale
+      # rows would otherwise fill the batch by itself and the per-host cap
+      # would leave the run half empty, starving everybody else.
+      limit: ^(@prune_batch * 4),
+      preload: [:user]
+    )
+    |> Repo.all()
+    |> spread_across_hosts()
+  end
+
+  defp spread_across_hosts(followers) do
+    followers
+    |> Enum.reduce({[], %{}}, fn follower, {kept, per_host} ->
+      host = BlockedInstance.normalize_host(follower.actor_uri) || follower.actor_uri
+      taken = Map.get(per_host, host, 0)
+
+      if taken < @prune_per_host,
+        do: {[follower | kept], Map.put(per_host, host, taken + 1)},
+        else: {kept, per_host}
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+    |> Enum.take(@prune_batch)
+  end
+
+  defp check_follower(%Follower{} = follower, actor, now) do
+    case fetch_remote_actor(follower.actor_uri, signer_for(follower.user, actor)) do
+      {:error, {:http, status}} when status in @gone_statuses ->
+        prune_follower(follower, status)
+
+      _ ->
+        touch_follower(follower, now)
+    end
+  end
+
+  defp prune_follower(%Follower{} = follower, status) do
+    Repo.delete(follower)
+
+    # The host is always parseable here (an unparseable actor URI never gets as
+    # far as an HTTP status), but fall back rather than lose the ledger row: a
+    # deletion the report cannot see is exactly what this is meant to prevent.
+    %FollowerPrune{user_id: follower.user_id}
+    |> FollowerPrune.changeset(%{
+      host: BlockedInstance.normalize_host(follower.actor_uri) || "unknown",
+      status: status
+    })
+    |> Repo.insert()
+
+    :pruned
+  end
+
+  # Everything that is not a "gone" answer only moves the clock, so the next run
+  # picks up other rows instead of hammering the same unhappy server.
+  defp touch_follower(%Follower{} = follower, now) do
+    follower |> Ecto.Changeset.change(last_checked_at: now) |> Repo.update()
+    :kept
+  end
+
+  defp signer_for(%User{} = user, %Actor{} = actor),
+    do: {Docs.key_id(user), actor.private_key_pem}
+
+  defp signer_for(_user, _actor), do: nil
 
   ## Blocked instances and inbound caps (issue #1067)
 
@@ -560,12 +698,7 @@ defmodule Vutuv.Fediverse do
 
   # The member's own key, to sign the target-actor fetch (authorized-fetch
   # instances reject anonymous GETs). federated?/1 guaranteed the actor exists.
-  defp signer(user) do
-    case get_actor(user) do
-      nil -> nil
-      actor -> {Docs.key_id(user), actor.private_key_pem}
-    end
-  end
+  defp signer(user), do: signer_for(user, get_actor(user))
 
   ## Federating posts (called from Vutuv.Posts after commit)
 
@@ -771,8 +904,10 @@ defmodule Vutuv.Fediverse do
     length(due)
   end
 
-  defp actors_by_user_id(deliveries) do
-    user_ids = deliveries |> Enum.map(& &1.user_id) |> Enum.uniq()
+  # The signing actor for each member behind a list of rows carrying `user_id`
+  # (deliveries, follower re-checks), in one query instead of one per row.
+  defp actors_by_user_id(rows) do
+    user_ids = rows |> Enum.map(& &1.user_id) |> Enum.uniq()
 
     from(a in Actor, where: a.user_id in ^user_ids)
     |> Repo.all()

--- a/lib/vutuv/fediverse/follower.ex
+++ b/lib/vutuv/fediverse/follower.ex
@@ -7,6 +7,11 @@ defmodule Vutuv.Fediverse.Follower do
   actor's own `Update` re-syncs them and its `Delete` removes them, so a
   renamed remote stops showing under its old handle and a deleted one stops
   counting as a follower.
+
+  Not every account announces its own departure, so `last_checked_at` carries
+  the slow re-check that catches the silent ones
+  (`Vutuv.Fediverse.FollowerPruner`): when the actor document was last
+  re-fetched, `nil` for a row that has never been checked.
   """
 
   use VutuvWeb, :model
@@ -27,6 +32,7 @@ defmodule Vutuv.Fediverse.Follower do
     field(:shared_inbox_uri, :string)
     field(:handle, :string)
     field(:name, :string)
+    field(:last_checked_at, :naive_datetime)
 
     belongs_to(:user, Vutuv.Accounts.User)
 

--- a/lib/vutuv/fediverse/follower_prune.ex
+++ b/lib/vutuv/fediverse/follower_prune.ex
@@ -1,0 +1,40 @@
+defmodule Vutuv.Fediverse.FollowerPrune do
+  @moduledoc """
+  One remote follower dropped because their account no longer exists (issue
+  #1072): `Vutuv.Fediverse.prune_due_followers/0` re-fetched the actor document
+  and the remote server answered `404` or `410`.
+
+  The row records **who lost a follower, from which server, on which evidence**
+  — and nothing about the person who left. Storing the actor URI here would
+  undo the very thing the pruning is for: not holding an online identifier of
+  somebody who deleted their account. What is left is what the nightly
+  Tagesbericht needs, so a mass-prune (a whole server answering 410 after a
+  botched migration, say) is visible the next morning instead of silent.
+  """
+
+  use VutuvWeb, :model
+
+  # Hostnames max out at 253 characters; the column is the usual varchar(255).
+  @max_host 253
+
+  # The only two answers that mean "this account is gone" (see the module doc of
+  # Vutuv.Fediverse.FollowerPruner for why nothing else prunes).
+  @statuses [404, 410]
+
+  schema "fediverse_follower_prunes" do
+    field(:host, :string)
+    field(:status, :integer)
+
+    belongs_to(:user, Vutuv.Accounts.User)
+
+    timestamps()
+  end
+
+  def changeset(%__MODULE__{} = prune, attrs) do
+    prune
+    |> cast(attrs, [:host, :status])
+    |> validate_required([:host, :status])
+    |> validate_length(:host, max: @max_host)
+    |> validate_inclusion(:status, @statuses)
+  end
+end

--- a/lib/vutuv/fediverse/follower_pruner.ex
+++ b/lib/vutuv/fediverse/follower_pruner.ex
@@ -1,0 +1,57 @@
+defmodule Vutuv.Fediverse.FollowerPruner do
+  @moduledoc """
+  Drops remote followers whose account no longer exists (issue #1072).
+
+  A remote who unfollows sends `Undo(Follow)` and one who deletes their account
+  broadcasts a `Delete`, and both remove the row at once. Neither reaches us
+  when a server just stops answering for one of its accounts: deliveries go to
+  that server's shared inbox, which keeps working for everybody else on it, so
+  the row would sit here forever — inflating the member's follower count and
+  keeping an online identifier of somebody who left.
+
+  So once an hour this re-fetches a small batch of due follower rows with the
+  SSRF-guarded, size-capped, signed `Vutuv.Fediverse.fetch_remote_actor/2` and
+  deletes the ones answered with `404` or `410`. Everything else (a timeout, a
+  connection error, a `5xx`, a `429`) leaves the row alone — see
+  `Vutuv.Fediverse.prune_due_followers/1` for the batch, per-server and
+  re-check-interval caps that keep this a trickle rather than a sweep.
+
+  Gated twice: the child starts only when `:fediverse_follower_pruning` is on
+  (off in tests, so it never touches the SQL sandbox from outside), and the
+  re-check itself is a no-op while `:fediverse_enabled` is off (an installation
+  that must not call out).
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Vutuv.Fediverse
+
+  @interval :timer.hours(1)
+
+  def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  @impl true
+  def init(:ok) do
+    schedule()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    try do
+      case Fediverse.prune_due_followers() do
+        0 -> :ok
+        count -> Logger.info("Fediverse follower prune: removed #{count} gone follower(s)")
+      end
+    rescue
+      error -> Logger.error("Fediverse follower prune failed: #{inspect(error)}")
+    end
+
+    schedule()
+    {:noreply, state}
+  end
+
+  defp schedule, do: Process.send_after(self(), :sweep, @interval)
+end

--- a/lib/vutuv/reports.ex
+++ b/lib/vutuv/reports.ex
@@ -4,7 +4,8 @@ defmodule Vutuv.Reports do
 
   `daily/1` tallies a single German calendar day (`Vutuv.BerlinTime`):
   confirmed-by-PIN new registrations, the number of posts, reposts, likes and
-  bookmarks created that day, and the new Fediverse followers gained. The admin
+  bookmarks created that day, the new Fediverse followers gained, and the
+  remote followers dropped again because their account is gone. The admin
   reports page
   (`VutuvWeb.Admin.ReportController`) renders any past day on demand;
   `Vutuv.Reports.DailyReporter` mails the previous day's report just after
@@ -17,6 +18,7 @@ defmodule Vutuv.Reports do
   alias Vutuv.BerlinTime
   alias Vutuv.Deliverability
   alias Vutuv.Fediverse.Follower
+  alias Vutuv.Fediverse.FollowerPrune
   alias Vutuv.Notifications.Emailer
   alias Vutuv.Posts.{Post, PostBookmark, PostLike, PostRepost}
   alias Vutuv.Repo
@@ -45,6 +47,7 @@ defmodule Vutuv.Reports do
       likes: count_between(PostLike, day_start, day_end),
       bookmarks: count_between(PostBookmark, day_start, day_end),
       fediverse_followers: count_between(Follower, day_start, day_end),
+      fediverse_prunes: count_between(FollowerPrune, day_start, day_end),
       bounces: deliverability.bounces,
       deactivations: deliverability.deactivations,
       freezes: deliverability.freezes,
@@ -57,6 +60,7 @@ defmodule Vutuv.Reports do
         likes: sample(PostLike, [:user, :post], day_start, day_end, limit),
         bookmarks: sample(PostBookmark, [:user, :post], day_start, day_end, limit),
         fediverse_followers: sample(Follower, [:user], day_start, day_end, limit),
+        fediverse_prunes: sample(FollowerPrune, [:user], day_start, day_end, limit),
         bounces: deliverability_details.bounces,
         deactivations: deliverability_details.deactivations,
         freezes: deliverability_details.freezes,

--- a/lib/vutuv/reports/daily_report.ex
+++ b/lib/vutuv/reports/daily_report.ex
@@ -2,16 +2,17 @@ defmodule Vutuv.Reports.DailyReport do
   @moduledoc """
   A single day's tally for the operator: confirmed-by-PIN new registrations,
   how many posts, reposts, likes and bookmarks were created, how many new
-  Fediverse followers were gained, the day's email-deliverability events
-  (hard bounces, address deactivations, account freezes and thaws) and the
-  accounts an admin removed as spam from a moderation case, on one German
-  calendar day (`Vutuv.BerlinTime`).
+  Fediverse followers were gained and how many were dropped again because the
+  remote account is gone, the day's email-deliverability events (hard bounces,
+  address deactivations, account freezes and thaws) and the accounts an admin
+  removed as spam from a moderation case, on one German calendar day
+  (`Vutuv.BerlinTime`).
 
   Every metric also carries a capped `details` sample (`detail_limit/0` rows,
   oldest first) so the report can name *who* and *what*, not just how many:
   the new members, the created posts, the reposters/likers/bookmarkers, the
-  new Fediverse followers, the bounced/deactivated/frozen/thawed addresses and
-  the removed spam accounts. `Vutuv.Reports.daily/1` fills the sample;
+  new and the pruned Fediverse followers, the bounced/deactivated/frozen/thawed
+  addresses and the removed spam accounts. `Vutuv.Reports.daily/1` fills the sample;
   `VutuvWeb.ReportDetails.sections/1` turns it into linked lines for the email
   and the admin page.
 
@@ -34,6 +35,7 @@ defmodule Vutuv.Reports.DailyReport do
     likes: 0,
     bookmarks: 0,
     fediverse_followers: 0,
+    fediverse_prunes: 0,
     bounces: 0,
     deactivations: 0,
     freezes: 0,
@@ -52,6 +54,7 @@ defmodule Vutuv.Reports.DailyReport do
           likes: non_neg_integer(),
           bookmarks: non_neg_integer(),
           fediverse_followers: non_neg_integer(),
+          fediverse_prunes: non_neg_integer(),
           bounces: non_neg_integer(),
           deactivations: non_neg_integer(),
           freezes: non_neg_integer(),
@@ -74,6 +77,7 @@ defmodule Vutuv.Reports.DailyReport do
     {:likes, "Like", "Likes"},
     {:bookmarks, "Lesezeichen", "Lesezeichen"},
     {:fediverse_followers, "neuer Fediverse-Follower", "neue Fediverse-Follower"},
+    {:fediverse_prunes, "entfernter Fediverse-Follower", "entfernte Fediverse-Follower"},
     {:bounces, "Bounce", "Bounces"},
     {:deactivations, "deaktivierte Adresse", "deaktivierte Adressen"},
     {:freezes, "eingefrorenes Konto", "eingefrorene Konten"},

--- a/lib/vutuv_web/report_details.ex
+++ b/lib/vutuv_web/report_details.ex
@@ -37,6 +37,7 @@ defmodule VutuvWeb.ReportDetails do
     {:likes, "Likes"},
     {:bookmarks, "Lesezeichen"},
     {:fediverse_followers, "Neue Fediverse-Follower"},
+    {:fediverse_prunes, "Entfernte Fediverse-Follower (Konto gelöscht)"},
     {:bounces, "Bounces"},
     {:deactivations, "Deaktivierte Adressen"},
     {:freezes, "Eingefrorene Konten"},
@@ -103,6 +104,17 @@ defmodule VutuvWeb.ReportDetails do
       primary: follower_display(follower),
       secondary: "@" <> follower.user.username,
       path: "/" <> follower.user.username
+    }
+  end
+
+  # A pruned follower is deliberately nameless — only the server it lived on
+  # survives the deletion (see Vutuv.Fediverse.FollowerPrune), so the line reads
+  # "mastodon.example (HTTP 410)" against the member who lost the follower.
+  defp entry(:fediverse_prunes, prune) do
+    %{
+      primary: prune.host,
+      secondary: "HTTP #{prune.status} · @#{prune.user.username}",
+      path: "/" <> prune.user.username
     }
   end
 

--- a/lib/vutuv_web/templates/email/daily_report_de.text.eex
+++ b/lib/vutuv_web/templates/email/daily_report_de.text.eex
@@ -7,6 +7,7 @@ Reposts:                                    <%= @report.reposts %>
 Likes:                                      <%= @report.likes %>
 Lesezeichen:                                <%= @report.bookmarks %>
 Neue Fediverse-Follower:                    <%= @report.fediverse_followers %>
+Entfernte Fediverse-Follower (gelöscht):    <%= @report.fediverse_prunes %>
 
 Zustellbarkeit (E-Mail)
 -----------------------

--- a/lib/vutuv_web/templates/email_body/daily_report_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/daily_report_de.html.heex
@@ -7,6 +7,9 @@
     <.email_row label="Likes">{@report.likes}</.email_row>
     <.email_row label="Lesezeichen">{@report.bookmarks}</.email_row>
     <.email_row label="Neue Fediverse-Follower">{@report.fediverse_followers}</.email_row>
+    <.email_row label="Entfernte Fediverse-Follower (Konto gelöscht)">
+      {@report.fediverse_prunes}
+    </.email_row>
   </.email_panel>
   <.email_p><strong>Zustellbarkeit (E-Mail)</strong></.email_p>
   <.email_panel>

--- a/lib/vutuv_web/templates/settings/fediverse.html.heex
+++ b/lib/vutuv_web/templates/settings/fediverse.html.heex
@@ -144,6 +144,14 @@ subpage now (/settings/fediverse/move), linked from the footer below. --%>
             total: delimited_count(@follower_count)
           )}
         </p>
+        <%!-- The list is kept honest without the member doing anything: a
+              follower whose account no longer exists is dropped by the
+              periodic re-check (Vutuv.Fediverse.FollowerPruner). --%>
+        <p class="mt-2 text-xs text-slate-600 dark:text-slate-400">
+          {gettext(
+            "Accounts that no longer exist on their own server drop off this list by themselves."
+          )}
+        </p>
       <% end %>
     </.card>
 

--- a/lib/vutuv_web/views/admin/report_html.ex
+++ b/lib/vutuv_web/views/admin/report_html.ex
@@ -13,6 +13,7 @@ defmodule VutuvWeb.Admin.ReportHTML do
     :likes,
     :bookmarks,
     :fediverse_followers,
+    :fediverse_prunes,
     :bounces,
     :deactivations,
     :freezes,
@@ -36,6 +37,10 @@ defmodule VutuvWeb.Admin.ReportHTML do
   def metric_label(:likes), do: gettext("Likes")
   def metric_label(:bookmarks), do: gettext("Bookmarks")
   def metric_label(:fediverse_followers), do: gettext("New Fediverse followers")
+
+  def metric_label(:fediverse_prunes),
+    do: gettext("Removed Fediverse followers (account deleted)")
+
   def metric_label(:bounces), do: gettext("Bounces")
   def metric_label(:deactivations), do: gettext("Deactivated addresses")
   def metric_label(:freezes), do: gettext("Frozen accounts")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.150.0",
+      version: "7.151.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -6679,6 +6679,11 @@ msgstr "Deaktivierte Adressen"
 msgid "New Fediverse followers"
 msgstr "Neue Fediverse-Follower"
 
+#: lib/vutuv_web/views/admin/report_html.ex:41
+#, elixir-autogen, elixir-format
+msgid "Removed Fediverse followers (account deleted)"
+msgstr "Entfernte Fediverse-Follower (Konto gelöscht)"
+
 #: lib/vutuv_web/templates/admin/report/index.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "… and %{count} more"
@@ -10463,6 +10468,13 @@ msgstr "Die ausgehende Föderation läuft störungsfrei."
 #, elixir-autogen, elixir-format
 msgid "Showing the most recent %{shown} of %{total}."
 msgstr "Die neuesten %{shown} von %{total} werden angezeigt."
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:151
+#, elixir-autogen, elixir-format
+msgid "Accounts that no longer exist on their own server drop off this list by themselves."
+msgstr ""
+"Konten, die es auf ihrem eigenen Server nicht mehr gibt, verschwinden von "
+"selbst aus dieser Liste."
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:296
 #, elixir-autogen, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -6399,6 +6399,11 @@ msgstr ""
 msgid "New Fediverse followers"
 msgstr ""
 
+#: lib/vutuv_web/views/admin/report_html.ex:41
+#, elixir-autogen, elixir-format
+msgid "Removed Fediverse followers (account deleted)"
+msgstr ""
+
 #: lib/vutuv_web/templates/admin/report/index.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "… and %{count} more"
@@ -9934,6 +9939,11 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Showing the most recent %{shown} of %{total}."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:151
+#, elixir-autogen, elixir-format
+msgid "Accounts that no longer exist on their own server drop off this list by themselves."
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:296

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -6397,6 +6397,11 @@ msgstr ""
 msgid "New Fediverse followers"
 msgstr ""
 
+#: lib/vutuv_web/views/admin/report_html.ex:41
+#, elixir-autogen, elixir-format
+msgid "Removed Fediverse followers (account deleted)"
+msgstr ""
+
 #: lib/vutuv_web/templates/admin/report/index.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "… and %{count} more"
@@ -9932,6 +9937,11 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Showing the most recent %{shown} of %{total}."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:151
+#, elixir-autogen, elixir-format
+msgid "Accounts that no longer exist on their own server drop off this list by themselves."
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:296

--- a/priv/repo/migrations/20260725072416_add_last_checked_at_to_fediverse_followers.exs
+++ b/priv/repo/migrations/20260725072416_add_last_checked_at_to_fediverse_followers.exs
@@ -1,0 +1,19 @@
+defmodule Vutuv.Repo.Migrations.AddLastCheckedAtToFediverseFollowers do
+  use Ecto.Migration
+
+  @moduledoc """
+  When this follower's remote actor document was last re-fetched by
+  Vutuv.Fediverse.FollowerPruner (issue #1072). NULL = never checked, so every
+  row written before this migration is due at once and the pruner works
+  through them oldest-first, in small batches. The index carries that ordering.
+  Plain addition, N-1 safe.
+  """
+
+  def change do
+    alter table(:fediverse_followers) do
+      add(:last_checked_at, :naive_datetime)
+    end
+
+    create(index(:fediverse_followers, [:last_checked_at]))
+  end
+end

--- a/priv/repo/migrations/20260725072425_create_fediverse_follower_prunes.exs
+++ b/priv/repo/migrations/20260725072425_create_fediverse_follower_prunes.exs
@@ -1,0 +1,26 @@
+defmodule Vutuv.Repo.Migrations.CreateFediverseFollowerPrunes do
+  use Ecto.Migration
+
+  @moduledoc """
+  One row per remote follower dropped because its account is gone (issue
+  #1072): the member who lost the follower, the remote server it lived on and
+  the HTTP status that proved it (404 or 410). Deliberately does NOT store the
+  remote actor URI — the point of the pruning is to stop holding an identifier
+  of somebody who deleted their account, so the ledger keeps only what the
+  nightly Tagesbericht needs to make a mass-prune visible. Plain addition,
+  N-1 safe.
+  """
+
+  def change do
+    create table(:fediverse_follower_prunes) do
+      add(:user_id, references(:users, on_delete: :delete_all), null: false)
+      add(:host, :string, null: false)
+      add(:status, :integer, null: false)
+
+      timestamps()
+    end
+
+    create(index(:fediverse_follower_prunes, [:inserted_at]))
+    create(index(:fediverse_follower_prunes, [:user_id]))
+  end
+end

--- a/test/vutuv/fediverse_follower_prune_test.exs
+++ b/test/vutuv/fediverse_follower_prune_test.exs
@@ -1,0 +1,192 @@
+defmodule Vutuv.FediverseFollowerPruneTest do
+  @moduledoc """
+  The slow re-check that drops remote followers whose account is gone (issue
+  #1072): what prunes (404/410), what deliberately does not (a timeout, a 5xx,
+  a rate limit), and the caps that keep a run a trickle rather than a sweep.
+
+  async: false — the HTTP stub lives in the application env, like the rest of
+  the Fediverse tests.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follower
+  alias Vutuv.Fediverse.FollowerPrune
+
+  # A plug stub that answers per remote host, so one run can meet a gone
+  # account and a server having a bad day at the same time. `answers` maps a
+  # host to an HTTP status or `:timeout`.
+  defp stub_hosts(answers) do
+    stub(fn conn ->
+      case Map.fetch!(answers, conn.host) do
+        :timeout -> Req.Test.transport_error(conn, :timeout)
+        status -> Plug.Conn.send_resp(conn, status, "")
+      end
+    end)
+  end
+
+  defp stub(fun) do
+    Application.put_env(:vutuv, :fediverse_req_options, plug: fun)
+    on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+  end
+
+  defp federated_user do
+    user = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    user
+  end
+
+  defp follower(user, host, attrs \\ []) do
+    {:ok, follower} =
+      Fediverse.add_follower(user, %{
+        actor_uri: "https://#{host}/users/alice",
+        inbox_uri: "https://#{host}/inbox"
+      })
+
+    case attrs[:last_checked_at] do
+      nil -> follower
+      stamp -> follower |> Ecto.Changeset.change(last_checked_at: stamp) |> Repo.update!()
+    end
+  end
+
+  describe "prune_due_followers/1" do
+    test "a 410 (Gone) drops the row and records the removal for the report" do
+      user = federated_user()
+      follower(user, "gone.example")
+
+      stub_hosts(%{"gone.example" => 410})
+
+      assert Fediverse.prune_due_followers() == 1
+      assert Fediverse.follower_count(user) == 0
+
+      assert [prune] = Repo.all(FollowerPrune)
+      assert prune.user_id == user.id
+      assert prune.host == "gone.example"
+      assert prune.status == 410
+    end
+
+    test "a 404 drops the row too" do
+      user = federated_user()
+      follower(user, "missing.example")
+
+      stub_hosts(%{"missing.example" => 404})
+
+      assert Fediverse.prune_due_followers() == 1
+      assert Fediverse.follower_count(user) == 0
+      assert [%FollowerPrune{status: 404}] = Repo.all(FollowerPrune)
+    end
+
+    test "a timeout, a 500 and a 429 keep the row and only move its clock" do
+      user = federated_user()
+
+      for host <- ~w(slow.example broken.example busy.example), do: follower(user, host)
+
+      stub_hosts(%{
+        "slow.example" => :timeout,
+        "broken.example" => 500,
+        "busy.example" => 429
+      })
+
+      assert Fediverse.prune_due_followers() == 0
+      assert Fediverse.follower_count(user) == 3
+      assert Repo.all(FollowerPrune) == []
+
+      # Each row was still stamped, so the next run moves on to other followers
+      # instead of retrying the same unhappy servers straight away.
+      assert Enum.all?(Repo.all(Follower), &(&1.last_checked_at != nil))
+    end
+
+    test "the actor fetch is signed with the member's own key" do
+      user = federated_user()
+      follower(user, "authorized.example")
+      test_pid = self()
+
+      stub(fn conn ->
+        send(test_pid, {:signature, Plug.Conn.get_req_header(conn, "signature")})
+        Plug.Conn.send_resp(conn, 200, "{}")
+      end)
+
+      Fediverse.prune_due_followers()
+
+      assert_received {:signature, [signature]}
+      assert signature =~ ~s(keyId=")
+    end
+
+    test "a row checked recently is skipped entirely" do
+      user = federated_user()
+      recent = NaiveDateTime.add(NaiveDateTime.utc_now(:second), -3600)
+      follower(user, "gone.example", last_checked_at: recent)
+
+      stub_hosts(%{"gone.example" => 410})
+
+      assert Fediverse.followers_due_for_prune() == []
+      assert Fediverse.prune_due_followers() == 0
+      assert Fediverse.follower_count(user) == 1
+    end
+
+    test "a row last checked longer ago than the interval is due again" do
+      user = federated_user()
+      days = Fediverse.prune_recheck_days()
+      stale = NaiveDateTime.add(NaiveDateTime.utc_now(:second), -(days + 1) * 86_400)
+      follower(user, "gone.example", last_checked_at: stale)
+
+      stub_hosts(%{"gone.example" => 410})
+
+      assert Fediverse.prune_due_followers() == 1
+      assert Fediverse.follower_count(user) == 0
+    end
+
+    test "the installation-wide switch stops it, without a single request" do
+      user = federated_user()
+      follower(user, "gone.example")
+
+      stub(fn _conn -> raise "the disabled installation must not call out" end)
+      Application.put_env(:vutuv, :fediverse_enabled, false)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_enabled) end)
+
+      assert Fediverse.prune_due_followers() == 0
+      assert Fediverse.follower_count(user) == 1
+    end
+  end
+
+  describe "followers_due_for_prune/1" do
+    test "the batch cap holds however many rows are due" do
+      user = federated_user()
+      over = Fediverse.prune_batch() + 5
+
+      # One host each, so only the batch cap can bite here.
+      for i <- 1..over, do: follower(user, "h#{i}.example")
+
+      assert length(Fediverse.followers_due_for_prune()) == Fediverse.prune_batch()
+    end
+
+    test "one server never fills the run by itself" do
+      user = federated_user()
+
+      for i <- 1..15 do
+        {:ok, _} =
+          Fediverse.add_follower(user, %{
+            actor_uri: "https://big.example/users/u#{i}",
+            inbox_uri: "https://big.example/inbox"
+          })
+      end
+
+      due = Fediverse.followers_due_for_prune()
+
+      assert length(due) < 15
+      assert Enum.all?(due, &(&1.actor_uri =~ "big.example"))
+    end
+
+    test "the oldest check comes first, never-checked rows before all of them" do
+      user = federated_user()
+      now = NaiveDateTime.utc_now(:second)
+
+      follower(user, "recent.example", last_checked_at: NaiveDateTime.add(now, -40 * 86_400))
+      follower(user, "ancient.example", last_checked_at: NaiveDateTime.add(now, -400 * 86_400))
+      follower(user, "never.example")
+
+      assert ["never.example", "ancient.example", "recent.example"] ==
+               Enum.map(Fediverse.followers_due_for_prune(), &URI.parse(&1.actor_uri).host)
+    end
+  end
+end

--- a/test/vutuv/reports_test.exs
+++ b/test/vutuv/reports_test.exs
@@ -106,6 +106,24 @@ defmodule Vutuv.ReportsTest do
       assert Reports.daily(@date).fediverse_followers == 2
     end
 
+    test "counts the remote followers pruned that Berlin day" do
+      user = insert(:user)
+
+      for naive <- [@on_day, @on_day, @other_day] do
+        Repo.insert!(
+          struct(
+            Vutuv.Fediverse.FollowerPrune,
+            [user_id: user.id, host: "social.example", status: 410] ++ at(naive)
+          )
+        )
+      end
+
+      report = Reports.daily(@date)
+
+      assert report.fediverse_prunes == 2
+      assert [%{host: "social.example"} | _] = report.details.fediverse_prunes
+    end
+
     test "the day range is half-open: the start instant counts, the end instant does not" do
       author = insert(:user)
       # day_start = 2026-01-14 23:00 UTC (inclusive), day_end = 2026-01-15 23:00 (exclusive).

--- a/test/vutuv_web/report_details_test.exs
+++ b/test/vutuv_web/report_details_test.exs
@@ -54,6 +54,21 @@ defmodule VutuvWeb.ReportDetailsTest do
              ]
     end
 
+    test "a pruned Fediverse follower names the server, not the person who left" do
+      user = insert(:user, username: "dora")
+
+      Repo.insert!(
+        struct(
+          Vutuv.Fediverse.FollowerPrune,
+          [user_id: user.id, host: "social.example", status: 410] ++ at(@on_day)
+        )
+      )
+
+      assert section(Reports.daily(@date), :fediverse_prunes).entries == [
+               %{primary: "social.example", secondary: "HTTP 410 · @dora", path: "/dora"}
+             ]
+    end
+
     test "a bounce names the address and its status, with no link" do
       insert(:email_bounce,
         email_value: "dead@example.com",


### PR DESCRIPTION
Closes #1072.

When somebody on another network deleted their account, their follower row stayed here forever: the member's follower count drifted upward and we kept an online identifier of a person who no longer exists. A failed delivery could not tell us — deliveries go to a server's shared inbox, so pruning on one would drop every follower on that server.

**What I did:** once an hour, `Vutuv.Fediverse.FollowerPruner` re-fetches a small batch of due follower rows through the existing SSRF-guarded, size-capped, signed `fetch_remote_actor/2` and deletes only the ones answered `404` or `410`. A timeout, a connection error, a `5xx`, a `429` or a redirect leaves the row alone and only stamps `last_checked_at` — that server is having a bad day, not losing a person.

Bounded so nobody gets hammered: a row is re-checked at most every 30 days, a run takes at most 50 rows and at most 10 from any one host, five requests in flight. A big server sees a handful of plain GETs an hour.

Each removal appends a row to the new `fediverse_follower_prunes` ledger with the member, the **host** and the status — deliberately not the remote actor URI, since not holding an identifier of someone who deleted their account is the point. The nightly Tagesbericht counts them ("Entfernte Fediverse-Follower") on the admin page and in both email parts, so a mass-prune is visible the next morning.

`/settings/fediverse` now says that gone accounts drop off the list by themselves; `docs/ADMINS.md` and `docs/architecture/fediverse.md` replace the old "not pruned, see the v1 limits" note.

**Tests** (`test/vutuv/fediverse_follower_prune_test.exs`, plus the report ones): a 410 prunes, a 404 prunes, a timeout / 500 / 429 do not, the fetch is signed, a recently checked row is skipped, one past the interval is due again, the global switch makes no request at all, the batch cap holds, one server cannot fill a run, and the oldest check comes first. The report counts and names what was pruned.

Two migrations, both plain additions (N-1 safe): `fediverse_followers.last_checked_at` and the `fediverse_follower_prunes` table. `mix precommit` green (4873 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01NxTzvBT1dSMhyhvmU2jWES
