### PR TITLE
Leaving the Fediverse: answer 410 Gone, and say so first

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1169,6 +1169,98 @@ function setupBirthdayRemove() {
 }
 onReady(setupBirthdayRemove)
 
+// The Fediverse take-part switch (see settings/fediverse.html.heex) asks before
+// it flips, in either direction: taking part means posts leave vutuv for good,
+// and leaving asks the other servers to forget an account they may then not show
+// again. Both are unreversible, so the submit is intercepted and the matching
+// dialog opened; its confirm button fills the `fediverse_ack` field and submits
+// for real. With JS off nothing here runs and the plain submit lands on the
+// server-side confirmation page, which asks the same question — the switch can
+// never flip unacknowledged.
+function setupFediverseConsent() {
+  const form = document.getElementById("fediverse-form")
+  if (!form || !once(form, "fediverseConsent")) return
+
+  const checkbox = form.querySelector("[data-fediverse-switch]")
+  const ack = form.querySelector("[data-fediverse-ack]")
+  const modals = {
+    true: document.getElementById("fediverse-consent-on"),
+    false: document.getElementById("fediverse-consent-off"),
+  }
+  if (!checkbox || !ack) return
+
+  let openModal = null
+  let lastFocused = null
+
+  const close = () => {
+    openModal?.classList.add("hidden")
+    openModal = null
+    if (lastFocused && typeof lastFocused.focus === "function") lastFocused.focus()
+    lastFocused = null
+  }
+
+  const open = (modal) => {
+    lastFocused = document.activeElement
+    openModal = modal
+    modal.classList.remove("hidden")
+    modal.querySelector("[data-fediverse-consent-confirm]")?.focus()
+  }
+
+  form.addEventListener("submit", (e) => {
+    // Only the switch itself needs acknowledging; saving the other settings on
+    // this page must not raise a dialog about a change nobody made.
+    if (ack.value === "1" || checkbox.checked === checkbox.defaultChecked) return
+
+    const modal = modals[String(checkbox.checked)]
+    if (!modal) return
+
+    e.preventDefault()
+    open(modal)
+  })
+
+  Object.values(modals).forEach((modal) => {
+    if (!modal) return
+
+    modal.addEventListener("click", (e) => {
+      if (e.target.closest("[data-fediverse-consent-confirm]")) {
+        ack.value = "1"
+        close()
+        form.requestSubmit ? form.requestSubmit() : form.submit()
+        return
+      }
+
+      if (
+        e.target.closest("[data-fediverse-consent-cancel]") ||
+        e.target.hasAttribute("data-fediverse-consent-backdrop")
+      ) {
+        close()
+      }
+    })
+
+    // Esc closes; Tab cycles inside the dialog so focus can't slip behind it.
+    modal.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault()
+        close()
+        return
+      }
+      if (e.key !== "Tab") return
+      const buttons = modal.querySelectorAll("button")
+      if (buttons.length === 0) return
+      const first = buttons[0]
+      const last = buttons[buttons.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    })
+  })
+}
+onReady(setupFediverseConsent)
+
 // The ad banner (layout strip between navigation and content, see
 // VutuvWeb.Plug.AdBanner) disappears on its own after two minutes: fade out,
 // then drop the node. Its ✕ removes it immediately AND keeps ads away for

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -491,6 +491,19 @@ where you would notice a whole server dropping out at once. This keeps your
 members' follower counts honest and stops the installation from holding the
 address of somebody who deleted their account.
 
+**When a member leaves.** Switching the feature off on `/settings/fediverse` does
+more than stop sending: from then on the member's Fediverse address answers "gone"
+(HTTP 410) instead of "not found", which the common servers read as a deleted
+account and take as the cue to delete their copies of that member's posts. Their
+remote followers are dropped here at the same time. It stays a request, not a
+guarantee, and it applies **only** to a member's own decision to leave: a frozen,
+suspended or deactivated account, and an installation you switch off centrally,
+keep answering the harmless "not found", so nobody's remote presence is erased
+over a temporary measure. Both directions of the switch ask the member to confirm
+first, in plain words, because neither can be undone: what has already been
+delivered is out of reach, and a member who leaves and comes back may not be
+shown again by every server right away.
+
 **What is stored from other servers.** Exactly one thing: a bare counter row per
 remote person per post per kind (favourite / re-share), holding only that
 person's account address, the kind and the time. No name, no picture, no text.

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -242,6 +242,44 @@ own redirect following would skip that second check), short timeouts, no
 retries, and a body ceiling that halts the stream rather than buffering. Every
 failure lands back on the profile with a plain-language flash naming the server,
 and the handle is right there to copy, so there is always a way through.
+## Leaving: 410 Gone, and saying so first
+
+Switching the opt-in off used to make every actor endpoint answer `404`, which
+remote servers shrug off — they kept the account and its copies of the member's
+posts indefinitely. Now `Vutuv.Fediverse.departed?/1` (took part once, the
+keypair is still here, opt-in now off) makes the actor, its collections, its
+inbox, WebFinger and the AP-negotiated profile URL answer **`410 Gone`**
+(`VutuvWeb.FediverseController.refuse/2`, shared with `UserController`). Mastodon
+& co. read a `410` on an actor they know as "this account was deleted" and purge
+the account **and its copies of that account's posts**: the closest the protocol
+comes to honouring "forget me", and the passive twin of the pruner above (which
+reads exactly that answer from the other side).
+
+Which is why `410` is **only** the member's own departure. Everything else keeps
+answering `404`: a member who never federated (nothing to forget), the
+installation switch being off (an operator decision must not erase members'
+remote presence), and every *temporary* hiding — frozen, suspended, deactivated,
+unconfirmed. A three-day suspension must never tell the network to delete the
+account.
+
+Because leaving now really does ask other servers to forget the member,
+switching off also **drops their follower rows** (`drop_followers/1`, the
+symmetry `drop_reactions/1` already had for the reaction counts): those servers
+drop the follow at their end, so a kept row would only be a relationship that
+exists nowhere else.
+
+And because neither direction can be taken back, the switch **asks first**. The
+words live in one place, `VutuvWeb.SettingsHTML.fediverse_consent_notice/1`, and
+are shown twice: as a modal on `/settings/fediverse` (the `fediverseConsent`
+enhancement in `app.js` intercepts the submit, and its confirm button sets the
+`fediverse_ack` field) and, for a browser without JavaScript, as the full-page
+`fediverse_confirm.html.heex`, which replays the submitted fields plus the
+acknowledgement. `SettingsController.update_fediverse/2` requires that
+acknowledgement whenever the submit actually flips the switch, so it can never
+flip unacknowledged; a save that only touches the other settings on the page
+passes straight through. What the words say is what vutuv cannot do: a delivered
+post is beyond reach for good, and leaving is a request to those servers, not a
+guarantee.
 
 ## Deliberate v1 limits
 

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -140,6 +140,44 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc """
+  Drops every remote follower stored for a member — what switching the opt-in
+  off means, the same way `drop_reactions/1` answers the reactions switch.
+
+  Two reasons it is a deletion rather than a pause. The rows are stored data
+  about people who never signed up here, so "off" has to mean off; and once the
+  actor answers `410 Gone` (see `departed?/1`) the remote servers drop the
+  follow at their end anyway, so keeping the rows would only inflate the
+  member's count with relationships that no longer exist anywhere else.
+  """
+  def drop_followers(%User{id: user_id}) do
+    {count, _} = Repo.delete_all(from(f in Follower, where: f.user_id == ^user_id))
+    count
+  end
+
+  @doc """
+  Whether this member's ActivityPub actor is **gone** rather than merely
+  absent: they took part once (the keypair from their opt-in is still here) and
+  have since switched the opt-in off.
+
+  This is the difference between `410 Gone` and `404 Not Found` on the actor
+  endpoints, and it matters more than the status code suggests: Mastodon & co.
+  read a `410` on an actor they know as "this account was deleted" and purge the
+  account **and its copies of that account's posts**, while a `404` is treated
+  as a hiccup and the copies stay. So `410` is the closest thing the protocol
+  offers to "please forget me", and it is reserved for the one case where the
+  member actually asked for it.
+
+  Deliberately **not** gone: a member who never federated (nothing to forget), a
+  member the installation switch turned off (an operator decision must not
+  erase members' remote presence), and every *temporary* state — frozen,
+  suspended, deactivated, unconfirmed. Those keep answering `404`, because a
+  three-day suspension must never tell the network to delete the account.
+  """
+  def departed?(%User{} = user) do
+    enabled?() and not user.fediverse_followers? and get_actor(user) != nil
+  end
+
+  @doc """
   A member's remote followers, newest first, for their own settings page (the
   public followers collection stays count-only, so this owner-only view is the
   only place the list is shown). Capped — a member with a huge following sees

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -15,7 +15,9 @@ defmodule VutuvWeb.FediverseController do
   servers authenticate with HTTP signatures instead, verified against the
   key of the actor named in the signature's `keyId` (fetched SSRF-guarded).
   Everything 404s for members without the opt-in and while the installation
-  switch (`:fediverse_enabled`) is off.
+  switch (`:fediverse_enabled`) is off — except for a member who took part and
+  then switched it off, whose actor answers `410 Gone` so remote servers delete
+  their copies (see `refuse/2`).
   """
 
   use VutuvWeb, :controller
@@ -37,11 +39,14 @@ defmodule VutuvWeb.FediverseController do
 
   def webfinger(conn, params) do
     with true <- Fediverse.enabled?(),
-         %User{} = user <- resolve_resource(params["resource"]),
-         true <- Fediverse.federated?(user) do
-      conn
-      |> put_resp_content_type("application/jrd+json")
-      |> send_resp(200, Jason.encode!(jrd(user)))
+         %User{} = user <- resolve_resource(params["resource"]) do
+      if Fediverse.federated?(user) do
+        conn
+        |> put_resp_content_type("application/jrd+json")
+        |> send_resp(200, Jason.encode!(jrd(user)))
+      else
+        refuse(conn, user)
+      end
     else
       _ -> send_resp(conn, 404, "")
     end
@@ -270,12 +275,32 @@ defmodule VutuvWeb.FediverseController do
 
   defp with_federated_user(conn, slug, fun) do
     with true <- Fediverse.enabled?(),
-         %User{} = user <- Accounts.get_user_by_username(slug),
-         true <- Fediverse.federated?(user) do
-      fun.(user)
+         %User{} = user <- Accounts.get_user_by_username(slug) do
+      if Fediverse.federated?(user), do: fun.(user), else: refuse(conn, user)
     else
       _ -> send_resp(conn, 404, "")
     end
+  end
+
+  @doc """
+  The refusal for an actor we will not serve: `410 Gone` once the member has
+  switched their opt-in off (`Vutuv.Fediverse.departed?/1`), `404` otherwise.
+
+  The distinction is the whole point rather than protocol pedantry: a remote
+  server that meets a `410` on an actor it knows deletes that account **and the
+  copies it kept of their posts**, which is the closest the protocol comes to
+  honouring "forget me"; a `404` it shrugs off and keeps everything. So the
+  `410` is reserved for the member's own decision to leave, and every temporary
+  reason we hide an actor (frozen, suspended, deactivated, or the installation
+  switch being off) keeps answering `404`.
+
+  Public because the profile URL answers the same two ways under an ActivityPub
+  `Accept` (`VutuvWeb.UserController`).
+  """
+  def refuse(conn, user) do
+    if Fediverse.departed?(user),
+      do: send_resp(conn, 410, ""),
+      else: send_resp(conn, 404, "")
   end
 
   defp send_activity_json(conn, doc) do

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -242,7 +242,30 @@ defmodule VutuvWeb.SettingsController do
     |> Ecto.Changeset.put_change(:also_known_as_input, Enum.join(user.also_known_as, "\n"))
   end
 
-  def update_fediverse(conn, %{"user" => params}) do
+  def update_fediverse(conn, %{"user" => params} = all) do
+    user = conn.assigns[:user]
+
+    # Taking part, and stopping again, both have consequences nobody can take
+    # back: a delivered post is beyond our reach for good, and leaving asks the
+    # other servers to forget an account that some of them may then not show
+    # again. So the switch never flips on a stray click — the member has to say
+    # they understood. With JS that is the modal on the page, which posts
+    # `fediverse_ack`; without it, this renders the same words as a full page
+    # with a confirm button. A save that leaves the switch alone (the reaction
+    # counts, say) needs no acknowledgement.
+    if switching_federation?(user, params) and all["fediverse_ack"] != "1" do
+      render(conn, "fediverse_confirm.html",
+        user: user,
+        params: params,
+        switching_on: truthy?(params["fediverse_followers?"]),
+        page_title: gettext("Fediverse")
+      )
+    else
+      save_fediverse(conn, params)
+    end
+  end
+
+  defp save_fediverse(conn, params) do
     save(
       conn,
       params,
@@ -256,9 +279,26 @@ defmodule VutuvWeb.SettingsController do
         # (issue #1068): what is already stored about people on other networks
         # goes with it, since that is the whole reason storing it is defensible.
         unless saved.fediverse_reactions?, do: Vutuv.Fediverse.drop_reactions(saved)
+
+        # Same rule for the followers themselves: leaving deletes the rows about
+        # people on other networks. The actor answers 410 from now on, so those
+        # servers drop the follow at their end too — a kept row would only be a
+        # relationship that no longer exists anywhere.
+        unless saved.fediverse_followers?, do: Vutuv.Fediverse.drop_followers(saved)
       end
     )
   end
+
+  # Whether this submit actually flips the take-part switch (in either
+  # direction), which is what needs acknowledging.
+  defp switching_federation?(user, params) do
+    case params["fediverse_followers?"] do
+      nil -> false
+      value -> truthy?(value) != user.fediverse_followers?
+    end
+  end
+
+  defp truthy?(value), do: value in [true, "true", "1", "on"]
 
   # Redirect the member's Fediverse followers to another account (issue #986,
   # half 2): broadcast a Move. The vutuv profile is untouched — only outbound

--- a/lib/vutuv_web/controllers/user_controller.ex
+++ b/lib/vutuv_web/controllers/user_controller.ex
@@ -31,7 +31,9 @@ defmodule VutuvWeb.UserController do
 
     # An ActivityPub Accept on the profile URL gets the actor document (what
     # Mastodon fetches when someone pastes the profile URL into its search) —
-    # or a 404 for members who don't federate, which AP clients read as
+    # or, for members who don't federate, the same refusal the actor endpoint
+    # gives: 410 once a member has switched their opt-in off (so remote servers
+    # delete their copies), 404 otherwise. Either reads to an AP client as
     # "nothing here" instead of choking on HTML.
     cond do
       FediverseController.ap_request?(conn) and Fediverse.federated?(user) ->
@@ -42,7 +44,7 @@ defmodule VutuvWeb.UserController do
         |> send_resp(200, Jason.encode!(Docs.actor(user, actor)))
 
       FediverseController.ap_request?(conn) ->
-        send_resp(conn, 404, "")
+        FediverseController.refuse(conn, user)
 
       true ->
         # The profile is the one page that also serves :vcf; the doc embeds the

--- a/lib/vutuv_web/templates/settings/fediverse.html.heex
+++ b/lib/vutuv_web/templates/settings/fediverse.html.heex
@@ -48,8 +48,16 @@ subpage now (/settings/fediverse/move), linked from the footer below. --%>
       >
         <.form_error changeset={@changeset} />
 
+        <%!-- Set to "1" by whichever consent modal the member agreed to. Empty
+              on a plain submit, which sends them to the full-page confirmation
+              instead (see fediverse_confirm.html.heex), so the switch cannot
+              flip unacknowledged with or without JavaScript. --%>
+        <input type="hidden" name="fediverse_ack" value="" data-fediverse-ack />
+
         <.setting_toggle label={gettext("Take part in the Fediverse")}>
-          <:checkbox><%= checkbox f, :fediverse_followers?, class: checkbox_class() %></:checkbox>
+          <:checkbox>
+            <%= checkbox f, :fediverse_followers?, class: checkbox_class(), data: [fediverse_switch: true] %>
+          </:checkbox>
           {gettext(
             "Off means your profile cannot be found there and nothing is sent. Posts already delivered may stay on those servers, beyond our reach."
           )}
@@ -185,5 +193,49 @@ subpage now (/settings/fediverse/move), linked from the footer below. --%>
         </p>
       </div>
     </.card>
+  </div>
+
+  <%!-- The two consent dialogs, one per direction of the switch. Hidden until
+        the fediverseConsent enhancement in app.js opens the matching one on
+        submit; its confirm button sets the ack field and submits for real. With
+        JS off neither is ever seen and the plain submit lands on the
+        full-page confirmation, which asks the same question with the same
+        words. Same overlay recipe as the birthday-remove dialog. --%>
+  <div
+    :for={
+      {id, on?} <- [{"fediverse-consent-on", true}, {"fediverse-consent-off", false}]
+    }
+    id={id}
+    class="hidden fixed inset-0 z-[60] items-center justify-center p-4 [&:not(.hidden)]:flex"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby={"#{id}-title"}
+    data-block-shortcuts
+  >
+    <div data-fediverse-consent-backdrop class="absolute inset-0 bg-slate-900/50 backdrop-blur-sm">
+    </div>
+    <div class="relative w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
+      <.fediverse_consent_notice switching_on={on?} title_id={"#{id}-title"} />
+      <div class="mt-6 flex flex-wrap justify-end gap-3">
+        <button
+          type="button"
+          data-fediverse-consent-cancel
+          class="rounded-lg bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+        >
+          {gettext("Cancel")}
+        </button>
+        <button
+          type="button"
+          data-fediverse-consent-confirm
+          class="rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
+        >
+          <%= if on? do %>
+            {gettext("I understand, take part")}
+          <% else %>
+            {gettext("I understand, switch off")}
+          <% end %>
+        </button>
+      </div>
+    </div>
   </div>
 </.settings_shell>

--- a/lib/vutuv_web/templates/settings/fediverse_confirm.html.heex
+++ b/lib/vutuv_web/templates/settings/fediverse_confirm.html.heex
@@ -1,0 +1,42 @@
+<%!-- The take-part switch never flips on a stray click: the member has to say
+they understood what nobody can undo afterwards. With JavaScript that happens in
+the modal on the settings page, which posts `fediverse_ack` straight away; this
+page is what a browser without it gets, and it asks with the same words
+(fediverse_consent_notice/1) and re-submits the very fields that were sent.
+
+Deliberately its own page rather than an inline banner: the whole screen is the
+question, so the answer is a decision rather than a scroll-past. --%>
+<.settings_shell user={@user} active={:fediverse} title={gettext("Fediverse")}>
+  <div class="space-y-6">
+    <.card>
+      <.fediverse_consent_notice switching_on={@switching_on} />
+
+      <.form for={%{}} action={~p"/settings/fediverse"} method="put" class="mt-6">
+        <%!-- Replay exactly what was submitted, plus the acknowledgement. The
+              changeset casts only what it permits, so echoing the form's own
+              fields cannot smuggle anything else in. --%>
+        <input :for={{key, value} <- @params} type="hidden" name={"user[#{key}]"} value={value} />
+        <input type="hidden" name="fediverse_ack" value="1" />
+
+        <div class="flex flex-wrap items-center justify-end gap-3">
+          <.link
+            navigate={~p"/settings/fediverse"}
+            class="rounded-lg bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+          >
+            {gettext("Cancel")}
+          </.link>
+          <button
+            type="submit"
+            class="rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
+          >
+            <%= if @switching_on do %>
+              {gettext("I understand, take part")}
+            <% else %>
+              {gettext("I understand, switch off")}
+            <% end %>
+          </button>
+        </div>
+      </.form>
+    </.card>
+  </div>
+</.settings_shell>

