### PR TITLE
Make the passkey login greet the member again

### DIFF
--- a/lib/vutuv_web/controllers/session_controller.ex
+++ b/lib/vutuv_web/controllers/session_controller.ex
@@ -7,6 +7,7 @@ defmodule VutuvWeb.SessionController do
   alias Vutuv.Credentials
   alias VutuvWeb.ControllerHelpers
   alias VutuvWeb.Home
+  alias VutuvWeb.Plug.PendingFlash
   alias VutuvWeb.RateLimit
   alias VutuvWeb.UI
 
@@ -22,35 +23,13 @@ defmodule VutuvWeb.SessionController do
     # PIN form while a PIN is pending (PageController.display_pin_entry/2). Not
     # gated on a PIN row existing in the DB: that would betray whether the
     # address has an account (issue #759's enumeration oracle).
+    #
+    # The passkey fallback's friendly note arrives on its own: it is stashed by
+    # `pin_fallback/2` and flashed by `VutuvWeb.Plug.PendingFlash` before this
+    # action runs.
     case Accounts.read_pin_cookie(conn) do
-      email when is_binary(email) ->
-        conn
-        |> flash_passkey_fallback()
-        |> render("pin_user_login.html")
-
-      nil ->
-        render(conn, "new.html")
-    end
-  end
-
-  # The passkey fallback (see passkey_challenge/2) marks the session before it
-  # bounces the visitor here, so we greet them with the friendly note explaining
-  # why they landed on the PIN form. It is set here, in the same request that
-  # renders the form, because Phoenix only carries a flash across requests on a
-  # redirect response — and the JSON challenge answer that mailed the PIN is a
-  # 200, not a 3xx. The marker is one-shot: read it, drop it.
-  defp flash_passkey_fallback(conn) do
-    if get_session(conn, :passkey_pin_fallback) do
-      conn
-      |> delete_session(:passkey_pin_fallback)
-      |> put_flash(
-        :info,
-        gettext(
-          "You don't have a passkey yet, so we've emailed you a one-time PIN to sign in instead."
-        )
-      )
-    else
-      conn
+      email when is_binary(email) -> render(conn, "pin_user_login.html")
+      nil -> render(conn, "new.html")
     end
   end
 
@@ -189,17 +168,22 @@ defmodule VutuvWeb.SessionController do
   # No passkey for the typed address: behave like the email-PIN step 1. Throttle
   # on the same per-email budget as the "Log in" button so this cannot be used
   # to out-mail that limit, mail the PIN (only when the account exists — the JSON
-  # is identical regardless), mark the session so /login greets the visitor with
-  # the friendly note, and tell the JS to navigate there. The note is flashed by
-  # `new/2` rather than here because Phoenix carries a flash across requests only
-  # on a redirect, and this is a 200 JSON answer.
+  # is identical regardless), stash the friendly note explaining why they are
+  # about to land on the PIN form, and tell the JS to navigate there. The note
+  # goes through `put_pending_flash/3` because this is a 200 JSON answer and
+  # Phoenix carries a flash across requests only on a redirect.
   defp pin_fallback(conn, email) do
     case RateLimit.check(conn, :login_email, email) do
       :ok ->
         {:ok, conn} = Accounts.login_by_email(conn, email)
 
         conn
-        |> put_session(:passkey_pin_fallback, true)
+        |> PendingFlash.put_pending_flash(
+          :info,
+          gettext(
+            "You don't have a passkey yet, so we've emailed you a one-time PIN to sign in instead."
+          )
+        )
         |> json(%{redirect: ~p"/login"})
 
       :rate_limited ->
@@ -246,7 +230,11 @@ defmodule VutuvWeb.SessionController do
         conn
         |> clear_auth_challenge()
         |> Accounts.login(user)
-        |> put_flash(:info, welcome_flash(nil, user))
+        # put_pending_flash/3, not put_flash/3: this answers 200 JSON and the JS
+        # navigates, and Phoenix keeps a flash across requests only on a 3xx —
+        # so a plain put_flash here was silently dropped and the passkey login
+        # never greeted anyone (the PIN login, which redirects, always did).
+        |> PendingFlash.put_pending_flash(:info, welcome_flash(nil, user))
         # Same landing as the PIN path: home is the feed once you follow someone,
         # otherwise your profile (see VutuvWeb.Home).
         |> json(%{ok: true, redirect: return_to || Home.path(user)})

