### PR TITLE
Show the Fediverse handle on the profile and let visitors follow from their own server

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -183,6 +183,15 @@ every endpoint 404s and nothing is delivered.
   will never move accounts — and where the two directions, 300px apart, read as
   the same thing. Every move action redirects back to that page, so the state
   change lands on screen.
+- **The profile** (issue #1081) is where everyone else finds out. A federating
+  member's `/:slug` carries a **Fediverse card**: the handle `@member@vutuv.de`
+  with a copy button, and the "Follow from your own server" field described
+  below. It is the one card written for a visitor who is not a member, and it
+  renders for nobody else (no opt-in, no card; installation switch off, no
+  card). A member who moved their account away
+  (`moved_to`) sees the forwarding address in its place, since the old handle
+  now only answers with a redirect. `ProfileDoc` carries the same facts into
+  the agent formats.
 - **The member** sees who follows them on `/settings/fediverse` (not just the
   count). The inbox captures each remote actor's `preferredUsername` and
   display name onto the `Follower` row (`handle`/`name`, cosmetic and
@@ -201,6 +210,38 @@ every endpoint 404s and nothing is delivered.
   server has stored here, biggest first, which is what a block decision is made
   from. The nightly Tagesbericht (`Vutuv.Reports`) counts new remote followers
   per Berlin day.
+
+## Follow from your own server
+
+Handing out a handle only gets a visitor halfway: they still have to switch
+apps, paste it into a search box and wait. The Fediverse's answer is the
+**remote-follow (OStatus subscribe) template**, which every server publishes in
+its own WebFinger document. So the profile card asks the visitor for *their*
+address, `Vutuv.Fediverse.RemoteFollow` looks up *their* server's follow dialog
+and `VutuvWeb.RemoteFollowController` (`POST /:slug/fediverse/follow`) redirects
+them into it with the member's `acct:` URI filled in. The follow is then
+confirmed where the visitor's account actually lives; no credential ever reaches
+vutuv and the typed address is used for one lookup and forgotten.
+
+    GET https://their.server/.well-known/webfinger?resource=acct:them@their.server
+    -> links: [{"rel": "http://ostatus.org/spec/1.0#subscribe",
+                "template": "https://their.server/authorize_interaction?uri={uri}"}]
+
+It is a plain HTML form post, not a `phx-click`: the person it is for arrives
+from another network and is the last visitor whose JavaScript we should assume
+anything about. (The profile is a LiveView, which loads the session's CSRF state,
+so the token the form stamps is valid from a live render too.)
+
+This is also the **only outbound fetch an anonymous visitor can trigger**, so it
+is fenced like the inbox path it borrows its shape from: the installation switch
+plus the member actually federating (a crafted POST to a non-federating member is
+refused), a rate limit per IP (`VutuvWeb.RateLimit`, 20/h), https only, the host
+vetted against `Vutuv.Ssrf` before the request **and again** after the single
+redirect hop that is allowed (the common apex-to-server WebFinger setup — Req's
+own redirect following would skip that second check), short timeouts, no
+retries, and a body ceiling that halts the stream rather than buffering. Every
+failure lands back on the profile with a plain-language flash naming the server,
+and the handle is right there to copy, so there is always a way through.
 
 ## Deliberate v1 limits
 

--- a/docs/architecture/profiles.md
+++ b/docs/architecture/profiles.md
@@ -815,6 +815,28 @@ A logged-out visitor sees the default set (Google primary).
 
 The geocoding query keeps the country even when it is hidden on screen
 
+## Fediverse card (issue #1081)
+
+A profile whose member federates gets a **"Fediverse" card** right under the
+header, the one card on the page written for a visitor who is *not* a member:
+someone arriving from Mastodon (or any other ActivityPub app) who wants to
+follow this person from where their own account already lives.
+
+It shows the member's address there, `@member@vutuv.de`, with the shared
+`data-copy` button, and below it a **"Follow from your own server"** field: the
+visitor types their own address and lands on their own server's follow dialog
+with this member filled in. See
+[fediverse.md](fediverse.md#follow-from-your-own-server) for how that resolves.
+
+A member who has moved their Fediverse account away (`moved_to`) gets the
+**forwarding address** instead of the follow tool, since following the old
+handle would only reach a redirect. The card is absent entirely for the
+majority who do not federate, and while `FEDIVERSE_ENABLED` is off.
+
+The handle is public data on a public page, so the agent-format siblings carry
+it too (`ProfileDoc`'s `fediverse` map: handle, actor URL, `moved_to`; a
+`Fediverse:` fact line in md/txt).
+
 ## Inline Mastodon + Bluesky feed
 
 A profile that lists Mastodon or Bluesky accounts gets a **"Social media posts"

--- a/lib/vutuv/fediverse/remote_follow.ex
+++ b/lib/vutuv/fediverse/remote_follow.ex
@@ -1,0 +1,217 @@
+defmodule Vutuv.Fediverse.RemoteFollow do
+  @moduledoc """
+  "Follow from your own server" — the one thing a visitor from another network
+  wants on a member's profile.
+
+  Handing out `@member@vutuv.de` only gets someone halfway: they still have to
+  switch to their own app, paste the handle into a search box and wait for it to
+  resolve. The Fediverse's answer to that is the **remote-follow (OStatus
+  subscribe) template**: every server publishes, in its own WebFinger document,
+  a URL template for its "you are about to follow someone" dialog. So the
+  visitor tells us *their* address, we look up *their* server's template and
+  send them there with our member already filled in. One click, and the follow
+  is confirmed where their account actually lives — no credentials ever touch
+  vutuv.
+
+      GET https://their.server/.well-known/webfinger?resource=acct:them@their.server
+      -> links: [{"rel": "http://ostatus.org/spec/1.0#subscribe",
+                  "template": "https://their.server/authorize_interaction?uri={uri}"}]
+
+  The `{uri}` is filled with the member's `acct:` URI, which their server then
+  resolves against our own WebFinger endpoint.
+
+  This is the only outbound fetch in vutuv that an **anonymous visitor** can
+  trigger, so it is fenced accordingly, in the same shape
+  `Vutuv.Fediverse.fetch_remote_actor/2` uses for the (equally hostile) inbox
+  path: https only, the host vetted against `Vutuv.Ssrf` before the request and
+  again after the single redirect hop that is allowed, short timeouts, a hard
+  body ceiling that halts the stream rather than buffering, and no retries. The
+  caller adds the rate limit and the `:fediverse_enabled` gate.
+  """
+
+  alias Vutuv.SocialFeed.Http
+  alias Vutuv.Ssrf
+
+  # A WebFinger document is a handful of links; anything larger is not one.
+  @max_body_bytes 60_000
+
+  # The rel an ActivityPub server publishes its follow dialog under. The OStatus
+  # URI is historical: Mastodon, Pleroma, Misskey and friends all kept it when
+  # they moved to ActivityPub, so it is the one portable way in. Both spellings
+  # are in the wild — `schema/1.0/subscribe` is what Mastodon actually serves
+  # (verified against mastodon.social), the `spec/1.0#subscribe` form appears in
+  # older OStatus documents and some implementations copied it.
+  @subscribe_rels [
+    "http://ostatus.org/schema/1.0/subscribe",
+    "http://ostatus.org/spec/1.0#subscribe"
+  ]
+
+  @doc """
+  The URL of the visitor's own follow dialog for `target_acct` (an `acct:` URI
+  without the scheme, e.g. `"member@vutuv.de"`), or an error naming what went
+  wrong so the profile can say something true:
+
+    * `:invalid_address` — not a Fediverse address at all (a typo, an email)
+    * `:unreachable` — their server did not answer, or not with a document
+    * `:no_remote_follow` — it answered, but publishes no follow dialog
+  """
+  def subscribe_url(input, target_acct) when is_binary(target_acct) do
+    with {:ok, {user, host}} <- parse_address(input),
+         {:ok, template} <- subscribe_template(user, host) do
+      {:ok, String.replace(template, "{uri}", URI.encode_www_form("acct:" <> target_acct))}
+    end
+  end
+
+  @doc """
+  The `{user, host}` of a Fediverse address, accepting every form people paste:
+  `@you@server`, `you@server`, or the profile URL `https://server/@you`.
+
+  Pure string work — no network, no DNS — so it is safe to call anywhere.
+  """
+  def parse_address(input) when is_binary(input) do
+    input |> String.trim() |> split_address()
+  end
+
+  def parse_address(_), do: {:error, :invalid_address}
+
+  @doc """
+  A remote account URI written the way people read it (`@you@server`), falling
+  back to the URI itself when it does not name a handle. Used where a stored
+  actor URI is shown to a human (the profile's forwarding address after a
+  member moved their Fediverse account away).
+  """
+  def display_address(uri) when is_binary(uri) do
+    case parse_address(uri) do
+      {:ok, {user, host}} -> "@#{user}@#{host}"
+      _ -> uri
+    end
+  end
+
+  defp split_address("https://" <> _ = url), do: url_address(url)
+  defp split_address("http://" <> _ = url), do: url_address(url)
+
+  defp split_address(handle) do
+    case handle |> String.trim_leading("@") |> String.split("@") do
+      [user, host] -> validated(user, host)
+      _ -> {:error, :invalid_address}
+    end
+  end
+
+  # A pasted profile URL: https://server/@you (Mastodon), /users/you (the actor
+  # URL some servers show). Anything else has no handle to read.
+  defp url_address(url) do
+    case URI.parse(url) do
+      %URI{host: host, path: path} when is_binary(host) and is_binary(path) ->
+        case String.split(path, "/", trim: true) do
+          [user] -> validated(String.trim_leading(user, "@"), host)
+          ["users", user] -> validated(user, host)
+          _ -> {:error, :invalid_address}
+        end
+
+      _ ->
+        {:error, :invalid_address}
+    end
+  end
+
+  # The shapes a WebFinger `acct:` can have. The host must look like a real
+  # domain (a dot, no port, no path), the local part like a handle — this is the
+  # only thing standing between a typo and an outbound request.
+  defp validated(user, host) do
+    user = String.trim(user)
+    host = host |> String.trim() |> String.downcase() |> String.trim_trailing(".")
+
+    if user =~ ~r/\A[a-zA-Z0-9_.\-]{1,64}\z/ and host =~ ~r/\A[a-z0-9.\-]+\.[a-z]{2,}\z/ do
+      {:ok, {user, host}}
+    else
+      {:error, :invalid_address}
+    end
+  end
+
+  defp subscribe_template(user, host) do
+    with {:ok, body} <- webfinger(user, host),
+         {:ok, %{"links" => links}} when is_list(links) <- Jason.decode(body),
+         %{"template" => template} when is_binary(template) <-
+           Enum.find(links, %{}, &(is_map(&1) and &1["rel"] in @subscribe_rels)),
+         {:ok, template} <- valid_template(template) do
+      {:ok, template}
+    else
+      {:error, reason} -> {:error, reason}
+      _no_usable_link -> {:error, :no_remote_follow}
+    end
+  end
+
+  # The template is handed to the visitor's browser, so it must be a real https
+  # URL with the placeholder still in it; a non-https or placeholder-less
+  # "template" would send them somewhere we cannot vouch for.
+  defp valid_template(template) do
+    case URI.parse(template) do
+      %URI{scheme: "https", host: host} when is_binary(host) ->
+        if String.contains?(template, "{uri}"),
+          do: {:ok, template},
+          else: {:error, :no_remote_follow}
+
+      _ ->
+        {:error, :no_remote_follow}
+    end
+  end
+
+  defp webfinger(user, host) do
+    url =
+      "https://#{host}/.well-known/webfinger?resource=" <>
+        URI.encode_www_form("acct:#{user}@#{host}")
+
+    fetch(url, 1)
+  end
+
+  # One redirect hop is followed by hand (apex -> the server's real host is a
+  # common WebFinger setup) so the new host is SSRF-vetted like the first;
+  # Req's own redirect following would skip that check.
+  defp fetch(_url, hops) when hops < 0, do: {:error, :unreachable}
+
+  defp fetch(url, hops) do
+    with {:parse, %URI{scheme: "https", host: host}} when is_binary(host) <-
+           {:parse, URI.parse(url)},
+         {:ssrf, false} <- {:ssrf, Ssrf.resolves_to_internal?(host)},
+         {:ok, %Req.Response{} = resp} <- Req.get(options(url)) do
+      handle_response(resp, hops)
+    else
+      _ -> {:error, :unreachable}
+    end
+  end
+
+  defp handle_response(%Req.Response{status: 200, body: body}, _hops) when is_binary(body) do
+    {:ok, binary_slice(body, 0, @max_body_bytes)}
+  end
+
+  defp handle_response(%Req.Response{status: status} = resp, hops)
+       when status in [301, 302, 303, 307, 308] do
+    case Req.Response.get_header(resp, "location") do
+      [location | _] -> fetch(location, hops - 1)
+      _ -> {:error, :unreachable}
+    end
+  end
+
+  defp handle_response(_resp, _hops), do: {:error, :unreachable}
+
+  defp options(url) do
+    Keyword.merge(
+      [
+        url: url,
+        headers: [
+          {"accept", "application/jrd+json, application/json"},
+          {"user-agent", Http.user_agent()}
+        ],
+        receive_timeout: 5_000,
+        connect_options: [timeout: 2_000],
+        retry: false,
+        redirect: false,
+        # Keep the body a raw binary: we decode it ourselves after the size
+        # ceiling, and Req's own JSON step would hand back a map (which the
+        # cap has already stopped bounding).
+        decode_body: false,
+        into: Vutuv.Http.capped_collector(@max_body_bytes)
+      ],
+      Application.get_env(:vutuv, :fediverse_req_options, [])
+    )
+  end
+end

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -426,6 +426,7 @@ defmodule VutuvWeb.AgentDocs.Markdown do
         "- #{gettext("Preferred workplace")}: #{User.desired_workplace_line(doc.desired_workplace_types)}",
       doc.desired_salary && "- " <> User.desired_salary_agent_line(doc.desired_salary),
       "- #{gettext("Member since")}: #{doc.member_since}",
+      fediverse_fact(doc[:fediverse]),
       count_facts(doc.counts),
       doc.gender && "- #{gettext("Gender")}: #{User.gender_gettext(doc.gender)}",
       doc.birthdate && "- #{gettext("Birthday")}: #{doc.birthdate}",
@@ -436,6 +437,18 @@ defmodule VutuvWeb.AgentDocs.Markdown do
     |> Enum.filter(& &1)
     |> Enum.join("\n\n")
   end
+
+  # The member's Fediverse address, the same fact the profile's Fediverse card
+  # shows; absent for the vast majority who do not federate. A moved account
+  # names where it went, so a reader follows the new address, not the redirect.
+  defp fediverse_fact(nil), do: nil
+
+  defp fediverse_fact(%{moved_to: moved_to} = fediverse) when is_binary(moved_to) do
+    "- #{gettext("Fediverse")}: #{fediverse.handle} " <>
+      "(#{gettext("moved to %{address}", address: moved_to)})"
+  end
+
+  defp fediverse_fact(fediverse), do: "- #{gettext("Fediverse")}: #{fediverse.handle}"
 
   # The follower / following / connection counts, each shown only when non-zero.
   defp count_facts(counts) do

--- a/lib/vutuv_web/agent_docs/profile_doc.ex
+++ b/lib/vutuv_web/agent_docs/profile_doc.ex
@@ -13,6 +13,7 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
   alias Vutuv.Accounts
   alias Vutuv.Accounts.User
   alias Vutuv.CodeStats
+  alias Vutuv.Fediverse
   alias Vutuv.Profiles.Address
   alias Vutuv.Profiles.Education
   alias Vutuv.Profiles.Language
@@ -26,6 +27,7 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
   alias Vutuv.Tags.UserTag
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.SectionDocs
+  alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.UserHelpers
 
   @doc """
@@ -153,6 +155,11 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
       # :fetch_code_stats flag is off or the member opted out — consistent
       # with the page.
       code_stats: Enum.map(CodeStats.visible_accounts(user), &code_stats_entry/1),
+      # The member's Fediverse address, mirroring the profile's Fediverse card:
+      # present only while they federate (and the installation switch is on),
+      # nil otherwise. An agent handing a human "where else can I follow this
+      # person" needs exactly the handle; the actor URL is the machine sibling.
+      fediverse: fediverse_entry(user),
       posts: Enum.map(posts, &post_entry/1)
     })
     |> Map.merge(birthday_fields(user))
@@ -211,6 +218,19 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
       title: UserHelpers.current_title(job),
       organization: UserHelpers.current_organization(job)
     }
+  end
+
+  # `moved_to` is the forwarding address a member set when they moved their
+  # Fediverse account elsewhere (issue #986): the handle still resolves, but it
+  # answers with a redirect, so the page and the docs both name the new home.
+  defp fediverse_entry(user) do
+    if Fediverse.federated?(user) do
+      %{
+        handle: Docs.handle(user),
+        actor_url: Docs.actor_url(user),
+        moved_to: user.moved_to
+      }
+    end
   end
 
   # The page hides "other" (the unspecified default); the docs do the same.

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -423,6 +423,7 @@ defmodule VutuvWeb.AgentDocs.Text do
         "#{gettext("Preferred workplace")}: #{User.desired_workplace_line(doc.desired_workplace_types)}",
       doc.desired_salary && User.desired_salary_agent_line(doc.desired_salary),
       "#{gettext("Member since")}: #{doc.member_since}",
+      fediverse_fact(doc[:fediverse]),
       count_facts(doc.counts),
       doc.gender && "#{gettext("Gender")}: #{User.gender_gettext(doc.gender)}",
       doc.birthdate && "#{gettext("Birthday")}: #{doc.birthdate}",
@@ -433,6 +434,18 @@ defmodule VutuvWeb.AgentDocs.Text do
     |> Enum.filter(& &1)
     |> Enum.join("\n")
   end
+
+  # The member's Fediverse address, the same fact the profile's Fediverse card
+  # shows; absent for the vast majority who do not federate. A moved account
+  # names where it went, so a reader follows the new address, not the redirect.
+  defp fediverse_fact(nil), do: nil
+
+  defp fediverse_fact(%{moved_to: moved_to} = fediverse) when is_binary(moved_to) do
+    "#{gettext("Fediverse")}: #{fediverse.handle} " <>
+      "(#{gettext("moved to %{address}", address: moved_to)})"
+  end
+
+  defp fediverse_fact(fediverse), do: "#{gettext("Fediverse")}: #{fediverse.handle}"
 
   # The follower / following / connection counts, each shown only when non-zero.
   defp count_facts(counts) do

--- a/lib/vutuv_web/controllers/remote_follow_controller.ex
+++ b/lib/vutuv_web/controllers/remote_follow_controller.ex
@@ -1,0 +1,99 @@
+defmodule VutuvWeb.RemoteFollowController do
+  @moduledoc """
+  The profile's "Follow from your own server" button
+  (`POST /:slug/fediverse/follow`).
+
+  A visitor from Mastodon (or any other ActivityPub app) types the address of
+  their own account; we resolve their server's follow dialog
+  (`Vutuv.Fediverse.RemoteFollow`) and send them there with this member filled
+  in, so the follow is confirmed where their account lives. Nothing is stored
+  here and no credential ever reaches vutuv — the address is used for one
+  lookup and then forgotten.
+
+  It is the one outbound fetch an anonymous visitor can trigger, so it is
+  fenced on three sides: the installation switch plus this member actually
+  federating (the form is not even rendered otherwise, and a crafted POST is
+  refused), a rate limit per IP, and the SSRF/size/timeout guards inside the
+  resolver. Every failure lands back on the profile with a plain-language
+  flash — the handle is on the page to copy, so there is always a way through.
+  """
+
+  use VutuvWeb, :controller
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.RemoteFollow
+  alias VutuvWeb.Fediverse.Docs
+  alias VutuvWeb.RateLimit
+
+  # A lookup is cheap for us and slow for the server we ask, so the budget is
+  # generous for a human and useless as a scanning gadget.
+  @limit 20
+  @window_ms :timer.hours(1)
+
+  def create(conn, params) do
+    user = conn.assigns[:user]
+    address = params["address"] || ""
+
+    cond do
+      not followable?(user) ->
+        conn
+        |> put_flash(:error, gettext("This profile is not on the Fediverse."))
+        |> back_to(user)
+
+      RateLimit.check(conn, :remote_follow, nil, limit: @limit, window_ms: @window_ms) ==
+          :rate_limited ->
+        conn
+        |> put_flash(:error, gettext("Too many attempts. Please try again later."))
+        |> back_to(user)
+
+      true ->
+        resolve(conn, user, address)
+    end
+  end
+
+  defp resolve(conn, user, address) do
+    case RemoteFollow.subscribe_url(address, Docs.acct(user)) do
+      {:ok, url} ->
+        redirect(conn, external: url)
+
+      {:error, reason} ->
+        conn
+        |> put_flash(:error, message(reason, address))
+        |> back_to(user)
+    end
+  end
+
+  # Same gate the profile card renders on: a member who moved their Fediverse
+  # account away is followed at the new address, not here.
+  defp followable?(user), do: Fediverse.federated?(user) and not Fediverse.moved?(user)
+
+  # Each message names what to do next, never just what failed.
+  defp message(:invalid_address, _address) do
+    gettext("That is not a Fediverse address. It looks like @you@example.social.")
+  end
+
+  defp message(:no_remote_follow, address) do
+    gettext(
+      "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead.",
+      server: server_name(address)
+    )
+  end
+
+  defp message(_unreachable, address) do
+    gettext(
+      "%{server} did not answer. Copy the handle above and paste it into your app's search instead.",
+      server: server_name(address)
+    )
+  end
+
+  # The typed host, echoed back so the message names the server the visitor
+  # meant — but only once it parsed, so nothing unvalidated reaches the page.
+  defp server_name(address) do
+    case RemoteFollow.parse_address(address) do
+      {:ok, {_user, host}} -> host
+      _ -> gettext("Your server")
+    end
+  end
+
+  defp back_to(conn, user), do: redirect(conn, to: ~p"/#{user}" <> "#profile-fediverse")
+end

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -328,8 +328,7 @@ defmodule VutuvWeb.SettingsController do
   defp fediverse_assigns(user) do
     [
       follower_count: Vutuv.Fediverse.follower_count(user),
-      followers: Vutuv.Fediverse.list_followers(user),
-      fediverse_host: VutuvWeb.Endpoint.host()
+      followers: Vutuv.Fediverse.list_followers(user)
     ]
   end
 

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -31,6 +31,17 @@ defmodule VutuvWeb.Fediverse.Docs do
   def key_id(user), do: actor_url(user) <> "#main-key"
   def note_url(user, post_id), do: "#{base()}/#{user.username}/posts/#{post_id}"
 
+  @doc """
+  The member's Fediverse address without the leading `@`
+  (`member@vutuv.de`) — the `acct:` form WebFinger answers under and remote
+  servers resolve. The host is this installation's, so it is right on
+  vutuv.de and on anybody else's vutuv.
+  """
+  def acct(user), do: "#{user.username}@#{VutuvWeb.Endpoint.host()}"
+
+  @doc "The same address the way it is written for humans: `@member@vutuv.de`."
+  def handle(user), do: "@" <> acct(user)
+
   @doc "The Person document WebFinger points at."
   def actor(user, %Actor{} = actor) do
     actor_url = actor_url(user)

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -29,6 +29,8 @@ defmodule VutuvWeb.UserProfileLive do
   alias Vutuv.Accounts.User
   alias Vutuv.Activity
   alias Vutuv.CodeStats
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.RemoteFollow
   alias Vutuv.Profiles.Address
   alias Vutuv.Profiles.Education
   alias Vutuv.Profiles.Language
@@ -46,6 +48,7 @@ defmodule VutuvWeb.UserProfileLive do
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.UserTag
   alias Vutuv.Tags.UserTagEndorsement
+  alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.Live.InitAssigns
 
   # The controller embeds this LiveView with `live_render/3` (not a `live/3`
@@ -609,6 +612,27 @@ defmodule VutuvWeb.UserProfileLive do
     |> put_social_feed_assigns(user)
     |> put_code_stats_assigns(user)
     |> put_job_search_assigns(user)
+    |> put_fediverse_assigns(user)
+  end
+
+  # The Fediverse card (nil = no card), the one thing on the profile written for
+  # a visitor who is NOT a member: someone on Mastodon and friends needs the
+  # member's address over there, which the page never showed. Pure field reads
+  # plus the federation gate, so it costs no query. `moved_to` is set when the
+  # member redirected their Fediverse followers to another account (issue #986):
+  # the handle here still resolves, but following it would be a dead end, so the
+  # card shows the forwarding address instead of the follow tool.
+  defp put_fediverse_assigns(socket, user) do
+    card =
+      if Fediverse.federated?(user) do
+        %{
+          handle: Docs.handle(user),
+          moved_to: user.moved_to,
+          moved_handle: user.moved_to && RemoteFollow.display_address(user.moved_to)
+        }
+      end
+
+    assign(socket, :fediverse, card)
   end
 
   # The two job-search field visibilities for this viewer (issue #928 base gate

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -1050,6 +1050,11 @@ defmodule VutuvWeb.Router do
       # The session-aware vCard (all emails for the owner / a follower-back
       # viewer); the anonymous canonical vCard is /:slug.vcf.
       get("/vcard", VCardController, :get)
+      # "Follow from your own server": the profile's Fediverse card posts the
+      # visitor's own address here and we redirect them to their server's
+      # follow dialog. No login (the whole point is that the visitor's account
+      # is elsewhere); refused unless this member federates.
+      post("/fediverse/follow", RemoteFollowController, :create)
       # The owner-only GDPR data export (RequireLogin + AuthUser in the
       # controller): the overview page + the one-JSON-file download.
       get("/export", ExportController, :index)

--- a/lib/vutuv_web/templates/settings/fediverse.html.heex
+++ b/lib/vutuv_web/templates/settings/fediverse.html.heex
@@ -89,7 +89,7 @@ subpage now (/settings/fediverse/move), linked from the footer below. --%>
         <code
           id="fediverse-handle"
           class="min-w-0 flex-1 select-all break-all text-sm text-slate-800 dark:text-slate-100"
-        >@{@user.username}@{@fediverse_host}</code>
+        >{VutuvWeb.Fediverse.Docs.handle(@user)}</code>
         <button
           type="button"
           data-copy

--- a/lib/vutuv_web/templates/settings/fediverse_move.html.heex
+++ b/lib/vutuv_web/templates/settings/fediverse_move.html.heex
@@ -119,7 +119,7 @@ do. --%>
         <ol class="mt-3 list-decimal space-y-1 pl-5 text-sm text-slate-600 dark:text-slate-400">
           <li>
             {gettext("On your other account, add your vutuv handle")}
-            <code class="select-all rounded bg-slate-100 px-1 py-0.5 text-slate-800 dark:bg-slate-800 dark:text-slate-100">@{@user.username}@{@fediverse_host}</code>
+            <code class="select-all rounded bg-slate-100 px-1 py-0.5 text-slate-800 dark:bg-slate-800 dark:text-slate-100">{VutuvWeb.Fediverse.Docs.handle(@user)}</code>
             {gettext("as an account alias.")}
           </li>
           <li>{gettext("Enter that account's address below and redirect.")}</li>

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -376,6 +376,102 @@ the resulting ~200px rail width. --%>
       </div>
     </section>
 
+    <%!-- Fediverse card (@fediverse is nil unless this member federates and the
+    installation switch is on, so most profiles never render it). It answers the
+    two questions a visitor from Mastodon and friends arrives with: what is this
+    member's address over there, and how do I follow it without leaving my own
+    app. The handle is a copy target (that is the action people come for) and
+    the form below it resolves the visitor's OWN server's follow dialog and
+    sends them there, so the follow is confirmed where their account lives —
+    plain HTML, no JavaScript needed, since a visitor from another network is
+    exactly the person we cannot assume anything about. A member who moved
+    their Fediverse account away shows the forwarding address instead; following
+    them here would be a dead end. --%>
+    <.card :if={@fediverse} id="profile-fediverse">
+      <.section_title>{gettext("Fediverse")}</.section_title>
+
+      <%= if @fediverse.moved_to do %>
+        <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+          {gettext("%{name} moved this Fediverse account. Follow the new address instead:",
+            name: full_name(@user)
+          )}
+        </p>
+        <p class="mt-3">
+          <a
+            id="fediverse-moved-to"
+            href={@fediverse.moved_to}
+            rel="nofollow noopener noreferrer"
+            class="break-all text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+          >
+            {@fediverse.moved_handle}
+          </a>
+        </p>
+      <% else %>
+        <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+          {gettext(
+            "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed.",
+            name: full_name(@user)
+          )}
+        </p>
+
+        <div class="mt-3 flex items-start gap-2 rounded-lg bg-slate-50 px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:ring-slate-700">
+          <code
+            id="profile-fediverse-handle"
+            class="min-w-0 flex-1 select-all break-all text-sm text-slate-800 dark:text-slate-100"
+          >{@fediverse.handle}</code>
+          <button
+            type="button"
+            data-copy
+            data-copy-target="profile-fediverse-handle"
+            data-label-copy={gettext("Copy")}
+            data-label-copied={gettext("Copied")}
+            class="shrink-0 rounded-md bg-white px-2 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-700"
+          >
+            {gettext("Copy")}
+          </button>
+        </div>
+
+        <%!-- A classic form post, not a phx-submit: the answer is a redirect to
+        another server, and this has to work for a visitor with JavaScript off
+        just as well. Phoenix stamps the CSRF token; the LiveView loads the
+        session's CSRF state, so the token is valid from a live render too. --%>
+        <.form
+          for={%{}}
+          action={~p"/#{@user}/fediverse/follow"}
+          id="remote-follow-form"
+          class="mt-4"
+        >
+          <label
+            for="remote-follow-address"
+            class="block text-sm font-semibold text-slate-900 dark:text-white"
+          >
+            {gettext("Follow from your own server")}
+          </label>
+          <div class="mt-1.5 flex flex-col gap-2 sm:flex-row">
+            <input
+              type="text"
+              id="remote-follow-address"
+              name="address"
+              inputmode="email"
+              autocomplete="off"
+              autocapitalize="none"
+              spellcheck="false"
+              placeholder={gettext("@you@example.social")}
+              class={[input_class(), "sm:min-w-0 sm:flex-1"]}
+            />
+            <.button type="submit" id="remote-follow-submit" class="shrink-0">
+              {gettext("Follow")}
+            </.button>
+          </div>
+          <p class="mt-1.5 text-xs text-slate-600 dark:text-slate-400">
+            {gettext(
+              "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
+            )}
+          </p>
+        </.form>
+      <% end %>
+    </.card>
+
     <%!-- Posts (latest visible to this viewer; writing happens in the /feed
     composer, which the owner's "Add" link points to) --%>
     <.card :if={@posts_total > 0 or @as_owner?} id="profile-posts">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.151.0",
+      version: "7.152.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -15939,3 +15939,59 @@ msgstr "Anwendung bearbeiten"
 #, elixir-autogen, elixir-format
 msgid "Book an ad"
 msgstr "Anzeige buchen"
+
+#: lib/vutuv_web/templates/user/show.html.heex:388
+#, elixir-autogen, elixir-format
+msgid "%{name} moved this Fediverse account. Follow the new address instead:"
+msgstr "%{name} hat dieses Fediverse-Konto umgezogen. Folgen Sie stattdessen der neuen Adresse:"
+
+#: lib/vutuv_web/templates/user/show.html.heex:405
+#, elixir-autogen, elixir-format
+msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
+msgstr "Sie sind auf Mastodon oder in einer anderen Fediverse-App? Folgen Sie %{name} von dort aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
+
+#: lib/vutuv_web/templates/user/show.html.heex:449
+#, elixir-autogen, elixir-format
+msgid "Follow from your own server"
+msgstr "Von Ihrem eigenen Server aus folgen"
+
+#: lib/vutuv_web/templates/user/show.html.heex:461
+#, elixir-autogen, elixir-format
+msgid "@you@example.social"
+msgstr "@name@example.social"
+
+#: lib/vutuv_web/templates/user/show.html.heex:469
+#, elixir-autogen, elixir-format
+msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
+msgstr "Ihre Adresse wird einmal verwendet, um Sie zum Folgen-Dialog Ihres eigenen Servers zu schicken. Gespeichert wird sie hier nicht."
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:40
+#, elixir-autogen, elixir-format
+msgid "This profile is not on the Fediverse."
+msgstr "Dieses Profil ist nicht im Fediverse."
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:69
+#, elixir-autogen, elixir-format
+msgid "That is not a Fediverse address. It looks like @you@example.social."
+msgstr "Das ist keine Fediverse-Adresse. Eine sieht so aus: @name@example.social."
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:73
+#, elixir-autogen, elixir-format
+msgid "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead."
+msgstr "%{server} bietet keinen Folgen-Dialog an. Kopieren Sie stattdessen die Adresse oben und fügen Sie sie in die Suche Ihrer App ein."
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:80
+#, elixir-autogen, elixir-format
+msgid "%{server} did not answer. Copy the handle above and paste it into your app's search instead."
+msgstr "%{server} hat nicht geantwortet. Kopieren Sie stattdessen die Adresse oben und fügen Sie sie in die Suche Ihrer App ein."
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:90
+#, elixir-autogen, elixir-format
+msgid "Your server"
+msgstr "Ihr Server"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/text.ex:444
+#, elixir-autogen, elixir-format
+msgid "moved to %{address}"
+msgstr "umgezogen nach %{address}"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -15200,3 +15200,59 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Book an ad"
 msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:388
+#, elixir-autogen, elixir-format
+msgid "%{name} moved this Fediverse account. Follow the new address instead:"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:405
+#, elixir-autogen, elixir-format
+msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
+msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:449
+#, elixir-autogen, elixir-format
+msgid "Follow from your own server"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:461
+#, elixir-autogen, elixir-format
+msgid "@you@example.social"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:469
+#, elixir-autogen, elixir-format
+msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:40
+#, elixir-autogen, elixir-format
+msgid "This profile is not on the Fediverse."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:69
+#, elixir-autogen, elixir-format
+msgid "That is not a Fediverse address. It looks like @you@example.social."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:73
+#, elixir-autogen, elixir-format
+msgid "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:80
+#, elixir-autogen, elixir-format
+msgid "%{server} did not answer. Copy the handle above and paste it into your app's search instead."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:90
+#, elixir-autogen, elixir-format
+msgid "Your server"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/text.ex:444
+#, elixir-autogen, elixir-format
+msgid "moved to %{address}"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -15198,3 +15198,59 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Book an ad"
 msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:388
+#, elixir-autogen, elixir-format
+msgid "%{name} moved this Fediverse account. Follow the new address instead:"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:405
+#, elixir-autogen, elixir-format
+msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
+msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:449
+#, elixir-autogen, elixir-format
+msgid "Follow from your own server"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:461
+#, elixir-autogen, elixir-format
+msgid "@you@example.social"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/show.html.heex:469
+#, elixir-autogen, elixir-format
+msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:40
+#, elixir-autogen, elixir-format
+msgid "This profile is not on the Fediverse."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:69
+#, elixir-autogen, elixir-format
+msgid "That is not a Fediverse address. It looks like @you@example.social."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:73
+#, elixir-autogen, elixir-format
+msgid "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:80
+#, elixir-autogen, elixir-format
+msgid "%{server} did not answer. Copy the handle above and paste it into your app's search instead."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:90
+#, elixir-autogen, elixir-format
+msgid "Your server"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/text.ex:444
+#, elixir-autogen, elixir-format
+msgid "moved to %{address}"
+msgstr ""

--- a/test/vutuv/fediverse/remote_follow_test.exs
+++ b/test/vutuv/fediverse/remote_follow_test.exs
@@ -1,0 +1,160 @@
+defmodule Vutuv.Fediverse.RemoteFollowTest do
+  # The "follow from your own server" resolver: parsing what a visitor pastes
+  # and looking up their server's follow dialog. async: false — the HTTP stub
+  # lives in the application env.
+  use ExUnit.Case, async: false
+
+  alias Vutuv.Fediverse.RemoteFollow
+
+  @template "https://social.example/authorize_interaction?uri={uri}"
+
+  defp stub(fun) do
+    Application.put_env(:vutuv, :fediverse_req_options, plug: fun)
+    on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+  end
+
+  defp jrd(links) do
+    fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/jrd+json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(%{"links" => links}))
+    end
+  end
+
+  # Mastodon and friends serve the `schema/1.0/subscribe` spelling; the older
+  # `spec/1.0#subscribe` one is also in the wild, so both must resolve.
+  defp subscribe_link(template \\ @template, rel \\ "http://ostatus.org/schema/1.0/subscribe") do
+    [
+      %{"rel" => "self", "href" => "https://social.example/users/them"},
+      %{"rel" => rel, "template" => template}
+    ]
+  end
+
+  describe "parse_address/1" do
+    test "accepts every shape people paste" do
+      assert {:ok, {"them", "social.example"}} =
+               RemoteFollow.parse_address("@them@social.example")
+
+      assert {:ok, {"them", "social.example"}} = RemoteFollow.parse_address("them@social.example")
+
+      assert {:ok, {"them", "social.example"}} =
+               RemoteFollow.parse_address(" @them@Social.Example ")
+
+      assert {:ok, {"them", "social.example"}} =
+               RemoteFollow.parse_address("https://social.example/@them")
+
+      assert {:ok, {"them", "social.example"}} =
+               RemoteFollow.parse_address("https://social.example/users/them")
+    end
+
+    test "rejects anything that is not a Fediverse address" do
+      for input <- ["", "them", "@them", "them@localhost", "them@example", "a@b@c@d", nil] do
+        assert {:error, :invalid_address} = RemoteFollow.parse_address(input)
+      end
+    end
+  end
+
+  describe "subscribe_url/2" do
+    test "asks the visitor's own server and fills our member into its dialog" do
+      stub(fn conn ->
+        assert conn.host == "social.example"
+        assert conn.request_path == "/.well-known/webfinger"
+        assert conn.query_string =~ "acct%3Athem%40social.example"
+
+        jrd(subscribe_link()).(conn)
+      end)
+
+      assert {:ok, url} = RemoteFollow.subscribe_url("@them@social.example", "greta@vutuv.de")
+
+      assert url ==
+               "https://social.example/authorize_interaction?uri=acct%3Agreta%40vutuv.de"
+    end
+
+    test "accepts either spelling of the subscribe rel" do
+      for rel <- [
+            "http://ostatus.org/schema/1.0/subscribe",
+            "http://ostatus.org/spec/1.0#subscribe"
+          ] do
+        stub(jrd(subscribe_link(@template, rel)))
+
+        assert {:ok, _url} = RemoteFollow.subscribe_url("@them@social.example", "g@vutuv.de")
+      end
+    end
+
+    test "never touches the network for an address that cannot be one" do
+      stub(fn _conn -> raise "must not be called" end)
+
+      assert {:error, :invalid_address} =
+               RemoteFollow.subscribe_url("not an address", "g@vutuv.de")
+    end
+
+    test "reports a server that publishes no follow dialog" do
+      stub(jrd([%{"rel" => "self", "href" => "https://social.example/users/them"}]))
+
+      assert {:error, :no_remote_follow} =
+               RemoteFollow.subscribe_url("@them@social.example", "g@vutuv.de")
+    end
+
+    test "refuses a dialog template that is not an https URL with a placeholder" do
+      for bad <- ["http://social.example/i?uri={uri}", "https://social.example/i?uri="] do
+        stub(jrd(subscribe_link(bad)))
+
+        assert {:error, :no_remote_follow} =
+                 RemoteFollow.subscribe_url("@them@social.example", "g@vutuv.de")
+      end
+    end
+
+    test "reports a server that does not answer with a document" do
+      stub(fn conn -> Plug.Conn.send_resp(conn, 404, "") end)
+
+      assert {:error, :unreachable} =
+               RemoteFollow.subscribe_url("@them@social.example", "g@vutuv.de")
+    end
+
+    test "follows one redirect hop, the common apex-to-server WebFinger setup" do
+      stub(fn conn ->
+        case conn.host do
+          "social.example" ->
+            conn
+            |> Plug.Conn.put_resp_header(
+              "location",
+              "https://mastodon.social.example/.well-known/webfinger?resource=acct:them@social.example"
+            )
+            |> Plug.Conn.send_resp(301, "")
+
+          "mastodon.social.example" ->
+            jrd(subscribe_link()).(conn)
+        end
+      end)
+
+      assert {:ok, url} = RemoteFollow.subscribe_url("@them@social.example", "g@vutuv.de")
+      assert url =~ "authorize_interaction"
+    end
+
+    test "stops at the second redirect rather than chasing a loop" do
+      stub(fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://other.example/.well-known/webfinger")
+        |> Plug.Conn.send_resp(302, "")
+      end)
+
+      assert {:error, :unreachable} =
+               RemoteFollow.subscribe_url("@them@social.example", "g@vutuv.de")
+    end
+
+    test "refuses a host that resolves into the private network" do
+      stub(fn _conn -> raise "must not be called" end)
+
+      # Restore the test-env resolver afterwards rather than deleting the key:
+      # every other outbound fetch in the suite resolves through it.
+      public = Application.get_env(:vutuv, :ssrf_resolver)
+
+      Application.put_env(:vutuv, :ssrf_resolver, fn _host, _family -> {:ok, [{127, 0, 0, 1}]} end)
+
+      on_exit(fn -> Application.put_env(:vutuv, :ssrf_resolver, public) end)
+
+      assert {:error, :unreachable} =
+               RemoteFollow.subscribe_url("@them@social.example", "g@vutuv.de")
+    end
+  end
+end

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -13,6 +13,7 @@ defmodule VutuvWeb.AgentDocsDriftTest do
 
   alias VutuvWeb.AgentDocs.ProfileDoc
   alias VutuvWeb.AgentDocs.SectionDocs
+  alias VutuvWeb.Fediverse.Docs
 
   setup do
     user =
@@ -20,6 +21,9 @@ defmodule VutuvWeb.AgentDocsDriftTest do
         username: "drift_tester",
         first_name: "Greta",
         last_name: "Gradient",
+        # Federating, so the profile's Fediverse card renders and its handle is
+        # drift-checked against the agent formats like every other public fact.
+        fediverse_followers?: true,
         headline: "Builds bridges between humans and agents",
         gender: "female",
         birthdate: ~D[1991-04-23],
@@ -214,6 +218,9 @@ defmodule VutuvWeb.AgentDocsDriftTest do
       "Berlin",
       # general info
       "female",
+      # the Fediverse address: the profile card shows it to a visitor arriving
+      # from Mastodon and friends, md/txt as a fact line, JSON/XML structured
+      Docs.handle(user),
       # posts
       "Suspension bridges are underrated."
     ]

--- a/test/vutuv_web/live/user_profile_fediverse_test.exs
+++ b/test/vutuv_web/live/user_profile_fediverse_test.exs
@@ -1,0 +1,167 @@
+defmodule VutuvWeb.UserProfileFediverseTest do
+  @moduledoc """
+  The profile's Fediverse card and its "Follow from your own server" button:
+  what a visitor arriving from Mastodon and friends sees, and what happens when
+  they hand us their own address. Not async — the installation switch and the
+  HTTP stub for the remote WebFinger lookup both live in the application env.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias VutuvWeb.Fediverse.Docs
+
+  @card "#profile-fediverse"
+  @handle "#profile-fediverse-handle"
+  @form "#remote-follow-form"
+
+  defp federating_member(attrs \\ []) do
+    insert_activated_user(Keyword.merge([fediverse_followers?: true], attrs))
+  end
+
+  defp stub_remote(fun) do
+    Application.put_env(:vutuv, :fediverse_req_options, plug: fun)
+    on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+  end
+
+  defp serve_subscribe_template do
+    stub_remote(fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/jrd+json")
+      |> Plug.Conn.send_resp(
+        200,
+        Jason.encode!(%{
+          "links" => [
+            %{
+              "rel" => "http://ostatus.org/spec/1.0#subscribe",
+              "template" => "https://social.example/authorize_interaction?uri={uri}"
+            }
+          ]
+        })
+      )
+    end)
+  end
+
+  describe "the card" do
+    test "shows a federating member's handle to a logged-out visitor", %{conn: conn} do
+      user = federating_member()
+
+      {:ok, view, _html} = live(conn, ~p"/#{user}")
+
+      assert has_element?(view, @card)
+      assert render(view) =~ Docs.handle(user)
+      assert has_element?(view, @form)
+    end
+
+    test "is absent for a member who does not federate", %{conn: conn} do
+      user = insert_activated_user()
+
+      {:ok, view, _html} = live(conn, ~p"/#{user}")
+
+      refute has_element?(view, @card)
+    end
+
+    test "is absent while the installation switch is off", %{conn: conn} do
+      Application.put_env(:vutuv, :fediverse_enabled, false)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_enabled) end)
+
+      user = federating_member()
+
+      {:ok, view, _html} = live(conn, ~p"/#{user}")
+
+      refute has_element?(view, @card)
+    end
+
+    test "points at the forwarding address once the member moved away", %{conn: conn} do
+      user = federating_member(moved_to: "https://social.example/users/greta")
+
+      {:ok, view, _html} = live(conn, ~p"/#{user}")
+
+      assert has_element?(view, "#fediverse-moved-to")
+      assert render(view) =~ "@greta@social.example"
+      # Following here would land on a redirect, so the tool is not offered.
+      refute has_element?(view, @form)
+      refute has_element?(view, @handle)
+    end
+
+    test "the form posts to the route that exists", %{conn: conn} do
+      user = federating_member()
+
+      {:ok, view, _html} = live(conn, ~p"/#{user}")
+
+      assert view
+             |> element(@form)
+             |> render() =~ ~s|action="/#{user.username}/fediverse/follow"|
+    end
+  end
+
+  describe "POST /:slug/fediverse/follow" do
+    test "sends the visitor to their own server's follow dialog", %{conn: conn} do
+      user = federating_member()
+      serve_subscribe_template()
+
+      conn = post(conn, ~p"/#{user}/fediverse/follow", %{"address" => "@them@social.example"})
+
+      assert redirected_to(conn) ==
+               "https://social.example/authorize_interaction?uri=" <>
+                 URI.encode_www_form("acct:" <> Docs.acct(user))
+    end
+
+    test "the token the rendered form carries really passes CSRF", %{conn: conn} do
+      user = federating_member()
+      serve_subscribe_template()
+
+      # ConnTest skips CSRF on a plain post/3, so the one thing worth proving
+      # here is that the token a LiveView-rendered form stamps is accepted: the
+      # profile is rendered by a LiveView, which loads the session's CSRF state
+      # separately from the controller.
+      conn = get(conn, ~p"/#{user}")
+
+      conn =
+        submit_with_csrf(conn, ~p"/#{user}/fediverse/follow", %{
+          "address" => "@them@social.example"
+        })
+
+      assert redirected_to(conn) =~ "https://social.example/authorize_interaction"
+    end
+
+    test "explains a typo instead of guessing", %{conn: conn} do
+      user = federating_member()
+      stub_remote(fn _conn -> raise "must not be called" end)
+
+      conn = post(conn, ~p"/#{user}/fediverse/follow", %{"address" => "not an address"})
+
+      assert redirected_to(conn) == "/#{user.username}#profile-fediverse"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "@you@example.social"
+    end
+
+    test "names the server that could not be reached", %{conn: conn} do
+      user = federating_member()
+      stub_remote(fn conn -> Plug.Conn.send_resp(conn, 500, "") end)
+
+      conn = post(conn, ~p"/#{user}/fediverse/follow", %{"address" => "@them@social.example"})
+
+      assert redirected_to(conn) == "/#{user.username}#profile-fediverse"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "social.example"
+    end
+
+    test "refuses a member who does not federate", %{conn: conn} do
+      user = insert_activated_user()
+      stub_remote(fn _conn -> raise "must not be called" end)
+
+      conn = post(conn, ~p"/#{user}/fediverse/follow", %{"address" => "@them@social.example"})
+
+      assert redirected_to(conn) == "/#{user.username}#profile-fediverse"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "not on the Fediverse"
+    end
+
+    test "refuses a member who moved their account away", %{conn: conn} do
+      user = federating_member(moved_to: "https://social.example/users/greta")
+      stub_remote(fn _conn -> raise "must not be called" end)
+
+      conn = post(conn, ~p"/#{user}/fediverse/follow", %{"address" => "@them@social.example"})
+
+      assert redirected_to(conn) == "/#{user.username}#profile-fediverse"
+    end
+  end
+end


### PR DESCRIPTION
Closes #1081.

A member could opt into federation and still be invisible to the very people the opt-in is for: someone arriving on `/wintermeyer` from Mastodon saw no hint that `@wintermeyer@vutuv.de` exists. The handle lived only on the member's own settings page.

### What a visitor sees now

A federating member's profile carries a **Fediverse card**, right under the header. It names the address with the shared copy button, and below it a **"Follow from your own server"** field.

Copying a handle is only half a follow: you still have to switch apps, paste it into a search box and wait. So the field resolves the visitor's *own* server's follow dialog through the remote-follow (OStatus subscribe) template every ActivityPub server publishes in its WebFinger document, and redirects them into it with the member filled in. The follow is confirmed where their account actually lives, and no credential ever touches vutuv.

It is a plain form post, not a `phx-click`: a visitor from another network is the last person whose JavaScript we should assume anything about. (The profile is a LiveView, which loads the session's CSRF state, so the token the form stamps is valid from a live render too — there is a test for exactly that.)

A member who **moved their Fediverse account away** gets the forwarding address instead of the follow tool, since following the old handle would only reach a redirect. Members who do not federate get no card at all, and neither does an installation with `FEDIVERSE_ENABLED` off.

### Fencing

This is the only outbound fetch an anonymous visitor can trigger, so it borrows the inbox path's shape: the federation gate (a crafted POST to a non-federating member is refused), a per-IP rate limit, https only, the host vetted against `Vutuv.Ssrf` before the request **and again** after the single redirect hop that is allowed (the common apex-to-server WebFinger setup; Req's own redirect following would skip that second check), short timeouts, no retries, and a body ceiling that halts the stream rather than buffering. Every failure lands back on the profile with a message naming the server, and the handle is right there to copy, so there is always a way through.

### Smoke test

Driven end to end in a browser against the real thing, which earned its keep: a live check against mastodon.social caught the subscribe rel. Servers serve `http://ostatus.org/schema/1.0/subscribe`, not the `spec/1.0#subscribe` spelling I had first written. Both are accepted now, and the flow ends where it should:

```
POST /beedell_roke/fediverse/follow  ->  302
location: https://mastodon.social/authorize_interaction?uri=acct%3Abeedell_roke%40localhost
```

Also checked in the browser: the German render of the whole card, the copy button (copies the handle, label flips), and the error toast for a typo.

### Notes

- The handle is public data on a public page, so `ProfileDoc` carries it into the agent formats (`fediverse` map, plus a `Fediverse:` fact line in md/txt); the drift test asserts it in every format.
- `VutuvWeb.Fediverse.Docs.handle/1` is now the single definition of `@member@host`; the two settings templates were building it inline.
- Docs: `docs/architecture/fediverse.md` (new "Follow from your own server" section) and `profiles.md`.
- Version bumped to 7.152.0; `mix precommit` green (4895 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01MESfzPReEBR1g1sdJCnv2F
