### PR TITLE
Drop the audience-Groups tables (contract half, six weeks late)

### DIFF
--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -595,19 +595,11 @@ defmodule Vutuv.Accounts do
 
   Most rows are removed by the database `ON DELETE` cascade (or `SET NULL` for
   the records that deliberately outlive their author: sent messages and
-  replies to a now-deleted post). Two things the cascade cannot do are handled
-  here:
-
-    * **On-disk files.** Post-image files and the avatar / cover trees live on
-      disk, not in a table, so the cascade never touches them. Their tokens
-      and paths are collected *before* the delete and removed *after* it
-      commits, so a rolled-back delete never strands the account without its
-      files.
-    * **Cascade ordering.** The user's posts are deleted first, inside the
-      transaction. The audience-Groups feature is gone, but its legacy
-      `post_denials.group_id` column (and its RESTRICT FK to `groups`) is kept
-      for one N-1 deploy, so clearing the user's posts before the `groups`
-      cascade keeps any stale group-denial row from blocking the delete.
+  replies to a now-deleted post). The one thing the cascade cannot do is
+  handled here: **on-disk files.** Post-image files and the avatar / cover
+  trees live on disk, not in a table, so the cascade never touches them. Their
+  tokens and paths are collected *before* the delete and removed *after* it
+  commits, so a rolled-back delete never strands the account without its files.
 
   Returns `{:ok, user}`.
   """
@@ -689,11 +681,11 @@ defmodule Vutuv.Accounts do
     # drop the logged-in chrome at once instead of on their next reload.
     Vutuv.Sessions.disconnect_user(user.id)
 
-    {:ok, _} =
-      Repo.transaction(fn ->
-        Repo.delete_all(from(p in Vutuv.Posts.Post, where: p.user_id == ^user.id))
-        Repo.delete!(user)
-      end)
+    # Every foreign key into `posts` cascades or nilifies, so the account's
+    # posts (and everything hanging off them) go with this one delete. The
+    # posts used to be cleared first, to keep a stale group denial's RESTRICT
+    # FK from blocking the cascade; that column is gone (drop_audience_groups).
+    {:ok, _} = Repo.delete(user)
 
     Enum.each(image_tokens, &Vutuv.PostImageStore.delete/1)
     Enum.each(job_image_tokens, &Vutuv.JobPostingImageStore.delete/1)

--- a/lib/vutuv/posts/post_denial.ex
+++ b/lib/vutuv/posts/post_denial.ex
@@ -24,10 +24,6 @@ defmodule Vutuv.Posts.PostDenial do
 
   @wildcards ~w(everyone non_connections non_followers non_followees logged_out)
 
-  # The post_denials.group_id column is intentionally still present (audience
-  # Groups were removed; the table-drop is a sequenced follow-up deploy), but
-  # the schema no longer maps it: a denial now targets a single user or a
-  # wildcard. The DB check constraint still holds (group_id stays NULL).
   schema "post_denials" do
     belongs_to(:post, Vutuv.Posts.Post)
     belongs_to(:denied_user, Vutuv.Accounts.User)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.154.0",
+      version: "7.154.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260725102403_drop_audience_groups.exs
+++ b/priv/repo/migrations/20260725102403_drop_audience_groups.exs
@@ -1,0 +1,78 @@
+defmodule Vutuv.Repo.Migrations.DropAudienceGroups do
+  use Ecto.Migration
+
+  @moduledoc """
+  Expand/contract step 2 of 2 for the audience-Groups removal (commit 02589063,
+  2026-06-13). That deploy dropped every line of the feature's code — the
+  controllers, schemas, composer sheet and the group branch of the post
+  visibility query — but deliberately kept its tables and the
+  `post_denials.group_id` column so the release still serving traffic during
+  the blue/green window kept working (the N-1 rule). That window closed with
+  the very next deploy; this finally removes them.
+
+  Dropped here:
+  - `post_denials.group_id` and its RESTRICT foreign key to `groups`. A denial
+    has targeted a single user or a wildcard since that deploy, so no live code
+    could have minted a group denial in the meantime.
+  - the `memberships` table (who was in which group),
+  - the `groups` table itself.
+
+  The row counts are printed before the drop, so the deploy log records what
+  was there. The feature had no reachable management UI, which is why it was
+  removed: nothing could build a group, and any surviving row is a relic of the
+  pre-redesign site.
+
+  N-1 safe: the currently deployed release already reads and writes none of
+  this. The one thing that still referenced the column was the defensive
+  posts-first ordering in `Vutuv.Accounts.delete_user/1`, dropped in the same
+  release — every remaining foreign key into `posts` cascades or nilifies, so
+  the plain `Repo.delete!(user)` cascade is enough on its own.
+  """
+
+  @counted [
+    {"groups", "SELECT count(*) FROM groups"},
+    {"memberships", "SELECT count(*) FROM memberships"},
+    {"post_denials naming a group", "SELECT count(*) FROM post_denials WHERE group_id IS NOT NULL"}
+  ]
+
+  def up do
+    for {label, sql} <- @counted do
+      %{rows: [[count]]} = repo().query!(sql, [])
+      IO.puts("drop_audience_groups: #{label}: #{count}")
+    end
+
+    alter table(:post_denials) do
+      remove(:group_id)
+    end
+
+    drop(table(:memberships))
+    drop(table(:groups))
+  end
+
+  def down do
+    # Best-effort: the schema comes back, the rows do not. They described a
+    # feature no member could reach and cannot be reconstructed here.
+    create table(:groups) do
+      add(:name, :string)
+      add(:user_id, references(:users, on_delete: :delete_all))
+
+      timestamps()
+    end
+
+    create(index(:groups, [:user_id]))
+
+    create table(:memberships) do
+      add(:follow_id, references(:follows, on_delete: :delete_all))
+      add(:group_id, references(:groups, on_delete: :delete_all))
+
+      timestamps()
+    end
+
+    create(index(:memberships, [:follow_id]))
+    create(index(:memberships, [:group_id]))
+
+    alter table(:post_denials) do
+      add(:group_id, references(:groups, on_delete: :restrict))
+    end
+  end
+end

--- a/test/vutuv/repo/audience_groups_dropped_test.exs
+++ b/test/vutuv/repo/audience_groups_dropped_test.exs
@@ -1,0 +1,79 @@
+defmodule Vutuv.Repo.AudienceGroupsDroppedTest do
+  @moduledoc """
+  The contract half of the audience-Groups removal.
+
+  Commit 02589063 (2026-06-13) deleted the feature's code but deliberately kept
+  its tables (`groups`, `memberships`) and the `post_denials.group_id` column
+  with its RESTRICT foreign key, so the release still serving traffic during
+  that blue/green deploy kept working (the N-1 rule). That window closed with
+  the very next deploy; `drop_audience_groups` finally removes them.
+
+  This guards the drop against a re-introduction by an old branch's migration
+  being replayed, and pins why `Vutuv.Accounts.delete_user/1` no longer needs
+  to clear the account's posts before the cascade: that RESTRICT FK was the
+  only thing that could have blocked the delete, and it is gone.
+  """
+  use Vutuv.DataCase, async: true
+
+  @dropped_tables ~w(groups memberships)
+
+  test "the audience-Groups tables are gone" do
+    for table <- @dropped_tables do
+      refute table_exists?(table),
+             "#{table} is a dropped audience-Groups table — nothing may recreate it"
+    end
+  end
+
+  test "post_denials no longer carries group_id" do
+    refute column_exists?("post_denials", "group_id"),
+           "post_denials.group_id belonged to the removed audience-Groups feature"
+  end
+
+  test "a denial still targets exactly one user or one wildcard" do
+    columns = table_columns("post_denials")
+
+    assert "denied_user_id" in columns
+    assert "wildcard" in columns
+  end
+
+  test "nothing references the dropped tables by a foreign key" do
+    %{rows: rows} =
+      Repo.query!(
+        """
+        SELECT cl.relname, c.conname
+        FROM pg_constraint c
+        JOIN pg_class cl ON cl.oid = c.conrelid
+        JOIN pg_class parent ON parent.oid = c.confrelid
+        WHERE c.contype = 'f' AND parent.relname = ANY($1)
+        """,
+        [@dropped_tables]
+      )
+
+    assert rows == [],
+           "dangling FKs to a dropped audience-Groups table: #{inspect(rows)}"
+  end
+
+  defp table_exists?(table) do
+    %{rows: [[count]]} =
+      Repo.query!(
+        "SELECT count(*) FROM information_schema.tables " <>
+          "WHERE table_schema = 'public' AND table_name = $1",
+        [table]
+      )
+
+    count > 0
+  end
+
+  defp column_exists?(table, column), do: column in table_columns(table)
+
+  defp table_columns(table) do
+    %{rows: rows} =
+      Repo.query!(
+        "SELECT column_name FROM information_schema.columns " <>
+          "WHERE table_schema = 'public' AND table_name = $1",
+        [table]
+      )
+
+    List.flatten(rows)
+  end
+end


### PR DESCRIPTION
**TL;DR** Finishes the expand/contract sequence that commit 02589063 started in June: drops the `groups` and `memberships` tables and `post_denials.group_id`, which were kept for one N-1 deploy and then forgotten.

### Why now

The audience-Groups feature was removed on 2026-06-13 because no member could reach it. That commit deleted the code but kept the schema on purpose, since a migration has to keep the previously deployed release working for exactly one step. The drop it announced as "a sequenced follow-up" was never written, so the dead tables have been in the schema for six weeks.

### What this does

- Drops `post_denials.group_id` and its RESTRICT foreign key to `groups`
- Drops `memberships` and `groups`
- Prints the row counts before dropping, so the deploy log records what was there
- Removes the posts-first delete in `Accounts.delete_user/1`. It existed only so a stale group denial's RESTRICT FK could not block the cascade; every remaining foreign key into `posts` cascades or nilifies, so `Repo.delete(user)` is enough
- Adds `test/vutuv/repo/audience_groups_dropped_test.exs` as the guard against the schema coming back

### Safety

Nothing has referenced any of it since June: no Ecto schema maps the tables, and the only mentions left in `lib/` were the two comments explaining the pending drop. Dev DB held 0 rows in all three. `down` recreates the schema (not the rows, which described a feature nobody could use).

Please check production row counts before merging if you want the extra certainty — I could not reach the box from this session.

`mix precommit` green: credo --strict found no issues, 4931 tests pass. Migration and rollback both exercised against the dev database.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