--- a/lib/vutuv_web/plugs/pending_flash.ex
+++ b/lib/vutuv_web/plugs/pending_flash.ex
@@ -1,0 +1,67 @@
+defmodule VutuvWeb.Plug.PendingFlash do
+  @moduledoc """
+  Carries a flash across a response that cannot carry one itself.
+
+  `Phoenix.Controller.fetch_flash/2` persists the flash into the session **only**
+  while `conn.status in 300..308`; on any other status its `before_send`
+  callback deletes it instead. So an action that answers **JSON** and lets the
+  browser navigate afterwards silently loses whatever it flashed. Both passkey
+  ceremonies work that way (`assets/js/webauthn.js` drives them with `fetch()`
+  and then sets `window.location`), which is why the passkey login's "Welcome
+  back" greeting never once appeared on screen.
+
+  Such an action calls `put_pending_flash/3` instead of `put_flash/3`. The
+  message rides in the session, and this plug — wired into the `:browser`
+  pipeline right after `fetch_flash` — pops it on the next request and flashes
+  it there, where an ordinary HTML response renders it as the usual toast.
+
+  It only ever *adds* to the flash, so a request that sets its own is untouched.
+
+  One deliberate limitation: it fires on the **next** request through the
+  `:browser` pipeline, which is normally the page the JS navigates to but could
+  in principle be a background `fetch()` from the page the member is leaving
+  (that request would consume the message and drop it). Both current callers
+  navigate immediately, so the race is theoretical; if a flow ever needs a hard
+  guarantee, hand the message to the client and let it render, rather than
+  making this plug guess which response will be HTML.
+  """
+
+  import Plug.Conn
+  import Phoenix.Controller, only: [put_flash: 3]
+
+  @session_key :pending_flash
+
+  # Only the kinds the toast tray renders; anything else would style as nothing.
+  @kinds ~w(info error)
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    case get_session(conn, @session_key) do
+      %{"kind" => kind, "message" => message} when kind in @kinds and is_binary(message) ->
+        conn
+        |> delete_session(@session_key)
+        |> put_flash(String.to_existing_atom(kind), message)
+
+      nil ->
+        conn
+
+      # Anything else is a leftover from an older shape; drop it rather than
+      # raise on a member's next page load.
+      _ ->
+        delete_session(conn, @session_key)
+    end
+  end
+
+  @doc """
+  Stashes `message` to be flashed on the member's next page.
+
+  Use it in place of `put_flash/3` in an action whose response is **not** a
+  redirect — a JSON answer the browser navigates away from. `kind` is `:info` or
+  `:error`, matching the toast tray.
+  """
+  def put_pending_flash(conn, kind, message)
+      when kind in [:info, :error] and is_binary(message) do
+    put_session(conn, @session_key, %{"kind" => Atom.to_string(kind), "message" => message})
+  end
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -13,6 +13,11 @@ defmodule VutuvWeb.Router do
     plug(:accepts, ["html", "activity+json"])
     plug(:fetch_session)
     plug(:fetch_flash)
+    # Flashes a message an action stashed because its own response could not
+    # carry one: Phoenix keeps a flash across requests only on a 3xx, so the
+    # passkey ceremonies (fetch() + window.location) lose theirs. Right after
+    # fetch_flash, so the message is in place before any controller runs.
+    plug(Plugs.PendingFlash)
     # Records a click on a newsletter's tracked vutuv.de link and redirects to
     # the clean URL. Early, so a tracked click never does the rest of the
     # pipeline's per-request work just to throw the page away on the redirect.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.157.1",