--- a/lib/vutuv_web/views/settings_html.ex
+++ b/lib/vutuv_web/views/settings_html.ex
@@ -294,6 +294,56 @@ defmodule VutuvWeb.SettingsHTML do
     """
   end
 
+  @doc """
+  What the member has to have read before the Fediverse take-part switch flips,
+  in either direction. Rendered in both places the question is asked — the modal
+  on the settings page and the JS-less confirmation page — from this one source,
+  so the two can never end up saying different things.
+
+  The point of the words is the part vutuv cannot do: a delivered post is beyond
+  our reach for good, and leaving is a request to the other servers, not a
+  guarantee.
+  """
+  attr(:switching_on, :boolean, required: true)
+  attr(:title_id, :string, default: nil)
+
+  def fediverse_consent_notice(assigns) do
+    ~H"""
+    <h2 id={@title_id} class="text-lg font-bold text-slate-900 dark:text-white">
+      <%= if @switching_on do %>
+        {gettext("Once a post has left vutuv, it is out of our hands")}
+      <% else %>
+        {gettext("Switching off does not delete what is already out there")}
+      <% end %>
+    </h2>
+    <div class="mt-3 space-y-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+      <%= if @switching_on do %>
+        <p>
+          {gettext(
+            "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
+          )}
+        </p>
+        <p>
+          {gettext(
+            "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
+          )}
+        </p>
+      <% else %>
+        <p>
+          {gettext(
+            "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
+          )}
+        </p>
+        <p>
+          {gettext(
+            "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
+          )}
+        </p>
+      <% end %>
+    </div>
+    """
+  end
+
   # A short, localized "last active" reading: just now / N minutes / N hours / N
   # days ago, falling back to an absolute date for anything older than a week.
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.153.1",
+      version: "7.154.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -35,7 +35,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1264
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -59,7 +59,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3188
+#: lib/vutuv_web/components/ui.ex:3239
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -94,11 +94,11 @@ msgstr "Avatar"
 msgid "Birthdate"
 msgstr "Geburtstag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:431
 #: lib/vutuv_web/agent_docs/markdown.ex:432
-#: lib/vutuv_web/agent_docs/text.ex:428
+#: lib/vutuv_web/agent_docs/markdown.ex:433
 #: lib/vutuv_web/agent_docs/text.ex:429
-#: lib/vutuv_web/templates/user/show.html.heex:828
+#: lib/vutuv_web/agent_docs/text.ex:430
+#: lib/vutuv_web/templates/user/show.html.heex:929
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
@@ -116,6 +116,8 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:86
 #: lib/vutuv_web/templates/report/new.html.heex:103
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:225
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:50
 #: lib/vutuv_web/templates/user/edit.html.heex:103
@@ -142,7 +144,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:866
+#: lib/vutuv_web/templates/user/show.html.heex:967
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -213,7 +215,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:851
+#: lib/vutuv_web/templates/user/show.html.heex:952
 #, elixir-autogen
 msgid "Edit"
 msgstr "Ändern"
@@ -286,7 +288,7 @@ msgstr "Nachname eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3179
+#: lib/vutuv_web/components/ui.ex:3204
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -310,8 +312,8 @@ msgstr "Fax"
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:443
-#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:456
+#: lib/vutuv_web/agent_docs/text.ex:453
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/live/notification_live/index.ex:798
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:136
@@ -321,8 +323,8 @@ msgstr "Vorname"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:444
-#: lib/vutuv_web/agent_docs/text.ex:441
+#: lib/vutuv_web/agent_docs/markdown.ex:457
+#: lib/vutuv_web/agent_docs/text.ex:454
 #: lib/vutuv_web/components/ui.ex:1551
 #: lib/vutuv_web/components/ui.ex:1576
 #: lib/vutuv_web/components/ui.ex:1579
@@ -337,8 +339,8 @@ msgstr "Follower"
 msgid "Following"
 msgstr "Folge ich"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:430
-#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/agent_docs/markdown.ex:431
+#: lib/vutuv_web/agent_docs/text.ex:428
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -347,7 +349,7 @@ msgstr "Folge ich"
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:823
+#: lib/vutuv_web/templates/user/show.html.heex:924
 #, elixir-autogen
 msgid "Gender"
 msgstr "Geschlecht"
@@ -408,7 +410,6 @@ msgstr "Link wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:52
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:3183
 #: lib/vutuv_web/controllers/url_controller.ex:23
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
@@ -458,7 +459,6 @@ msgstr "Einloggen"
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
-#: lib/vutuv_web/components/ui.ex:3199
 #: lib/vutuv_web/live/notification_live/index.ex:722
 #, elixir-autogen
 msgid "More"
@@ -618,13 +618,13 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/live/post_live/composer.ex:818
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:72
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:80
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:73
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
 #: lib/vutuv_web/templates/settings/preferences.html.heex:205
-#: lib/vutuv_web/templates/settings/privacy.html.heex:64
+#: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:383
 #: lib/vutuv_web/views/settings_html.ex:138
@@ -669,7 +669,6 @@ msgstr "Slug"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:55
 #: lib/vutuv_web/agent_docs/text.ex:52
-#: lib/vutuv_web/components/ui.ex:3184
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
@@ -682,13 +681,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:977
+#: lib/vutuv_web/templates/user/show.html.heex:1078
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:979
+#: lib/vutuv_web/templates/user/show.html.heex:1080
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -730,10 +729,10 @@ msgstr "Soziale Netzwerke"
 msgid "Code & repositories"
 msgstr "Code & Repositorys"
 
-#: lib/vutuv_web/controllers/block_controller.ex:31
+#: lib/vutuv_web/controllers/block_controller.ex:34
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:113
+#: lib/vutuv_web/live/user_profile_live.ex:116
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
@@ -770,12 +769,12 @@ msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr ""
 "Der User %{name} wurde angelegt. Eine E-Mail mit einem PIN wurde verschickt."
 
-#: lib/vutuv_web/controllers/user_controller.ex:291
+#: lib/vutuv_web/controllers/user_controller.ex:293
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr "User wurde gelöscht."
 
-#: lib/vutuv_web/controllers/user_controller.ex:210
+#: lib/vutuv_web/controllers/user_controller.ex:212
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr "Profil aktualisiert."
@@ -785,6 +784,8 @@ msgstr "Profil aktualisiert."
 msgid "User verified successfully."
 msgstr "User wurde verifiziert."
 
+#: lib/vutuv_web/components/ui.ex:3200
+#: lib/vutuv_web/controllers/username_controller.ex:60
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
@@ -792,10 +793,11 @@ msgstr "User wurde verifiziert."
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
-#: lib/vutuv_web/templates/settings/security.html.heex:11
+#: lib/vutuv_web/templates/settings/security.html.heex:23
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:5
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:21
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:26
+#: lib/vutuv_web/templates/username/new.html.heex:10
 #, elixir-autogen
 msgid "Username"
 msgstr "Benutzername"
@@ -843,10 +845,13 @@ msgstr "vCard"
 msgid "View All"
 msgstr "Alle anzeigen"
 
+#: lib/vutuv_web/components/ui.ex:3280
+#: lib/vutuv_web/controllers/settings_controller.ex:141
 #: lib/vutuv_web/live/job_posting_live/form.ex:550
 #: lib/vutuv_web/live/organization_live/edit.ex:298
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
+#: lib/vutuv_web/templates/settings/privacy.html.heex:14
 #, elixir-autogen
 msgid "Visibility"
 msgstr "Sichtbarkeit"
@@ -1061,7 +1066,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:812
+#: lib/vutuv_web/templates/user/show.html.heex:913
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1421,11 +1426,11 @@ msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
 #: lib/vutuv_web/agent_docs/markdown.ex:368
-#: lib/vutuv_web/agent_docs/markdown.ex:802
+#: lib/vutuv_web/agent_docs/markdown.ex:815
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:394
-#: lib/vutuv_web/agent_docs/text.ex:571
-#: lib/vutuv_web/components/ui.ex:3189
+#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/components/ui.ex:3220
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1462,7 +1467,7 @@ msgstr "Tags"
 
 #: lib/vutuv_web/controllers/email_controller.ex:156
 #: lib/vutuv_web/controllers/session_controller.ex:433
-#: lib/vutuv_web/controllers/user_controller.ex:311
+#: lib/vutuv_web/controllers/user_controller.ex:313
 #, elixir-autogen
 msgid "Too many incorrect attempts."
 msgstr "Zu viele fehlerhafter Versuche."
@@ -1716,7 +1721,7 @@ msgstr "Nutzungsbedingungen"
 msgid "Delete my account"
 msgstr "Mein Konto löschen"
 
-#: lib/vutuv_web/controllers/user_controller.ex:151
+#: lib/vutuv_web/controllers/user_controller.ex:153
 #: lib/vutuv_web/templates/user/show.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
@@ -1739,6 +1744,7 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/components/ui.ex:1605
 #: lib/vutuv_web/components/ui.ex:1608
 #: lib/vutuv_web/components/ui.ex:1681
+#: lib/vutuv_web/templates/user/show.html.heex:884
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1807,7 +1813,7 @@ msgstr "Hier gibt es noch nichts."
 msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
-#: lib/vutuv_web/components/ui.ex:3203
+#: lib/vutuv_web/components/ui.ex:3261
 #: lib/vutuv_web/live/notification_live/index.ex:103
 #: lib/vutuv_web/live/notification_live/index.ex:275
 #: lib/vutuv_web/live/shell_live.ex:508
@@ -1866,13 +1872,14 @@ msgstr "Diese E-Mail-Adresse konnte nicht hinzugefügt werden."
 
 #: lib/vutuv_web/controllers/email_controller.ex:97
 #: lib/vutuv_web/controllers/email_controller.ex:110
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:46
 #: lib/vutuv_web/controllers/session_controller.ex:70
 #: lib/vutuv_web/controllers/session_controller.ex:86
 #: lib/vutuv_web/controllers/session_controller.ex:177
 #: lib/vutuv_web/controllers/session_controller.ex:208
 #: lib/vutuv_web/controllers/session_controller.ex:224
-#: lib/vutuv_web/controllers/user_controller.ex:247
-#: lib/vutuv_web/controllers/user_controller.ex:276
+#: lib/vutuv_web/controllers/user_controller.ex:249
+#: lib/vutuv_web/controllers/user_controller.ex:278
 #, elixir-autogen, elixir-format
 msgid "Too many attempts. Please try again later."
 msgstr "Zu viele Versuche. Bitte versuchen Sie es später erneut."
@@ -1904,7 +1911,7 @@ msgstr ""
 "unten ein, um die Adresse zu bestätigen."
 
 #: lib/vutuv_web/live/post_live/feed.ex:757
-#: lib/vutuv_web/templates/user/show.html.heex:1251
+#: lib/vutuv_web/templates/user/show.html.heex:1352
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
@@ -2245,7 +2252,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/agent_docs/post_doc.ex:92
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
-#: lib/vutuv_web/controllers/user_controller.ex:73
+#: lib/vutuv_web/controllers/user_controller.ex:75
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
 #: lib/vutuv_web/live/notification_live/index.ex:720
@@ -2253,7 +2260,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/live/search_live.ex:179
 #: lib/vutuv_web/live/search_live.ex:462
 #: lib/vutuv_web/templates/settings/preferences.html.heex:118
-#: lib/vutuv_web/views/admin/report_html.ex:34
+#: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr "Beiträge"
@@ -2338,7 +2345,7 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:3389
+#: lib/vutuv_web/components/ui.ex:3505
 #: lib/vutuv_web/live/shell_live.ex:551
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2383,7 +2390,7 @@ msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:300
+#: lib/vutuv_web/views/settings_html.ex:350
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr "unbekannt"
@@ -2427,12 +2434,12 @@ msgstr "Alle Beiträge"
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:837
+#: lib/vutuv_web/agent_docs/markdown.ex:850
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:490
 #: lib/vutuv_web/live/shell_live.ex:556
-#: lib/vutuv_web/views/admin/report_html.ex:37
+#: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
@@ -2447,13 +2454,13 @@ msgstr "Lesezeichen"
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:836
+#: lib/vutuv_web/agent_docs/markdown.ex:849
 #: lib/vutuv_web/components/post_components.ex:2226
 #: lib/vutuv_web/live/notification_live/index.ex:800
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:559
-#: lib/vutuv_web/views/admin/report_html.ex:36
+#: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Likes"
 msgstr "Likes"
@@ -2511,7 +2518,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1648
 #: lib/vutuv_web/live/post_live/feed.ex:746
-#: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
+#: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr "Entfolgen"
@@ -2713,7 +2720,7 @@ msgstr ""
 " ich helfen.“"
 
 #: lib/vutuv_web/templates/page/index.html.heex:143
-#: lib/vutuv_web/templates/settings/privacy.html.heex:53
+#: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
 msgstr "Suchmaschinen dürfen dieses Profil indizieren"
@@ -2757,26 +2764,26 @@ msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:940
+#: lib/vutuv_web/templates/user/show.html.heex:1041
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1266
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:868
+#: lib/vutuv_web/templates/user/show.html.heex:969
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:814
+#: lib/vutuv_web/templates/user/show.html.heex:915
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
@@ -2788,7 +2795,7 @@ msgstr "Persönliche Angaben hinzufügen"
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
-#: lib/vutuv_web/live/user_profile_live.ex:970
+#: lib/vutuv_web/live/user_profile_live.ex:994
 #: lib/vutuv_web/templates/user/show.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
@@ -2799,9 +2806,9 @@ msgstr "Ersten Beitrag schreiben"
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
-#: lib/vutuv_web/templates/settings/privacy.html.heex:133
+#: lib/vutuv_web/templates/settings/privacy.html.heex:138
 #: lib/vutuv_web/templates/settings/security.html.heex:20
-#: lib/vutuv_web/templates/settings/security.html.heex:175
+#: lib/vutuv_web/templates/settings/security.html.heex:181
 #: lib/vutuv_web/templates/user/show.html.heex:492
 #, elixir-autogen, elixir-format
 msgid "Manage"
@@ -2841,8 +2848,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 weiteres Tag"
 msgstr[1] "+%{formatted} weitere Tags"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:445
-#: lib/vutuv_web/agent_docs/text.ex:442
+#: lib/vutuv_web/agent_docs/markdown.ex:458
+#: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/live/notification_live/index.ex:799
 #: lib/vutuv_web/templates/connection/index.html.heex:5
@@ -3161,8 +3168,8 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:908
-#: lib/vutuv_web/templates/user/show.html.heex:909
+#: lib/vutuv_web/templates/user/show.html.heex:1009
+#: lib/vutuv_web/templates/user/show.html.heex:1010
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
@@ -3222,7 +3229,7 @@ msgstr ""
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/components/ui.ex:3176
+#: lib/vutuv_web/components/ui.ex:3194
 #: lib/vutuv_web/live/shell_live.ex:443
 #: lib/vutuv_web/live/shell_live.ex:644
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3629,12 +3636,12 @@ msgstr "Ihr vutuv-Konto wurde deaktiviert"
 msgid "Your vutuv account is suspended"
 msgstr "Ihr vutuv-Konto ist gesperrt"
 
-#: lib/vutuv_web/controllers/username_controller.ex:77
+#: lib/vutuv_web/controllers/username_controller.ex:82
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is already taken."
 msgstr "@%{handle} ist bereits vergeben."
 
-#: lib/vutuv_web/controllers/username_controller.ex:86
+#: lib/vutuv_web/controllers/username_controller.ex:91
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is available."
 msgstr "@%{handle} ist frei."
@@ -3650,14 +3657,7 @@ msgstr "Neuer Benutzername"
 msgid "Your username is now @%{handle}."
 msgstr "Ihr Benutzername ist jetzt @%{handle}."
 
-#: lib/vutuv_web/templates/username/new.html.heex:14
-#, elixir-autogen, elixir-format
-msgid "Your username is your profile address (vutuv.de/username) and how others mention you, like %{handle}."
-msgstr ""
-"Ihr Benutzername ist Ihre Profiladresse (vutuv.de/benutzername) und der "
-"Name, mit dem andere Sie erwähnen, z. B. %{handle}."
-
-#: lib/vutuv_web/templates/username/new.html.heex:41
+#: lib/vutuv_web/templates/username/new.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "%{remaining} of %{limit} changes left."
 msgstr "Noch %{remaining} von %{limit} Änderungen übrig."
@@ -3672,19 +3672,19 @@ msgstr "Kein Mitglied verwendet diesen Benutzernamen."
 msgid "Username replaced with @%{handle}."
 msgstr "Benutzername ersetzt durch @%{handle}."
 
-#: lib/vutuv_web/templates/username/new.html.heex:61
+#: lib/vutuv_web/templates/username/new.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "You can change it again on %{date}."
 msgstr "Ab dem %{date} können Sie ihn wieder ändern."
 
-#: lib/vutuv_web/templates/username/new.html.heex:36
+#: lib/vutuv_web/templates/username/new.html.heex:59
 #, elixir-autogen, elixir-format
 msgid "You can change your username up to %{limit} times within %{days} days."
 msgstr ""
 "Sie können Ihren Benutzernamen bis zu %{limit}-mal innerhalb von %{days} "
 "Tagen ändern."
 
-#: lib/vutuv_web/templates/username/new.html.heex:57
+#: lib/vutuv_web/templates/username/new.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "You have used all %{limit} username changes of the last %{days} days."
 msgstr ""
@@ -3959,12 +3959,12 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:535
+#: lib/vutuv_web/agent_docs/markdown.ex:548
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:890
+#: lib/vutuv_web/agent_docs/markdown.ex:903
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -3978,11 +3978,11 @@ msgstr "%{count} Beiträge von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:151
 #: lib/vutuv_web/agent_docs/markdown.ex:164
-#: lib/vutuv_web/agent_docs/markdown.ex:802
+#: lib/vutuv_web/agent_docs/markdown.ex:815
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:140
 #: lib/vutuv_web/agent_docs/text.ex:153
-#: lib/vutuv_web/agent_docs/text.ex:571
+#: lib/vutuv_web/agent_docs/text.ex:584
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
@@ -3999,22 +3999,22 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:820
-#: lib/vutuv_web/agent_docs/text.ex:582
+#: lib/vutuv_web/agent_docs/markdown.ex:833
+#: lib/vutuv_web/agent_docs/text.ex:595
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:817
-#: lib/vutuv_web/agent_docs/text.ex:579
+#: lib/vutuv_web/agent_docs/markdown.ex:830
+#: lib/vutuv_web/agent_docs/text.ex:592
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:824
-#: lib/vutuv_web/agent_docs/markdown.ex:925
-#: lib/vutuv_web/agent_docs/text.ex:585
-#: lib/vutuv_web/agent_docs/text.ex:613
+#: lib/vutuv_web/agent_docs/markdown.ex:837
+#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/text.ex:598
+#: lib/vutuv_web/agent_docs/text.ex:626
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
@@ -4066,17 +4066,17 @@ msgstr "Beiträge (insgesamt %{count})"
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:784
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:701
+#: lib/vutuv_web/agent_docs/markdown.ex:714
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:702
+#: lib/vutuv_web/agent_docs/markdown.ex:715
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4646,7 +4646,7 @@ msgstr "Suchen Sie Tags nach ihrem Namen."
 msgid "Search for words in public posts."
 msgstr "Suchen Sie nach Wörtern in öffentlichen Beiträgen."
 
-#: lib/vutuv_web/templates/block/index.html.heex:28
+#: lib/vutuv_web/templates/block/index.html.heex:36
 #: lib/vutuv_web/templates/user/show.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Block"
@@ -4661,14 +4661,16 @@ msgstr ""
 "beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das "
 "Entfernte nicht wieder her."
 
-#: lib/vutuv_web/templates/block/index.html.heex:1
-#: lib/vutuv_web/templates/block/index.html.heex:1
-#: lib/vutuv_web/templates/settings/privacy.html.heex:130
+#: lib/vutuv_web/components/ui.ex:3284
+#: lib/vutuv_web/controllers/block_controller.ex:20
+#: lib/vutuv_web/templates/block/index.html.heex:9
+#: lib/vutuv_web/templates/block/index.html.heex:41
+#: lib/vutuv_web/templates/settings/privacy.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Blocked members"
 msgstr "Blockierte Mitglieder"
 
-#: lib/vutuv_web/templates/block/index.html.heex:34
+#: lib/vutuv_web/templates/block/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Blocked members cannot follow you, connect with you, message you, or reply to your posts - and you cannot interact with them either. Blocking removed any follows and connection between you; unblocking does not restore them."
 msgstr ""
@@ -4678,13 +4680,13 @@ msgstr ""
 "Blockieren wurden alle Follows und die Vernetzung zwischen Ihnen entfernt; "
 "eine Aufhebung stellt sie nicht wieder her."
 
-#: lib/vutuv_web/templates/block/index.html.heex:63
+#: lib/vutuv_web/templates/block/index.html.heex:74
 #: lib/vutuv_web/templates/user/show.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr "Blockierung aufheben"
 
-#: lib/vutuv_web/templates/block/index.html.heex:61
+#: lib/vutuv_web/templates/block/index.html.heex:72
 #: lib/vutuv_web/templates/user/show.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "Unblock @%{slug}?"
@@ -4697,13 +4699,13 @@ msgstr ""
 "Sie haben @%{slug} blockiert. Auf Ihrer Liste blockierter Mitglieder können "
 "Sie das rückgängig machen."
 
-#: lib/vutuv_web/templates/block/index.html.heex:40
+#: lib/vutuv_web/templates/block/index.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "You have not blocked anyone."
 msgstr "Sie haben niemanden blockiert."
 
-#: lib/vutuv_web/controllers/block_controller.ex:86
-#: lib/vutuv_web/live/user_profile_live.ex:242
+#: lib/vutuv_web/controllers/block_controller.ex:89
+#: lib/vutuv_web/live/user_profile_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
@@ -4838,7 +4840,7 @@ msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/live/user_profile_live.ex:958
+#: lib/vutuv_web/live/user_profile_live.ex:982
 #: lib/vutuv_web/templates/user/show.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -5460,7 +5462,7 @@ msgstr ""
 "Entwicklung erlaubt."
 
 #: lib/vutuv_web/templates/page/index.html.heex:148
-#: lib/vutuv_web/templates/settings/privacy.html.heex:58
+#: lib/vutuv_web/templates/settings/privacy.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
 msgstr "KI-Agenten und LLMs dürfen dieses Profil nutzen"
@@ -5475,8 +5477,8 @@ msgstr "API-Token (%{date})"
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:3210
-#: lib/vutuv_web/controllers/settings_controller.ex:130
+#: lib/vutuv_web/components/ui.ex:3315
+#: lib/vutuv_web/controllers/settings_controller.ex:132
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
@@ -5521,7 +5523,7 @@ msgstr ""
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:136
+#: lib/vutuv_web/templates/settings/privacy.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
@@ -5558,17 +5560,16 @@ msgstr "Tastaturkürzel"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:3296
-#: lib/vutuv_web/components/ui.ex:3301
-#: lib/vutuv_web/components/ui.ex:3380
-#: lib/vutuv_web/components/ui.ex:3444
+#: lib/vutuv_web/components/ui.ex:3412
+#: lib/vutuv_web/components/ui.ex:3417
+#: lib/vutuv_web/components/ui.ex:3496
+#: lib/vutuv_web/components/ui.ex:3560
 #: lib/vutuv_web/controllers/settings_controller.ex:52
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
-#: lib/vutuv_web/templates/username/new.html.heex:6
 #: lib/vutuv_web/views/settings_html.ex:167
 #, elixir-autogen, elixir-format
 msgid "Settings"
@@ -5606,7 +5607,7 @@ msgstr "Profil vervollständigen"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/live/user_profile_live.ex:960
+#: lib/vutuv_web/live/user_profile_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -5687,20 +5688,14 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:3191
+#: lib/vutuv_web/components/ui.ex:3293
 #: lib/vutuv_web/live/admin/user_live.ex:266
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr "Konto"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:18
-#, elixir-autogen, elixir-format
-msgid "Add, remove or pick your primary address."
-msgstr "Adressen hinzufügen, entfernen oder Ihre Hauptadresse wählen."
-
 #: lib/vutuv_web/live/organization_live/edit.ex:441
-#: lib/vutuv_web/templates/settings/security.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr "Ändern"
@@ -5711,7 +5706,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:3186
+#: lib/vutuv_web/components/ui.ex:3231
 #: lib/vutuv_web/controllers/email_controller.ex:30
 #: lib/vutuv_web/controllers/email_controller.ex:49
 #: lib/vutuv_web/controllers/email_controller.ex:191
@@ -5725,12 +5720,12 @@ msgstr ""
 msgid "Email addresses"
 msgstr "E-Mail-Adressen"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:352
+#: lib/vutuv_web/controllers/settings_controller.ex:393
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr "Benachrichtigungseinstellungen gespeichert."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:131
+#: lib/vutuv_web/templates/settings/privacy.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you."
 msgstr "Personen, die nicht mit Ihnen interagieren können."
@@ -5745,13 +5740,12 @@ msgstr "Persönliche Tokens für die vutuv-API."
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:3201
-#: lib/vutuv_web/templates/settings/privacy.html.heex:9
+#: lib/vutuv_web/components/ui.ex:3278
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privatsphäre"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:168
+#: lib/vutuv_web/controllers/settings_controller.ex:170
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr "Datenschutzeinstellungen gespeichert."
@@ -5761,7 +5755,7 @@ msgstr "Datenschutzeinstellungen gespeichert."
 msgid "Third-party apps you authorized."
 msgstr "Apps von Drittanbietern, die Sie autorisiert haben."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:139
+#: lib/vutuv_web/templates/settings/privacy.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Ansehen"
@@ -5776,7 +5770,7 @@ msgstr "Ihr Name"
 msgid "Your post"
 msgstr "Ihr Beitrag"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:137
+#: lib/vutuv_web/templates/settings/privacy.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Your posts or profile a moderator is looking at."
 msgstr "Ihre Beiträge oder Ihr Profil, die ein Moderator gerade prüft."
@@ -5806,7 +5800,7 @@ msgstr "Sprache der Oberfläche"
 msgid "Language & region"
 msgstr "Sprache & Region"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:494
+#: lib/vutuv_web/controllers/settings_controller.ex:535
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr "Sprache aktualisiert."
@@ -5815,11 +5809,6 @@ msgstr "Sprache aktualisiert."
 #, elixir-autogen, elixir-format
 msgid "Read the API docs"
 msgstr "API-Dokumentation lesen"
-
-#: lib/vutuv_web/templates/settings/security.html.heex:8
-#, elixir-autogen, elixir-format
-msgid "Sign-in & identity"
-msgstr "Anmeldung & Identität"
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:22
 #, elixir-autogen, elixir-format
@@ -5860,13 +5849,13 @@ msgstr "@%{slug} hat Sie auf vutuv empfohlen"
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 
-#: lib/vutuv_web/components/ui.ex:3209
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:145
+#: lib/vutuv_web/components/ui.ex:3311
+#: lib/vutuv_web/controllers/settings_controller.ex:147
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr "Apps & API-Zugang"
@@ -5895,7 +5884,7 @@ msgstr "Benachrichtigungen in der App"
 msgid "New followers"
 msgstr "Neue Follower"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:342
+#: lib/vutuv_web/controllers/settings_controller.ex:383
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr "Benachrichtigungseinstellungen"
@@ -5905,22 +5894,17 @@ msgstr "Benachrichtigungseinstellungen"
 msgid "Open your notifications"
 msgstr "Benachrichtigungen öffnen"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:139
-#, elixir-autogen, elixir-format
-msgid "Privacy settings"
-msgstr "Privatsphäre-Einstellungen"
-
 #: lib/vutuv_web/templates/settings/notifications.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr "Antworten und Likes zu Ihren Beiträgen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:127
+#: lib/vutuv_web/templates/settings/privacy.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr "Sicherheit"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:13
+#: lib/vutuv_web/templates/settings/privacy.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Search engines & AI"
 msgstr "Suchmaschinen & KI"
@@ -5952,7 +5936,7 @@ msgstr "Wenn Ihnen jemand schreibt und Sie es noch nicht gelesen haben."
 msgid "When someone starts following you."
 msgstr "Wenn jemand beginnt, Ihnen zu folgen."
 
-#: lib/vutuv_web/templates/block/index.html.heex:23
+#: lib/vutuv_web/templates/block/index.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "@handle"
 msgstr "@handle"
@@ -5962,63 +5946,63 @@ msgstr "@handle"
 msgid "Block @%{slug}"
 msgstr "@%{slug} blockieren"
 
-#: lib/vutuv_web/templates/block/index.html.heex:8
+#: lib/vutuv_web/templates/block/index.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Block someone"
 msgstr "Jemanden blockieren"
 
-#: lib/vutuv_web/controllers/block_controller.ex:69
+#: lib/vutuv_web/controllers/block_controller.ex:72
 #, elixir-autogen, elixir-format
 msgid "Enter a member's @handle to block them."
 msgstr "Geben Sie den @handle eines Mitglieds ein, um es zu blockieren."
 
-#: lib/vutuv_web/templates/block/index.html.heex:10
+#: lib/vutuv_web/templates/block/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Type a member's @handle. You do not have to visit their profile."
 msgstr ""
 "Geben Sie den @handle eines Mitglieds ein. Sie müssen dafür nicht das Profil"
 " der Person besuchen."
 
-#: lib/vutuv_web/controllers/block_controller.ex:72
+#: lib/vutuv_web/controllers/block_controller.ex:75
 #, elixir-autogen, elixir-format
 msgid "We could not find a member with the handle @%{handle}."
 msgstr "Wir konnten kein Mitglied mit dem Handle @%{handle} finden."
 
-#: lib/vutuv_web/controllers/block_controller.ex:75
+#: lib/vutuv_web/controllers/block_controller.ex:78
 #, elixir-autogen, elixir-format
 msgid "You already blocked @%{slug}."
 msgstr "Sie haben @%{slug} bereits blockiert."
 
-#: lib/vutuv_web/controllers/block_controller.ex:78
+#: lib/vutuv_web/controllers/block_controller.ex:81
 #, elixir-autogen, elixir-format
 msgid "You blocked @%{slug}."
 msgstr "Sie haben @%{slug} blockiert."
 
-#: lib/vutuv_web/controllers/block_controller.ex:54
+#: lib/vutuv_web/controllers/block_controller.ex:57
 #, elixir-autogen, elixir-format
 msgid "You cannot block yourself."
 msgstr "Sie können sich nicht selbst blockieren."
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:23
-#: lib/vutuv_web/live/user_profile_live.ex:208
+#: lib/vutuv_web/live/user_profile_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Bookmark removed."
 msgstr "Lesezeichen entfernt."
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:19
-#: lib/vutuv_web/live/user_profile_live.ex:205
+#: lib/vutuv_web/live/user_profile_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Bookmarked."
 msgstr "Lesezeichen gesetzt."
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:31
-#: lib/vutuv_web/live/user_profile_live.ex:214
+#: lib/vutuv_web/live/user_profile_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Like removed."
 msgstr "Gefällt mir entfernt."
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:27
-#: lib/vutuv_web/live/user_profile_live.ex:211
+#: lib/vutuv_web/live/user_profile_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Liked."
 msgstr "Gefällt mir."
@@ -6080,28 +6064,28 @@ msgid "Sort"
 msgstr "Sortieren"
 
 #: lib/vutuv_web/components/job_components.ex:174
-#: lib/vutuv_web/views/settings_html.ex:309
+#: lib/vutuv_web/views/settings_html.ex:359
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor %{count} Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/vutuv_web/views/settings_html.ex:308
+#: lib/vutuv_web/views/settings_html.ex:358
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor %{count} Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/vutuv_web/views/settings_html.ex:307
+#: lib/vutuv_web/views/settings_html.ex:357
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] "vor %{count} Minute"
 msgstr[1] "vor %{count} Minuten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:589
+#: lib/vutuv_web/controllers/settings_controller.ex:630
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
@@ -6116,12 +6100,12 @@ msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
 msgid "Last active"
 msgstr "Zuletzt aktiv"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:47
+#: lib/vutuv_web/templates/settings/security.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Log out all other devices"
 msgstr "Alle anderen Geräte abmelden"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:44
+#: lib/vutuv_web/templates/settings/security.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Log out of every device except this one?"
 msgstr "Von allen Geräten außer diesem abmelden?"
@@ -6136,12 +6120,12 @@ msgstr "Dieses Gerät von Ihrem Konto abmelden?"
 msgid "New sign-in to your vutuv account"
 msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:30
+#: lib/vutuv_web/templates/settings/security.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Signed-in devices"
 msgstr "Angemeldete Geräte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:578
+#: lib/vutuv_web/controllers/settings_controller.ex:619
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
@@ -6163,36 +6147,36 @@ msgstr ""
 "Das ist die erste Anmeldung, die wir von diesem Gerät oder Browser gesehen "
 "haben."
 
-#: lib/vutuv_web/views/settings_html.ex:306
+#: lib/vutuv_web/views/settings_html.ex:356
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:79
+#: lib/vutuv_web/templates/settings/privacy.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 "Ein grüner Punkt auf Ihrem Avatar zeigt anderen Mitgliedern, dass Sie gerade"
 " online sind."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:78
+#: lib/vutuv_web/templates/settings/privacy.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr "Online-Status"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:80
+#: lib/vutuv_web/templates/settings/privacy.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Show when I'm online"
 msgstr "Anzeigen, wenn ich online bin"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:81
+#: lib/vutuv_web/templates/settings/privacy.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
 "Wenn ausgeschaltet, sieht niemand den grünen Punkt auf Ihrem Avatar, und Sie"
 " werden nie als online angezeigt."
 
-#: lib/vutuv_web/templates/settings/security.html.heex:104
+#: lib/vutuv_web/templates/settings/security.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Add a passkey"
 msgstr "Passkey hinzufügen"
@@ -6203,7 +6187,7 @@ msgstr "Passkey hinzufügen"
 msgid "Added"
 msgstr "Hinzugefügt"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:101
+#: lib/vutuv_web/templates/settings/security.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Could not add the passkey. Please try again."
 msgstr ""
@@ -6214,7 +6198,7 @@ msgstr ""
 msgid "Last used"
 msgstr "Zuletzt verwendet"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:85
+#: lib/vutuv_web/templates/settings/security.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Name (optional)"
 msgstr "Name (optional)"
@@ -6234,7 +6218,7 @@ msgstr "Passkey hinzugefügt."
 msgid "Passkey removed."
 msgstr "Passkey entfernt."
 
-#: lib/vutuv_web/templates/settings/security.html.heex:59
+#: lib/vutuv_web/templates/settings/security.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Passkeys"
 msgstr "Passkeys"
@@ -6244,7 +6228,7 @@ msgstr "Passkeys"
 msgid "Remove this passkey?"
 msgstr "Diesen Passkey entfernen?"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:61
+#: lib/vutuv_web/templates/settings/security.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Sign in with Touch ID, Windows Hello or a security key instead of waiting for an email PIN. Your email PIN stays available as a backup."
 msgstr ""
@@ -6274,12 +6258,12 @@ msgstr "Dieser Passkey konnte nicht registriert werden."
 msgid "That passkey could not be verified."
 msgstr "Dieser Passkey konnte nicht verifiziert werden."
 
-#: lib/vutuv_web/templates/settings/security.html.heex:115
+#: lib/vutuv_web/templates/settings/security.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "This browser does not support passkeys."
 msgstr "Dieser Browser unterstützt keine Passkeys."
 
-#: lib/vutuv_web/templates/settings/security.html.heex:75
+#: lib/vutuv_web/templates/settings/security.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "You have not added any passkeys yet."
 msgstr "Sie haben noch keine Passkeys hinzugefügt."
@@ -6289,7 +6273,7 @@ msgstr "Sie haben noch keine Passkeys hinzugefügt."
 msgid "Your sign-in attempt expired. Please try again."
 msgstr "Ihr Anmeldeversuch ist abgelaufen. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/templates/settings/security.html.heex:91
+#: lib/vutuv_web/templates/settings/security.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "e.g. MacBook"
 msgstr "z. B. MacBook"
@@ -6299,7 +6283,7 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/live/user_profile_live.ex:964
+#: lib/vutuv_web/live/user_profile_live.ex:988
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
@@ -6334,7 +6318,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1216
+#: lib/vutuv_web/templates/user/show.html.heex:1317
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6379,16 +6363,16 @@ msgstr "Foto verwenden"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:834
-#: lib/vutuv_web/templates/user/show.html.heex:844
+#: lib/vutuv_web/templates/user/show.html.heex:935
+#: lib/vutuv_web/templates/user/show.html.heex:945
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:433
-#: lib/vutuv_web/agent_docs/text.ex:430
+#: lib/vutuv_web/agent_docs/markdown.ex:434
+#: lib/vutuv_web/agent_docs/text.ex:431
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Alter"
@@ -6422,12 +6406,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:955
+#: lib/vutuv_web/templates/user/show.html.heex:1056
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:966
+#: lib/vutuv_web/templates/user/show.html.heex:1067
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6437,7 +6421,7 @@ msgstr "Telefon verwalten"
 msgid "Metric"
 msgstr "Kennzahl"
 
-#: lib/vutuv_web/views/admin/report_html.ex:33
+#: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "New confirmed registrations (by PIN)"
 msgstr "Neue bestätigte Registrierungen (per PIN)"
@@ -6462,14 +6446,14 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:836
+#: lib/vutuv_web/agent_docs/markdown.ex:849
 #: lib/vutuv_web/components/post_components.ex:275
-#: lib/vutuv_web/views/admin/report_html.ex:35
+#: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:964
+#: lib/vutuv_web/templates/user/show.html.heex:1065
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6509,7 +6493,7 @@ msgstr "Empfehlung zurücknehmen"
 msgid "Default map"
 msgstr "Standardkarte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:509
+#: lib/vutuv_web/controllers/settings_controller.ex:550
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr "Karteneinstellungen gespeichert."
@@ -6525,9 +6509,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1202
-#: lib/vutuv_web/templates/user/show.html.heex:1210
-#: lib/vutuv_web/templates/user/show.html.heex:1222
+#: lib/vutuv_web/templates/user/show.html.heex:1303
+#: lib/vutuv_web/templates/user/show.html.heex:1311
+#: lib/vutuv_web/templates/user/show.html.heex:1323
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6572,7 +6556,7 @@ msgstr "Noch keine Empfehlungen."
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:815
+#: lib/vutuv_web/agent_docs/markdown.ex:828
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -6669,17 +6653,17 @@ msgstr ""
 "auf."
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:153
-#: lib/vutuv_web/views/admin/report_html.ex:40
+#: lib/vutuv_web/views/admin/report_html.ex:45
 #, elixir-autogen, elixir-format
 msgid "Deactivated addresses"
 msgstr "Deaktivierte Adressen"
 
-#: lib/vutuv_web/views/admin/report_html.ex:38
+#: lib/vutuv_web/views/admin/report_html.ex:39
 #, elixir-autogen, elixir-format
 msgid "New Fediverse followers"
 msgstr "Neue Fediverse-Follower"
 
-#: lib/vutuv_web/views/admin/report_html.ex:41
+#: lib/vutuv_web/views/admin/report_html.ex:42
 #, elixir-autogen, elixir-format
 msgid "Removed Fediverse followers (account deleted)"
 msgstr "Entfernte Fediverse-Follower (Konto gelöscht)"
@@ -6714,7 +6698,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:2
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:8
-#: lib/vutuv_web/views/admin/report_html.ex:41
+#: lib/vutuv_web/views/admin/report_html.ex:46
 #, elixir-autogen, elixir-format
 msgid "Frozen accounts"
 msgstr "Eingefrorene Konten"
@@ -6840,17 +6824,17 @@ msgstr "wiederholte harte Bounces"
 msgid "system"
 msgstr "System"
 
-#: lib/vutuv_web/views/admin/report_html.ex:39
+#: lib/vutuv_web/views/admin/report_html.ex:44
 #, elixir-autogen, elixir-format
 msgid "Bounces"
 msgstr "Bounces"
 
-#: lib/vutuv_web/views/admin/report_html.ex:42
+#: lib/vutuv_web/views/admin/report_html.ex:47
 #, elixir-autogen, elixir-format
 msgid "Thawed accounts"
 msgstr "Aufgetaute Konten"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:60
+#: lib/vutuv_web/templates/settings/privacy.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "When on, AI assistants and crawlers may read and train on your public profile. When off, we ask them not to."
 msgstr ""
@@ -6858,19 +6842,19 @@ msgstr ""
 "lesen und damit trainieren. Wenn deaktiviert, bitten wir sie, dies zu "
 "unterlassen."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:55
+#: lib/vutuv_web/templates/settings/privacy.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "When on, your public profile can appear in Google and other search engines. When off, we ask them to leave it out."
 msgstr ""
 "Wenn aktiviert, kann Ihr öffentliches Profil in Google und anderen "
 "Suchmaschinen erscheinen. Wenn deaktiviert, bitten wir sie, es auszulassen."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:35
+#: lib/vutuv_web/templates/settings/privacy.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Exactly what we send"
 msgstr "Was wir technisch genau senden"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:45
+#: lib/vutuv_web/templates/settings/privacy.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Compliant crawlers honor these; they are not a hard block. A noindexed profile is also kept out of the sitemap and structured data."
 msgstr ""
@@ -6878,7 +6862,7 @@ msgstr ""
 "technische Sperre. Ein nicht indiziertes Profil bleibt außerdem aus Sitemap "
 "und strukturierten Daten heraus."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:38
+#: lib/vutuv_web/templates/settings/privacy.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
@@ -6893,7 +6877,7 @@ msgid "Mute"
 msgstr "Stummschalten"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:190
+#: lib/vutuv_web/live/user_profile_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr "Stummgeschaltet. Die Beiträge erscheinen nicht mehr in Ihrem Feed."
@@ -6916,7 +6900,7 @@ msgid "Unmute"
 msgstr "Stummschaltung aufheben"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:192
+#: lib/vutuv_web/live/user_profile_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -7835,17 +7819,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:895
+#: lib/vutuv_web/agent_docs/markdown.ex:908
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Dein Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:898
+#: lib/vutuv_web/agent_docs/markdown.ex:911
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:905
+#: lib/vutuv_web/agent_docs/markdown.ex:918
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -8430,7 +8414,7 @@ msgstr "Nicht erreichbar"
 msgid "Verified"
 msgstr "Verifiziert"
 
-#: lib/vutuv_web/controllers/user_controller.ex:203
+#: lib/vutuv_web/controllers/user_controller.ex:205
 #, elixir-autogen, elixir-format
 msgid "Your verified badge was removed because you changed your name, gender or date of birth. We re-check identity against those details so members can trust verified profiles and nobody can set up a fake verified account. An admin can verify you again anytime."
 msgstr ""
@@ -8520,7 +8504,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3180
+#: lib/vutuv_web/components/ui.ex:3208
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8579,7 +8563,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:3196
+#: lib/vutuv_web/components/ui.ex:3303
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8608,7 +8592,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:3187
+#: lib/vutuv_web/components/ui.ex:3235
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8702,7 +8686,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/live/user_profile_live.ex:983
+#: lib/vutuv_web/live/user_profile_live.ex:1007
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr "Zum Beispiel ein Gedanke zu %{tag}."
@@ -8731,8 +8715,8 @@ msgstr[1] ""
 msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:94
-#: lib/vutuv_web/templates/user/show.html.heex:1069
+#: lib/vutuv_web/templates/settings/privacy.html.heex:99
+#: lib/vutuv_web/templates/user/show.html.heex:1170
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8811,14 +8795,14 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:3178
+#: lib/vutuv_web/components/ui.ex:3196
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:3195
-#: lib/vutuv_web/controllers/settings_controller.ex:107
+#: lib/vutuv_web/components/ui.ex:3299
+#: lib/vutuv_web/controllers/settings_controller.ex:109
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
@@ -8829,17 +8813,16 @@ msgstr "Sprache & Anzeige"
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:3193
-#: lib/vutuv_web/controllers/settings_controller.ex:90
+#: lib/vutuv_web/components/ui.ex:3295
+#: lib/vutuv_web/controllers/settings_controller.ex:92
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
-#: lib/vutuv_web/templates/settings/security.html.heex:5
+#: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/totp/new.html.heex:5
-#: lib/vutuv_web/templates/username/new.html.heex:7
 #, elixir-autogen, elixir-format
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:3197
+#: lib/vutuv_web/components/ui.ex:3307
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8854,7 +8837,7 @@ msgstr ""
 "Nachrichten und Einstellungen. Sie enthält private Daten, bewahren Sie sie "
 "also sorgfältig auf."
 
-#: lib/vutuv_web/controllers/user_controller.ex:227
+#: lib/vutuv_web/controllers/user_controller.ex:229
 #, elixir-autogen, elixir-format
 msgid "Please type your username exactly as shown to confirm the deletion."
 msgstr ""
@@ -8877,19 +8860,19 @@ msgstr "Andere Beiträge anzeigen"
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:96
+#: lib/vutuv_web/templates/settings/privacy.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 "Wenn Sie ein Mastodon- oder Bluesky-Konto angeben, kann Ihr Profil Ihre "
 "neuesten öffentlichen Beiträge von dort anzeigen."
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:100
+#: lib/vutuv_web/templates/settings/privacy.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Show my latest social media posts on my profile"
 msgstr "Meine neuesten Social-Media-Beiträge auf meinem Profil anzeigen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:101
+#: lib/vutuv_web/templates/settings/privacy.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
@@ -9087,13 +9070,20 @@ msgstr "Die Seite wurde veröffentlicht."
 msgid "Write it under Admin › Legal pages"
 msgstr "Unter Admin › Rechtstexte verfassen"
 
-#: lib/vutuv_web/components/ui.ex:3202
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/markdown.ex:451
+#: lib/vutuv_web/agent_docs/text.ex:444
+#: lib/vutuv_web/agent_docs/text.ex:448
+#: lib/vutuv_web/components/ui.ex:3288
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:29
-#: lib/vutuv_web/controllers/settings_controller.ex:192
+#: lib/vutuv_web/controllers/settings_controller.ex:194
+#: lib/vutuv_web/controllers/settings_controller.ex:261
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:288
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
+#: lib/vutuv_web/templates/user/show.html.heex:812
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverse"
@@ -9118,17 +9108,17 @@ msgstr ""
 "als Link in Ihren Mastodon-Profileinstellungen ein, und Mastodon zeigt ihn "
 "grün als bestätigt an."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:249
+#: lib/vutuv_web/controllers/settings_controller.ex:274
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr "Fediverse-Einstellungen gespeichert."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:175
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr "Social-Media-Konten verwalten"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:82
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
@@ -9160,7 +9150,7 @@ msgid "Employment"
 msgstr "Anstellung"
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:595
+#: lib/vutuv_web/agent_docs/markdown.ex:608
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -9183,7 +9173,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr "Berufserfahrung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:596
+#: lib/vutuv_web/agent_docs/markdown.ex:609
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -9214,13 +9204,13 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:633
+#: lib/vutuv_web/agent_docs/markdown.ex:646
 #: lib/vutuv_web/views/education_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:632
+#: lib/vutuv_web/agent_docs/markdown.ex:645
 #: lib/vutuv_web/views/education_html.ex:29
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9256,7 +9246,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:774
+#: lib/vutuv_web/agent_docs/markdown.ex:787
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9349,14 +9339,14 @@ msgstr ""
 "Der Lebenslauf von %{name} auf vutuv: Berufserfahrung, Ausbildung und "
 "Kenntnisse zum Ansehen und Herunterladen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:594
+#: lib/vutuv_web/agent_docs/markdown.ex:607
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr "Freiberuflich / Selbstständig"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:597
+#: lib/vutuv_web/agent_docs/markdown.ex:610
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9512,8 +9502,8 @@ msgstr "Ehren-Tag"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Ehren-Tag (nur Admins können es vergeben)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:454
-#: lib/vutuv_web/agent_docs/text.ex:449
+#: lib/vutuv_web/agent_docs/markdown.ex:467
+#: lib/vutuv_web/agent_docs/text.ex:462
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "Ehren-Tag"
@@ -9742,7 +9732,6 @@ msgstr "Sprache erfolgreich aktualisiert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:49
 #: lib/vutuv_web/agent_docs/text.ex:46
-#: lib/vutuv_web/components/ui.ex:3182
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
@@ -10051,7 +10040,7 @@ msgstr[1] "%{count} Zertifikate oder Lizenzen"
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:695
+#: lib/vutuv_web/agent_docs/markdown.ex:708
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -10079,7 +10068,7 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3181
+#: lib/vutuv_web/components/ui.ex:3212
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -10128,7 +10117,7 @@ msgstr "Läuft nicht ab"
 msgid "Expired"
 msgstr "Abgelaufen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:670
+#: lib/vutuv_web/agent_docs/markdown.ex:683
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10145,7 +10134,7 @@ msgstr "Ausgestellt"
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:694
+#: lib/vutuv_web/agent_docs/markdown.ex:707
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10175,7 +10164,7 @@ msgstr "Nachweis"
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:668
+#: lib/vutuv_web/agent_docs/markdown.ex:681
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10190,7 +10179,7 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:669
+#: lib/vutuv_web/agent_docs/markdown.ex:682
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -10209,15 +10198,15 @@ msgstr ""
 msgid "Preferred"
 msgstr "Bevorzugt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:552
+#: lib/vutuv_web/agent_docs/markdown.ex:565
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:930
-#: lib/vutuv_web/templates/user/show.html.heex:931
+#: lib/vutuv_web/templates/user/show.html.heex:1031
+#: lib/vutuv_web/templates/user/show.html.heex:1032
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10398,7 +10387,7 @@ msgstr "An"
 msgid "Your invitation is on its way"
 msgstr "Ihre Einladung ist unterwegs"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:186
+#: lib/vutuv_web/templates/username/new.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Permanent profile link"
 msgstr "Dauerhafter Profillink"
@@ -10409,44 +10398,28 @@ msgstr "Dauerhafter Profillink"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:98
-#: lib/vutuv_web/templates/settings/security.html.heex:202
-#: lib/vutuv_web/templates/settings/security.html.heex:219
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:106
 #: lib/vutuv_web/templates/totp/new.html.heex:58
+#: lib/vutuv_web/templates/user/show.html.heex:848
+#: lib/vutuv_web/templates/username/new.html.heex:27
+#: lib/vutuv_web/templates/username/new.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr "Kopiert"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:97
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:101
-#: lib/vutuv_web/templates/settings/security.html.heex:201
-#: lib/vutuv_web/templates/settings/security.html.heex:205
-#: lib/vutuv_web/templates/settings/security.html.heex:218
-#: lib/vutuv_web/templates/settings/security.html.heex:222
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:109
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
+#: lib/vutuv_web/templates/user/show.html.heex:847
+#: lib/vutuv_web/templates/user/show.html.heex:851
+#: lib/vutuv_web/templates/username/new.html.heex:26
+#: lib/vutuv_web/templates/username/new.html.heex:30
+#: lib/vutuv_web/templates/username/new.html.heex:113
+#: lib/vutuv_web/templates/username/new.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Copy"
 msgstr "Kopieren"
-
-#: lib/vutuv_web/templates/settings/security.html.heex:209
-#, elixir-autogen, elixir-format
-msgid "For everyday sharing, your normal profile address is shorter:"
-msgstr "Zum Teilen im Alltag ist Ihre normale Profiladresse praktischer:"
-
-#: lib/vutuv_web/templates/settings/security.html.heex:188
-#, elixir-autogen, elixir-format
-msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename."
-msgstr ""
-"Dieser Link öffnet immer Ihr Profil, auch nach einer Änderung Ihres "
-"Benutzernamens. Er basiert auf einer festen Kennung und funktioniert daher "
-"über jede Umbenennung hinweg."
-
-#: lib/vutuv_web/templates/settings/index.html.heex:29
-#, elixir-autogen, elixir-format
-msgid "Pick a section from the menu on the left to view or change it."
-msgstr ""
-"Wählen Sie links im Menü einen Bereich, um ihn anzusehen oder zu ändern."
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:304
 #, elixir-autogen, elixir-format
@@ -10464,12 +10437,12 @@ msgstr "Achtung:"
 msgid "Outbound federation is healthy."
 msgstr "Die ausgehende Föderation läuft störungsfrei."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:142
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Showing the most recent %{shown} of %{total}."
 msgstr "Die neuesten %{shown} von %{total} werden angezeigt."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:151
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Accounts that no longer exist on their own server drop off this list by themselves."
 msgstr ""
@@ -10536,7 +10509,7 @@ msgstr "Konto entfernt"
 msgid "Account restored. The member can sign in again."
 msgstr "Konto wiederhergestellt. Das Mitglied kann sich wieder anmelden."
 
-#: lib/vutuv_web/views/admin/report_html.ex:43
+#: lib/vutuv_web/views/admin/report_html.ex:48
 #, elixir-autogen, elixir-format
 msgid "Accounts removed as spam"
 msgstr "Als Spam entfernte Konten"
@@ -10624,7 +10597,7 @@ msgstr ""
 "Nachrichten. Stufen unsere Admins die Meldung als unbegründet ein, wird das "
 "rückgängig gemacht."
 
-#: lib/vutuv_web/templates/settings/security.html.heex:168
+#: lib/vutuv_web/templates/settings/security.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "%{unused} of %{total} codes unused."
 msgstr "%{unused} von %{total} Codes unbenutzt."
@@ -10737,7 +10710,7 @@ msgstr "Kursiv"
 msgid "Link URL"
 msgstr "Link-URL"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:125
+#: lib/vutuv_web/templates/settings/security.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Login codes"
 msgstr "Anmelde-Codes"
@@ -10748,8 +10721,8 @@ msgstr "Anmelde-Codes"
 msgid "More formatting"
 msgstr "Mehr Formatierung"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:138
-#: lib/vutuv_web/templates/settings/security.html.heex:172
+#: lib/vutuv_web/templates/settings/security.html.heex:144
+#: lib/vutuv_web/templates/settings/security.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Not set up."
 msgstr "Nicht eingerichtet."
@@ -10790,8 +10763,8 @@ msgstr ""
 "FreeOTP, Google Authenticator oder 1Password). Die App zeigt danach alle 30 "
 "Sekunden einen neuen 6-stelligen Code an."
 
-#: lib/vutuv_web/templates/settings/security.html.heex:159
-#: lib/vutuv_web/templates/settings/security.html.heex:175
+#: lib/vutuv_web/templates/settings/security.html.heex:165
+#: lib/vutuv_web/templates/settings/security.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Set up"
 msgstr "Einrichten"
@@ -10823,12 +10796,12 @@ msgstr "Geben Sie zum Abschluss den Code ein, den Ihre App jetzt anzeigt"
 msgid "Toggle Markdown source"
 msgstr "Markdown-Quelltext umschalten"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:152
+#: lib/vutuv_web/templates/settings/security.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Turn off"
 msgstr "Ausschalten"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:146
+#: lib/vutuv_web/templates/settings/security.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Turn off the authenticator app? Its codes stop working at login; the emailed PIN is unaffected."
 msgstr ""
@@ -10840,7 +10813,7 @@ msgstr ""
 msgid "Turn on"
 msgstr "Einschalten"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:138
+#: lib/vutuv_web/templates/settings/security.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Turned on."
 msgstr "Eingeschaltet."
@@ -10883,7 +10856,7 @@ msgstr ""
 "Kennwortliste funktioniert hier, anstelle der PIN aus der E-Mail."
 
 #: lib/vutuv_web/controllers/totp_controller.ex:83
-#: lib/vutuv_web/templates/settings/security.html.heex:135
+#: lib/vutuv_web/templates/settings/security.html.heex:141
 #: lib/vutuv_web/templates/totp/new.html.heex:2
 #: lib/vutuv_web/templates/totp/new.html.heex:6
 #, elixir-autogen, elixir-format
@@ -10893,7 +10866,7 @@ msgstr "Authenticator-App (TOTP)"
 #: lib/vutuv_web/controllers/login_code_controller.ex:25
 #: lib/vutuv_web/templates/login_code/index.html.heex:2
 #: lib/vutuv_web/templates/login_code/index.html.heex:6
-#: lib/vutuv_web/templates/settings/security.html.heex:164
+#: lib/vutuv_web/templates/settings/security.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "One-time code list (OTP)"
 msgstr "Kennwortliste (OTP)"
@@ -10905,7 +10878,7 @@ msgstr ""
 "Sie lesen dies auf dem Gerät, das die Codes erzeugen soll? Der eigene "
 "Bildschirm lässt sich nicht scannen. Stattdessen:"
 
-#: lib/vutuv_web/templates/settings/security.html.heex:127
+#: lib/vutuv_web/templates/settings/security.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
@@ -10918,21 +10891,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr "auf diesem Gerät einrichten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:512
+#: lib/vutuv_web/agent_docs/markdown.ex:525
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} Follower"
 msgstr[1] "%{count} Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:510
+#: lib/vutuv_web/agent_docs/markdown.ex:523
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} Repository"
 msgstr[1] "%{count} Repositories"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:508
+#: lib/vutuv_web/agent_docs/markdown.ex:521
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10955,17 +10928,17 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1043
+#: lib/vutuv_web/templates/user/show.html.heex:1144
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:113
+#: lib/vutuv_web/templates/settings/privacy.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr "Code-Statistiken"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:115
+#: lib/vutuv_web/templates/settings/privacy.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
@@ -10978,24 +10951,24 @@ msgstr ""
 msgid "Last active %{date}"
 msgstr "Zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:119
+#: lib/vutuv_web/templates/settings/privacy.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Show code statistics on my profile"
 msgstr "Code-Statistiken auf meinem Profil anzeigen"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:120
+#: lib/vutuv_web/templates/settings/privacy.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten nur als einfache "
 "Links."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:526
+#: lib/vutuv_web/agent_docs/markdown.ex:539
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/markdown.ex:526
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "seit %{date}"
@@ -11287,7 +11260,7 @@ msgstr ""
 "Längere Beiträge erhalten einen „Weiterlesen“-Link. Mit 0 (oder leer) wird "
 "nie gekürzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:522
+#: lib/vutuv_web/controllers/settings_controller.ex:563
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
@@ -11346,7 +11319,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr "Standard der Installation (%{value})"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:553
+#: lib/vutuv_web/controllers/settings_controller.ex:594
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr "Karten-Einstellungen auf die Standardwerte zurückgesetzt."
@@ -11365,7 +11338,7 @@ msgstr ""
 "Eigener Wert; leeren Sie das Feld, um zum Standard der Installation "
 "zurückzukehren."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:549
+#: lib/vutuv_web/controllers/settings_controller.ex:590
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -12446,8 +12419,8 @@ msgstr ""
 "Wir konnten den Nachweis noch nicht finden. Die Verbreitung kann etwas "
 "dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
-#: lib/vutuv_web/agent_docs/text.ex:545
+#: lib/vutuv_web/agent_docs/markdown.ex:728
+#: lib/vutuv_web/agent_docs/text.ex:558
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -12698,8 +12671,8 @@ msgid "Organization unfrozen."
 msgstr "Organisation"
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:3194
-#: lib/vutuv_web/controllers/settings_controller.ex:158
+#: lib/vutuv_web/components/ui.ex:3224
+#: lib/vutuv_web/controllers/settings_controller.ex:160
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
 #: lib/vutuv_web/live/post_live/saved.ex:455
@@ -12823,7 +12796,7 @@ msgstr "hat dich zum Inhaber von %{company} gemacht."
 msgid "your_organization"
 msgstr "ihre_organisation"
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:15
+#: lib/vutuv_web/templates/settings/privacy.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "We can't stop a search engine or AI service from reading a page it can open. What we can do is tell them, in the machine-readable way they look for, that you don't want your profile listed in search results or used by AI. Reputable search engines and AI companies follow that request; we can't force the rest."
 msgstr ""
@@ -13258,7 +13231,7 @@ msgstr "Gehalt"
 msgid "Salary on request"
 msgstr "Gehalt auf Anfrage"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:230
+#: lib/vutuv_web/controllers/settings_controller.ex:232
 #: lib/vutuv_web/live/job_posting_live/form.ex:231
 #, elixir-autogen, elixir-format
 msgid "Saved."
@@ -13822,7 +13795,7 @@ msgstr[1] "%{count} neue Treffer für deine gespeicherten Suchen"
 msgid "Alert frequency"
 msgstr "Häufigkeit der Benachrichtigung"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:447
+#: lib/vutuv_web/controllers/settings_controller.ex:488
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr "Benachrichtigung aktualisiert."
@@ -13888,13 +13861,13 @@ msgstr "Speichere eine Suche in der Stellenbörse oder in der Personensuche, und
 msgid "Save search"
 msgstr "Suche speichern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:465
+#: lib/vutuv_web/controllers/settings_controller.ex:506
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:3233
-#: lib/vutuv_web/controllers/settings_controller.ex:370
+#: lib/vutuv_web/components/ui.ex:3273
+#: lib/vutuv_web/controllers/settings_controller.ex:411
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13913,8 +13886,8 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr "E-Mail-Benachrichtigungen für deine gespeicherte Suche „%{label}“ stoppen?"
 
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:452
-#: lib/vutuv_web/controllers/settings_controller.ex:470
+#: lib/vutuv_web/controllers/settings_controller.ex:493
+#: lib/vutuv_web/controllers/settings_controller.ex:511
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr "Das hat nicht funktioniert."
@@ -14242,14 +14215,14 @@ msgstr "Vollständiges Datum und Alter"
 msgid "Show my birthday as"
 msgstr "Geburtstag anzeigen als"
 
-#: lib/vutuv_web/templates/username/new.html.heex:26
+#: lib/vutuv_web/templates/username/new.html.heex:49
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post currently mentions %{handle} and will be updated when you rename."
 msgid_plural "%{formatted} posts currently mention %{handle} and will be updated when you rename."
 msgstr[0] "%{formatted} Beitrag erwähnt aktuell %{handle} und wird beim Umbenennen aktualisiert."
 msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Umbenennen aktualisiert."
 
-#: lib/vutuv_web/templates/username/new.html.heex:18
+#: lib/vutuv_web/templates/username/new.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
@@ -14360,8 +14333,8 @@ msgstr "Eigene Beiträge"
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr "Beiträge mit einem Tag, dem du folgst, landen in deinem Feed, und passende Personen tauchen in deinen Vorschlägen auf. Einem Tag folgst du auf seiner Seite."
 
-#: lib/vutuv_web/components/ui.ex:3222
-#: lib/vutuv_web/controllers/settings_controller.ex:384
+#: lib/vutuv_web/components/ui.ex:3269
+#: lib/vutuv_web/controllers/settings_controller.ex:425
 #: lib/vutuv_web/live/post_live/feed.ex:732
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -14411,7 +14384,7 @@ msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzerna
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1009
+#: lib/vutuv_web/templates/user/show.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14440,7 +14413,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3185
+#: lib/vutuv_web/components/ui.ex:3254
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14448,7 +14421,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1007
+#: lib/vutuv_web/templates/user/show.html.heex:1108
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14540,7 +14513,7 @@ msgstr "Autor/in"
 msgid "Book"
 msgstr "Buch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:857
+#: lib/vutuv_web/agent_docs/markdown.ex:870
 #: lib/vutuv_web/components/post_components.ex:1897
 #: lib/vutuv_web/live/post_live/composer.ex:671
 #, elixir-autogen, elixir-format
@@ -14572,7 +14545,7 @@ msgstr "E-Book"
 msgid "Film"
 msgstr "Film"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:857
+#: lib/vutuv_web/agent_docs/markdown.ex:870
 #: lib/vutuv_web/components/post_components.ex:1896
 #: lib/vutuv_web/live/post_live/composer.ex:670
 #, elixir-autogen, elixir-format
@@ -14714,7 +14687,7 @@ msgstr "Qualifikation"
 msgid "With qualification:"
 msgstr "Mit Qualifikation:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:581
+#: lib/vutuv_web/agent_docs/markdown.ex:594
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
@@ -14810,19 +14783,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] "Für %{formatted} Job genutzt"
 msgstr[1] "Für %{formatted} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:684
+#: lib/vutuv_web/agent_docs/markdown.ex:697
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr "aktuell genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:683
+#: lib/vutuv_web/agent_docs/markdown.ex:696
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] "für %{count} Job genutzt"
 msgstr[1] "für %{count} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:689
+#: lib/vutuv_web/agent_docs/markdown.ex:702
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14901,8 +14874,8 @@ msgstr "Hochgeladener Nachweis für %{name}"
 msgid "View the uploaded proof (%{label})"
 msgstr "Hochgeladenen Nachweis ansehen (%{label})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:652
-#: lib/vutuv_web/agent_docs/text.ex:537
+#: lib/vutuv_web/agent_docs/markdown.ex:665
+#: lib/vutuv_web/agent_docs/text.ex:550
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "Nachweis"
@@ -15249,7 +15222,7 @@ msgstr "Konto, zu dem Sie umziehen"
 msgid "Cancel redirect"
 msgstr "Weiterleitung aufheben"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:272
+#: lib/vutuv_web/controllers/settings_controller.ex:314
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr "Fertig. Ihre Fediverse-Follower wurden gebeten, Ihrem neuen Konto zu folgen, und neue Beiträge werden von hier nicht mehr föderiert. Ihr vutuv-Profil bleibt unverändert."
@@ -15264,12 +15237,12 @@ msgstr "Tragen Sie unten die Adresse dieses Kontos ein und leiten Sie weiter."
 msgid "On your other account, add your vutuv handle"
 msgstr "Fügen Sie auf Ihrem anderen Konto Ihr vutuv-Handle"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:311
+#: lib/vutuv_web/controllers/settings_controller.ex:353
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr "Bitte geben Sie die vollständige https-Adresse des Kontos ein, zu dem Sie umziehen."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:297
+#: lib/vutuv_web/controllers/settings_controller.ex:339
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr "Weiterleitung aufgehoben. Ihre Beiträge werden wieder von hier föderiert."
@@ -15284,17 +15257,17 @@ msgstr "Meine Follower weiterleiten"
 msgid "Redirected on %{date}"
 msgstr "Weitergeleitet am %{date}"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:324
+#: lib/vutuv_web/controllers/settings_controller.ex:366
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr "Dieses Konto war nicht erreichbar. Prüfen Sie die Adresse und ob der andere Server online ist."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:318
+#: lib/vutuv_web/controllers/settings_controller.ex:360
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr "Dieses Konto führt Ihr vutuv-Profil noch nicht als Alias. Fügen Sie dort zuerst die Adresse dieses Profils hinzu und versuchen Sie es dann erneut."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:314
+#: lib/vutuv_web/controllers/settings_controller.ex:356
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr "Das ist dieses Konto. Geben Sie das Konto an, zu dem Sie umziehen."
@@ -15304,12 +15277,12 @@ msgstr "Das ist dieses Konto. Geben Sie das Konto an, zu dem Sie umziehen."
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr "Damit werden Ihre Fediverse-Follower gebeten, stattdessen Ihrem neuen Konto zu folgen, und Ihre Beiträge werden von hier nicht mehr föderiert. Ihr vutuv-Profil ist nicht betroffen. Fortfahren?"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:302
+#: lib/vutuv_web/controllers/settings_controller.ex:344
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr "Schalten Sie zuerst die Föderation ein, dann können Sie Ihre Follower weiterleiten."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:306
+#: lib/vutuv_web/controllers/settings_controller.ex:348
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr "Sie können nur alle %{days} Tage umziehen."
@@ -15331,7 +15304,7 @@ msgstr[1] "%{formatted} Empfehlungen"
 msgid "All endorsers"
 msgstr "Alle Empfehlenden"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:401
+#: lib/vutuv_web/controllers/settings_controller.ex:442
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgeblendet."
@@ -15341,7 +15314,7 @@ msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgebl
 msgid "Filter by a tag"
 msgstr "Nach einem Tag filtern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:426
+#: lib/vutuv_web/controllers/settings_controller.ex:467
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr "Filter entfernt."
@@ -15361,8 +15334,8 @@ msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wo
 msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
-#: lib/vutuv_web/components/ui.ex:3204
-#: lib/vutuv_web/controllers/settings_controller.ex:437
+#: lib/vutuv_web/components/ui.ex:3265
+#: lib/vutuv_web/controllers/settings_controller.ex:478
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -15457,7 +15430,7 @@ msgstr "Sie dürfen den Benutzernamen dieser Organisation nicht ändern."
 msgid "You have not muted anything yet."
 msgstr "Sie haben noch nichts stummgeschaltet."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:409
+#: lib/vutuv_web/controllers/settings_controller.ex:450
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
@@ -15598,12 +15571,12 @@ msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
 msgid "none yet"
 msgstr "noch keiner"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:845
+#: lib/vutuv_web/agent_docs/markdown.ex:858
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:63
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Count reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken zählen"
@@ -15645,49 +15618,49 @@ msgstr "Ihre öffentlichen vutuv-Beiträge erscheinen in deren Timelines."
 msgid "Nothing changes on vutuv itself, and you can switch it off again."
 msgstr "Auf vutuv selbst ändert sich nichts, und Sie können es jederzeit wieder ausschalten."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:51
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Take part in the Fediverse"
 msgstr "Am Fediverse teilnehmen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:53
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Off means your profile cannot be found there and nothing is sent. Posts already delivered may stay on those servers, beyond our reach."
 msgstr "Ausgeschaltet ist Ihr Profil dort nicht auffindbar und es wird nichts zugestellt. Bereits ausgelieferte Beiträge können auf jenen Servern verbleiben, außerhalb unseres Zugriffs."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:66
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Show under each of your posts how many people out there liked or shared it. A number only, visible to everyone who sees the post. Switching it off deletes what is stored for it."
 msgstr "Zeigen Sie unter jedem Ihrer Beiträge, wie viele Menschen dort draußen ihn geliked oder geteilt haben. Nur eine Zahl, sichtbar für alle, die den Beitrag sehen. Ausschalten löscht, was dafür gespeichert ist."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:84
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr "Geben Sie es weiter wie eine E-Mail-Adresse. Jeder bei Mastodon und Co. kann es in die Suche einfügen und Ihnen von dort folgen."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:116
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr "Noch niemand. Posten Sie Ihr Handle dort, wo andere es sehen, dann tauchen die ersten Follower hier auf."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:155
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Related"
 msgstr "Verwandte Themen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:158
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Moving to or away from another Fediverse account?"
 msgstr "Ziehen Sie zu einem anderen Fediverse-Konto um oder von dort zu vutuv?"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:214
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:164
+#: lib/vutuv_web/controllers/settings_controller.ex:216
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:180
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Move your account"
 msgstr "Konto umziehen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:168
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr "Sie möchten das Häkchen in Ihrem Mastodon-Profil? Das geht ohne Teilnahme hier: Ihr vutuv-Profil verlinkt Ihre eingetragenen Konten mit rel=\"me\"."
@@ -15742,7 +15715,7 @@ msgstr "Schicken Sie Ihre Fediverse-Follower zu einem anderen Konto. Sie werden 
 msgid "Back to Fediverse settings"
 msgstr "Zurück zu den Fediverse-Einstellungen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:106
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower from other networks"
 msgid_plural "%{formatted} followers from other networks"
@@ -15924,12 +15897,6 @@ msgstr "Bis"
 msgid "Add tags"
 msgstr "Tags hinzufügen"
 
-#: lib/vutuv_web/templates/username/new.html.heex:4
-#: lib/vutuv_web/templates/username/new.html.heex:8
-#, elixir-autogen, elixir-format
-msgid "Change username"
-msgstr "Benutzernamen ändern"
-
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Edit application"
@@ -15940,27 +15907,27 @@ msgstr "Anwendung bearbeiten"
 msgid "Book an ad"
 msgstr "Anzeige buchen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:388
+#: lib/vutuv_web/templates/user/show.html.heex:816
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr "%{name} hat dieses Fediverse-Konto umgezogen. Folgen Sie stattdessen der neuen Adresse:"
 
-#: lib/vutuv_web/templates/user/show.html.heex:405
+#: lib/vutuv_web/templates/user/show.html.heex:832
 #, elixir-autogen, elixir-format
 msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
 msgstr "Sie sind auf Mastodon oder in einer anderen Fediverse-App? Folgen Sie %{name} von dort aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/templates/user/show.html.heex:449
+#: lib/vutuv_web/templates/user/show.html.heex:869
 #, elixir-autogen, elixir-format
 msgid "Follow from your own server"
 msgstr "Von Ihrem eigenen Server aus folgen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:461
+#: lib/vutuv_web/templates/user/show.html.heex:880
 #, elixir-autogen, elixir-format
 msgid "@you@example.social"
 msgstr "@name@example.social"
 
-#: lib/vutuv_web/templates/user/show.html.heex:469
+#: lib/vutuv_web/templates/user/show.html.heex:888
 #, elixir-autogen, elixir-format
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr "Ihre Adresse wird einmal verwendet, um Sie zum Folgen-Dialog Ihres eigenen Servers zu schicken. Gespeichert wird sie hier nicht."
@@ -15970,308 +15937,435 @@ msgstr "Ihre Adresse wird einmal verwendet, um Sie zum Folgen-Dialog Ihres eigen
 msgid "This profile is not on the Fediverse."
 msgstr "Dieses Profil ist nicht im Fediverse."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:69
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:72
 #, elixir-autogen, elixir-format
 msgid "That is not a Fediverse address. It looks like @you@example.social."
 msgstr "Das ist keine Fediverse-Adresse. Eine sieht so aus: @name@example.social."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:73
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:76
 #, elixir-autogen, elixir-format
 msgid "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead."
 msgstr "%{server} bietet keinen Folgen-Dialog an. Kopieren Sie stattdessen die Adresse oben und fügen Sie sie in die Suche Ihrer App ein."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:80
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:83
 #, elixir-autogen, elixir-format
 msgid "%{server} did not answer. Copy the handle above and paste it into your app's search instead."
 msgstr "%{server} hat nicht geantwortet. Kopieren Sie stattdessen die Adresse oben und fügen Sie sie in die Suche Ihrer App ein."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:90
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:94
 #, elixir-autogen, elixir-format
 msgid "Your server"
 msgstr "Ihr Server"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:447
-#: lib/vutuv_web/agent_docs/text.ex:444
+#: lib/vutuv_web/agent_docs/markdown.ex:448
+#: lib/vutuv_web/agent_docs/text.ex:445
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
 
+#: lib/vutuv_web/components/ui.ex:3197
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Name, Foto, Titelbild, Kurzbeschreibung"
 
+#: lib/vutuv_web/components/ui.ex:3198
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "avatar profilbild portrait foto bild geburtstag geburtsdatum geschlecht über mich"
 
+#: lib/vutuv_web/components/ui.ex:3202
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle spitzname nutzername umbenennen slug profiladresse url erwähnung"
 
+#: lib/vutuv_web/components/ui.ex:3205
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Die Stationen in Ihrem Lebenslauf"
 
+#: lib/vutuv_web/components/ui.ex:3206
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "lebenslauf cv karriere beruf arbeitgeber position stelle job firma"
 
+#: lib/vutuv_web/components/ui.ex:3209
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Schulen, Hochschulen, Abschlüsse"
 
+#: lib/vutuv_web/components/ui.ex:3210
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "lebenslauf studium schule universität hochschule abschluss ausbildung"
 
+#: lib/vutuv_web/components/ui.ex:3213
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Nachweise, mit Belegdokumenten"
 
+#: lib/vutuv_web/components/ui.ex:3214
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr "zertifikat lizenz urkunde diplom nachweis beleg auszeichnung dokument"
 
+#: lib/vutuv_web/components/ui.ex:3216
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Sprachkenntnisse"
 
+#: lib/vutuv_web/components/ui.ex:3217
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Die Sprachen, die Sie sprechen"
 
+#: lib/vutuv_web/components/ui.ex:3218
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "sprache sprachen sprechen fließend muttersprache verhandlungssicher"
 
+#: lib/vutuv_web/components/ui.ex:3221
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Die Themen, für die Sie bekannt sind"
 
+#: lib/vutuv_web/components/ui.ex:3222
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
+#: lib/vutuv_web/components/ui.ex:3225
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Firmenseiten, die Sie verwalten"
 
+#: lib/vutuv_web/components/ui.ex:3226
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
 
+#: lib/vutuv_web/components/ui.ex:3229
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
+#: lib/vutuv_web/components/ui.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Wo wir Sie erreichen, und welche Adresse öffentlich ist"
 
+#: lib/vutuv_web/components/ui.ex:3233
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "mail e-mail email adresse hauptadresse primär"
 
+#: lib/vutuv_web/components/ui.ex:3236
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Festnetz, Mobil, Fax"
 
+#: lib/vutuv_web/components/ui.ex:3237
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefon handy mobil festnetz fax nummer rufnummer"
 
+#: lib/vutuv_web/components/ui.ex:3240
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Postanschriften auf Ihrem Profil"
 
+#: lib/vutuv_web/components/ui.ex:3241
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "straße stadt ort postleitzahl plz land anschrift karte"
 
+#: lib/vutuv_web/components/ui.ex:3243
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Webseiten & Links"
 
+#: lib/vutuv_web/components/ui.ex:3244
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Ihre Homepage und weitere Links"
 
+#: lib/vutuv_web/components/ui.ex:3245
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url webseite website homepage blog link verifizieren bestätigen rel=me"
 
+#: lib/vutuv_web/components/ui.ex:3247
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Social-Media-Profile"
 
+#: lib/vutuv_web/components/ui.ex:3248
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub und die anderen"
 
+#: lib/vutuv_web/components/ui.ex:3250
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr "mastodon bluesky github gitlab codeberg linkedin x twitter instagram soziale netzwerke"
 
+#: lib/vutuv_web/components/ui.ex:3255
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix und die anderen"
 
+#: lib/vutuv_web/components/ui.ex:3256
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger nachrichten"
 
+#: lib/vutuv_web/components/ui.ex:3259
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Mitteilungen & Feed"
 
+#: lib/vutuv_web/components/ui.ex:3262
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Welche E-Mails wir schicken, und was die Glocke meldet"
 
+#: lib/vutuv_web/components/ui.ex:3263
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer"
 msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe"
 
+#: lib/vutuv_web/components/ui.ex:3266
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Beiträge aus Ihrem Feed heraushalten"
 
+#: lib/vutuv_web/components/ui.ex:3267
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "stummschalten ausblenden verbergen filter wort begriff tag feed blockieren"
 
+#: lib/vutuv_web/components/ui.ex:3270
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Themen, deren Beiträge in Ihrem Feed landen"
 
+#: lib/vutuv_web/components/ui.ex:3271
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag thema abonnieren folgen feed"
 
+#: lib/vutuv_web/components/ui.ex:3274
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr "Job- und Personensuchen, die Ihnen neue Treffer mailen"
 
+#: lib/vutuv_web/components/ui.ex:3275
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "job stelle stellenangebot suchauftrag suche alarm benachrichtigung merkliste"
 
+#: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Suchmaschinen, KI, Online-Status"
 
+#: lib/vutuv_web/components/ui.ex:3282
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar"
 
+#: lib/vutuv_web/components/ui.ex:3285
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Personen, die nicht mit Ihnen interagieren können"
 
+#: lib/vutuv_web/components/ui.ex:3286
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blockieren sperren bannen stummschalten melden missbrauch belästigung"
 
+#: lib/vutuv_web/components/ui.ex:3289
 #, elixir-autogen, elixir-format
 msgid "Followers from Mastodon and other networks"
 msgstr "Follower aus Mastodon und anderen Netzwerken"
 
+#: lib/vutuv_web/components/ui.ex:3290
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower move migrate"
 msgstr "mastodon activitypub fediverse föderation follower umzug umziehen migration"
 
+#: lib/vutuv_web/components/ui.ex:3296
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 
+#: lib/vutuv_web/components/ui.ex:3297
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
+#: lib/vutuv_web/components/ui.ex:3300
 #, elixir-autogen, elixir-format
 msgid "Interface language, maps, how posts are shortened"
 msgstr "Sprache der Oberfläche, Karten, Kürzung von Beiträgen"
 
+#: lib/vutuv_web/components/ui.ex:3301
 #, elixir-autogen, elixir-format
 msgid "german english locale translation map font length hyphenation"
 msgstr "deutsch englisch sprache übersetzung karte schrift länge silbentrennung darstellung"
 
+#: lib/vutuv_web/components/ui.ex:3304
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
+#: lib/vutuv_web/components/ui.ex:3305
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
+#: lib/vutuv_web/components/ui.ex:3308
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
+#: lib/vutuv_web/components/ui.ex:3309
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
+#: lib/vutuv_web/components/ui.ex:3312
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr "Verbundene Apps und Zugriffstoken"
 
+#: lib/vutuv_web/components/ui.ex:3313
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle"
 
+#: lib/vutuv_web/components/ui.ex:3316
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
+#: lib/vutuv_web/components/ui.ex:3317
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
 
+#: lib/vutuv_web/templates/settings/index.html.heex:20
+#: lib/vutuv_web/templates/settings/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Search settings"
 msgstr "Einstellungen durchsuchen"
 
+#: lib/vutuv_web/templates/settings/index.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Nothing here matches. Try another word, or clear the search."
 msgstr "Dazu passt hier nichts. Versuchen Sie ein anderes Wort, oder leeren Sie die Suche."
 
+#: lib/vutuv_web/templates/settings/security.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "How you sign in"
 msgstr "Wie Sie sich anmelden"
 
+#: lib/vutuv_web/templates/settings/security.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "You sign in with your primary address, and we mail your PIN there."
 msgstr "Mit Ihrer Hauptadresse melden Sie sich an, und dorthin schicken wir Ihre PIN."
 
+#: lib/vutuv_web/templates/settings/security.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "Your profile address. It is not used to sign in."
 msgstr "Ihre Profiladresse. Zum Anmelden wird sie nicht verwendet."
 
+#: lib/vutuv_web/templates/settings/security.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr "Öffnen"
 
+#: lib/vutuv_web/templates/settings/followed_tags.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "You do not follow any tags yet. Open a tag page and press Follow, for example"
 msgstr "Sie folgen noch keinem Tag. Öffnen Sie eine Tag-Seite und klicken Sie auf Folgen, zum Beispiel"
 
+#: lib/vutuv_web/templates/settings/followed_tags.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "from the tag directory"
 msgstr "aus dem Tag-Verzeichnis"
 
+#: lib/vutuv_web/templates/username/new.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Your profile address"
 msgstr "Ihre Profiladresse"
 
+#: lib/vutuv_web/templates/username/new.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Other members mention you as %{handle}."
 msgstr "Andere Mitglieder erwähnen Sie als %{handle}."
 
+#: lib/vutuv_web/templates/username/new.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Change your username"
 msgstr "Benutzernamen ändern"
 
+#: lib/vutuv_web/templates/username/new.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr "Dieser Link öffnet immer Ihr Profil, auch nachdem Sie Ihren Benutzernamen geändert haben. Er wird aus einer festen Id gebildet und geht bei einer Umbenennung nie kaputt. Für den Alltag ist die kurze Adresse oben freundlicher."
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:235
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
+#, elixir-autogen, elixir-format
+msgid "I understand, switch off"
+msgstr "Verstanden, abschalten"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:233
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "I understand, take part"
+msgstr "Verstanden, teilnehmen"
+
+#: lib/vutuv_web/views/settings_html.ex:338
+#, elixir-autogen, elixir-format
+msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
+msgstr ""
+"Die meisten, nicht alle: Wir können nicht überprüfen, ob sie es tun, und was "
+"anderswo geteilt, archiviert oder indexiert wurde, bleibt außer Reichweite. "
+"Wenn Sie später wieder teilnehmen, müssen Ihnen die Leute dort erneut folgen."
+
+#: lib/vutuv_web/views/settings_html.ex:333
+#, elixir-autogen, elixir-format
+msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
+msgstr ""
+"Es gehen keine neuen Beiträge mehr hinaus, und Ihre Follower aus anderen "
+"Netzwerken werden hier entfernt. Wenn diese Server das nächste Mal nachsehen, "
+"erfahren sie, dass dieses Konto nicht mehr existiert, und die meisten löschen "
+"daraufhin ihre Kopien Ihrer Beiträge."
+
+#: lib/vutuv_web/views/settings_html.ex:314
+#, elixir-autogen, elixir-format
+msgid "Once a post has left vutuv, it is out of our hands"
+msgstr ""
+"Was einmal von vutuv aus verschickt wurde, können wir nicht zurückholen"
+
+#: lib/vutuv_web/views/settings_html.ex:316
+#, elixir-autogen, elixir-format
+msgid "Switching off does not delete what is already out there"
+msgstr "Abschalten löscht nicht, was bereits draußen ist"
+
+#: lib/vutuv_web/views/settings_html.ex:327
+#, elixir-autogen, elixir-format
+msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
+msgstr ""
+"Wenn Sie das später wieder abschalten, gehen keine neuen Beiträge mehr "
+"hinaus. Bereits zugestellte Beiträge holt das nicht zurück."
+
+#: lib/vutuv_web/views/settings_html.ex:322
+#, elixir-autogen, elixir-format
+msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
+msgstr ""
+"Ihre öffentlichen Beiträge werden auf andere Server kopiert. Ist eine Kopie "
+"erst dort, können wir sie nicht löschen, nicht ändern und nicht verfolgen, "
+"wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
+"Server nur eine Bitte, und nicht jeder Server befolgt sie."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -37,7 +37,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1264
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -61,7 +61,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3188
+#: lib/vutuv_web/components/ui.ex:3239
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -96,11 +96,11 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:431
 #: lib/vutuv_web/agent_docs/markdown.ex:432
-#: lib/vutuv_web/agent_docs/text.ex:428
+#: lib/vutuv_web/agent_docs/markdown.ex:433
 #: lib/vutuv_web/agent_docs/text.ex:429
-#: lib/vutuv_web/templates/user/show.html.heex:828
+#: lib/vutuv_web/agent_docs/text.ex:430
+#: lib/vutuv_web/templates/user/show.html.heex:929
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -118,6 +118,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:86
 #: lib/vutuv_web/templates/report/new.html.heex:103
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:225
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:50
 #: lib/vutuv_web/templates/user/edit.html.heex:103
@@ -142,7 +144,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:866
+#: lib/vutuv_web/templates/user/show.html.heex:967
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -213,7 +215,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:851
+#: lib/vutuv_web/templates/user/show.html.heex:952
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -286,7 +288,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3179
+#: lib/vutuv_web/components/ui.ex:3204
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -310,8 +312,8 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:443
-#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:456
+#: lib/vutuv_web/agent_docs/text.ex:453
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/live/notification_live/index.ex:798
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:136
@@ -321,8 +323,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:444
-#: lib/vutuv_web/agent_docs/text.ex:441
+#: lib/vutuv_web/agent_docs/markdown.ex:457
+#: lib/vutuv_web/agent_docs/text.ex:454
 #: lib/vutuv_web/components/ui.ex:1551
 #: lib/vutuv_web/components/ui.ex:1576
 #: lib/vutuv_web/components/ui.ex:1579
@@ -337,8 +339,8 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:430
-#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/agent_docs/markdown.ex:431
+#: lib/vutuv_web/agent_docs/text.ex:428
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -347,7 +349,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:823
+#: lib/vutuv_web/templates/user/show.html.heex:924
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -408,7 +410,6 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:52
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:3183
 #: lib/vutuv_web/controllers/url_controller.ex:23
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
@@ -458,7 +459,6 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3199
 #: lib/vutuv_web/live/notification_live/index.ex:722
 #, elixir-autogen
 msgid "More"
@@ -618,13 +618,13 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:818
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:72
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:80
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:73
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
 #: lib/vutuv_web/templates/settings/preferences.html.heex:205
-#: lib/vutuv_web/templates/settings/privacy.html.heex:64
+#: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:383
 #: lib/vutuv_web/views/settings_html.ex:138
@@ -669,7 +669,6 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:55
 #: lib/vutuv_web/agent_docs/text.ex:52
-#: lib/vutuv_web/components/ui.ex:3184
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
@@ -682,13 +681,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:977
+#: lib/vutuv_web/templates/user/show.html.heex:1078
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:979
+#: lib/vutuv_web/templates/user/show.html.heex:1080
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -728,10 +727,10 @@ msgstr ""
 msgid "Code & repositories"
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:31
+#: lib/vutuv_web/controllers/block_controller.ex:34
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:113
+#: lib/vutuv_web/live/user_profile_live.ex:116
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr ""
@@ -767,12 +766,12 @@ msgstr ""
 msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:291
+#: lib/vutuv_web/controllers/user_controller.ex:293
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:210
+#: lib/vutuv_web/controllers/user_controller.ex:212
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr ""
@@ -782,6 +781,8 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3200
+#: lib/vutuv_web/controllers/username_controller.ex:60
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
@@ -789,10 +790,11 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
-#: lib/vutuv_web/templates/settings/security.html.heex:11
+#: lib/vutuv_web/templates/settings/security.html.heex:23
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:5
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:21
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:26
+#: lib/vutuv_web/templates/username/new.html.heex:10
 #, elixir-autogen
 msgid "Username"
 msgstr ""
@@ -840,10 +842,13 @@ msgstr ""
 msgid "View All"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3280
+#: lib/vutuv_web/controllers/settings_controller.ex:141
 #: lib/vutuv_web/live/job_posting_live/form.ex:550
 #: lib/vutuv_web/live/organization_live/edit.ex:298
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
+#: lib/vutuv_web/templates/settings/privacy.html.heex:14
 #, elixir-autogen
 msgid "Visibility"
 msgstr ""
@@ -1039,7 +1044,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:812
+#: lib/vutuv_web/templates/user/show.html.heex:913
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1393,11 +1398,11 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
 #: lib/vutuv_web/agent_docs/markdown.ex:368
-#: lib/vutuv_web/agent_docs/markdown.ex:802
+#: lib/vutuv_web/agent_docs/markdown.ex:815
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:394
-#: lib/vutuv_web/agent_docs/text.ex:571
-#: lib/vutuv_web/components/ui.ex:3189
+#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/components/ui.ex:3220
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1434,7 +1439,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:156
 #: lib/vutuv_web/controllers/session_controller.ex:433
-#: lib/vutuv_web/controllers/user_controller.ex:311
+#: lib/vutuv_web/controllers/user_controller.ex:313
 #, elixir-autogen
 msgid "Too many incorrect attempts."
 msgstr ""
@@ -1683,7 +1688,7 @@ msgstr ""
 msgid "Delete my account"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:151
+#: lib/vutuv_web/controllers/user_controller.ex:153
 #: lib/vutuv_web/templates/user/show.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
@@ -1706,6 +1711,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1605
 #: lib/vutuv_web/components/ui.ex:1608
 #: lib/vutuv_web/components/ui.ex:1681
+#: lib/vutuv_web/templates/user/show.html.heex:884
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1771,7 +1777,7 @@ msgstr ""
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3203
+#: lib/vutuv_web/components/ui.ex:3261
 #: lib/vutuv_web/live/notification_live/index.ex:103
 #: lib/vutuv_web/live/notification_live/index.ex:275
 #: lib/vutuv_web/live/shell_live.ex:508
@@ -1830,13 +1836,14 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:97
 #: lib/vutuv_web/controllers/email_controller.ex:110
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:46
 #: lib/vutuv_web/controllers/session_controller.ex:70
 #: lib/vutuv_web/controllers/session_controller.ex:86
 #: lib/vutuv_web/controllers/session_controller.ex:177
 #: lib/vutuv_web/controllers/session_controller.ex:208
 #: lib/vutuv_web/controllers/session_controller.ex:224
-#: lib/vutuv_web/controllers/user_controller.ex:247
-#: lib/vutuv_web/controllers/user_controller.ex:276
+#: lib/vutuv_web/controllers/user_controller.ex:249
+#: lib/vutuv_web/controllers/user_controller.ex:278
 #, elixir-autogen, elixir-format
 msgid "Too many attempts. Please try again later."
 msgstr ""
@@ -1862,7 +1869,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:757
-#: lib/vutuv_web/templates/user/show.html.heex:1251
+#: lib/vutuv_web/templates/user/show.html.heex:1352
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -2197,7 +2204,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/post_doc.ex:92
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
-#: lib/vutuv_web/controllers/user_controller.ex:73
+#: lib/vutuv_web/controllers/user_controller.ex:75
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
 #: lib/vutuv_web/live/notification_live/index.ex:720
@@ -2205,7 +2212,7 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:179
 #: lib/vutuv_web/live/search_live.ex:462
 #: lib/vutuv_web/templates/settings/preferences.html.heex:118
-#: lib/vutuv_web/views/admin/report_html.ex:34
+#: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr ""
@@ -2288,7 +2295,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3389
+#: lib/vutuv_web/components/ui.ex:3505
 #: lib/vutuv_web/live/shell_live.ex:551
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2333,7 +2340,7 @@ msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:300
+#: lib/vutuv_web/views/settings_html.ex:350
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2377,12 +2384,12 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:837
+#: lib/vutuv_web/agent_docs/markdown.ex:850
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:490
 #: lib/vutuv_web/live/shell_live.ex:556
-#: lib/vutuv_web/views/admin/report_html.ex:37
+#: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
@@ -2397,13 +2404,13 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:836
+#: lib/vutuv_web/agent_docs/markdown.ex:849
 #: lib/vutuv_web/components/post_components.ex:2226
 #: lib/vutuv_web/live/notification_live/index.ex:800
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:559
-#: lib/vutuv_web/views/admin/report_html.ex:36
+#: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Likes"
 msgstr ""
@@ -2461,7 +2468,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1648
 #: lib/vutuv_web/live/post_live/feed.ex:746
-#: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
+#: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
@@ -2655,7 +2662,7 @@ msgid "“Tired of LinkedIn, and want your data to stay in Germany? I can help.�
 msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:143
-#: lib/vutuv_web/templates/settings/privacy.html.heex:53
+#: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
 msgstr ""
@@ -2699,26 +2706,26 @@ msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:940
+#: lib/vutuv_web/templates/user/show.html.heex:1041
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1266
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:868
+#: lib/vutuv_web/templates/user/show.html.heex:969
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:814
+#: lib/vutuv_web/templates/user/show.html.heex:915
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
@@ -2730,7 +2737,7 @@ msgstr ""
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:970
+#: lib/vutuv_web/live/user_profile_live.ex:994
 #: lib/vutuv_web/templates/user/show.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
@@ -2741,9 +2748,9 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
-#: lib/vutuv_web/templates/settings/privacy.html.heex:133
+#: lib/vutuv_web/templates/settings/privacy.html.heex:138
 #: lib/vutuv_web/templates/settings/security.html.heex:20
-#: lib/vutuv_web/templates/settings/security.html.heex:175
+#: lib/vutuv_web/templates/settings/security.html.heex:181
 #: lib/vutuv_web/templates/user/show.html.heex:492
 #, elixir-autogen, elixir-format
 msgid "Manage"
@@ -2781,8 +2788,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:445
-#: lib/vutuv_web/agent_docs/text.ex:442
+#: lib/vutuv_web/agent_docs/markdown.ex:458
+#: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/live/notification_live/index.ex:799
 #: lib/vutuv_web/templates/connection/index.html.heex:5
@@ -3083,8 +3090,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:908
-#: lib/vutuv_web/templates/user/show.html.heex:909
+#: lib/vutuv_web/templates/user/show.html.heex:1009
+#: lib/vutuv_web/templates/user/show.html.heex:1010
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -3138,7 +3145,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3176
+#: lib/vutuv_web/components/ui.ex:3194
 #: lib/vutuv_web/live/shell_live.ex:443
 #: lib/vutuv_web/live/shell_live.ex:644
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3515,12 +3522,12 @@ msgstr ""
 msgid "Your vutuv account is suspended"
 msgstr ""
 
-#: lib/vutuv_web/controllers/username_controller.ex:77
+#: lib/vutuv_web/controllers/username_controller.ex:82
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is already taken."
 msgstr ""
 
-#: lib/vutuv_web/controllers/username_controller.ex:86
+#: lib/vutuv_web/controllers/username_controller.ex:91
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is available."
 msgstr ""
@@ -3536,12 +3543,7 @@ msgstr ""
 msgid "Your username is now @%{handle}."
 msgstr ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:14
-#, elixir-autogen, elixir-format
-msgid "Your username is your profile address (vutuv.de/username) and how others mention you, like %{handle}."
-msgstr ""
-
-#: lib/vutuv_web/templates/username/new.html.heex:41
+#: lib/vutuv_web/templates/username/new.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "%{remaining} of %{limit} changes left."
 msgstr ""
@@ -3556,17 +3558,17 @@ msgstr ""
 msgid "Username replaced with @%{handle}."
 msgstr ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:61
+#: lib/vutuv_web/templates/username/new.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "You can change it again on %{date}."
 msgstr ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:36
+#: lib/vutuv_web/templates/username/new.html.heex:59
 #, elixir-autogen, elixir-format
 msgid "You can change your username up to %{limit} times within %{days} days."
 msgstr ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:57
+#: lib/vutuv_web/templates/username/new.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "You have used all %{limit} username changes of the last %{days} days."
 msgstr ""
@@ -3818,12 +3820,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:535
+#: lib/vutuv_web/agent_docs/markdown.ex:548
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:890
+#: lib/vutuv_web/agent_docs/markdown.ex:903
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3837,11 +3839,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:151
 #: lib/vutuv_web/agent_docs/markdown.ex:164
-#: lib/vutuv_web/agent_docs/markdown.ex:802
+#: lib/vutuv_web/agent_docs/markdown.ex:815
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:140
 #: lib/vutuv_web/agent_docs/text.ex:153
-#: lib/vutuv_web/agent_docs/text.ex:571
+#: lib/vutuv_web/agent_docs/text.ex:584
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3858,22 +3860,22 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:820
-#: lib/vutuv_web/agent_docs/text.ex:582
+#: lib/vutuv_web/agent_docs/markdown.ex:833
+#: lib/vutuv_web/agent_docs/text.ex:595
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:817
-#: lib/vutuv_web/agent_docs/text.ex:579
+#: lib/vutuv_web/agent_docs/markdown.ex:830
+#: lib/vutuv_web/agent_docs/text.ex:592
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:824
-#: lib/vutuv_web/agent_docs/markdown.ex:925
-#: lib/vutuv_web/agent_docs/text.ex:585
-#: lib/vutuv_web/agent_docs/text.ex:613
+#: lib/vutuv_web/agent_docs/markdown.ex:837
+#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/text.ex:598
+#: lib/vutuv_web/agent_docs/text.ex:626
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
@@ -3925,17 +3927,17 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:784
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:701
+#: lib/vutuv_web/agent_docs/markdown.ex:714
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:702
+#: lib/vutuv_web/agent_docs/markdown.ex:715
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4473,7 +4475,7 @@ msgstr ""
 msgid "Search for words in public posts."
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:28
+#: lib/vutuv_web/templates/block/index.html.heex:36
 #: lib/vutuv_web/templates/user/show.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Block"
@@ -4484,25 +4486,27 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:1
-#: lib/vutuv_web/templates/block/index.html.heex:1
-#: lib/vutuv_web/templates/settings/privacy.html.heex:130
+#: lib/vutuv_web/components/ui.ex:3284
+#: lib/vutuv_web/controllers/block_controller.ex:20
+#: lib/vutuv_web/templates/block/index.html.heex:9
+#: lib/vutuv_web/templates/block/index.html.heex:41
+#: lib/vutuv_web/templates/settings/privacy.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Blocked members"
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:34
+#: lib/vutuv_web/templates/block/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Blocked members cannot follow you, connect with you, message you, or reply to your posts - and you cannot interact with them either. Blocking removed any follows and connection between you; unblocking does not restore them."
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:63
+#: lib/vutuv_web/templates/block/index.html.heex:74
 #: lib/vutuv_web/templates/user/show.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:61
+#: lib/vutuv_web/templates/block/index.html.heex:72
 #: lib/vutuv_web/templates/user/show.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "Unblock @%{slug}?"
@@ -4513,13 +4517,13 @@ msgstr ""
 msgid "You blocked @%{slug}. You can undo this on your blocked list."
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:40
+#: lib/vutuv_web/templates/block/index.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "You have not blocked anyone."
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:86
-#: lib/vutuv_web/live/user_profile_live.ex:242
+#: lib/vutuv_web/controllers/block_controller.ex:89
+#: lib/vutuv_web/live/user_profile_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr ""
@@ -4650,7 +4654,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/live/user_profile_live.ex:958
+#: lib/vutuv_web/live/user_profile_live.ex:982
 #: lib/vutuv_web/templates/user/show.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -5227,7 +5231,7 @@ msgid "vutuv POSTs signed JSON envelopes here (see the webhooks documentation). 
 msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:148
-#: lib/vutuv_web/templates/settings/privacy.html.heex:58
+#: lib/vutuv_web/templates/settings/privacy.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
 msgstr ""
@@ -5242,8 +5246,8 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3210
-#: lib/vutuv_web/controllers/settings_controller.ex:130
+#: lib/vutuv_web/components/ui.ex:3315
+#: lib/vutuv_web/controllers/settings_controller.ex:132
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
@@ -5283,7 +5287,7 @@ msgstr ""
 msgid "You can no longer reply to this post."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:136
+#: lib/vutuv_web/templates/settings/privacy.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Content under review"
 msgstr ""
@@ -5320,17 +5324,16 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3296
-#: lib/vutuv_web/components/ui.ex:3301
-#: lib/vutuv_web/components/ui.ex:3380
-#: lib/vutuv_web/components/ui.ex:3444
+#: lib/vutuv_web/components/ui.ex:3412
+#: lib/vutuv_web/components/ui.ex:3417
+#: lib/vutuv_web/components/ui.ex:3496
+#: lib/vutuv_web/components/ui.ex:3560
 #: lib/vutuv_web/controllers/settings_controller.ex:52
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
-#: lib/vutuv_web/templates/username/new.html.heex:6
 #: lib/vutuv_web/views/settings_html.ex:167
 #, elixir-autogen, elixir-format
 msgid "Settings"
@@ -5366,7 +5369,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:960
+#: lib/vutuv_web/live/user_profile_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5447,20 +5450,14 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3191
+#: lib/vutuv_web/components/ui.ex:3293
 #: lib/vutuv_web/live/admin/user_live.ex:266
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:18
-#, elixir-autogen, elixir-format
-msgid "Add, remove or pick your primary address."
-msgstr ""
-
 #: lib/vutuv_web/live/organization_live/edit.ex:441
-#: lib/vutuv_web/templates/settings/security.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr ""
@@ -5470,7 +5467,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3186
+#: lib/vutuv_web/components/ui.ex:3231
 #: lib/vutuv_web/controllers/email_controller.ex:30
 #: lib/vutuv_web/controllers/email_controller.ex:49
 #: lib/vutuv_web/controllers/email_controller.ex:191
@@ -5484,12 +5481,12 @@ msgstr ""
 msgid "Email addresses"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:352
+#: lib/vutuv_web/controllers/settings_controller.ex:393
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:131
+#: lib/vutuv_web/templates/settings/privacy.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you."
 msgstr ""
@@ -5504,13 +5501,12 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3201
-#: lib/vutuv_web/templates/settings/privacy.html.heex:9
+#: lib/vutuv_web/components/ui.ex:3278
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:168
+#: lib/vutuv_web/controllers/settings_controller.ex:170
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr ""
@@ -5520,7 +5516,7 @@ msgstr ""
 msgid "Third-party apps you authorized."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:139
+#: lib/vutuv_web/templates/settings/privacy.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -5535,7 +5531,7 @@ msgstr ""
 msgid "Your post"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:137
+#: lib/vutuv_web/templates/settings/privacy.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Your posts or profile a moderator is looking at."
 msgstr ""
@@ -5565,7 +5561,7 @@ msgstr ""
 msgid "Language & region"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:494
+#: lib/vutuv_web/controllers/settings_controller.ex:535
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr ""
@@ -5573,11 +5569,6 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "Read the API docs"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/security.html.heex:8
-#, elixir-autogen, elixir-format
-msgid "Sign-in & identity"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:22
@@ -5617,13 +5608,13 @@ msgstr ""
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3209
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:145
+#: lib/vutuv_web/components/ui.ex:3311
+#: lib/vutuv_web/controllers/settings_controller.ex:147
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr ""
@@ -5652,7 +5643,7 @@ msgstr ""
 msgid "New followers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:342
+#: lib/vutuv_web/controllers/settings_controller.ex:383
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr ""
@@ -5662,22 +5653,17 @@ msgstr ""
 msgid "Open your notifications"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:139
-#, elixir-autogen, elixir-format
-msgid "Privacy settings"
-msgstr ""
-
 #: lib/vutuv_web/templates/settings/notifications.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:127
+#: lib/vutuv_web/templates/settings/privacy.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:13
+#: lib/vutuv_web/templates/settings/privacy.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Search engines & AI"
 msgstr ""
@@ -5707,7 +5693,7 @@ msgstr ""
 msgid "When someone starts following you."
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:23
+#: lib/vutuv_web/templates/block/index.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "@handle"
 msgstr ""
@@ -5717,61 +5703,61 @@ msgstr ""
 msgid "Block @%{slug}"
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:8
+#: lib/vutuv_web/templates/block/index.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Block someone"
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:69
+#: lib/vutuv_web/controllers/block_controller.ex:72
 #, elixir-autogen, elixir-format
 msgid "Enter a member's @handle to block them."
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:10
+#: lib/vutuv_web/templates/block/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Type a member's @handle. You do not have to visit their profile."
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:72
+#: lib/vutuv_web/controllers/block_controller.ex:75
 #, elixir-autogen, elixir-format
 msgid "We could not find a member with the handle @%{handle}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:75
+#: lib/vutuv_web/controllers/block_controller.ex:78
 #, elixir-autogen, elixir-format
 msgid "You already blocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:78
+#: lib/vutuv_web/controllers/block_controller.ex:81
 #, elixir-autogen, elixir-format
 msgid "You blocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:54
+#: lib/vutuv_web/controllers/block_controller.ex:57
 #, elixir-autogen, elixir-format
 msgid "You cannot block yourself."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:23
-#: lib/vutuv_web/live/user_profile_live.ex:208
+#: lib/vutuv_web/live/user_profile_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Bookmark removed."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:19
-#: lib/vutuv_web/live/user_profile_live.ex:205
+#: lib/vutuv_web/live/user_profile_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Bookmarked."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:31
-#: lib/vutuv_web/live/user_profile_live.ex:214
+#: lib/vutuv_web/live/user_profile_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Like removed."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:27
-#: lib/vutuv_web/live/user_profile_live.ex:211
+#: lib/vutuv_web/live/user_profile_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Liked."
 msgstr ""
@@ -5833,28 +5819,28 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:174
-#: lib/vutuv_web/views/settings_html.ex:309
+#: lib/vutuv_web/views/settings_html.ex:359
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:308
+#: lib/vutuv_web/views/settings_html.ex:358
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:307
+#: lib/vutuv_web/views/settings_html.ex:357
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:589
+#: lib/vutuv_web/controllers/settings_controller.ex:630
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5869,12 +5855,12 @@ msgstr ""
 msgid "Last active"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:47
+#: lib/vutuv_web/templates/settings/security.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Log out all other devices"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:44
+#: lib/vutuv_web/templates/settings/security.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Log out of every device except this one?"
 msgstr ""
@@ -5889,12 +5875,12 @@ msgstr ""
 msgid "New sign-in to your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:30
+#: lib/vutuv_web/templates/settings/security.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:578
+#: lib/vutuv_web/controllers/settings_controller.ex:619
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5914,32 +5900,32 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:306
+#: lib/vutuv_web/views/settings_html.ex:356
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:79
+#: lib/vutuv_web/templates/settings/privacy.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:78
+#: lib/vutuv_web/templates/settings/privacy.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:80
+#: lib/vutuv_web/templates/settings/privacy.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Show when I'm online"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:81
+#: lib/vutuv_web/templates/settings/privacy.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:104
+#: lib/vutuv_web/templates/settings/security.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Add a passkey"
 msgstr ""
@@ -5950,7 +5936,7 @@ msgstr ""
 msgid "Added"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:101
+#: lib/vutuv_web/templates/settings/security.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Could not add the passkey. Please try again."
 msgstr ""
@@ -5960,7 +5946,7 @@ msgstr ""
 msgid "Last used"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:85
+#: lib/vutuv_web/templates/settings/security.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Name (optional)"
 msgstr ""
@@ -5980,7 +5966,7 @@ msgstr ""
 msgid "Passkey removed."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:59
+#: lib/vutuv_web/templates/settings/security.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Passkeys"
 msgstr ""
@@ -5990,7 +5976,7 @@ msgstr ""
 msgid "Remove this passkey?"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:61
+#: lib/vutuv_web/templates/settings/security.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Sign in with Touch ID, Windows Hello or a security key instead of waiting for an email PIN. Your email PIN stays available as a backup."
 msgstr ""
@@ -6015,12 +6001,12 @@ msgstr ""
 msgid "That passkey could not be verified."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:115
+#: lib/vutuv_web/templates/settings/security.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "This browser does not support passkeys."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:75
+#: lib/vutuv_web/templates/settings/security.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "You have not added any passkeys yet."
 msgstr ""
@@ -6030,7 +6016,7 @@ msgstr ""
 msgid "Your sign-in attempt expired. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:91
+#: lib/vutuv_web/templates/settings/security.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "e.g. MacBook"
 msgstr ""
@@ -6040,7 +6026,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:964
+#: lib/vutuv_web/live/user_profile_live.ex:988
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6075,7 +6061,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1216
+#: lib/vutuv_web/templates/user/show.html.heex:1317
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6118,16 +6104,16 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:834
-#: lib/vutuv_web/templates/user/show.html.heex:844
+#: lib/vutuv_web/templates/user/show.html.heex:935
+#: lib/vutuv_web/templates/user/show.html.heex:945
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:433
-#: lib/vutuv_web/agent_docs/text.ex:430
+#: lib/vutuv_web/agent_docs/markdown.ex:434
+#: lib/vutuv_web/agent_docs/text.ex:431
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6159,12 +6145,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:955
+#: lib/vutuv_web/templates/user/show.html.heex:1056
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:966
+#: lib/vutuv_web/templates/user/show.html.heex:1067
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6174,7 +6160,7 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:33
+#: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "New confirmed registrations (by PIN)"
 msgstr ""
@@ -6199,14 +6185,14 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:836
+#: lib/vutuv_web/agent_docs/markdown.ex:849
 #: lib/vutuv_web/components/post_components.ex:275
-#: lib/vutuv_web/views/admin/report_html.ex:35
+#: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:964
+#: lib/vutuv_web/templates/user/show.html.heex:1065
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6244,7 +6230,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:509
+#: lib/vutuv_web/controllers/settings_controller.ex:550
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -6260,9 +6246,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1202
-#: lib/vutuv_web/templates/user/show.html.heex:1210
-#: lib/vutuv_web/templates/user/show.html.heex:1222
+#: lib/vutuv_web/templates/user/show.html.heex:1303
+#: lib/vutuv_web/templates/user/show.html.heex:1311
+#: lib/vutuv_web/templates/user/show.html.heex:1323
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6303,7 +6289,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:815
+#: lib/vutuv_web/agent_docs/markdown.ex:828
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6389,17 +6375,17 @@ msgid "Confirmed members whose every email address bounced, so they can no longe
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:153
-#: lib/vutuv_web/views/admin/report_html.ex:40
+#: lib/vutuv_web/views/admin/report_html.ex:45
 #, elixir-autogen, elixir-format
 msgid "Deactivated addresses"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:38
+#: lib/vutuv_web/views/admin/report_html.ex:39
 #, elixir-autogen, elixir-format
 msgid "New Fediverse followers"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:41
+#: lib/vutuv_web/views/admin/report_html.ex:42
 #, elixir-autogen, elixir-format
 msgid "Removed Fediverse followers (account deleted)"
 msgstr ""
@@ -6432,7 +6418,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:2
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:8
-#: lib/vutuv_web/views/admin/report_html.ex:41
+#: lib/vutuv_web/views/admin/report_html.ex:46
 #, elixir-autogen, elixir-format
 msgid "Frozen accounts"
 msgstr ""
@@ -6553,37 +6539,37 @@ msgstr ""
 msgid "system"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:39
+#: lib/vutuv_web/views/admin/report_html.ex:44
 #, elixir-autogen, elixir-format
 msgid "Bounces"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:42
+#: lib/vutuv_web/views/admin/report_html.ex:47
 #, elixir-autogen, elixir-format
 msgid "Thawed accounts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:60
+#: lib/vutuv_web/templates/settings/privacy.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "When on, AI assistants and crawlers may read and train on your public profile. When off, we ask them not to."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:55
+#: lib/vutuv_web/templates/settings/privacy.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "When on, your public profile can appear in Google and other search engines. When off, we ask them to leave it out."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:35
+#: lib/vutuv_web/templates/settings/privacy.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Exactly what we send"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:45
+#: lib/vutuv_web/templates/settings/privacy.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Compliant crawlers honor these; they are not a hard block. A noindexed profile is also kept out of the sitemap and structured data."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:38
+#: lib/vutuv_web/templates/settings/privacy.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
@@ -6596,7 +6582,7 @@ msgid "Mute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:190
+#: lib/vutuv_web/live/user_profile_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
@@ -6619,7 +6605,7 @@ msgid "Unmute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:192
+#: lib/vutuv_web/live/user_profile_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -7498,17 +7484,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:895
+#: lib/vutuv_web/agent_docs/markdown.ex:908
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:898
+#: lib/vutuv_web/agent_docs/markdown.ex:911
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:905
+#: lib/vutuv_web/agent_docs/markdown.ex:918
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8040,7 +8026,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:203
+#: lib/vutuv_web/controllers/user_controller.ex:205
 #, elixir-autogen, elixir-format
 msgid "Your verified badge was removed because you changed your name, gender or date of birth. We re-check identity against those details so members can trust verified profiles and nobody can set up a fake verified account. An admin can verify you again anytime."
 msgstr ""
@@ -8125,7 +8111,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3180
+#: lib/vutuv_web/components/ui.ex:3208
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8179,7 +8165,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3196
+#: lib/vutuv_web/components/ui.ex:3303
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8208,7 +8194,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3187
+#: lib/vutuv_web/components/ui.ex:3235
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8299,7 +8285,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:983
+#: lib/vutuv_web/live/user_profile_live.ex:1007
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
@@ -8324,8 +8310,8 @@ msgstr[1] ""
 msgid "Loading posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:94
-#: lib/vutuv_web/templates/user/show.html.heex:1069
+#: lib/vutuv_web/templates/settings/privacy.html.heex:99
+#: lib/vutuv_web/templates/user/show.html.heex:1170
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8385,14 +8371,14 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3178
+#: lib/vutuv_web/components/ui.ex:3196
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3195
-#: lib/vutuv_web/controllers/settings_controller.ex:107
+#: lib/vutuv_web/components/ui.ex:3299
+#: lib/vutuv_web/controllers/settings_controller.ex:109
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
@@ -8403,17 +8389,16 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3193
-#: lib/vutuv_web/controllers/settings_controller.ex:90
+#: lib/vutuv_web/components/ui.ex:3295
+#: lib/vutuv_web/controllers/settings_controller.ex:92
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
-#: lib/vutuv_web/templates/settings/security.html.heex:5
+#: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/totp/new.html.heex:5
-#: lib/vutuv_web/templates/username/new.html.heex:7
 #, elixir-autogen, elixir-format
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3197
+#: lib/vutuv_web/components/ui.ex:3307
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8425,7 +8410,7 @@ msgstr ""
 msgid "The file is in JSON format and includes your profile, posts, messages and settings. It contains private data, so store it carefully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:227
+#: lib/vutuv_web/controllers/user_controller.ex:229
 #, elixir-autogen, elixir-format
 msgid "Please type your username exactly as shown to confirm the deletion."
 msgstr ""
@@ -8446,17 +8431,17 @@ msgstr ""
 msgid "Suggested posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:96
+#: lib/vutuv_web/templates/settings/privacy.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:100
+#: lib/vutuv_web/templates/settings/privacy.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Show my latest social media posts on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:101
+#: lib/vutuv_web/templates/settings/privacy.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
@@ -8632,13 +8617,20 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3202
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/markdown.ex:451
+#: lib/vutuv_web/agent_docs/text.ex:444
+#: lib/vutuv_web/agent_docs/text.ex:448
+#: lib/vutuv_web/components/ui.ex:3288
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:29
-#: lib/vutuv_web/controllers/settings_controller.ex:192
+#: lib/vutuv_web/controllers/settings_controller.ex:194
+#: lib/vutuv_web/controllers/settings_controller.ex:261
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:288
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
+#: lib/vutuv_web/templates/user/show.html.heex:812
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8658,17 +8650,17 @@ msgstr ""
 msgid "as a link in your Mastodon profile settings, and Mastodon will show it as verified with a green check."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:249
+#: lib/vutuv_web/controllers/settings_controller.ex:274
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:175
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:82
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr ""
@@ -8698,7 +8690,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:595
+#: lib/vutuv_web/agent_docs/markdown.ex:608
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8719,7 +8711,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:596
+#: lib/vutuv_web/agent_docs/markdown.ex:609
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8750,13 +8742,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:633
+#: lib/vutuv_web/agent_docs/markdown.ex:646
 #: lib/vutuv_web/views/education_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:632
+#: lib/vutuv_web/agent_docs/markdown.ex:645
 #: lib/vutuv_web/views/education_html.ex:29
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8789,7 +8781,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:774
+#: lib/vutuv_web/agent_docs/markdown.ex:787
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8867,14 +8859,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:594
+#: lib/vutuv_web/agent_docs/markdown.ex:607
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:597
+#: lib/vutuv_web/agent_docs/markdown.ex:610
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9018,8 +9010,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:454
-#: lib/vutuv_web/agent_docs/text.ex:449
+#: lib/vutuv_web/agent_docs/markdown.ex:467
+#: lib/vutuv_web/agent_docs/text.ex:462
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9248,7 +9240,6 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:49
 #: lib/vutuv_web/agent_docs/text.ex:46
-#: lib/vutuv_web/components/ui.ex:3182
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
@@ -9546,7 +9537,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:695
+#: lib/vutuv_web/agent_docs/markdown.ex:708
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9574,7 +9565,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3181
+#: lib/vutuv_web/components/ui.ex:3212
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -9623,7 +9614,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:670
+#: lib/vutuv_web/agent_docs/markdown.ex:683
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9640,7 +9631,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:694
+#: lib/vutuv_web/agent_docs/markdown.ex:707
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9667,7 +9658,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:668
+#: lib/vutuv_web/agent_docs/markdown.ex:681
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9682,7 +9673,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:669
+#: lib/vutuv_web/agent_docs/markdown.ex:682
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -9699,15 +9690,15 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:552
+#: lib/vutuv_web/agent_docs/markdown.ex:565
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:930
-#: lib/vutuv_web/templates/user/show.html.heex:931
+#: lib/vutuv_web/templates/user/show.html.heex:1031
+#: lib/vutuv_web/templates/user/show.html.heex:1032
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9875,7 +9866,7 @@ msgstr ""
 msgid "Your invitation is on its way"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:186
+#: lib/vutuv_web/templates/username/new.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Permanent profile link"
 msgstr ""
@@ -9886,39 +9877,27 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:98
-#: lib/vutuv_web/templates/settings/security.html.heex:202
-#: lib/vutuv_web/templates/settings/security.html.heex:219
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:106
 #: lib/vutuv_web/templates/totp/new.html.heex:58
+#: lib/vutuv_web/templates/user/show.html.heex:848
+#: lib/vutuv_web/templates/username/new.html.heex:27
+#: lib/vutuv_web/templates/username/new.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:97
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:101
-#: lib/vutuv_web/templates/settings/security.html.heex:201
-#: lib/vutuv_web/templates/settings/security.html.heex:205
-#: lib/vutuv_web/templates/settings/security.html.heex:218
-#: lib/vutuv_web/templates/settings/security.html.heex:222
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:109
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
+#: lib/vutuv_web/templates/user/show.html.heex:847
+#: lib/vutuv_web/templates/user/show.html.heex:851
+#: lib/vutuv_web/templates/username/new.html.heex:26
+#: lib/vutuv_web/templates/username/new.html.heex:30
+#: lib/vutuv_web/templates/username/new.html.heex:113
+#: lib/vutuv_web/templates/username/new.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Copy"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/security.html.heex:209
-#, elixir-autogen, elixir-format
-msgid "For everyday sharing, your normal profile address is shorter:"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/security.html.heex:188
-#, elixir-autogen, elixir-format
-msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename."
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/index.html.heex:29
-#, elixir-autogen, elixir-format
-msgid "Pick a section from the menu on the left to view or change it."
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:304
@@ -9936,12 +9915,12 @@ msgstr ""
 msgid "Outbound federation is healthy."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:142
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Showing the most recent %{shown} of %{total}."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:151
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Accounts that no longer exist on their own server drop off this list by themselves."
 msgstr ""
@@ -10004,7 +9983,7 @@ msgstr ""
 msgid "Account restored. The member can sign in again."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:43
+#: lib/vutuv_web/views/admin/report_html.ex:48
 #, elixir-autogen, elixir-format
 msgid "Accounts removed as spam"
 msgstr ""
@@ -10080,7 +10059,7 @@ msgstr ""
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:168
+#: lib/vutuv_web/templates/settings/security.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "%{unused} of %{total} codes unused."
 msgstr ""
@@ -10185,7 +10164,7 @@ msgstr ""
 msgid "Link URL"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:125
+#: lib/vutuv_web/templates/settings/security.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Login codes"
 msgstr ""
@@ -10196,8 +10175,8 @@ msgstr ""
 msgid "More formatting"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:138
-#: lib/vutuv_web/templates/settings/security.html.heex:172
+#: lib/vutuv_web/templates/settings/security.html.heex:144
+#: lib/vutuv_web/templates/settings/security.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Not set up."
 msgstr ""
@@ -10232,8 +10211,8 @@ msgstr ""
 msgid "Scan this QR code with an authenticator app (for example FreeOTP, Google Authenticator or 1Password). The app then shows a fresh 6-digit code every 30 seconds."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:159
-#: lib/vutuv_web/templates/settings/security.html.heex:175
+#: lib/vutuv_web/templates/settings/security.html.heex:165
+#: lib/vutuv_web/templates/settings/security.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Set up"
 msgstr ""
@@ -10263,12 +10242,12 @@ msgstr ""
 msgid "Toggle Markdown source"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:152
+#: lib/vutuv_web/templates/settings/security.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Turn off"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:146
+#: lib/vutuv_web/templates/settings/security.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Turn off the authenticator app? Its codes stop working at login; the emailed PIN is unaffected."
 msgstr ""
@@ -10278,7 +10257,7 @@ msgstr ""
 msgid "Turn on"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:138
+#: lib/vutuv_web/templates/settings/security.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Turned on."
 msgstr ""
@@ -10314,7 +10293,7 @@ msgid "A one-time code (OTP) from your authenticator app or your code list also 
 msgstr ""
 
 #: lib/vutuv_web/controllers/totp_controller.ex:83
-#: lib/vutuv_web/templates/settings/security.html.heex:135
+#: lib/vutuv_web/templates/settings/security.html.heex:141
 #: lib/vutuv_web/templates/totp/new.html.heex:2
 #: lib/vutuv_web/templates/totp/new.html.heex:6
 #, elixir-autogen, elixir-format
@@ -10324,7 +10303,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/login_code_controller.ex:25
 #: lib/vutuv_web/templates/login_code/index.html.heex:2
 #: lib/vutuv_web/templates/login_code/index.html.heex:6
-#: lib/vutuv_web/templates/settings/security.html.heex:164
+#: lib/vutuv_web/templates/settings/security.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "One-time code list (OTP)"
 msgstr ""
@@ -10334,7 +10313,7 @@ msgstr ""
 msgid "Reading this on the phone that should generate the codes? You can't scan your own screen. Instead:"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:127
+#: lib/vutuv_web/templates/settings/security.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
@@ -10344,21 +10323,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:512
+#: lib/vutuv_web/agent_docs/markdown.ex:525
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:510
+#: lib/vutuv_web/agent_docs/markdown.ex:523
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:508
+#: lib/vutuv_web/agent_docs/markdown.ex:521
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10381,17 +10360,17 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1043
+#: lib/vutuv_web/templates/user/show.html.heex:1144
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:113
+#: lib/vutuv_web/templates/settings/privacy.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:115
+#: lib/vutuv_web/templates/settings/privacy.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
@@ -10401,22 +10380,22 @@ msgstr ""
 msgid "Last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:119
+#: lib/vutuv_web/templates/settings/privacy.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Show code statistics on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:120
+#: lib/vutuv_web/templates/settings/privacy.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:526
+#: lib/vutuv_web/agent_docs/markdown.ex:539
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/markdown.ex:526
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10682,7 +10661,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:522
+#: lib/vutuv_web/controllers/settings_controller.ex:563
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10731,7 +10710,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:553
+#: lib/vutuv_web/controllers/settings_controller.ex:594
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10746,7 +10725,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:549
+#: lib/vutuv_web/controllers/settings_controller.ex:590
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -11768,8 +11747,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
-#: lib/vutuv_web/agent_docs/text.ex:545
+#: lib/vutuv_web/agent_docs/markdown.ex:728
+#: lib/vutuv_web/agent_docs/text.ex:558
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -12000,8 +11979,8 @@ msgid "Organization unfrozen."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:3194
-#: lib/vutuv_web/controllers/settings_controller.ex:158
+#: lib/vutuv_web/components/ui.ex:3224
+#: lib/vutuv_web/controllers/settings_controller.ex:160
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
 #: lib/vutuv_web/live/post_live/saved.ex:455
@@ -12117,7 +12096,7 @@ msgstr ""
 msgid "your_organization"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:15
+#: lib/vutuv_web/templates/settings/privacy.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "We can't stop a search engine or AI service from reading a page it can open. What we can do is tell them, in the machine-readable way they look for, that you don't want your profile listed in search results or used by AI. Reputable search engines and AI companies follow that request; we can't force the rest."
 msgstr ""
@@ -12547,7 +12526,7 @@ msgstr ""
 msgid "Salary on request"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:230
+#: lib/vutuv_web/controllers/settings_controller.ex:232
 #: lib/vutuv_web/live/job_posting_live/form.ex:231
 #, elixir-autogen, elixir-format
 msgid "Saved."
@@ -13111,7 +13090,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:447
+#: lib/vutuv_web/controllers/settings_controller.ex:488
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -13177,13 +13156,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:465
+#: lib/vutuv_web/controllers/settings_controller.ex:506
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3233
-#: lib/vutuv_web/controllers/settings_controller.ex:370
+#: lib/vutuv_web/components/ui.ex:3273
+#: lib/vutuv_web/controllers/settings_controller.ex:411
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13202,8 +13181,8 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:452
-#: lib/vutuv_web/controllers/settings_controller.ex:470
+#: lib/vutuv_web/controllers/settings_controller.ex:493
+#: lib/vutuv_web/controllers/settings_controller.ex:511
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -13531,14 +13510,14 @@ msgstr ""
 msgid "Show my birthday as"
 msgstr ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:26
+#: lib/vutuv_web/templates/username/new.html.heex:49
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post currently mentions %{handle} and will be updated when you rename."
 msgid_plural "%{formatted} posts currently mention %{handle} and will be updated when you rename."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:18
+#: lib/vutuv_web/templates/username/new.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
@@ -13647,8 +13626,8 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3222
-#: lib/vutuv_web/controllers/settings_controller.ex:384
+#: lib/vutuv_web/components/ui.ex:3269
+#: lib/vutuv_web/controllers/settings_controller.ex:425
 #: lib/vutuv_web/live/post_live/feed.ex:732
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -13698,7 +13677,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1009
+#: lib/vutuv_web/templates/user/show.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13727,7 +13706,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3185
+#: lib/vutuv_web/components/ui.ex:3254
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13735,7 +13714,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1007
+#: lib/vutuv_web/templates/user/show.html.heex:1108
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13827,7 +13806,7 @@ msgstr ""
 msgid "Book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:857
+#: lib/vutuv_web/agent_docs/markdown.ex:870
 #: lib/vutuv_web/components/post_components.ex:1897
 #: lib/vutuv_web/live/post_live/composer.ex:671
 #, elixir-autogen, elixir-format
@@ -13859,7 +13838,7 @@ msgstr ""
 msgid "Film"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:857
+#: lib/vutuv_web/agent_docs/markdown.ex:870
 #: lib/vutuv_web/components/post_components.ex:1896
 #: lib/vutuv_web/live/post_live/composer.ex:670
 #, elixir-autogen, elixir-format
@@ -14001,7 +13980,7 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:581
+#: lib/vutuv_web/agent_docs/markdown.ex:594
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
@@ -14097,19 +14076,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:684
+#: lib/vutuv_web/agent_docs/markdown.ex:697
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:683
+#: lib/vutuv_web/agent_docs/markdown.ex:696
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:689
+#: lib/vutuv_web/agent_docs/markdown.ex:702
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14188,8 +14167,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:652
-#: lib/vutuv_web/agent_docs/text.ex:537
+#: lib/vutuv_web/agent_docs/markdown.ex:665
+#: lib/vutuv_web/agent_docs/text.ex:550
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14512,7 +14491,7 @@ msgstr ""
 msgid "Cancel redirect"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:272
+#: lib/vutuv_web/controllers/settings_controller.ex:314
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr ""
@@ -14527,12 +14506,12 @@ msgstr ""
 msgid "On your other account, add your vutuv handle"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:311
+#: lib/vutuv_web/controllers/settings_controller.ex:353
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:297
+#: lib/vutuv_web/controllers/settings_controller.ex:339
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr ""
@@ -14547,17 +14526,17 @@ msgstr ""
 msgid "Redirected on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:324
+#: lib/vutuv_web/controllers/settings_controller.ex:366
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:318
+#: lib/vutuv_web/controllers/settings_controller.ex:360
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:314
+#: lib/vutuv_web/controllers/settings_controller.ex:356
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr ""
@@ -14567,12 +14546,12 @@ msgstr ""
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:302
+#: lib/vutuv_web/controllers/settings_controller.ex:344
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:306
+#: lib/vutuv_web/controllers/settings_controller.ex:348
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr ""
@@ -14594,7 +14573,7 @@ msgstr[1] ""
 msgid "All endorsers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:401
+#: lib/vutuv_web/controllers/settings_controller.ex:442
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
@@ -14604,7 +14583,7 @@ msgstr ""
 msgid "Filter by a tag"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:426
+#: lib/vutuv_web/controllers/settings_controller.ex:467
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr ""
@@ -14624,8 +14603,8 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3204
-#: lib/vutuv_web/controllers/settings_controller.ex:437
+#: lib/vutuv_web/components/ui.ex:3265
+#: lib/vutuv_web/controllers/settings_controller.ex:478
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14718,7 +14697,7 @@ msgstr ""
 msgid "You have not muted anything yet."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:409
+#: lib/vutuv_web/controllers/settings_controller.ex:450
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
@@ -14859,12 +14838,12 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:845
+#: lib/vutuv_web/agent_docs/markdown.ex:858
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:63
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Count reactions from other networks"
 msgstr ""
@@ -14906,49 +14885,49 @@ msgstr ""
 msgid "Nothing changes on vutuv itself, and you can switch it off again."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:51
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Take part in the Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:53
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Off means your profile cannot be found there and nothing is sent. Posts already delivered may stay on those servers, beyond our reach."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:66
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Show under each of your posts how many people out there liked or shared it. A number only, visible to everyone who sees the post. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:84
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:116
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:155
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Related"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:158
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:214
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:164
+#: lib/vutuv_web/controllers/settings_controller.ex:216
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:180
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Move your account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:168
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr ""
@@ -15003,7 +14982,7 @@ msgstr ""
 msgid "Back to Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:106
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower from other networks"
 msgid_plural "%{formatted} followers from other networks"
@@ -15185,12 +15164,6 @@ msgstr ""
 msgid "Add tags"
 msgstr ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:4
-#: lib/vutuv_web/templates/username/new.html.heex:8
-#, elixir-autogen, elixir-format
-msgid "Change username"
-msgstr ""
-
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Edit application"
@@ -15201,27 +15174,27 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:388
+#: lib/vutuv_web/templates/user/show.html.heex:816
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:405
+#: lib/vutuv_web/templates/user/show.html.heex:832
 #, elixir-autogen, elixir-format
 msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:449
+#: lib/vutuv_web/templates/user/show.html.heex:869
 #, elixir-autogen, elixir-format
 msgid "Follow from your own server"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:461
+#: lib/vutuv_web/templates/user/show.html.heex:880
 #, elixir-autogen, elixir-format
 msgid "@you@example.social"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:469
+#: lib/vutuv_web/templates/user/show.html.heex:888
 #, elixir-autogen, elixir-format
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr ""
@@ -15231,308 +15204,421 @@ msgstr ""
 msgid "This profile is not on the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:69
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:72
 #, elixir-autogen, elixir-format
 msgid "That is not a Fediverse address. It looks like @you@example.social."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:73
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:76
 #, elixir-autogen, elixir-format
 msgid "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:80
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:83
 #, elixir-autogen, elixir-format
 msgid "%{server} did not answer. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:90
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:94
 #, elixir-autogen, elixir-format
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:447
-#: lib/vutuv_web/agent_docs/text.ex:444
+#: lib/vutuv_web/agent_docs/markdown.ex:448
+#: lib/vutuv_web/agent_docs/text.ex:445
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3197
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3198
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3202
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3205
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3206
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3209
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3210
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3213
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3214
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3216
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3217
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3218
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3221
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3222
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3225
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3226
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3229
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3233
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3236
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3237
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3240
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3241
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3243
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3244
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3245
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3247
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3248
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3250
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3255
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3256
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3259
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3262
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3263
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3266
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3267
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3270
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3271
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3274
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3275
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3282
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3285
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3286
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3289
 #, elixir-autogen, elixir-format
 msgid "Followers from Mastodon and other networks"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3290
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower move migrate"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3296
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3297
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3300
 #, elixir-autogen, elixir-format
 msgid "Interface language, maps, how posts are shortened"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3301
 #, elixir-autogen, elixir-format
 msgid "german english locale translation map font length hyphenation"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3304
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3305
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3308
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3309
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3312
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3313
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3316
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3317
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/index.html.heex:20
+#: lib/vutuv_web/templates/settings/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Search settings"
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/index.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Nothing here matches. Try another word, or clear the search."
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/security.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "How you sign in"
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/security.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "You sign in with your primary address, and we mail your PIN there."
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/security.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "Your profile address. It is not used to sign in."
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/security.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/followed_tags.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "You do not follow any tags yet. Open a tag page and press Follow, for example"
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/followed_tags.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "from the tag directory"
 msgstr ""
 
+#: lib/vutuv_web/templates/username/new.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Your profile address"
 msgstr ""
 
+#: lib/vutuv_web/templates/username/new.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Other members mention you as %{handle}."
 msgstr ""
 
+#: lib/vutuv_web/templates/username/new.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Change your username"
 msgstr ""
 
+#: lib/vutuv_web/templates/username/new.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:235
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
+#, elixir-autogen, elixir-format
+msgid "I understand, switch off"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:233
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "I understand, take part"
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:338
+#, elixir-autogen, elixir-format
+msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:333
+#, elixir-autogen, elixir-format
+msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:314
+#, elixir-autogen, elixir-format
+msgid "Once a post has left vutuv, it is out of our hands"
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:316
+#, elixir-autogen, elixir-format
+msgid "Switching off does not delete what is already out there"
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:327
+#, elixir-autogen, elixir-format
+msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:322
+#, elixir-autogen, elixir-format
+msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -35,7 +35,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1264
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -59,7 +59,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3188
+#: lib/vutuv_web/components/ui.ex:3239
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -94,11 +94,11 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:431
 #: lib/vutuv_web/agent_docs/markdown.ex:432
-#: lib/vutuv_web/agent_docs/text.ex:428
+#: lib/vutuv_web/agent_docs/markdown.ex:433
 #: lib/vutuv_web/agent_docs/text.ex:429
-#: lib/vutuv_web/templates/user/show.html.heex:828
+#: lib/vutuv_web/agent_docs/text.ex:430
+#: lib/vutuv_web/templates/user/show.html.heex:929
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -116,6 +116,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:86
 #: lib/vutuv_web/templates/report/new.html.heex:103
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:225
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:50
 #: lib/vutuv_web/templates/user/edit.html.heex:103
@@ -140,7 +142,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:866
+#: lib/vutuv_web/templates/user/show.html.heex:967
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -211,7 +213,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:851
+#: lib/vutuv_web/templates/user/show.html.heex:952
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -284,7 +286,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3179
+#: lib/vutuv_web/components/ui.ex:3204
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -308,8 +310,8 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:443
-#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:456
+#: lib/vutuv_web/agent_docs/text.ex:453
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/live/notification_live/index.ex:798
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:136
@@ -319,8 +321,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:444
-#: lib/vutuv_web/agent_docs/text.ex:441
+#: lib/vutuv_web/agent_docs/markdown.ex:457
+#: lib/vutuv_web/agent_docs/text.ex:454
 #: lib/vutuv_web/components/ui.ex:1551
 #: lib/vutuv_web/components/ui.ex:1576
 #: lib/vutuv_web/components/ui.ex:1579
@@ -335,8 +337,8 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:430
-#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/agent_docs/markdown.ex:431
+#: lib/vutuv_web/agent_docs/text.ex:428
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -345,7 +347,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:823
+#: lib/vutuv_web/templates/user/show.html.heex:924
 #, elixir-autogen
 msgid "Gender"
 msgstr ""
@@ -406,7 +408,6 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:52
 #: lib/vutuv_web/agent_docs/text.ex:49
-#: lib/vutuv_web/components/ui.ex:3183
 #: lib/vutuv_web/controllers/url_controller.ex:23
 #: lib/vutuv_web/controllers/url_controller.ex:34
 #: lib/vutuv_web/controllers/url_controller.ex:83
@@ -456,7 +457,6 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3199
 #: lib/vutuv_web/live/notification_live/index.ex:722
 #, elixir-autogen
 msgid "More"
@@ -616,13 +616,13 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:818
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:72
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:80
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:73
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
 #: lib/vutuv_web/templates/settings/preferences.html.heex:85
 #: lib/vutuv_web/templates/settings/preferences.html.heex:205
-#: lib/vutuv_web/templates/settings/privacy.html.heex:64
+#: lib/vutuv_web/templates/settings/privacy.html.heex:69
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:65
 #: lib/vutuv_web/templates/user/edit.html.heex:383
 #: lib/vutuv_web/views/settings_html.ex:138
@@ -667,7 +667,6 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:55
 #: lib/vutuv_web/agent_docs/text.ex:52
-#: lib/vutuv_web/components/ui.ex:3184
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:22
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:39
 #: lib/vutuv_web/cv/docx.ex:217
@@ -680,13 +679,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:977
+#: lib/vutuv_web/templates/user/show.html.heex:1078
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:979
+#: lib/vutuv_web/templates/user/show.html.heex:1080
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -726,10 +725,10 @@ msgstr ""
 msgid "Code & repositories"
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:31
+#: lib/vutuv_web/controllers/block_controller.ex:34
 #: lib/vutuv_web/controllers/follow_controller.ex:24
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:113
+#: lib/vutuv_web/live/user_profile_live.ex:116
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr ""
@@ -765,12 +764,12 @@ msgstr ""
 msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:291
+#: lib/vutuv_web/controllers/user_controller.ex:293
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:210
+#: lib/vutuv_web/controllers/user_controller.ex:212
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr ""
@@ -780,6 +779,8 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3200
+#: lib/vutuv_web/controllers/username_controller.ex:60
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
@@ -787,10 +788,11 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
-#: lib/vutuv_web/templates/settings/security.html.heex:11
+#: lib/vutuv_web/templates/settings/security.html.heex:23
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:5
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:21
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:26
+#: lib/vutuv_web/templates/username/new.html.heex:10
 #, elixir-autogen
 msgid "Username"
 msgstr ""
@@ -838,10 +840,13 @@ msgstr ""
 msgid "View All"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3280
+#: lib/vutuv_web/controllers/settings_controller.ex:141
 #: lib/vutuv_web/live/job_posting_live/form.ex:550
 #: lib/vutuv_web/live/organization_live/edit.ex:298
 #: lib/vutuv_web/templates/email/card_list.html.heex:7
 #: lib/vutuv_web/templates/email/show.html.heex:24
+#: lib/vutuv_web/templates/settings/privacy.html.heex:14
 #, elixir-autogen
 msgid "Visibility"
 msgstr ""
@@ -1037,7 +1042,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:812
+#: lib/vutuv_web/templates/user/show.html.heex:913
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1391,11 +1396,11 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
 #: lib/vutuv_web/agent_docs/markdown.ex:368
-#: lib/vutuv_web/agent_docs/markdown.ex:802
+#: lib/vutuv_web/agent_docs/markdown.ex:815
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:394
-#: lib/vutuv_web/agent_docs/text.ex:571
-#: lib/vutuv_web/components/ui.ex:3189
+#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/components/ui.ex:3220
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1432,7 +1437,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:156
 #: lib/vutuv_web/controllers/session_controller.ex:433
-#: lib/vutuv_web/controllers/user_controller.ex:311
+#: lib/vutuv_web/controllers/user_controller.ex:313
 #, elixir-autogen
 msgid "Too many incorrect attempts."
 msgstr ""
@@ -1681,7 +1686,7 @@ msgstr ""
 msgid "Delete my account"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:151
+#: lib/vutuv_web/controllers/user_controller.ex:153
 #: lib/vutuv_web/templates/user/show.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
@@ -1704,6 +1709,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1605
 #: lib/vutuv_web/components/ui.ex:1608
 #: lib/vutuv_web/components/ui.ex:1681
+#: lib/vutuv_web/templates/user/show.html.heex:884
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1769,7 +1775,7 @@ msgstr ""
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3203
+#: lib/vutuv_web/components/ui.ex:3261
 #: lib/vutuv_web/live/notification_live/index.ex:103
 #: lib/vutuv_web/live/notification_live/index.ex:275
 #: lib/vutuv_web/live/shell_live.ex:508
@@ -1828,13 +1834,14 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:97
 #: lib/vutuv_web/controllers/email_controller.ex:110
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:46
 #: lib/vutuv_web/controllers/session_controller.ex:70
 #: lib/vutuv_web/controllers/session_controller.ex:86
 #: lib/vutuv_web/controllers/session_controller.ex:177
 #: lib/vutuv_web/controllers/session_controller.ex:208
 #: lib/vutuv_web/controllers/session_controller.ex:224
-#: lib/vutuv_web/controllers/user_controller.ex:247
-#: lib/vutuv_web/controllers/user_controller.ex:276
+#: lib/vutuv_web/controllers/user_controller.ex:249
+#: lib/vutuv_web/controllers/user_controller.ex:278
 #, elixir-autogen, elixir-format
 msgid "Too many attempts. Please try again later."
 msgstr ""
@@ -1860,7 +1867,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:757
-#: lib/vutuv_web/templates/user/show.html.heex:1251
+#: lib/vutuv_web/templates/user/show.html.heex:1352
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -2195,7 +2202,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/post_doc.ex:92
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
-#: lib/vutuv_web/controllers/user_controller.ex:73
+#: lib/vutuv_web/controllers/user_controller.ex:75
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
 #: lib/vutuv_web/live/notification_live/index.ex:720
@@ -2203,7 +2210,7 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:179
 #: lib/vutuv_web/live/search_live.ex:462
 #: lib/vutuv_web/templates/settings/preferences.html.heex:118
-#: lib/vutuv_web/views/admin/report_html.ex:34
+#: lib/vutuv_web/views/admin/report_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr ""
@@ -2286,7 +2293,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3389
+#: lib/vutuv_web/components/ui.ex:3505
 #: lib/vutuv_web/live/shell_live.ex:551
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2331,7 +2338,7 @@ msgid "people you don't follow"
 msgstr ""
 
 #: lib/vutuv_web/views/post_html.ex:19
-#: lib/vutuv_web/views/settings_html.ex:300
+#: lib/vutuv_web/views/settings_html.ex:350
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2375,12 +2382,12 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:837
+#: lib/vutuv_web/agent_docs/markdown.ex:850
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:490
 #: lib/vutuv_web/live/shell_live.ex:556
-#: lib/vutuv_web/views/admin/report_html.ex:37
+#: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
@@ -2395,13 +2402,13 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:836
+#: lib/vutuv_web/agent_docs/markdown.ex:849
 #: lib/vutuv_web/components/post_components.ex:2226
 #: lib/vutuv_web/live/notification_live/index.ex:800
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:559
-#: lib/vutuv_web/views/admin/report_html.ex:36
+#: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Likes"
 msgstr ""
@@ -2459,7 +2466,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1648
 #: lib/vutuv_web/live/post_live/feed.ex:746
-#: lib/vutuv_web/templates/settings/followed_tags.html.heex:27
+#: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
@@ -2653,7 +2660,7 @@ msgid "“Tired of LinkedIn, and want your data to stay in Germany? I can help.�
 msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:143
-#: lib/vutuv_web/templates/settings/privacy.html.heex:53
+#: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
 msgstr ""
@@ -2697,26 +2704,26 @@ msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:940
+#: lib/vutuv_web/templates/user/show.html.heex:1041
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1165
+#: lib/vutuv_web/templates/user/show.html.heex:1266
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:868
+#: lib/vutuv_web/templates/user/show.html.heex:969
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:814
+#: lib/vutuv_web/templates/user/show.html.heex:915
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
@@ -2728,7 +2735,7 @@ msgstr ""
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:970
+#: lib/vutuv_web/live/user_profile_live.ex:994
 #: lib/vutuv_web/templates/user/show.html.heex:404
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
@@ -2739,9 +2746,9 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
-#: lib/vutuv_web/templates/settings/privacy.html.heex:133
+#: lib/vutuv_web/templates/settings/privacy.html.heex:138
 #: lib/vutuv_web/templates/settings/security.html.heex:20
-#: lib/vutuv_web/templates/settings/security.html.heex:175
+#: lib/vutuv_web/templates/settings/security.html.heex:181
 #: lib/vutuv_web/templates/user/show.html.heex:492
 #, elixir-autogen, elixir-format
 msgid "Manage"
@@ -2779,8 +2786,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:445
-#: lib/vutuv_web/agent_docs/text.ex:442
+#: lib/vutuv_web/agent_docs/markdown.ex:458
+#: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/live/notification_live/index.ex:799
 #: lib/vutuv_web/templates/connection/index.html.heex:5
@@ -3081,8 +3088,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:908
-#: lib/vutuv_web/templates/user/show.html.heex:909
+#: lib/vutuv_web/templates/user/show.html.heex:1009
+#: lib/vutuv_web/templates/user/show.html.heex:1010
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -3136,7 +3143,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3176
+#: lib/vutuv_web/components/ui.ex:3194
 #: lib/vutuv_web/live/shell_live.ex:443
 #: lib/vutuv_web/live/shell_live.ex:644
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3513,12 +3520,12 @@ msgstr ""
 msgid "Your vutuv account is suspended"
 msgstr ""
 
-#: lib/vutuv_web/controllers/username_controller.ex:77
+#: lib/vutuv_web/controllers/username_controller.ex:82
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is already taken."
 msgstr ""
 
-#: lib/vutuv_web/controllers/username_controller.ex:86
+#: lib/vutuv_web/controllers/username_controller.ex:91
 #, elixir-autogen, elixir-format
 msgid "@%{handle} is available."
 msgstr ""
@@ -3534,12 +3541,7 @@ msgstr ""
 msgid "Your username is now @%{handle}."
 msgstr ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:14
-#, elixir-autogen, elixir-format
-msgid "Your username is your profile address (vutuv.de/username) and how others mention you, like %{handle}."
-msgstr ""
-
-#: lib/vutuv_web/templates/username/new.html.heex:41
+#: lib/vutuv_web/templates/username/new.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "%{remaining} of %{limit} changes left."
 msgstr ""
@@ -3554,17 +3556,17 @@ msgstr ""
 msgid "Username replaced with @%{handle}."
 msgstr ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:61
+#: lib/vutuv_web/templates/username/new.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "You can change it again on %{date}."
 msgstr ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:36
+#: lib/vutuv_web/templates/username/new.html.heex:59
 #, elixir-autogen, elixir-format
 msgid "You can change your username up to %{limit} times within %{days} days."
 msgstr ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:57
+#: lib/vutuv_web/templates/username/new.html.heex:82
 #, elixir-autogen, elixir-format
 msgid "You have used all %{limit} username changes of the last %{days} days."
 msgstr ""
@@ -3816,12 +3818,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:535
+#: lib/vutuv_web/agent_docs/markdown.ex:548
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:890
+#: lib/vutuv_web/agent_docs/markdown.ex:903
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3835,11 +3837,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:151
 #: lib/vutuv_web/agent_docs/markdown.ex:164
-#: lib/vutuv_web/agent_docs/markdown.ex:802
+#: lib/vutuv_web/agent_docs/markdown.ex:815
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:140
 #: lib/vutuv_web/agent_docs/text.ex:153
-#: lib/vutuv_web/agent_docs/text.ex:571
+#: lib/vutuv_web/agent_docs/text.ex:584
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3856,22 +3858,22 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:820
-#: lib/vutuv_web/agent_docs/text.ex:582
+#: lib/vutuv_web/agent_docs/markdown.ex:833
+#: lib/vutuv_web/agent_docs/text.ex:595
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:817
-#: lib/vutuv_web/agent_docs/text.ex:579
+#: lib/vutuv_web/agent_docs/markdown.ex:830
+#: lib/vutuv_web/agent_docs/text.ex:592
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:824
-#: lib/vutuv_web/agent_docs/markdown.ex:925
-#: lib/vutuv_web/agent_docs/text.ex:585
-#: lib/vutuv_web/agent_docs/text.ex:613
+#: lib/vutuv_web/agent_docs/markdown.ex:837
+#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/text.ex:598
+#: lib/vutuv_web/agent_docs/text.ex:626
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
@@ -3923,17 +3925,17 @@ msgstr ""
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:784
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:701
+#: lib/vutuv_web/agent_docs/markdown.ex:714
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:702
+#: lib/vutuv_web/agent_docs/markdown.ex:715
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4471,7 +4473,7 @@ msgstr ""
 msgid "Search for words in public posts."
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:28
+#: lib/vutuv_web/templates/block/index.html.heex:36
 #: lib/vutuv_web/templates/user/show.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Block"
@@ -4482,25 +4484,27 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:1
-#: lib/vutuv_web/templates/block/index.html.heex:1
-#: lib/vutuv_web/templates/settings/privacy.html.heex:130
+#: lib/vutuv_web/components/ui.ex:3284
+#: lib/vutuv_web/controllers/block_controller.ex:20
+#: lib/vutuv_web/templates/block/index.html.heex:9
+#: lib/vutuv_web/templates/block/index.html.heex:41
+#: lib/vutuv_web/templates/settings/privacy.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Blocked members"
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:34
+#: lib/vutuv_web/templates/block/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Blocked members cannot follow you, connect with you, message you, or reply to your posts - and you cannot interact with them either. Blocking removed any follows and connection between you; unblocking does not restore them."
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:63
+#: lib/vutuv_web/templates/block/index.html.heex:74
 #: lib/vutuv_web/templates/user/show.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:61
+#: lib/vutuv_web/templates/block/index.html.heex:72
 #: lib/vutuv_web/templates/user/show.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "Unblock @%{slug}?"
@@ -4511,13 +4515,13 @@ msgstr ""
 msgid "You blocked @%{slug}. You can undo this on your blocked list."
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:40
+#: lib/vutuv_web/templates/block/index.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "You have not blocked anyone."
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:86
-#: lib/vutuv_web/live/user_profile_live.ex:242
+#: lib/vutuv_web/controllers/block_controller.ex:89
+#: lib/vutuv_web/live/user_profile_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr ""
@@ -4648,7 +4652,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/live/user_profile_live.ex:958
+#: lib/vutuv_web/live/user_profile_live.ex:982
 #: lib/vutuv_web/templates/user/show.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -5225,7 +5229,7 @@ msgid "vutuv POSTs signed JSON envelopes here (see the webhooks documentation). 
 msgstr ""
 
 #: lib/vutuv_web/templates/page/index.html.heex:148
-#: lib/vutuv_web/templates/settings/privacy.html.heex:58
+#: lib/vutuv_web/templates/settings/privacy.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
 msgstr ""
@@ -5240,8 +5244,8 @@ msgstr ""
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3210
-#: lib/vutuv_web/controllers/settings_controller.ex:130
+#: lib/vutuv_web/components/ui.ex:3315
+#: lib/vutuv_web/controllers/settings_controller.ex:132
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
 #: lib/vutuv_web/live/admin/user_delete_live.ex:103
@@ -5281,7 +5285,7 @@ msgstr ""
 msgid "You can no longer reply to this post."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:136
+#: lib/vutuv_web/templates/settings/privacy.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Content under review"
 msgstr ""
@@ -5318,17 +5322,16 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3296
-#: lib/vutuv_web/components/ui.ex:3301
-#: lib/vutuv_web/components/ui.ex:3380
-#: lib/vutuv_web/components/ui.ex:3444
+#: lib/vutuv_web/components/ui.ex:3412
+#: lib/vutuv_web/components/ui.ex:3417
+#: lib/vutuv_web/components/ui.ex:3496
+#: lib/vutuv_web/components/ui.ex:3560
 #: lib/vutuv_web/controllers/settings_controller.ex:52
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
 #: lib/vutuv_web/templates/totp/new.html.heex:4
-#: lib/vutuv_web/templates/username/new.html.heex:6
 #: lib/vutuv_web/views/settings_html.ex:167
 #, elixir-autogen, elixir-format
 msgid "Settings"
@@ -5364,7 +5367,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:960
+#: lib/vutuv_web/live/user_profile_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5445,20 +5448,14 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3191
+#: lib/vutuv_web/components/ui.ex:3293
 #: lib/vutuv_web/live/admin/user_live.ex:266
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:18
-#, elixir-autogen, elixir-format
-msgid "Add, remove or pick your primary address."
-msgstr ""
-
 #: lib/vutuv_web/live/organization_live/edit.ex:441
-#: lib/vutuv_web/templates/settings/security.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr ""
@@ -5468,7 +5465,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3186
+#: lib/vutuv_web/components/ui.ex:3231
 #: lib/vutuv_web/controllers/email_controller.ex:30
 #: lib/vutuv_web/controllers/email_controller.ex:49
 #: lib/vutuv_web/controllers/email_controller.ex:191
@@ -5482,12 +5479,12 @@ msgstr ""
 msgid "Email addresses"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:352
+#: lib/vutuv_web/controllers/settings_controller.ex:393
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:131
+#: lib/vutuv_web/templates/settings/privacy.html.heex:136
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you."
 msgstr ""
@@ -5502,13 +5499,12 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3201
-#: lib/vutuv_web/templates/settings/privacy.html.heex:9
+#: lib/vutuv_web/components/ui.ex:3278
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:168
+#: lib/vutuv_web/controllers/settings_controller.ex:170
 #, elixir-autogen, elixir-format
 msgid "Privacy settings saved."
 msgstr ""
@@ -5518,7 +5514,7 @@ msgstr ""
 msgid "Third-party apps you authorized."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:139
+#: lib/vutuv_web/templates/settings/privacy.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -5533,7 +5529,7 @@ msgstr ""
 msgid "Your post"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:137
+#: lib/vutuv_web/templates/settings/privacy.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Your posts or profile a moderator is looking at."
 msgstr ""
@@ -5563,7 +5559,7 @@ msgstr ""
 msgid "Language & region"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:494
+#: lib/vutuv_web/controllers/settings_controller.ex:535
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr ""
@@ -5571,11 +5567,6 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/apps.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "Read the API docs"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/security.html.heex:8
-#, elixir-autogen, elixir-format
-msgid "Sign-in & identity"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/preferences.html.heex:22
@@ -5615,13 +5606,13 @@ msgstr ""
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3209
 #: lib/vutuv_web/templates/settings/apps.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:145
+#: lib/vutuv_web/components/ui.ex:3311
+#: lib/vutuv_web/controllers/settings_controller.ex:147
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr ""
@@ -5650,7 +5641,7 @@ msgstr ""
 msgid "New followers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:342
+#: lib/vutuv_web/controllers/settings_controller.ex:383
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr ""
@@ -5660,22 +5651,17 @@ msgstr ""
 msgid "Open your notifications"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:139
-#, elixir-autogen, elixir-format
-msgid "Privacy settings"
-msgstr ""
-
 #: lib/vutuv_web/templates/settings/notifications.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Replies to and likes on your posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:127
+#: lib/vutuv_web/templates/settings/privacy.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Safety"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:13
+#: lib/vutuv_web/templates/settings/privacy.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Search engines & AI"
 msgstr ""
@@ -5705,7 +5691,7 @@ msgstr ""
 msgid "When someone starts following you."
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:23
+#: lib/vutuv_web/templates/block/index.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "@handle"
 msgstr ""
@@ -5715,61 +5701,61 @@ msgstr ""
 msgid "Block @%{slug}"
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:8
+#: lib/vutuv_web/templates/block/index.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Block someone"
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:69
+#: lib/vutuv_web/controllers/block_controller.ex:72
 #, elixir-autogen, elixir-format
 msgid "Enter a member's @handle to block them."
 msgstr ""
 
-#: lib/vutuv_web/templates/block/index.html.heex:10
+#: lib/vutuv_web/templates/block/index.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "Type a member's @handle. You do not have to visit their profile."
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:72
+#: lib/vutuv_web/controllers/block_controller.ex:75
 #, elixir-autogen, elixir-format
 msgid "We could not find a member with the handle @%{handle}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:75
+#: lib/vutuv_web/controllers/block_controller.ex:78
 #, elixir-autogen, elixir-format
 msgid "You already blocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:78
+#: lib/vutuv_web/controllers/block_controller.ex:81
 #, elixir-autogen, elixir-format
 msgid "You blocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/controllers/block_controller.ex:54
+#: lib/vutuv_web/controllers/block_controller.ex:57
 #, elixir-autogen, elixir-format
 msgid "You cannot block yourself."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:23
-#: lib/vutuv_web/live/user_profile_live.ex:208
+#: lib/vutuv_web/live/user_profile_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Bookmark removed."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:19
-#: lib/vutuv_web/live/user_profile_live.ex:205
+#: lib/vutuv_web/live/user_profile_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Bookmarked."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:31
-#: lib/vutuv_web/live/user_profile_live.ex:214
+#: lib/vutuv_web/live/user_profile_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Like removed."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:27
-#: lib/vutuv_web/live/user_profile_live.ex:211
+#: lib/vutuv_web/live/user_profile_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Liked."
 msgstr ""
@@ -5831,28 +5817,28 @@ msgid "Sort"
 msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:174
-#: lib/vutuv_web/views/settings_html.ex:309
+#: lib/vutuv_web/views/settings_html.ex:359
 #, elixir-autogen, elixir-format
 msgid "%{count} day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:308
+#: lib/vutuv_web/views/settings_html.ex:358
 #, elixir-autogen, elixir-format
 msgid "%{count} hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/settings_html.ex:307
+#: lib/vutuv_web/views/settings_html.ex:357
 #, elixir-autogen, elixir-format
 msgid "%{count} minute ago"
 msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:589
+#: lib/vutuv_web/controllers/settings_controller.ex:630
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5867,12 +5853,12 @@ msgstr ""
 msgid "Last active"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:47
+#: lib/vutuv_web/templates/settings/security.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Log out all other devices"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:44
+#: lib/vutuv_web/templates/settings/security.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Log out of every device except this one?"
 msgstr ""
@@ -5887,12 +5873,12 @@ msgstr ""
 msgid "New sign-in to your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:30
+#: lib/vutuv_web/templates/settings/security.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:578
+#: lib/vutuv_web/controllers/settings_controller.ex:619
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -5912,32 +5898,32 @@ msgstr ""
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
 
-#: lib/vutuv_web/views/settings_html.ex:306
+#: lib/vutuv_web/views/settings_html.ex:356
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:79
+#: lib/vutuv_web/templates/settings/privacy.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "A green dot on your avatar tells other members you are online right now."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:78
+#: lib/vutuv_web/templates/settings/privacy.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Online status"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:80
+#: lib/vutuv_web/templates/settings/privacy.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Show when I'm online"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:81
+#: lib/vutuv_web/templates/settings/privacy.html.heex:86
 #, elixir-autogen, elixir-format
 msgid "When off, no one sees the green dot on your avatar, and you never show as online."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:104
+#: lib/vutuv_web/templates/settings/security.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Add a passkey"
 msgstr ""
@@ -5948,7 +5934,7 @@ msgstr ""
 msgid "Added"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:101
+#: lib/vutuv_web/templates/settings/security.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Could not add the passkey. Please try again."
 msgstr ""
@@ -5958,7 +5944,7 @@ msgstr ""
 msgid "Last used"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:85
+#: lib/vutuv_web/templates/settings/security.html.heex:91
 #, elixir-autogen, elixir-format
 msgid "Name (optional)"
 msgstr ""
@@ -5978,7 +5964,7 @@ msgstr ""
 msgid "Passkey removed."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:59
+#: lib/vutuv_web/templates/settings/security.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "Passkeys"
 msgstr ""
@@ -5988,7 +5974,7 @@ msgstr ""
 msgid "Remove this passkey?"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:61
+#: lib/vutuv_web/templates/settings/security.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Sign in with Touch ID, Windows Hello or a security key instead of waiting for an email PIN. Your email PIN stays available as a backup."
 msgstr ""
@@ -6013,12 +5999,12 @@ msgstr ""
 msgid "That passkey could not be verified."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:115
+#: lib/vutuv_web/templates/settings/security.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "This browser does not support passkeys."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:75
+#: lib/vutuv_web/templates/settings/security.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "You have not added any passkeys yet."
 msgstr ""
@@ -6028,7 +6014,7 @@ msgstr ""
 msgid "Your sign-in attempt expired. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:91
+#: lib/vutuv_web/templates/settings/security.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "e.g. MacBook"
 msgstr ""
@@ -6038,7 +6024,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:964
+#: lib/vutuv_web/live/user_profile_live.ex:988
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6073,7 +6059,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1216
+#: lib/vutuv_web/templates/user/show.html.heex:1317
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6116,16 +6102,16 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:834
-#: lib/vutuv_web/templates/user/show.html.heex:844
+#: lib/vutuv_web/templates/user/show.html.heex:935
+#: lib/vutuv_web/templates/user/show.html.heex:945
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:433
-#: lib/vutuv_web/agent_docs/text.ex:430
+#: lib/vutuv_web/agent_docs/markdown.ex:434
+#: lib/vutuv_web/agent_docs/text.ex:431
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6157,12 +6143,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:955
+#: lib/vutuv_web/templates/user/show.html.heex:1056
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:966
+#: lib/vutuv_web/templates/user/show.html.heex:1067
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6172,7 +6158,7 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:33
+#: lib/vutuv_web/views/admin/report_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "New confirmed registrations (by PIN)"
 msgstr ""
@@ -6197,14 +6183,14 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:836
+#: lib/vutuv_web/agent_docs/markdown.ex:849
 #: lib/vutuv_web/components/post_components.ex:275
-#: lib/vutuv_web/views/admin/report_html.ex:35
+#: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:964
+#: lib/vutuv_web/templates/user/show.html.heex:1065
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6242,7 +6228,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:509
+#: lib/vutuv_web/controllers/settings_controller.ex:550
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -6258,9 +6244,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1202
-#: lib/vutuv_web/templates/user/show.html.heex:1210
-#: lib/vutuv_web/templates/user/show.html.heex:1222
+#: lib/vutuv_web/templates/user/show.html.heex:1303
+#: lib/vutuv_web/templates/user/show.html.heex:1311
+#: lib/vutuv_web/templates/user/show.html.heex:1323
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6301,7 +6287,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:815
+#: lib/vutuv_web/agent_docs/markdown.ex:828
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6387,17 +6373,17 @@ msgid "Confirmed members whose every email address bounced, so they can no longe
 msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:153
-#: lib/vutuv_web/views/admin/report_html.ex:40
+#: lib/vutuv_web/views/admin/report_html.ex:45
 #, elixir-autogen, elixir-format
 msgid "Deactivated addresses"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:38
+#: lib/vutuv_web/views/admin/report_html.ex:39
 #, elixir-autogen, elixir-format
 msgid "New Fediverse followers"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:41
+#: lib/vutuv_web/views/admin/report_html.ex:42
 #, elixir-autogen, elixir-format
 msgid "Removed Fediverse followers (account deleted)"
 msgstr ""
@@ -6430,7 +6416,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:2
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:8
-#: lib/vutuv_web/views/admin/report_html.ex:41
+#: lib/vutuv_web/views/admin/report_html.ex:46
 #, elixir-autogen, elixir-format
 msgid "Frozen accounts"
 msgstr ""
@@ -6551,37 +6537,37 @@ msgstr ""
 msgid "system"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:39
+#: lib/vutuv_web/views/admin/report_html.ex:44
 #, elixir-autogen, elixir-format
 msgid "Bounces"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:42
+#: lib/vutuv_web/views/admin/report_html.ex:47
 #, elixir-autogen, elixir-format
 msgid "Thawed accounts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:60
+#: lib/vutuv_web/templates/settings/privacy.html.heex:65
 #, elixir-autogen, elixir-format
 msgid "When on, AI assistants and crawlers may read and train on your public profile. When off, we ask them not to."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:55
+#: lib/vutuv_web/templates/settings/privacy.html.heex:60
 #, elixir-autogen, elixir-format
 msgid "When on, your public profile can appear in Google and other search engines. When off, we ask them to leave it out."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:35
+#: lib/vutuv_web/templates/settings/privacy.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Exactly what we send"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:45
+#: lib/vutuv_web/templates/settings/privacy.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Compliant crawlers honor these; they are not a hard block. A noindexed profile is also kept out of the sitemap and structured data."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:38
+#: lib/vutuv_web/templates/settings/privacy.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
@@ -6594,7 +6580,7 @@ msgid "Mute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:190
+#: lib/vutuv_web/live/user_profile_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
@@ -6617,7 +6603,7 @@ msgid "Unmute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:192
+#: lib/vutuv_web/live/user_profile_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -7496,17 +7482,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:895
+#: lib/vutuv_web/agent_docs/markdown.ex:908
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:898
+#: lib/vutuv_web/agent_docs/markdown.ex:911
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:905
+#: lib/vutuv_web/agent_docs/markdown.ex:918
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8038,7 +8024,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:203
+#: lib/vutuv_web/controllers/user_controller.ex:205
 #, elixir-autogen, elixir-format
 msgid "Your verified badge was removed because you changed your name, gender or date of birth. We re-check identity against those details so members can trust verified profiles and nobody can set up a fake verified account. An admin can verify you again anytime."
 msgstr ""
@@ -8123,7 +8109,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3180
+#: lib/vutuv_web/components/ui.ex:3208
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8177,7 +8163,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3196
+#: lib/vutuv_web/components/ui.ex:3303
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8206,7 +8192,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3187
+#: lib/vutuv_web/components/ui.ex:3235
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8297,7 +8283,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:983
+#: lib/vutuv_web/live/user_profile_live.ex:1007
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
@@ -8322,8 +8308,8 @@ msgstr[1] ""
 msgid "Loading posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:94
-#: lib/vutuv_web/templates/user/show.html.heex:1069
+#: lib/vutuv_web/templates/settings/privacy.html.heex:99
+#: lib/vutuv_web/templates/user/show.html.heex:1170
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8383,14 +8369,14 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3178
+#: lib/vutuv_web/components/ui.ex:3196
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3195
-#: lib/vutuv_web/controllers/settings_controller.ex:107
+#: lib/vutuv_web/components/ui.ex:3299
+#: lib/vutuv_web/controllers/settings_controller.ex:109
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Language & display"
@@ -8401,17 +8387,16 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3193
-#: lib/vutuv_web/controllers/settings_controller.ex:90
+#: lib/vutuv_web/components/ui.ex:3295
+#: lib/vutuv_web/controllers/settings_controller.ex:92
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
-#: lib/vutuv_web/templates/settings/security.html.heex:5
+#: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/totp/new.html.heex:5
-#: lib/vutuv_web/templates/username/new.html.heex:7
 #, elixir-autogen, elixir-format
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3197
+#: lib/vutuv_web/components/ui.ex:3307
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8423,7 +8408,7 @@ msgstr ""
 msgid "The file is in JSON format and includes your profile, posts, messages and settings. It contains private data, so store it carefully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:227
+#: lib/vutuv_web/controllers/user_controller.ex:229
 #, elixir-autogen, elixir-format
 msgid "Please type your username exactly as shown to confirm the deletion."
 msgstr ""
@@ -8444,17 +8429,17 @@ msgstr ""
 msgid "Suggested posts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:96
+#: lib/vutuv_web/templates/settings/privacy.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "If you list a Mastodon or Bluesky account, your profile can show your latest public posts from it."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:100
+#: lib/vutuv_web/templates/settings/privacy.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Show my latest social media posts on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:101
+#: lib/vutuv_web/templates/settings/privacy.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts without any posts."
 msgstr ""
@@ -8630,13 +8615,20 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3202
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/markdown.ex:451
+#: lib/vutuv_web/agent_docs/text.ex:444
+#: lib/vutuv_web/agent_docs/text.ex:448
+#: lib/vutuv_web/components/ui.ex:3288
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:29
-#: lib/vutuv_web/controllers/settings_controller.ex:192
+#: lib/vutuv_web/controllers/settings_controller.ex:194
+#: lib/vutuv_web/controllers/settings_controller.ex:261
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:288
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
+#: lib/vutuv_web/templates/user/show.html.heex:812
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8656,17 +8648,17 @@ msgstr ""
 msgid "as a link in your Mastodon profile settings, and Mastodon will show it as verified with a green check."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:249
+#: lib/vutuv_web/controllers/settings_controller.ex:274
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:175
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:82
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr ""
@@ -8696,7 +8688,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:595
+#: lib/vutuv_web/agent_docs/markdown.ex:608
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8717,7 +8709,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:596
+#: lib/vutuv_web/agent_docs/markdown.ex:609
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8748,13 +8740,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:633
+#: lib/vutuv_web/agent_docs/markdown.ex:646
 #: lib/vutuv_web/views/education_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:632
+#: lib/vutuv_web/agent_docs/markdown.ex:645
 #: lib/vutuv_web/views/education_html.ex:29
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8787,7 +8779,7 @@ msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:774
+#: lib/vutuv_web/agent_docs/markdown.ex:787
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8865,14 +8857,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:594
+#: lib/vutuv_web/agent_docs/markdown.ex:607
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:597
+#: lib/vutuv_web/agent_docs/markdown.ex:610
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9016,8 +9008,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:454
-#: lib/vutuv_web/agent_docs/text.ex:449
+#: lib/vutuv_web/agent_docs/markdown.ex:467
+#: lib/vutuv_web/agent_docs/text.ex:462
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9246,7 +9238,6 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:49
 #: lib/vutuv_web/agent_docs/text.ex:46
-#: lib/vutuv_web/components/ui.ex:3182
 #: lib/vutuv_web/controllers/language_controller.ex:32
 #: lib/vutuv_web/controllers/language_controller.ex:47
 #: lib/vutuv_web/cv/docx.ex:192
@@ -9544,7 +9535,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:695
+#: lib/vutuv_web/agent_docs/markdown.ex:708
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9572,7 +9563,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3181
+#: lib/vutuv_web/components/ui.ex:3212
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -9621,7 +9612,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:670
+#: lib/vutuv_web/agent_docs/markdown.ex:683
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9638,7 +9629,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:694
+#: lib/vutuv_web/agent_docs/markdown.ex:707
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9665,7 +9656,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:668
+#: lib/vutuv_web/agent_docs/markdown.ex:681
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9680,7 +9671,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:669
+#: lib/vutuv_web/agent_docs/markdown.ex:682
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -9697,15 +9688,15 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:552
+#: lib/vutuv_web/agent_docs/markdown.ex:565
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:930
-#: lib/vutuv_web/templates/user/show.html.heex:931
+#: lib/vutuv_web/templates/user/show.html.heex:1031
+#: lib/vutuv_web/templates/user/show.html.heex:1032
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9873,7 +9864,7 @@ msgstr ""
 msgid "Your invitation is on its way"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:186
+#: lib/vutuv_web/templates/username/new.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Permanent profile link"
 msgstr ""
@@ -9884,39 +9875,27 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:98
-#: lib/vutuv_web/templates/settings/security.html.heex:202
-#: lib/vutuv_web/templates/settings/security.html.heex:219
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:106
 #: lib/vutuv_web/templates/totp/new.html.heex:58
+#: lib/vutuv_web/templates/user/show.html.heex:848
+#: lib/vutuv_web/templates/username/new.html.heex:27
+#: lib/vutuv_web/templates/username/new.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:97
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:101
-#: lib/vutuv_web/templates/settings/security.html.heex:201
-#: lib/vutuv_web/templates/settings/security.html.heex:205
-#: lib/vutuv_web/templates/settings/security.html.heex:218
-#: lib/vutuv_web/templates/settings/security.html.heex:222
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:109
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
+#: lib/vutuv_web/templates/user/show.html.heex:847
+#: lib/vutuv_web/templates/user/show.html.heex:851
+#: lib/vutuv_web/templates/username/new.html.heex:26
+#: lib/vutuv_web/templates/username/new.html.heex:30
+#: lib/vutuv_web/templates/username/new.html.heex:113
+#: lib/vutuv_web/templates/username/new.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Copy"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/security.html.heex:209
-#, elixir-autogen, elixir-format
-msgid "For everyday sharing, your normal profile address is shorter:"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/security.html.heex:188
-#, elixir-autogen, elixir-format
-msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename."
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/index.html.heex:29
-#, elixir-autogen, elixir-format
-msgid "Pick a section from the menu on the left to view or change it."
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:304
@@ -9934,12 +9913,12 @@ msgstr ""
 msgid "Outbound federation is healthy."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:142
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Showing the most recent %{shown} of %{total}."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:151
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
 #, elixir-autogen, elixir-format
 msgid "Accounts that no longer exist on their own server drop off this list by themselves."
 msgstr ""
@@ -10002,7 +9981,7 @@ msgstr ""
 msgid "Account restored. The member can sign in again."
 msgstr ""
 
-#: lib/vutuv_web/views/admin/report_html.ex:43
+#: lib/vutuv_web/views/admin/report_html.ex:48
 #, elixir-autogen, elixir-format
 msgid "Accounts removed as spam"
 msgstr ""
@@ -10078,7 +10057,7 @@ msgstr ""
 msgid "To protect you, the connection between you and the reported member is paused - no contact in either direction, including messages. If our admins find the report unfounded, this is undone."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:168
+#: lib/vutuv_web/templates/settings/security.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "%{unused} of %{total} codes unused."
 msgstr ""
@@ -10183,7 +10162,7 @@ msgstr ""
 msgid "Link URL"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:125
+#: lib/vutuv_web/templates/settings/security.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Login codes"
 msgstr ""
@@ -10194,8 +10173,8 @@ msgstr ""
 msgid "More formatting"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:138
-#: lib/vutuv_web/templates/settings/security.html.heex:172
+#: lib/vutuv_web/templates/settings/security.html.heex:144
+#: lib/vutuv_web/templates/settings/security.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Not set up."
 msgstr ""
@@ -10230,8 +10209,8 @@ msgstr ""
 msgid "Scan this QR code with an authenticator app (for example FreeOTP, Google Authenticator or 1Password). The app then shows a fresh 6-digit code every 30 seconds."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:159
-#: lib/vutuv_web/templates/settings/security.html.heex:175
+#: lib/vutuv_web/templates/settings/security.html.heex:165
+#: lib/vutuv_web/templates/settings/security.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Set up"
 msgstr ""
@@ -10261,12 +10240,12 @@ msgstr ""
 msgid "Toggle Markdown source"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:152
+#: lib/vutuv_web/templates/settings/security.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Turn off"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:146
+#: lib/vutuv_web/templates/settings/security.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Turn off the authenticator app? Its codes stop working at login; the emailed PIN is unaffected."
 msgstr ""
@@ -10276,7 +10255,7 @@ msgstr ""
 msgid "Turn on"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:138
+#: lib/vutuv_web/templates/settings/security.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Turned on."
 msgstr ""
@@ -10312,7 +10291,7 @@ msgid "A one-time code (OTP) from your authenticator app or your code list also 
 msgstr ""
 
 #: lib/vutuv_web/controllers/totp_controller.ex:83
-#: lib/vutuv_web/templates/settings/security.html.heex:135
+#: lib/vutuv_web/templates/settings/security.html.heex:141
 #: lib/vutuv_web/templates/totp/new.html.heex:2
 #: lib/vutuv_web/templates/totp/new.html.heex:6
 #, elixir-autogen, elixir-format
@@ -10322,7 +10301,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/login_code_controller.ex:25
 #: lib/vutuv_web/templates/login_code/index.html.heex:2
 #: lib/vutuv_web/templates/login_code/index.html.heex:6
-#: lib/vutuv_web/templates/settings/security.html.heex:164
+#: lib/vutuv_web/templates/settings/security.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "One-time code list (OTP)"
 msgstr ""
@@ -10332,7 +10311,7 @@ msgstr ""
 msgid "Reading this on the phone that should generate the codes? You can't scan your own screen. Instead:"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/security.html.heex:127
+#: lib/vutuv_web/templates/settings/security.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Sign in with a one-time code (OTP) from an authenticator app or from a printed code list, typed into the normal PIN field. Your emailed PIN always keeps working."
 msgstr ""
@@ -10342,21 +10321,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:512
+#: lib/vutuv_web/agent_docs/markdown.ex:525
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:510
+#: lib/vutuv_web/agent_docs/markdown.ex:523
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:508
+#: lib/vutuv_web/agent_docs/markdown.ex:521
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10379,17 +10358,17 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1043
+#: lib/vutuv_web/templates/user/show.html.heex:1144
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:113
+#: lib/vutuv_web/templates/settings/privacy.html.heex:118
 #, elixir-autogen, elixir-format
 msgid "Code statistics"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:115
+#: lib/vutuv_web/templates/settings/privacy.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
@@ -10399,22 +10378,22 @@ msgstr ""
 msgid "Last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:119
+#: lib/vutuv_web/templates/settings/privacy.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Show code statistics on my profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:120
+#: lib/vutuv_web/templates/settings/privacy.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:526
+#: lib/vutuv_web/agent_docs/markdown.ex:539
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:513
+#: lib/vutuv_web/agent_docs/markdown.ex:526
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10680,7 +10659,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:522
+#: lib/vutuv_web/controllers/settings_controller.ex:563
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10729,7 +10708,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:553
+#: lib/vutuv_web/controllers/settings_controller.ex:594
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10744,7 +10723,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:549
+#: lib/vutuv_web/controllers/settings_controller.ex:590
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -11766,8 +11745,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
-#: lib/vutuv_web/agent_docs/text.ex:545
+#: lib/vutuv_web/agent_docs/markdown.ex:728
+#: lib/vutuv_web/agent_docs/text.ex:558
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11998,8 +11977,8 @@ msgid "Organization unfrozen."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:3194
-#: lib/vutuv_web/controllers/settings_controller.ex:158
+#: lib/vutuv_web/components/ui.ex:3224
+#: lib/vutuv_web/controllers/settings_controller.ex:160
 #: lib/vutuv_web/live/organization_live/index.ex:29
 #: lib/vutuv_web/live/organization_live/index.ex:69
 #: lib/vutuv_web/live/post_live/saved.ex:455
@@ -12115,7 +12094,7 @@ msgstr ""
 msgid "your_organization"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/privacy.html.heex:15
+#: lib/vutuv_web/templates/settings/privacy.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "We can't stop a search engine or AI service from reading a page it can open. What we can do is tell them, in the machine-readable way they look for, that you don't want your profile listed in search results or used by AI. Reputable search engines and AI companies follow that request; we can't force the rest."
 msgstr ""
@@ -12545,7 +12524,7 @@ msgstr ""
 msgid "Salary on request"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:230
+#: lib/vutuv_web/controllers/settings_controller.ex:232
 #: lib/vutuv_web/live/job_posting_live/form.ex:231
 #, elixir-autogen, elixir-format
 msgid "Saved."
@@ -13109,7 +13088,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:447
+#: lib/vutuv_web/controllers/settings_controller.ex:488
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -13175,13 +13154,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:465
+#: lib/vutuv_web/controllers/settings_controller.ex:506
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3233
-#: lib/vutuv_web/controllers/settings_controller.ex:370
+#: lib/vutuv_web/components/ui.ex:3273
+#: lib/vutuv_web/controllers/settings_controller.ex:411
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13200,8 +13179,8 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:452
-#: lib/vutuv_web/controllers/settings_controller.ex:470
+#: lib/vutuv_web/controllers/settings_controller.ex:493
+#: lib/vutuv_web/controllers/settings_controller.ex:511
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -13529,14 +13508,14 @@ msgstr ""
 msgid "Show my birthday as"
 msgstr ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:26
+#: lib/vutuv_web/templates/username/new.html.heex:49
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post currently mentions %{handle} and will be updated when you rename."
 msgid_plural "%{formatted} posts currently mention %{handle} and will be updated when you rename."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:18
+#: lib/vutuv_web/templates/username/new.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
@@ -13645,8 +13624,8 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3222
-#: lib/vutuv_web/controllers/settings_controller.ex:384
+#: lib/vutuv_web/components/ui.ex:3269
+#: lib/vutuv_web/controllers/settings_controller.ex:425
 #: lib/vutuv_web/live/post_live/feed.ex:732
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -13696,7 +13675,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1009
+#: lib/vutuv_web/templates/user/show.html.heex:1110
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13725,7 +13704,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3185
+#: lib/vutuv_web/components/ui.ex:3254
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13733,7 +13712,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1007
+#: lib/vutuv_web/templates/user/show.html.heex:1108
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13825,7 +13804,7 @@ msgstr ""
 msgid "Book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:857
+#: lib/vutuv_web/agent_docs/markdown.ex:870
 #: lib/vutuv_web/components/post_components.ex:1897
 #: lib/vutuv_web/live/post_live/composer.ex:671
 #, elixir-autogen, elixir-format
@@ -13857,7 +13836,7 @@ msgstr ""
 msgid "Film"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:857
+#: lib/vutuv_web/agent_docs/markdown.ex:870
 #: lib/vutuv_web/components/post_components.ex:1896
 #: lib/vutuv_web/live/post_live/composer.ex:670
 #, elixir-autogen, elixir-format
@@ -13999,7 +13978,7 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:581
+#: lib/vutuv_web/agent_docs/markdown.ex:594
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
@@ -14095,19 +14074,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:684
+#: lib/vutuv_web/agent_docs/markdown.ex:697
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:683
+#: lib/vutuv_web/agent_docs/markdown.ex:696
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:689
+#: lib/vutuv_web/agent_docs/markdown.ex:702
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14186,8 +14165,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:652
-#: lib/vutuv_web/agent_docs/text.ex:537
+#: lib/vutuv_web/agent_docs/markdown.ex:665
+#: lib/vutuv_web/agent_docs/text.ex:550
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14510,7 +14489,7 @@ msgstr ""
 msgid "Cancel redirect"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:272
+#: lib/vutuv_web/controllers/settings_controller.ex:314
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr ""
@@ -14525,12 +14504,12 @@ msgstr ""
 msgid "On your other account, add your vutuv handle"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:311
+#: lib/vutuv_web/controllers/settings_controller.ex:353
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:297
+#: lib/vutuv_web/controllers/settings_controller.ex:339
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr ""
@@ -14545,17 +14524,17 @@ msgstr ""
 msgid "Redirected on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:324
+#: lib/vutuv_web/controllers/settings_controller.ex:366
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:318
+#: lib/vutuv_web/controllers/settings_controller.ex:360
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:314
+#: lib/vutuv_web/controllers/settings_controller.ex:356
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr ""
@@ -14565,12 +14544,12 @@ msgstr ""
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:302
+#: lib/vutuv_web/controllers/settings_controller.ex:344
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:306
+#: lib/vutuv_web/controllers/settings_controller.ex:348
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr ""
@@ -14592,7 +14571,7 @@ msgstr[1] ""
 msgid "All endorsers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:401
+#: lib/vutuv_web/controllers/settings_controller.ex:442
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
@@ -14602,7 +14581,7 @@ msgstr ""
 msgid "Filter by a tag"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:426
+#: lib/vutuv_web/controllers/settings_controller.ex:467
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter removed."
 msgstr ""
@@ -14622,8 +14601,8 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3204
-#: lib/vutuv_web/controllers/settings_controller.ex:437
+#: lib/vutuv_web/components/ui.ex:3265
+#: lib/vutuv_web/controllers/settings_controller.ex:478
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14716,7 +14695,7 @@ msgstr ""
 msgid "You have not muted anything yet."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:409
+#: lib/vutuv_web/controllers/settings_controller.ex:450
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
@@ -14857,12 +14836,12 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:845
+#: lib/vutuv_web/agent_docs/markdown.ex:858
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:63
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Count reactions from other networks"
 msgstr ""
@@ -14904,49 +14883,49 @@ msgstr ""
 msgid "Nothing changes on vutuv itself, and you can switch it off again."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:51
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Take part in the Fediverse"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:53
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Off means your profile cannot be found there and nothing is sent. Posts already delivered may stay on those servers, beyond our reach."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:66
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Show under each of your posts how many people out there liked or shared it. A number only, visible to everyone who sees the post. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:84
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:116
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:155
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Related"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:158
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:214
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:164
+#: lib/vutuv_web/controllers/settings_controller.ex:216
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:180
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Move your account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:168
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr ""
@@ -15001,7 +14980,7 @@ msgstr ""
 msgid "Back to Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:106
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:114
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower from other networks"
 msgid_plural "%{formatted} followers from other networks"
@@ -15183,12 +15162,6 @@ msgstr ""
 msgid "Add tags"
 msgstr ""
 
-#: lib/vutuv_web/templates/username/new.html.heex:4
-#: lib/vutuv_web/templates/username/new.html.heex:8
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Change username"
-msgstr ""
-
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Edit application"
@@ -15199,27 +15172,27 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:388
+#: lib/vutuv_web/templates/user/show.html.heex:816
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:405
+#: lib/vutuv_web/templates/user/show.html.heex:832
 #, elixir-autogen, elixir-format
 msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:449
+#: lib/vutuv_web/templates/user/show.html.heex:869
 #, elixir-autogen, elixir-format
 msgid "Follow from your own server"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:461
+#: lib/vutuv_web/templates/user/show.html.heex:880
 #, elixir-autogen, elixir-format
 msgid "@you@example.social"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:469
+#: lib/vutuv_web/templates/user/show.html.heex:888
 #, elixir-autogen, elixir-format
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr ""
@@ -15229,308 +15202,421 @@ msgstr ""
 msgid "This profile is not on the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:69
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:72
 #, elixir-autogen, elixir-format
 msgid "That is not a Fediverse address. It looks like @you@example.social."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:73
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:76
 #, elixir-autogen, elixir-format
 msgid "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:80
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:83
 #, elixir-autogen, elixir-format
 msgid "%{server} did not answer. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:90
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:94
 #, elixir-autogen, elixir-format
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:447
-#: lib/vutuv_web/agent_docs/text.ex:444
+#: lib/vutuv_web/agent_docs/markdown.ex:448
+#: lib/vutuv_web/agent_docs/text.ex:445
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3197
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3198
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3202
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3205
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3206
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3209
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3210
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3213
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3214
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3216
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3217
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3218
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3221
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3222
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3225
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3226
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3229
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3233
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3236
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3237
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3240
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3241
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3243
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3244
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3245
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3247
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3248
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3250
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3255
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3256
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3259
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3262
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3263
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3266
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3267
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3270
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3271
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3274
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3275
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3282
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3285
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3286
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3289
 #, elixir-autogen, elixir-format
 msgid "Followers from Mastodon and other networks"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3290
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower move migrate"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3296
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3297
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3300
 #, elixir-autogen, elixir-format
 msgid "Interface language, maps, how posts are shortened"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3301
 #, elixir-autogen, elixir-format
 msgid "german english locale translation map font length hyphenation"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3304
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3305
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3308
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3309
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3312
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3313
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3316
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
+#: lib/vutuv_web/components/ui.ex:3317
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/index.html.heex:20
+#: lib/vutuv_web/templates/settings/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Search settings"
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/index.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Nothing here matches. Try another word, or clear the search."
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/security.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "How you sign in"
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/security.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "You sign in with your primary address, and we mail your PIN there."
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/security.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "Your profile address. It is not used to sign in."
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/security.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/followed_tags.html.heex:18
 #, elixir-autogen, elixir-format
 msgid "You do not follow any tags yet. Open a tag page and press Follow, for example"
 msgstr ""
 
+#: lib/vutuv_web/templates/settings/followed_tags.html.heex:20
 #, elixir-autogen, elixir-format
 msgid "from the tag directory"
 msgstr ""
 
+#: lib/vutuv_web/templates/username/new.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Your profile address"
 msgstr ""
 
+#: lib/vutuv_web/templates/username/new.html.heex:34
 #, elixir-autogen, elixir-format
 msgid "Other members mention you as %{handle}."
 msgstr ""
 
+#: lib/vutuv_web/templates/username/new.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Change your username"
 msgstr ""
 
+#: lib/vutuv_web/templates/username/new.html.heex:100
 #, elixir-autogen, elixir-format
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:235
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
+#, elixir-autogen, elixir-format
+msgid "I understand, switch off"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:233
+#: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
+#, elixir-autogen, elixir-format
+msgid "I understand, take part"
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:338
+#, elixir-autogen, elixir-format
+msgid "Most of them, not all: we cannot check whether they do it, and anything that was re-shared, archived or indexed elsewhere stays out of reach. If you take part again later, people there have to follow you anew."
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:333
+#, elixir-autogen, elixir-format
+msgid "No new posts go out, and your followers from other networks are removed here. The next time those servers look you up they learn that this account is gone, and most of them then delete their copies of your posts."
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:314
+#, elixir-autogen, elixir-format
+msgid "Once a post has left vutuv, it is out of our hands"
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:316
+#, elixir-autogen, elixir-format
+msgid "Switching off does not delete what is already out there"
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:327
+#, elixir-autogen, elixir-format
+msgid "Switching this off again later stops new posts from going out. It cannot bring back what has already been delivered."
+msgstr ""
+
+#: lib/vutuv_web/views/settings_html.ex:322
+#, elixir-autogen, elixir-format
+msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""

--- a/test/vutuv/fediverse_test.exs
+++ b/test/vutuv/fediverse_test.exs
@@ -38,6 +38,42 @@ defmodule Vutuv.FediverseTest do
     end
   end
 
+  describe "departed?/1" do
+    test "only a member who took part and then switched it off counts as gone" do
+      departed = federated_user()
+      {:ok, _actor} = Fediverse.ensure_actor(departed)
+      {:ok, departed} = Vutuv.Accounts.update_user(departed, %{"fediverse_followers?" => "false"})
+
+      assert Fediverse.departed?(departed)
+
+      # Never took part: there is nothing for a remote server to forget.
+      refute Fediverse.departed?(insert(:activated_user))
+
+      # Still taking part.
+      still_in = federated_user()
+      {:ok, _actor} = Fediverse.ensure_actor(still_in)
+      refute Fediverse.departed?(still_in)
+    end
+
+    test "a temporary state is not a departure, and neither is the operator's switch" do
+      # Hidden for now (a suspension), but still opted in: telling the network
+      # this account is gone would delete it over a three-day timeout.
+      suspended = federated_user(suspended_until: ~N[2099-01-01 00:00:00])
+      {:ok, _actor} = Fediverse.ensure_actor(suspended)
+      refute Fediverse.federated?(suspended)
+      refute Fediverse.departed?(suspended)
+
+      departed = federated_user()
+      {:ok, _actor} = Fediverse.ensure_actor(departed)
+      {:ok, departed} = Vutuv.Accounts.update_user(departed, %{"fediverse_followers?" => "false"})
+
+      Application.put_env(:vutuv, :fediverse_enabled, false)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_enabled) end)
+
+      refute Fediverse.departed?(departed)
+    end
+  end
+
   describe "ensure_actor/1" do
     test "creates the keypair once and returns the same actor after" do
       user = federated_user()
@@ -72,6 +108,23 @@ defmodule Vutuv.FediverseTest do
 
       Fediverse.remove_follower(user, "https://social.example/users/alice")
       assert Fediverse.follower_count(user) == 0
+    end
+
+    test "drop_followers/1 deletes every row of that member and nobody else's" do
+      user = federated_user()
+      other = federated_user()
+
+      for member <- [user, other] do
+        {:ok, _} =
+          Fediverse.add_follower(member, %{
+            actor_uri: "https://social.example/users/#{member.username}",
+            inbox_uri: "https://social.example/inbox"
+          })
+      end
+
+      assert Fediverse.drop_followers(user) == 1
+      assert Fediverse.follower_count(user) == 0
+      assert Fediverse.follower_count(other) == 1
     end
 
     test "delivery_inboxes prefers the shared inbox and dedupes by it" do

--- a/test/vutuv_web/controllers/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/fediverse_controller_test.exs
@@ -201,6 +201,89 @@ defmodule VutuvWeb.FediverseControllerTest do
     end
   end
 
+  # A member who took part and then switched it off is *gone*, not merely
+  # absent: the remote servers read a 410 on an actor they know as "this account
+  # was deleted" and drop their copies of its posts, which is the closest the
+  # protocol comes to honouring "forget me". So 410 is reserved for that one
+  # case, and every other reason we withhold an actor keeps answering 404 — a
+  # temporary suspension must never tell the network to delete the account.
+  describe "410 Gone after a member opts out" do
+    defp departed_user do
+      user = federated_user()
+      {:ok, user} = Vutuv.Accounts.update_user(user, %{"fediverse_followers?" => "false"})
+      user
+    end
+
+    test "the actor, its collections and WebFinger all answer 410", %{conn: conn} do
+      user = departed_user()
+
+      for path <- [
+            "/#{user.username}/actor",
+            "/#{user.username}/actor/followers",
+            "/#{user.username}/actor/outbox",
+            "/.well-known/webfinger?resource=acct:#{user.username}@#{host()}"
+          ] do
+        assert conn |> recycle() |> get(path) |> Map.fetch!(:status) == 410
+      end
+    end
+
+    test "the profile URL answers an AP Accept with 410 too", %{conn: conn} do
+      user = departed_user()
+
+      conn =
+        conn
+        |> put_req_header("accept", "application/activity+json")
+        |> get("/#{user.username}")
+
+      assert conn.status == 410
+    end
+
+    test "a delivery to the inbox is answered 410, so the remote drops the follow",
+         %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = departed_user()
+
+      conn = signed_post(conn, user, follow_activity(user), priv)
+
+      assert conn.status == 410
+      assert Fediverse.follower_count(user) == 0
+    end
+
+    test "a member who never took part stays a 404 — nothing to forget", %{conn: conn} do
+      plain = insert(:activated_user)
+
+      assert conn |> get("/#{plain.username}/actor") |> Map.fetch!(:status) == 404
+
+      assert conn
+             |> recycle()
+             |> get("/.well-known/webfinger?resource=acct:#{plain.username}@#{host()}")
+             |> Map.fetch!(:status) == 404
+    end
+
+    test "a temporarily hidden member stays a 404, never a 410", %{conn: conn} do
+      for attrs <- [
+            %{suspended_until: ~N[2099-01-01 00:00:00]},
+            %{frozen_at: ~N[2026-07-01 00:00:00]},
+            %{deactivated_at: ~N[2026-07-01 00:00:00]}
+          ] do
+        user = insert(:activated_user, Map.put(attrs, :fediverse_followers?, true))
+        {:ok, _actor} = Fediverse.ensure_actor(user)
+
+        assert conn |> recycle() |> get("/#{user.username}/actor") |> Map.fetch!(:status) == 404
+      end
+    end
+
+    test "the installation switch being off is a 404, not the operator deleting members",
+         %{conn: conn} do
+      user = departed_user()
+      Application.put_env(:vutuv, :fediverse_enabled, false)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_enabled) end)
+
+      assert conn |> get("/#{user.username}/actor") |> Map.fetch!(:status) == 404
+    end
+  end
+
   describe "POST /:slug/actor/inbox — Follow" do
     test "a signed Follow stores the follower and queues the Accept", %{conn: conn} do
       {priv, pub} = Keys.generate()

--- a/test/vutuv_web/controllers/settings_controller_test.exs
+++ b/test/vutuv_web/controllers/settings_controller_test.exs
@@ -313,6 +313,83 @@ defmodule VutuvWeb.SettingsControllerTest do
     end
   end
 
+  # Both directions of the take-part switch are unreversible in ways nobody can
+  # fix afterwards, so neither flips until the member says they understood.
+  describe "fediverse: the take-part switch asks first (#1072)" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      %{conn: conn, user: user}
+    end
+
+    test "the page carries the acknowledgement field and both dialogs", %{conn: conn} do
+      html = conn |> get(~p"/settings/fediverse") |> html_response(200)
+
+      assert html =~ ~s(data-fediverse-ack)
+      assert html =~ ~s(id="fediverse-consent-on")
+      assert html =~ ~s(id="fediverse-consent-off")
+      assert html =~ "out of our hands"
+    end
+
+    test "switching on without the acknowledgement asks instead of saving", %{
+      conn: conn,
+      user: user
+    } do
+      conn = put(conn, ~p"/settings/fediverse", user: %{"fediverse_followers?" => "true"})
+
+      html = html_response(conn, 200)
+      assert html =~ "out of our hands"
+      assert html =~ "I understand, take part"
+      refute Repo.get(User, user.id).fediverse_followers?
+    end
+
+    test "the acknowledged submit saves and mints the actor", %{conn: conn, user: user} do
+      conn =
+        put(conn, ~p"/settings/fediverse",
+          user: %{"fediverse_followers?" => "true"},
+          fediverse_ack: "1"
+        )
+
+      assert redirected_to(conn) == ~p"/settings/fediverse"
+      saved = Repo.get(User, user.id)
+      assert saved.fediverse_followers?
+      assert Vutuv.Fediverse.get_actor(saved)
+    end
+
+    test "switching off asks with the words for leaving, then drops the remote followers",
+         %{conn: conn, user: user} do
+      {:ok, user} = Accounts.update_user(user, %{"fediverse_followers?" => "true"})
+      {:ok, _actor} = Vutuv.Fediverse.ensure_actor(user)
+
+      {:ok, _} =
+        Vutuv.Fediverse.add_follower(user, %{
+          actor_uri: "https://social.example/users/alice",
+          inbox_uri: "https://social.example/inbox"
+        })
+
+      asked =
+        put(conn, ~p"/settings/fediverse", user: %{"fediverse_followers?" => "false"})
+
+      html = html_response(asked, 200)
+      assert html =~ "does not delete what is already out there"
+      assert html =~ "I understand, switch off"
+      assert Repo.get(User, user.id).fediverse_followers?
+      assert Vutuv.Fediverse.follower_count(user) == 1
+
+      confirmed =
+        put(recycle(conn), ~p"/settings/fediverse",
+          user: %{"fediverse_followers?" => "false"},
+          fediverse_ack: "1"
+        )
+
+      assert redirected_to(confirmed) == ~p"/settings/fediverse"
+      refute Repo.get(User, user.id).fediverse_followers?
+
+      # The actor answers 410 from now on, so those servers drop the follow at
+      # their end too — a kept row would be a relationship that exists nowhere.
+      assert Vutuv.Fediverse.follower_count(user) == 0
+    end
+  end
+
   describe "fediverse: alsoKnownAs account migration (#986)" do
     setup %{conn: conn} do
       {conn, user} = create_and_login_user(conn)

--- a/test/vutuv_web/fediverse_groundwork_test.exs
+++ b/test/vutuv_web/fediverse_groundwork_test.exs
@@ -83,7 +83,11 @@ defmodule VutuvWeb.FediverseGroundworkTest do
       {conn, user} = create_and_login_user(conn)
       assert Vutuv.Fediverse.get_actor(user) == nil
 
-      conn = put(conn, ~p"/settings/fediverse", %{"user" => %{"fediverse_followers?" => "true"}})
+      conn =
+        put(conn, ~p"/settings/fediverse", %{
+          "user" => %{"fediverse_followers?" => "true"},
+          "fediverse_ack" => "1"
+        })
 
       assert redirected_to(conn) == ~p"/settings/fediverse"
       assert Vutuv.Accounts.get_user(user.id).fediverse_followers?
@@ -95,7 +99,13 @@ defmodule VutuvWeb.FediverseGroundworkTest do
 
     test "lists who follows the member from the Fediverse", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
-      conn = put(conn, ~p"/settings/fediverse", %{"user" => %{"fediverse_followers?" => "true"}})
+
+      conn =
+        put(conn, ~p"/settings/fediverse", %{
+          "user" => %{"fediverse_followers?" => "true"},
+          "fediverse_ack" => "1"
+        })
+
       user = Vutuv.Accounts.get_user(user.id)
 
       {:ok, _} =


### PR DESCRIPTION
Follow-up to the follower pruning (#1072): the other side of the same problem, plus the transparency Stefan asked for.

**404 → 410.** Switching the Fediverse opt-in off made every actor endpoint answer `404`, which remote servers shrug off — they kept the account and their copies of the member's posts indefinitely. A member who took part and then switched it off is now **gone**: the actor, its collections, its inbox, WebFinger and the AP-negotiated profile URL answer **`410`**. Mastodon and the other common implementations read a `410` on an actor they know as "this account was deleted" and purge the account together with its copies of that account's posts, which is the closest the protocol comes to honouring "please forget me" — and the passive twin of the pruner, which reads that same answer from the other side.

`410` is **only ever the member's own departure**. A member who never federated, an installation the operator switched off, and every temporary hiding (frozen, suspended, deactivated, unconfirmed) keep answering `404`: a three-day suspension must never tell the network to delete an account, and an operator's switch must not erase their members' remote presence.

**Leaving drops the follower rows**, the symmetry the reaction counts already had. Those servers drop the follow at their end once they meet the 410, so a kept row would only be a relationship that exists nowhere else.

**Both directions ask first.** Taking part means posts leave vutuv for good; leaving may mean some servers never show the member again if they return. The words live in one place (`fediverse_consent_notice/1`) and appear twice: as a modal on the settings page whose confirm button posts the acknowledgement, and as a full-page confirmation for a browser without JavaScript, which replays the submitted fields. The controller requires that acknowledgement whenever the submit really flips the switch, so it cannot flip unacknowledged either way; saving the other settings on the page passes straight through.

**Smoke-tested in a real browser, in German**, end to end: both dialogs, Cancel, the JS-less confirmation page (via `form.submit()`, which bypasses the handler exactly like no JS), the 410s on all five surfaces afterwards, and 200s again after opting back in. No console errors.

Tests cover the 410 on every surface, the 404 for never-federated / temporarily hidden / installation-off, `departed?/1`, `drop_followers/1`, and the consent gate in both directions. `mix precommit` green (4927 tests). Docs updated in `docs/architecture/fediverse.md` and `docs/ADMINS.md`.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01NxTzvBT1dSMhyhvmU2jWES
