### PR TITLE
Show replies written on other networks under a member's post

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -134,6 +134,31 @@ config :vutuv, :fediverse_enabled, true
 # an Undo or a Delete. A no-op anyway while :fediverse_enabled is off.
 config :vutuv, :fediverse_follower_pruning, true
 
+# Whether the hourly GenServer that deletes expired remote replies runs (off in
+# tests, same sandbox reasoning; tests call Vutuv.Fediverse.expire_due_notes/1
+# directly). A no-op while :fediverse_enabled is off.
+config :vutuv, :fediverse_note_sweeping, true
+
+# Whether opening a page queues the freshness re-fetch for the stale replies on
+# it (off in tests, where it would run outside the SQL sandbox). Off, the hard
+# ceiling still governs; on, a reply confirmed still published at its origin
+# refreshes and pushes its ceiling out, and one that is gone is deleted early.
+config :vutuv, :fediverse_note_refresh, true
+
+# How long a reply written on another network may be held here (issues #1069 and
+# #1071), and how stale a stored copy may get before its origin is asked whether
+# it is still published there.
+#
+# The two work as a pair: the ceiling is the promise the privacy page makes and
+# fires whatever else happens, while a note confirmed still live pushes that date
+# forward, so a reply people keep reading tracks its original and one nobody has
+# opened in six months is collected. An operator holding a stranger's words has
+# to be able to set both, so they are env-overridable
+# (FEDIVERSE_NOTE_RETENTION_DAYS / FEDIVERSE_NOTE_REFRESH_DAYS in
+# config/runtime.exs).
+config :vutuv, :fediverse_note_retention_days, 183
+config :vutuv, :fediverse_note_refresh_days, 7
+
 # The site-wide AI-crawler stance (see VutuvWeb.ContentPolicy): :permissive
 # welcomes search, live AI input AND model training; :block_training keeps
 # retrieval but declares ai-train=no and blocks the training crawlers in

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -161,6 +161,19 @@ if config_env() == :prod do
     config :vutuv, :fediverse_inbound_caps, {host_cap, actor_cap}
   end
 
+  # How long a reply written on another network may be held here, and how stale
+  # a stored copy may get before its origin is asked whether it is still
+  # published (issues #1069 and #1071). Holding a stranger's words is a call the
+  # operator has to be able to make, so both are settable per installation; the
+  # shipped six months / one week are what vutuv.de runs.
+  if days = System.get_env("FEDIVERSE_NOTE_RETENTION_DAYS") do
+    config :vutuv, :fediverse_note_retention_days, String.to_integer(String.trim(days))
+  end
+
+  if days = System.get_env("FEDIVERSE_NOTE_REFRESH_DAYS") do
+    config :vutuv, :fediverse_note_refresh_days, String.to_integer(String.trim(days))
+  end
+
   # Book metadata + covers for post reviews come keyless from Open Library.
   # FETCH_BOOK_METADATA=false turns every such fetch off (intranets); the
   # review panel then has no lookup button and covers stay empty.

--- a/config/test.exs
+++ b/config/test.exs
@@ -30,6 +30,14 @@ config :vutuv, :fediverse_deliverer, false
 # outside; tests call Vutuv.Fediverse.prune_due_followers/1 directly with a
 # stubbed HTTP layer.
 config :vutuv, :fediverse_follower_pruning, false
+# The hourly retention sweep of stored remote replies, same reasoning; tests
+# call Vutuv.Fediverse.expire_due_notes/1 directly.
+config :vutuv, :fediverse_note_sweeping, false
+# The on-view freshness re-fetch spawns a task under Vutuv.TaskSupervisor, which
+# does not own the sandbox connection — so it would crash there, and only into
+# the log, since nothing awaits a Task. Tests call
+# Vutuv.Fediverse.refresh_note/1 directly with a stubbed HTTP layer.
+config :vutuv, :fediverse_note_refresh, false
 # Post link-screenshots drain via a polling GenServer that would touch the
 # sandbox from outside; tests call Vutuv.Posts.Screenshots.deliver_due/1 directly
 # with a stubbed capture. ScreenshotWorker.nudge/0 casts into the void then.

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -117,6 +117,8 @@ Everything else has a default (the vutuv.de production value):
 | `POST_EDIT_WINDOW_MINUTES` | `30` | How long a post stays editable after publishing. Editing also closes with the first like, repost or reply, whatever this value says (an edit would silently rewrite what somebody else endorsed); deleting is never blocked. Raise it for a closed community where posts get little immediate engagement |
 | `FEDIVERSE_ENABLED` | `true` | `false` turns follow-only ActivityPub federation off entirely (endpoints 404, nothing is delivered) — set it on intranet installations |
 | `FEDIVERSE_INBOUND_CAPS` | `600,60` | `host,actor`: how many rows one remote server, and one remote account, may store here per hour. Anything past the budget is dropped for that hour. The floor under the operator blocklist at `/admin/fediverse`, since it also bounds servers nobody has blocked yet |
+| `FEDIVERSE_NOTE_RETENTION_DAYS` | `183` | How long a reply written on another network may be held here at the very most, in days. It is deleted when the clock runs out whatever else happens, so this is the promise your privacy page can make. Only applies once a member switches replies on (off by default) |
+| `FEDIVERSE_NOTE_REFRESH_DAYS` | `7` | How stale a stored reply may get before vutuv asks its origin server whether it is still published there. Still there means the text is refreshed and the retention clock starts again; gone (or locked away) means it is deleted at once; unreachable changes nothing. Replies sent to a member privately are never re-checked |
 | `FETCH_BOOK_METADATA` | `true` | `false` turns the catalogue lookups behind post **book reviews** off (the composer's ISBN → title/author/year prefill, the cover image, page count and publisher from Open Library, and an audiobook's running time). The review feature itself keeps working — members type the fields by hand and the card renders without a cover or those details. Set it on installations that must not call out (intranets) |
 | `DNB_SRU_URL` | `https://services.dnb.de/sru/dnb` | Where an **audiobook's running time** is looked up by ISBN: an SRU endpoint answering MARC21-xml (the Deutsche Nationalbibliothek by default — Open Library records no durations). Point it at another catalogue's SRU endpoint, or set it **empty** (`DNB_SRU_URL=`) to switch that one lookup off while the rest of the book metadata keeps working |
 | `AMAZON_DOMAIN` | `www.amazon.de` | The store a book review card's shop link points at (`https://<domain>/dp/<isbn10>`). Set your regional store (`www.amazon.com`, …) — or an **empty** value (`AMAZON_DOMAIN=`) to remove the shop link entirely |
@@ -466,7 +468,8 @@ is not a vetted party. Your levers live at **`/admin` → Fediverse**
   and before any of its documents are fetched, and it is answered with a plain
   `202` rather than a refusal, so the list cannot be probed from outside.
   Blocking also **deletes what that server already stored here** (its remote
-  followers, its queued deliveries) and stops your members' posts from going
+  followers, the replies its members wrote under your members' posts, its queued
+  deliveries) and stops your members' posts from going
   there. Lifting a block later does not bring any of that back — the server has
   to follow again.
 - **Caps.** Independent of the list, one remote server may store at most 600
@@ -474,8 +477,47 @@ is not a vetted party. Your levers live at **`/admin` → Fediverse**
   nobody has thought to block yet; anything past the budget is dropped for that
   hour. Set `FEDIVERSE_INBOUND_CAPS` to change it (see the configuration table).
 - **Inbound volume.** The same page lists what each server has stored here,
-  biggest first, and the dashboard card names the busiest one. That is the list
-  a block decision is made from.
+  biggest first (followers and stored replies side by side), and the dashboard
+  card names the busiest one. That is the list a block decision is made from.
+- **Takedowns.** Below it, the replies your members removed or reported. A report
+  deletes the reply immediately — there is no queue to work through, because the
+  original still sits on the server it was written on and only our copy goes.
+  The list is there so you can see a pattern: one account showing up again and
+  again, or a whole server doing so, is what the blocklist above is for. It
+  deliberately holds **no text and no links**, only which server, which account
+  (as a short digest, so repeats are recognizable without keeping the account's
+  address), and when — keeping a stranger's words after deleting their reply
+  would make the deletion untrue.
+
+**Replies from other networks.** Off by default and switched on per member on
+their own Fediverse settings page. Once on, an answer written on another server
+under one of their public posts is stored here as **plain text** (never HTML,
+and no copy of the author's picture) and shown in the conversation, clearly
+marked as coming from elsewhere and linking to the original. A reply addressed
+to the member alone is shown only to them.
+
+The retention model, which is what makes holding a stranger's words defensible
+at all — they never signed up here and cannot practically be asked:
+
+- A copy is deleted after **six months** at the latest, whatever else happens
+  (`FEDIVERSE_NOTE_RETENTION_DAYS`).
+- Before that, vutuv asks the origin server now and then whether the reply is
+  still published there (`FEDIVERSE_NOTE_REFRESH_DAYS`, and only when somebody
+  actually opens the page). Gone or locked away means it is deleted at once,
+  usually far earlier than the six months; still there means the text is
+  refreshed and the clock starts again, so a reply people keep reading stays in
+  step with its original. A server that is simply unreachable changes nothing.
+- If the author deletes or edits it on their own server and that reaches us, we
+  follow immediately.
+- The member can remove any single reply, and switching the setting off deletes
+  every one of them.
+- Replies sent to a member privately are never re-checked against their origin:
+  the answer would be "not found" for anyone but the recipient, and asking would
+  tell that server we are holding it.
+
+If you run an installation where holding third-party text is not acceptable at
+all, leave it as it is: members have to switch it on themselves, and
+`FEDIVERSE_ENABLED=false` turns the whole of federation off.
 
 **Followers who leave without saying so.** Somebody on another server who
 unfollows, or who deletes their account and whose server announces it, disappears

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -2,12 +2,14 @@
 
 People on Mastodon and other ActivityPub servers can follow an opted-in
 member and receive their **public** posts. Federation is outbound-first by
-design: no remote posts or reply text is stored. The one thing that does come
-back is a **count** (issue #1068) — how many people out there favourited or
-re-shared a post — and even that is a bare counter row. The inbox otherwise
-processes only `Follow`, `Undo(Follow)` and the remote actor's own lifecycle
-(`Update` / `Delete`); everything else is acknowledged (202) and dropped.
-Everything lives in `Vutuv.Fediverse`.
+design, and what comes back is accepted in two tiers, each with its own switch:
+a bare **count** of favourites and re-shares (issue #1068, on by default) and,
+behind a second and deliberately separate opt-in, the **replies** people out
+there write under a member's post (issues #1069 and #1071, off by default). The
+inbox otherwise processes only `Follow`, `Undo(Follow)`, the remote actor's own
+lifecycle (`Update` / `Delete`) and an author's `Update`/`Delete` of a reply they
+sent us; everything else is acknowledged (202) and dropped. Everything lives in
+`Vutuv.Fediverse`.
 
 ## Consent first
 
@@ -119,6 +121,75 @@ every endpoint 404s and nothing is delivered.
   vutuv counters, never folded into them: a hostile server can then inflate
   only its own line, and the reader sees which world answered. Public and
   hidden at zero.
+- **Replies from other networks** (issues #1069 and #1071, the first content
+  vutuv stores that its own members did not write): a `Create(Note)` whose
+  `inReplyTo` names one of a member's public posts becomes a row in
+  `fediverse_notes` (`Vutuv.Fediverse.Note`). `record_reply/3` holds the gates in
+  order — the installation switch, the member federates, the member switched
+  **replies** on (`users.fediverse_replies?`, **off** by default, its own switch
+  beside the counts because a counter row says nothing about a person while a
+  sentence with their name on it does), the Note answers one of *their own*
+  posts, the post is public, the sender is within its inbound cap, and there is
+  text left once the markup is gone. Same 202 whatever it decides.
+  - **Plain text, never HTML.** `Vutuv.RemoteHtml.to_text/2` (shared with the
+    Mastodon profile feed, so remote HTML is reduced exactly one way) drops
+    `<script>`/`<style>` **with their contents**, turns `<br>`/`</p>` into line
+    breaks, strips every remaining tag, decodes the base entities once and
+    clamps. So nothing a stranger wrote is ever rendered `raw`, the agent-format
+    siblings carry the value unchanged, and the cap is well defined. **No avatar
+    is copied**: the card renders initials and links to the origin.
+  - **Audience** (issue #1071), read from `to`/`cc` on both the Create and the
+    Note, handling all three spellings of the public collection. Only `"public"`
+    is public; `"followers"`, `"direct"` and `"unknown"` render to the addressed
+    member alone, signed in, on their own post, behind the same 🔒 a restricted
+    post wears plus "sent to you only". Never widened, and there is deliberately
+    **no** button to publish one: we can never ask the author of a private
+    message whether that would be alright. `list_notes/2` is the one
+    viewer-scoped read, so no call site can forget the rule; `PostDoc` takes
+    public notes even on the authenticated `viewer:` path, so a private reply
+    cannot leave through `/api/2.0` or a `.json` sibling; and the public count
+    (`engagement_count_select` → `:fediverse_replies`) counts public notes only,
+    or the figure itself would leak that a private message exists.
+  - **Retention is two layers.** The ceiling is `expires_at`, six months out
+    (`:fediverse_note_retention_days`), swept hourly by
+    `Vutuv.Fediverse.NoteSweeper` — the promise that holds whatever else fails.
+    Under it a **lazy on-view freshness check**: rendering a note whose
+    `checked_at` is older than a week (`:fediverse_note_refresh_days`) queues an
+    SSRF-vetted `refresh_note/1` in a task, so no render waits on a stranger's
+    server. `200` and still public refreshes the text **and pushes the ceiling
+    out**; `404`/`410`/`403`, or an audience narrowed away from public, deletes
+    at once; anything else changes nothing, so an offline server buys no
+    retention and an outage triggers no mass delete. Net effect, and the reason
+    "cache" is an honest word here: a reply people keep reading tracks its
+    original, one nobody has opened in six months is collected. **Non-public
+    notes are never re-fetched** — a direct message answers 403/404 to any fetch
+    we can make, which the checker would read as "deleted upstream" and act on,
+    and asking would tell the origin we hold it. They live by the ceiling and an
+    upstream `Delete` alone.
+  - **Takedown, with no workflow.** The member removes a reply from their own
+    post; anyone who can see it reports it, which **deletes it immediately** —
+    no case, no freezer, because unlike a member's own post this is a cache of
+    something that still exists at its origin. Both write one
+    `Vutuv.Fediverse.NoteEvent` row, which keeps **no content and no URIs**
+    (following `FollowerPrune`, #1072): action, host, a keyed HMAC of the actor
+    URI, who acted, when. That is enough for the only decision it serves — one
+    troll or the whole server — without holding an identifier of somebody whose
+    words we just deleted. Reports are rate limited per reporter. Automatic
+    deletions are **not** logged per row (an expiry run would drown it); they go
+    to the log in aggregate.
+  - Everything else that deletes: the post, the account (both by FK cascade),
+    `purge_instance/1` when the server is blocked, and switching the opt-in off
+    (`drop_notes/1`) — the switch is a delete lever, not a display toggle.
+  - **Where it shows.** Woven into the permalink's conversation as an ordinary
+    sibling in time order (`VutuvWeb.PostLive.Thread` +
+    `PostComponents.remote_reply_card/1`), wearing its own skin so the two worlds
+    are told apart without colour: a **slate** initials tile with the 🌐 badge,
+    a **dashed** left rail against the solid connector rail, the name as plain
+    text beside a `@handle@host` that links out, and **no action bar** (liking a
+    note on someone else's server is not a thing that exists). A content warning
+    renders as a closed lid. The member also gets a notification: the
+    `fediverse_reply` kind, sourced **straight from the notes table**, so
+    deleting a note deletes its notification with no second place to remember.
 - **The operator's safety floor** (issue #1067): anyone can run an ActivityPub
   server, so before anything a remote sends is stored, two independent levers
   sit in front of it. The **blocklist**
@@ -283,11 +354,21 @@ guarantee.
 
 ## Deliberate v1 limits
 
-No inbound **content** — remote reply text, names, avatars and boost rosters are
-all still dropped. Only the reaction *count* is stored (issue #1068, above); the
-rest of the inbound tier is planned in issues #1069–#1071 under the agreed
-retention model: counts before text, a counter row lives as long as its post,
-stored remote text expires after six months. The operator blocklist and the
+Inbound **reply text** is stored now (issues #1069 and #1071, see the bullet
+above) under the agreed retention model: counts before text, a counter row lives
+as long as its post, stored remote text expires after six months unless its
+origin confirms it is still published. Still dropped: **avatars** (initials and
+a link out instead), **boost rosters** (who re-shared stays a number), inline
+**images** in a remote reply, and replies that answer another *remote* reply
+rather than a vutuv post — that conversation lives on its author's server, and
+following it would mean storing arbitrary third-party threads.
+
+Replying **back** to somebody on another network from vutuv is not built either:
+it would mean delivering to servers that never followed us and sending a member's
+words somewhere they did not choose, which deserves its own decision. The card
+links to the original instead.
+
+The operator blocklist and the
 inbound caps that were the condition for storing anything shipped alongside it
 (issue #1067, see the safety-floor bullet above). Reposts
 now federate as

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -195,6 +195,16 @@ defmodule Vutuv.Accounts.User do
     # deletion path is) and a switch nobody finds helps nobody. Switching it off
     # drops every stored row (`Vutuv.Fediverse.drop_reactions/1`).
     field(:fediverse_reactions?, :boolean, default: true)
+    # Whether replies written on other networks are shown under the member's
+    # posts (issues #1069 and #1071). **Off** by default, unlike the reaction
+    # counts above, and that difference is the point: a counter row says nothing
+    # about a person, while a reply is a stranger's words with their name on
+    # them, held on our server. That is a decision the member has to take
+    # deliberately, so it is its own switch on /settings/fediverse. Covers both
+    # public replies and ones addressed to them alone, the way vutuv's own
+    # messages work. Switching it off deletes every stored note
+    # (`Vutuv.Fediverse.drop_notes/1`).
+    field(:fediverse_replies?, :boolean, default: false)
     # The Fediverse account(s) the member is migrating *from* (issue #986,
     # half 1): actor URIs rendered as `alsoKnownAs` on the actor document. A
     # remote server (Mastodon) checks this before it moves a member's followers
@@ -363,7 +373,7 @@ defmodule Vutuv.Accounts.User do
   # :email_confirmed? is NOT here either: it flips only via the login-PIN path
   # (Accounts.activate_user/1, its own narrow cast) — castable, it would let a
   # registration self-activate without ever proving control of an email.
-  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? fediverse_reactions? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix gender birthdate birthdate_visibility locale tag_list)a
+  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix gender birthdate birthdate_visibility locale tag_list)a
 
   # The job-availability values a member can advertise (issue #870), other
   # than the "not specified" default which is stored as nil. The single source

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -27,6 +27,7 @@ defmodule Vutuv.Activity do
 
   alias Vutuv.Accounts.HandleChangeNotification
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse.Note
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Notifications.Emailer
   alias Vutuv.Organizations.Organization
@@ -342,6 +343,34 @@ defmodule Vutuv.Activity do
   end
 
   @doc ~S"""
+  Convenience: a "replied to your post from another network" notification
+  (issue #1069) — somebody on Mastodon or a comparable server answered a post of
+  the member's, and the reply is now stored as a `Vutuv.Fediverse.Note`.
+
+  The live push only; the durable half is the note row itself, which
+  `fediverse_reply_items/3` derives the notification from. That is the point of
+  sourcing this kind straight from the notes table: when the note is deleted
+  (reported, expired, withdrawn upstream), its notification goes with it and
+  there is no second place to remember.
+
+  The actor is a stranger with no vutuv profile, so the item carries their
+  display name, their `@handle@host` and a link **out** to their account, and
+  none of the local `actor_param` / avatar fields a member's actor would.
+  """
+  def notify_fediverse_reply(%User{} = user, post, note) do
+    notify(
+      user.id,
+      Map.merge(remote_actor_fields(note), %{
+        kind: "fediverse_reply",
+        text: "replied to your post from another network.",
+        post_id: post.id,
+        note_id: note.id,
+        at: note.received_at
+      })
+    )
+  end
+
+  @doc ~S"""
   Convenience: a "mentioned you in a post" notification for a member the post's
   body names by `@handle`. `post_id` is that post — written by the actor, not by
   the recipient, so the row links it under the **author's** profile.
@@ -511,6 +540,7 @@ defmodule Vutuv.Activity do
       {"reply", &reply_items(user_id, &1, &2)},
       {"thread", &thread_items(user_id, &1, &2)},
       {"mention", &mention_items(user_id, &1, &2)},
+      {"fediverse_reply", &fediverse_reply_items(user_id, &1, &2)},
       {"like", &like_items(user_id, &1, &2)},
       {"organization_role", &organization_role_items(user_id, &1, &2)},
       {"moderation", &moderation_items(user_id, &1, &2)},
@@ -608,6 +638,7 @@ defmodule Vutuv.Activity do
       {"reply", count_replies(user_id, read_at)},
       {"thread", count_thread_replies(user_id, read_at)},
       {"mention", count_mentions(user_id, read_at)},
+      {"fediverse_reply", count_fediverse_replies(user_id, read_at)},
       {"like", count_likes(user_id, read_at)},
       {"organization_role", count_organization_roles(user_id, read_at)},
       {"cv_update", count_cv_updates(user_id, read_at)},
@@ -771,6 +802,69 @@ defmodule Vutuv.Activity do
       |> Map.put(:post_id, post_id)
     end)
   end
+
+  # Replies written on other networks under the member's posts (issue #1069),
+  # derived **straight from the notes table** rather than from a stored
+  # notification row. That is deliberate: when the note goes — reported,
+  # expired, withdrawn upstream, the server blocked — its notification goes with
+  # it, and there is no second place that has to remember to forget.
+  #
+  # No viewer scoping is needed here: every note under the member's own posts is
+  # theirs to see, including the ones addressed to them alone (issue #1071).
+  defp fediverse_reply_items(user_id, limit, cursor) do
+    user_id
+    |> fediverse_reply_events()
+    |> order_by([note: n], desc: n.received_at, desc: n.id)
+    |> limit(^limit)
+    |> select([note: n], n)
+    |> note_at_or_before(cursor)
+    |> Repo.all()
+    |> Enum.map(fn note ->
+      note
+      |> remote_actor_fields()
+      |> Map.merge(%{
+        id: "fediverse_reply-#{note.id}",
+        kind: "fediverse_reply",
+        # The merged feed sorts and cursors on NaiveDateTime (Vutuv.FeedPage);
+        # this is the one source whose column is a DateTime.
+        at: DateTime.to_naive(note.received_at),
+        post_id: note.post_id,
+        note_id: note.id,
+        note_audience: note.audience,
+        note_text: note.summary || note.content_text
+      })
+    end)
+  end
+
+  defp fediverse_reply_events(user_id) do
+    from(n in Note,
+      as: :note,
+      join: p in Post,
+      on: p.id == n.post_id,
+      where: p.user_id == ^user_id
+    )
+  end
+
+  defp count_fediverse_replies(user_id, read_at) do
+    user_id
+    |> fediverse_reply_events()
+    |> select([note: n], %{count: count()})
+    |> note_since(read_at)
+  end
+
+  # `received_at` is a :utc_datetime while the feed's cursor and the read marker
+  # are NaiveDateTimes, so both boundaries are converted rather than left to an
+  # implicit cast.
+  defp note_at_or_before(query, nil), do: query
+
+  defp note_at_or_before(query, %{at: at}),
+    do: where(query, [note: n], n.received_at <= ^to_utc(at))
+
+  defp note_since(query, nil), do: query
+  defp note_since(query, read_at), do: where(query, [note: n], n.received_at > ^to_utc(read_at))
+
+  defp to_utc(%NaiveDateTime{} = at), do: DateTime.from_naive!(at, "Etc/UTC")
+  defp to_utc(%DateTime{} = at), do: at
 
   # The base scope behind the "mention" kind, shared by items / count / read
   # marker. The write side already excludes self-mentions and posts the member
@@ -1087,6 +1181,27 @@ defmodule Vutuv.Activity do
 
   defp actor_item(id, kind, at, actor) do
     Map.merge(actor_fields(actor), %{id: id, kind: kind, at: at})
+  end
+
+  # The actor half for somebody on **another** network (issue #1069). They have
+  # no vutuv profile, so the three local fields are deliberately nil — the row
+  # then renders the kind glyph instead of an avatar and does not link into a
+  # profile that does not exist — and two remote-only fields carry what a reader
+  # actually needs: the `@handle@host` that names which network answered, and
+  # the account URL to follow out to.
+  #
+  # `actor_url` also gives the grouping a stable identity: without it two
+  # different strangers who share a display name would fold into one row
+  # (`VutuvWeb.NotificationLive.Groups.actor_key/1`).
+  defp remote_actor_fields(%Note{} = note) do
+    %{
+      actor_id: nil,
+      actor_name: note.display_name || Note.display_handle(note),
+      actor_param: nil,
+      actor_avatar: nil,
+      actor_handle: Note.display_handle(note),
+      actor_url: note.actor_uri
+    }
   end
 
   # The actor fields (id / name / route param / avatar) that the live `notify_*`

--- a/lib/vutuv/application.ex
+++ b/lib/vutuv/application.ex
@@ -80,6 +80,7 @@ defmodule Vutuv.Application do
         optional_child(:webhook_deliverer, Vutuv.Webhooks.Deliverer) ++
         optional_child(:fediverse_deliverer, Vutuv.Fediverse.Deliverer) ++
         optional_child(:fediverse_follower_pruning, Vutuv.Fediverse.FollowerPruner) ++
+        optional_child(:fediverse_note_sweeping, Vutuv.Fediverse.NoteSweeper) ++
         optional_child(:post_screenshot_worker, Vutuv.Posts.ScreenshotWorker) ++
         optional_child(:image_scan_worker, Vutuv.Moderation.ImageScanWorker) ++
         optional_child(:daily_report_email, Vutuv.Reports.DailyReporter) ++

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -31,6 +31,7 @@ defmodule Vutuv.Fediverse do
   require Logger
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Activity
   alias Vutuv.Fediverse.Actor
   alias Vutuv.Fediverse.BlockedInstance
   alias Vutuv.Fediverse.Deliverer
@@ -39,11 +40,14 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.FollowerPrune
   alias Vutuv.Fediverse.HttpSignature
   alias Vutuv.Fediverse.Keys
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.NoteEvent
   alias Vutuv.Fediverse.Reaction
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostDenial
   alias Vutuv.RateLimiter
+  alias Vutuv.RemoteHtml
   alias Vutuv.Repo
   alias Vutuv.SocialFeed.Http
   alias Vutuv.UUIDv7
@@ -51,6 +55,27 @@ defmodule Vutuv.Fediverse do
 
   @max_attempts 8
   @max_body_bytes 500_000
+
+  # Inbound replies (issues #1069 and #1071). Six months is the hard ceiling a
+  # confirmed-live note pushes forward and nothing else does; a week is how
+  # stale a copy may get before its origin is asked again. Both are
+  # per-installation knobs (see `note_retention_days/0`), because "how long may
+  # we hold a stranger's words" is a call an operator has to be able to make.
+  @note_retention_days 183
+  @note_refresh_days 7
+  # How many remote replies one member may report per day. Deleting a cached
+  # copy is cheap and reversible only for its author, so the lever stays open —
+  # but not unlimited, or wiping every answer under somebody's post is free.
+  @note_report_limit 20
+
+  # Every spelling of the public collection that servers use in the wild. A note
+  # is public if one of these is addressed, and private otherwise — including
+  # when we cannot tell.
+  @public_collections [
+    "https://www.w3.org/ns/activitystreams#Public",
+    "as:Public",
+    "Public"
+  ]
 
   @doc "The installation-wide switch (FEDIVERSE_ENABLED; off = no endpoints, no deliveries)."
   def enabled?, do: Application.get_env(:vutuv, :fediverse_enabled, true)
@@ -472,17 +497,23 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc """
-  Deletes everything stored from `host`: its remote followers, and the outbound
-  deliveries still queued for it. Returns `%{followers: n, deliveries: n}`.
+  Deletes everything stored from `host`: its remote followers, the replies its
+  members wrote under vutuv posts, and the outbound deliveries still queued for
+  it. Returns `%{followers: n, notes: n, deliveries: n}`.
   """
   def purge_instance(host) when is_binary(host) do
     {followers, _} =
       Repo.delete_all(from(f in Follower, where: uri_host(f.actor_uri) == ^host))
 
+    # A block is also a takedown: text that server's members wrote under our
+    # members' posts goes with it (issue #1069), not just the follow rows.
+    {notes, _} =
+      Repo.delete_all(from(n in Note, where: uri_host(n.actor_uri) == ^host))
+
     {deliveries, _} =
       Repo.delete_all(from(d in Delivery, where: uri_host(d.inbox_uri) == ^host))
 
-    %{followers: followers, deliveries: deliveries}
+    %{followers: followers, notes: notes, deliveries: deliveries}
   end
 
   @doc """
@@ -640,6 +671,515 @@ defmodule Vutuv.Fediverse do
   defp activity_object_id(%{"id" => id}) when is_binary(id), do: id
   defp activity_object_id(id) when is_binary(id), do: id
   defp activity_object_id(_), do: nil
+
+  ## Inbound replies (issues #1069 and #1071)
+
+  @doc "How long a stored remote reply may live at the very most (days)."
+  def note_retention_days,
+    do: Application.get_env(:vutuv, :fediverse_note_retention_days, @note_retention_days)
+
+  @doc "How stale a stored reply may get before its origin is asked again (days)."
+  def note_refresh_days,
+    do: Application.get_env(:vutuv, :fediverse_note_refresh_days, @note_refresh_days)
+
+  @doc "How many remote replies one member may report per day."
+  def report_limit, do: @note_report_limit
+
+  @doc """
+  Stores a reply somebody on another network wrote under a member's post
+  (issues #1069 and #1071). `actor` is the fetched remote actor as
+  `%{uri:, handle:, name:}`.
+
+  This is the first time vutuv keeps a stranger's *words*, so every gate that
+  must hold sits here, in order: the installation switch, the member federates,
+  the member switched replies on (`users.fediverse_replies?`, off by default and
+  deliberately separate from the reaction counts), the activity really carries a
+  Note, that Note answers one of *their own* posts, the post is public, the
+  sending server is within its inbound cap, and there is text left once the
+  markup is gone. Anything else is `:skip` — the inbox answers the same 202
+  either way, so a misdirected activity never learns which gate it failed.
+
+  The note is stored as **plain text** (`Vutuv.RemoteHtml`), never HTML, and
+  without any copy of the author's picture: the card renders initials and links
+  to the origin.
+
+  A redelivery of a note we already hold is a no-op; an author's edit arrives as
+  an `Update` and goes through `update_reply/3`.
+  """
+  def record_reply(%User{} = user, activity, actor) do
+    with true <- enabled?(),
+         true <- federated?(user),
+         true <- user.fediverse_replies?,
+         %{} = object <- note_object(activity["object"]),
+         %Post{} = post <- resolve_own_note(user, object["inReplyTo"]),
+         false <- Posts.restricted?(post),
+         :ok <- check_inbound_cap(actor.uri),
+         {:ok, note} <- insert_note(user, post, activity, object, actor) do
+      Posts.broadcast_post_counters(post.id)
+      Activity.notify_fediverse_reply(user, post, note)
+      :ok
+    else
+      _ -> :skip
+    end
+  end
+
+  @doc """
+  Applies an author's edit of a reply they already sent (`Update(Note)`).
+
+  Scoped to the actor that wrote it, so one server cannot rewrite another's
+  words, and it re-reads the audience: an author who narrows a public reply to
+  their followers has said "stop showing this", and that has to take effect.
+  """
+  def update_reply(%User{} = user, activity, actor_uri) when is_binary(actor_uri) do
+    with %{} = object <- note_object(activity["object"]),
+         uri when is_binary(uri) <- object["id"],
+         %Note{} = note <- Repo.get_by(Note, object_uri: uri, actor_uri: actor_uri),
+         text when text != "" <- remote_text(object["content"], Note.max_content()) do
+      note
+      |> Note.changeset(%{
+        content_text: text,
+        summary: remote_text(object["summary"], Note.max_summary()),
+        audience: audience(user, activity, object),
+        checked_at: DateTime.utc_now(:second)
+      })
+      |> Repo.update()
+
+      Posts.broadcast_post_counters(note.post_id)
+    end
+
+    :ok
+  end
+
+  def update_reply(_user, _activity, _actor_uri), do: :ok
+
+  @doc """
+  Honours an upstream `Delete` of a reply.
+
+  Deliberately **un**gated, like `remove_reaction/4`: an author withdrawing their
+  words is the deletion path that makes storing them defensible in the first
+  place, so it must not depend on any switch still being on. Scoped to the actor
+  that wrote the note, so one server cannot delete another's.
+  """
+  def delete_reply(actor_uri, object_uri)
+      when is_binary(actor_uri) and is_binary(object_uri) do
+    post_ids =
+      Repo.all(
+        from(n in Note,
+          where: n.object_uri == ^object_uri and n.actor_uri == ^actor_uri,
+          select: n.post_id
+        )
+      )
+
+    if post_ids != [] do
+      Repo.delete_all(from(n in Note, where: n.object_uri == ^object_uri))
+      Enum.each(post_ids, &Posts.broadcast_post_counters/1)
+    end
+
+    :ok
+  end
+
+  def delete_reply(_actor_uri, _object_uri), do: :ok
+
+  @doc """
+  The stored replies for `post_ids`, grouped by post id, oldest first — what the
+  thread renderer interleaves among the vutuv replies.
+
+  **Viewer-scoped** (issue #1071): a public reply is for everyone, anything else
+  only ever reaches the member whose post it answers, signed in. This is the one
+  read the pages use, so the visibility rule cannot be forgotten at a call site.
+  """
+  def list_notes(post_ids, viewer) do
+    from(n in Note,
+      join: p in Post,
+      on: p.id == n.post_id,
+      where: n.post_id in ^post_ids,
+      where: n.audience == "public" or p.user_id == ^note_viewer_id(viewer),
+      order_by: [asc: n.received_at, asc: n.id]
+    )
+    |> Repo.all()
+    |> Enum.group_by(& &1.post_id)
+  end
+
+  @doc """
+  How many replies from other networks a post carries **publicly**.
+
+  Public notes only, on purpose: a reply addressed to the member alone must not
+  move a figure anybody else can read, or the count itself leaks that a private
+  message exists.
+  """
+  def note_count(post_id) do
+    Repo.aggregate(
+      from(n in Note, where: n.post_id == ^post_id and n.audience == "public"),
+      :count
+    )
+  end
+
+  @doc "One stored reply, or nil."
+  def get_note(id), do: UUIDv7.with_cast(id, &Repo.get(Note, &1))
+
+  @doc """
+  The member takes a reply off their own post. Deletes it at once and records
+  the takedown in `Vutuv.Fediverse.NoteEvent`.
+  """
+  def remove_note(note_id, %User{} = actor),
+    do: take_down_note(note_id, actor, "removed_by_member", &note_owner?/3)
+
+  @doc """
+  Somebody marks a reply as not appropriate. **Deletes it immediately** — there
+  is no case workflow and no freezer, because unlike a member's own post this is
+  a cache of something that still exists at its origin, so removing it costs the
+  author nothing they did not keep.
+
+  Rate limited per reporter (`report_limit/0` a day), so quietly wiping every
+  answer under somebody's post is not free. A private reply can only be reported
+  by the member it was addressed to, since nobody else may even see it.
+  """
+  def report_note(note_id, %User{} = reporter) do
+    case RateLimiter.hit(
+           {:fediverse_note_report, reporter.id},
+           @note_report_limit,
+           :timer.hours(24)
+         ) do
+      :ok -> take_down_note(note_id, reporter, "reported", &note_visible?/3)
+      _ -> {:error, :rate_limited}
+    end
+  end
+
+  @doc """
+  Drops every remote reply stored under a member's posts — what switching the
+  replies off means. Nothing is kept "just in case": the switch is the member's
+  deletion lever over third-party data they never asked for.
+  """
+  def drop_notes(%User{id: user_id}) do
+    {count, _} =
+      Repo.delete_all(
+        from(n in Note,
+          where:
+            n.post_id in subquery(from(p in Post, where: p.user_id == ^user_id, select: p.id))
+        )
+      )
+
+    count
+  end
+
+  @doc """
+  Deletes every stored reply past its ceiling — the floor under everything else,
+  so a copy nobody looked at and no server told us about still goes.
+  """
+  def expire_due_notes(now \\ nil) do
+    now = now || DateTime.utc_now(:second)
+    {count, _} = Repo.delete_all(from(n in Note, where: n.expires_at <= ^now))
+    count
+  end
+
+  @doc """
+  Which of `notes` should have their origin asked again — the lazy on-view
+  freshness check (issue #1069).
+
+  **Public notes only.** A reply addressed to the member alone answers `403` or
+  `404` to any fetch we can make, which `refresh_note/1` would read as "deleted
+  upstream" and act on, quietly destroying every private reply about a week
+  after it arrived; and asking would tell the origin server that we are sitting
+  on their member's private message, and how often we look at it. Those are
+  governed by the ceiling and an upstream `Delete` alone.
+  """
+  def due_for_refresh(notes) do
+    cutoff = DateTime.add(DateTime.utc_now(:second), -note_refresh_days() * 86_400)
+
+    Enum.filter(notes, fn note ->
+      Note.public?(note) and
+        (is_nil(note.checked_at) or DateTime.compare(note.checked_at, cutoff) == :lt)
+    end)
+  end
+
+  @doc """
+  Asks a note's origin whether it is still published there, and acts on the
+  answer. The half of retention that deletes *earlier* than the ceiling, and the
+  half that keeps the word "cache" honest.
+
+  `200` and still public refreshes the text and pushes the ceiling out (a copy
+  confirmed live last week has a far better claim to being necessary than one
+  that is merely young). `404`, `410` and `403` delete at once — gone, or the
+  author locked their account, which is equally a "stop showing this" signal we
+  would otherwise never see. **Anything else changes nothing**, so a server that
+  stays offline cannot buy indefinite retention and a three-week outage cannot
+  trigger a mass delete.
+  """
+  def refresh_note(%Note{} = note) do
+    with true <- enabled?(),
+         true <- Note.public?(note),
+         %Post{} = post <- Repo.get(Post, note.post_id),
+         %User{} = author <- Repo.get(User, post.user_id) do
+      apply_refresh(note, fetch_remote_note(note.object_uri, signer(author)))
+    else
+      _ -> :skip
+    end
+  end
+
+  @doc """
+  Runs `refresh_note/1` for every due note in the background, so a page render
+  never waits on a stranger's server. Returns immediately.
+
+  Off in tests (`:fediverse_note_refresh`), like every other background job that
+  talks to the network: the task runs outside the SQL sandbox's ownership, so it
+  would crash there — silently, since a Task's crash is only logged. Tests call
+  `refresh_note/1` directly with a stubbed HTTP layer instead.
+  """
+  def refresh_async(notes) do
+    with true <- Application.get_env(:vutuv, :fediverse_note_refresh, true),
+         [_ | _] = due <- due_for_refresh(notes) do
+      Task.Supervisor.start_child(Vutuv.TaskSupervisor, fn ->
+        Enum.each(due, &refresh_note/1)
+      end)
+    end
+
+    :ok
+  end
+
+  @doc """
+  What each remote server has stored here as replies, biggest first — the other
+  half of the operator's `/admin/fediverse` picture beside `inbound_hosts/1`.
+  """
+  def note_hosts(limit \\ 20) do
+    Repo.all(
+      from(n in Note,
+        group_by: uri_host(n.actor_uri),
+        order_by: [desc: count(n.id)],
+        limit: ^limit,
+        select: %{host: uri_host(n.actor_uri), notes: count(n.id)}
+      )
+    )
+  end
+
+  @doc """
+  The most recent member takedowns of remote replies, newest first — the log an
+  operator reads before deciding whether one troll or a whole server is the
+  problem. Carries no content and no URIs by construction (see
+  `Vutuv.Fediverse.NoteEvent`).
+  """
+  def recent_note_events(limit \\ 25) do
+    Repo.all(from(e in NoteEvent, order_by: [desc: e.id], limit: ^limit))
+  end
+
+  @doc "How many remote replies are stored across the installation."
+  def note_total, do: Repo.aggregate(Note, :count)
+
+  # An activity delivers what it claims, or it is dropped: a Create whose object
+  # is a bare id is not worth an outbound request to a stranger's server.
+  defp note_object(%{"type" => "Note"} = object), do: object
+  defp note_object(_), do: nil
+
+  defp insert_note(user, post, activity, object, actor) do
+    uri = object["id"]
+    text = remote_text(object["content"], Note.max_content())
+    received = DateTime.utc_now(:second)
+
+    cond do
+      not is_binary(uri) or uri == "" ->
+        :error
+
+      # Nothing left once the markup is gone (a picture-only or empty note): a
+      # row about a third party has to earn its place.
+      text in [nil, ""] ->
+        :error
+
+      Repo.exists?(from(n in Note, where: n.object_uri == ^uri)) ->
+        :error
+
+      true ->
+        %Note{post_id: post.id}
+        |> Note.changeset(%{
+          object_uri: uri,
+          actor_uri: actor.uri,
+          origin_url: presence(object["url"]),
+          in_reply_to_uri: object["inReplyTo"],
+          handle: actor.handle,
+          display_name: actor.name,
+          content_text: text,
+          summary: remote_text(object["summary"], Note.max_summary()),
+          audience: audience(user, activity, object),
+          received_at: received,
+          # It was demonstrably published the moment it was delivered, so the
+          # delivery is the first freshness confirmation.
+          checked_at: received,
+          expires_at: DateTime.add(received, note_retention_days() * 86_400)
+        })
+        |> Repo.insert()
+    end
+  end
+
+  # How the note was addressed, read from `to`/`cc` on **both** the Create and
+  # the Note (servers put the audience on either). Only the public collection
+  # makes it public; everything else, including anything we cannot read, renders
+  # to the addressed member alone. Never widen the sender's audience.
+  defp audience(user, activity, object) do
+    addressed =
+      [object["to"], object["cc"], activity["to"], activity["cc"]]
+      |> Enum.flat_map(&normalize_uri_list/1)
+
+    cond do
+      Enum.any?(addressed, &(&1 in @public_collections)) -> "public"
+      Enum.any?(addressed, &String.ends_with?(&1, "/followers")) -> "followers"
+      Docs.actor_url(user) in addressed -> "direct"
+      true -> "unknown"
+    end
+  end
+
+  defp remote_text(nil, _max), do: nil
+
+  defp remote_text(html, max) when is_binary(html), do: presence(RemoteHtml.to_text(html, max))
+
+  defp remote_text(_html, _max), do: nil
+
+  defp presence(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp presence(_), do: nil
+
+  # The nil UUID can never match a row: "not the author" without a NULL arm,
+  # the same trick `Vutuv.Posts.engagement_viewer_id/1` uses.
+  defp note_viewer_id(%User{id: id}), do: id
+  defp note_viewer_id(id) when is_binary(id), do: id
+  defp note_viewer_id(_), do: "00000000-0000-0000-0000-000000000000"
+
+  # Only the member whose post it sits under (or an admin) may remove a reply.
+  defp note_owner?(_note, author_id, %User{} = actor),
+    do: actor.id == author_id or actor.admin? == true
+
+  # Anyone who can see it may report it, which for a private reply is its
+  # addressee alone.
+  defp note_visible?(note, author_id, %User{} = actor),
+    do: Note.public?(note) or note_owner?(note, author_id, actor)
+
+  defp take_down_note(note_id, %User{} = actor, action, authorized?) do
+    query =
+      from(n in Note,
+        join: p in Post,
+        on: p.id == n.post_id,
+        where: n.id == ^to_string(note_id),
+        select: {n, p.user_id}
+      )
+
+    case UUIDv7.with_cast(note_id, fn _ -> Repo.one(query) end) do
+      {%Note{} = note, author_id} ->
+        if authorized?.(note, author_id, actor) do
+          Repo.delete(note)
+          log_note_event(note, author_id, actor, action)
+          Posts.broadcast_post_counters(note.post_id)
+          :ok
+        else
+          {:error, :not_allowed}
+        end
+
+      _ ->
+        {:error, :not_found}
+    end
+  end
+
+  defp log_note_event(%Note{} = note, author_id, %User{} = actor, action) do
+    Repo.insert!(%NoteEvent{
+      action: action,
+      host: Note.host(note.actor_uri) || "unknown",
+      actor_digest: note_actor_digest(note.actor_uri),
+      audience: note.audience,
+      user_id: author_id,
+      actor_id: actor.id
+    })
+  end
+
+  # A keyed HMAC, not a bare hash: it groups a repeat offender across takedowns
+  # without keeping an online identifier of somebody whose words we just
+  # deleted, and a DB or backup leak alone cannot turn it back into the actor
+  # URI. Same pepper construction as the invitation and login-PIN hashes.
+  defp note_actor_digest(actor_uri) do
+    :hmac
+    |> :crypto.mac(:sha256, note_actor_pepper(), actor_uri)
+    |> Base.encode16(case: :lower)
+  end
+
+  defp note_actor_pepper do
+    secret = Application.fetch_env!(:vutuv, VutuvWeb.Endpoint)[:secret_key_base]
+    :crypto.hash(:sha256, "vutuv/fediverse_note_actor/pepper/v1" <> secret)
+  end
+
+  defp apply_refresh(%Note{} = note, {:ok, doc}) do
+    text = remote_text(doc["content"], Note.max_content())
+    still_public? = doc_public?(doc)
+
+    cond do
+      # The author narrowed the audience: the same "stop showing this" signal a
+      # 403 carries, just visible to us.
+      not still_public? ->
+        delete_note_row(note)
+        :deleted
+
+      text in [nil, ""] ->
+        delete_note_row(note)
+        :deleted
+
+      true ->
+        now = DateTime.utc_now(:second)
+
+        note
+        |> Note.changeset(%{
+          content_text: text,
+          summary: remote_text(doc["summary"], Note.max_summary()),
+          checked_at: now,
+          expires_at: DateTime.add(now, note_retention_days() * 86_400)
+        })
+        |> Repo.update()
+
+        :refreshed
+    end
+  end
+
+  defp apply_refresh(%Note{} = note, {:gone, status}) do
+    Logger.info("fediverse note #{note.id} gone upstream (#{status}), deleting")
+    delete_note_row(note)
+    :deleted
+  end
+
+  # Unreachable, a 5xx, a 429, a malformed body: not fresh, but not evidence of
+  # anything either. Nothing changes, so the ceiling still governs.
+  defp apply_refresh(%Note{}, _other), do: :unchanged
+
+  # By id, not by struct: `refresh_async/1` is fire-and-forget and undeduped, so
+  # two page renders can queue a check for the same note and both conclude it is
+  # gone. `Repo.delete/1` on the loser's stale struct raises
+  # `Ecto.StaleEntryError` — inside a Task, where it would only ever be logged.
+  # Deleting by id is simply a no-op the second time.
+  defp delete_note_row(%Note{} = note) do
+    Repo.delete_all(from(n in Note, where: n.id == ^note.id))
+    Posts.broadcast_post_counters(note.post_id)
+  end
+
+  # A refetched note counts as public only if it still addresses the public
+  # collection; anything else (including an answer we cannot parse) is a signal
+  # to stop showing it, never a reason to keep it.
+  defp doc_public?(doc) do
+    [doc["to"], doc["cc"]]
+    |> Enum.flat_map(&normalize_uri_list/1)
+    |> Enum.any?(&(&1 in @public_collections))
+  end
+
+  # The same https-only, SSRF-guarded, size-capped, signed GET
+  # `fetch_remote_actor/2` uses — pointed at a note instead of an actor.
+  defp fetch_remote_note(uri, signer) do
+    with {:parse, %URI{scheme: "https", host: host}} <- {:parse, URI.parse(uri)},
+         {:ssrf, false} <- {:ssrf, Vutuv.Ssrf.resolves_to_internal?(host)},
+         {:ok, %Req.Response{status: 200, body: body}} <- ap_get(uri, signer),
+         {:size, true} <- {:size, byte_size(body) <= @max_body_bytes},
+         {:ok, %{} = doc} <- Jason.decode(body) do
+      {:ok, doc}
+    else
+      {:ok, %Req.Response{status: status}} when status in [403, 404, 410] -> {:gone, status}
+      other -> {:error, other}
+    end
+  end
 
   ## Account migration — move out (issue #986, half 2)
 

--- a/lib/vutuv/fediverse/note.ex
+++ b/lib/vutuv/fediverse/note.ex
@@ -1,0 +1,149 @@
+defmodule Vutuv.Fediverse.Note do
+  @moduledoc """
+  One reply written on another network under a member's post (issues #1069 and
+  #1071).
+
+  This is the first content vutuv stores that its own members did not write, so
+  every field here is either something the member needs in order to read the
+  answer, or something the deletion path needs in order to work:
+
+    * `object_uri` — the note's own AP id. Unique: a redelivery upserts, and an
+      upstream `Update`/`Delete` finds its row on this key.
+    * `actor_uri`, `handle`, `display_name` — who said it, in the form the card
+      shows (`@handle@host`) and links out to. Cosmetic and hostile, so capped.
+    * `content_text` — **plain text, never HTML.** Reduced by
+      `Vutuv.RemoteHtml.to_text/2` at the inbox, so nothing a stranger wrote is
+      ever rendered `raw`, the agent-format siblings get the value for free and
+      the cap is well defined in characters.
+    * `audience` — how it was addressed. Only `"public"` is public; the other
+      three render to the addressed member alone (issue #1071).
+    * `received_at` / `checked_at` / `expires_at` — the retention triple.
+
+  There is no avatar column and there never will be: the card renders initials
+  and links to the origin, so vutuv does not host a third party's picture.
+  """
+
+  use VutuvWeb, :model
+
+  @audiences ~w(public followers direct unknown)
+
+  # Remote URIs are unbounded in theory. Cap them in **bytes**, because
+  # `object_uri` is part of a btree unique index whose key has a hard size
+  # limit — a hostile multi-kilobyte id must fail the changeset, never the index
+  # insert (which would be a 500 out of the inbox).
+  @max_uri_bytes 2_048
+
+  # Long enough for any real post on those networks (Mastodon's own ceiling is
+  # 500 characters, some servers raise it), short enough that a hostile server
+  # cannot park a novel per delivery.
+  @max_content 10_000
+
+  # A content warning is a headline, not a second post.
+  @max_summary 500
+
+  @doc "The audience values a delivered note is classified into."
+  def audiences, do: @audiences
+
+  @doc "The longest remote text a note may carry."
+  def max_content, do: @max_content
+
+  @doc "The longest content warning a note may carry."
+  def max_summary, do: @max_summary
+
+  @doc """
+  Whether the note's author put it behind a content warning. The card then
+  renders the warning as the closed lid and reveals the text on a click, which
+  is the one thing that author asked for.
+  """
+  def warned?(%__MODULE__{summary: summary}), do: is_binary(summary) and summary != ""
+
+  schema "fediverse_notes" do
+    field(:object_uri, :string)
+    field(:actor_uri, :string)
+    field(:origin_url, :string)
+    field(:in_reply_to_uri, :string)
+    field(:handle, :string)
+    field(:display_name, :string)
+    field(:content_text, :string)
+    field(:summary, :string)
+    field(:audience, :string)
+    field(:received_at, :utc_datetime)
+    field(:checked_at, :utc_datetime)
+    field(:expires_at, :utc_datetime)
+
+    belongs_to(:post, Vutuv.Posts.Post)
+  end
+
+  @doc """
+  Whether everyone may see this note, or only the member it was addressed to.
+
+  The single gate the thread renderer, the count line, the agent-format doc
+  builder and the freshness check all read, so they cannot drift apart. Anything
+  we could not classify counts as private: never widen the sender's audience.
+  """
+  def public?(%__MODULE__{audience: "public"}), do: true
+  def public?(%__MODULE__{}), do: false
+
+  @doc """
+  How the card names the author: `@handle@host`, the form every one of these
+  networks uses. Falls back to the bare host when the remote document carried no
+  `preferredUsername`.
+  """
+  def display_handle(%__MODULE__{handle: handle, actor_uri: actor_uri}) do
+    case {handle, host(actor_uri)} do
+      {_, nil} -> handle
+      {nil, host} -> "@#{host}"
+      {handle, host} -> "@#{handle}@#{host}"
+    end
+  end
+
+  @doc "The server this note came from, for the card's footer and the ledger."
+  def host(uri) when is_binary(uri) do
+    case URI.parse(uri) do
+      %URI{host: host} when is_binary(host) and host != "" -> host
+      _ -> nil
+    end
+  end
+
+  def host(_), do: nil
+
+  @doc "Where a human reads the original: the note's own page, or its id."
+  def origin(%__MODULE__{origin_url: url}) when is_binary(url) and url != "", do: url
+  def origin(%__MODULE__{object_uri: uri}), do: uri
+
+  def changeset(%__MODULE__{} = note, attrs) do
+    note
+    |> cast(attrs, [
+      :object_uri,
+      :actor_uri,
+      :origin_url,
+      :in_reply_to_uri,
+      :handle,
+      :display_name,
+      :content_text,
+      :summary,
+      :audience,
+      :received_at,
+      :checked_at,
+      :expires_at
+    ])
+    |> validate_required([
+      :object_uri,
+      :actor_uri,
+      :content_text,
+      :audience,
+      :received_at,
+      :expires_at
+    ])
+    |> validate_inclusion(:audience, @audiences)
+    |> validate_length(:object_uri, max: @max_uri_bytes, count: :bytes)
+    |> validate_length(:actor_uri, max: @max_uri_bytes, count: :bytes)
+    |> validate_length(:origin_url, max: @max_uri_bytes, count: :bytes)
+    |> validate_length(:in_reply_to_uri, max: @max_uri_bytes, count: :bytes)
+    |> validate_length(:handle, max: 255)
+    |> validate_length(:display_name, max: 255)
+    |> validate_length(:content_text, max: @max_content)
+    |> validate_length(:summary, max: @max_summary)
+    |> unique_constraint(:object_uri)
+  end
+end

--- a/lib/vutuv/fediverse/note_event.ex
+++ b/lib/vutuv/fediverse/note_event.ex
@@ -1,0 +1,49 @@
+defmodule Vutuv.Fediverse.NoteEvent do
+  @moduledoc """
+  One remote reply taken down by a member (issue #1069): they removed it from
+  their own post, or reported it as not appropriate — which deletes it at once,
+  with no case workflow, because the note is a cache of something that still
+  exists at its origin.
+
+  The row exists so the operator can answer one question: **is this one troll,
+  or is this server the problem?** That is the decision the blocklist at
+  `/admin/fediverse` acts on, and it needs the host, a way to tell repeat actors
+  apart, and a count over time. Nothing else.
+
+  So, following the precedent `Vutuv.Fediverse.FollowerPrune` set in #1072, this
+  keeps **no content and no URIs**. Retaining a stranger's words after deleting
+  their note would make the deletion we just promised untrue, and retaining their
+  actor URI would keep an online identifier of somebody whose words we removed.
+  `actor_digest` is a keyed HMAC of the actor URI (peppered from
+  `secret_key_base`, per the project rule that a bare hash of a guessable value
+  is not privacy), which groups repeat offenders without holding the identifier.
+
+  `user_id` (whose post it sat under) and `actor_id` (who acted) are plain
+  values, not associations, like the deliverability and admin-action ledgers:
+  an audit row must stay readable after the rows it references are gone. Rows
+  are written by `Vutuv.Fediverse` only, never built from user params.
+
+  Automatic deletions are deliberately **not** recorded here. An expiry sweep, a
+  server block or an upstream `Delete` can remove thousands of rows at once and
+  would drown the signal; those are reported in aggregate to the log, the way
+  `Vutuv.Fediverse.FollowerPruner` reports.
+  """
+
+  use VutuvWeb, :model
+
+  @actions ~w(reported removed_by_member)
+
+  @doc "The closed set of `action` values this ledger records."
+  def actions, do: @actions
+
+  schema "fediverse_note_events" do
+    field(:action, :string)
+    field(:host, :string)
+    field(:actor_digest, :string)
+    field(:audience, :string)
+    field(:user_id, :binary_id)
+    field(:actor_id, :binary_id)
+
+    timestamps(updated_at: false)
+  end
+end

--- a/lib/vutuv/fediverse/note_sweeper.ex
+++ b/lib/vutuv/fediverse/note_sweeper.ex
@@ -1,0 +1,62 @@
+defmodule Vutuv.Fediverse.NoteSweeper do
+  @moduledoc """
+  The hard ceiling under the stored replies from other networks (issue #1069).
+
+  Everything else that deletes a remote reply depends on somebody doing
+  something: the author withdrawing it, the member taking it down, a reader
+  reporting it, the operator blocking the server, or the on-view freshness check
+  noticing it is gone from its origin. Each of those can fail to happen — the
+  `Delete` never arrives because the server was down or we defederated, and a
+  copy nobody has opened in months is never checked at all.
+
+  So once an hour this deletes every note whose `expires_at` has passed, and
+  that is the promise the privacy page can actually make: six months from
+  arrival at the very latest, whatever else does or does not happen. A note
+  confirmed still published at its origin pushes that date forward
+  (`Vutuv.Fediverse.refresh_note/1`), so a reply people keep reading tracks its
+  original while an abandoned copy is collected.
+
+  Nothing is logged per row — an expiry run can remove thousands and would
+  drown the ledger, which exists for member takedowns. The count goes to the log
+  in aggregate, the way `Vutuv.Fediverse.FollowerPruner` reports.
+
+  Gated twice, like the pruner: the child starts only when
+  `:fediverse_note_sweeping` is on (off in tests, so it never touches the SQL
+  sandbox from outside), and it is a no-op while `:fediverse_enabled` is off.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Vutuv.Fediverse
+
+  @interval :timer.hours(1)
+
+  def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  @impl true
+  def init(:ok) do
+    schedule()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    try do
+      if Fediverse.enabled?() do
+        case Fediverse.expire_due_notes() do
+          0 -> :ok
+          count -> Logger.info("Fediverse note sweep: deleted #{count} expired remote reply(s)")
+        end
+      end
+    rescue
+      error -> Logger.error("Fediverse note sweep failed: #{inspect(error)}")
+    end
+
+    schedule()
+    {:noreply, state}
+  end
+
+  defp schedule, do: Process.send_after(self(), :sweep, @interval)
+end

--- a/lib/vutuv/mastodon.ex
+++ b/lib/vutuv/mastodon.ex
@@ -185,31 +185,11 @@ defmodule Vutuv.Mastodon do
 
   @doc """
   Reduces a status' HTML `content` (untrusted, server-rendered by a federated
-  instance) to plain text: `<br>`/`</p>` become line breaks, every tag is
-  stripped, the base entities are decoded exactly once, and runaway posts are
-  capped. The result is plain text that the template interpolates (and HEEx
-  escapes again) — the sanitization chokepoint for everything Mastodon.
-  """
-  def text_content(html) when is_binary(html) do
-    html
-    |> String.replace(~r{<br\s*/?>}i, "\n")
-    |> String.replace(~r{</p>}i, "\n\n")
-    |> HtmlSanitizeEx.strip_tags()
-    |> decode_entities()
-    |> String.trim()
-    |> Post.truncate()
-  end
+  instance) to plain text — the sanitization chokepoint for everything Mastodon.
 
-  # strip_tags/1 returns text with the base named entities still escaped (the
-  # numeric ones it decodes itself); undo them exactly once. `&amp;` must come
-  # last so a literal "&amp;amp;" cannot double-unescape.
-  defp decode_entities(text) do
-    text
-    |> String.replace("&lt;", "<")
-    |> String.replace("&gt;", ">")
-    |> String.replace("&quot;", "\"")
-    |> String.replace("&#39;", "'")
-    |> String.replace("&nbsp;", " ")
-    |> String.replace("&amp;", "&")
-  end
+  The reduction itself lives in `Vutuv.RemoteHtml`, shared with the inbound
+  Fediverse replies (issue #1069), so remote HTML is turned into text exactly
+  one way in this codebase.
+  """
+  defdelegate text_content(html), to: Vutuv.RemoteHtml, as: :to_text
 end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -911,6 +911,15 @@ defmodule Vutuv.Posts do
           fragment(
             "(SELECT count(*) FROM fediverse_reactions fr WHERE fr.post_id = ?)",
             unquote(post).id
+          ),
+        # Replies written on other networks (issue #1069), on their own figure
+        # for the same reason. **Public ones only**: a reply addressed to the
+        # member alone (issue #1071) must not move a number anybody else can
+        # read, or the count itself would leak that a private message exists.
+        fediverse_replies:
+          fragment(
+            "(SELECT count(*) FROM fediverse_notes fn WHERE fn.post_id = ? AND fn.audience = 'public')",
+            unquote(post).id
           )
       }
     end
@@ -923,7 +932,14 @@ defmodule Vutuv.Posts do
       |> select([p], engagement_count_select(p))
 
     Repo.one(query) ||
-      %{likes: 0, bookmarks: 0, reposts: 0, replies: 0, fediverse_reactions: 0}
+      %{
+        likes: 0,
+        bookmarks: 0,
+        reposts: 0,
+        replies: 0,
+        fediverse_reactions: 0,
+        fediverse_replies: 0
+      }
   end
 
   @doc """

--- a/lib/vutuv/remote_html.ex
+++ b/lib/vutuv/remote_html.ex
@@ -1,0 +1,71 @@
+defmodule Vutuv.RemoteHtml do
+  @moduledoc """
+  The one place where HTML written by a *remote* server becomes something vutuv
+  is willing to store and show: plain text.
+
+  Two callers, one rule. `Vutuv.Mastodon` reduces the statuses of a member's own
+  linked account for their profile feed, and `Vutuv.Fediverse` reduces a reply
+  written on another network under a member's post (issue #1069). Both hold text
+  an attacker controls, and neither has any use for the remote markup, so the
+  answer to "how do we sanitise this safely" is to not keep HTML at all:
+
+    * `<script>` and `<style>` elements go **with their contents**,
+    * `<br>` and `</p>` become the line breaks that carried the meaning,
+    * every remaining tag is stripped (`HtmlSanitizeEx.strip_tags/1`), so there
+      is no allowlist to get wrong and nothing to render `raw`,
+    * the base entities are decoded exactly **once**, and
+    * the result is clamped, so one hostile delivery cannot park a novel.
+
+  The script/style pass matters because `strip_tags/1` removes the *tags* and
+  keeps the *text between them*: without it `<script>alert(1)</script>Hallo`
+  reduces to the literal `alert(1)Hallo`. That was never an execution risk (the
+  output is escaped again on the way to the page), but it let a remote server
+  push arbitrary invisible text into a member's profile feed, and it would have
+  put the same junk into a stored reply.
+
+  What comes out is plain text that HEEx escapes again on the way to the page,
+  and that the agent-format siblings can carry unchanged. Links survive as bare
+  URLs, which `VutuvWeb.Markdown` linkifies anyway — including the `@user@host`
+  handles of those networks, which it maps to the right remote profile.
+  """
+
+  alias Vutuv.SocialFeed.Post
+
+  @doc """
+  Reduces a remote server's HTML to clamped plain text, at most `max`
+  characters (the shared social-feed clamp by default).
+  """
+  def to_text(html, max \\ nil)
+
+  def to_text(html, max) when is_binary(html) do
+    html
+    |> String.replace(~r{<(script|style)\b[^>]*>.*?</\1\s*>}is, "")
+    # An element left open runs to the end of the document by definition, so
+    # there is nothing after it worth keeping either.
+    |> String.replace(~r{<(script|style)\b[^>]*>.*}is, "")
+    |> String.replace(~r{<br\s*/?>}i, "\n")
+    |> String.replace(~r{</p>}i, "\n\n")
+    |> HtmlSanitizeEx.strip_tags()
+    |> decode_entities()
+    |> String.trim()
+    |> clamp(max)
+  end
+
+  def to_text(_html, _max), do: ""
+
+  defp clamp(text, nil), do: Post.truncate(text)
+  defp clamp(text, max), do: Post.truncate(text, max)
+
+  # strip_tags/1 returns text with the base named entities still escaped (the
+  # numeric ones it decodes itself); undo them exactly once. `&amp;` must come
+  # last so a literal "&amp;amp;" cannot double-unescape.
+  defp decode_entities(text) do
+    text
+    |> String.replace("&lt;", "<")
+    |> String.replace("&gt;", ">")
+    |> String.replace("&quot;", "\"")
+    |> String.replace("&#39;", "'")
+    |> String.replace("&nbsp;", " ")
+    |> String.replace("&amp;", "&")
+  end
+end

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -113,7 +113,15 @@ defmodule VutuvWeb.AgentDocs.Markdown do
         "#{gettext("Conversation")} (#{length(doc.thread)})",
         doc.thread |> Enum.reject(&(&1.id == doc.id)) |> Enum.map(&thread_block/1)
       ),
-      if(doc.thread_truncated, do: gettext("Only part of this long conversation is shown."))
+      if(doc.thread_truncated, do: gettext("Only part of this long conversation is shown.")),
+      # Replies written on other networks (issue #1069), in their own section so
+      # a reader can tell which world answered — the same distinction the HTML
+      # card draws with its skin. Public ones only; a reply addressed to the
+      # member alone never leaves the page it was sent to (issue #1071).
+      section(
+        "#{gettext("Replies from other networks")} (#{length(doc.fediverse_replies)})",
+        Enum.map(doc.fediverse_replies, &remote_reply_block/1)
+      )
     ]
     |> join_blocks()
   end
@@ -857,6 +865,12 @@ defmodule VutuvWeb.AgentDocs.Markdown do
         vutuv_counts <>
           " · " <> gettext("Reactions from other networks") <> ": #{count}"
     end
+    |> then(fn line ->
+      case doc[:fediverse_reply_count] || 0 do
+        0 -> line
+        count -> line <> " · " <> gettext("Replies from other networks") <> ": #{count}"
+      end
+    end)
   end
 
   @doc """
@@ -943,6 +957,22 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       "#{heading} [#{md_text(entry.author)}](#{entry.url}) · #{entry.published_on}",
       reply_to,
       entry.body_markdown
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n\n")
+  end
+
+  # A reply from another network: who wrote it, where the authoritative original
+  # lives (ours is a cache and says so), and the plain text. Escaped as text
+  # rather than emitted as Markdown — it is a stranger's writing, and it must
+  # not be able to mint links in our document.
+  defp remote_reply_block(entry) do
+    [
+      "### #{md_text(entry.author)} (#{md_text(entry.handle)})",
+      entry.content_warning &&
+        "> " <> gettext("Content warning") <> ": " <> md_text(entry.content_warning),
+      md_text(entry.text),
+      "[#{gettext("View the original")}](#{entry.url})"
     ]
     |> Enum.reject(&is_nil/1)
     |> Enum.join("\n\n")

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -11,6 +11,8 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
 
   use Gettext, backend: VutuvWeb.Gettext
 
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Note
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
@@ -75,7 +77,15 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       bookmark_count: engagement.bookmarks,
       # Favourites and re-shares from OTHER networks (issue #1068), the same
       # separate figure the HTML shows on its own line under the vutuv counters.
-      fediverse_reaction_count: engagement.fediverse_reactions
+      fediverse_reaction_count: engagement.fediverse_reactions,
+      fediverse_reply_count: engagement.fediverse_replies,
+      # The replies written on other networks that the HTML thread weaves in
+      # (issue #1069). **Public ones only, on every path** — note the hardcoded
+      # `nil` viewer: `build/3` also serves the authenticated `/api/2.0` reads,
+      # and a reply addressed to the member alone (issue #1071) must not leave
+      # the page it was sent to, not through an API and not through a `.json`
+      # sibling. The member reads their private replies on the post itself.
+      fediverse_replies: [post.id] |> Fediverse.list_notes(nil) |> remote_entries(post.id)
     })
   end
 
@@ -159,6 +169,26 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     Enum.reduce(posts, %{}, fn post, depths ->
       parent_id = post.reply_ref && post.reply_ref.parent_post_id
       Map.put(depths, post.id, (parent_id && depths[parent_id] && depths[parent_id] + 1) || 0)
+    end)
+  end
+
+  # One reply from another network as a doc entry: who wrote it in the
+  # `@handle@host` form the HTML card shows, where the original lives, and the
+  # plain text. No avatar (there is none stored) and no actor URI beyond the
+  # public account link.
+  defp remote_entries(by_post, post_id) do
+    by_post
+    |> Map.get(post_id, [])
+    |> Enum.map(fn note ->
+      %{
+        handle: Note.display_handle(note),
+        author: note.display_name || Note.display_handle(note),
+        network: Note.host(note.actor_uri),
+        url: Note.origin(note),
+        received_at: note.received_at,
+        content_warning: note.summary,
+        text: note.content_text
+      }
     end)
   end
 

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -106,6 +106,13 @@ defmodule VutuvWeb.AgentDocs.Text do
         doc.thread |> Enum.reject(&(&1.id == doc.id)) |> Enum.map(&thread_lines/1)
       ),
       if(doc.thread_truncated, do: gettext("Only part of this long conversation is shown.")),
+      # Replies written on other networks (issue #1069), in their own section so
+      # a reader can tell which world answered. Public ones only; a reply
+      # addressed to the member alone stays on the page it was sent to (#1071).
+      section(
+        "#{gettext("Replies from other networks")} (#{length(doc.fediverse_replies)})",
+        Enum.map(doc.fediverse_replies, &remote_reply_lines/1)
+      ),
       footer(doc)
     ]
     |> join_blocks()
@@ -629,6 +636,19 @@ defmodule VutuvWeb.AgentDocs.Text do
     pad <>
       "* #{entry.author} · #{entry.published_on} · #{entry.url}\n" <>
       reply_to <> indent_block(entry.body_markdown, pad <> "  ")
+  end
+
+  # A reply from another network: who wrote it, where the authoritative original
+  # lives, and the plain text. Ours is a cache, so the origin URL rides along on
+  # every entry.
+  defp remote_reply_lines(entry) do
+    warning =
+      if entry.content_warning,
+        do: "  " <> gettext("Content warning") <> ": #{entry.content_warning}\n",
+        else: ""
+
+    "* #{entry.author} (#{entry.handle}) · #{entry.url}\n" <>
+      warning <> indent_block(entry.text, "  ")
   end
 
   defp indent_block(text, pad) do

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -27,6 +27,7 @@ defmodule VutuvWeb.PostComponents do
   import VutuvWeb.UserHelpers, only: [full_name: 1]
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse.Note
   alias Vutuv.Isbn
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Posts
@@ -677,19 +678,26 @@ defmodule VutuvWeb.PostComponents do
           aria-hidden="true"
         >
         </span>
-        <.post_card
-          post={node.post}
-          viewer={@viewer}
-          viewer_follow={node.viewer_follow}
-          engagement={node.engagement}
-          reposted_by={node.reposted_by}
-          reposters={node.reposters}
-          entry_id={node.entry_id}
-          surface={@surface}
-          conn_or_socket={@conn_or_socket}
-          mode={Map.get(node, :mode, :preview)}
-          show_reply_banner={reply_banner?(node, @connected?, @indent?, first?)}
-        />
+        <%!-- A node is either a vutuv post or a reply from another network
+        (issue #1069), which sits among them as an ordinary sibling in time
+        order and wears its own skin. --%>
+        <%= if Map.has_key?(node, :note) do %>
+          <.remote_reply_card note={node.note} owner?={node.owner?} viewer={@viewer} />
+        <% else %>
+          <.post_card
+            post={node.post}
+            viewer={@viewer}
+            viewer_follow={node.viewer_follow}
+            engagement={node.engagement}
+            reposted_by={node.reposted_by}
+            reposters={node.reposters}
+            entry_id={node.entry_id}
+            surface={@surface}
+            conn_or_socket={@conn_or_socket}
+            mode={Map.get(node, :mode, :preview)}
+            show_reply_banner={reply_banner?(node, @connected?, @indent?, first?)}
+          />
+        <% end %>
       </div>
       <.thread_chain
         :if={node.children != []}
@@ -701,6 +709,170 @@ defmodule VutuvWeb.PostComponents do
         conn_or_socket={@conn_or_socket}
       />
     </div>
+    """
+  end
+
+  @doc """
+  One reply written on **another network**, rendered as a sibling of the vutuv
+  replies in the same conversation (issues #1069 and #1071).
+
+  Same rhythm as a `<.post_card>` — avatar column, name, time, body, in the same
+  36px geometry so the thread's connector lines still land on the avatar centres
+  — and deliberately different material, because a reader has to be able to tell
+  the two worlds apart at a glance and without colour:
+
+    * an initials tile in **slate**, not the brand tint members get, carrying the
+      globe badge that issue #1068 established for "another network". No picture
+      is ever fetched or hosted: vutuv does not host a third party's image.
+    * a **dashed** left rail down the body, against the solid connector rail the
+      vutuv cards hang from.
+    * the author's name as plain text (there is no vutuv profile to link to)
+      beside their `@handle@host`, which links out to the account.
+    * **no action bar.** Liking, reposting or bookmarking a note that lives on
+      someone else's server is not a thing that exists, so the row is absent
+      rather than dead. What is there instead is where it came from, a link to
+      the original, and the takedown controls.
+
+  The body is escaped **plain text** (`Vutuv.RemoteHtml` reduced it at the
+  inbox), rendered with `whitespace-pre-line` and deliberately *not* run through
+  `VutuvWeb.Markdown`: a stranger's text must not be able to mint links, least
+  of all `@mention` links into local profiles. The "view the original" link
+  carries the reader on when they want the real thing.
+
+  A note its author put behind a content warning renders the warning as a closed
+  lid and reveals the text on a click, which is the one thing that author asked
+  for.
+
+  Rendered only inside `VutuvWeb.PostLive.Thread`, so the takedown controls are
+  plain `phx-click` events on that LiveView.
+  """
+  attr(:note, :map, required: true, doc: "a Vutuv.Fediverse.Note")
+
+  attr(:owner?, :boolean,
+    default: false,
+    doc: "whether the viewer is the member whose post this answers (they may remove it)"
+  )
+
+  attr(:viewer, :any, default: nil, doc: "the logged-in member, or nil")
+
+  def remote_reply_card(assigns) do
+    note = assigns.note
+
+    assigns =
+      assigns
+      |> assign(:author, note.display_name || Note.display_handle(note))
+      |> assign(:handle, Note.display_handle(note))
+      |> assign(:host, Note.host(note.actor_uri))
+      |> assign(:origin, Note.origin(note))
+      |> assign(:initials, name_initials(note.display_name || note.handle))
+      |> assign(:public?, Note.public?(note))
+      |> assign(:warned?, Note.warned?(note))
+
+    ~H"""
+    <article data-fediverse-reply={@note.id} data-audience={@note.audience}>
+      <div class="flex items-start gap-3">
+        <span class="relative shrink-0">
+          <span
+            data-remote-avatar
+            aria-hidden="true"
+            class="inline-flex h-9 w-9 select-none items-center justify-center rounded-full bg-slate-200 text-xs font-semibold text-slate-600 dark:bg-slate-700 dark:text-slate-300"
+          >
+            {@initials}
+          </span>
+          <span
+            aria-hidden="true"
+            title={gettext("From another network")}
+            class="absolute -bottom-1 -left-1 flex h-4 w-4 items-center justify-center rounded-full bg-white text-[9px] ring-2 ring-white dark:bg-slate-900 dark:ring-slate-900"
+          >
+            🌐
+          </span>
+        </span>
+
+        <div class="min-w-0 flex-1">
+          <div class="flex items-start gap-2">
+            <div class="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2">
+              <span class="font-semibold text-slate-900 dark:text-white">{@author}</span>
+              <span class="text-xs text-slate-600 dark:text-slate-400">
+                <a
+                  href={@note.actor_uri}
+                  target="_blank"
+                  rel="nofollow noopener noreferrer"
+                  class="hover:text-brand-700 dark:hover:text-brand-300"
+                >{@handle}</a>
+                · <.post_time at={@note.received_at} />
+              </span>
+            </div>
+
+            <%!-- The takedown controls. Report is open to anyone who can see the
+            reply (which for a private one is its addressee alone) and deletes it
+            at once — no case workflow, because this is a cache of something that
+            still exists at its origin. --%>
+            <.card_menu :if={@viewer} id={"remote-reply-menu-#{@note.id}"}>
+              <:item
+                :if={@owner?}
+                click="remove-remote-reply"
+                value={@note.id}
+                confirm={gettext("Remove this reply from your post?")}
+              >
+                {gettext("Remove")}
+              </:item>
+              <:item
+                click="report-remote-reply"
+                value={@note.id}
+                danger
+                confirm={
+                  gettext("Report this reply as not appropriate? It is deleted right away.")
+                }
+              >
+                {gettext("Report")}
+              </:item>
+            </.card_menu>
+          </div>
+
+          <%!-- A reply addressed to the member alone (issue #1071). The lock is
+          the same glyph a restricted post wears, so "not everybody sees this"
+          reads the same way across the app — and the member must know it before
+          they answer as if the world were watching. --%>
+          <p
+            :if={!@public?}
+            data-remote-private
+            class="mb-0 mt-0.5 text-xs font-medium text-slate-600 dark:text-slate-400"
+          >
+            <span aria-hidden="true">🔒</span> {gettext("Sent to you only, visible to nobody else")}
+          </p>
+
+          <div class="mt-1.5 border-l-2 border-dashed border-slate-300 pl-3 dark:border-slate-600">
+            <%= if @warned? do %>
+              <details data-remote-warning class="group">
+                <summary class="cursor-pointer list-none text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <span aria-hidden="true">⚠</span> {@note.summary}
+                  <span class="ml-1 text-xs font-normal text-brand-600 group-open:hidden dark:text-brand-400">
+                    {gettext("Show")}
+                  </span>
+                </summary>
+                <p class="mb-0 mt-1.5 whitespace-pre-line text-sm text-slate-700 dark:text-slate-300">
+                  {@note.content_text}
+                </p>
+              </details>
+            <% else %>
+              <p class="mb-0 whitespace-pre-line text-sm text-slate-700 dark:text-slate-300">
+                {@note.content_text}
+              </p>
+            <% end %>
+          </div>
+
+          <p class="mb-0 mt-1.5 text-xs text-slate-600 dark:text-slate-400">
+            {gettext("From another network")}<span :if={@host}> · {@host}</span> ·
+            <a
+              href={@origin}
+              target="_blank"
+              rel="nofollow noopener noreferrer"
+              class="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+            >{gettext("View the original")}</a>
+          </p>
+        </div>
+      </div>
+    </article>
     """
   end
 
@@ -758,6 +930,14 @@ defmodule VutuvWeb.PostComponents do
         "batched by the host so the cards' bars don't each load their own"
   )
 
+  attr(:remote_replies, :map,
+    default: %{},
+    doc:
+      "replies from other networks by the post id they answer " <>
+        "(Vutuv.Fediverse.list_notes/2, already viewer-scoped): woven in as " <>
+        "siblings of that post's own answers, in time order"
+  )
+
   attr(:conn_or_socket, :any, required: true)
 
   def thread_conversation(assigns) do
@@ -785,6 +965,7 @@ defmodule VutuvWeb.PostComponents do
   attr(:auto_scroll?, :boolean, default: true)
   attr(:viewer_follows, :map, default: %{})
   attr(:engagement, :map, default: %{})
+  attr(:remote_replies, :map, default: %{})
   attr(:conn_or_socket, :any, required: true)
 
   def thread_window_conversation(assigns) do
@@ -878,7 +1059,43 @@ defmodule VutuvWeb.PostComponents do
     end)
     |> Posts.thread_forest()
     |> banner_on_roots()
+    |> weave_remote_replies(assigns[:remote_replies] || %{}, assigns.viewer)
   end
+
+  # Hangs the replies written on other networks (issue #1069) under the posts
+  # they answer, merged into that post's own answers **in time order** rather
+  # than parked in a block below them. They are part of the conversation, so
+  # they read as part of it; what marks them out is the card, not a ghetto.
+  #
+  # `remote_replies` is `Vutuv.Fediverse.list_notes/2`'s per-post map, already
+  # viewer-scoped — a reply addressed to the member alone never reaches anybody
+  # else's render.
+  defp weave_remote_replies(nodes, remote, _viewer) when remote == %{}, do: nodes
+
+  defp weave_remote_replies(nodes, remote, viewer) do
+    Enum.map(nodes, fn node ->
+      children =
+        node.children
+        |> weave_remote_replies(remote, viewer)
+        |> merge_remote_nodes(Map.get(remote, node.post.id, []), node.post, viewer)
+
+      %{node | children: children}
+    end)
+  end
+
+  defp merge_remote_nodes(children, [], _post, _viewer), do: children
+
+  defp merge_remote_nodes(children, notes, post, viewer) do
+    owner? = match?(%User{}, viewer) and viewer.id == post.user_id
+
+    remote_nodes =
+      Enum.map(notes, &%{note: &1, owner?: owner?, children: []})
+
+    Enum.sort_by(children ++ remote_nodes, &node_time/1, {:asc, NaiveDateTime})
+  end
+
+  defp node_time(%{note: note}), do: DateTime.to_naive(note.received_at)
+  defp node_time(%{post: post}), do: post.inserted_at
 
   # Fallback when a caller does not compute the full visible chain: the single
   # preloaded `reply_ref` parent (one level), or none when nesting is off (the
@@ -2162,37 +2379,70 @@ defmodule VutuvWeb.PostComponents do
       </.action_button>
     </div>
 
-    <.fediverse_reaction_line :if={@engagement} count={@engagement.fediverse_reactions} />
+    <.fediverse_line
+      :if={@engagement}
+      reactions={@engagement.fediverse_reactions}
+      replies={Map.get(@engagement, :fediverse_replies, 0)}
+    />
     """
   end
 
-  # What other networks did with this post (issue #1068): a labelled count on
-  # its OWN line under the vutuv counters, never folded into them. A member who
-  # publishes outward otherwise gets no feedback at all, and keeping the figure
-  # separate means a hostile remote server can inflate only its own line — and
-  # the reader can see which world answered. Public, because it is an aggregate
-  # with no identity attached. Renders nothing at zero, so a post nobody out
-  # there touched stays clean.
-  attr(:count, :integer, required: true)
+  # What other networks did with this post (issues #1068 and #1069): labelled
+  # counts on their OWN line under the vutuv counters, never folded into them. A
+  # member who publishes outward otherwise gets no feedback at all, and keeping
+  # the figures separate means a hostile remote server can inflate only its own
+  # line — and the reader can see which world answered. Public, because both are
+  # aggregates with no identity attached; the reply figure counts **public**
+  # replies only, so a note addressed to the member alone (issue #1071) never
+  # moves a number a stranger can read. Renders nothing while both are zero, so
+  # a post nobody out there touched stays clean.
+  attr(:reactions, :integer, required: true)
+  attr(:replies, :integer, required: true)
 
-  defp fediverse_reaction_line(%{count: count} = assigns) when count > 0 do
+  defp fediverse_line(%{reactions: reactions, replies: replies} = assigns)
+       when reactions > 0 or replies > 0 do
+    assigns = assign(assigns, :text, fediverse_line_text(reactions, replies))
+
     ~H"""
     <div
       class="mt-2 border-t border-slate-100 pt-2 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-400"
-      data-fediverse-reactions={@count}
+      data-fediverse-reactions={@reactions}
+      data-fediverse-replies={@replies}
     >
-      <span aria-hidden="true" class="mr-1">🌐</span>
-      {ngettext(
-        "%{formatted} reaction from other networks",
-        "%{formatted} reactions from other networks",
-        @count,
-        formatted: compact_count(@count)
-      )}
+      <span aria-hidden="true" class="mr-1">🌐</span>{@text}
     </div>
     """
   end
 
-  defp fediverse_reaction_line(assigns), do: ~H""
+  defp fediverse_line(assigns), do: ~H""
+
+  # One **whole** sentence per case, never a line assembled from fragments: the
+  # figures go in as placeholders so a translator owns the word order (German
+  # would otherwise be at the mercy of where the English happens to put "from
+  # other networks"). The noun phrases are their own ngettext calls, because
+  # only they need the singular/plural split.
+  defp fediverse_line_text(reactions, 0), do: gettext_from_networks(reaction_phrase(reactions))
+  defp fediverse_line_text(0, replies), do: gettext_from_networks(reply_phrase(replies))
+
+  defp fediverse_line_text(reactions, replies) do
+    gettext("%{reactions} and %{replies} from other networks",
+      reactions: reaction_phrase(reactions),
+      replies: reply_phrase(replies)
+    )
+  end
+
+  defp gettext_from_networks(phrase),
+    do: gettext("%{count} from other networks", count: phrase)
+
+  defp reaction_phrase(count) do
+    ngettext("%{formatted} reaction", "%{formatted} reactions", count,
+      formatted: compact_count(count)
+    )
+  end
+
+  defp reply_phrase(count) do
+    ngettext("%{formatted} reply", "%{formatted} replies", count, formatted: compact_count(count))
+  end
 
   # The Like control: a real toggle for everyone but the author. On your OWN
   # post it is a plain, non-interactive count instead of a clickable heart —

--- a/lib/vutuv_web/controllers/admin/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/admin/fediverse_controller.ex
@@ -24,6 +24,11 @@ defmodule VutuvWeb.Admin.FediverseController do
     render(conn, "index.html",
       blocked: Fediverse.list_blocked_instances(),
       inbound_hosts: Fediverse.inbound_hosts(),
+      # Stored replies per server (issue #1069), keyed by host so the volume
+      # table can show them beside the follower counts: the same "who is sending
+      # us the most" question, now that text arrives too.
+      note_hosts: Map.new(Fediverse.note_hosts(), &{&1.host, &1.notes}),
+      note_events: Fediverse.recent_note_events(),
       stats: Fediverse.stats(),
       caps: Fediverse.inbound_caps(),
       page_title: gettext("Fediverse")

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -6,10 +6,12 @@ defmodule VutuvWeb.FediverseController do
       `@handle@host` into an actor URL,
     * `GET /:slug/actor` (+ `/followers`, `/outbox`) — the member's
       machine-readable identity,
-    * `POST /:slug/actor/inbox` — receives signed `Follow`/`Undo` activities
-      plus the remote actor's own lifecycle (`Update` re-syncs the stored
-      follower, `Delete` of the actor removes it); everything else is
-      acknowledged and dropped (outbound-only by design).
+    * `POST /:slug/actor/inbox` — receives signed `Follow`/`Undo` activities,
+      the reactions and replies other networks send back (`Like`/`Announce`,
+      issue #1068; `Create(Note)`, issues #1069 and #1071, plus the author's own
+      `Update`/`Delete` of such a note) and the remote actor's own lifecycle
+      (`Update` re-syncs the stored follower, `Delete` of the actor removes it);
+      everything else is acknowledged and dropped.
 
   Deliberately outside the `:browser` pipeline: no session, no CSRF — remote
   servers authenticate with HTTP signatures instead, verified against the
@@ -191,15 +193,30 @@ defmodule VutuvWeb.FediverseController do
     send_resp(conn, 202, "")
   end
 
+  # Somebody on another network answered one of the member's posts (issues
+  # #1069 and #1071). Every gate lives in `Fediverse.record_reply/3` — the
+  # member's separate opt-in among them — and the answer is the same 202
+  # whatever it decides, so a misdirected activity never learns which gate it
+  # failed.
+  defp perform(conn, user, %{"type" => "Create"} = activity, remote) do
+    Fediverse.record_reply(user, activity, remote_author(remote))
+    send_resp(conn, 202, "")
+  end
+
   # A remote actor that renamed or moved its inbox broadcasts an `Update` of
   # itself to everyone following it. Re-sync from the actor document we just
   # fetched: the row is both a delivery target and what the member sees on
   # their Fediverse settings page, so a stale copy shows the wrong handle and
-  # can deliver to the wrong inbox. An `Update` of anything else (a remote
-  # note) falls through to the catch-all.
+  # can deliver to the wrong inbox.
+  #
+  # An `Update` of anything else is an author editing a note they sent us, which
+  # is honoured too — including a narrowed audience, which is the same "stop
+  # showing this" signal a 403 carries.
   defp perform(conn, user, %{"type" => "Update"} = activity, remote) do
     if object_id(activity["object"]) == remote.id do
       Fediverse.refresh_follower(user, follower_attrs(remote))
+    else
+      Fediverse.update_reply(user, activity, remote.id)
     end
 
     send_resp(conn, 202, "")
@@ -216,6 +233,12 @@ defmodule VutuvWeb.FediverseController do
   defp perform(conn, user, %{"type" => "Delete"} = activity, remote) do
     if object_id(activity["object"]) == remote.id do
       Fediverse.remove_follower(user, remote.id)
+    else
+      # Not the actor: the author is withdrawing a note they wrote under one of
+      # our members' posts. Honoured at once and unconditionally — an upstream
+      # withdrawal is the deletion path that makes storing their words
+      # defensible, so it must not depend on any switch still being on.
+      Fediverse.delete_reply(remote.id, object_id(activity["object"]))
     end
 
     send_resp(conn, 202, "")
@@ -227,6 +250,14 @@ defmodule VutuvWeb.FediverseController do
 
   defp reaction_kind("Like"), do: "like"
   defp reaction_kind("Announce"), do: "announce"
+
+  # What a stored reply keeps about its author: the actor URI (the takedown and
+  # dedupe key) plus the two cosmetic display strings. No avatar — the card
+  # renders initials and links out, so vutuv never hosts a third party's
+  # picture.
+  defp remote_author(remote) do
+    %{uri: remote.id, handle: remote.preferred_username, name: remote.name}
+  end
 
   defp follower_attrs(remote) do
     %{

--- a/lib/vutuv_web/controllers/settings_controller.ex
+++ b/lib/vutuv_web/controllers/settings_controller.ex
@@ -280,6 +280,11 @@ defmodule VutuvWeb.SettingsController do
         # goes with it, since that is the whole reason storing it is defensible.
         unless saved.fediverse_reactions?, do: Vutuv.Fediverse.drop_reactions(saved)
 
+        # And the same for the replies (issues #1069 and #1071), where it
+        # matters more: those rows hold a stranger's words, so the switch has to
+        # be a real delete lever and not a display toggle.
+        unless saved.fediverse_replies?, do: Vutuv.Fediverse.drop_notes(saved)
+
         # Same rule for the followers themselves: leaving deletes the rows about
         # people on other networks. The actor answers 410 from now on, so those
         # servers drop the follow at their end too — a kept row would only be a

--- a/lib/vutuv_web/live/notification_live/groups.ex
+++ b/lib/vutuv_web/live/notification_live/groups.ex
@@ -149,15 +149,24 @@ defmodule VutuvWeb.NotificationLive.Groups do
         id: &1[:actor_id],
         name: &1[:actor_name],
         param: &1[:actor_param],
-        avatar: &1[:actor_avatar]
+        avatar: &1[:actor_avatar],
+        # Somebody on another network (issue #1069): no vutuv profile to link
+        # to, so the row links out to their account instead and names them by
+        # their `@handle@host`.
+        url: &1[:actor_url],
+        handle: &1[:actor_handle]
       }
     )
   end
 
-  # One stable identity per actor: their id when we have it, otherwise a hash
-  # of the display name (live-pushed test payloads carry bare maps).
+  # One stable identity per actor: their id when we have it, then their remote
+  # account URL, then their route param, and only as a last resort a hash of the
+  # display name (live-pushed test payloads carry bare maps). The remote URL
+  # matters — without it two different strangers who happen to share a display
+  # name would fold into a single row.
   defp actor_key(item) do
-    item[:actor_id] || item[:actor_param] || "anon-#{:erlang.phash2(item[:actor_name])}"
+    item[:actor_id] || item[:actor_url] || item[:actor_param] ||
+      "anon-#{:erlang.phash2(item[:actor_name])}"
   end
 
   defp unread?(_item, nil), do: true

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -74,7 +74,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   # `kinds:` option keeps. "all" passes nil (every source).
   @filters %{
     "all" => nil,
-    "posts" => ~w(reply thread mention like),
+    "posts" => ~w(reply thread mention like fediverse_reply),
     "people" => ~w(follower connection endorsement),
     "other" =>
       ~w(organization_role moderation image_rejected report_protection handle_change cv_update
@@ -464,6 +464,31 @@ defmodule VutuvWeb.NotificationLive.Index do
           />
         </div>
 
+        <%!-- A reply from another network quotes its text (issue #1069). Plain
+        text, clamped like the other quotes and deliberately NOT run through the
+        Markdown renderer: a stranger's words must not be able to mint links,
+        least of all @mention links into local profiles. A private reply
+        (issue #1071) says so, since the member has to know that before they
+        answer. --%>
+        <div :if={@group.kind == "fediverse_reply" and @n[:note_text]} class="mt-1.5 space-y-1">
+          <p
+            :if={@n[:note_audience] && @n.note_audience != "public"}
+            data-remote-private
+            class="mb-0 text-xs font-medium text-slate-600 dark:text-slate-400"
+          >
+            <span aria-hidden="true">🔒</span> {gettext("Sent to you only, visible to nobody else")}
+          </p>
+          <div
+            data-remote-reply-preview="true"
+            class="border-l-2 border-dashed border-slate-300 pl-2.5 dark:border-slate-600"
+          >
+            <p
+              class="notif-clamp mb-0 whitespace-pre-line text-sm text-slate-600 dark:text-slate-400"
+              {clamp_attrs(@quote_lines)}
+            >{@n.note_text}</p>
+          </div>
+        </div>
+
         <%!-- The day's first thread row says why it is here and links to the
         switch that stops it (issue #1025), once per day so it stays a hint and
         not a banner. It shows only when thread events reach this reader, which
@@ -650,13 +675,27 @@ defmodule VutuvWeb.NotificationLive.Index do
 
   defp actor_link(assigns) do
     ~H"""
-    <%= if @actor.param do %>
-      <.link
-        href={~p"/#{@actor.param}"}
-        class="font-semibold text-slate-900 hover:text-brand-700 dark:text-white dark:hover:text-brand-300"
-      >{@actor.name}</.link>
-    <% else %>
-      <span class="font-semibold">{@actor.name}</span>
+    <%= cond do %>
+      <% @actor.param -> %>
+        <.link
+          href={~p"/#{@actor.param}"}
+          class="font-semibold text-slate-900 hover:text-brand-700 dark:text-white dark:hover:text-brand-300"
+        >{@actor.name}</.link>
+      <% @actor[:url] -> %>
+        <%!-- Somebody on another network (issue #1069). There is no vutuv
+        profile behind the name, so it links out to their account and the
+        `@handle@host` beside it says which network answered. --%>
+        <a
+          href={@actor.url}
+          target="_blank"
+          rel="nofollow noopener noreferrer"
+          class="font-semibold text-slate-900 hover:text-brand-700 dark:text-white dark:hover:text-brand-300"
+        >{@actor.name}</a><span
+          :if={@actor[:handle] && @actor.handle != @actor.name}
+          class="text-xs font-normal text-slate-600 dark:text-slate-400"
+        > {@actor.handle}</span>
+      <% true -> %>
+        <span class="font-semibold">{@actor.name}</span>
     <% end %>
     """
   end
@@ -806,7 +845,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   # Event kinds that share the brand badge colour, so the class string lives
   # in one place.
   @brand_kind_classes "bg-brand-50 text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
-  @brand_kinds ~w(follower reply thread mention connection report_protection organization_role handle_change cv_update)
+  @brand_kinds ~w(follower reply thread mention connection report_protection organization_role handle_change cv_update fediverse_reply)
 
   defp kind_classes("endorsement"),
     do: "bg-emerald-50 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-300"
@@ -834,6 +873,9 @@ defmodule VutuvWeb.NotificationLive.Index do
   # label tells them apart where the glyph alone would not.
   defp kind_glyph("mention"), do: "@"
   defp kind_glyph("like"), do: "♥"
+  # A reply written on another network (issue #1069) — the same globe the
+  # post card's "from other networks" line uses, so one glyph means one thing.
+  defp kind_glyph("fediverse_reply"), do: "🌐"
   # "connection" is the vernetzt (mutual-follow) event; the handshake glyph.
   defp kind_glyph("connection"), do: "🤝"
   defp kind_glyph("moderation"), do: "⚑"
@@ -854,6 +896,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp kind_label("thread"), do: gettext("Thread reply")
   defp kind_label("mention"), do: gettext("Mention")
   defp kind_label("like"), do: gettext("Like")
+  defp kind_label("fediverse_reply"), do: gettext("Reply from another network")
   defp kind_label("connection"), do: gettext("Connection")
   defp kind_label("moderation"), do: gettext("Moderation")
   defp kind_label("image_rejected"), do: gettext("Image review")
@@ -975,7 +1018,13 @@ defmodule VutuvWeb.NotificationLive.Index do
     primary_target(n, viewer) || actor_target(n)
   end
 
-  defp primary_target(%{kind: kind} = n, viewer) when kind in ["reply", "like"] do
+  # A reply from another network (issue #1069) opens the reader's **own** post,
+  # where the reply card sits among the rest of the conversation — deliberately
+  # not the remote original, which the card itself links to. The reader stays on
+  # vutuv unless they choose otherwise, and a private reply (issue #1071) has no
+  # public page to open anyway.
+  defp primary_target(%{kind: kind} = n, viewer)
+       when kind in ["reply", "like", "fediverse_reply"] do
     if is_binary(n[:post_id]) and viewer != nil, do: ~p"/#{viewer}/posts/#{n.post_id}"
   end
 
@@ -994,6 +1043,9 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp notification_text(%{kind: "reply"}), do: gettext("replied to your post.")
 
   defp notification_text(%{kind: "mention"}), do: gettext("mentioned you in a post.")
+
+  defp notification_text(%{kind: "fediverse_reply"}),
+    do: gettext("replied to your post from another network.")
 
   # Live-pushed thread events land here (no group context yet): one actor.
   defp notification_text(%{kind: "thread"}), do: thread_text(1)

--- a/lib/vutuv_web/live/post_live/action_bar.ex
+++ b/lib/vutuv_web/live/post_live/action_bar.ex
@@ -95,9 +95,11 @@ defmodule VutuvWeb.PostLive.ActionBar do
               bookmarks: bookmarks,
               reposts: reposts,
               replies: replies,
-              # Issue #1068: a reaction from another network arrives without any
-              # viewer of ours acting, so this is the only path that updates it.
-              fediverse_reactions: payload.fediverse_reactions
+              # Issues #1068 and #1069: a reaction or a reply from another
+              # network arrives without any viewer of ours acting, so this is the
+              # only path that updates the two remote figures.
+              fediverse_reactions: payload.fediverse_reactions,
+              fediverse_replies: payload.fediverse_replies
           })
         end
     end

--- a/lib/vutuv_web/live/post_live/thread.ex
+++ b/lib/vutuv_web/live/post_live/thread.ex
@@ -5,6 +5,13 @@ defmodule VutuvWeb.PostLive.Thread do
   pattern: the controller keeps owning the URL, the agent-format negotiation
   and the page chrome; the socket owns the conversation card).
 
+  Replies written on **other networks** (issues #1069 and #1071) are woven into
+  the same conversation as ordinary siblings, in time order, wearing their own
+  card (`VutuvWeb.PostComponents.remote_reply_card/1`); `Vutuv.Fediverse.list_notes/2`
+  scopes them to the viewer, so one addressed to the member alone never reaches
+  anybody else's render. Their takedown controls are the `remove-remote-reply` /
+  `report-remote-reply` events below.
+
   It renders `Vutuv.Posts.thread_window/3`: a small conversation whole
   (`:all`, the issue #1006 page unchanged), a big one as a **window around
   the permalinked post** — the root pinned on top, a "Show N earlier posts"
@@ -36,6 +43,7 @@ defmodule VutuvWeb.PostLive.Thread do
 
   use Gettext, backend: VutuvWeb.Gettext
 
+  alias Vutuv.Fediverse
   alias Vutuv.Posts
   alias Vutuv.Social
   alias VutuvWeb.Live.InitAssigns
@@ -53,6 +61,7 @@ defmodule VutuvWeb.PostLive.Thread do
       |> assign(:ancestor_budget, defaults.ancestors)
       |> assign(:reply_budget, defaults.replies)
       |> assign(:subscribed_ids, MapSet.new())
+      |> assign(:notice, nil)
       |> load_window()
 
     {:ok, socket}
@@ -75,6 +84,25 @@ defmodule VutuvWeb.PostLive.Thread do
      socket
      |> assign(:reply_budget, socket.assigns.reply_budget + step)
      |> load_window()}
+  end
+
+  # The member takes a reply from another network off their own post, or
+  # anybody who can see it marks it as not appropriate. Both delete at once
+  # (`Vutuv.Fediverse`), which is the whole workflow — there is no case and no
+  # freezer, because unlike a member's own post this is a cache of something
+  # that still exists at its origin.
+  def handle_event("remove-remote-reply", %{"id" => id}, socket) do
+    {:noreply, take_down(socket, id, &Fediverse.remove_note/2, gettext("Reply removed."))}
+  end
+
+  def handle_event("report-remote-reply", %{"id" => id}, socket) do
+    {:noreply,
+     take_down(
+       socket,
+       id,
+       &Fediverse.report_note/2,
+       gettext("Thank you. The reply was deleted right away.")
+     )}
   end
 
   @impl true
@@ -103,7 +131,7 @@ defmodule VutuvWeb.PostLive.Thread do
     case Posts.get_post(socket.assigns.post_id) do
       nil ->
         # Deleted while the socket lived; the controller 404s the next load.
-        socket |> assign(:window, nil) |> assign(:focus, nil)
+        socket |> assign(:window, nil) |> assign(:focus, nil) |> assign(:remote_replies, %{})
 
       post ->
         window =
@@ -126,12 +154,56 @@ defmodule VutuvWeb.PostLive.Thread do
             %{}
           end
 
+        # Replies written on other networks under any post in the window
+        # (issues #1069 and #1071), viewer-scoped by `list_notes/2` — a reply
+        # addressed to the member alone never reaches anybody else's render.
+        remote = Fediverse.list_notes(ids, viewer)
+
+        # The lazy freshness check (issue #1069): ask the origins of the stale
+        # public ones whether they are still published there. Deliberately
+        # fire-and-forget in a task, so a stranger's slow server can never hold
+        # up this render, and only on connect, so the throwaway dead render
+        # does not pay for it.
+        if connected?(socket) do
+          remote |> Map.values() |> List.flatten() |> Fediverse.refresh_async()
+        end
+
         socket
         |> assign(:window, window)
         |> assign(:focus, Enum.find(posts, &(&1.id == post.id)) || post)
         |> assign(:engagement, Posts.post_engagement_map(ids, viewer))
         |> assign(:viewer_follows, follows)
+        |> assign(:remote_replies, remote)
         |> subscribe_shown(ids)
+    end
+  end
+
+  # The outcome is shown as an inline notice above the conversation, not as a
+  # toast: this is an **embedded** LiveView and the toast tray lives in the dead
+  # app layout, so a `put_flash/3` here would never reach the screen.
+  #
+  # A successful takedown says so by the card vanishing, which is why it clears
+  # the notice rather than setting one.
+  defp take_down(socket, id, fun, _message) do
+    case socket.assigns.current_user do
+      nil ->
+        socket
+
+      viewer ->
+        case fun.(id, viewer) do
+          :ok ->
+            socket |> assign(:notice, nil) |> load_window()
+
+          {:error, :rate_limited} ->
+            assign(
+              socket,
+              :notice,
+              gettext("You have reported a lot today. Please try again tomorrow.")
+            )
+
+          _ ->
+            assign(socket, :notice, gettext("That reply is not yours to remove."))
+        end
     end
   end
 
@@ -158,12 +230,23 @@ defmodule VutuvWeb.PostLive.Thread do
   def render(assigns) do
     ~H"""
     <div id="post-thread-frame">
+      <p
+        :if={@notice}
+        id="thread-notice"
+        role="status"
+        class="mb-3 rounded-lg bg-slate-100 px-3 py-2 text-sm text-slate-700 dark:bg-slate-800 dark:text-slate-200"
+      >
+        {@notice}
+      </p>
       <%= cond do %>
         <% is_nil(@window) -> %>
           <div id="post-thread-gone"></div>
-        <% @window.mode == :all and @window.total == 1 -> %>
-          <%!-- No conversation: the post stands alone as its own card. The
-          author's Edit/Delete live in the card's own ⋯ menu. --%>
+        <% @window.mode == :all and @window.total == 1 and @remote_replies == %{} -> %>
+          <%!-- No conversation at all: the post stands alone as its own card.
+          The author's Edit/Delete live in the card's own ⋯ menu. A post with no
+          vutuv replies but an answer from another network (issue #1069) is not
+          this case — it falls through to the conversation below, which is what
+          weaves that answer in. --%>
           <.post_card
             post={@focus}
             viewer={@current_user}
@@ -186,6 +269,7 @@ defmodule VutuvWeb.PostLive.Thread do
                 viewer={@current_user}
                 viewer_follows={@viewer_follows}
                 engagement={@engagement}
+                remote_replies={@remote_replies}
                 auto_scroll?={@auto_scroll?}
                 conn_or_socket={@socket}
               />
@@ -196,6 +280,7 @@ defmodule VutuvWeb.PostLive.Thread do
                 viewer={@current_user}
                 viewer_follows={@viewer_follows}
                 engagement={@engagement}
+                remote_replies={@remote_replies}
                 auto_scroll?={@auto_scroll?}
                 conn_or_socket={@socket}
               />

--- a/lib/vutuv_web/templates/admin/fediverse/index.html.heex
+++ b/lib/vutuv_web/templates/admin/fediverse/index.html.heex
@@ -134,12 +134,56 @@ Classic admin page, so it uses the shared card/table/editform classes. --%>
             <tr>
               <th>{gettext("Server")}</th>
               <th>{gettext("Followers")}</th>
+              <th>{gettext("Stored replies")}</th>
             </tr>
           </thead>
           <tbody>
             <tr :for={row <- @inbound_hosts} data-inbound-host={row.host}>
               <td class="breakwrap">{row.host}</td>
               <td>{delimited_count(row.followers)}</td>
+              <td>{delimited_count(Map.get(@note_hosts, row.host, 0))}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+  </section>
+</div>
+
+<%!-- The takedown log (issue #1069). It answers one question — is this one
+troll, or is this server the problem — because that is the decision the
+blocklist above acts on. It deliberately carries no content and no URIs: keeping
+a stranger's words after deleting their reply would make the deletion untrue.
+The short digest stands in for the account, so repeat offenders are still
+visible as repeats. Automatic deletions (expiry, an upstream withdrawal, a
+block) are not listed; they would drown this and go to the log file instead. --%>
+<div class="card-list">
+  <section class="card">
+    <h2 class="card__label">{gettext("Replies taken down by members")}</h2>
+    <%= if @note_events == [] do %>
+      <p class="card__empty">{gettext("Nobody has removed or reported a reply yet.")}</p>
+    <% else %>
+      <p class="editform__hint">
+        {gettext(
+          "A report deletes the reply right away, with no queue to work through. This is the trail, so a server that keeps showing up here can be blocked above. It holds no text and no links, only which server and which account (as a short digest)."
+        )}
+      </p>
+      <div class="card__tablewrap">
+        <table>
+          <thead>
+            <tr>
+              <th>{gettext("When")}</th>
+              <th>{gettext("What")}</th>
+              <th>{gettext("Server")}</th>
+              <th>{gettext("Account")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={event <- @note_events} data-note-event={event.action}>
+              <td><.local_time at={event.inserted_at} /></td>
+              <td>{note_event_label(event)}</td>
+              <td class="breakwrap">{event.host}</td>
+              <td><code>{String.slice(event.actor_digest, 0, 8)}</code></td>
             </tr>
           </tbody>
         </table>

--- a/lib/vutuv_web/templates/settings/fediverse.html.heex
+++ b/lib/vutuv_web/templates/settings/fediverse.html.heex
@@ -76,6 +76,21 @@ subpage now (/settings/fediverse/move), linked from the footer below. --%>
           )}
         </.setting_toggle>
 
+        <%!-- Replies (issues #1069 and #1071): its own switch, off by default,
+              because this is the one thing here that stores what somebody else
+              wrote. The wording says the three things that decide it: you get
+              to read the answers, we keep a copy for a while, and you can throw
+              any of it away. --%>
+        <.setting_toggle
+          :if={Vutuv.Fediverse.federated?(@user)}
+          label={gettext("Show replies from other networks")}
+        >
+          <:checkbox><%= checkbox f, :fediverse_replies?, class: checkbox_class() %></:checkbox>
+          {gettext(
+            "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
+          )}
+        </.setting_toggle>
+
         <div class="pt-1">
           <.button type="submit">{gettext("Save")}</.button>
         </div>

--- a/lib/vutuv_web/views/admin/fediverse_html.ex
+++ b/lib/vutuv_web/views/admin/fediverse_html.ex
@@ -5,4 +5,13 @@ defmodule VutuvWeb.Admin.FediverseHTML do
   import VutuvWeb.UserHelpers, only: [member_name: 1]
 
   embed_templates("../../templates/admin/fediverse/*")
+
+  @doc """
+  What a takedown row means, in words. The stored `action` values are the closed
+  set `Vutuv.Fediverse.NoteEvent.actions/0` holds; an unknown one still renders
+  something rather than leaking a raw string at the operator.
+  """
+  def note_event_label(%{action: "reported"}), do: gettext("Reported as not appropriate")
+  def note_event_label(%{action: "removed_by_member"}), do: gettext("Removed by the member")
+  def note_event_label(_event), do: gettext("Taken down")
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.154.1",
+      version: "7.155.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -24,9 +24,9 @@ msgstr "Impressum"
 msgid "Add"
 msgstr "Eintrag hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:208
+#: lib/vutuv_web/agent_docs/markdown.ex:216
 #: lib/vutuv_web/agent_docs/section_docs.ex:121
-#: lib/vutuv_web/agent_docs/text.ex:197
+#: lib/vutuv_web/agent_docs/text.ex:204
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
@@ -94,10 +94,10 @@ msgstr "Avatar"
 msgid "Birthdate"
 msgstr "Geburtstag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:432
-#: lib/vutuv_web/agent_docs/markdown.ex:433
-#: lib/vutuv_web/agent_docs/text.ex:429
-#: lib/vutuv_web/agent_docs/text.ex:430
+#: lib/vutuv_web/agent_docs/markdown.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:441
+#: lib/vutuv_web/agent_docs/text.ex:436
+#: lib/vutuv_web/agent_docs/text.ex:437
 #: lib/vutuv_web/templates/user/show.html.heex:929
 #, elixir-autogen
 msgid "Birthday"
@@ -116,7 +116,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:86
 #: lib/vutuv_web/templates/report/new.html.heex:103
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:225
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:240
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:50
@@ -153,7 +153,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "Konnte nicht zu %{name} zurückfolgen."
 
-#: lib/vutuv_web/components/post_components.ex:1054
+#: lib/vutuv_web/components/post_components.ex:1271
 #: lib/vutuv_web/components/ui.ex:2935
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -201,7 +201,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:1047
+#: lib/vutuv_web/components/post_components.ex:1264
 #: lib/vutuv_web/components/ui.ex:2926
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -312,10 +312,10 @@ msgstr "Fax"
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:456
-#: lib/vutuv_web/agent_docs/text.ex:453
+#: lib/vutuv_web/agent_docs/markdown.ex:464
+#: lib/vutuv_web/agent_docs/text.ex:460
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/notification_live/index.ex:798
+#: lib/vutuv_web/live/notification_live/index.ex:837
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:136
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -323,8 +323,8 @@ msgstr "Vorname"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:457
-#: lib/vutuv_web/agent_docs/text.ex:454
+#: lib/vutuv_web/agent_docs/markdown.ex:465
+#: lib/vutuv_web/agent_docs/text.ex:461
 #: lib/vutuv_web/components/ui.ex:1551
 #: lib/vutuv_web/components/ui.ex:1576
 #: lib/vutuv_web/components/ui.ex:1579
@@ -339,8 +339,8 @@ msgstr "Follower"
 msgid "Following"
 msgstr "Folge ich"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:431
-#: lib/vutuv_web/agent_docs/text.ex:428
+#: lib/vutuv_web/agent_docs/markdown.ex:439
+#: lib/vutuv_web/agent_docs/text.ex:435
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -459,7 +459,7 @@ msgstr "Einloggen"
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
-#: lib/vutuv_web/live/notification_live/index.ex:722
+#: lib/vutuv_web/live/notification_live/index.ex:761
 #, elixir-autogen
 msgid "More"
 msgstr "Mehr"
@@ -476,7 +476,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:525
+#: lib/vutuv_web/live/notification_live/index.ex:550
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -618,7 +618,7 @@ msgstr "Öffentlich"
 #: lib/vutuv_web/live/post_live/composer.ex:818
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:80
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:95
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:73
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
@@ -647,6 +647,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
+#: lib/vutuv_web/components/post_components.ex:850
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -789,7 +790,7 @@ msgstr "User wurde verifiziert."
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
-#: lib/vutuv_web/live/notification_live/index.ex:864
+#: lib/vutuv_web/live/notification_live/index.ex:907
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -992,14 +993,14 @@ msgstr "+49 30 12345678"
 msgid "http://www.example.com"
 msgstr "https://www.example.com"
 
-#: lib/vutuv/accounts/user.ex:937
+#: lib/vutuv/accounts/user.ex:947
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr "Frau"
 
-#: lib/vutuv/accounts/user.ex:936
+#: lib/vutuv/accounts/user.ex:946
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1425,11 +1426,11 @@ msgid "Tag urls"
 msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
-#: lib/vutuv_web/agent_docs/markdown.ex:368
-#: lib/vutuv_web/agent_docs/markdown.ex:815
+#: lib/vutuv_web/agent_docs/markdown.ex:376
+#: lib/vutuv_web/agent_docs/markdown.ex:823
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:394
-#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/text.ex:401
+#: lib/vutuv_web/agent_docs/text.ex:591
 #: lib/vutuv_web/components/ui.ex:3220
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1800,7 +1801,7 @@ msgstr "Nachrichten"
 msgid "Network"
 msgstr "Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:287
+#: lib/vutuv_web/components/post_components.ex:288
 #: lib/vutuv_web/components/ui.ex:3045
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
@@ -1947,17 +1948,17 @@ msgstr "folgt"
 msgid "submit a bug report"
 msgstr "einen Fehlerbericht erstellen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:885
+#: lib/vutuv_web/live/notification_live/index.ex:928
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr "hat Sie für %{tag} empfohlen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:880
+#: lib/vutuv_web/live/notification_live/index.ex:923
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr "ist jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:875
+#: lib/vutuv_web/live/notification_live/index.ex:918
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
@@ -2152,7 +2153,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:1051
+#: lib/vutuv_web/components/post_components.ex:1268
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2198,8 +2199,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:1033
-#: lib/vutuv_web/components/post_components.ex:1035
+#: lib/vutuv_web/components/post_components.ex:1250
+#: lib/vutuv_web/components/post_components.ex:1252
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2249,13 +2250,13 @@ msgstr "Posten"
 msgid "Post deleted successfully."
 msgstr "Beitrag erfolgreich gelöscht."
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:92
+#: lib/vutuv_web/agent_docs/post_doc.ex:102
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:75
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/notification_live/index.ex:720
+#: lib/vutuv_web/live/notification_live/index.ex:759
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:179
 #: lib/vutuv_web/live/search_live.ex:462
@@ -2265,18 +2266,19 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1444
-#: lib/vutuv_web/components/post_components.ex:1448
+#: lib/vutuv_web/components/post_components.ex:1661
+#: lib/vutuv_web/components/post_components.ex:1665
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:1445
+#: lib/vutuv_web/components/post_components.ex:1662
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
+#: lib/vutuv_web/components/post_components.ex:817
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:209
 #: lib/vutuv_web/live/organization_live/edit.ex:371
@@ -2364,27 +2366,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:1030
+#: lib/vutuv_web/components/post_components.ex:1247
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:2077
+#: lib/vutuv_web/components/post_components.ex:2294
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:2081
+#: lib/vutuv_web/components/post_components.ex:2298
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:2079
+#: lib/vutuv_web/components/post_components.ex:2296
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:2080
+#: lib/vutuv_web/components/post_components.ex:2297
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2425,7 +2427,7 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2158
+#: lib/vutuv_web/components/post_components.ex:2375
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2484
@@ -2434,7 +2436,7 @@ msgstr "Alle Beiträge"
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:850
+#: lib/vutuv_web/agent_docs/markdown.ex:858
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:490
@@ -2444,19 +2446,19 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:2217
+#: lib/vutuv_web/components/post_components.ex:2467
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2470
-#: lib/vutuv_web/live/notification_live/index.ex:856
+#: lib/vutuv_web/live/notification_live/index.ex:898
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:849
-#: lib/vutuv_web/components/post_components.ex:2226
-#: lib/vutuv_web/live/notification_live/index.ex:800
+#: lib/vutuv_web/agent_docs/markdown.ex:857
+#: lib/vutuv_web/components/post_components.ex:2476
+#: lib/vutuv_web/live/notification_live/index.ex:839
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:559
@@ -2475,12 +2477,12 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:2147
+#: lib/vutuv_web/components/post_components.ex:2364
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:2158
+#: lib/vutuv_web/components/post_components.ex:2375
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2489,23 +2491,23 @@ msgstr "Nur öffentliche Beiträge können repostet werden."
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/components/post_components.ex:2361
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1562
+#: lib/vutuv_web/components/post_components.ex:1779
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/components/post_components.ex:2361
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:2217
+#: lib/vutuv_web/components/post_components.ex:2467
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2528,26 +2530,26 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:2266
+#: lib/vutuv_web/components/post_components.ex:2516
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/components/post_components.ex:276
-#: lib/vutuv_web/live/notification_live/index.ex:801
+#: lib/vutuv_web/components/post_components.ex:277
+#: lib/vutuv_web/live/notification_live/index.ex:840
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2249
-#: lib/vutuv_web/components/post_components.ex:2250
-#: lib/vutuv_web/live/notification_live/index.ex:853
+#: lib/vutuv_web/components/post_components.ex:2499
+#: lib/vutuv_web/components/post_components.ex:2500
+#: lib/vutuv_web/live/notification_live/index.ex:895
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1001
+#: lib/vutuv_web/components/post_components.ex:1218
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2567,7 +2569,7 @@ msgstr ""
 "Dieser Beitrag wurde repostet oder beantwortet. Er bleibt öffentlich, "
 "solange Reposts oder Antworten existieren; löschen können Sie ihn jederzeit."
 
-#: lib/vutuv_web/live/notification_live/index.ex:994
+#: lib/vutuv_web/live/notification_live/index.ex:1043
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
@@ -2577,12 +2579,12 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:996
+#: lib/vutuv_web/components/post_components.ex:1213
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:990
+#: lib/vutuv_web/components/post_components.ex:1207
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2848,10 +2850,10 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 weiteres Tag"
 msgstr[1] "+%{formatted} weitere Tags"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:458
-#: lib/vutuv_web/agent_docs/text.ex:455
+#: lib/vutuv_web/agent_docs/markdown.ex:466
+#: lib/vutuv_web/agent_docs/text.ex:462
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:799
+#: lib/vutuv_web/live/notification_live/index.ex:838
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2895,7 +2897,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:2078
+#: lib/vutuv_web/components/post_components.ex:2295
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -2905,22 +2907,22 @@ msgstr "Personen, mit denen Sie nicht vernetzt sind"
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:865
+#: lib/vutuv_web/live/notification_live/index.ex:908
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:857
+#: lib/vutuv_web/live/notification_live/index.ex:900
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:852
+#: lib/vutuv_web/live/notification_live/index.ex:894
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:851
+#: lib/vutuv_web/live/notification_live/index.ex:893
 #: lib/vutuv_web/templates/user/show.html.heex:757
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2933,7 +2935,7 @@ msgstr[1] "Follower"
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Willkommen bei vutuv, %{name}!"
 
-#: lib/vutuv_web/live/notification_live/index.ex:882
+#: lib/vutuv_web/live/notification_live/index.ex:925
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr "gefällt Ihr Beitrag."
@@ -2965,12 +2967,12 @@ msgstr "(gelöschtes Konto)"
 msgid "(no text)"
 msgstr "(kein Text)"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1073
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde bestätigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1022
+#: lib/vutuv_web/live/notification_live/index.ex:1074
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
@@ -3000,8 +3002,8 @@ msgstr "Gibt es etwas, das unsere Admins wissen sollten? (optional)"
 msgid "Bullying or harassment"
 msgstr "Mobbing oder Belästigung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/text.ex:272
+#: lib/vutuv_web/agent_docs/markdown.ex:295
+#: lib/vutuv_web/agent_docs/text.ex:279
 #: lib/vutuv_web/controllers/page_controller.ex:55
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3085,7 +3087,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:858
+#: lib/vutuv_web/live/notification_live/index.ex:901
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3174,7 +3176,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:978
+#: lib/vutuv_web/components/post_components.ex:1195
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3255,7 +3257,8 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:1075
+#: lib/vutuv_web/components/post_components.ex:827
+#: lib/vutuv_web/components/post_components.ex:1292
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3543,12 +3546,12 @@ msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1024
+#: lib/vutuv_web/live/notification_live/index.ex:1076
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt gelöscht; der Fall ist abgeschlossen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1023
+#: lib/vutuv_web/live/notification_live/index.ex:1075
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
@@ -3558,7 +3561,7 @@ msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
 msgid "Your content was reported"
 msgstr "Ihr Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1025
+#: lib/vutuv_web/live/notification_live/index.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3753,7 +3756,7 @@ msgstr "Verlauf"
 msgid "Open the profile"
 msgstr "Profil öffnen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1049
+#: lib/vutuv_web/live/notification_live/index.ex:1101
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3780,7 +3783,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:860
+#: lib/vutuv_web/live/notification_live/index.ex:903
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -3862,7 +3865,7 @@ msgstr "Bestätigt"
 msgid "Waiting for the owner"
 msgstr "Wartet auf den Besitzer"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1054
+#: lib/vutuv_web/live/notification_live/index.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -3959,30 +3962,30 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:548
+#: lib/vutuv_web/agent_docs/markdown.ex:556
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:903
+#: lib/vutuv_web/agent_docs/markdown.ex:917
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:128
-#: lib/vutuv_web/agent_docs/text.ex:117
+#: lib/vutuv_web/agent_docs/markdown.ex:136
+#: lib/vutuv_web/agent_docs/text.ex:124
 #, elixir-autogen, elixir-format
 msgid "%{count} posts by %{name}"
 msgstr "%{count} Beiträge von %{name}"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:82
-#: lib/vutuv_web/agent_docs/markdown.ex:151
-#: lib/vutuv_web/agent_docs/markdown.ex:164
-#: lib/vutuv_web/agent_docs/markdown.ex:815
+#: lib/vutuv_web/agent_docs/markdown.ex:159
+#: lib/vutuv_web/agent_docs/markdown.ex:172
+#: lib/vutuv_web/agent_docs/markdown.ex:823
 #: lib/vutuv_web/agent_docs/text.ex:79
-#: lib/vutuv_web/agent_docs/text.ex:140
-#: lib/vutuv_web/agent_docs/text.ex:153
-#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/text.ex:147
+#: lib/vutuv_web/agent_docs/text.ex:160
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
@@ -3999,34 +4002,34 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:833
-#: lib/vutuv_web/agent_docs/text.ex:595
+#: lib/vutuv_web/agent_docs/markdown.ex:841
+#: lib/vutuv_web/agent_docs/text.ex:602
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:830
-#: lib/vutuv_web/agent_docs/text.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:838
+#: lib/vutuv_web/agent_docs/text.ex:599
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:837
-#: lib/vutuv_web/agent_docs/markdown.ex:938
-#: lib/vutuv_web/agent_docs/text.ex:598
-#: lib/vutuv_web/agent_docs/text.ex:626
+#: lib/vutuv_web/agent_docs/markdown.ex:845
+#: lib/vutuv_web/agent_docs/markdown.ex:952
+#: lib/vutuv_web/agent_docs/text.ex:605
+#: lib/vutuv_web/agent_docs/text.ex:633
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:428
-#: lib/vutuv_web/agent_docs/text.ex:425
+#: lib/vutuv_web/agent_docs/markdown.ex:436
+#: lib/vutuv_web/agent_docs/text.ex:432
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Mitglied seit"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:177
-#: lib/vutuv_web/agent_docs/text.ex:166
+#: lib/vutuv_web/agent_docs/markdown.ex:185
+#: lib/vutuv_web/agent_docs/text.ex:173
 #, elixir-autogen, elixir-format
 msgid "Most endorsed members"
 msgstr "Am häufigsten empfohlene Mitglieder"
@@ -4041,7 +4044,7 @@ msgstr "Mitglieder mit den meisten Followern"
 msgid "People %{name} follows"
 msgstr "Wem %{name} folgt"
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:93
+#: lib/vutuv_web/agent_docs/post_doc.ex:103
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr "Beitragsarchiv von %{name}"
@@ -4060,23 +4063,23 @@ msgstr "Beitrag von %{name}"
 msgid "Posts (%{count} total)"
 msgstr "Beiträge (insgesamt %{count})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:422
-#: lib/vutuv_web/agent_docs/text.ex:419
+#: lib/vutuv_web/agent_docs/markdown.ex:430
+#: lib/vutuv_web/agent_docs/text.ex:426
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:784
+#: lib/vutuv_web/agent_docs/markdown.ex:792
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:714
+#: lib/vutuv_web/agent_docs/markdown.ex:722
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
+#: lib/vutuv_web/agent_docs/markdown.ex:723
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4153,8 +4156,8 @@ msgstr ""
 msgid "Billing name"
 msgstr "Name für die Rechnung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:301
-#: lib/vutuv_web/agent_docs/text.ex:280
+#: lib/vutuv_web/agent_docs/markdown.ex:309
+#: lib/vutuv_web/agent_docs/text.ex:287
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr "Online buchen (Login erforderlich): %{url}"
@@ -4206,8 +4209,8 @@ msgstr "Tag"
 msgid "Markdown is supported. At most %{max} characters."
 msgstr "Markdown wird unterstützt. Höchstens %{max} Zeichen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:291
-#: lib/vutuv_web/agent_docs/text.ex:276
+#: lib/vutuv_web/agent_docs/markdown.ex:299
+#: lib/vutuv_web/agent_docs/text.ex:283
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4223,8 +4226,8 @@ msgstr "Ein Tag. Eine Anzeige. Alle Besucher."
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr "Eine reine Textanzeige pro Kalendertag, gesehen von allen Besuchern."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:288
-#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:296
+#: lib/vutuv_web/agent_docs/text.ex:280
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4458,14 +4461,14 @@ msgstr "gebucht am"
 msgid "deleted account"
 msgstr "gelöschtes Konto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:293
-#: lib/vutuv_web/agent_docs/text.ex:278
+#: lib/vutuv_web/agent_docs/markdown.ex:301
+#: lib/vutuv_web/agent_docs/text.ex:285
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr "Bereits gebucht"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:289
-#: lib/vutuv_web/agent_docs/text.ex:274
+#: lib/vutuv_web/agent_docs/markdown.ex:297
+#: lib/vutuv_web/agent_docs/text.ex:281
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr "Buchungszeitraum"
@@ -4764,10 +4767,10 @@ msgstr "Keine Ergebnisse für \"%{query}\""
 msgid "Not an exact match, but sounds like your search."
 msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:316
-#: lib/vutuv_web/agent_docs/text.ex:342
+#: lib/vutuv_web/agent_docs/markdown.ex:324
+#: lib/vutuv_web/agent_docs/text.ex:349
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:721
+#: lib/vutuv_web/live/notification_live/index.ex:760
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:177
@@ -4788,10 +4791,10 @@ msgstr ""
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
-#: lib/vutuv_web/components/post_components.ex:273
+#: lib/vutuv_web/components/post_components.ex:274
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:719
+#: lib/vutuv_web/live/notification_live/index.ex:758
 #: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -4892,8 +4895,8 @@ msgstr "Entwickler"
 msgid "Edit your profile and its sections"
 msgstr "Ihr Profil und seine Bereiche bearbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:230
-#: lib/vutuv_web/agent_docs/text.ex:218
+#: lib/vutuv_web/agent_docs/markdown.ex:238
+#: lib/vutuv_web/agent_docs/text.ex:225
 #: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
@@ -5633,10 +5636,10 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:1137
-#: lib/vutuv_web/components/post_components.ex:1191
-#: lib/vutuv_web/components/post_components.ex:1506
-#: lib/vutuv_web/live/notification_live/index.ex:558
+#: lib/vutuv_web/components/post_components.ex:1354
+#: lib/vutuv_web/components/post_components.ex:1408
+#: lib/vutuv_web/components/post_components.ex:1723
+#: lib/vutuv_web/live/notification_live/index.ex:583
 #: lib/vutuv_web/live/post_live/feed.ex:818
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5652,7 +5655,7 @@ msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr "Ihre Tags (z.B. JavaScript, Kochen, Origami, Katze)"
 
-#: lib/vutuv/accounts/user.ex:940
+#: lib/vutuv/accounts/user.ex:950
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5690,6 +5693,7 @@ msgstr "Über Sie"
 
 #: lib/vutuv_web/components/ui.ex:3293
 #: lib/vutuv_web/live/admin/user_live.ex:266
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:178
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Account"
@@ -5720,7 +5724,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr "E-Mail-Adressen"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:393
+#: lib/vutuv_web/controllers/settings_controller.ex:398
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr "Benachrichtigungseinstellungen gespeichert."
@@ -5800,7 +5804,7 @@ msgstr "Sprache der Oberfläche"
 msgid "Language & region"
 msgstr "Sprache & Region"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:535
+#: lib/vutuv_web/controllers/settings_controller.ex:540
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr "Sprache aktualisiert."
@@ -5861,7 +5865,7 @@ msgid "Apps & API"
 msgstr "Apps & API-Zugang"
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:802
+#: lib/vutuv_web/live/notification_live/index.ex:841
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -5884,7 +5888,7 @@ msgstr "Benachrichtigungen in der App"
 msgid "New followers"
 msgstr "Neue Follower"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:383
+#: lib/vutuv_web/controllers/settings_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr "Benachrichtigungseinstellungen"
@@ -6085,7 +6089,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] "vor %{count} Minute"
 msgstr[1] "vor %{count} Minuten"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:630
+#: lib/vutuv_web/controllers/settings_controller.ex:635
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
@@ -6125,7 +6129,7 @@ msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
 msgid "Signed-in devices"
 msgstr "Angemeldete Geräte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:619
+#: lib/vutuv_web/controllers/settings_controller.ex:624
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
@@ -6371,8 +6375,8 @@ msgid_plural "%{count} years old"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:434
-#: lib/vutuv_web/agent_docs/text.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:442
+#: lib/vutuv_web/agent_docs/text.ex:438
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Alter"
@@ -6446,8 +6450,8 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:849
-#: lib/vutuv_web/components/post_components.ex:275
+#: lib/vutuv_web/agent_docs/markdown.ex:857
+#: lib/vutuv_web/components/post_components.ex:276
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
@@ -6493,7 +6497,7 @@ msgstr "Empfehlung zurücknehmen"
 msgid "Default map"
 msgstr "Standardkarte"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:550
+#: lib/vutuv_web/controllers/settings_controller.ex:555
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr "Karteneinstellungen gespeichert."
@@ -6548,15 +6552,15 @@ msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
 #: lib/vutuv_web/components/ui.ex:1332
-#: lib/vutuv_web/live/notification_live/index.ex:503
-#: lib/vutuv_web/live/notification_live/index.ex:518
-#: lib/vutuv_web/live/notification_live/index.ex:641
-#: lib/vutuv_web/live/notification_live/index.ex:643
+#: lib/vutuv_web/live/notification_live/index.ex:528
+#: lib/vutuv_web/live/notification_live/index.ex:543
+#: lib/vutuv_web/live/notification_live/index.ex:666
+#: lib/vutuv_web/live/notification_live/index.ex:668
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:828
+#: lib/vutuv_web/agent_docs/markdown.ex:836
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -6783,6 +6787,7 @@ msgstr "Das rohe Bounce-Protokoll, neueste zuerst."
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:175
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -6917,7 +6922,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:1072
+#: lib/vutuv_web/components/post_components.ex:1289
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6927,7 +6932,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:1071
+#: lib/vutuv_web/components/post_components.ex:1288
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7132,8 +7137,8 @@ msgstr "Filtern"
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:204
-#: lib/vutuv_web/agent_docs/text.ex:193
+#: lib/vutuv_web/agent_docs/markdown.ex:212
+#: lib/vutuv_web/agent_docs/text.ex:200
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #: lib/vutuv_web/templates/settings/filters.html.heex:17
@@ -7819,17 +7824,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:908
+#: lib/vutuv_web/agent_docs/markdown.ex:922
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Dein Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:911
+#: lib/vutuv_web/agent_docs/markdown.ex:925
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:918
+#: lib/vutuv_web/agent_docs/markdown.ex:932
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -8058,13 +8063,13 @@ msgstr "Neue Mitglieder"
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:748
+#: lib/vutuv_web/live/notification_live/index.ex:787
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Heute"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:751
+#: lib/vutuv_web/live/notification_live/index.ex:790
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Gestern"
@@ -9070,12 +9075,12 @@ msgstr "Die Seite wurde veröffentlicht."
 msgid "Write it under Admin › Legal pages"
 msgstr "Unter Admin › Rechtstexte verfassen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:447
-#: lib/vutuv_web/agent_docs/markdown.ex:451
-#: lib/vutuv_web/agent_docs/text.ex:444
-#: lib/vutuv_web/agent_docs/text.ex:448
+#: lib/vutuv_web/agent_docs/markdown.ex:455
+#: lib/vutuv_web/agent_docs/markdown.ex:459
+#: lib/vutuv_web/agent_docs/text.ex:451
+#: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/components/ui.ex:3288
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:29
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:34
 #: lib/vutuv_web/controllers/settings_controller.ex:194
 #: lib/vutuv_web/controllers/settings_controller.ex:261
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:288
@@ -9113,12 +9118,12 @@ msgstr ""
 msgid "Fediverse settings saved."
 msgstr "Fediverse-Einstellungen gespeichert."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:191
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr "Social-Media-Konten verwalten"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
@@ -9150,7 +9155,7 @@ msgid "Employment"
 msgstr "Anstellung"
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:608
+#: lib/vutuv_web/agent_docs/markdown.ex:616
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -9173,7 +9178,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr "Berufserfahrung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:609
+#: lib/vutuv_web/agent_docs/markdown.ex:617
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -9204,13 +9209,13 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:646
+#: lib/vutuv_web/agent_docs/markdown.ex:654
 #: lib/vutuv_web/views/education_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:645
+#: lib/vutuv_web/agent_docs/markdown.ex:653
 #: lib/vutuv_web/views/education_html.ex:29
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9239,14 +9244,14 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:1565
+#: lib/vutuv_web/components/post_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:787
+#: lib/vutuv_web/agent_docs/markdown.ex:795
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9339,14 +9344,14 @@ msgstr ""
 "Der Lebenslauf von %{name} auf vutuv: Berufserfahrung, Ausbildung und "
 "Kenntnisse zum Ansehen und Herunterladen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:607
+#: lib/vutuv_web/agent_docs/markdown.ex:615
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr "Freiberuflich / Selbstständig"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:610
+#: lib/vutuv_web/agent_docs/markdown.ex:618
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9502,8 +9507,8 @@ msgstr "Ehren-Tag"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Ehren-Tag (nur Admins können es vergeben)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:467
-#: lib/vutuv_web/agent_docs/text.ex:462
+#: lib/vutuv_web/agent_docs/markdown.ex:475
+#: lib/vutuv_web/agent_docs/text.ex:469
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "Ehren-Tag"
@@ -9925,13 +9930,13 @@ msgstr "Walisisch"
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:424
-#: lib/vutuv_web/agent_docs/text.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:432
+#: lib/vutuv_web/agent_docs/text.ex:428
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:788
+#: lib/vutuv/accounts/user.ex:798
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9942,7 +9947,7 @@ msgstr "Auf Jobsuche"
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:785
+#: lib/vutuv/accounts/user.ex:795
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10040,7 +10045,7 @@ msgstr[1] "%{count} Zertifikate oder Lizenzen"
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:708
+#: lib/vutuv_web/agent_docs/markdown.ex:716
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -10117,7 +10122,7 @@ msgstr "Läuft nicht ab"
 msgid "Expired"
 msgstr "Abgelaufen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:683
+#: lib/vutuv_web/agent_docs/markdown.ex:691
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10134,7 +10139,7 @@ msgstr "Ausgestellt"
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:707
+#: lib/vutuv_web/agent_docs/markdown.ex:715
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10164,7 +10169,7 @@ msgstr "Nachweis"
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:681
+#: lib/vutuv_web/agent_docs/markdown.ex:689
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10179,7 +10184,7 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:682
+#: lib/vutuv_web/agent_docs/markdown.ex:690
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -10198,7 +10203,7 @@ msgstr ""
 msgid "Preferred"
 msgstr "Bevorzugt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:565
+#: lib/vutuv_web/agent_docs/markdown.ex:573
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -10398,7 +10403,7 @@ msgstr "Dauerhafter Profillink"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:106
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:121
 #: lib/vutuv_web/templates/totp/new.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:848
 #: lib/vutuv_web/templates/username/new.html.heex:27
@@ -10407,8 +10412,8 @@ msgstr "Schließen"
 msgid "Copied"
 msgstr "Kopiert"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:109
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:120
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
 #: lib/vutuv_web/templates/user/show.html.heex:847
@@ -10437,12 +10442,12 @@ msgstr "Achtung:"
 msgid "Outbound federation is healthy."
 msgstr "Die ausgehende Föderation läuft störungsfrei."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:150
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Showing the most recent %{shown} of %{total}."
 msgstr "Die neuesten %{shown} von %{total} werden angezeigt."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Accounts that no longer exist on their own server drop off this list by themselves."
 msgstr ""
@@ -10891,21 +10896,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr "auf diesem Gerät einrichten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:525
+#: lib/vutuv_web/agent_docs/markdown.ex:533
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} Follower"
 msgstr[1] "%{count} Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:523
+#: lib/vutuv_web/agent_docs/markdown.ex:531
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} Repository"
 msgstr[1] "%{count} Repositories"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:521
+#: lib/vutuv_web/agent_docs/markdown.ex:529
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10963,12 +10968,12 @@ msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten nur als einfache "
 "Links."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:539
+#: lib/vutuv_web/agent_docs/markdown.ex:547
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:526
+#: lib/vutuv_web/agent_docs/markdown.ex:534
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "seit %{date}"
@@ -11260,7 +11265,7 @@ msgstr ""
 "Längere Beiträge erhalten einen „Weiterlesen“-Link. Mit 0 (oder leer) wird "
 "nie gekürzt."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:563
+#: lib/vutuv_web/controllers/settings_controller.ex:568
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr "Anzeige-Einstellungen für Beiträge gespeichert."
@@ -11319,7 +11324,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr "Standard der Installation (%{value})"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:594
+#: lib/vutuv_web/controllers/settings_controller.ex:599
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr "Karten-Einstellungen auf die Standardwerte zurückgesetzt."
@@ -11338,7 +11343,7 @@ msgstr ""
 "Eigener Wert; leeren Sie das Feld, um zum Standard der Installation "
 "zurückzukehren."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:590
+#: lib/vutuv_web/controllers/settings_controller.ex:595
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -11574,19 +11579,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:826
+#: lib/vutuv/accounts/user.ex:836
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:831
+#: lib/vutuv/accounts/user.ex:841
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:829
+#: lib/vutuv/accounts/user.ex:839
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
@@ -11915,8 +11920,8 @@ msgstr "Verifizierungsmethode"
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:205
-#: lib/vutuv_web/agent_docs/text.ex:194
+#: lib/vutuv_web/agent_docs/markdown.ex:213
+#: lib/vutuv_web/agent_docs/text.ex:201
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr "Verifiziert über"
@@ -11945,8 +11950,8 @@ msgstr ""
 "Wir konnten den Eintrag oder die Datei noch nicht finden. Die Verbreitung "
 "kann etwas dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:207
-#: lib/vutuv_web/agent_docs/text.ex:196
+#: lib/vutuv_web/agent_docs/markdown.ex:215
+#: lib/vutuv_web/agent_docs/text.ex:203
 #: lib/vutuv_web/live/organization_live/edit.ex:285
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -12032,8 +12037,8 @@ msgstr "Alias hinzugefügt."
 msgid "Alias removed."
 msgstr "Alias entfernt."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:308
-#: lib/vutuv_web/agent_docs/text.ex:335
+#: lib/vutuv_web/agent_docs/markdown.ex:316
+#: lib/vutuv_web/agent_docs/text.ex:342
 #: lib/vutuv_web/live/organization_live/edit.ex:351
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
@@ -12277,8 +12282,8 @@ msgstr "ausstehend"
 msgid "primary"
 msgstr "primär"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:329
-#: lib/vutuv_web/agent_docs/text.ex:355
+#: lib/vutuv_web/agent_docs/markdown.ex:337
+#: lib/vutuv_web/agent_docs/text.ex:362
 #: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -12419,8 +12424,8 @@ msgstr ""
 "Wir konnten den Nachweis noch nicht finden. Die Verbreitung kann etwas "
 "dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:728
-#: lib/vutuv_web/agent_docs/text.ex:558
+#: lib/vutuv_web/agent_docs/markdown.ex:736
+#: lib/vutuv_web/agent_docs/text.ex:565
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -12456,8 +12461,8 @@ msgstr "Verknüpft mit {name}"
 msgid "Remove link"
 msgstr "Verknüpfung entfernen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:320
-#: lib/vutuv_web/agent_docs/text.ex:346
+#: lib/vutuv_web/agent_docs/markdown.ex:328
+#: lib/vutuv_web/agent_docs/text.ex:353
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr "ehemalig"
@@ -12660,7 +12665,7 @@ msgstr "Organisation"
 msgid "Organization pages"
 msgstr "Organisation"
 
-#: lib/vutuv_web/live/notification_live/index.ex:861
+#: lib/vutuv_web/live/notification_live/index.ex:904
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisation"
@@ -12771,22 +12776,22 @@ msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
 msgid "Your organization page was updated."
 msgstr "Ihre Organisationsseite wurde aktualisiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1013
+#: lib/vutuv_web/live/notification_live/index.ex:1065
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr "hat dir eine Rolle bei %{company} gegeben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1010
+#: lib/vutuv_web/live/notification_live/index.ex:1062
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr "hat dich zum Recruiter für %{company} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1007
+#: lib/vutuv_web/live/notification_live/index.ex:1059
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr "hat dich zum Administrator von %{company} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1004
+#: lib/vutuv_web/live/notification_live/index.ex:1056
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr "hat dich zum Inhaber von %{company} gemacht."
@@ -12934,10 +12939,10 @@ msgstr "Entwürfe"
 msgid "Edit posting"
 msgstr "Anzeige bearbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:224
-#: lib/vutuv_web/agent_docs/markdown.ex:353
-#: lib/vutuv_web/agent_docs/text.ex:212
-#: lib/vutuv_web/agent_docs/text.ex:379
+#: lib/vutuv_web/agent_docs/markdown.ex:232
+#: lib/vutuv_web/agent_docs/markdown.ex:361
+#: lib/vutuv_web/agent_docs/text.ex:219
+#: lib/vutuv_web/agent_docs/text.ex:386
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Employer"
@@ -12948,10 +12953,10 @@ msgstr "Arbeitgeber"
 msgid "Employer name (optional)"
 msgstr "Name des Arbeitgebers (optional)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:225
-#: lib/vutuv_web/agent_docs/markdown.ex:354
-#: lib/vutuv_web/agent_docs/text.ex:213
-#: lib/vutuv_web/agent_docs/text.ex:380
+#: lib/vutuv_web/agent_docs/markdown.ex:233
+#: lib/vutuv_web/agent_docs/markdown.ex:362
+#: lib/vutuv_web/agent_docs/text.ex:220
+#: lib/vutuv_web/agent_docs/text.ex:387
 #: lib/vutuv_web/live/job_board_live.ex:367
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
@@ -12990,7 +12995,7 @@ msgstr "Halten Sie Strg / Cmd gedrückt, um mehrere auszuwählen."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:800
+#: lib/vutuv/accounts/user.ex:810
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -13028,12 +13033,12 @@ msgstr "Jobs"
 msgid "Let search engines index this posting."
 msgstr "Suchmaschinen dürfen diese Anzeige indexieren."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:335
-#: lib/vutuv_web/agent_docs/markdown.ex:339
-#: lib/vutuv_web/agent_docs/markdown.ex:341
-#: lib/vutuv_web/agent_docs/text.ex:361
-#: lib/vutuv_web/agent_docs/text.ex:365
-#: lib/vutuv_web/agent_docs/text.ex:367
+#: lib/vutuv_web/agent_docs/markdown.ex:343
+#: lib/vutuv_web/agent_docs/markdown.ex:347
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/text.ex:368
+#: lib/vutuv_web/agent_docs/text.ex:372
+#: lib/vutuv_web/agent_docs/text.ex:374
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -13082,8 +13087,8 @@ msgstr "Neue Konten können nach einigen Tagen veröffentlichen."
 msgid "New posting"
 msgstr "Neue Anzeige"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:236
-#: lib/vutuv_web/agent_docs/text.ex:223
+#: lib/vutuv_web/agent_docs/markdown.ex:244
+#: lib/vutuv_web/agent_docs/text.ex:230
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
@@ -13110,7 +13115,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:799
+#: lib/vutuv/accounts/user.ex:809
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -13167,10 +13172,10 @@ msgstr "Veröffentlichen als"
 msgid "Postal code"
 msgstr "Postleitzahl"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:229
-#: lib/vutuv_web/agent_docs/markdown.ex:358
-#: lib/vutuv_web/agent_docs/text.ex:217
-#: lib/vutuv_web/agent_docs/text.ex:384
+#: lib/vutuv_web/agent_docs/markdown.ex:237
+#: lib/vutuv_web/agent_docs/markdown.ex:366
+#: lib/vutuv_web/agent_docs/text.ex:224
+#: lib/vutuv_web/agent_docs/text.ex:391
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -13192,13 +13197,13 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:801
+#: lib/vutuv/accounts/user.ex:811
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
-#: lib/vutuv_web/agent_docs/markdown.ex:339
-#: lib/vutuv_web/agent_docs/markdown.ex:341
-#: lib/vutuv_web/agent_docs/text.ex:365
-#: lib/vutuv_web/agent_docs/text.ex:367
+#: lib/vutuv_web/agent_docs/markdown.ex:347
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/text.ex:372
+#: lib/vutuv_web/agent_docs/text.ex:374
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format
@@ -13210,18 +13215,18 @@ msgstr "Remote"
 msgid "Report this posting"
 msgstr "Diese Anzeige melden"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:235
-#: lib/vutuv_web/agent_docs/text.ex:222
+#: lib/vutuv_web/agent_docs/markdown.ex:243
+#: lib/vutuv_web/agent_docs/text.ex:229
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Erforderlich"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:228
-#: lib/vutuv_web/agent_docs/markdown.ex:357
-#: lib/vutuv_web/agent_docs/text.ex:216
-#: lib/vutuv_web/agent_docs/text.ex:383
+#: lib/vutuv_web/agent_docs/markdown.ex:236
+#: lib/vutuv_web/agent_docs/markdown.ex:365
+#: lib/vutuv_web/agent_docs/text.ex:223
+#: lib/vutuv_web/agent_docs/text.ex:390
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr "Gehalt"
@@ -13315,10 +13320,10 @@ msgstr "Wer kann sie sehen"
 msgid "Working student"
 msgstr "Werkstudent:in"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:226
-#: lib/vutuv_web/agent_docs/markdown.ex:355
-#: lib/vutuv_web/agent_docs/text.ex:214
-#: lib/vutuv_web/agent_docs/text.ex:381
+#: lib/vutuv_web/agent_docs/markdown.ex:234
+#: lib/vutuv_web/agent_docs/markdown.ex:363
+#: lib/vutuv_web/agent_docs/text.ex:221
+#: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -13491,13 +13496,13 @@ msgstr "%{km} km"
 msgid "All countries"
 msgstr "Alle Länder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:376
+#: lib/vutuv_web/agent_docs/markdown.ex:384
 #: lib/vutuv_web/templates/tag/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Alle Stellen mit diesem Tag"
 
-#: lib/vutuv_web/agent_docs/text.ex:401
+#: lib/vutuv_web/agent_docs/text.ex:408
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr "Alle Stellen mit diesem Tag: %{url}"
@@ -13543,12 +13548,12 @@ msgstr "Mindestgehalt pro Jahr"
 msgid "More jobs"
 msgstr "Weitere Stellen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:248
+#: lib/vutuv_web/agent_docs/markdown.ex:256
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr "Nächste Seite"
 
-#: lib/vutuv_web/agent_docs/text.ex:235
+#: lib/vutuv_web/agent_docs/text.ex:242
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr "Nächste Seite: %{url}"
@@ -13563,10 +13568,10 @@ msgstr "Noch keine Stellenanzeigen."
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Keine passenden Stellen. Passe die Filter an."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:374
-#: lib/vutuv_web/agent_docs/markdown.ex:386
-#: lib/vutuv_web/agent_docs/text.ex:399
-#: lib/vutuv_web/agent_docs/text.ex:411
+#: lib/vutuv_web/agent_docs/markdown.ex:382
+#: lib/vutuv_web/agent_docs/markdown.ex:394
+#: lib/vutuv_web/agent_docs/text.ex:406
+#: lib/vutuv_web/agent_docs/text.ex:418
 #: lib/vutuv_web/live/organization_live/show.ex:329
 #: lib/vutuv_web/templates/tag/show.html.heex:57
 #, elixir-autogen, elixir-format
@@ -13795,7 +13800,7 @@ msgstr[1] "%{count} neue Treffer für deine gespeicherten Suchen"
 msgid "Alert frequency"
 msgstr "Häufigkeit der Benachrichtigung"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:488
+#: lib/vutuv_web/controllers/settings_controller.ex:493
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr "Benachrichtigung aktualisiert."
@@ -13861,13 +13866,13 @@ msgstr "Speichere eine Suche in der Stellenbörse oder in der Personensuche, und
 msgid "Save search"
 msgstr "Suche speichern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:506
+#: lib/vutuv_web/controllers/settings_controller.ex:511
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
 #: lib/vutuv_web/components/ui.ex:3273
-#: lib/vutuv_web/controllers/settings_controller.ex:411
+#: lib/vutuv_web/controllers/settings_controller.ex:416
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13886,8 +13891,8 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr "E-Mail-Benachrichtigungen für deine gespeicherte Suche „%{label}“ stoppen?"
 
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:493
-#: lib/vutuv_web/controllers/settings_controller.ex:511
+#: lib/vutuv_web/controllers/settings_controller.ex:498
+#: lib/vutuv_web/controllers/settings_controller.ex:516
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr "Das hat nicht funktioniert."
@@ -14127,7 +14132,7 @@ msgstr "Dieses Mitglied existiert nicht mehr."
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 Tagen abgelehnt. Eine wachsende Warteschlange bedeutet meist, dass Ollama nicht erreichbar ist."
 
-#: lib/vutuv_web/components/post_components.ex:1268
+#: lib/vutuv_web/components/post_components.ex:1485
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -14135,12 +14140,12 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:1258
+#: lib/vutuv_web/components/post_components.ex:1475
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr "Bild wird geprüft"
 
-#: lib/vutuv_web/live/notification_live/index.ex:859
+#: lib/vutuv_web/live/notification_live/index.ex:902
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -14181,7 +14186,7 @@ msgstr "Screenshot entfernt."
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:844
+#: lib/vutuv/accounts/user.ex:854
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14192,19 +14197,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:847
+#: lib/vutuv/accounts/user.ex:857
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:850
+#: lib/vutuv/accounts/user.ex:860
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:841
+#: lib/vutuv/accounts/user.ex:851
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14227,7 +14232,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:862
+#: lib/vutuv_web/live/notification_live/index.ex:905
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -14239,7 +14244,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] "Wir haben %{formatted} Beitrag aktualisiert, der Ihren alten Handle erwähnt hat, und dessen Verfasser benachrichtigt."
 msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle erwähnt haben, und deren Verfasser benachrichtigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1063
+#: lib/vutuv_web/live/notification_live/index.ex:1115
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
@@ -14279,8 +14284,8 @@ msgstr "Bild einfügen"
 msgid "Insert into text"
 msgstr "In den Text einfügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:180
-#: lib/vutuv_web/agent_docs/text.ex:169
+#: lib/vutuv_web/agent_docs/markdown.ex:188
+#: lib/vutuv_web/agent_docs/text.ex:176
 #: lib/vutuv_web/templates/tag/show.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
@@ -14308,22 +14313,22 @@ msgstr "Mobil (privat)"
 msgid "Work mobile"
 msgstr "Mobil (Arbeit)"
 
-#: lib/vutuv_web/components/post_components.ex:284
+#: lib/vutuv_web/components/post_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Noch keine Beiträge."
 
-#: lib/vutuv_web/components/post_components.ex:286
+#: lib/vutuv_web/components/post_components.ex:287
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Noch keine Antworten."
 
-#: lib/vutuv_web/components/post_components.ex:285
+#: lib/vutuv_web/components/post_components.ex:286
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Noch keine Reposts."
 
-#: lib/vutuv_web/components/post_components.ex:274
+#: lib/vutuv_web/components/post_components.ex:275
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Eigene Beiträge"
@@ -14334,7 +14339,7 @@ msgid "Posts tagged with a tag you follow show up in your feed, and people known
 msgstr "Beiträge mit einem Tag, dem du folgst, landen in deinem Feed, und passende Personen tauchen in deinen Vorschlägen auf. Einem Tag folgst du auf seiner Seite."
 
 #: lib/vutuv_web/components/ui.ex:3269
-#: lib/vutuv_web/controllers/settings_controller.ex:425
+#: lib/vutuv_web/controllers/settings_controller.ex:430
 #: lib/vutuv_web/live/post_live/feed.ex:732
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -14453,22 +14458,22 @@ msgstr[1] "Meine %{formatted} Follower darüber informieren"
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:863
+#: lib/vutuv_web/live/notification_live/index.ex:906
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1083
+#: lib/vutuv_web/live/notification_live/index.ex:1135
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr "hat eine neue Station im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1075
+#: lib/vutuv_web/live/notification_live/index.ex:1127
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr "hat eine neue Ausbildung im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1080
+#: lib/vutuv_web/live/notification_live/index.ex:1132
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr "hat ein neues Zertifikat im Lebenslauf: %{entry}"
@@ -14493,12 +14498,12 @@ msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folg
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1088
+#: lib/vutuv_web/live/notification_live/index.ex:1140
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:1940
+#: lib/vutuv_web/components/post_components.ex:2157
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
@@ -14513,19 +14518,19 @@ msgstr "Autor/in"
 msgid "Book"
 msgstr "Buch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:870
-#: lib/vutuv_web/components/post_components.ex:1897
+#: lib/vutuv_web/agent_docs/markdown.ex:884
+#: lib/vutuv_web/components/post_components.ex:2114
 #: lib/vutuv_web/live/post_live/composer.ex:671
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:1941
+#: lib/vutuv_web/components/post_components.ex:2158
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:1943
+#: lib/vutuv_web/components/post_components.ex:2160
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
@@ -14535,7 +14540,7 @@ msgstr "DVD/Blu-ray"
 msgid "Director"
 msgstr "Regie"
 
-#: lib/vutuv_web/components/post_components.ex:1939
+#: lib/vutuv_web/components/post_components.ex:2156
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
@@ -14545,8 +14550,8 @@ msgstr "E-Book"
 msgid "Film"
 msgstr "Film"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:870
-#: lib/vutuv_web/components/post_components.ex:1896
+#: lib/vutuv_web/agent_docs/markdown.ex:884
+#: lib/vutuv_web/components/post_components.ex:2113
 #: lib/vutuv_web/live/post_live/composer.ex:670
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -14577,7 +14582,7 @@ msgstr "Schlage nach …"
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr "Zu dieser ISBN wurde nichts gefunden. Bitte füllen Sie die Felder selbst aus."
 
-#: lib/vutuv_web/components/post_components.ex:1938
+#: lib/vutuv_web/components/post_components.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
@@ -14604,7 +14609,7 @@ msgstr "Ein Buch besprechen"
 msgid "Review a film"
 msgstr "Einen Film besprechen"
 
-#: lib/vutuv_web/components/post_components.ex:1942
+#: lib/vutuv_web/components/post_components.ex:2159
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14635,34 +14640,34 @@ msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:1979
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:2009
+#: lib/vutuv_web/components/post_components.ex:2226
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:2010
+#: lib/vutuv_web/components/post_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:2008
+#: lib/vutuv_web/components/post_components.ex:2225
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:1968
+#: lib/vutuv_web/components/post_components.ex:2185
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:2015
+#: lib/vutuv_web/components/post_components.ex:2232
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14687,24 +14692,24 @@ msgstr "Qualifikation"
 msgid "With qualification:"
 msgstr "Mit Qualifikation:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:594
+#: lib/vutuv_web/agent_docs/markdown.ex:602
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1782
+#: lib/vutuv_web/components/post_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:740
+#: lib/vutuv_web/live/notification_live/index.ex:779
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} neue Mitteilung"
 msgstr[1] "%{formatted} neue Mitteilungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:754
+#: lib/vutuv_web/live/notification_live/index.ex:793
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day}. %{month} %{year}"
@@ -14719,28 +14724,28 @@ msgstr "Zurückfolgen"
 msgid "Last 30 days"
 msgstr "Letzte 30 Tage"
 
-#: lib/vutuv_web/live/notification_live/index.ex:706
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:745
+#: lib/vutuv_web/live/notification_live/index.ex:954
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/vutuv_web/live/notification_live/index.ex:878
+#: lib/vutuv_web/live/notification_live/index.ex:921
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "sind jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:873
+#: lib/vutuv_web/live/notification_live/index.ex:916
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "folgen Ihnen jetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:888
+#: lib/vutuv_web/live/notification_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:1773
+#: lib/vutuv_web/components/post_components.ex:1990
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14783,19 +14788,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] "Für %{formatted} Job genutzt"
 msgstr[1] "Für %{formatted} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:697
+#: lib/vutuv_web/agent_docs/markdown.ex:705
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr "aktuell genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:696
+#: lib/vutuv_web/agent_docs/markdown.ex:704
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] "für %{count} Job genutzt"
 msgstr[1] "für %{count} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:702
+#: lib/vutuv_web/agent_docs/markdown.ex:710
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14874,8 +14879,8 @@ msgstr "Hochgeladener Nachweis für %{name}"
 msgid "View the uploaded proof (%{label})"
 msgstr "Hochgeladenen Nachweis ansehen (%{label})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:665
-#: lib/vutuv_web/agent_docs/text.ex:550
+#: lib/vutuv_web/agent_docs/markdown.ex:673
+#: lib/vutuv_web/agent_docs/text.ex:557
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "Nachweis"
@@ -14970,8 +14975,8 @@ msgstr "Speichern und weiter"
 msgid "Skip for now"
 msgstr "Erstmal überspringen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:426
-#: lib/vutuv_web/agent_docs/text.ex:423
+#: lib/vutuv_web/agent_docs/markdown.ex:434
+#: lib/vutuv_web/agent_docs/text.ex:430
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr "Bevorzugte Arbeitsform"
@@ -14982,7 +14987,7 @@ msgstr "Bevorzugte Arbeitsform"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: lib/vutuv_web/live/notification_live/index.ex:676
+#: lib/vutuv_web/live/notification_live/index.ex:715
 #, elixir-autogen, elixir-format
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
@@ -14994,7 +14999,7 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1037
+#: lib/vutuv_web/live/notification_live/index.ex:1089
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
@@ -15002,12 +15007,12 @@ msgstr ""
 "familienfreundlich genug für ein Arbeitsumfeld. Sie kann sich irren, "
 "antworten Sie in dem Fall einfach auf unsere E-Mail."
 
-#: lib/vutuv_web/live/notification_live/index.ex:854
+#: lib/vutuv_web/live/notification_live/index.ex:896
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Thread-Antwort"
 
-#: lib/vutuv_web/live/notification_live/index.ex:898
+#: lib/vutuv_web/live/notification_live/index.ex:941
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -15026,12 +15031,12 @@ msgstr "Unterhaltung"
 msgid "Only part of this long conversation is shown."
 msgstr "Von dieser langen Unterhaltung wird nur ein Teil angezeigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:855
+#: lib/vutuv_web/live/notification_live/index.ex:897
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Erwähnung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:996
+#: lib/vutuv_web/live/notification_live/index.ex:1045
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
@@ -15118,7 +15123,7 @@ msgstr "Konto einfrieren"
 msgid "No accounts are currently frozen."
 msgstr "Zurzeit sind keine Konten eingefroren."
 
-#: lib/vutuv_web/live/post_live/thread.ex:216
+#: lib/vutuv_web/live/post_live/thread.ex:301
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr "Von Anfang an lesen"
@@ -15138,14 +15143,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:824
+#: lib/vutuv_web/components/post_components.ex:1005
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:846
+#: lib/vutuv_web/components/post_components.ex:1027
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -15157,7 +15162,7 @@ msgstr[1] "%{formatted} weitere Antworten anzeigen"
 msgid "This page is no longer available."
 msgstr "Diese Seite ist nicht mehr verfügbar."
 
-#: lib/vutuv_web/live/post_live/thread.ex:208
+#: lib/vutuv_web/live/post_live/thread.ex:293
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr "Dieser Beitrag ist Teil einer Unterhaltung mit %{formatted} Beiträgen."
@@ -15172,7 +15177,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:2225
+#: lib/vutuv_web/components/post_components.ex:2475
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15222,7 +15227,7 @@ msgstr "Konto, zu dem Sie umziehen"
 msgid "Cancel redirect"
 msgstr "Weiterleitung aufheben"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:314
+#: lib/vutuv_web/controllers/settings_controller.ex:319
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr "Fertig. Ihre Fediverse-Follower wurden gebeten, Ihrem neuen Konto zu folgen, und neue Beiträge werden von hier nicht mehr föderiert. Ihr vutuv-Profil bleibt unverändert."
@@ -15237,12 +15242,12 @@ msgstr "Tragen Sie unten die Adresse dieses Kontos ein und leiten Sie weiter."
 msgid "On your other account, add your vutuv handle"
 msgstr "Fügen Sie auf Ihrem anderen Konto Ihr vutuv-Handle"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:353
+#: lib/vutuv_web/controllers/settings_controller.ex:358
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr "Bitte geben Sie die vollständige https-Adresse des Kontos ein, zu dem Sie umziehen."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:339
+#: lib/vutuv_web/controllers/settings_controller.ex:344
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr "Weiterleitung aufgehoben. Ihre Beiträge werden wieder von hier föderiert."
@@ -15257,17 +15262,17 @@ msgstr "Meine Follower weiterleiten"
 msgid "Redirected on %{date}"
 msgstr "Weitergeleitet am %{date}"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:366
+#: lib/vutuv_web/controllers/settings_controller.ex:371
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr "Dieses Konto war nicht erreichbar. Prüfen Sie die Adresse und ob der andere Server online ist."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:360
+#: lib/vutuv_web/controllers/settings_controller.ex:365
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr "Dieses Konto führt Ihr vutuv-Profil noch nicht als Alias. Fügen Sie dort zuerst die Adresse dieses Profils hinzu und versuchen Sie es dann erneut."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:356
+#: lib/vutuv_web/controllers/settings_controller.ex:361
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr "Das ist dieses Konto. Geben Sie das Konto an, zu dem Sie umziehen."
@@ -15277,12 +15282,12 @@ msgstr "Das ist dieses Konto. Geben Sie das Konto an, zu dem Sie umziehen."
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr "Damit werden Ihre Fediverse-Follower gebeten, stattdessen Ihrem neuen Konto zu folgen, und Ihre Beiträge werden von hier nicht mehr föderiert. Ihr vutuv-Profil ist nicht betroffen. Fortfahren?"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:344
+#: lib/vutuv_web/controllers/settings_controller.ex:349
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr "Schalten Sie zuerst die Föderation ein, dann können Sie Ihre Follower weiterleiten."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:348
+#: lib/vutuv_web/controllers/settings_controller.ex:353
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr "Sie können nur alle %{days} Tage umziehen."
@@ -15304,7 +15309,7 @@ msgstr[1] "%{formatted} Empfehlungen"
 msgid "All endorsers"
 msgstr "Alle Empfehlenden"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:442
+#: lib/vutuv_web/controllers/settings_controller.ex:447
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgeblendet."
@@ -15314,7 +15319,7 @@ msgstr "Filter hinzugefügt. Passende Beiträge sind jetzt in Ihrem Feed ausgebl
 msgid "Filter by a tag"
 msgstr "Nach einem Tag filtern"
 
-#: lib/vutuv_web/controllers/settings_controller.ex:467
+#: lib/vutuv_web/controllers/settings_controller.ex:472
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr "Filter entfernt."
@@ -15335,7 +15340,7 @@ msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
 #: lib/vutuv_web/components/ui.ex:3265
-#: lib/vutuv_web/controllers/settings_controller.ex:478
+#: lib/vutuv_web/controllers/settings_controller.ex:483
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -15384,7 +15389,7 @@ msgstr "Diese Ausbildung wird jetzt oben in Ihrem Profil angezeigt."
 msgid "Thread replies"
 msgstr "Thread-Antworten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:481
+#: lib/vutuv_web/live/notification_live/index.ex:506
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr "Thread-Benachrichtigungen abschalten"
@@ -15430,12 +15435,12 @@ msgstr "Sie dürfen den Benutzernamen dieser Organisation nicht ändern."
 msgid "You have not muted anything yet."
 msgstr "Sie haben noch nichts stummgeschaltet."
 
-#: lib/vutuv_web/controllers/settings_controller.ex:450
+#: lib/vutuv_web/controllers/settings_controller.ex:455
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:476
+#: lib/vutuv_web/live/notification_live/index.ex:501
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr "Sie haben in diesem Thread geschrieben."
@@ -15445,17 +15450,17 @@ msgstr "Sie haben in diesem Thread geschrieben."
 msgid "e.g. crypto*, \"machine learning\", politics"
 msgstr "z. B. crypto*, \"machine learning\", Politik"
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:44
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:49
 #, elixir-autogen, elixir-format
 msgid "Enter the server name on its own, for example mastodon.example."
 msgstr "Geben Sie nur den Servernamen ein, zum Beispiel mastodon.example."
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:58
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:63
 #, elixir-autogen, elixir-format
 msgid "%{host} is no longer blocked. What was deleted stays deleted; the server has to follow again."
 msgstr "%{host} ist nicht mehr blockiert. Gelöschtes bleibt gelöscht; der Server muss erneut folgen."
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:71
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:76
 #, elixir-autogen, elixir-format
 msgid "%{host} is blocked. Removed: %{followers} remote followers and %{deliveries} queued deliveries."
 msgstr "%{host} ist blockiert. Entfernt: %{followers} entfernte Follower und %{deliveries} wartende Zustellungen."
@@ -15522,6 +15527,7 @@ msgstr "Kein Server ist blockiert."
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:84
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:135
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "Server"
 msgstr "Server"
@@ -15571,7 +15577,7 @@ msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
 msgid "none yet"
 msgstr "noch keiner"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:858
+#: lib/vutuv_web/agent_docs/markdown.ex:866
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken"
@@ -15580,13 +15586,6 @@ msgstr "Reaktionen aus anderen Netzwerken"
 #, elixir-autogen, elixir-format
 msgid "Count reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken zählen"
-
-#: lib/vutuv_web/components/post_components.ex:2185
-#, elixir-autogen, elixir-format
-msgid "%{formatted} reaction from other networks"
-msgid_plural "%{formatted} reactions from other networks"
-msgstr[0] "%{formatted} Reaktion aus anderen Netzwerken"
-msgstr[1] "%{formatted} Reaktionen aus anderen Netzwerken"
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:15
 #, elixir-autogen, elixir-format
@@ -15633,34 +15632,34 @@ msgstr "Ausgeschaltet ist Ihr Profil dort nicht auffindbar und es wird nichts zu
 msgid "Show under each of your posts how many people out there liked or shared it. A number only, visible to everyone who sees the post. Switching it off deletes what is stored for it."
 msgstr "Zeigen Sie unter jedem Ihrer Beiträge, wie viele Menschen dort draußen ihn geliked oder geteilt haben. Nur eine Zahl, sichtbar für alle, die den Beitrag sehen. Ausschalten löscht, was dafür gespeichert ist."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:92
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr "Geben Sie es weiter wie eine E-Mail-Adresse. Jeder bei Mastodon und Co. kann es in die Suche einfügen und Ihnen von dort folgen."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr "Noch niemand. Posten Sie Ihr Handle dort, wo andere es sehen, dann tauchen die ersten Follower hier auf."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:171
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Related"
 msgstr "Verwandte Themen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:174
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Moving to or away from another Fediverse account?"
 msgstr "Ziehen Sie zu einem anderen Fediverse-Konto um oder von dort zu vutuv?"
 
 #: lib/vutuv_web/controllers/settings_controller.ex:216
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:180
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:195
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Move your account"
 msgstr "Konto umziehen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:184
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr "Sie möchten das Häkchen in Ihrem Mastodon-Profil? Das geht ohne Teilnahme hier: Ihr vutuv-Profil verlinkt Ihre eingetragenen Konten mit rel=\"me\"."
@@ -15715,7 +15714,7 @@ msgstr "Schicken Sie Ihre Fediverse-Follower zu einem anderen Konto. Sie werden 
 msgid "Back to Fediverse settings"
 msgstr "Zurück zu den Fediverse-Einstellungen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:114
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower from other networks"
 msgid_plural "%{formatted} followers from other networks"
@@ -15957,8 +15956,8 @@ msgstr "%{server} hat nicht geantwortet. Kopieren Sie stattdessen die Adresse ob
 msgid "Your server"
 msgstr "Ihr Server"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:448
-#: lib/vutuv_web/agent_docs/text.ex:445
+#: lib/vutuv_web/agent_docs/markdown.ex:456
+#: lib/vutuv_web/agent_docs/text.ex:452
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
@@ -16314,13 +16313,13 @@ msgstr "Benutzernamen ändern"
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr "Dieser Link öffnet immer Ihr Profil, auch nachdem Sie Ihren Benutzernamen geändert haben. Er wird aus einer festen Id gebildet und geht bei einer Umbenennung nie kaputt. Für den Alltag ist die kurze Adresse oben freundlicher."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:235
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:250
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr "Verstanden, abschalten"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:233
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:248
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
@@ -16369,3 +16368,150 @@ msgstr ""
 "erst dort, können wir sie nicht löschen, nicht ändern und nicht verfolgen, "
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
+
+#: lib/vutuv_web/components/post_components.ex:2435
+#, elixir-autogen, elixir-format
+msgid "%{count} from other networks"
+msgstr "%{count} aus anderen Netzwerken"
+
+#: lib/vutuv_web/components/post_components.ex:2438
+#, elixir-autogen, elixir-format
+msgid "%{formatted} reaction"
+msgid_plural "%{formatted} reactions"
+msgstr[0] "%{formatted} Reaktion"
+msgstr[1] "%{formatted} Reaktionen"
+
+#: lib/vutuv_web/components/post_components.ex:2444
+#, elixir-autogen, elixir-format
+msgid "%{formatted} reply"
+msgid_plural "%{formatted} replies"
+msgstr[0] "%{formatted} Antwort"
+msgstr[1] "%{formatted} Antworten"
+
+#: lib/vutuv_web/components/post_components.ex:2428
+#, elixir-autogen, elixir-format
+msgid "%{reactions} and %{replies} from other networks"
+msgstr "%{reactions} und %{replies} aus anderen Netzwerken"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:167
+#, elixir-autogen, elixir-format
+msgid "A report deletes the reply right away, with no queue to work through. This is the trail, so a server that keeps showing up here can be blocked above. It holds no text and no links, only which server and which account (as a short digest)."
+msgstr "Eine Meldung löscht die Antwort sofort, es gibt keine Warteschlange. Dies ist die Spur dazu: Ein Server, der hier immer wieder auftaucht, lässt sich oben sperren. Festgehalten werden weder Text noch Links, nur welcher Server und welches Konto (als kurzer Prüfwert)."
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:89
+#, elixir-autogen, elixir-format
+msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
+msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem Beitrag, gekennzeichnet als aus einem anderen Netzwerk. Wir speichern eine Kopie für bis zu sechs Monate und prüfen ab und zu, ob sie dort noch veröffentlicht ist; löscht sie die Autorin oder der Autor, verschwindet auch unsere. Sie können jede einzelne Antwort entfernen, und wenn Sie das hier ausschalten, werden alle gelöscht."
+
+#: lib/vutuv_web/agent_docs/markdown.ex:973
+#: lib/vutuv_web/agent_docs/text.ex:647
+#, elixir-autogen, elixir-format
+msgid "Content warning"
+msgstr "Inhaltswarnung"
+
+#: lib/vutuv_web/components/post_components.ex:784
+#: lib/vutuv_web/components/post_components.ex:865
+#, elixir-autogen, elixir-format
+msgid "From another network"
+msgstr "Aus einem anderen Netzwerk"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:164
+#, elixir-autogen, elixir-format
+msgid "Nobody has removed or reported a reply yet."
+msgstr "Bisher hat niemand eine Antwort entfernt oder gemeldet."
+
+#: lib/vutuv_web/components/post_components.ex:815
+#, elixir-autogen, elixir-format
+msgid "Remove this reply from your post?"
+msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:15
+#, elixir-autogen, elixir-format
+msgid "Removed by the member"
+msgstr "Vom Mitglied entfernt"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:122
+#: lib/vutuv_web/agent_docs/markdown.ex:871
+#: lib/vutuv_web/agent_docs/text.ex:113
+#, elixir-autogen, elixir-format
+msgid "Replies from other networks"
+msgstr "Antworten aus anderen Netzwerken"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:162
+#, elixir-autogen, elixir-format
+msgid "Replies taken down by members"
+msgstr "Von Mitgliedern entfernte Antworten"
+
+#: lib/vutuv_web/live/notification_live/index.ex:899
+#, elixir-autogen, elixir-format
+msgid "Reply from another network"
+msgstr "Antwort aus einem anderen Netzwerk"
+
+#: lib/vutuv_web/live/post_live/thread.ex:95
+#, elixir-autogen, elixir-format
+msgid "Reply removed."
+msgstr "Antwort entfernt."
+
+#: lib/vutuv_web/components/post_components.ex:824
+#, elixir-autogen, elixir-format
+msgid "Report this reply as not appropriate? It is deleted right away."
+msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:14
+#, elixir-autogen, elixir-format
+msgid "Reported as not appropriate"
+msgstr "Als unangemessen gemeldet"
+
+#: lib/vutuv_web/components/post_components.ex:841
+#: lib/vutuv_web/live/notification_live/index.ex:479
+#, elixir-autogen, elixir-format
+msgid "Sent to you only, visible to nobody else"
+msgstr "Nur an Sie gesendet, für niemanden sonst sichtbar"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Show replies from other networks"
+msgstr "Antworten aus anderen Netzwerken anzeigen"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:137
+#, elixir-autogen, elixir-format
+msgid "Stored replies"
+msgstr "Gespeicherte Antworten"
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:16
+#, elixir-autogen, elixir-format
+msgid "Taken down"
+msgstr "Entfernt"
+
+#: lib/vutuv_web/live/post_live/thread.ex:104
+#, elixir-autogen, elixir-format
+msgid "Thank you. The reply was deleted right away."
+msgstr "Danke. Die Antwort wurde sofort gelöscht."
+
+#: lib/vutuv_web/live/post_live/thread.ex:205
+#, elixir-autogen, elixir-format
+msgid "That reply is not yours to remove."
+msgstr "Diese Antwort können Sie nicht entfernen."
+
+#: lib/vutuv_web/agent_docs/markdown.ex:975
+#: lib/vutuv_web/components/post_components.ex:871
+#, elixir-autogen, elixir-format
+msgid "View the original"
+msgstr "Original ansehen"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:176
+#, elixir-autogen, elixir-format
+msgid "What"
+msgstr "Was"
+
+#: lib/vutuv_web/live/post_live/thread.ex:201
+#, elixir-autogen, elixir-format
+msgid "You have reported a lot today. Please try again tomorrow."
+msgstr "Sie haben heute schon viel gemeldet. Bitte versuchen Sie es morgen wieder."
+"Sie haben das heutige Einladungslimit erreicht. Bitte versuchen Sie es "
+"morgen erneut."
+
+#: lib/vutuv_web/live/notification_live/index.ex:1048
+#, elixir-autogen, elixir-format
+msgid "replied to your post from another network."
+msgstr "hat aus einem anderen Netzwerk auf Ihren Beitrag geantwortet."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -26,9 +26,9 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:208
+#: lib/vutuv_web/agent_docs/markdown.ex:216
 #: lib/vutuv_web/agent_docs/section_docs.ex:121
-#: lib/vutuv_web/agent_docs/text.ex:197
+#: lib/vutuv_web/agent_docs/text.ex:204
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
@@ -96,10 +96,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:432
-#: lib/vutuv_web/agent_docs/markdown.ex:433
-#: lib/vutuv_web/agent_docs/text.ex:429
-#: lib/vutuv_web/agent_docs/text.ex:430
+#: lib/vutuv_web/agent_docs/markdown.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:441
+#: lib/vutuv_web/agent_docs/text.ex:436
+#: lib/vutuv_web/agent_docs/text.ex:437
 #: lib/vutuv_web/templates/user/show.html.heex:929
 #, elixir-autogen
 msgid "Birthday"
@@ -118,7 +118,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:86
 #: lib/vutuv_web/templates/report/new.html.heex:103
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:225
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:240
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:50
@@ -153,7 +153,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1054
+#: lib/vutuv_web/components/post_components.ex:1271
 #: lib/vutuv_web/components/ui.ex:2935
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -201,7 +201,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1047
+#: lib/vutuv_web/components/post_components.ex:1264
 #: lib/vutuv_web/components/ui.ex:2926
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -312,10 +312,10 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:456
-#: lib/vutuv_web/agent_docs/text.ex:453
+#: lib/vutuv_web/agent_docs/markdown.ex:464
+#: lib/vutuv_web/agent_docs/text.ex:460
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/notification_live/index.ex:798
+#: lib/vutuv_web/live/notification_live/index.ex:837
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:136
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -323,8 +323,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:457
-#: lib/vutuv_web/agent_docs/text.ex:454
+#: lib/vutuv_web/agent_docs/markdown.ex:465
+#: lib/vutuv_web/agent_docs/text.ex:461
 #: lib/vutuv_web/components/ui.ex:1551
 #: lib/vutuv_web/components/ui.ex:1576
 #: lib/vutuv_web/components/ui.ex:1579
@@ -339,8 +339,8 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:431
-#: lib/vutuv_web/agent_docs/text.ex:428
+#: lib/vutuv_web/agent_docs/markdown.ex:439
+#: lib/vutuv_web/agent_docs/text.ex:435
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -459,7 +459,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:722
+#: lib/vutuv_web/live/notification_live/index.ex:761
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -476,7 +476,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:525
+#: lib/vutuv_web/live/notification_live/index.ex:550
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -618,7 +618,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:818
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:80
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:95
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:73
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
@@ -647,6 +647,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+#: lib/vutuv_web/components/post_components.ex:850
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -786,7 +787,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
-#: lib/vutuv_web/live/notification_live/index.ex:864
+#: lib/vutuv_web/live/notification_live/index.ex:907
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -976,14 +977,14 @@ msgstr ""
 msgid "http://www.example.com"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:937
+#: lib/vutuv/accounts/user.ex:947
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:936
+#: lib/vutuv/accounts/user.ex:946
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1397,11 +1398,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
-#: lib/vutuv_web/agent_docs/markdown.ex:368
-#: lib/vutuv_web/agent_docs/markdown.ex:815
+#: lib/vutuv_web/agent_docs/markdown.ex:376
+#: lib/vutuv_web/agent_docs/markdown.ex:823
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:394
-#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/text.ex:401
+#: lib/vutuv_web/agent_docs/text.ex:591
 #: lib/vutuv_web/components/ui.ex:3220
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1764,7 +1765,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:287
+#: lib/vutuv_web/components/post_components.ex:288
 #: lib/vutuv_web/components/ui.ex:3045
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
@@ -1905,17 +1906,17 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:885
+#: lib/vutuv_web/live/notification_live/index.ex:928
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:880
+#: lib/vutuv_web/live/notification_live/index.ex:923
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:875
+#: lib/vutuv_web/live/notification_live/index.ex:918
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1051
+#: lib/vutuv_web/components/post_components.ex:1268
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2152,8 +2153,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1033
-#: lib/vutuv_web/components/post_components.ex:1035
+#: lib/vutuv_web/components/post_components.ex:1250
+#: lib/vutuv_web/components/post_components.ex:1252
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2201,13 +2202,13 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:92
+#: lib/vutuv_web/agent_docs/post_doc.ex:102
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:75
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/notification_live/index.ex:720
+#: lib/vutuv_web/live/notification_live/index.ex:759
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:179
 #: lib/vutuv_web/live/search_live.ex:462
@@ -2217,18 +2218,19 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1444
-#: lib/vutuv_web/components/post_components.ex:1448
+#: lib/vutuv_web/components/post_components.ex:1661
+#: lib/vutuv_web/components/post_components.ex:1665
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1445
+#: lib/vutuv_web/components/post_components.ex:1662
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
+#: lib/vutuv_web/components/post_components.ex:817
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:209
 #: lib/vutuv_web/live/organization_live/edit.ex:371
@@ -2314,27 +2316,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1030
+#: lib/vutuv_web/components/post_components.ex:1247
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2077
+#: lib/vutuv_web/components/post_components.ex:2294
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2081
+#: lib/vutuv_web/components/post_components.ex:2298
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2079
+#: lib/vutuv_web/components/post_components.ex:2296
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2080
+#: lib/vutuv_web/components/post_components.ex:2297
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2375,7 +2377,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2158
+#: lib/vutuv_web/components/post_components.ex:2375
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2484
@@ -2384,7 +2386,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:850
+#: lib/vutuv_web/agent_docs/markdown.ex:858
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:490
@@ -2394,19 +2396,19 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2217
+#: lib/vutuv_web/components/post_components.ex:2467
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2470
-#: lib/vutuv_web/live/notification_live/index.ex:856
+#: lib/vutuv_web/live/notification_live/index.ex:898
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:849
-#: lib/vutuv_web/components/post_components.ex:2226
-#: lib/vutuv_web/live/notification_live/index.ex:800
+#: lib/vutuv_web/agent_docs/markdown.ex:857
+#: lib/vutuv_web/components/post_components.ex:2476
+#: lib/vutuv_web/live/notification_live/index.ex:839
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:559
@@ -2425,12 +2427,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2147
+#: lib/vutuv_web/components/post_components.ex:2364
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2158
+#: lib/vutuv_web/components/post_components.ex:2375
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2439,23 +2441,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/components/post_components.ex:2361
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1562
+#: lib/vutuv_web/components/post_components.ex:1779
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/components/post_components.ex:2361
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2217
+#: lib/vutuv_web/components/post_components.ex:2467
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2478,26 +2480,26 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2266
+#: lib/vutuv_web/components/post_components.ex:2516
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:276
-#: lib/vutuv_web/live/notification_live/index.ex:801
+#: lib/vutuv_web/components/post_components.ex:277
+#: lib/vutuv_web/live/notification_live/index.ex:840
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2249
-#: lib/vutuv_web/components/post_components.ex:2250
-#: lib/vutuv_web/live/notification_live/index.ex:853
+#: lib/vutuv_web/components/post_components.ex:2499
+#: lib/vutuv_web/components/post_components.ex:2500
+#: lib/vutuv_web/live/notification_live/index.ex:895
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1001
+#: lib/vutuv_web/components/post_components.ex:1218
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2513,7 +2515,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:994
+#: lib/vutuv_web/live/notification_live/index.ex:1043
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2523,12 +2525,12 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:996
+#: lib/vutuv_web/components/post_components.ex:1213
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:990
+#: lib/vutuv_web/components/post_components.ex:1207
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2788,10 +2790,10 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:458
-#: lib/vutuv_web/agent_docs/text.ex:455
+#: lib/vutuv_web/agent_docs/markdown.ex:466
+#: lib/vutuv_web/agent_docs/text.ex:462
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:799
+#: lib/vutuv_web/live/notification_live/index.ex:838
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2835,7 +2837,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2078
+#: lib/vutuv_web/components/post_components.ex:2295
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2845,22 +2847,22 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:865
+#: lib/vutuv_web/live/notification_live/index.ex:908
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:857
+#: lib/vutuv_web/live/notification_live/index.ex:900
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:852
+#: lib/vutuv_web/live/notification_live/index.ex:894
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:851
+#: lib/vutuv_web/live/notification_live/index.ex:893
 #: lib/vutuv_web/templates/user/show.html.heex:757
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2873,7 +2875,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:882
+#: lib/vutuv_web/live/notification_live/index.ex:925
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2905,12 +2907,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1073
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1022
+#: lib/vutuv_web/live/notification_live/index.ex:1074
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -2940,8 +2942,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/text.ex:272
+#: lib/vutuv_web/agent_docs/markdown.ex:295
+#: lib/vutuv_web/agent_docs/text.ex:279
 #: lib/vutuv_web/controllers/page_controller.ex:55
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3016,7 +3018,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:858
+#: lib/vutuv_web/live/notification_live/index.ex:901
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3096,7 +3098,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:978
+#: lib/vutuv_web/components/post_components.ex:1195
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3171,7 +3173,8 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1075
+#: lib/vutuv_web/components/post_components.ex:827
+#: lib/vutuv_web/components/post_components.ex:1292
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3436,12 +3439,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1024
+#: lib/vutuv_web/live/notification_live/index.ex:1076
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1023
+#: lib/vutuv_web/live/notification_live/index.ex:1075
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3451,7 +3454,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1025
+#: lib/vutuv_web/live/notification_live/index.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3635,7 +3638,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1049
+#: lib/vutuv_web/live/notification_live/index.ex:1101
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3660,7 +3663,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:860
+#: lib/vutuv_web/live/notification_live/index.ex:903
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3735,7 +3738,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1054
+#: lib/vutuv_web/live/notification_live/index.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -3820,30 +3823,30 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:548
+#: lib/vutuv_web/agent_docs/markdown.ex:556
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:903
+#: lib/vutuv_web/agent_docs/markdown.ex:917
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:128
-#: lib/vutuv_web/agent_docs/text.ex:117
+#: lib/vutuv_web/agent_docs/markdown.ex:136
+#: lib/vutuv_web/agent_docs/text.ex:124
 #, elixir-autogen, elixir-format
 msgid "%{count} posts by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:82
-#: lib/vutuv_web/agent_docs/markdown.ex:151
-#: lib/vutuv_web/agent_docs/markdown.ex:164
-#: lib/vutuv_web/agent_docs/markdown.ex:815
+#: lib/vutuv_web/agent_docs/markdown.ex:159
+#: lib/vutuv_web/agent_docs/markdown.ex:172
+#: lib/vutuv_web/agent_docs/markdown.ex:823
 #: lib/vutuv_web/agent_docs/text.ex:79
-#: lib/vutuv_web/agent_docs/text.ex:140
-#: lib/vutuv_web/agent_docs/text.ex:153
-#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/text.ex:147
+#: lib/vutuv_web/agent_docs/text.ex:160
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3860,34 +3863,34 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:833
-#: lib/vutuv_web/agent_docs/text.ex:595
+#: lib/vutuv_web/agent_docs/markdown.ex:841
+#: lib/vutuv_web/agent_docs/text.ex:602
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:830
-#: lib/vutuv_web/agent_docs/text.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:838
+#: lib/vutuv_web/agent_docs/text.ex:599
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:837
-#: lib/vutuv_web/agent_docs/markdown.ex:938
-#: lib/vutuv_web/agent_docs/text.ex:598
-#: lib/vutuv_web/agent_docs/text.ex:626
+#: lib/vutuv_web/agent_docs/markdown.ex:845
+#: lib/vutuv_web/agent_docs/markdown.ex:952
+#: lib/vutuv_web/agent_docs/text.ex:605
+#: lib/vutuv_web/agent_docs/text.ex:633
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:428
-#: lib/vutuv_web/agent_docs/text.ex:425
+#: lib/vutuv_web/agent_docs/markdown.ex:436
+#: lib/vutuv_web/agent_docs/text.ex:432
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:177
-#: lib/vutuv_web/agent_docs/text.ex:166
+#: lib/vutuv_web/agent_docs/markdown.ex:185
+#: lib/vutuv_web/agent_docs/text.ex:173
 #, elixir-autogen, elixir-format
 msgid "Most endorsed members"
 msgstr ""
@@ -3902,7 +3905,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:93
+#: lib/vutuv_web/agent_docs/post_doc.ex:103
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -3921,23 +3924,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:422
-#: lib/vutuv_web/agent_docs/text.ex:419
+#: lib/vutuv_web/agent_docs/markdown.ex:430
+#: lib/vutuv_web/agent_docs/text.ex:426
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:784
+#: lib/vutuv_web/agent_docs/markdown.ex:792
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:714
+#: lib/vutuv_web/agent_docs/markdown.ex:722
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
+#: lib/vutuv_web/agent_docs/markdown.ex:723
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4012,8 +4015,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:301
-#: lib/vutuv_web/agent_docs/text.ex:280
+#: lib/vutuv_web/agent_docs/markdown.ex:309
+#: lib/vutuv_web/agent_docs/text.ex:287
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4065,8 +4068,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:291
-#: lib/vutuv_web/agent_docs/text.ex:276
+#: lib/vutuv_web/agent_docs/markdown.ex:299
+#: lib/vutuv_web/agent_docs/text.ex:283
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4082,8 +4085,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:288
-#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:296
+#: lib/vutuv_web/agent_docs/text.ex:280
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4297,14 +4300,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:293
-#: lib/vutuv_web/agent_docs/text.ex:278
+#: lib/vutuv_web/agent_docs/markdown.ex:301
+#: lib/vutuv_web/agent_docs/text.ex:285
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:289
-#: lib/vutuv_web/agent_docs/text.ex:274
+#: lib/vutuv_web/agent_docs/markdown.ex:297
+#: lib/vutuv_web/agent_docs/text.ex:281
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4580,10 +4583,10 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:316
-#: lib/vutuv_web/agent_docs/text.ex:342
+#: lib/vutuv_web/agent_docs/markdown.ex:324
+#: lib/vutuv_web/agent_docs/text.ex:349
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:721
+#: lib/vutuv_web/live/notification_live/index.ex:760
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:177
@@ -4602,10 +4605,10 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:273
+#: lib/vutuv_web/components/post_components.ex:274
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:719
+#: lib/vutuv_web/live/notification_live/index.ex:758
 #: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -4704,8 +4707,8 @@ msgstr ""
 msgid "Edit your profile and its sections"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:230
-#: lib/vutuv_web/agent_docs/text.ex:218
+#: lib/vutuv_web/agent_docs/markdown.ex:238
+#: lib/vutuv_web/agent_docs/text.ex:225
 #: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
@@ -5395,10 +5398,10 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1137
-#: lib/vutuv_web/components/post_components.ex:1191
-#: lib/vutuv_web/components/post_components.ex:1506
-#: lib/vutuv_web/live/notification_live/index.ex:558
+#: lib/vutuv_web/components/post_components.ex:1354
+#: lib/vutuv_web/components/post_components.ex:1408
+#: lib/vutuv_web/components/post_components.ex:1723
+#: lib/vutuv_web/live/notification_live/index.ex:583
 #: lib/vutuv_web/live/post_live/feed.ex:818
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5414,7 +5417,7 @@ msgstr ""
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:940
+#: lib/vutuv/accounts/user.ex:950
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5452,6 +5455,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3293
 #: lib/vutuv_web/live/admin/user_live.ex:266
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:178
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Account"
@@ -5481,7 +5485,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:393
+#: lib/vutuv_web/controllers/settings_controller.ex:398
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr ""
@@ -5561,7 +5565,7 @@ msgstr ""
 msgid "Language & region"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:535
+#: lib/vutuv_web/controllers/settings_controller.ex:540
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr ""
@@ -5620,7 +5624,7 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:802
+#: lib/vutuv_web/live/notification_live/index.ex:841
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -5643,7 +5647,7 @@ msgstr ""
 msgid "New followers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:383
+#: lib/vutuv_web/controllers/settings_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr ""
@@ -5840,7 +5844,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:630
+#: lib/vutuv_web/controllers/settings_controller.ex:635
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5880,7 +5884,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:619
+#: lib/vutuv_web/controllers/settings_controller.ex:624
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -6112,8 +6116,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:434
-#: lib/vutuv_web/agent_docs/text.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:442
+#: lib/vutuv_web/agent_docs/text.ex:438
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6185,8 +6189,8 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:849
-#: lib/vutuv_web/components/post_components.ex:275
+#: lib/vutuv_web/agent_docs/markdown.ex:857
+#: lib/vutuv_web/components/post_components.ex:276
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
@@ -6230,7 +6234,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:550
+#: lib/vutuv_web/controllers/settings_controller.ex:555
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -6281,15 +6285,15 @@ msgid "No endorsements yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1332
-#: lib/vutuv_web/live/notification_live/index.ex:503
-#: lib/vutuv_web/live/notification_live/index.ex:518
-#: lib/vutuv_web/live/notification_live/index.ex:641
-#: lib/vutuv_web/live/notification_live/index.ex:643
+#: lib/vutuv_web/live/notification_live/index.ex:528
+#: lib/vutuv_web/live/notification_live/index.ex:543
+#: lib/vutuv_web/live/notification_live/index.ex:666
+#: lib/vutuv_web/live/notification_live/index.ex:668
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:828
+#: lib/vutuv_web/agent_docs/markdown.ex:836
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6498,6 +6502,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:175
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -6620,7 +6625,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1072
+#: lib/vutuv_web/components/post_components.ex:1289
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6630,7 +6635,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1071
+#: lib/vutuv_web/components/post_components.ex:1288
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -6825,8 +6830,8 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:204
-#: lib/vutuv_web/agent_docs/text.ex:193
+#: lib/vutuv_web/agent_docs/markdown.ex:212
+#: lib/vutuv_web/agent_docs/text.ex:200
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #: lib/vutuv_web/templates/settings/filters.html.heex:17
@@ -7484,17 +7489,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:908
+#: lib/vutuv_web/agent_docs/markdown.ex:922
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:911
+#: lib/vutuv_web/agent_docs/markdown.ex:925
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:918
+#: lib/vutuv_web/agent_docs/markdown.ex:932
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -7702,13 +7707,13 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:748
+#: lib/vutuv_web/live/notification_live/index.ex:787
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:751
+#: lib/vutuv_web/live/notification_live/index.ex:790
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -8617,12 +8622,12 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:447
-#: lib/vutuv_web/agent_docs/markdown.ex:451
-#: lib/vutuv_web/agent_docs/text.ex:444
-#: lib/vutuv_web/agent_docs/text.ex:448
+#: lib/vutuv_web/agent_docs/markdown.ex:455
+#: lib/vutuv_web/agent_docs/markdown.ex:459
+#: lib/vutuv_web/agent_docs/text.ex:451
+#: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/components/ui.ex:3288
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:29
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:34
 #: lib/vutuv_web/controllers/settings_controller.ex:194
 #: lib/vutuv_web/controllers/settings_controller.ex:261
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:288
@@ -8655,12 +8660,12 @@ msgstr ""
 msgid "Fediverse settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:191
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr ""
@@ -8690,7 +8695,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:608
+#: lib/vutuv_web/agent_docs/markdown.ex:616
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8711,7 +8716,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:609
+#: lib/vutuv_web/agent_docs/markdown.ex:617
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8742,13 +8747,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:646
+#: lib/vutuv_web/agent_docs/markdown.ex:654
 #: lib/vutuv_web/views/education_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:645
+#: lib/vutuv_web/agent_docs/markdown.ex:653
 #: lib/vutuv_web/views/education_html.ex:29
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8774,14 +8779,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1565
+#: lib/vutuv_web/components/post_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:787
+#: lib/vutuv_web/agent_docs/markdown.ex:795
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8859,14 +8864,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:607
+#: lib/vutuv_web/agent_docs/markdown.ex:615
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:610
+#: lib/vutuv_web/agent_docs/markdown.ex:618
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9010,8 +9015,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:467
-#: lib/vutuv_web/agent_docs/text.ex:462
+#: lib/vutuv_web/agent_docs/markdown.ex:475
+#: lib/vutuv_web/agent_docs/text.ex:469
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9433,13 +9438,13 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:424
-#: lib/vutuv_web/agent_docs/text.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:432
+#: lib/vutuv_web/agent_docs/text.ex:428
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:788
+#: lib/vutuv/accounts/user.ex:798
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9450,7 +9455,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:785
+#: lib/vutuv/accounts/user.ex:795
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9537,7 +9542,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:708
+#: lib/vutuv_web/agent_docs/markdown.ex:716
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9614,7 +9619,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:683
+#: lib/vutuv_web/agent_docs/markdown.ex:691
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9631,7 +9636,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:707
+#: lib/vutuv_web/agent_docs/markdown.ex:715
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9658,7 +9663,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:681
+#: lib/vutuv_web/agent_docs/markdown.ex:689
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9673,7 +9678,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:682
+#: lib/vutuv_web/agent_docs/markdown.ex:690
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -9690,7 +9695,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:565
+#: lib/vutuv_web/agent_docs/markdown.ex:573
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -9877,7 +9882,7 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:106
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:121
 #: lib/vutuv_web/templates/totp/new.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:848
 #: lib/vutuv_web/templates/username/new.html.heex:27
@@ -9886,8 +9891,8 @@ msgstr ""
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:109
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:120
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
 #: lib/vutuv_web/templates/user/show.html.heex:847
@@ -9915,12 +9920,12 @@ msgstr ""
 msgid "Outbound federation is healthy."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:150
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Showing the most recent %{shown} of %{total}."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Accounts that no longer exist on their own server drop off this list by themselves."
 msgstr ""
@@ -10323,21 +10328,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:525
+#: lib/vutuv_web/agent_docs/markdown.ex:533
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:523
+#: lib/vutuv_web/agent_docs/markdown.ex:531
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:521
+#: lib/vutuv_web/agent_docs/markdown.ex:529
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10390,12 +10395,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:539
+#: lib/vutuv_web/agent_docs/markdown.ex:547
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:526
+#: lib/vutuv_web/agent_docs/markdown.ex:534
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10661,7 +10666,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:563
+#: lib/vutuv_web/controllers/settings_controller.ex:568
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10710,7 +10715,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:594
+#: lib/vutuv_web/controllers/settings_controller.ex:599
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10725,7 +10730,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:590
+#: lib/vutuv_web/controllers/settings_controller.ex:595
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -10941,19 +10946,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:826
+#: lib/vutuv/accounts/user.ex:836
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:831
+#: lib/vutuv/accounts/user.ex:841
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:829
+#: lib/vutuv/accounts/user.ex:839
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
@@ -11264,8 +11269,8 @@ msgstr ""
 msgid "Verified domains"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:205
-#: lib/vutuv_web/agent_docs/text.ex:194
+#: lib/vutuv_web/agent_docs/markdown.ex:213
+#: lib/vutuv_web/agent_docs/text.ex:201
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr ""
@@ -11292,8 +11297,8 @@ msgstr ""
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:207
-#: lib/vutuv_web/agent_docs/text.ex:196
+#: lib/vutuv_web/agent_docs/markdown.ex:215
+#: lib/vutuv_web/agent_docs/text.ex:203
 #: lib/vutuv_web/live/organization_live/edit.ex:285
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -11377,8 +11382,8 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:308
-#: lib/vutuv_web/agent_docs/text.ex:335
+#: lib/vutuv_web/agent_docs/markdown.ex:316
+#: lib/vutuv_web/agent_docs/text.ex:342
 #: lib/vutuv_web/live/organization_live/edit.ex:351
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
@@ -11613,8 +11618,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:329
-#: lib/vutuv_web/agent_docs/text.ex:355
+#: lib/vutuv_web/agent_docs/markdown.ex:337
+#: lib/vutuv_web/agent_docs/text.ex:362
 #: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11747,8 +11752,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:728
-#: lib/vutuv_web/agent_docs/text.ex:558
+#: lib/vutuv_web/agent_docs/markdown.ex:736
+#: lib/vutuv_web/agent_docs/text.ex:565
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11784,8 +11789,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:320
-#: lib/vutuv_web/agent_docs/text.ex:346
+#: lib/vutuv_web/agent_docs/markdown.ex:328
+#: lib/vutuv_web/agent_docs/text.ex:353
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -11968,7 +11973,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:861
+#: lib/vutuv_web/live/notification_live/index.ex:904
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12071,22 +12076,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1013
+#: lib/vutuv_web/live/notification_live/index.ex:1065
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1010
+#: lib/vutuv_web/live/notification_live/index.ex:1062
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1007
+#: lib/vutuv_web/live/notification_live/index.ex:1059
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1004
+#: lib/vutuv_web/live/notification_live/index.ex:1056
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12229,10 +12234,10 @@ msgstr ""
 msgid "Edit posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:224
-#: lib/vutuv_web/agent_docs/markdown.ex:353
-#: lib/vutuv_web/agent_docs/text.ex:212
-#: lib/vutuv_web/agent_docs/text.ex:379
+#: lib/vutuv_web/agent_docs/markdown.ex:232
+#: lib/vutuv_web/agent_docs/markdown.ex:361
+#: lib/vutuv_web/agent_docs/text.ex:219
+#: lib/vutuv_web/agent_docs/text.ex:386
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Employer"
@@ -12243,10 +12248,10 @@ msgstr ""
 msgid "Employer name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:225
-#: lib/vutuv_web/agent_docs/markdown.ex:354
-#: lib/vutuv_web/agent_docs/text.ex:213
-#: lib/vutuv_web/agent_docs/text.ex:380
+#: lib/vutuv_web/agent_docs/markdown.ex:233
+#: lib/vutuv_web/agent_docs/markdown.ex:362
+#: lib/vutuv_web/agent_docs/text.ex:220
+#: lib/vutuv_web/agent_docs/text.ex:387
 #: lib/vutuv_web/live/job_board_live.ex:367
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
@@ -12285,7 +12290,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:800
+#: lib/vutuv/accounts/user.ex:810
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12323,12 +12328,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:335
-#: lib/vutuv_web/agent_docs/markdown.ex:339
-#: lib/vutuv_web/agent_docs/markdown.ex:341
-#: lib/vutuv_web/agent_docs/text.ex:361
-#: lib/vutuv_web/agent_docs/text.ex:365
-#: lib/vutuv_web/agent_docs/text.ex:367
+#: lib/vutuv_web/agent_docs/markdown.ex:343
+#: lib/vutuv_web/agent_docs/markdown.ex:347
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/text.ex:368
+#: lib/vutuv_web/agent_docs/text.ex:372
+#: lib/vutuv_web/agent_docs/text.ex:374
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12377,8 +12382,8 @@ msgstr ""
 msgid "New posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:236
-#: lib/vutuv_web/agent_docs/text.ex:223
+#: lib/vutuv_web/agent_docs/markdown.ex:244
+#: lib/vutuv_web/agent_docs/text.ex:230
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
@@ -12405,7 +12410,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:799
+#: lib/vutuv/accounts/user.ex:809
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12462,10 +12467,10 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:229
-#: lib/vutuv_web/agent_docs/markdown.ex:358
-#: lib/vutuv_web/agent_docs/text.ex:217
-#: lib/vutuv_web/agent_docs/text.ex:384
+#: lib/vutuv_web/agent_docs/markdown.ex:237
+#: lib/vutuv_web/agent_docs/markdown.ex:366
+#: lib/vutuv_web/agent_docs/text.ex:224
+#: lib/vutuv_web/agent_docs/text.ex:391
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12487,13 +12492,13 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:801
+#: lib/vutuv/accounts/user.ex:811
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
-#: lib/vutuv_web/agent_docs/markdown.ex:339
-#: lib/vutuv_web/agent_docs/markdown.ex:341
-#: lib/vutuv_web/agent_docs/text.ex:365
-#: lib/vutuv_web/agent_docs/text.ex:367
+#: lib/vutuv_web/agent_docs/markdown.ex:347
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/text.ex:372
+#: lib/vutuv_web/agent_docs/text.ex:374
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format
@@ -12505,18 +12510,18 @@ msgstr ""
 msgid "Report this posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:235
-#: lib/vutuv_web/agent_docs/text.ex:222
+#: lib/vutuv_web/agent_docs/markdown.ex:243
+#: lib/vutuv_web/agent_docs/text.ex:229
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:228
-#: lib/vutuv_web/agent_docs/markdown.ex:357
-#: lib/vutuv_web/agent_docs/text.ex:216
-#: lib/vutuv_web/agent_docs/text.ex:383
+#: lib/vutuv_web/agent_docs/markdown.ex:236
+#: lib/vutuv_web/agent_docs/markdown.ex:365
+#: lib/vutuv_web/agent_docs/text.ex:223
+#: lib/vutuv_web/agent_docs/text.ex:390
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12610,10 +12615,10 @@ msgstr ""
 msgid "Working student"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:226
-#: lib/vutuv_web/agent_docs/markdown.ex:355
-#: lib/vutuv_web/agent_docs/text.ex:214
-#: lib/vutuv_web/agent_docs/text.ex:381
+#: lib/vutuv_web/agent_docs/markdown.ex:234
+#: lib/vutuv_web/agent_docs/markdown.ex:363
+#: lib/vutuv_web/agent_docs/text.ex:221
+#: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -12786,13 +12791,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:376
+#: lib/vutuv_web/agent_docs/markdown.ex:384
 #: lib/vutuv_web/templates/tag/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:401
+#: lib/vutuv_web/agent_docs/text.ex:408
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12838,12 +12843,12 @@ msgstr ""
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:248
+#: lib/vutuv_web/agent_docs/markdown.ex:256
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:235
+#: lib/vutuv_web/agent_docs/text.ex:242
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
@@ -12858,10 +12863,10 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:374
-#: lib/vutuv_web/agent_docs/markdown.ex:386
-#: lib/vutuv_web/agent_docs/text.ex:399
-#: lib/vutuv_web/agent_docs/text.ex:411
+#: lib/vutuv_web/agent_docs/markdown.ex:382
+#: lib/vutuv_web/agent_docs/markdown.ex:394
+#: lib/vutuv_web/agent_docs/text.ex:406
+#: lib/vutuv_web/agent_docs/text.ex:418
 #: lib/vutuv_web/live/organization_live/show.ex:329
 #: lib/vutuv_web/templates/tag/show.html.heex:57
 #, elixir-autogen, elixir-format
@@ -13090,7 +13095,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:488
+#: lib/vutuv_web/controllers/settings_controller.ex:493
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -13156,13 +13161,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:506
+#: lib/vutuv_web/controllers/settings_controller.ex:511
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3273
-#: lib/vutuv_web/controllers/settings_controller.ex:411
+#: lib/vutuv_web/controllers/settings_controller.ex:416
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13181,8 +13186,8 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:493
-#: lib/vutuv_web/controllers/settings_controller.ex:511
+#: lib/vutuv_web/controllers/settings_controller.ex:498
+#: lib/vutuv_web/controllers/settings_controller.ex:516
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -13422,7 +13427,7 @@ msgstr ""
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1268
+#: lib/vutuv_web/components/post_components.ex:1485
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -13430,12 +13435,12 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1258
+#: lib/vutuv_web/components/post_components.ex:1475
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:859
+#: lib/vutuv_web/live/notification_live/index.ex:902
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13476,7 +13481,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:844
+#: lib/vutuv/accounts/user.ex:854
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13487,19 +13492,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:847
+#: lib/vutuv/accounts/user.ex:857
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:850
+#: lib/vutuv/accounts/user.ex:860
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:841
+#: lib/vutuv/accounts/user.ex:851
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13522,7 +13527,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:862
+#: lib/vutuv_web/live/notification_live/index.ex:905
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13534,7 +13539,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1063
+#: lib/vutuv_web/live/notification_live/index.ex:1115
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13574,8 +13579,8 @@ msgstr ""
 msgid "Insert into text"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:180
-#: lib/vutuv_web/agent_docs/text.ex:169
+#: lib/vutuv_web/agent_docs/markdown.ex:188
+#: lib/vutuv_web/agent_docs/text.ex:176
 #: lib/vutuv_web/templates/tag/show.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
@@ -13601,22 +13606,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:284
+#: lib/vutuv_web/components/post_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:286
+#: lib/vutuv_web/components/post_components.ex:287
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:285
+#: lib/vutuv_web/components/post_components.ex:286
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:274
+#: lib/vutuv_web/components/post_components.ex:275
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13627,7 +13632,7 @@ msgid "Posts tagged with a tag you follow show up in your feed, and people known
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3269
-#: lib/vutuv_web/controllers/settings_controller.ex:425
+#: lib/vutuv_web/controllers/settings_controller.ex:430
 #: lib/vutuv_web/live/post_live/feed.ex:732
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -13746,22 +13751,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:863
+#: lib/vutuv_web/live/notification_live/index.ex:906
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1083
+#: lib/vutuv_web/live/notification_live/index.ex:1135
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1075
+#: lib/vutuv_web/live/notification_live/index.ex:1127
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1080
+#: lib/vutuv_web/live/notification_live/index.ex:1132
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13786,12 +13791,12 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1088
+#: lib/vutuv_web/live/notification_live/index.ex:1140
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1940
+#: lib/vutuv_web/components/post_components.ex:2157
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
@@ -13806,19 +13811,19 @@ msgstr ""
 msgid "Book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:870
-#: lib/vutuv_web/components/post_components.ex:1897
+#: lib/vutuv_web/agent_docs/markdown.ex:884
+#: lib/vutuv_web/components/post_components.ex:2114
 #: lib/vutuv_web/live/post_live/composer.ex:671
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1941
+#: lib/vutuv_web/components/post_components.ex:2158
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1943
+#: lib/vutuv_web/components/post_components.ex:2160
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
@@ -13828,7 +13833,7 @@ msgstr ""
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1939
+#: lib/vutuv_web/components/post_components.ex:2156
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
@@ -13838,8 +13843,8 @@ msgstr ""
 msgid "Film"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:870
-#: lib/vutuv_web/components/post_components.ex:1896
+#: lib/vutuv_web/agent_docs/markdown.ex:884
+#: lib/vutuv_web/components/post_components.ex:2113
 #: lib/vutuv_web/live/post_live/composer.ex:670
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13870,7 +13875,7 @@ msgstr ""
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1938
+#: lib/vutuv_web/components/post_components.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
@@ -13897,7 +13902,7 @@ msgstr ""
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1942
+#: lib/vutuv_web/components/post_components.ex:2159
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13928,34 +13933,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1979
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2009
+#: lib/vutuv_web/components/post_components.ex:2226
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2010
+#: lib/vutuv_web/components/post_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2008
+#: lib/vutuv_web/components/post_components.ex:2225
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1968
+#: lib/vutuv_web/components/post_components.ex:2185
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2015
+#: lib/vutuv_web/components/post_components.ex:2232
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13980,24 +13985,24 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:594
+#: lib/vutuv_web/agent_docs/markdown.ex:602
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1782
+#: lib/vutuv_web/components/post_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:740
+#: lib/vutuv_web/live/notification_live/index.ex:779
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:754
+#: lib/vutuv_web/live/notification_live/index.ex:793
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
@@ -14012,28 +14017,28 @@ msgstr ""
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:706
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:745
+#: lib/vutuv_web/live/notification_live/index.ex:954
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:878
+#: lib/vutuv_web/live/notification_live/index.ex:921
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:873
+#: lib/vutuv_web/live/notification_live/index.ex:916
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:888
+#: lib/vutuv_web/live/notification_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1773
+#: lib/vutuv_web/components/post_components.ex:1990
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14076,19 +14081,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:697
+#: lib/vutuv_web/agent_docs/markdown.ex:705
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:696
+#: lib/vutuv_web/agent_docs/markdown.ex:704
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:702
+#: lib/vutuv_web/agent_docs/markdown.ex:710
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14167,8 +14172,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:665
-#: lib/vutuv_web/agent_docs/text.ex:550
+#: lib/vutuv_web/agent_docs/markdown.ex:673
+#: lib/vutuv_web/agent_docs/text.ex:557
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14251,8 +14256,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:426
-#: lib/vutuv_web/agent_docs/text.ex:423
+#: lib/vutuv_web/agent_docs/markdown.ex:434
+#: lib/vutuv_web/agent_docs/text.ex:430
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14263,7 +14268,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:676
+#: lib/vutuv_web/live/notification_live/index.ex:715
 #, elixir-autogen, elixir-format
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
@@ -14273,17 +14278,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1037
+#: lib/vutuv_web/live/notification_live/index.ex:1089
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:854
+#: lib/vutuv_web/live/notification_live/index.ex:896
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:898
+#: lib/vutuv_web/live/notification_live/index.ex:941
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14302,12 +14307,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:855
+#: lib/vutuv_web/live/notification_live/index.ex:897
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:996
+#: lib/vutuv_web/live/notification_live/index.ex:1045
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -14387,7 +14392,7 @@ msgstr ""
 msgid "No accounts are currently frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:216
+#: lib/vutuv_web/live/post_live/thread.ex:301
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr ""
@@ -14407,14 +14412,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:824
+#: lib/vutuv_web/components/post_components.ex:1005
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:846
+#: lib/vutuv_web/components/post_components.ex:1027
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14426,7 +14431,7 @@ msgstr[1] ""
 msgid "This page is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:208
+#: lib/vutuv_web/live/post_live/thread.ex:293
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr ""
@@ -14441,7 +14446,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2225
+#: lib/vutuv_web/components/post_components.ex:2475
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14491,7 +14496,7 @@ msgstr ""
 msgid "Cancel redirect"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:314
+#: lib/vutuv_web/controllers/settings_controller.ex:319
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr ""
@@ -14506,12 +14511,12 @@ msgstr ""
 msgid "On your other account, add your vutuv handle"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:353
+#: lib/vutuv_web/controllers/settings_controller.ex:358
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:339
+#: lib/vutuv_web/controllers/settings_controller.ex:344
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr ""
@@ -14526,17 +14531,17 @@ msgstr ""
 msgid "Redirected on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:366
+#: lib/vutuv_web/controllers/settings_controller.ex:371
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:360
+#: lib/vutuv_web/controllers/settings_controller.ex:365
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:356
+#: lib/vutuv_web/controllers/settings_controller.ex:361
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr ""
@@ -14546,12 +14551,12 @@ msgstr ""
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:344
+#: lib/vutuv_web/controllers/settings_controller.ex:349
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:348
+#: lib/vutuv_web/controllers/settings_controller.ex:353
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr ""
@@ -14573,7 +14578,7 @@ msgstr[1] ""
 msgid "All endorsers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:442
+#: lib/vutuv_web/controllers/settings_controller.ex:447
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
@@ -14583,7 +14588,7 @@ msgstr ""
 msgid "Filter by a tag"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:467
+#: lib/vutuv_web/controllers/settings_controller.ex:472
 #, elixir-autogen, elixir-format
 msgid "Filter removed."
 msgstr ""
@@ -14604,7 +14609,7 @@ msgid "Match whole words only (word/phrase)"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3265
-#: lib/vutuv_web/controllers/settings_controller.ex:478
+#: lib/vutuv_web/controllers/settings_controller.ex:483
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14651,7 +14656,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:481
+#: lib/vutuv_web/live/notification_live/index.ex:506
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14697,12 +14702,12 @@ msgstr ""
 msgid "You have not muted anything yet."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:450
+#: lib/vutuv_web/controllers/settings_controller.ex:455
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:476
+#: lib/vutuv_web/live/notification_live/index.ex:501
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -14712,17 +14717,17 @@ msgstr ""
 msgid "e.g. crypto*, \"machine learning\", politics"
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:44
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:49
 #, elixir-autogen, elixir-format
 msgid "Enter the server name on its own, for example mastodon.example."
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:58
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:63
 #, elixir-autogen, elixir-format
 msgid "%{host} is no longer blocked. What was deleted stays deleted; the server has to follow again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:71
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:76
 #, elixir-autogen, elixir-format
 msgid "%{host} is blocked. Removed: %{followers} remote followers and %{deliveries} queued deliveries."
 msgstr ""
@@ -14789,6 +14794,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:84
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:135
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "Server"
 msgstr ""
@@ -14838,7 +14844,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:858
+#: lib/vutuv_web/agent_docs/markdown.ex:866
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -14847,13 +14853,6 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Count reactions from other networks"
 msgstr ""
-
-#: lib/vutuv_web/components/post_components.ex:2185
-#, elixir-autogen, elixir-format
-msgid "%{formatted} reaction from other networks"
-msgid_plural "%{formatted} reactions from other networks"
-msgstr[0] ""
-msgstr[1] ""
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:15
 #, elixir-autogen, elixir-format
@@ -14900,34 +14899,34 @@ msgstr ""
 msgid "Show under each of your posts how many people out there liked or shared it. A number only, visible to everyone who sees the post. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:92
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:171
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Related"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:174
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
 #: lib/vutuv_web/controllers/settings_controller.ex:216
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:180
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:195
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Move your account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:184
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr ""
@@ -14982,7 +14981,7 @@ msgstr ""
 msgid "Back to Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:114
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower from other networks"
 msgid_plural "%{formatted} followers from other networks"
@@ -15224,8 +15223,8 @@ msgstr ""
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:448
-#: lib/vutuv_web/agent_docs/text.ex:445
+#: lib/vutuv_web/agent_docs/markdown.ex:456
+#: lib/vutuv_web/agent_docs/text.ex:452
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
@@ -15581,13 +15580,13 @@ msgstr ""
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:235
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:250
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:233
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:248
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
@@ -15621,4 +15620,149 @@ msgstr ""
 #: lib/vutuv_web/views/settings_html.ex:322
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:2435
+#, elixir-autogen, elixir-format
+msgid "%{count} from other networks"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:2438
+#, elixir-autogen, elixir-format
+msgid "%{formatted} reaction"
+msgid_plural "%{formatted} reactions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/components/post_components.ex:2444
+#, elixir-autogen, elixir-format
+msgid "%{formatted} reply"
+msgid_plural "%{formatted} replies"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/components/post_components.ex:2428
+#, elixir-autogen, elixir-format
+msgid "%{reactions} and %{replies} from other networks"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:167
+#, elixir-autogen, elixir-format
+msgid "A report deletes the reply right away, with no queue to work through. This is the trail, so a server that keeps showing up here can be blocked above. It holds no text and no links, only which server and which account (as a short digest)."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:89
+#, elixir-autogen, elixir-format
+msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:973
+#: lib/vutuv_web/agent_docs/text.ex:647
+#, elixir-autogen, elixir-format
+msgid "Content warning"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:784
+#: lib/vutuv_web/components/post_components.ex:865
+#, elixir-autogen, elixir-format
+msgid "From another network"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:164
+#, elixir-autogen, elixir-format
+msgid "Nobody has removed or reported a reply yet."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:815
+#, elixir-autogen, elixir-format
+msgid "Remove this reply from your post?"
+msgstr ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:15
+#, elixir-autogen, elixir-format
+msgid "Removed by the member"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:122
+#: lib/vutuv_web/agent_docs/markdown.ex:871
+#: lib/vutuv_web/agent_docs/text.ex:113
+#, elixir-autogen, elixir-format
+msgid "Replies from other networks"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:162
+#, elixir-autogen, elixir-format
+msgid "Replies taken down by members"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:899
+#, elixir-autogen, elixir-format
+msgid "Reply from another network"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/thread.ex:95
+#, elixir-autogen, elixir-format
+msgid "Reply removed."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:824
+#, elixir-autogen, elixir-format
+msgid "Report this reply as not appropriate? It is deleted right away."
+msgstr ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:14
+#, elixir-autogen, elixir-format
+msgid "Reported as not appropriate"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:841
+#: lib/vutuv_web/live/notification_live/index.ex:479
+#, elixir-autogen, elixir-format
+msgid "Sent to you only, visible to nobody else"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Show replies from other networks"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:137
+#, elixir-autogen, elixir-format
+msgid "Stored replies"
+msgstr ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:16
+#, elixir-autogen, elixir-format
+msgid "Taken down"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/thread.ex:104
+#, elixir-autogen, elixir-format
+msgid "Thank you. The reply was deleted right away."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/thread.ex:205
+#, elixir-autogen, elixir-format
+msgid "That reply is not yours to remove."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:975
+#: lib/vutuv_web/components/post_components.ex:871
+#, elixir-autogen, elixir-format
+msgid "View the original"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:176
+#, elixir-autogen, elixir-format
+msgid "What"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/thread.ex:201
+#, elixir-autogen, elixir-format
+msgid "You have reported a lot today. Please try again tomorrow."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1048
+#, elixir-autogen, elixir-format
+msgid "replied to your post from another network."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -24,9 +24,9 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:208
+#: lib/vutuv_web/agent_docs/markdown.ex:216
 #: lib/vutuv_web/agent_docs/section_docs.ex:121
-#: lib/vutuv_web/agent_docs/text.ex:197
+#: lib/vutuv_web/agent_docs/text.ex:204
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
@@ -94,10 +94,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:432
-#: lib/vutuv_web/agent_docs/markdown.ex:433
-#: lib/vutuv_web/agent_docs/text.ex:429
-#: lib/vutuv_web/agent_docs/text.ex:430
+#: lib/vutuv_web/agent_docs/markdown.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:441
+#: lib/vutuv_web/agent_docs/text.ex:436
+#: lib/vutuv_web/agent_docs/text.ex:437
 #: lib/vutuv_web/templates/user/show.html.heex:929
 #, elixir-autogen
 msgid "Birthday"
@@ -116,7 +116,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:86
 #: lib/vutuv_web/templates/report/new.html.heex:103
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:225
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:240
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:50
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1054
+#: lib/vutuv_web/components/post_components.ex:1271
 #: lib/vutuv_web/components/ui.ex:2935
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -199,7 +199,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1047
+#: lib/vutuv_web/components/post_components.ex:1264
 #: lib/vutuv_web/components/ui.ex:2926
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -310,10 +310,10 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:456
-#: lib/vutuv_web/agent_docs/text.ex:453
+#: lib/vutuv_web/agent_docs/markdown.ex:464
+#: lib/vutuv_web/agent_docs/text.ex:460
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/notification_live/index.ex:798
+#: lib/vutuv_web/live/notification_live/index.ex:837
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:136
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -321,8 +321,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:457
-#: lib/vutuv_web/agent_docs/text.ex:454
+#: lib/vutuv_web/agent_docs/markdown.ex:465
+#: lib/vutuv_web/agent_docs/text.ex:461
 #: lib/vutuv_web/components/ui.ex:1551
 #: lib/vutuv_web/components/ui.ex:1576
 #: lib/vutuv_web/components/ui.ex:1579
@@ -337,8 +337,8 @@ msgstr ""
 msgid "Following"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:431
-#: lib/vutuv_web/agent_docs/text.ex:428
+#: lib/vutuv_web/agent_docs/markdown.ex:439
+#: lib/vutuv_web/agent_docs/text.ex:435
 #: lib/vutuv_web/cv/docx.ex:136
 #: lib/vutuv_web/cv/html.ex:85
 #: lib/vutuv_web/cv/latex.ex:69
@@ -457,7 +457,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:722
+#: lib/vutuv_web/live/notification_live/index.ex:761
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:525
+#: lib/vutuv_web/live/notification_live/index.ex:550
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -616,7 +616,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:818
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:80
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:95
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:73
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
@@ -645,6 +645,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+#: lib/vutuv_web/components/post_components.ex:850
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -784,7 +785,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:156
-#: lib/vutuv_web/live/notification_live/index.ex:864
+#: lib/vutuv_web/live/notification_live/index.ex:907
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -974,14 +975,14 @@ msgstr ""
 msgid "http://www.example.com"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:937
+#: lib/vutuv/accounts/user.ex:947
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:936
+#: lib/vutuv/accounts/user.ex:946
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1395,11 +1396,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
-#: lib/vutuv_web/agent_docs/markdown.ex:368
-#: lib/vutuv_web/agent_docs/markdown.ex:815
+#: lib/vutuv_web/agent_docs/markdown.ex:376
+#: lib/vutuv_web/agent_docs/markdown.ex:823
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:394
-#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/text.ex:401
+#: lib/vutuv_web/agent_docs/text.ex:591
 #: lib/vutuv_web/components/ui.ex:3220
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1762,7 +1763,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:287
+#: lib/vutuv_web/components/post_components.ex:288
 #: lib/vutuv_web/components/ui.ex:3045
 #: lib/vutuv_web/live/admin/user_live.ex:298
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
@@ -1903,17 +1904,17 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:885
+#: lib/vutuv_web/live/notification_live/index.ex:928
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:880
+#: lib/vutuv_web/live/notification_live/index.ex:923
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:875
+#: lib/vutuv_web/live/notification_live/index.ex:918
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -2104,7 +2105,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1051
+#: lib/vutuv_web/components/post_components.ex:1268
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2150,8 +2151,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1033
-#: lib/vutuv_web/components/post_components.ex:1035
+#: lib/vutuv_web/components/post_components.ex:1250
+#: lib/vutuv_web/components/post_components.ex:1252
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2199,13 +2200,13 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:92
+#: lib/vutuv_web/agent_docs/post_doc.ex:102
 #: lib/vutuv_web/controllers/post_controller.ex:59
 #: lib/vutuv_web/controllers/post_controller.ex:68
 #: lib/vutuv_web/controllers/user_controller.ex:75
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/notification_live/index.ex:720
+#: lib/vutuv_web/live/notification_live/index.ex:759
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:179
 #: lib/vutuv_web/live/search_live.ex:462
@@ -2215,18 +2216,19 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1444
-#: lib/vutuv_web/components/post_components.ex:1448
+#: lib/vutuv_web/components/post_components.ex:1661
+#: lib/vutuv_web/components/post_components.ex:1665
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1445
+#: lib/vutuv_web/components/post_components.ex:1662
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
+#: lib/vutuv_web/components/post_components.ex:817
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:209
 #: lib/vutuv_web/live/organization_live/edit.ex:371
@@ -2312,27 +2314,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1030
+#: lib/vutuv_web/components/post_components.ex:1247
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2077
+#: lib/vutuv_web/components/post_components.ex:2294
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2081
+#: lib/vutuv_web/components/post_components.ex:2298
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2079
+#: lib/vutuv_web/components/post_components.ex:2296
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2080
+#: lib/vutuv_web/components/post_components.ex:2297
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2373,7 +2375,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2158
+#: lib/vutuv_web/components/post_components.ex:2375
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2484
@@ -2382,7 +2384,7 @@ msgstr ""
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:850
+#: lib/vutuv_web/agent_docs/markdown.ex:858
 #: lib/vutuv_web/live/post_live/saved.ex:139
 #: lib/vutuv_web/live/post_live/saved.ex:442
 #: lib/vutuv_web/live/shell_live.ex:490
@@ -2392,19 +2394,19 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2217
+#: lib/vutuv_web/components/post_components.ex:2467
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2470
-#: lib/vutuv_web/live/notification_live/index.ex:856
+#: lib/vutuv_web/live/notification_live/index.ex:898
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:849
-#: lib/vutuv_web/components/post_components.ex:2226
-#: lib/vutuv_web/live/notification_live/index.ex:800
+#: lib/vutuv_web/agent_docs/markdown.ex:857
+#: lib/vutuv_web/components/post_components.ex:2476
+#: lib/vutuv_web/live/notification_live/index.ex:839
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:559
@@ -2423,12 +2425,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2147
+#: lib/vutuv_web/components/post_components.ex:2364
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2158
+#: lib/vutuv_web/components/post_components.ex:2375
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2437,23 +2439,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/components/post_components.ex:2361
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1562
+#: lib/vutuv_web/components/post_components.ex:1779
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2144
+#: lib/vutuv_web/components/post_components.ex:2361
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2217
+#: lib/vutuv_web/components/post_components.ex:2467
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2476,26 +2478,26 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2266
+#: lib/vutuv_web/components/post_components.ex:2516
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:276
-#: lib/vutuv_web/live/notification_live/index.ex:801
+#: lib/vutuv_web/components/post_components.ex:277
+#: lib/vutuv_web/live/notification_live/index.ex:840
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2249
-#: lib/vutuv_web/components/post_components.ex:2250
-#: lib/vutuv_web/live/notification_live/index.ex:853
+#: lib/vutuv_web/components/post_components.ex:2499
+#: lib/vutuv_web/components/post_components.ex:2500
+#: lib/vutuv_web/live/notification_live/index.ex:895
 #: lib/vutuv_web/live/post_live/reply.ex:25
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1001
+#: lib/vutuv_web/components/post_components.ex:1218
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2511,7 +2513,7 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:994
+#: lib/vutuv_web/live/notification_live/index.ex:1043
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2521,12 +2523,12 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:996
+#: lib/vutuv_web/components/post_components.ex:1213
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:990
+#: lib/vutuv_web/components/post_components.ex:1207
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2786,10 +2788,10 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:458
-#: lib/vutuv_web/agent_docs/text.ex:455
+#: lib/vutuv_web/agent_docs/markdown.ex:466
+#: lib/vutuv_web/agent_docs/text.ex:462
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:799
+#: lib/vutuv_web/live/notification_live/index.ex:838
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
@@ -2833,7 +2835,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2078
+#: lib/vutuv_web/components/post_components.ex:2295
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2843,22 +2845,22 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:865
+#: lib/vutuv_web/live/notification_live/index.ex:908
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:857
+#: lib/vutuv_web/live/notification_live/index.ex:900
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:852
+#: lib/vutuv_web/live/notification_live/index.ex:894
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:851
+#: lib/vutuv_web/live/notification_live/index.ex:893
 #: lib/vutuv_web/templates/user/show.html.heex:757
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2871,7 +2873,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:882
+#: lib/vutuv_web/live/notification_live/index.ex:925
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2903,12 +2905,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1073
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1022
+#: lib/vutuv_web/live/notification_live/index.ex:1074
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -2938,8 +2940,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:287
-#: lib/vutuv_web/agent_docs/text.ex:272
+#: lib/vutuv_web/agent_docs/markdown.ex:295
+#: lib/vutuv_web/agent_docs/text.ex:279
 #: lib/vutuv_web/controllers/page_controller.ex:55
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3014,7 +3016,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:858
+#: lib/vutuv_web/live/notification_live/index.ex:901
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3094,7 +3096,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:978
+#: lib/vutuv_web/components/post_components.ex:1195
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3169,7 +3171,8 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1075
+#: lib/vutuv_web/components/post_components.ex:827
+#: lib/vutuv_web/components/post_components.ex:1292
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3434,12 +3437,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1024
+#: lib/vutuv_web/live/notification_live/index.ex:1076
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1023
+#: lib/vutuv_web/live/notification_live/index.ex:1075
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3449,7 +3452,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1025
+#: lib/vutuv_web/live/notification_live/index.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3633,7 +3636,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1049
+#: lib/vutuv_web/live/notification_live/index.ex:1101
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3658,7 +3661,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:860
+#: lib/vutuv_web/live/notification_live/index.ex:903
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3733,7 +3736,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1054
+#: lib/vutuv_web/live/notification_live/index.ex:1106
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -3818,30 +3821,30 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:548
+#: lib/vutuv_web/agent_docs/markdown.ex:556
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:903
+#: lib/vutuv_web/agent_docs/markdown.ex:917
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:128
-#: lib/vutuv_web/agent_docs/text.ex:117
+#: lib/vutuv_web/agent_docs/markdown.ex:136
+#: lib/vutuv_web/agent_docs/text.ex:124
 #, elixir-autogen, elixir-format
 msgid "%{count} posts by %{name}"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:82
-#: lib/vutuv_web/agent_docs/markdown.ex:151
-#: lib/vutuv_web/agent_docs/markdown.ex:164
-#: lib/vutuv_web/agent_docs/markdown.ex:815
+#: lib/vutuv_web/agent_docs/markdown.ex:159
+#: lib/vutuv_web/agent_docs/markdown.ex:172
+#: lib/vutuv_web/agent_docs/markdown.ex:823
 #: lib/vutuv_web/agent_docs/text.ex:79
-#: lib/vutuv_web/agent_docs/text.ex:140
-#: lib/vutuv_web/agent_docs/text.ex:153
-#: lib/vutuv_web/agent_docs/text.ex:584
+#: lib/vutuv_web/agent_docs/text.ex:147
+#: lib/vutuv_web/agent_docs/text.ex:160
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
@@ -3858,34 +3861,34 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:833
-#: lib/vutuv_web/agent_docs/text.ex:595
+#: lib/vutuv_web/agent_docs/markdown.ex:841
+#: lib/vutuv_web/agent_docs/text.ex:602
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:830
-#: lib/vutuv_web/agent_docs/text.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:838
+#: lib/vutuv_web/agent_docs/text.ex:599
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:837
-#: lib/vutuv_web/agent_docs/markdown.ex:938
-#: lib/vutuv_web/agent_docs/text.ex:598
-#: lib/vutuv_web/agent_docs/text.ex:626
+#: lib/vutuv_web/agent_docs/markdown.ex:845
+#: lib/vutuv_web/agent_docs/markdown.ex:952
+#: lib/vutuv_web/agent_docs/text.ex:605
+#: lib/vutuv_web/agent_docs/text.ex:633
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:428
-#: lib/vutuv_web/agent_docs/text.ex:425
+#: lib/vutuv_web/agent_docs/markdown.ex:436
+#: lib/vutuv_web/agent_docs/text.ex:432
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:177
-#: lib/vutuv_web/agent_docs/text.ex:166
+#: lib/vutuv_web/agent_docs/markdown.ex:185
+#: lib/vutuv_web/agent_docs/text.ex:173
 #, elixir-autogen, elixir-format
 msgid "Most endorsed members"
 msgstr ""
@@ -3900,7 +3903,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:93
+#: lib/vutuv_web/agent_docs/post_doc.ex:103
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -3919,23 +3922,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:422
-#: lib/vutuv_web/agent_docs/text.ex:419
+#: lib/vutuv_web/agent_docs/markdown.ex:430
+#: lib/vutuv_web/agent_docs/text.ex:426
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:784
+#: lib/vutuv_web/agent_docs/markdown.ex:792
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:714
+#: lib/vutuv_web/agent_docs/markdown.ex:722
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:715
+#: lib/vutuv_web/agent_docs/markdown.ex:723
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -4010,8 +4013,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:301
-#: lib/vutuv_web/agent_docs/text.ex:280
+#: lib/vutuv_web/agent_docs/markdown.ex:309
+#: lib/vutuv_web/agent_docs/text.ex:287
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4063,8 +4066,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:291
-#: lib/vutuv_web/agent_docs/text.ex:276
+#: lib/vutuv_web/agent_docs/markdown.ex:299
+#: lib/vutuv_web/agent_docs/text.ex:283
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4080,8 +4083,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:288
-#: lib/vutuv_web/agent_docs/text.ex:273
+#: lib/vutuv_web/agent_docs/markdown.ex:296
+#: lib/vutuv_web/agent_docs/text.ex:280
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4295,14 +4298,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:293
-#: lib/vutuv_web/agent_docs/text.ex:278
+#: lib/vutuv_web/agent_docs/markdown.ex:301
+#: lib/vutuv_web/agent_docs/text.ex:285
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:289
-#: lib/vutuv_web/agent_docs/text.ex:274
+#: lib/vutuv_web/agent_docs/markdown.ex:297
+#: lib/vutuv_web/agent_docs/text.ex:281
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4578,10 +4581,10 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:316
-#: lib/vutuv_web/agent_docs/text.ex:342
+#: lib/vutuv_web/agent_docs/markdown.ex:324
+#: lib/vutuv_web/agent_docs/text.ex:349
 #: lib/vutuv_web/components/saved_search_components.ex:57
-#: lib/vutuv_web/live/notification_live/index.ex:721
+#: lib/vutuv_web/live/notification_live/index.ex:760
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:177
@@ -4600,10 +4603,10 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:273
+#: lib/vutuv_web/components/post_components.ex:274
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:719
+#: lib/vutuv_web/live/notification_live/index.ex:758
 #: lib/vutuv_web/live/search_live.ex:176
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -4702,8 +4705,8 @@ msgstr ""
 msgid "Edit your profile and its sections"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:230
-#: lib/vutuv_web/agent_docs/text.ex:218
+#: lib/vutuv_web/agent_docs/markdown.ex:238
+#: lib/vutuv_web/agent_docs/text.ex:225
 #: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
@@ -5393,10 +5396,10 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1137
-#: lib/vutuv_web/components/post_components.ex:1191
-#: lib/vutuv_web/components/post_components.ex:1506
-#: lib/vutuv_web/live/notification_live/index.ex:558
+#: lib/vutuv_web/components/post_components.ex:1354
+#: lib/vutuv_web/components/post_components.ex:1408
+#: lib/vutuv_web/components/post_components.ex:1723
+#: lib/vutuv_web/live/notification_live/index.ex:583
 #: lib/vutuv_web/live/post_live/feed.ex:818
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5412,7 +5415,7 @@ msgstr ""
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:940
+#: lib/vutuv/accounts/user.ex:950
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5450,6 +5453,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3293
 #: lib/vutuv_web/live/admin/user_live.ex:266
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:178
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Account"
@@ -5479,7 +5483,7 @@ msgstr ""
 msgid "Email addresses"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:393
+#: lib/vutuv_web/controllers/settings_controller.ex:398
 #, elixir-autogen, elixir-format
 msgid "Notification settings saved."
 msgstr ""
@@ -5559,7 +5563,7 @@ msgstr ""
 msgid "Language & region"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:535
+#: lib/vutuv_web/controllers/settings_controller.ex:540
 #, elixir-autogen, elixir-format
 msgid "Language updated."
 msgstr ""
@@ -5618,7 +5622,7 @@ msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:802
+#: lib/vutuv_web/live/notification_live/index.ex:841
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -5641,7 +5645,7 @@ msgstr ""
 msgid "New followers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:383
+#: lib/vutuv_web/controllers/settings_controller.ex:388
 #, elixir-autogen, elixir-format
 msgid "Notification settings"
 msgstr ""
@@ -5838,7 +5842,7 @@ msgid_plural "%{count} minutes ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:630
+#: lib/vutuv_web/controllers/settings_controller.ex:635
 #, elixir-autogen, elixir-format
 msgid "All other devices have been logged out."
 msgstr ""
@@ -5878,7 +5882,7 @@ msgstr ""
 msgid "Signed-in devices"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:619
+#: lib/vutuv_web/controllers/settings_controller.ex:624
 #, elixir-autogen, elixir-format
 msgid "That device has been logged out."
 msgstr ""
@@ -6110,8 +6114,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:434
-#: lib/vutuv_web/agent_docs/text.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:442
+#: lib/vutuv_web/agent_docs/text.ex:438
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6183,8 +6187,8 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:849
-#: lib/vutuv_web/components/post_components.ex:275
+#: lib/vutuv_web/agent_docs/markdown.ex:857
+#: lib/vutuv_web/components/post_components.ex:276
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
@@ -6228,7 +6232,7 @@ msgstr ""
 msgid "Default map"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:550
+#: lib/vutuv_web/controllers/settings_controller.ex:555
 #, elixir-autogen, elixir-format
 msgid "Map preferences saved."
 msgstr ""
@@ -6279,15 +6283,15 @@ msgid "No endorsements yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1332
-#: lib/vutuv_web/live/notification_live/index.ex:503
-#: lib/vutuv_web/live/notification_live/index.ex:518
-#: lib/vutuv_web/live/notification_live/index.ex:641
-#: lib/vutuv_web/live/notification_live/index.ex:643
+#: lib/vutuv_web/live/notification_live/index.ex:528
+#: lib/vutuv_web/live/notification_live/index.ex:543
+#: lib/vutuv_web/live/notification_live/index.ex:666
+#: lib/vutuv_web/live/notification_live/index.ex:668
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:828
+#: lib/vutuv_web/agent_docs/markdown.ex:836
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6496,6 +6500,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:175
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -6618,7 +6623,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1072
+#: lib/vutuv_web/components/post_components.ex:1289
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6628,7 +6633,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1071
+#: lib/vutuv_web/components/post_components.ex:1288
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -6823,8 +6828,8 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:204
-#: lib/vutuv_web/agent_docs/text.ex:193
+#: lib/vutuv_web/agent_docs/markdown.ex:212
+#: lib/vutuv_web/agent_docs/text.ex:200
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #: lib/vutuv_web/templates/settings/filters.html.heex:17
@@ -7482,17 +7487,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:908
+#: lib/vutuv_web/agent_docs/markdown.ex:922
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:911
+#: lib/vutuv_web/agent_docs/markdown.ex:925
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:918
+#: lib/vutuv_web/agent_docs/markdown.ex:932
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -7700,13 +7705,13 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:748
+#: lib/vutuv_web/live/notification_live/index.ex:787
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:751
+#: lib/vutuv_web/live/notification_live/index.ex:790
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -8615,12 +8620,12 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:447
-#: lib/vutuv_web/agent_docs/markdown.ex:451
-#: lib/vutuv_web/agent_docs/text.ex:444
-#: lib/vutuv_web/agent_docs/text.ex:448
+#: lib/vutuv_web/agent_docs/markdown.ex:455
+#: lib/vutuv_web/agent_docs/markdown.ex:459
+#: lib/vutuv_web/agent_docs/text.ex:451
+#: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/components/ui.ex:3288
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:29
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:34
 #: lib/vutuv_web/controllers/settings_controller.ex:194
 #: lib/vutuv_web/controllers/settings_controller.ex:261
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:288
@@ -8653,12 +8658,12 @@ msgstr ""
 msgid "Fediverse settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:191
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:90
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr ""
@@ -8688,7 +8693,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:608
+#: lib/vutuv_web/agent_docs/markdown.ex:616
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8709,7 +8714,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:609
+#: lib/vutuv_web/agent_docs/markdown.ex:617
 #: lib/vutuv_web/views/work_experience_html.ex:30
 #: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
@@ -8740,13 +8745,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:646
+#: lib/vutuv_web/agent_docs/markdown.ex:654
 #: lib/vutuv_web/views/education_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:645
+#: lib/vutuv_web/agent_docs/markdown.ex:653
 #: lib/vutuv_web/views/education_html.ex:29
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8772,14 +8777,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1565
+#: lib/vutuv_web/components/post_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:787
+#: lib/vutuv_web/agent_docs/markdown.ex:795
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8857,14 +8862,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:607
+#: lib/vutuv_web/agent_docs/markdown.ex:615
 #: lib/vutuv_web/views/work_experience_html.ex:25
 #: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:610
+#: lib/vutuv_web/agent_docs/markdown.ex:618
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9008,8 +9013,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:467
-#: lib/vutuv_web/agent_docs/text.ex:462
+#: lib/vutuv_web/agent_docs/markdown.ex:475
+#: lib/vutuv_web/agent_docs/text.ex:469
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9431,13 +9436,13 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:424
-#: lib/vutuv_web/agent_docs/text.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:432
+#: lib/vutuv_web/agent_docs/text.ex:428
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:788
+#: lib/vutuv/accounts/user.ex:798
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
@@ -9448,7 +9453,7 @@ msgstr ""
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:785
+#: lib/vutuv/accounts/user.ex:795
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9535,7 +9540,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:708
+#: lib/vutuv_web/agent_docs/markdown.ex:716
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9612,7 +9617,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:683
+#: lib/vutuv_web/agent_docs/markdown.ex:691
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9629,7 +9634,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:707
+#: lib/vutuv_web/agent_docs/markdown.ex:715
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9656,7 +9661,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:681
+#: lib/vutuv_web/agent_docs/markdown.ex:689
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9671,7 +9676,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:682
+#: lib/vutuv_web/agent_docs/markdown.ex:690
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -9688,7 +9693,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:565
+#: lib/vutuv_web/agent_docs/markdown.ex:573
 #: lib/vutuv_web/live/section_reorder_live.ex:287
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -9875,7 +9880,7 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:106
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:121
 #: lib/vutuv_web/templates/totp/new.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:848
 #: lib/vutuv_web/templates/username/new.html.heex:27
@@ -9884,8 +9889,8 @@ msgstr ""
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:109
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:120
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
 #: lib/vutuv_web/templates/user/show.html.heex:847
@@ -9913,12 +9918,12 @@ msgstr ""
 msgid "Outbound federation is healthy."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:150
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Showing the most recent %{shown} of %{total}."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Accounts that no longer exist on their own server drop off this list by themselves."
 msgstr ""
@@ -10321,21 +10326,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:525
+#: lib/vutuv_web/agent_docs/markdown.ex:533
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:523
+#: lib/vutuv_web/agent_docs/markdown.ex:531
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:521
+#: lib/vutuv_web/agent_docs/markdown.ex:529
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10388,12 +10393,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:539
+#: lib/vutuv_web/agent_docs/markdown.ex:547
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:526
+#: lib/vutuv_web/agent_docs/markdown.ex:534
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10659,7 +10664,7 @@ msgstr ""
 msgid "Longer posts get a “Read more” link. Set 0 (or leave empty) to never shorten."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:563
+#: lib/vutuv_web/controllers/settings_controller.ex:568
 #, elixir-autogen, elixir-format
 msgid "Post display settings saved."
 msgstr ""
@@ -10708,7 +10713,7 @@ msgstr ""
 msgid "Installation default (%{value})"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:594
+#: lib/vutuv_web/controllers/settings_controller.ex:599
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
 msgstr ""
@@ -10723,7 +10728,7 @@ msgstr ""
 msgid "Own value; blank the field to go back to the installation default."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:590
+#: lib/vutuv_web/controllers/settings_controller.ex:595
 #, elixir-autogen, elixir-format
 msgid "Post display settings reset to the site defaults."
 msgstr ""
@@ -10939,19 +10944,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:826
+#: lib/vutuv/accounts/user.ex:836
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:831
+#: lib/vutuv/accounts/user.ex:841
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:829
+#: lib/vutuv/accounts/user.ex:839
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:555
 #, elixir-autogen, elixir-format
@@ -11262,8 +11267,8 @@ msgstr ""
 msgid "Verified domains"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:205
-#: lib/vutuv_web/agent_docs/text.ex:194
+#: lib/vutuv_web/agent_docs/markdown.ex:213
+#: lib/vutuv_web/agent_docs/text.ex:201
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr ""
@@ -11290,8 +11295,8 @@ msgstr ""
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:207
-#: lib/vutuv_web/agent_docs/text.ex:196
+#: lib/vutuv_web/agent_docs/markdown.ex:215
+#: lib/vutuv_web/agent_docs/text.ex:203
 #: lib/vutuv_web/live/organization_live/edit.ex:285
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -11375,8 +11380,8 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:308
-#: lib/vutuv_web/agent_docs/text.ex:335
+#: lib/vutuv_web/agent_docs/markdown.ex:316
+#: lib/vutuv_web/agent_docs/text.ex:342
 #: lib/vutuv_web/live/organization_live/edit.ex:351
 #: lib/vutuv_web/live/organization_live/show.ex:360
 #, elixir-autogen, elixir-format
@@ -11611,8 +11616,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:329
-#: lib/vutuv_web/agent_docs/text.ex:355
+#: lib/vutuv_web/agent_docs/markdown.ex:337
+#: lib/vutuv_web/agent_docs/text.ex:362
 #: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11745,8 +11750,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:728
-#: lib/vutuv_web/agent_docs/text.ex:558
+#: lib/vutuv_web/agent_docs/markdown.ex:736
+#: lib/vutuv_web/agent_docs/text.ex:565
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11782,8 +11787,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:320
-#: lib/vutuv_web/agent_docs/text.ex:346
+#: lib/vutuv_web/agent_docs/markdown.ex:328
+#: lib/vutuv_web/agent_docs/text.ex:353
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -11966,7 +11971,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:861
+#: lib/vutuv_web/live/notification_live/index.ex:904
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12069,22 +12074,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1013
+#: lib/vutuv_web/live/notification_live/index.ex:1065
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1010
+#: lib/vutuv_web/live/notification_live/index.ex:1062
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1007
+#: lib/vutuv_web/live/notification_live/index.ex:1059
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1004
+#: lib/vutuv_web/live/notification_live/index.ex:1056
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12227,10 +12232,10 @@ msgstr ""
 msgid "Edit posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:224
-#: lib/vutuv_web/agent_docs/markdown.ex:353
-#: lib/vutuv_web/agent_docs/text.ex:212
-#: lib/vutuv_web/agent_docs/text.ex:379
+#: lib/vutuv_web/agent_docs/markdown.ex:232
+#: lib/vutuv_web/agent_docs/markdown.ex:361
+#: lib/vutuv_web/agent_docs/text.ex:219
+#: lib/vutuv_web/agent_docs/text.ex:386
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Employer"
@@ -12241,10 +12246,10 @@ msgstr ""
 msgid "Employer name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:225
-#: lib/vutuv_web/agent_docs/markdown.ex:354
-#: lib/vutuv_web/agent_docs/text.ex:213
-#: lib/vutuv_web/agent_docs/text.ex:380
+#: lib/vutuv_web/agent_docs/markdown.ex:233
+#: lib/vutuv_web/agent_docs/markdown.ex:362
+#: lib/vutuv_web/agent_docs/text.ex:220
+#: lib/vutuv_web/agent_docs/text.ex:387
 #: lib/vutuv_web/live/job_board_live.ex:367
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
@@ -12283,7 +12288,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:800
+#: lib/vutuv/accounts/user.ex:810
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12321,12 +12326,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:335
-#: lib/vutuv_web/agent_docs/markdown.ex:339
-#: lib/vutuv_web/agent_docs/markdown.ex:341
-#: lib/vutuv_web/agent_docs/text.ex:361
-#: lib/vutuv_web/agent_docs/text.ex:365
-#: lib/vutuv_web/agent_docs/text.ex:367
+#: lib/vutuv_web/agent_docs/markdown.ex:343
+#: lib/vutuv_web/agent_docs/markdown.ex:347
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/text.ex:368
+#: lib/vutuv_web/agent_docs/text.ex:372
+#: lib/vutuv_web/agent_docs/text.ex:374
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12375,8 +12380,8 @@ msgstr ""
 msgid "New posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:236
-#: lib/vutuv_web/agent_docs/text.ex:223
+#: lib/vutuv_web/agent_docs/markdown.ex:244
+#: lib/vutuv_web/agent_docs/text.ex:230
 #: lib/vutuv_web/live/job_posting_live/form.ex:519
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
@@ -12403,7 +12408,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:799
+#: lib/vutuv/accounts/user.ex:809
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12460,10 +12465,10 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:229
-#: lib/vutuv_web/agent_docs/markdown.ex:358
-#: lib/vutuv_web/agent_docs/text.ex:217
-#: lib/vutuv_web/agent_docs/text.ex:384
+#: lib/vutuv_web/agent_docs/markdown.ex:237
+#: lib/vutuv_web/agent_docs/markdown.ex:366
+#: lib/vutuv_web/agent_docs/text.ex:224
+#: lib/vutuv_web/agent_docs/text.ex:391
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12485,13 +12490,13 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:801
+#: lib/vutuv/accounts/user.ex:811
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:413
-#: lib/vutuv_web/agent_docs/markdown.ex:339
-#: lib/vutuv_web/agent_docs/markdown.ex:341
-#: lib/vutuv_web/agent_docs/text.ex:365
-#: lib/vutuv_web/agent_docs/text.ex:367
+#: lib/vutuv_web/agent_docs/markdown.ex:347
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/text.ex:372
+#: lib/vutuv_web/agent_docs/text.ex:374
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format
@@ -12503,18 +12508,18 @@ msgstr ""
 msgid "Report this posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:235
-#: lib/vutuv_web/agent_docs/text.ex:222
+#: lib/vutuv_web/agent_docs/markdown.ex:243
+#: lib/vutuv_web/agent_docs/text.ex:229
 #: lib/vutuv_web/live/job_posting_live/form.ex:514
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:228
-#: lib/vutuv_web/agent_docs/markdown.ex:357
-#: lib/vutuv_web/agent_docs/text.ex:216
-#: lib/vutuv_web/agent_docs/text.ex:383
+#: lib/vutuv_web/agent_docs/markdown.ex:236
+#: lib/vutuv_web/agent_docs/markdown.ex:365
+#: lib/vutuv_web/agent_docs/text.ex:223
+#: lib/vutuv_web/agent_docs/text.ex:390
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12608,10 +12613,10 @@ msgstr ""
 msgid "Working student"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:226
-#: lib/vutuv_web/agent_docs/markdown.ex:355
-#: lib/vutuv_web/agent_docs/text.ex:214
-#: lib/vutuv_web/agent_docs/text.ex:381
+#: lib/vutuv_web/agent_docs/markdown.ex:234
+#: lib/vutuv_web/agent_docs/markdown.ex:363
+#: lib/vutuv_web/agent_docs/text.ex:221
+#: lib/vutuv_web/agent_docs/text.ex:388
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -12784,13 +12789,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:376
+#: lib/vutuv_web/agent_docs/markdown.ex:384
 #: lib/vutuv_web/templates/tag/show.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:401
+#: lib/vutuv_web/agent_docs/text.ex:408
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12836,12 +12841,12 @@ msgstr ""
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:248
+#: lib/vutuv_web/agent_docs/markdown.ex:256
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:235
+#: lib/vutuv_web/agent_docs/text.ex:242
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
@@ -12856,10 +12861,10 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:374
-#: lib/vutuv_web/agent_docs/markdown.ex:386
-#: lib/vutuv_web/agent_docs/text.ex:399
-#: lib/vutuv_web/agent_docs/text.ex:411
+#: lib/vutuv_web/agent_docs/markdown.ex:382
+#: lib/vutuv_web/agent_docs/markdown.ex:394
+#: lib/vutuv_web/agent_docs/text.ex:406
+#: lib/vutuv_web/agent_docs/text.ex:418
 #: lib/vutuv_web/live/organization_live/show.ex:329
 #: lib/vutuv_web/templates/tag/show.html.heex:57
 #, elixir-autogen, elixir-format
@@ -13088,7 +13093,7 @@ msgstr[1] ""
 msgid "Alert frequency"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:488
+#: lib/vutuv_web/controllers/settings_controller.ex:493
 #, elixir-autogen, elixir-format
 msgid "Alert updated."
 msgstr ""
@@ -13154,13 +13159,13 @@ msgstr ""
 msgid "Save search"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:506
+#: lib/vutuv_web/controllers/settings_controller.ex:511
 #, elixir-autogen, elixir-format
 msgid "Saved search deleted."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3273
-#: lib/vutuv_web/controllers/settings_controller.ex:411
+#: lib/vutuv_web/controllers/settings_controller.ex:416
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
 #, elixir-autogen, elixir-format
@@ -13179,8 +13184,8 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:43
-#: lib/vutuv_web/controllers/settings_controller.ex:493
-#: lib/vutuv_web/controllers/settings_controller.ex:511
+#: lib/vutuv_web/controllers/settings_controller.ex:498
+#: lib/vutuv_web/controllers/settings_controller.ex:516
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -13420,7 +13425,7 @@ msgstr ""
 msgid "%{pending} image(s) in the scan queue; %{rejected} rejected in the last 7 days. A growing queue usually means Ollama is unreachable."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1268
+#: lib/vutuv_web/components/post_components.ex:1485
 #: lib/vutuv_web/templates/user/edit.html.heex:38
 #: lib/vutuv_web/templates/user/edit.html.heex:91
 #: lib/vutuv_web/templates/user/show.html.heex:61
@@ -13428,12 +13433,12 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1258
+#: lib/vutuv_web/components/post_components.ex:1475
 #, elixir-autogen, elixir-format
 msgid "Image is being reviewed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:859
+#: lib/vutuv_web/live/notification_live/index.ex:902
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13474,7 +13479,7 @@ msgstr ""
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:844
+#: lib/vutuv/accounts/user.ex:854
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13485,19 +13490,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:847
+#: lib/vutuv/accounts/user.ex:857
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:850
+#: lib/vutuv/accounts/user.ex:860
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:841
+#: lib/vutuv/accounts/user.ex:851
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13520,7 +13525,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:862
+#: lib/vutuv_web/live/notification_live/index.ex:905
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13532,7 +13537,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1063
+#: lib/vutuv_web/live/notification_live/index.ex:1115
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13572,8 +13577,8 @@ msgstr ""
 msgid "Insert into text"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:180
-#: lib/vutuv_web/agent_docs/text.ex:169
+#: lib/vutuv_web/agent_docs/markdown.ex:188
+#: lib/vutuv_web/agent_docs/text.ex:176
 #: lib/vutuv_web/templates/tag/show.html.heex:39
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
@@ -13599,22 +13604,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:284
+#: lib/vutuv_web/components/post_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:286
+#: lib/vutuv_web/components/post_components.ex:287
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:285
+#: lib/vutuv_web/components/post_components.ex:286
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:274
+#: lib/vutuv_web/components/post_components.ex:275
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13625,7 +13630,7 @@ msgid "Posts tagged with a tag you follow show up in your feed, and people known
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3269
-#: lib/vutuv_web/controllers/settings_controller.ex:425
+#: lib/vutuv_web/controllers/settings_controller.ex:430
 #: lib/vutuv_web/live/post_live/feed.ex:732
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
@@ -13744,22 +13749,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:863
+#: lib/vutuv_web/live/notification_live/index.ex:906
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1083
+#: lib/vutuv_web/live/notification_live/index.ex:1135
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1075
+#: lib/vutuv_web/live/notification_live/index.ex:1127
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1080
+#: lib/vutuv_web/live/notification_live/index.ex:1132
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13784,12 +13789,12 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1088
+#: lib/vutuv_web/live/notification_live/index.ex:1140
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1940
+#: lib/vutuv_web/components/post_components.ex:2157
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
@@ -13804,19 +13809,19 @@ msgstr ""
 msgid "Book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:870
-#: lib/vutuv_web/components/post_components.ex:1897
+#: lib/vutuv_web/agent_docs/markdown.ex:884
+#: lib/vutuv_web/components/post_components.ex:2114
 #: lib/vutuv_web/live/post_live/composer.ex:671
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1941
+#: lib/vutuv_web/components/post_components.ex:2158
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1943
+#: lib/vutuv_web/components/post_components.ex:2160
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
@@ -13826,7 +13831,7 @@ msgstr ""
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1939
+#: lib/vutuv_web/components/post_components.ex:2156
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
@@ -13836,8 +13841,8 @@ msgstr ""
 msgid "Film"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:870
-#: lib/vutuv_web/components/post_components.ex:1896
+#: lib/vutuv_web/agent_docs/markdown.ex:884
+#: lib/vutuv_web/components/post_components.ex:2113
 #: lib/vutuv_web/live/post_live/composer.ex:670
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13868,7 +13873,7 @@ msgstr ""
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1938
+#: lib/vutuv_web/components/post_components.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
@@ -13895,7 +13900,7 @@ msgstr ""
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1942
+#: lib/vutuv_web/components/post_components.ex:2159
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13926,34 +13931,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1979
+#: lib/vutuv_web/components/post_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2009
+#: lib/vutuv_web/components/post_components.ex:2226
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2010
+#: lib/vutuv_web/components/post_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2008
+#: lib/vutuv_web/components/post_components.ex:2225
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1968
+#: lib/vutuv_web/components/post_components.ex:2185
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2015
+#: lib/vutuv_web/components/post_components.ex:2232
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13978,24 +13983,24 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:594
+#: lib/vutuv_web/agent_docs/markdown.ex:602
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1782
+#: lib/vutuv_web/components/post_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:740
+#: lib/vutuv_web/live/notification_live/index.ex:779
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:754
+#: lib/vutuv_web/live/notification_live/index.ex:793
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
@@ -14010,28 +14015,28 @@ msgstr ""
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:706
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:745
+#: lib/vutuv_web/live/notification_live/index.ex:954
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:878
+#: lib/vutuv_web/live/notification_live/index.ex:921
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:873
+#: lib/vutuv_web/live/notification_live/index.ex:916
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:888
+#: lib/vutuv_web/live/notification_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1773
+#: lib/vutuv_web/components/post_components.ex:1990
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14074,19 +14079,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:697
+#: lib/vutuv_web/agent_docs/markdown.ex:705
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:696
+#: lib/vutuv_web/agent_docs/markdown.ex:704
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:702
+#: lib/vutuv_web/agent_docs/markdown.ex:710
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14165,8 +14170,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:665
-#: lib/vutuv_web/agent_docs/text.ex:550
+#: lib/vutuv_web/agent_docs/markdown.ex:673
+#: lib/vutuv_web/agent_docs/text.ex:557
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14249,8 +14254,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:426
-#: lib/vutuv_web/agent_docs/text.ex:423
+#: lib/vutuv_web/agent_docs/markdown.ex:434
+#: lib/vutuv_web/agent_docs/text.ex:430
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14261,7 +14266,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:676
+#: lib/vutuv_web/live/notification_live/index.ex:715
 #, elixir-autogen, elixir-format
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
@@ -14271,17 +14276,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1037
+#: lib/vutuv_web/live/notification_live/index.ex:1089
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:854
+#: lib/vutuv_web/live/notification_live/index.ex:896
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:898
+#: lib/vutuv_web/live/notification_live/index.ex:941
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14300,12 +14305,12 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:855
+#: lib/vutuv_web/live/notification_live/index.ex:897
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:996
+#: lib/vutuv_web/live/notification_live/index.ex:1045
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
@@ -14385,7 +14390,7 @@ msgstr ""
 msgid "No accounts are currently frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:216
+#: lib/vutuv_web/live/post_live/thread.ex:301
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr ""
@@ -14405,14 +14410,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:824
+#: lib/vutuv_web/components/post_components.ex:1005
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:846
+#: lib/vutuv_web/components/post_components.ex:1027
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14424,7 +14429,7 @@ msgstr[1] ""
 msgid "This page is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:208
+#: lib/vutuv_web/live/post_live/thread.ex:293
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr ""
@@ -14439,7 +14444,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2225
+#: lib/vutuv_web/components/post_components.ex:2475
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14489,7 +14494,7 @@ msgstr ""
 msgid "Cancel redirect"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:314
+#: lib/vutuv_web/controllers/settings_controller.ex:319
 #, elixir-autogen, elixir-format
 msgid "Done. Your Fediverse followers have been asked to follow your new account, and new posts are no longer federated from here. Your vutuv profile is unchanged."
 msgstr ""
@@ -14504,12 +14509,12 @@ msgstr ""
 msgid "On your other account, add your vutuv handle"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:353
+#: lib/vutuv_web/controllers/settings_controller.ex:358
 #, elixir-autogen, elixir-format
 msgid "Please enter the full https address of the account you are moving to."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:339
+#: lib/vutuv_web/controllers/settings_controller.ex:344
 #, elixir-autogen, elixir-format
 msgid "Redirect cancelled. Your posts federate from here again."
 msgstr ""
@@ -14524,17 +14529,17 @@ msgstr ""
 msgid "Redirected on %{date}"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:366
+#: lib/vutuv_web/controllers/settings_controller.ex:371
 #, elixir-autogen, elixir-format
 msgid "That account could not be reached. Check the address, and that the other server is online."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:360
+#: lib/vutuv_web/controllers/settings_controller.ex:365
 #, elixir-autogen, elixir-format
 msgid "That account does not list your vutuv profile as an alias yet. Add this profile's address there first, then try again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:356
+#: lib/vutuv_web/controllers/settings_controller.ex:361
 #, elixir-autogen, elixir-format
 msgid "That is this account. Enter the account you are moving to."
 msgstr ""
@@ -14544,12 +14549,12 @@ msgstr ""
 msgid "This tells your Fediverse followers to follow your new account instead, and stops federating your posts from here. Your vutuv profile is not affected. Continue?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:344
+#: lib/vutuv_web/controllers/settings_controller.ex:349
 #, elixir-autogen, elixir-format
 msgid "Turn on federation first, then you can redirect your followers."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:348
+#: lib/vutuv_web/controllers/settings_controller.ex:353
 #, elixir-autogen, elixir-format
 msgid "You can only move once every %{days} days."
 msgstr ""
@@ -14571,7 +14576,7 @@ msgstr[1] ""
 msgid "All endorsers"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:442
+#: lib/vutuv_web/controllers/settings_controller.ex:447
 #, elixir-autogen, elixir-format
 msgid "Filter added. Matching posts are now hidden from your feed."
 msgstr ""
@@ -14581,7 +14586,7 @@ msgstr ""
 msgid "Filter by a tag"
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:467
+#: lib/vutuv_web/controllers/settings_controller.ex:472
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter removed."
 msgstr ""
@@ -14602,7 +14607,7 @@ msgid "Match whole words only (word/phrase)"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3265
-#: lib/vutuv_web/controllers/settings_controller.ex:478
+#: lib/vutuv_web/controllers/settings_controller.ex:483
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
 #, elixir-autogen, elixir-format
@@ -14649,7 +14654,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:481
+#: lib/vutuv_web/live/notification_live/index.ex:506
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14695,12 +14700,12 @@ msgstr ""
 msgid "You have not muted anything yet."
 msgstr ""
 
-#: lib/vutuv_web/controllers/settings_controller.ex:450
+#: lib/vutuv_web/controllers/settings_controller.ex:455
 #, elixir-autogen, elixir-format
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:476
+#: lib/vutuv_web/live/notification_live/index.ex:501
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -14710,17 +14715,17 @@ msgstr ""
 msgid "e.g. crypto*, \"machine learning\", politics"
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:44
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:49
 #, elixir-autogen, elixir-format
 msgid "Enter the server name on its own, for example mastodon.example."
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:58
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:63
 #, elixir-autogen, elixir-format
 msgid "%{host} is no longer blocked. What was deleted stays deleted; the server has to follow again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:71
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:76
 #, elixir-autogen, elixir-format
 msgid "%{host} is blocked. Removed: %{followers} remote followers and %{deliveries} queued deliveries."
 msgstr ""
@@ -14787,6 +14792,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:84
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:135
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "Server"
 msgstr ""
@@ -14836,7 +14842,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:858
+#: lib/vutuv_web/agent_docs/markdown.ex:866
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -14845,13 +14851,6 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Count reactions from other networks"
 msgstr ""
-
-#: lib/vutuv_web/components/post_components.ex:2185
-#, elixir-autogen, elixir-format
-msgid "%{formatted} reaction from other networks"
-msgid_plural "%{formatted} reactions from other networks"
-msgstr[0] ""
-msgstr[1] ""
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:15
 #, elixir-autogen, elixir-format
@@ -14898,34 +14897,34 @@ msgstr ""
 msgid "Show under each of your posts how many people out there liked or shared it. A number only, visible to everyone who sees the post. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:92
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:139
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:171
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Related"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:174
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
 #: lib/vutuv_web/controllers/settings_controller.ex:216
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:180
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:195
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Move your account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:184
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr ""
@@ -14980,7 +14979,7 @@ msgstr ""
 msgid "Back to Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:114
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower from other networks"
 msgid_plural "%{formatted} followers from other networks"
@@ -15222,8 +15221,8 @@ msgstr ""
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:448
-#: lib/vutuv_web/agent_docs/text.ex:445
+#: lib/vutuv_web/agent_docs/markdown.ex:456
+#: lib/vutuv_web/agent_docs/text.ex:452
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
@@ -15579,13 +15578,13 @@ msgstr ""
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:235
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:250
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:233
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:248
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
@@ -15619,4 +15618,149 @@ msgstr ""
 #: lib/vutuv_web/views/settings_html.ex:322
 #, elixir-autogen, elixir-format
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:2435
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{count} from other networks"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:2438
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{formatted} reaction"
+msgid_plural "%{formatted} reactions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/components/post_components.ex:2444
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{formatted} reply"
+msgid_plural "%{formatted} replies"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/components/post_components.ex:2428
+#, elixir-autogen, elixir-format
+msgid "%{reactions} and %{replies} from other networks"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:167
+#, elixir-autogen, elixir-format
+msgid "A report deletes the reply right away, with no queue to work through. This is the trail, so a server that keeps showing up here can be blocked above. It holds no text and no links, only which server and which account (as a short digest)."
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:89
+#, elixir-autogen, elixir-format
+msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:973
+#: lib/vutuv_web/agent_docs/text.ex:647
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Content warning"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:784
+#: lib/vutuv_web/components/post_components.ex:865
+#, elixir-autogen, elixir-format
+msgid "From another network"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:164
+#, elixir-autogen, elixir-format
+msgid "Nobody has removed or reported a reply yet."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:815
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Remove this reply from your post?"
+msgstr ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:15
+#, elixir-autogen, elixir-format
+msgid "Removed by the member"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:122
+#: lib/vutuv_web/agent_docs/markdown.ex:871
+#: lib/vutuv_web/agent_docs/text.ex:113
+#, elixir-autogen, elixir-format
+msgid "Replies from other networks"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:162
+#, elixir-autogen, elixir-format
+msgid "Replies taken down by members"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:899
+#, elixir-autogen, elixir-format
+msgid "Reply from another network"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/thread.ex:95
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Reply removed."
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:824
+#, elixir-autogen, elixir-format
+msgid "Report this reply as not appropriate? It is deleted right away."
+msgstr ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:14
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Reported as not appropriate"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:841
+#: lib/vutuv_web/live/notification_live/index.ex:479
+#, elixir-autogen, elixir-format
+msgid "Sent to you only, visible to nobody else"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:86
+#, elixir-autogen, elixir-format
+msgid "Show replies from other networks"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:137
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Stored replies"
+msgstr ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:16
+#, elixir-autogen, elixir-format
+msgid "Taken down"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/thread.ex:104
+#, elixir-autogen, elixir-format
+msgid "Thank you. The reply was deleted right away."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/thread.ex:205
+#, elixir-autogen, elixir-format
+msgid "That reply is not yours to remove."
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:975
+#: lib/vutuv_web/components/post_components.ex:871
+#, elixir-autogen, elixir-format
+msgid "View the original"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:176
+#, elixir-autogen, elixir-format
+msgid "What"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/thread.ex:201
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You have reported a lot today. Please try again tomorrow."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:1048
+#, elixir-autogen, elixir-format, fuzzy
+msgid "replied to your post from another network."
 msgstr ""

--- a/priv/repo/migrations/20260725093328_create_fediverse_notes.exs
+++ b/priv/repo/migrations/20260725093328_create_fediverse_notes.exs
@@ -1,0 +1,114 @@
+defmodule Vutuv.Repo.Migrations.CreateFediverseNotes do
+  use Ecto.Migration
+
+  # Replies written on other networks under a member's post (issues #1069 and
+  # #1071). The first time vutuv stores a stranger's *words*, which is why this
+  # table carries a clock and the reactions table (#1068) does not: a counter row
+  # says nothing about a person, a sentence with their name on it does.
+  #
+  # What is deliberately absent: any copy of their picture. The card renders
+  # initials and links to the origin, so we never host a third party's image.
+  #
+  # The retention triple is the whole legal footing, since consent from someone
+  # on another server is not obtainable:
+  #
+  #   received_at — when it arrived,
+  #   checked_at  — when we last confirmed it is still published at its origin,
+  #   expires_at  — the hard ceiling, six months out, which a confirmed-live
+  #                 note pushes forward and nothing else does.
+  #
+  # New tables + a new column with a default -> N-1 safe for the blue/green
+  # window.
+  def change do
+    create table(:fediverse_notes) do
+      add(:post_id, references(:posts, type: :binary_id, on_delete: :delete_all), null: false)
+
+      # The note's own AP id and the actor who wrote it. `text`, because remote
+      # URIs are unbounded in theory; the schema caps the length in BYTES before
+      # anything is written, because object_uri carries a btree unique index
+      # whose key has a hard size limit.
+      add(:object_uri, :text, null: false)
+      add(:actor_uri, :text, null: false)
+      # Where a human reads the original. Mastodon serves this separately from
+      # the id; we fall back to the id when it is absent.
+      add(:origin_url, :text)
+      # What the note answered, as delivered. Unused while only direct answers
+      # to a vutuv post are stored, kept so remote-to-remote nesting is later a
+      # change and not a migration.
+      add(:in_reply_to_uri, :text)
+
+      # Cosmetic, remote-supplied and hostile: capped at the usual varchar(255).
+      add(:handle, :string)
+      add(:display_name, :string)
+
+      # Plain text, never HTML: nothing a stranger wrote is ever rendered raw.
+      # `text` with a generous cap in the schema, per the varchar rule.
+      add(:content_text, :text, null: false)
+      # The note's content warning, if it carried one. Kept as its own column
+      # rather than folded into the text, because a warning exists precisely so
+      # the reader chooses whether to read what is behind it: the card renders
+      # it as the closed lid and reveals the text on a click. Silently showing
+      # a warned reply unwrapped would defeat the one thing its author asked
+      # for.
+      add(:summary, :text)
+
+      # public | followers | direct | unknown (issue #1071). Only "public" is
+      # public; every other value renders to the addressed member alone. The
+      # distinction is kept rather than collapsed to a boolean so the member can
+      # be told honestly what kind of message reached them.
+      add(:audience, :string, null: false)
+
+      add(:received_at, :utc_datetime, null: false)
+      add(:checked_at, :utc_datetime)
+      add(:expires_at, :utc_datetime, null: false)
+    end
+
+    # One row per remote note: a redelivery is an upsert, and an upstream
+    # Update/Delete finds its row here.
+    create(unique_index(:fediverse_notes, [:object_uri]))
+    # The thread renderer's read: every note under one post, oldest first.
+    create(index(:fediverse_notes, [:post_id, :received_at]))
+    # The retention sweep's read.
+    create(index(:fediverse_notes, [:expires_at]))
+    # The per-actor takedown and the instance purge read this one.
+    create(index(:fediverse_notes, [:actor_uri]))
+
+    # The operator's window on the takedown path (issue #1069): what members are
+    # removing, and from which servers, so a block decision has evidence behind
+    # it.
+    #
+    # It keeps NO content and NO URIs, following the precedent
+    # Vutuv.Fediverse.FollowerPrune set in #1072: retaining a stranger's words or
+    # their online identifier after deleting the note would undo the deletion we
+    # just promised. `actor_digest` is a keyed HMAC of the actor URI (peppered
+    # from secret_key_base), which is enough to tell one troll from a whole
+    # server without holding the identifier itself.
+    #
+    # Only member-initiated actions land here. Automatic deletions (expiry, an
+    # upstream Delete, a server block) would flood the table and are reported in
+    # aggregate to the log instead.
+    create table(:fediverse_note_events) do
+      add(:action, :string, null: false)
+      add(:host, :string, null: false)
+      add(:actor_digest, :string, null: false)
+      add(:audience, :string, null: false)
+      # Whose post the note sat under, and who acted. Plain values, not
+      # associations: an audit row must stay readable after the rows it
+      # references are gone.
+      add(:user_id, :binary_id)
+      add(:actor_id, :binary_id)
+
+      timestamps(updated_at: false)
+    end
+
+    create(index(:fediverse_note_events, [:host]))
+    create(index(:fediverse_note_events, [:inserted_at]))
+
+    alter table(:users) do
+      # The second, explicit opt-in (issue #1069): counts are one thing, a
+      # stranger's words under your post are another. Off by default, unlike the
+      # reaction counts, and switching it off deletes what was stored.
+      add(:fediverse_replies?, :boolean, null: false, default: false)
+    end
+  end
+end

--- a/test/vutuv/fediverse_blocklist_test.exs
+++ b/test/vutuv/fediverse_blocklist_test.exs
@@ -138,7 +138,9 @@ defmodule Vutuv.FediverseBlocklistTest do
       assert {:ok, {_blocked, purged}} =
                Fediverse.block_instance(%{"host" => "spam.example"}, admin())
 
-      assert purged == %{followers: 1, deliveries: 1}
+      # `notes` joined the tally with issue #1069: a block is also a takedown of
+      # the replies that server's members wrote under vutuv posts.
+      assert purged == %{followers: 1, deliveries: 1, notes: 0}
       assert [%Follower{actor_uri: "https://social.example/users/alice"}] = Repo.all(Follower)
       assert [%Delivery{inbox_uri: "https://social.example/inbox"}] = Repo.all(Delivery)
     end

--- a/test/vutuv/fediverse_notes_test.exs
+++ b/test/vutuv/fediverse_notes_test.exs
@@ -1,0 +1,762 @@
+defmodule Vutuv.FediverseNotesTest do
+  @moduledoc """
+  Replies written on other networks under a member's post (issues #1069 and
+  #1071): the first content vutuv stores that its own members did not write.
+
+  async: false — the inbound caps (issue #1067) and the report rate limit live
+  in the shared `Vutuv.RateLimiter` ETS table, which the SQL sandbox does not
+  roll back.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Accounts
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.NoteEvent
+  alias Vutuv.Posts
+  alias VutuvWeb.Fediverse.Docs
+
+  @actor "https://social.example/users/alice"
+  @other_actor "https://chaos.example/users/bob"
+  @public "https://www.w3.org/ns/activitystreams#Public"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    user = insert(:activated_user, fediverse_followers?: true, fediverse_replies?: true)
+    post = create_post!(user, %{"body" => "Federated far and wide."})
+    {:ok, user: user, post: post, note_url: Docs.note_url(user, post.id)}
+  end
+
+  # A Create(Note) the way Mastodon sends one: the note embedded, addressed to
+  # the public collection, cc'ing the author's followers.
+  defp create_activity(note_url, opts \\ []) do
+    actor = Keyword.get(opts, :actor, @actor)
+    object_id = Keyword.get(opts, :object_id, "#{actor}/statuses/1")
+
+    object =
+      %{
+        "id" => object_id,
+        "type" => Keyword.get(opts, :type, "Note"),
+        "inReplyTo" => note_url,
+        "content" => Keyword.get(opts, :content, "<p>Guter Punkt.</p>"),
+        "url" => Keyword.get(opts, :url, "https://social.example/@alice/1"),
+        "to" => Keyword.get(opts, :to, [@public]),
+        "cc" => Keyword.get(opts, :cc, ["#{actor}/followers"])
+      }
+      |> maybe_put("summary", opts[:summary])
+
+    %{
+      "type" => "Create",
+      "actor" => actor,
+      "to" => Keyword.get(opts, :to, [@public]),
+      "object" => object
+    }
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp remote(uri \\ @actor), do: %{uri: uri, handle: "alice", name: "Alice Anders"}
+
+  describe "record_reply/3 — the gates" do
+    test "stores a public reply to the member's own post", %{
+      user: user,
+      post: post,
+      note_url: note_url
+    } do
+      assert :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+
+      assert [%Note{} = note] = Repo.all(Note)
+      assert note.post_id == post.id
+      assert note.actor_uri == @actor
+      assert note.handle == "alice"
+      assert note.display_name == "Alice Anders"
+      assert note.content_text == "Guter Punkt."
+      assert note.audience == "public"
+      assert note.origin_url == "https://social.example/@alice/1"
+      assert note.received_at
+      # It was demonstrably live the moment it was delivered, so that counts as
+      # the first freshness confirmation.
+      assert note.checked_at == note.received_at
+      assert DateTime.compare(note.expires_at, note.received_at) == :gt
+    end
+
+    test "the same note delivered twice stores one row", %{user: user, note_url: note_url} do
+      assert :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+      assert :skip = Fediverse.record_reply(user, create_activity(note_url), remote())
+
+      assert Repo.aggregate(Note, :count) == 1
+    end
+
+    test "stores nothing for a member who did not switch replies on", %{
+      user: user,
+      note_url: note_url
+    } do
+      {:ok, user} = Accounts.update_user(user, %{"fediverse_replies?" => false})
+
+      assert :skip = Fediverse.record_reply(user, create_activity(note_url), remote())
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "the reply switch is independent of the reaction switch", %{
+      user: user,
+      note_url: note_url
+    } do
+      # Counts off, replies on: the reply still lands. The two are separate
+      # decisions, which is why they are separate columns.
+      {:ok, user} = Accounts.update_user(user, %{"fediverse_reactions?" => false})
+
+      assert :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+      assert Repo.aggregate(Note, :count) == 1
+    end
+
+    test "stores nothing for a member who does not federate", %{note_url: note_url} do
+      plain = insert(:activated_user, fediverse_replies?: true)
+
+      assert :skip = Fediverse.record_reply(plain, create_activity(note_url), remote())
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "stores nothing while federation is off installation-wide", %{
+      user: user,
+      note_url: note_url
+    } do
+      Application.put_env(:vutuv, :fediverse_enabled, false)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_enabled) end)
+
+      assert :skip = Fediverse.record_reply(user, create_activity(note_url), remote())
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "ignores a reply to somebody else's post", %{note_url: note_url} do
+      stranger = insert(:activated_user, fediverse_followers?: true, fediverse_replies?: true)
+
+      assert :skip = Fediverse.record_reply(stranger, create_activity(note_url), remote())
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "ignores a reply to a restricted post", %{user: user} do
+      restricted =
+        create_post!(user, %{
+          body: "Just for some.",
+          denials: [%{"wildcard" => "logged_out"}]
+        })
+
+      activity = create_activity(Docs.note_url(user, restricted.id))
+
+      assert :skip = Fediverse.record_reply(user, activity, remote())
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "ignores an inReplyTo that is not one of our Note URLs", %{user: user} do
+      for target <- [
+            "https://social.example/users/alice/statuses/9",
+            "#{VutuvWeb.Endpoint.url()}/#{user.username}/posts/not-a-uuid",
+            "#{VutuvWeb.Endpoint.url()}/#{user.username}",
+            nil
+          ] do
+        assert :skip = Fediverse.record_reply(user, create_activity(target), remote())
+      end
+
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "ignores an object that is not a Note", %{user: user, note_url: note_url} do
+      assert :skip =
+               Fediverse.record_reply(user, create_activity(note_url, type: "Video"), remote())
+
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "ignores a Create whose object is only an id", %{user: user, note_url: note_url} do
+      # We never go and fetch it: an activity that does not carry what it claims
+      # to deliver is not worth an outbound request to a stranger's server.
+      activity = Map.put(create_activity(note_url), "object", "https://social.example/statuses/1")
+
+      assert :skip = Fediverse.record_reply(user, activity, remote())
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "ignores a note whose text is empty once the markup is gone", %{
+      user: user,
+      note_url: note_url
+    } do
+      assert :skip =
+               Fediverse.record_reply(
+                 user,
+                 create_activity(note_url, content: "<p>  </p><img src=x>"),
+                 remote()
+               )
+
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "is subject to the inbound caps (#1067)", %{user: user, note_url: note_url} do
+      Application.put_env(:vutuv, :fediverse_inbound_caps, {1, 1})
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_inbound_caps) end)
+
+      assert :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+
+      assert :skip =
+               Fediverse.record_reply(
+                 user,
+                 create_activity(note_url, object_id: "#{@actor}/statuses/2"),
+                 remote()
+               )
+    end
+  end
+
+  describe "record_reply/3 — the text is reduced to plain text" do
+    test "script and markup are stripped away", %{user: user, note_url: note_url} do
+      content = "<script>alert(1)</script><p>Hallo <b>Welt</b></p><p>Zweiter Absatz</p>"
+
+      assert :ok =
+               Fediverse.record_reply(user, create_activity(note_url, content: content), remote())
+
+      assert [%Note{content_text: text}] = Repo.all(Note)
+      assert text == "Hallo Welt\n\nZweiter Absatz"
+      refute text =~ "<"
+      refute text =~ "alert"
+    end
+
+    test "a runaway note is clamped", %{user: user, note_url: note_url} do
+      long = "<p>" <> String.duplicate("a", Note.max_content() * 2) <> "</p>"
+
+      assert :ok =
+               Fediverse.record_reply(user, create_activity(note_url, content: long), remote())
+
+      assert [%Note{content_text: text}] = Repo.all(Note)
+      assert String.length(text) <= Note.max_content()
+    end
+
+    test "a content warning is kept as the lid, not folded into the text", %{
+      user: user,
+      note_url: note_url
+    } do
+      activity =
+        create_activity(note_url, summary: "Spoiler: Staffelfinale", content: "<p>Er stirbt.</p>")
+
+      assert :ok = Fediverse.record_reply(user, activity, remote())
+
+      assert [%Note{} = note] = Repo.all(Note)
+      assert note.summary == "Spoiler: Staffelfinale"
+      assert note.content_text == "Er stirbt."
+      assert Note.warned?(note)
+    end
+  end
+
+  describe "audience (#1071)" do
+    test "every spelling of the public collection counts as public", %{
+      user: user,
+      note_url: note_url
+    } do
+      for {spelling, index} <-
+            Enum.with_index([@public, "as:Public", "Public"]) do
+        activity =
+          create_activity(note_url, to: [spelling], object_id: "#{@actor}/statuses/pub#{index}")
+
+        assert :ok = Fediverse.record_reply(user, activity, remote())
+      end
+
+      assert Repo.all(from(n in Note, select: n.audience)) == ~w(public public public)
+    end
+
+    test "a note addressed only to the member is direct", %{user: user, note_url: note_url} do
+      activity = create_activity(note_url, to: [Docs.actor_url(user)], cc: [])
+
+      assert :ok = Fediverse.record_reply(user, activity, remote())
+
+      assert [%Note{audience: "direct"} = note] = Repo.all(Note)
+      refute Note.public?(note)
+    end
+
+    test "a followers-only note is not public", %{user: user, note_url: note_url} do
+      activity =
+        create_activity(note_url, to: ["#{@actor}/followers"], cc: [Docs.actor_url(user)])
+
+      assert :ok = Fediverse.record_reply(user, activity, remote())
+
+      assert [%Note{audience: "followers"} = note] = Repo.all(Note)
+      refute Note.public?(note)
+    end
+
+    test "an audience we cannot read is treated as private, never widened", %{
+      user: user,
+      note_url: note_url
+    } do
+      activity = create_activity(note_url, to: ["https://social.example/some/collection"], cc: [])
+
+      assert :ok = Fediverse.record_reply(user, activity, remote())
+
+      assert [%Note{audience: "unknown"} = note] = Repo.all(Note)
+      refute Note.public?(note)
+    end
+  end
+
+  describe "list_notes/2 — who may see what" do
+    setup %{user: user, note_url: note_url} do
+      :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+
+      :ok =
+        Fediverse.record_reply(
+          user,
+          create_activity(note_url,
+            actor: @other_actor,
+            object_id: "#{@other_actor}/statuses/7",
+            to: [Docs.actor_url(user)],
+            cc: []
+          ),
+          remote(@other_actor)
+        )
+
+      :ok
+    end
+
+    test "a logged-out visitor sees only the public one", %{post: post} do
+      assert [%Note{audience: "public"}] = notes_for(post, nil)
+    end
+
+    test "another member sees only the public one", %{post: post} do
+      assert [%Note{audience: "public"}] = notes_for(post, insert(:activated_user))
+    end
+
+    test "the member whose post it is sees both", %{post: post, user: user} do
+      assert [%Note{audience: "public"}, %Note{audience: "direct"}] = notes_for(post, user)
+    end
+
+    test "the public count never moves for a private note", %{post: post} do
+      assert Fediverse.note_count(post.id) == 1
+    end
+  end
+
+  defp notes_for(post, viewer) do
+    Fediverse.list_notes([post.id], viewer) |> Map.get(post.id, [])
+  end
+
+  describe "takedown" do
+    setup %{user: user, note_url: note_url} do
+      :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+      {:ok, note: Repo.one!(Note)}
+    end
+
+    test "the member removes a reply from their own post", %{user: user, note: note} do
+      assert :ok = Fediverse.remove_note(note.id, user)
+
+      assert Repo.aggregate(Note, :count) == 0
+      assert [%NoteEvent{action: "removed_by_member"} = event] = Repo.all(NoteEvent)
+      assert event.host == "social.example"
+      assert event.user_id == user.id
+      assert event.actor_id == user.id
+    end
+
+    test "somebody else cannot remove it", %{note: note} do
+      assert {:error, :not_allowed} = Fediverse.remove_note(note.id, insert(:activated_user))
+      assert Repo.aggregate(Note, :count) == 1
+    end
+
+    test "a report deletes it at once, with no case workflow", %{note: note} do
+      reporter = insert(:activated_user)
+
+      assert :ok = Fediverse.report_note(note.id, reporter)
+
+      assert Repo.aggregate(Note, :count) == 0
+      assert [%NoteEvent{action: "reported"} = event] = Repo.all(NoteEvent)
+      assert event.actor_id == reporter.id
+      assert Repo.aggregate(Vutuv.Moderation.Case, :count) == 0
+    end
+
+    test "the ledger keeps no content and no URIs", %{note: note} do
+      :ok = Fediverse.report_note(note.id, insert(:activated_user))
+
+      assert [%NoteEvent{} = event] = Repo.all(NoteEvent)
+      # A keyed digest groups a repeat offender without holding the identifier.
+      assert event.actor_digest != @actor
+      assert String.length(event.actor_digest) == 64
+
+      encoded = inspect(Map.from_struct(event))
+      refute encoded =~ "Guter Punkt"
+      refute encoded =~ @actor
+    end
+
+    test "the same actor digests the same way twice", %{user: user, note_url: note_url} do
+      :ok = Fediverse.report_note(Repo.one!(Note).id, insert(:activated_user))
+
+      :ok =
+        Fediverse.record_reply(
+          user,
+          create_activity(note_url, object_id: "#{@actor}/statuses/2"),
+          remote()
+        )
+
+      :ok = Fediverse.report_note(Repo.one!(Note).id, insert(:activated_user))
+
+      assert [a, b] = Repo.all(from(e in NoteEvent, select: e.actor_digest))
+      assert a == b
+    end
+
+    test "a private reply cannot be reported by anyone but its addressee", %{
+      user: user,
+      note_url: note_url
+    } do
+      Repo.delete_all(Note)
+
+      :ok =
+        Fediverse.record_reply(
+          user,
+          create_activity(note_url, to: [Docs.actor_url(user)], cc: []),
+          remote()
+        )
+
+      private = Repo.one!(Note)
+
+      assert {:error, :not_allowed} = Fediverse.report_note(private.id, insert(:activated_user))
+      assert Repo.aggregate(Note, :count) == 1
+
+      assert :ok = Fediverse.report_note(private.id, user)
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "reporting is rate limited per reporter", %{user: user, note_url: note_url} do
+      reporter = insert(:activated_user)
+
+      for index <- 1..(Fediverse.report_limit() + 1) do
+        Repo.delete_all(Note)
+
+        :ok =
+          Fediverse.record_reply(
+            user,
+            create_activity(note_url, object_id: "#{@actor}/statuses/r#{index}"),
+            remote()
+          )
+
+        note = Repo.one!(Note)
+
+        if index > Fediverse.report_limit() do
+          assert {:error, :rate_limited} = Fediverse.report_note(note.id, reporter)
+        else
+          assert :ok = Fediverse.report_note(note.id, reporter)
+        end
+      end
+    end
+  end
+
+  describe "upstream signals" do
+    setup %{user: user, note_url: note_url} do
+      :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+      {:ok, note: Repo.one!(Note)}
+    end
+
+    test "a Delete of the note removes it immediately", %{note: note} do
+      assert :ok = Fediverse.delete_reply(@actor, note.object_uri)
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "a Delete from a different server cannot touch it", %{note: note} do
+      assert :ok = Fediverse.delete_reply(@other_actor, note.object_uri)
+      assert Repo.aggregate(Note, :count) == 1
+    end
+
+    test "an upstream Delete is honoured after the member switched replies off", %{
+      user: user,
+      note: note
+    } do
+      # The withdrawal path must never depend on a switch still being on.
+      {:ok, _} = Accounts.update_user(user, %{"fediverse_replies?" => false})
+
+      assert :ok = Fediverse.delete_reply(@actor, note.object_uri)
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "an Update rewrites the stored text", %{user: user, note_url: note_url, note: note} do
+      activity =
+        create_activity(note_url, content: "<p>Korrigiert: doch nicht.</p>")
+        |> Map.put("type", "Update")
+
+      assert :ok = Fediverse.update_reply(user, activity, @actor)
+
+      assert %Note{content_text: "Korrigiert: doch nicht."} = Repo.reload!(note)
+    end
+
+    test "an Update from a different server is ignored", %{
+      user: user,
+      note_url: note_url,
+      note: note
+    } do
+      activity =
+        create_activity(note_url,
+          actor: @other_actor,
+          object_id: note.object_uri,
+          content: "<p>Hijack</p>"
+        )
+        |> Map.put("type", "Update")
+
+      assert :ok = Fediverse.update_reply(user, activity, @other_actor)
+
+      assert %Note{content_text: "Guter Punkt."} = Repo.reload!(note)
+    end
+  end
+
+  describe "retention" do
+    test "a note past its ceiling is swept", %{user: user, note_url: note_url} do
+      :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+
+      Repo.update_all(Note, set: [expires_at: DateTime.add(DateTime.utc_now(:second), -60)])
+
+      assert Fediverse.expire_due_notes() == 1
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "a note inside its ceiling is left alone", %{user: user, note_url: note_url} do
+      :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+
+      assert Fediverse.expire_due_notes() == 0
+      assert Repo.aggregate(Note, :count) == 1
+    end
+
+    test "the ceiling is the configured number of days out", %{user: user, note_url: note_url} do
+      :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+
+      note = Repo.one!(Note)
+      days = DateTime.diff(note.expires_at, note.received_at, :day)
+
+      assert days == Fediverse.note_retention_days()
+    end
+
+    test "only a public note is ever re-fetched", %{user: user, note_url: note_url} do
+      # A direct message answers 403/404 to any fetch we can make, which the
+      # checker would read as "deleted upstream" and act on — quietly destroying
+      # every private reply about a week after it arrived. It also tells the
+      # origin we are holding it. So it is never checked.
+      :ok =
+        Fediverse.record_reply(
+          user,
+          create_activity(note_url, to: [Docs.actor_url(user)], cc: []),
+          remote()
+        )
+
+      note = Repo.one!(Note)
+
+      Repo.update_all(Note,
+        set: [checked_at: DateTime.add(DateTime.utc_now(:second), -400 * 86_400)]
+      )
+
+      assert Fediverse.due_for_refresh([Repo.reload!(note)]) == []
+    end
+
+    test "a stale public note is due for a re-fetch", %{user: user, note_url: note_url} do
+      :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+
+      fresh = Repo.one!(Note)
+      assert Fediverse.due_for_refresh([fresh]) == []
+
+      stale_at =
+        DateTime.add(DateTime.utc_now(:second), -(Fediverse.note_refresh_days() + 1) * 86_400)
+
+      Repo.update_all(Note, set: [checked_at: stale_at])
+
+      assert [%Note{}] = Fediverse.due_for_refresh([Repo.reload!(fresh)])
+    end
+  end
+
+  # The half of retention that deletes *earlier* than the ceiling, and the half
+  # that keeps "cache" an honest word. Stubbed at the HTTP layer, the way the
+  # other Fediverse outbound tests stub it.
+  describe "refresh_note/1" do
+    defp stub_origin(response) do
+      Application.put_env(:vutuv, :fediverse_req_options, plug: response)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+    end
+
+    defp answer(status, body \\ "") do
+      fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/activity+json")
+        |> Plug.Conn.send_resp(status, body)
+      end
+    end
+
+    defp note_doc(fields) do
+      Jason.encode!(
+        Map.merge(
+          %{
+            "id" => "#{@actor}/statuses/1",
+            "type" => "Note",
+            "content" => "<p>Guter Punkt.</p>",
+            "to" => [@public]
+          },
+          fields
+        )
+      )
+    end
+
+    defp stored_note(user, note_url) do
+      :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+      Repo.one!(Note)
+    end
+
+    test "still published: the text is refreshed and the ceiling pushed out", %{
+      user: user,
+      note_url: note_url
+    } do
+      note = stored_note(user, note_url)
+      stub_origin(answer(200, note_doc(%{"content" => "<p>Nachtrag: doch.</p>"})))
+
+      # Age it, so the new ceiling is visibly later than the old one.
+      old_expiry = DateTime.add(note.expires_at, -10 * 86_400)
+      Repo.update_all(Note, set: [expires_at: old_expiry])
+
+      assert :refreshed = Fediverse.refresh_note(Repo.reload!(note))
+
+      refreshed = Repo.reload!(note)
+      assert refreshed.content_text == "Nachtrag: doch."
+      assert DateTime.compare(refreshed.expires_at, old_expiry) == :gt
+    end
+
+    test "gone from its origin: deleted at once", %{user: user, note_url: note_url} do
+      for {status, index} <- Enum.with_index([404, 410, 403]) do
+        :ok =
+          Fediverse.record_reply(
+            user,
+            create_activity(note_url, object_id: "#{@actor}/statuses/gone#{index}"),
+            remote()
+          )
+
+        note = Repo.one!(Note)
+        stub_origin(answer(status))
+
+        assert :deleted = Fediverse.refresh_note(note)
+        assert Repo.aggregate(Note, :count) == 0
+      end
+    end
+
+    test "checking a note twice does not raise on the second delete", %{
+      user: user,
+      note_url: note_url
+    } do
+      # Two open pages can both queue a check for the same note, and both can
+      # conclude it is gone. The loser must find nothing to do, not raise.
+      note = stored_note(user, note_url)
+      stub_origin(answer(410))
+
+      assert :deleted = Fediverse.refresh_note(note)
+      assert :deleted = Fediverse.refresh_note(note)
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "no longer public: also deleted, it is the same signal", %{
+      user: user,
+      note_url: note_url
+    } do
+      # The author narrowed the audience. We would never see a Delete for
+      # that, and it means "stop showing this" just as plainly.
+      note = stored_note(user, note_url)
+      stub_origin(answer(200, note_doc(%{"to" => ["#{@actor}/followers"]})))
+
+      assert :deleted = Fediverse.refresh_note(note)
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "unreachable: nothing changes, so an outage buys no retention", %{
+      user: user,
+      note_url: note_url
+    } do
+      note = stored_note(user, note_url)
+
+      for response <- [answer(500), answer(429), answer(200, "not json at all")] do
+        stub_origin(response)
+        assert :unchanged = Fediverse.refresh_note(Repo.reload!(note))
+      end
+
+      kept = Repo.reload!(note)
+      assert kept.content_text == "Guter Punkt."
+      # The ceiling did NOT move: a server that stays offline cannot keep a
+      # copy alive by being offline.
+      assert kept.expires_at == note.expires_at
+    end
+
+    test "a private note is never asked about at all", %{user: user, note_url: note_url} do
+      :ok =
+        Fediverse.record_reply(
+          user,
+          create_activity(note_url, to: [Docs.actor_url(user)], cc: []),
+          remote()
+        )
+
+      # Any request would be a failure here: the stub raises if it is called.
+      stub_origin(fn _conn -> raise "the origin of a private note must never be asked" end)
+
+      assert :skip = Fediverse.refresh_note(Repo.one!(Note))
+      assert Repo.aggregate(Note, :count) == 1
+    end
+  end
+
+  describe "cascades" do
+    setup %{user: user, note_url: note_url} do
+      :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+      :ok
+    end
+
+    test "deleting the post takes its remote replies", %{post: post} do
+      {:ok, _} = Posts.delete_post(post)
+
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "deleting the account takes them too", %{user: user} do
+      {:ok, _} = Accounts.delete_user(user)
+
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "switching replies off deletes what was stored", %{user: user} do
+      assert Fediverse.drop_notes(user) == 1
+      assert Repo.aggregate(Note, :count) == 0
+    end
+
+    test "blocking the server takes its notes with it" do
+      admin = insert(:activated_user)
+
+      {:ok, {_blocked, purged}} =
+        Fediverse.block_instance(%{"host" => "social.example"}, admin)
+
+      assert purged.notes == 1
+      assert Repo.aggregate(Note, :count) == 0
+    end
+  end
+
+  describe "the count reaches the action bar" do
+    test "engagement_counts/1 carries public replies on their own figure", %{
+      user: user,
+      post: post,
+      note_url: note_url
+    } do
+      assert Posts.engagement_counts(post.id).fediverse_replies == 0
+
+      :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+
+      counts = Posts.engagement_counts(post.id)
+      assert counts.fediverse_replies == 1
+      # Never folded into the vutuv figures: a hostile remote server may only
+      # inflate its own line.
+      assert counts.replies == 0
+      assert counts.fediverse_reactions == 0
+    end
+
+    test "a private reply is invisible to the public figure", %{
+      user: user,
+      post: post,
+      note_url: note_url
+    } do
+      :ok =
+        Fediverse.record_reply(
+          user,
+          create_activity(note_url, to: [Docs.actor_url(user)], cc: []),
+          remote()
+        )
+
+      assert Posts.engagement_counts(post.id).fediverse_replies == 0
+    end
+  end
+end

--- a/test/vutuv/remote_html_test.exs
+++ b/test/vutuv/remote_html_test.exs
@@ -1,0 +1,59 @@
+defmodule Vutuv.RemoteHtmlTest do
+  @moduledoc """
+  The one place HTML written by a remote server becomes text vutuv will store
+  and show — shared by the Mastodon profile feed and the inbound Fediverse
+  replies (issue #1069), so it is worth testing on its own rather than only
+  through either caller.
+  """
+  use ExUnit.Case, async: true
+
+  alias Vutuv.RemoteHtml
+
+  test "paragraphs and line breaks survive as line breaks" do
+    assert RemoteHtml.to_text("<p>Hallo <b>Welt</b></p><p>Zweiter</p>") == "Hallo Welt\n\nZweiter"
+    assert RemoteHtml.to_text("eins<br>zwei<br/>drei") == "eins\nzwei\ndrei"
+  end
+
+  test "the base entities are decoded exactly once" do
+    assert RemoteHtml.to_text("<p>Tom &amp; Jerry &lt;3</p>") == "Tom & Jerry <3"
+    assert RemoteHtml.to_text("<p>&amp;amp;</p>") == "&amp;"
+  end
+
+  describe "script and style go with their contents" do
+    test "a paired element leaves nothing behind" do
+      assert RemoteHtml.to_text("<script>alert(1)</script><p>safe</p>") == "safe"
+      assert RemoteHtml.to_text("<style>body{color:red}</style><p>safe</p>") == "safe"
+    end
+
+    test "the tag may carry attributes and odd casing" do
+      assert RemoteHtml.to_text(~s(<SCRIPT type="text/javascript">x=1</SCRIPT>hi)) == "hi"
+    end
+
+    test "an unclosed element takes the rest with it" do
+      # It runs to the end of the document by definition, so there is nothing
+      # after it worth keeping.
+      assert RemoteHtml.to_text("<p>before</p><script>alert(1)") == "before"
+    end
+
+    test "a member's own text mentioning the word is untouched" do
+      assert RemoteHtml.to_text("<p>Ich schreibe ein Script.</p>") == "Ich schreibe ein Script."
+    end
+  end
+
+  test "everything else is stripped, attributes included" do
+    assert RemoteHtml.to_text("<img src=x onerror=alert(2)>danach") == "danach"
+    refute RemoteHtml.to_text(~s(<a href="javascript:x">klick</a>)) =~ "javascript:"
+  end
+
+  test "the result is clamped to the requested length" do
+    long = "<p>" <> String.duplicate("a", 200) <> "</p>"
+
+    assert String.length(RemoteHtml.to_text(long, 50)) == 50
+    assert String.ends_with?(RemoteHtml.to_text(long, 50), "…")
+  end
+
+  test "anything that is not a string reduces to nothing" do
+    assert RemoteHtml.to_text(nil) == ""
+    assert RemoteHtml.to_text(42) == ""
+  end
+end

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -447,6 +447,77 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert rendered.txt =~ "Reactions from other networks: 1"
   end
 
+  test "post permalink: a reply from another network reaches every format (issue #1069)", %{
+    user: user,
+    post: post
+  } do
+    now = DateTime.utc_now(:second)
+
+    Vutuv.Repo.insert!(%Vutuv.Fediverse.Note{
+      post_id: post.id,
+      object_uri: "https://social.example/users/alice/statuses/9",
+      actor_uri: "https://social.example/users/alice",
+      origin_url: "https://social.example/@alice/9",
+      handle: "alice",
+      display_name: "Alice Anders",
+      content_text: "Sturdier than they look.",
+      audience: "public",
+      received_at: now,
+      checked_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+
+    rendered = formats_for("/drift_tester/posts/#{post.id}")
+
+    for fact <- ["Alice Anders", "Sturdier than they look.", "@alice@social.example"],
+        do: assert_fact_everywhere(rendered, fact)
+
+    doc = Jason.decode!(rendered.json)
+    assert doc["fediverse_reply_count"] == 1
+    assert [entry] = doc["fediverse_replies"]
+    assert entry["handle"] == "@alice@social.example"
+    assert entry["url"] == "https://social.example/@alice/9"
+    # Never folded into the vutuv reply figure: this post has no vutuv reply,
+    # and one from another network must not make it look as though it had.
+    assert doc["reply_count"] == 0
+
+    assert rendered.md =~ "Replies from other networks: 1"
+    assert rendered.txt =~ "Replies from other networks: 1"
+  end
+
+  test "a reply sent to the member alone never reaches an agent format (issue #1071)", %{
+    user: user,
+    post: post
+  } do
+    now = DateTime.utc_now(:second)
+
+    Vutuv.Repo.insert!(%Vutuv.Fediverse.Note{
+      post_id: post.id,
+      object_uri: "https://social.example/users/mallory/statuses/1",
+      actor_uri: "https://social.example/users/mallory",
+      handle: "mallory",
+      display_name: "Mallory Private",
+      content_text: "This one is between us.",
+      audience: "direct",
+      received_at: now,
+      checked_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+
+    rendered = formats_for("/drift_tester/posts/#{post.id}")
+
+    for format <- [rendered.md, rendered.txt, rendered.json, rendered.xml] do
+      refute format =~ "This one is between us."
+      refute format =~ "Mallory Private"
+    end
+
+    doc = Jason.decode!(rendered.json)
+    assert doc["fediverse_replies"] == []
+    # The count a stranger can read must not move either, or it leaks that a
+    # private message exists.
+    assert doc["fediverse_reply_count"] == 0
+  end
+
   test "post permalink: the whole conversation reaches every format (issue #1006)", %{
     user: user,
     post: post

--- a/test/vutuv_web/controllers/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/fediverse_controller_test.exs
@@ -464,6 +464,143 @@ defmodule VutuvWeb.FediverseControllerTest do
     end
   end
 
+  describe "POST /:slug/actor/inbox — replies from other networks (#1069, #1071)" do
+    @public "https://www.w3.org/ns/activitystreams#Public"
+
+    defp replying_user do
+      user = insert(:activated_user, fediverse_followers?: true, fediverse_replies?: true)
+      {:ok, _actor} = Fediverse.ensure_actor(user)
+      user
+    end
+
+    defp create_note(note_url, opts \\ []) do
+      %{
+        "@context" => "https://www.w3.org/ns/activitystreams",
+        "id" => "https://social.example/activities/create-1",
+        "type" => "Create",
+        "actor" => @remote_actor,
+        "to" => Keyword.get(opts, :to, [@public]),
+        "object" => %{
+          "id" => Keyword.get(opts, :object_id, "#{@remote_actor}/statuses/1"),
+          "type" => "Note",
+          "inReplyTo" => note_url,
+          "content" => Keyword.get(opts, :content, "<p>Sehe ich auch so.</p>"),
+          "url" => "https://social.example/@alice/1",
+          "to" => Keyword.get(opts, :to, [@public])
+        }
+      }
+    end
+
+    test "a signed public reply is stored under the post", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub, %{"preferredUsername" => "alice", "name" => "Alice Anders"})
+      user = replying_user()
+      post = create_post!(user, %{body: "Reachable from anywhere."})
+
+      conn = signed_post(conn, user, create_note(Docs.note_url(user, post.id)), priv)
+
+      assert conn.status == 202
+      assert [note] = Fediverse.list_notes([post.id], user)[post.id]
+      assert note.content_text == "Sehe ich auch so."
+      assert note.handle == "alice"
+      assert note.display_name == "Alice Anders"
+      assert Fediverse.note_count(post.id) == 1
+    end
+
+    test "a member who did not switch replies on stores nothing", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      # federated_user/0 leaves fediverse_replies? at its default: off.
+      user = federated_user()
+      post = create_post!(user, %{body: "Reachable from anywhere."})
+
+      conn = signed_post(conn, user, create_note(Docs.note_url(user, post.id)), priv)
+
+      # Same 202 as a stored one, so a sender cannot probe the setting.
+      assert conn.status == 202
+      assert Fediverse.list_notes([post.id], user) == %{}
+    end
+
+    test "a reply addressed only to the member is stored, but privately", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = replying_user()
+      post = create_post!(user, %{body: "Reachable from anywhere."})
+
+      activity = create_note(Docs.note_url(user, post.id), to: [Docs.actor_url(user)])
+      conn = signed_post(conn, user, activity, priv)
+
+      assert conn.status == 202
+      assert [%{audience: "direct"}] = Fediverse.list_notes([post.id], user)[post.id]
+      # Nobody else sees it, and the public figure does not move.
+      assert Fediverse.list_notes([post.id], nil) == %{}
+      assert Fediverse.note_count(post.id) == 0
+    end
+
+    test "the author's Update rewrites the stored text", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = replying_user()
+      post = create_post!(user, %{body: "Reachable from anywhere."})
+      note_url = Docs.note_url(user, post.id)
+
+      signed_post(conn, user, create_note(note_url), priv)
+
+      update =
+        note_url
+        |> create_note(content: "<p>Korrektur: doch nicht.</p>")
+        |> Map.put("type", "Update")
+
+      conn = signed_post(recycle(conn), user, update, priv)
+
+      assert conn.status == 202
+
+      assert [%{content_text: "Korrektur: doch nicht."}] =
+               Fediverse.list_notes([post.id], user)[post.id]
+    end
+
+    test "the author's Delete removes it, and does not touch the follow", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = replying_user()
+      post = create_post!(user, %{body: "Reachable from anywhere."})
+      note_url = Docs.note_url(user, post.id)
+
+      signed_post(conn, user, follow_activity(user), priv)
+      signed_post(recycle(conn), user, create_note(note_url), priv)
+      assert Fediverse.note_count(post.id) == 1
+
+      delete = %{
+        "@context" => "https://www.w3.org/ns/activitystreams",
+        "id" => "https://social.example/activities/delete-1",
+        "type" => "Delete",
+        "actor" => @remote_actor,
+        "object" => %{"id" => "#{@remote_actor}/statuses/1", "type" => "Tombstone"}
+      }
+
+      conn = signed_post(recycle(conn), user, delete, priv)
+
+      assert conn.status == 202
+      assert Fediverse.note_count(post.id) == 0
+      # Deleting a note must leave the follow intact (only a Delete of the
+      # actor itself drops that).
+      assert Fediverse.follower_count(user) == 1
+    end
+
+    test "a reply to somebody else's post is acknowledged and dropped", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = replying_user()
+      stranger = replying_user()
+      post = create_post!(stranger, %{body: "Not yours to answer here."})
+
+      conn = signed_post(conn, user, create_note(Docs.note_url(stranger, post.id)), priv)
+
+      assert conn.status == 202
+      assert Fediverse.note_count(post.id) == 0
+    end
+  end
+
   describe "POST /:slug/actor/inbox — blocked servers (#1067)" do
     setup do
       admin = insert(:activated_user, admin?: true)

--- a/test/vutuv_web/live/post_thread_remote_replies_test.exs
+++ b/test/vutuv_web/live/post_thread_remote_replies_test.exs
@@ -1,0 +1,264 @@
+defmodule VutuvWeb.PostThreadRemoteRepliesTest do
+  @moduledoc """
+  Replies written on other networks, as they appear in the permalink's
+  conversation (issues #1069 and #1071): who sees them, how they are told apart
+  from a vutuv reply, and the takedown controls.
+
+  async: false — the report rate limit lives in the shared `Vutuv.RateLimiter`
+  ETS table, which the SQL sandbox does not roll back.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Posts
+
+  @actor "https://social.example/users/alice"
+
+  setup %{conn: conn} do
+    Vutuv.RateLimiter.reset()
+    {conn, user} = create_and_login_user(conn)
+
+    user =
+      user
+      |> Ecto.Changeset.change(%{fediverse_followers?: true, fediverse_replies?: true})
+      |> Repo.update!()
+
+    post = create_post!(user, %{body: "Reachable from anywhere."})
+
+    # The embedded thread resolves the viewer from the cookie's session_token
+    # (issue #1036), never a bare user_id, so its tests hand it a real session.
+    {:ok, user: user, post: post, owner: Plug.Conn.get_session(conn)}
+  end
+
+  defp note!(post, attrs \\ []) do
+    now = Keyword.get(attrs, :received_at, DateTime.utc_now(:second))
+
+    Repo.insert!(%Note{
+      post_id: post.id,
+      object_uri: Keyword.get(attrs, :object_uri, "#{@actor}/statuses/1"),
+      actor_uri: Keyword.get(attrs, :actor_uri, @actor),
+      origin_url: "https://social.example/@alice/1",
+      handle: Keyword.get(attrs, :handle, "alice"),
+      display_name: Keyword.get(attrs, :display_name, "Alice Anders"),
+      content_text: Keyword.get(attrs, :content_text, "Sturdier than they look."),
+      summary: Keyword.get(attrs, :summary),
+      audience: Keyword.get(attrs, :audience, "public"),
+      received_at: now,
+      checked_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+  end
+
+  defp thread_view(post, cookie \\ %{}) do
+    session = Map.merge(cookie, %{"post_id" => post.id, "locale" => "en"})
+
+    live_isolated(build_conn(), VutuvWeb.PostLive.Thread, session: session)
+  end
+
+  # A second logged-in member, with their cookie session. `init_test_session/2`
+  # mirrors what ConnCase does to the conn it hands each test — the login flow
+  # configures the session, which needs one fetched.
+  defp other_member do
+    {conn, user} =
+      build_conn() |> Plug.Test.init_test_session(%{}) |> create_and_login_user()
+
+    {user, Plug.Conn.get_session(conn)}
+  end
+
+  describe "a public reply" do
+    test "renders under the post for a logged-out visitor", %{post: post} do
+      note = note!(post)
+
+      {:ok, _view, html} = thread_view(post)
+
+      assert html =~ "Sturdier than they look."
+      assert html =~ "Alice Anders"
+      assert html =~ "@alice@social.example"
+      assert html =~ ~s(data-fediverse-reply="#{note.id}")
+    end
+
+    test "is marked as coming from another network, never disguised as a vutuv reply", %{
+      post: post
+    } do
+      note!(post)
+
+      {:ok, _view, html} = thread_view(post)
+
+      assert html =~ "From another network"
+      assert html =~ "social.example"
+      assert html =~ "View the original"
+      # The link goes to the origin, so the original stays the authoritative copy.
+      assert html =~ "https://social.example/@alice/1"
+      # Its own visual language: the slate initials tile, not a member avatar.
+      assert html =~ "data-remote-avatar"
+    end
+
+    test "shows no action bar, because none of those actions exist for it", %{post: post} do
+      note!(post)
+
+      {:ok, _view, html} = thread_view(post)
+
+      refute html =~ "data-fediverse-reply=\"\" "
+      # A vutuv card would carry the like/repost/bookmark bar; this one must not
+      # offer controls that cannot work on somebody else's server.
+      [remote_card] = Regex.run(~r{<article data-fediverse-reply.*?</article>}s, html)
+      refute remote_card =~ "phx-click=\"toggle-like\""
+      refute remote_card =~ "post-actions"
+    end
+
+    test "a content warning stays closed until the reader opens it", %{post: post} do
+      note!(post, summary: "Spoiler: Staffelfinale", content_text: "Er stirbt.")
+
+      {:ok, _view, html} = thread_view(post)
+
+      assert html =~ "data-remote-warning"
+      assert html =~ "Spoiler: Staffelfinale"
+      # `<details>` keeps the body out of view until clicked; it is in the DOM
+      # but behind the lid its author asked for.
+      assert html =~ "<details"
+    end
+
+    test "a lone post with only a remote reply still renders the conversation", %{post: post} do
+      # The single-card shortcut must not swallow the one answer the post got.
+      note!(post)
+
+      {:ok, _view, html} = thread_view(post)
+
+      assert html =~ "post-thread"
+      assert html =~ "Sturdier than they look."
+    end
+
+    test "sits in time order among the vutuv replies", %{post: post, owner: owner} do
+      # Explicit stamps: three rows created in the same second would tie, and a
+      # tie proves nothing about ordering.
+      base = ~N[2026-07-25 10:00:00]
+
+      {:ok, early} = Posts.create_reply(insert(:activated_user), post, %{body: "First in."})
+      {:ok, late} = Posts.create_reply(insert(:activated_user), post, %{body: "Last in."})
+
+      early |> Ecto.Changeset.change(inserted_at: base) |> Repo.update!()
+      late |> Ecto.Changeset.change(inserted_at: NaiveDateTime.add(base, 120)) |> Repo.update!()
+
+      note!(post,
+        received_at: base |> NaiveDateTime.add(60) |> DateTime.from_naive!("Etc/UTC")
+      )
+
+      {:ok, _view, html} = thread_view(post, owner)
+
+      early = :binary.match(html, "First in.") |> elem(0)
+      remote = :binary.match(html, "Sturdier than they look.") |> elem(0)
+      late = :binary.match(html, "Last in.") |> elem(0)
+
+      assert early < remote and remote < late
+    end
+  end
+
+  describe "a reply sent to the member alone (#1071)" do
+    test "is invisible to a logged-out visitor", %{post: post} do
+      note!(post, audience: "direct", content_text: "This one is between us.")
+
+      {:ok, _view, html} = thread_view(post)
+
+      refute html =~ "This one is between us."
+    end
+
+    test "is invisible to another member", %{post: post} do
+      note!(post, audience: "direct", content_text: "This one is between us.")
+
+      {_other, cookie} = other_member()
+      {:ok, _view, html} = thread_view(post, cookie)
+
+      refute html =~ "This one is between us."
+    end
+
+    test "the addressed member sees it, and is told nobody else does", %{post: post, owner: owner} do
+      note!(post, audience: "direct", content_text: "This one is between us.")
+
+      {:ok, _view, html} = thread_view(post, owner)
+
+      assert html =~ "This one is between us."
+      assert html =~ "data-remote-private"
+      assert html =~ "Sent to you only, visible to nobody else"
+    end
+
+    test "an audience we could not read is treated the same way", %{post: post, owner: owner} do
+      note!(post, audience: "unknown", content_text: "Ambiguous delivery.")
+
+      {:ok, _view, html} = thread_view(post)
+      refute html =~ "Ambiguous delivery."
+
+      {:ok, _view, html} = thread_view(post, owner)
+      assert html =~ "Ambiguous delivery."
+    end
+  end
+
+  describe "takedown" do
+    test "the member removes a reply from their own post", %{post: post, owner: owner} do
+      note = note!(post)
+
+      {:ok, view, _html} = thread_view(post, owner)
+
+      assert render(view) =~ "Sturdier than they look."
+
+      html =
+        view
+        |> element(~s([phx-click="remove-remote-reply"][phx-value-id="#{note.id}"]))
+        |> render_click()
+
+      refute html =~ "Sturdier than they look."
+      refute Repo.get(Note, note.id)
+    end
+
+    test "another member has no Remove, but can report", %{post: post} do
+      note = note!(post)
+      {_other, cookie} = other_member()
+
+      {:ok, view, html} = thread_view(post, cookie)
+
+      refute html =~ ~s(phx-click="remove-remote-reply")
+
+      html =
+        view
+        |> element(~s([phx-click="report-remote-reply"][phx-value-id="#{note.id}"]))
+        |> render_click()
+
+      # Deleted right away — no case workflow, nothing to work through.
+      refute html =~ "Sturdier than they look."
+      refute Repo.get(Note, note.id)
+      assert Repo.aggregate(Vutuv.Moderation.Case, :count) == 0
+    end
+
+    test "a logged-out visitor gets no controls at all", %{post: post} do
+      note!(post)
+
+      {:ok, _view, html} = thread_view(post)
+
+      refute html =~ ~s(phx-click="report-remote-reply")
+      refute html =~ ~s(phx-click="remove-remote-reply")
+    end
+
+    test "the takedown is logged for the operator, without content or URIs", %{
+      post: post,
+      owner: owner
+    } do
+      note = note!(post)
+
+      {:ok, view, _html} = thread_view(post, owner)
+
+      view
+      |> element(~s([phx-click="remove-remote-reply"][phx-value-id="#{note.id}"]))
+      |> render_click()
+
+      assert [event] = Repo.all(Vutuv.Fediverse.NoteEvent)
+      assert event.action == "removed_by_member"
+      assert event.host == "social.example"
+
+      encoded = inspect(Map.from_struct(event))
+      refute encoded =~ "Sturdier than they look."
+      refute encoded =~ @actor
+    end
+  end
+end


### PR DESCRIPTION
Closes #1069. Closes #1071.

Step two of inbound federation, and the first content vutuv stores that its own members did not write. A member who switches it on sees the answers people write on Mastodon and comparable servers under their public posts, in the conversation where they belong. The decisions behind it are recorded in [#1069](https://github.com/wintermeyer/vutuv/issues/1069#issuecomment-5077992899) and [#1071](https://github.com/wintermeyer/vutuv/issues/1071#issuecomment-5077993505); this is what got built.

## Its own opt-in, off by default

A counter row (#1068) says nothing about a person. A reply is a stranger's words with their name on them, held on our server, so it is a separate switch on `/settings/fediverse` and it starts off. It is also a real delete lever, not a display toggle: turning it off removes every stored reply.

## Retention in two layers

A hard ceiling of six months fires whatever else happens, so the privacy page can make a promise that holds. Under it, a lazy on-view freshness check asks the origin whether the reply is still published: gone or locked away deletes at once, usually far earlier than the ceiling; still there refreshes the text and pushes the ceiling out. An unreachable server changes nothing, so an outage neither buys retention nor triggers a mass delete.

That layering is what makes "cache" an honest word here. A reply people keep reading tracks its original; one nobody has opened in six months is collected. Both intervals are per-installation (`FEDIVERSE_NOTE_RETENTION_DAYS`, `FEDIVERSE_NOTE_REFRESH_DAYS`).

## Plain text, never HTML

`Vutuv.Mastodon`'s reduction of a remote instance's markup to text moved into a shared `Vutuv.RemoteHtml` and is reused here, so there is one such chokepoint instead of two. Nothing a stranger wrote is ever rendered `raw`, the agent-format siblings carry the value unchanged, and no picture is fetched or hosted.

It also grew a fix while it moved: `HtmlSanitizeEx.strip_tags/1` removes the `<script>` tags but keeps the text between them, so `<script>alert(1)</script>Hallo` reduced to the literal `alert(1)Hallo`. Never an execution risk, but it let a remote server push arbitrary invisible text into a member's profile feed, and it would have put the same junk into every stored reply.

## Telling the two worlds apart

That mattered as much as showing the reply at all, and the difference had to survive greyscale:

- a **slate** initials tile with the globe badge #1068 established, against the brand tint members get
- a **dashed** left rail, against the solid connector rail vutuv cards hang from
- the name as plain text (there is no vutuv profile behind it) beside a `@handle@host` that links out
- **no action bar** — liking a note on someone else's server is not a thing that exists, so the row is absent rather than dead
- a content warning renders as a closed lid, which is the one thing its author asked for

It sits among the vutuv replies in time order rather than in an annex below them, and it carries the same weight in notifications: a `fediverse_reply` kind sourced **straight from the notes table**, so deleting a note deletes its notification with nowhere left to forget.

## Replies meant only for the member (#1071)

Stored rather than dropped, and rendered only to them, behind the same lock a restricted post wears plus a line saying nobody else sees it. Never widened, and deliberately **no** button to publish one: unlike a member, the author of a private message can never be asked whether that would be alright.

Three leaks closed explicitly, each with a test: the doc builder takes public notes **even on the authenticated `viewer:` path**, so a private reply cannot leave through `/api/2.0` or a `.json` sibling; the public count counts public notes only, or the figure itself would leak that a private message exists; and the freshness check skips non-public notes entirely, since their origin answers 404 to any request we can make and the checker would read that as a deletion.

## Takedown without a workflow

Marking a reply as not appropriate deletes it immediately. There is no case and no freezer, because unlike a member's own post this is a cache of something that still sits where it was written.

The ledger behind it holds no text and no URIs, following the precedent `FollowerPrune` set in #1072: the server, a keyed digest of the account, who acted, when. That is all the one decision it serves needs — one troll, or the whole server — without keeping an identifier of somebody whose words we just deleted. `/admin/fediverse` shows it beside the per-host volume, one click from the block button. Reports are rate limited per reporter.

## Deliberately not in this

Replying **back** from vutuv. It would mean delivering to servers that never followed us and sending a member's words somewhere they did not choose, which deserves its own decision. The card links to the original instead. Also still dropped: avatars, inline images in a remote reply, and replies that answer another remote reply rather than a vutuv post.

#1073 (the shared inbox) stays separate — it changes the inbox's entry shape from one member to N and mixing it in would make both hard to review.

## Two things for you

**The privacy page needs a paragraph.** Legal pages are data, not code, so it is not in this diff. The German wording is drafted and I will paste it into `/admin/legal` once this merges.

**A pre-existing bug I did not fix here:** no LiveView in this app renders `@flash`, so `put_flash/3` inside an embedded LiveView never reaches the screen — `UserProfileLive` has five such calls that silently do nothing. Making it work touches the shell and layout for every LiveView on the site and needs a decision about where those toasts belong, so I left it alone and used an inline notice in the thread instead of adding a sixth dead call. Worth its own issue.

`mix precommit` green: 5011 tests.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01PoZm93MvVcwn5PE3TUyjSW
