### PR TITLE
Drop the 2016 locales and exonyms tables

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -72,7 +72,7 @@ Business logic is organized into Phoenix context modules under `lib/vutuv/`:
 
 | Context | Schemas | Purpose |
 |---|---|---|
-| `Vutuv.Accounts` | User, Email, UsernameChange, SearchTerm, LoginPin, Locale, Exonym | Registration, PIN-based authentication, user management |
+| `Vutuv.Accounts` | User, Email, UsernameChange, SearchTerm, LoginPin | Registration, PIN-based authentication, user management |
 | `Vutuv.Sessions` | UserSession | Server-side per-device sessions: signed-in-devices list, remote logout, new-device security email |
 | `Vutuv.Credentials` | UserCredential | Passkeys (WebAuthn/FIDO2): enrolment + assertion verification for passkey login |
 | `Vutuv.ApiAuth` | Token, App, Grant, AuthCode | API credentials: personal access tokens, OAuth 2 apps/grants/codes, scopes |

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.156.0",
+      version: "7.156.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260725104543_drop_legacy_locale_tables.exs
+++ b/priv/repo/migrations/20260725104543_drop_legacy_locale_tables.exs
@@ -1,0 +1,69 @@
+defmodule Vutuv.Repo.Migrations.DropLegacyLocaleTables do
+  use Ecto.Migration
+
+  @moduledoc """
+  Drops `exonyms` and `locales`, the 2016 language tables the current spoken
+  languages feature superseded.
+
+  The old design kept the world's languages as data: `locales` held the ISO
+  639-1 code plus its endonym (the language's name in itself — "Deutsch",
+  "日本語"), seeded by `populate_locales`, and `exonyms` was to hold each
+  language's name *in another language*, so a name could be shown translated.
+  It never received a row.
+
+  Spoken languages were rebuilt around `Vutuv.Languages` (issue #865): a
+  curated, finite list in code, stored per member in `languages` as a bare ISO
+  639-1 code, with the display name coming from Gettext in the viewer's own
+  locale. That replaced both tables — a translated language name is now a
+  `.po` entry, which is what `exonyms` was reaching for. Nothing has read
+  either table since; no Ecto schema maps them (the `Vutuv.Accounts.Locale`
+  and `Exonym` modules are long gone) and no query names them.
+
+  Nothing else points a foreign key at either table, and the two FKs being
+  removed are the ones `exonyms` holds into `locales`. Both drops are plain
+  removals of tables the running code never touches, so this is N-1 safe on
+  its own: the currently deployed release keeps working unchanged.
+
+  The row counts are printed first, so the deploy log records what was there.
+  """
+
+  @counted [
+    {"locales", "SELECT count(*) FROM locales"},
+    {"exonyms", "SELECT count(*) FROM exonyms"}
+  ]
+
+  def up do
+    for {label, sql} <- @counted do
+      %{rows: [[count]]} = repo().query!(sql, [])
+      IO.puts("drop_legacy_locale_tables: #{label}: #{count}")
+    end
+
+    # exonyms first: it is the only thing holding a FK into locales.
+    drop(table(:exonyms))
+    drop(table(:locales))
+  end
+
+  def down do
+    # Best-effort: the empty schema comes back. The `locales` rows are not
+    # restored here — they are the seed data of `populate_locales`, which is
+    # where that list lives if it is ever wanted again.
+    create table(:locales) do
+      add(:value, :string)
+      add(:endonym, :string)
+
+      timestamps()
+    end
+
+    create(unique_index(:locales, [:value]))
+
+    create table(:exonyms) do
+      add(:value, :string)
+      add(:locale_id, references(:locales, on_delete: :nothing))
+      add(:exonym_locale_id, references(:locales, on_delete: :nothing))
+
+      timestamps()
+    end
+
+    create(unique_index(:exonyms, [:value, :locale_id]))
+  end
+end