+      version: "7.157.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/plugs/pending_flash_test.exs
+++ b/test/vutuv_web/plugs/pending_flash_test.exs
@@ -1,0 +1,118 @@
+defmodule VutuvWeb.Plug.PendingFlashTest do
+  use VutuvWeb.ConnCase, async: true
+
+  @moduledoc """
+  A flash set on a response that is not a redirect is thrown away.
+
+  `Phoenix.Controller.fetch_flash/2` persists the flash into the session only
+  while `conn.status in 300..308`; on any other status its `before_send`
+  callback *deletes* it. An action that answers **JSON** and lets the browser
+  navigate afterwards — the passkey ceremonies, driven by `fetch()` — therefore
+  loses whatever it flashed, with no error anywhere. That is why the passkey
+  login's "Welcome back" greeting never appeared on screen.
+
+  `put_pending_flash/3` + this plug carry the message to the next request
+  instead, where an ordinary HTML response renders it.
+  """
+
+  alias VutuvWeb.Plug.PendingFlash
+
+  # The member's next page load: same session, fresh request, the plug running
+  # where the router puts it (right after fetch_flash).
+  defp next_request(conn) do
+    build_conn()
+    |> Plug.Test.init_test_session(Plug.Conn.get_session(conn))
+    |> Phoenix.Controller.fetch_flash()
+    |> PendingFlash.call([])
+  end
+
+  describe "the problem it exists for" do
+    test "Phoenix drops a flash set on a 200 JSON response", %{conn: conn} do
+      # Pinning the platform behaviour this plug works around: if this ever
+      # starts passing a flash through, the plug can go.
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{})
+        |> Phoenix.Controller.fetch_flash()
+        |> Phoenix.Controller.put_flash(:info, "carried?")
+        |> Phoenix.Controller.json(%{ok: true})
+
+      assert conn.status == 200
+      refute get_session(conn, "phoenix_flash")
+    end
+  end
+
+  describe "put_pending_flash/3 + the plug" do
+    test "carries the message to the next request", %{conn: conn} do
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{})
+        |> PendingFlash.put_pending_flash(:info, "Welcome back, Ada!")
+        |> Phoenix.Controller.json(%{ok: true})
+
+      # Survives the JSON response, unlike a flash...
+      assert get_session(conn, :pending_flash)
+
+      # ...and lands in the flash of the very next page.
+      next = next_request(conn)
+
+      assert Phoenix.Flash.get(next.assigns.flash, :info) == "Welcome back, Ada!"
+      # One-shot: it must not follow the member from page to page.
+      refute get_session(next, :pending_flash)
+    end
+
+    test "keeps the kind, so an error does not arrive as good news", %{conn: conn} do
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{})
+        |> PendingFlash.put_pending_flash(:error, "That did not work.")
+        |> Phoenix.Controller.json(%{ok: false})
+        |> next_request()
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "That did not work."
+      refute Phoenix.Flash.get(conn.assigns.flash, :info)
+    end
+
+    test "does nothing when there is none pending", %{conn: conn} do
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{})
+        |> Phoenix.Controller.fetch_flash()
+        |> PendingFlash.call([])
+
+      assert conn.assigns.flash == %{}
+    end
+
+    test "an already-flashed message on the same request is not clobbered", %{conn: conn} do
+      # The plug runs on every browser request, including ones that set their own
+      # flash later; it must only ever add.
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{})
+        |> PendingFlash.put_pending_flash(:info, "from the JSON step")
+        |> next_request()
+        |> Phoenix.Controller.put_flash(:error, "from this request")
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) == "from the JSON step"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) == "from this request"
+    end
+  end
+
+  describe "the passkey sign-in fallback (a real JSON action)" do
+    test "the friendly note survives the JSON answer and shows on /login", %{conn: conn} do
+      # Typing an address with no passkey mails a PIN and answers JSON telling
+      # the JS where to go; the explanation has to reach the page it sends them
+      # to (issue #834).
+      user = insert(:user, email_confirmed?: true)
+      insert(:email, value: "no-passkey@example.com", user: user)
+
+      conn =
+        post(conn, ~p"/login/passkey/challenge", %{"email" => "no-passkey@example.com"})
+
+      assert %{"redirect" => "/login"} = json_response(conn, 200)
+
+      html = conn |> recycle() |> get(~p"/login") |> html_response(200)
+      assert html =~ "emailed you a one-time PIN"
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #1092, where I noticed this while building the username confirmation on the same ceremony.

### The bug

A flash set on a response that is not a redirect is thrown away. `Phoenix.Controller.fetch_flash/2` persists the flash into the session only while `conn.status in 300..308`, and on any other status its `before_send` callback *deletes* it.

Both passkey ceremonies answer 200 JSON and let `assets/js/webauthn.js` navigate afterwards, so every flash they set went on the floor. The passkey login has therefore never once shown its "Welcome back, <name>!" greeting, while the PIN login, which redirects, always did. Nothing errored anywhere, which is why it sat there unnoticed.

The no-passkey fallback already worked around it with a bespoke `:passkey_pin_fallback` session marker that `SessionController.new/2` converted into a flash by hand.

### The fix

`VutuvWeb.Plug.PendingFlash` carries such a message in the session and flashes it on the next request through the `:browser` pipeline, where an ordinary HTML response renders it as the usual toast. An action that cannot carry its own flash calls `put_pending_flash/3` instead of `put_flash/3`.

That covers both call sites with one mechanism, so the hand-rolled marker is gone and `new/2` goes back to just rendering a form. The plug only ever *adds* to the flash, and pops its message once.

One limitation is documented rather than papered over: it fires on the next browser-pipeline request, which for both callers is the navigation they just triggered, but in principle a background `fetch()` from the page being left could consume it. If a flow ever needs a hard guarantee, the message should go to the client instead.

### Testing

`mix precommit` green (5092 tests). New tests pin the platform behaviour this exists for (a flash on a 200 JSON response is dropped — if that ever stops being true, the plug can go), the carry / one-shot / kind / no-clobber behaviour, and the passkey fallback end to end through the real pipeline.

Also verified in a browser: driving the real ceremony for an address with no passkey shows *"Sie haben noch keinen Passkey. Wir haben Ihnen stattdessen eine Einmal-PIN per E-Mail geschickt, mit der Sie sich anmelden können."* on the page the JS navigates to, and a second load does not repeat it. The passkey *success* greeting shares that mechanism but cannot be driven without a real authenticator, so it is covered by the plug's tests rather than a live ceremony.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
