### PR TITLE
Move the Fediverse card to the foot of the profile

### DIFF
--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -376,102 +376,6 @@ the resulting ~200px rail width. --%>
       </div>
     </section>
 
-    <%!-- Fediverse card (@fediverse is nil unless this member federates and the
-    installation switch is on, so most profiles never render it). It answers the
-    two questions a visitor from Mastodon and friends arrives with: what is this
-    member's address over there, and how do I follow it without leaving my own
-    app. The handle is a copy target (that is the action people come for) and
-    the form below it resolves the visitor's OWN server's follow dialog and
-    sends them there, so the follow is confirmed where their account lives —
-    plain HTML, no JavaScript needed, since a visitor from another network is
-    exactly the person we cannot assume anything about. A member who moved
-    their Fediverse account away shows the forwarding address instead; following
-    them here would be a dead end. --%>
-    <.card :if={@fediverse} id="profile-fediverse">
-      <.section_title>{gettext("Fediverse")}</.section_title>
-
-      <%= if @fediverse.moved_to do %>
-        <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-          {gettext("%{name} moved this Fediverse account. Follow the new address instead:",
-            name: full_name(@user)
-          )}
-        </p>
-        <p class="mt-3">
-          <a
-            id="fediverse-moved-to"
-            href={@fediverse.moved_to}
-            rel="nofollow noopener noreferrer"
-            class="break-all text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-          >
-            {@fediverse.moved_handle}
-          </a>
-        </p>
-      <% else %>
-        <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-          {gettext(
-            "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed.",
-            name: full_name(@user)
-          )}
-        </p>
-
-        <div class="mt-3 flex items-start gap-2 rounded-lg bg-slate-50 px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:ring-slate-700">
-          <code
-            id="profile-fediverse-handle"
-            class="min-w-0 flex-1 select-all break-all text-sm text-slate-800 dark:text-slate-100"
-          >{@fediverse.handle}</code>
-          <button
-            type="button"
-            data-copy
-            data-copy-target="profile-fediverse-handle"
-            data-label-copy={gettext("Copy")}
-            data-label-copied={gettext("Copied")}
-            class="shrink-0 rounded-md bg-white px-2 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-700"
-          >
-            {gettext("Copy")}
-          </button>
-        </div>
-
-        <%!-- A classic form post, not a phx-submit: the answer is a redirect to
-        another server, and this has to work for a visitor with JavaScript off
-        just as well. Phoenix stamps the CSRF token; the LiveView loads the
-        session's CSRF state, so the token is valid from a live render too. --%>
-        <.form
-          for={%{}}
-          action={~p"/#{@user}/fediverse/follow"}
-          id="remote-follow-form"
-          class="mt-4"
-        >
-          <label
-            for="remote-follow-address"
-            class="block text-sm font-semibold text-slate-900 dark:text-white"
-          >
-            {gettext("Follow from your own server")}
-          </label>
-          <div class="mt-1.5 flex flex-col gap-2 sm:flex-row">
-            <input
-              type="text"
-              id="remote-follow-address"
-              name="address"
-              inputmode="email"
-              autocomplete="off"
-              autocapitalize="none"
-              spellcheck="false"
-              placeholder={gettext("@you@example.social")}
-              class={[input_class(), "sm:min-w-0 sm:flex-1"]}
-            />
-            <.button type="submit" id="remote-follow-submit" class="shrink-0">
-              {gettext("Follow")}
-            </.button>
-          </div>
-          <p class="mt-1.5 text-xs text-slate-600 dark:text-slate-400">
-            {gettext(
-              "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
-            )}
-          </p>
-        </.form>
-      <% end %>
-    </.card>
-
     <%!-- Posts (latest visible to this viewer; writing happens in the /feed
     composer, which the owner's "Add" link points to) --%>
     <.card :if={@posts_total > 0 or @as_owner?} id="profile-posts">
@@ -887,6 +791,107 @@ the resulting ~200px rail width. --%>
         </.card_footer_link>
       </.card>
     </div>
+
+    <%!-- Fediverse card (@fediverse is nil unless this member federates and the
+    installation switch is on, so most profiles never render it). It answers the
+    two questions a visitor from Mastodon and friends arrives with: what is this
+    member's address over there, and how do I follow it without leaving my own
+    app. The handle is a copy target (that is the action people come for) and
+    the form below it resolves the visitor's OWN server's follow dialog and
+    sends them there, so the follow is confirmed where their account lives —
+    plain HTML, no JavaScript needed, since a visitor from another network is
+    exactly the person we cannot assume anything about. A member who moved
+    their Fediverse account away shows the forwarding address instead; following
+    them here would be a dead end.
+
+    It closes the page: the profile itself is what a visitor came for, and this
+    is the "take me with you" footer under it. `order-3` keeps it last on a
+    phone too, where every card is one flex child of a single column and the
+    rail's utility footer sits at `order-2`. --%>
+    <.card :if={@fediverse} id="profile-fediverse" class="order-3 md:order-none">
+      <.section_title>{gettext("Fediverse")}</.section_title>
+
+      <%= if @fediverse.moved_to do %>
+        <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+          {gettext("%{name} moved this Fediverse account. Follow the new address instead:",
+            name: full_name(@user)
+          )}
+        </p>
+        <p class="mt-3">
+          <a
+            id="fediverse-moved-to"
+            href={@fediverse.moved_to}
+            rel="nofollow noopener noreferrer"
+            class="break-all text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+          >
+            {@fediverse.moved_handle}
+          </a>
+        </p>
+      <% else %>
+        <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+          {gettext(
+            "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed.",
+            name: full_name(@user)
+          )}
+        </p>
+
+        <div class="mt-3 flex items-start gap-2 rounded-lg bg-slate-50 px-3 py-2 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:ring-slate-700">
+          <code
+            id="profile-fediverse-handle"
+            class="min-w-0 flex-1 select-all break-all text-sm text-slate-800 dark:text-slate-100"
+          >{@fediverse.handle}</code>
+          <button
+            type="button"
+            data-copy
+            data-copy-target="profile-fediverse-handle"
+            data-label-copy={gettext("Copy")}
+            data-label-copied={gettext("Copied")}
+            class="shrink-0 rounded-md bg-white px-2 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700 dark:hover:bg-slate-700"
+          >
+            {gettext("Copy")}
+          </button>
+        </div>
+
+        <%!-- A classic form post, not a phx-submit: the answer is a redirect to
+        another server, and this has to work for a visitor with JavaScript off
+        just as well. Phoenix stamps the CSRF token; the LiveView loads the
+        session's CSRF state, so the token is valid from a live render too. --%>
+        <.form
+          for={%{}}
+          action={~p"/#{@user}/fediverse/follow"}
+          id="remote-follow-form"
+          class="mt-4"
+        >
+          <label
+            for="remote-follow-address"
+            class="block text-sm font-semibold text-slate-900 dark:text-white"
+          >
+            {gettext("Follow from your own server")}
+          </label>
+          <div class="mt-1.5 flex flex-col gap-2 sm:flex-row">
+            <input
+              type="text"
+              id="remote-follow-address"
+              name="address"
+              inputmode="email"
+              autocomplete="off"
+              autocapitalize="none"
+              spellcheck="false"
+              placeholder={gettext("@you@example.social")}
+              class={[input_class(), "sm:min-w-0 sm:flex-1"]}
+            />
+            <.button type="submit" id="remote-follow-submit" class="shrink-0">
+              {gettext("Follow")}
+            </.button>
+          </div>
+          <p class="mt-1.5 text-xs text-slate-600 dark:text-slate-400">
+            {gettext(
+              "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
+            )}
+          </p>
+        </.form>
+      <% end %>
+    </.card>
   </div>
 
   <%!-- Right rail. `contents` on a phone (see the main column comment) so its

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.153.0",
+      version: "7.153.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/user_profile_fediverse_test.exs
+++ b/test/vutuv_web/live/user_profile_fediverse_test.exs
@@ -9,6 +9,7 @@ defmodule VutuvWeb.UserProfileFediverseTest do
 
   import Phoenix.LiveViewTest
 
+  alias Vutuv.Social
   alias VutuvWeb.Fediverse.Docs
 
   @card "#profile-fediverse"
@@ -17,6 +18,11 @@ defmodule VutuvWeb.UserProfileFediverseTest do
 
   defp federating_member(attrs \\ []) do
     insert_activated_user(Keyword.merge([fediverse_followers?: true], attrs))
+  end
+
+  defp position(html, id) do
+    {at, _len} = :binary.match(html, ~s|id="#{id}"|)
+    at
   end
 
   defp stub_remote(fun) do
@@ -82,6 +88,23 @@ defmodule VutuvWeb.UserProfileFediverseTest do
       # Following here would land on a redirect, so the tool is not offered.
       refute has_element?(view, @form)
       refute has_element?(view, @handle)
+    end
+
+    test "closes the page, below the member's own cards", %{conn: conn} do
+      user = federating_member()
+      {:ok, _follow} = Social.follow(insert_activated_user(), user.id)
+
+      {:ok, view, html} = live(conn, ~p"/#{user}")
+
+      # The follower/following pair is the last block of the main content
+      # column, and the rail follows it in the DOM: a card between the two is
+      # the foot of the column on a desktop.
+      assert position(html, "profile-fediverse") > position(html, "profile-followers")
+      assert position(html, "profile-fediverse") < position(html, "profile-other-formats")
+
+      # On a phone every card is one flex child of a single column, so the
+      # order utility is what puts it below the rail's cards there.
+      assert has_element?(view, "#profile-fediverse.order-3")
     end
 
     test "the form posts to the route that exists", %{conn: conn} do


### PR DESCRIPTION
**TL;DR** The Fediverse card sat above a member's posts; it now closes the profile page.

**Where:** `lib/vutuv_web/templates/user/show.html.heex`
**Now:** the card renders right under the profile-completion card, so a "here is my address on Mastodon" box outranks the profile itself.
**Want:** it closes the main content column, below the follower/following previews, the way a footer affordance should read: a visitor takes the member with them to their own server *after* reading the profile.

Below `md` every card of both columns is one flex child of a single column, and the rail's utility footer (CV card, other formats) already claims `order-2`, so the card carries `order-3` to stay last on a phone too.

Covered by a new test in `user_profile_fediverse_test.exs` that asserts the card sits between the follower preview and the rail, and carries the phone ordering class. Nothing about the card's content changed, so the agent-format siblings (`ProfileDoc`) are untouched. `mix precommit` green (4,914 tests); version bumped to 7.153.1.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*