--- a/test/vutuv/repo/legacy_locale_tables_dropped_test.exs
+++ b/test/vutuv/repo/legacy_locale_tables_dropped_test.exs
@@ -1,0 +1,62 @@
+defmodule Vutuv.Repo.LegacyLocaleTablesDroppedTest do
+  @moduledoc """
+  The 2016 `locales` / `exonyms` tables are gone (`drop_legacy_locale_tables`).
+
+  Spoken languages live in `Vutuv.Languages` — a curated list in code, stored
+  per member in `languages` as an ISO 639-1 code, with the display name coming
+  from Gettext in the viewer's locale. That is what replaced the old
+  language-names-as-data design, so nothing may reintroduce it.
+  """
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Profiles.Language
+
+  @dropped_tables ~w(locales exonyms)
+
+  test "the legacy language tables are gone" do
+    for table <- @dropped_tables do
+      refute table_exists?(table),
+             "#{table} is a dropped 2016 language table — Vutuv.Languages replaced it"
+    end
+  end
+
+  test "nothing references the dropped tables by a foreign key" do
+    %{rows: rows} =
+      Repo.query!(
+        """
+        SELECT cl.relname, c.conname
+        FROM pg_constraint c
+        JOIN pg_class cl ON cl.oid = c.conrelid
+        JOIN pg_class parent ON parent.oid = c.confrelid
+        WHERE c.contype = 'f' AND parent.relname = ANY($1)
+        """,
+        [@dropped_tables]
+      )
+
+    assert rows == [], "dangling FKs to a dropped language table: #{inspect(rows)}"
+  end
+
+  test "a member's languages still resolve their name without the dropped tables" do
+    user = insert(:user)
+
+    {:ok, language} =
+      %Language{user_id: user.id}
+      |> Language.changeset(%{"language_code" => "de", "proficiency" => "native"})
+      |> Repo.insert()
+
+    assert language.language_code == "de"
+    # The name comes from Vutuv.Languages (code + Gettext), never from a table.
+    assert Vutuv.Languages.name("de") in ["German", "Deutsch"]
+  end
+
+  defp table_exists?(table) do
+    %{rows: [[count]]} =
+      Repo.query!(
+        "SELECT count(*) FROM information_schema.tables " <>
+          "WHERE table_schema = 'public' AND table_name = $1",
+        [table]
+      )
+
+    count > 0
+  end
+end


### PR DESCRIPTION
**TL;DR** Drops `locales` and `exonyms`, the 2016 language tables that `Vutuv.Languages` superseded. Dead schema, not a half-finished migration sequence.

### What they were

The original site kept the world's languages as data: `locales` held each ISO 639-1 code with its endonym (the language's name in itself, "Deutsch", "日本語"), seeded by `populate_locales`. `exonyms` was to hold a language's name *in another language*, so it could be shown translated. It never received a row.

### Why they can go

Spoken languages were rebuilt around `Vutuv.Languages` (#865): a curated list in code, stored per member in `languages` as a bare ISO 639-1 code, with the display name coming from Gettext in the viewer's locale. That replaced both tables — a translated language name is a `.po` entry now, which is what `exonyms` was reaching for.

Verified across the whole repo, not just `lib/`: no Ecto schema maps either table (`Vutuv.Accounts.Locale` and `Exonym` were deleted years ago), no query names them, and `config/`, `priv/`, `rel/`, `scripts/`, `mix.exs` and `.github/` are clean. The only remaining mentions are the historical migrations, which run before this drop and stay valid. Nothing outside `exonyms` points a foreign key at either table.

### Notes

- Both drops are plain removals of tables the running code never touches, so this is N-1 safe in one deploy
- Row counts print before the drop, so the deploy log records what was there (dev: 183 locales, 0 exonyms)
- `down` recreates the empty schema; the language list itself still lives in `populate_locales` if ever wanted
- Also fixes `docs/architecture/README.md`, which still listed Locale and Exonym as `Vutuv.Accounts` schemas

`mix precommit` green: credo --strict found no issues, 5018 tests pass. Migration and rollback both exercised against the dev database.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
