### PR TITLE
Tell an organization's owners when its domain proof fails

### DIFF
--- a/docs/architecture/organizations.md
+++ b/docs/architecture/organizations.md
@@ -163,6 +163,32 @@ domain — the domain, not the name, is what viewers trust.
   falls back to `pending` and the operator is alerted
   (`Emailer.organization_unverified_notice/2`).
 
+### Who hears about a failing proof
+
+Two audiences, two mails, and they must not be confused. The
+`Emailer.organization_*_notice/2` builders go to the installation's
+**operator** (`:operator_recipient`) and link to `/admin/organizations`, the
+oversight dashboard — a page the organization's own staff cannot even open. On
+their own they leave the one person who can republish the proof uninformed,
+which is why the **owners** get their own mails (`Organizations.owners/1`, each
+in their own locale, linking to `/organizations/:slug/domains`):
+
+- **Grace start** — `Emailer.organization_domain_grace_email/5`, sent **once per
+  window** from the `:grace_started` arm. The `:in_grace` re-checks stay silent;
+  a weekly nag is how a warning mail gets filtered away. The subject and the
+  body branch on `last?` (`verified_domain_count/1 <= 1`), so a page with other
+  verified domains is not told it is about to go offline.
+- **Demotion** — `Emailer.organization_page_unverified_email/4`, sent alongside
+  the operator notice when the last verified domain is dropped.
+
+Recipients are **owners only**: domains are an owner-only power
+(`can_manage_domains?/2`), so an admin or recruiter would get a call to action
+they cannot follow. The domains page is the landing spot for both mails, so a
+domain in its grace window renders an amber "Proof missing" pill plus the
+deadline there, and its verification panel (record/file + **Verify now**) is
+shown for a grace-window domain as well as a never-verified one — otherwise the
+mail's recipient would arrive at a green "Verified" badge contradicting it.
+
 ## Team roles (`organization_roles`, #930)
 
 A page is run by a team, not just its claimant. Each `OrganizationRole` grants a

--- a/lib/vutuv/notifications/emailer.ex
+++ b/lib/vutuv/notifications/emailer.ex
@@ -798,6 +798,62 @@ defmodule Vutuv.Notifications.Emailer do
     })
   end
 
+  @doc """
+  Warns an organization **owner** that a domain proof stopped resolving and a
+  grace window is running: restore the DNS record / well-known file before
+  `deadline` or the domain is dropped. `last?` says whether it is the page's
+  only verified domain, i.e. whether the page itself goes offline with it.
+
+  The operator notices above go to the installation's operator; this is the
+  member-facing twin, and the only one whose recipient can actually fix the
+  proof. Transactional (about their own page), so no opt-out, and it links to
+  the owner's domains page, never the admin dashboard.
+  """
+  def organization_domain_grace_email(user, email, organization, domain, last?) do
+    build_email(
+      user,
+      email,
+      "organization_domain_grace",
+      %{
+        organization_name: organization.name,
+        organization_slug: organization.slug,
+        domain: domain.domain,
+        method: domain.method,
+        deadline: domain.grace_deadline_at,
+        last?: last?
+      },
+      # A page with other verified domains is not about to go offline, so it
+      # must not be told it is.
+      fn -> grace_subject(last?) end
+    )
+  end
+
+  defp grace_subject(true),
+    do: gettext("Your organization page on vutuv is about to lose its verification")
+
+  defp grace_subject(false),
+    do: gettext("A domain of your organization page on vutuv is about to be dropped")
+
+  @doc """
+  Tells an organization owner the grace window ran out on the page's last
+  verified domain: it is back to "pending" and no longer publicly visible. The
+  member-facing twin of `organization_unverified_notice/2`.
+  """
+  def organization_page_unverified_email(user, email, organization, domain) do
+    build_email(
+      user,
+      email,
+      "organization_page_unverified",
+      %{
+        organization_name: organization.name,
+        organization_slug: organization.slug,
+        domain: domain.domain,
+        method: domain.method
+      },
+      fn -> gettext("Your organization page on vutuv is no longer public") end
+    )
+  end
+
   ## Moderation (see Vutuv.Moderation.Notifier, the only caller)
 
   @doc "Owner notice: content frozen, please delete / edit / dispute within 72h."

--- a/lib/vutuv/organizations.ex
+++ b/lib/vutuv/organizations.ex
@@ -18,6 +18,7 @@ defmodule Vutuv.Organizations do
   import Vutuv.Organizations.Query, only: [organization_public_row: 1]
   import Vutuv.SearchText, only: [escape_like: 1, normalize_search: 1]
 
+  alias Vutuv.Accounts
   alias Vutuv.Accounts.User
   alias Vutuv.Engagement
   alias Vutuv.Handles
@@ -817,12 +818,18 @@ defmodule Vutuv.Organizations do
       is_nil(domain.grace_deadline_at) ->
         deadline = NaiveDateTime.add(now, @grace_days * 86_400)
 
-        domain
-        |> OrganizationDomain.check_changeset(%{
-          last_checked_at: now,
-          grace_deadline_at: deadline
-        })
-        |> Repo.update()
+        {:ok, domain} =
+          domain
+          |> OrganizationDomain.check_changeset(%{
+            last_checked_at: now,
+            grace_deadline_at: deadline
+          })
+          |> Repo.update()
+
+        # The one moment the owners can still prevent the outage: warn them now,
+        # once per window (the `:in_grace` arm below stays silent, so a weekly
+        # re-check does not nag them into ignoring the mail).
+        notify_owners_of_grace(domain)
 
         :grace_started
 
@@ -868,6 +875,10 @@ defmodule Vutuv.Organizations do
       |> Emailer.organization_unverified_notice(domain)
       |> Emailer.deliver()
 
+      # The operator hears about it above; the owners are the ones who have to
+      # act, so they hear about it too.
+      notify_owners_of_unverified(organization, domain)
+
       :demoted_organization
     else
       # A non-last domain was dropped: the page stays verified via its others,
@@ -881,6 +892,62 @@ defmodule Vutuv.Organizations do
 
       :demoted_domain
     end
+  end
+
+  # --- owner notices ----------------------------------------------------------
+  #
+  # The operator notices above tell the *installation operator* that a page
+  # changed state. They deliberately link to /admin/organizations, which the
+  # page's own staff cannot even open — so on their own they leave the one
+  # person who can republish the proof in the dark. These are the member-facing
+  # twins. Recipients are the **owners**: domains are an owner-only power
+  # (`can_manage_domains?/2`), so an admin or recruiter would get a call to
+  # action they cannot follow.
+
+  defp notify_owners_of_grace(domain) do
+    organization = get_organization!(domain.organization_id)
+    last? = verified_domain_count(organization.id) <= 1
+
+    notify_owners(organization, fn user, address ->
+      Emailer.organization_domain_grace_email(user, address, organization, domain, last?)
+    end)
+  end
+
+  defp notify_owners_of_unverified(organization, domain) do
+    notify_owners(organization, fn user, address ->
+      Emailer.organization_page_unverified_email(user, address, organization, domain)
+    end)
+  end
+
+  # Mails every owner at their first address, each in their own locale (the
+  # builder picks the template by `user.locale`). An owner without a usable
+  # address is simply skipped.
+  defp notify_owners(organization, build) do
+    organization
+    |> owners()
+    |> Enum.each(fn user ->
+      case Accounts.first_email_value(user) do
+        nil -> :ok
+        address -> user |> build.(address) |> Emailer.deliver()
+      end
+    end)
+  end
+
+  @doc """
+  The members who may manage `organization`'s domains, oldest role first. The
+  claim wizard makes the creator an owner, so this is never empty for a page
+  that went through it.
+  """
+  def owners(%Organization{id: id}) do
+    Repo.all(
+      from(r in OrganizationRole,
+        join: u in User,
+        on: u.id == r.user_id,
+        where: r.organization_id == ^id and r.role == "owner",
+        order_by: [asc: r.id],
+        select: u
+      )
+    )
   end
 
   # --- engagement (like + bookmark) ------------------------------------------

--- a/lib/vutuv_web/live/organization_live/domains.ex
+++ b/lib/vutuv_web/live/organization_live/domains.ex
@@ -174,10 +174,13 @@ defmodule VutuvWeb.OrganizationLive.Domains do
             <span :if={domain.primary?} class="rounded-full bg-brand-50 px-2 py-0.5 text-xs font-semibold text-brand-700 dark:bg-brand-900/40 dark:text-brand-100">
               {gettext("Primary")}
             </span>
-            <span :if={domain.verified_at} class="rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200">
+            <span :if={domain.verified_at && !domain.grace_deadline_at} class="rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200">
               {gettext("Verified")}
             </span>
-            <span :if={!domain.verified_at} class="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+            <span :if={domain.grace_deadline_at} class="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+              {gettext("Proof missing")}
+            </span>
+            <span :if={!domain.verified_at && !domain.grace_deadline_at} class="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
               {gettext("Pending")}
             </span>
           </div>
@@ -185,6 +188,23 @@ defmodule VutuvWeb.OrganizationLive.Domains do
           <p :if={domain.last_checked_at} class="mt-1 text-xs text-slate-600 dark:text-slate-400">
             {gettext("Method")}: {domain.method} &middot; {gettext("Last checked")}:
             <.local_time at={domain.last_checked_at} id={"domain-checked-#{domain.id}"} />
+          </p>
+
+          <%!-- The landing page of the grace-window warning email: it has to
+                explain the same thing the mail did, or the green pill above
+                would read as "nothing is wrong here". --%>
+          <p
+            :if={domain.grace_deadline_at}
+            id={"domain-grace-#{domain.id}"}
+            class="mt-3 rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
+          >
+            {gettext("We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification.")}
+            {gettext("Deadline")}:
+            <.local_time
+              at={domain.grace_deadline_at}
+              id={"domain-grace-time-#{domain.id}"}
+              format="%Y-%m-%d"
+            />
           </p>
 
           {verify_block(assigns, domain)}
@@ -252,7 +272,10 @@ defmodule VutuvWeb.OrganizationLive.Domains do
       |> assign(:well_known_content, Organizations.well_known_content(domain))
 
     ~H"""
-    <div :if={is_nil(@domain.verified_at) and @verification_enabled?} class="mt-3 rounded-lg bg-slate-50 p-4 text-sm dark:bg-slate-800/60">
+    <%!-- Shown for a domain that was never verified AND for one whose proof
+          vanished (grace window running): the second case needs the record and
+          the "Verify now" button just as much, to fix it before the deadline. --%>
+    <div :if={(is_nil(@domain.verified_at) or not is_nil(@domain.grace_deadline_at)) and @verification_enabled?} class="mt-3 rounded-lg bg-slate-50 p-4 text-sm dark:bg-slate-800/60">
       <div class="flex gap-4">
         <label class="flex items-center gap-1.5 text-xs font-medium">
           <input

--- a/lib/vutuv_web/templates/email/organization_domain_grace_de.text.eex
+++ b/lib/vutuv_web/templates/email/organization_domain_grace_de.text.eex
@@ -1,0 +1,23 @@
+<%= email_greeting(@user) %>,
+
+der Domain-Nachweis Ihrer Firmenseite "<%= @organization_name %>" lässt sich nicht mehr
+abrufen. Betroffen ist die Domain <%= @domain %>.
+
+Wir prüfen den Nachweis wöchentlich, und Sie haben bis zum
+<%= Calendar.strftime(@deadline, "%d.%m.%Y") %> Zeit, ihn wiederherzustellen.
+<%= if @last? do %>
+Passiert bis dahin nichts, verliert die Seite ihre Verifizierung und ist nicht mehr
+öffentlich sichtbar.
+<% else %>
+Passiert bis dahin nichts, entfällt diese eine Domain. Die Seite bleibt über Ihre
+übrigen verifizierten Domains öffentlich.
+<% end %>
+Meist genügt es, den ursprünglichen Nachweis wiederherzustellen:
+<%= if @method == "dns" do %>den DNS-TXT-Eintrag für <%= @domain %><% else %>die Prüfdatei auf <%= @domain %><% end %>.
+Den genauen Wert und den Knopf zum erneuten Prüfen finden Sie hier:
+
+<%= @url %>organizations/<%= @organization_slug %>/domains
+
+<%= render "_signature_de.text" %>
+
+<%= render "_footer.text" %>

--- a/lib/vutuv_web/templates/email/organization_domain_grace_en.text.eex
+++ b/lib/vutuv_web/templates/email/organization_domain_grace_en.text.eex
@@ -1,0 +1,23 @@
+<%= email_greeting(@user) %>,
+
+the domain proof for your organization page "<%= @organization_name %>" no longer resolves.
+The domain in question is <%= @domain %>.
+
+We re-check the proof weekly, and you have until
+<%= Calendar.strftime(@deadline, "%Y-%m-%d") %> to restore it.
+<%= if @last? do %>
+If nothing changes by then, the page loses its verification and is no longer
+publicly visible.
+<% else %>
+If nothing changes by then, this one domain is dropped. The page stays public
+through your other verified domains.
+<% end %>
+Restoring the original proof is usually enough:
+<%= if @method == "dns" do %>the DNS TXT record for <%= @domain %><% else %>the verification file on <%= @domain %><% end %>.
+The exact value and the button to check again are here:
+
+<%= @url %>organizations/<%= @organization_slug %>/domains
+
+<%= render "_signature_en.text" %>
+
+<%= render "_footer.text" %>

--- a/lib/vutuv_web/templates/email/organization_page_unverified_de.text.eex
+++ b/lib/vutuv_web/templates/email/organization_page_unverified_de.text.eex
@@ -1,0 +1,15 @@
+<%= email_greeting(@user) %>,
+
+Ihre Firmenseite "<%= @organization_name %>" hat ihre letzte verifizierte Domain verloren
+und steht wieder auf "Verifizierung ausstehend". Sie ist damit nicht mehr öffentlich
+sichtbar. Betroffen ist die Domain <%= @domain %>.
+
+Der Nachweis war eine Woche lang nicht abrufbar. Sobald Sie ihn wiederherstellen und die
+Domain erneut prüfen lassen, ist die Seite wieder online. Ihre Inhalte bleiben in der
+Zwischenzeit erhalten, nur eben unveröffentlicht.
+
+<%= @url %>organizations/<%= @organization_slug %>/domains
+
+<%= render "_signature_de.text" %>
+
+<%= render "_footer.text" %>

--- a/lib/vutuv_web/templates/email/organization_page_unverified_en.text.eex
+++ b/lib/vutuv_web/templates/email/organization_page_unverified_en.text.eex
@@ -1,0 +1,14 @@
+<%= email_greeting(@user) %>,
+
+your organization page "<%= @organization_name %>" has lost its last verified domain and is
+back to "verification pending". It is no longer publicly visible. The domain in question
+is <%= @domain %>.
+
+The proof had been unreachable for a week. Restore it, run the check again, and the page
+is back online. Your content is kept in the meantime, just unpublished.
+
+<%= @url %>organizations/<%= @organization_slug %>/domains
+
+<%= render "_signature_en.text" %>
+
+<%= render "_footer.text" %>

--- a/lib/vutuv_web/templates/email_body/organization_domain_grace_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/organization_domain_grace_de.html.heex
@@ -1,0 +1,33 @@
+<.email_layout preheader="Der Domain-Nachweis Ihrer Firmenseite fehlt" locale={@locale}>
+  <.email_p>{email_greeting(@user)},</.email_p>
+  <.email_p>
+    der Domain-Nachweis Ihrer Firmenseite „{@organization_name}" lässt sich nicht mehr abrufen.
+    Betroffen ist die Domain <strong>{@domain}</strong>. Wir prüfen den Nachweis wöchentlich, und
+    Sie haben bis zum <strong>{Calendar.strftime(@deadline, "%d.%m.%Y")}</strong> Zeit, ihn
+    wiederherzustellen.
+  </.email_p>
+  <%= if @last? do %>
+    <.email_p>
+      Passiert bis dahin nichts, verliert die Seite ihre Verifizierung und ist nicht mehr
+      öffentlich sichtbar.
+    </.email_p>
+  <% else %>
+    <.email_p>
+      Passiert bis dahin nichts, entfällt diese eine Domain. Die Seite bleibt über Ihre übrigen
+      verifizierten Domains öffentlich.
+    </.email_p>
+  <% end %>
+  <.email_p>
+    Meist genügt es, den ursprünglichen Nachweis wiederherzustellen:
+    <%= if @method == "dns" do %>
+      den DNS-TXT-Eintrag für {@domain}.
+    <% else %>
+      die Prüfdatei auf {@domain}.
+    <% end %>
+    Den genauen Wert und den Knopf zum erneuten Prüfen finden Sie auf der Domain-Seite.
+  </.email_p>
+  <.email_button href={"#{@url}organizations/#{@organization_slug}/domains"}>
+    Domains verwalten
+  </.email_button>
+  <.email_signature locale={@locale} />
+</.email_layout>

--- a/lib/vutuv_web/templates/email_body/organization_domain_grace_en.html.heex
+++ b/lib/vutuv_web/templates/email_body/organization_domain_grace_en.html.heex
@@ -1,0 +1,32 @@
+<.email_layout preheader="Your organization page's domain proof is missing" locale={@locale}>
+  <.email_p>{email_greeting(@user)},</.email_p>
+  <.email_p>
+    the domain proof for your organization page "{@organization_name}" no longer resolves. The
+    domain in question is <strong>{@domain}</strong>. We re-check the proof weekly, and you have
+    until <strong>{Calendar.strftime(@deadline, "%Y-%m-%d")}</strong> to restore it.
+  </.email_p>
+  <%= if @last? do %>
+    <.email_p>
+      If nothing changes by then, the page loses its verification and is no longer publicly
+      visible.
+    </.email_p>
+  <% else %>
+    <.email_p>
+      If nothing changes by then, this one domain is dropped. The page stays public through your
+      other verified domains.
+    </.email_p>
+  <% end %>
+  <.email_p>
+    Restoring the original proof is usually enough:
+    <%= if @method == "dns" do %>
+      the DNS TXT record for {@domain}.
+    <% else %>
+      the verification file on {@domain}.
+    <% end %>
+    The exact value and the button to check again are on the domains page.
+  </.email_p>
+  <.email_button href={"#{@url}organizations/#{@organization_slug}/domains"}>
+    Manage domains
+  </.email_button>
+  <.email_signature locale={@locale} />
+</.email_layout>

--- a/lib/vutuv_web/templates/email_body/organization_page_unverified_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/organization_page_unverified_de.html.heex
@@ -1,0 +1,17 @@
+<.email_layout preheader="Ihre Firmenseite ist nicht mehr öffentlich" locale={@locale}>
+  <.email_p>{email_greeting(@user)},</.email_p>
+  <.email_p>
+    Ihre Firmenseite „{@organization_name}" hat ihre letzte verifizierte Domain verloren
+    (<strong>{@domain}</strong>) und steht wieder auf „Verifizierung ausstehend". Sie ist damit
+    nicht mehr öffentlich sichtbar.
+  </.email_p>
+  <.email_p>
+    Der Nachweis war eine Woche lang nicht abrufbar. Sobald Sie ihn wiederherstellen und die
+    Domain erneut prüfen lassen, ist die Seite wieder online. Ihre Inhalte bleiben in der
+    Zwischenzeit erhalten, nur eben unveröffentlicht.
+  </.email_p>
+  <.email_button href={"#{@url}organizations/#{@organization_slug}/domains"}>
+    Domain erneut prüfen
+  </.email_button>
+  <.email_signature locale={@locale} />
+</.email_layout>

--- a/lib/vutuv_web/templates/email_body/organization_page_unverified_en.html.heex
+++ b/lib/vutuv_web/templates/email_body/organization_page_unverified_en.html.heex
@@ -1,0 +1,16 @@
+<.email_layout preheader="Your organization page is no longer public" locale={@locale}>
+  <.email_p>{email_greeting(@user)},</.email_p>
+  <.email_p>
+    your organization page "{@organization_name}" has lost its last verified domain
+    (<strong>{@domain}</strong>) and is back to "verification pending". It is no longer publicly
+    visible.
+  </.email_p>
+  <.email_p>
+    The proof had been unreachable for a week. Restore it, run the check again, and the page is
+    back online. Your content is kept in the meantime, just unpublished.
+  </.email_p>
+  <.email_button href={"#{@url}organizations/#{@organization_slug}/domains"}>
+    Check the domain again
+  </.email_button>
+  <.email_signature locale={@locale} />
+</.email_layout>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.157.2",
+      version: "7.158.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -13339,6 +13339,36 @@ msgstr "Sie haben bereits die maximale Anzahl veröffentlichter Anzeigen."
 msgid "Your job posting on vutuv expires soon"
 msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
 
+#: lib/vutuv/notifications/emailer.ex:835
+#, elixir-autogen, elixir-format
+msgid "A domain of your organization page on vutuv is about to be dropped"
+msgstr "Eine Domain Ihrer Firmenseite auf vutuv entfällt bald"
+
+#: lib/vutuv_web/live/organization_live/domains.ex:202
+#, elixir-autogen, elixir-format
+msgid "Deadline"
+msgstr "Frist"
+
+#: lib/vutuv_web/live/organization_live/domains.ex:181
+#, elixir-autogen, elixir-format
+msgid "Proof missing"
+msgstr "Nachweis fehlt"
+
+#: lib/vutuv_web/live/organization_live/domains.ex:201
+#, elixir-autogen, elixir-format
+msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
+msgstr "Der Nachweis dieser Domain war bei der letzten Prüfung nicht abrufbar. Stellen Sie ihn wieder her und prüfen Sie erneut, sonst verliert die Domain ihre Verifizierung."
+
+#: lib/vutuv/notifications/emailer.ex:832
+#, elixir-autogen, elixir-format
+msgid "Your organization page on vutuv is about to lose its verification"
+msgstr "Ihre Firmenseite auf vutuv verliert bald ihre Verifizierung"
+
+#: lib/vutuv/notifications/emailer.ex:853
+#, elixir-autogen, elixir-format
+msgid "Your organization page on vutuv is no longer public"
+msgstr "Ihre Firmenseite auf vutuv ist nicht mehr öffentlich"
+
 #: lib/vutuv_web/live/job_posting_live/show.ex:176
 #, elixir-autogen, elixir-format
 msgid "Your posting"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -12634,6 +12634,36 @@ msgstr ""
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
+#: lib/vutuv/notifications/emailer.ex:835
+#, elixir-autogen, elixir-format
+msgid "A domain of your organization page on vutuv is about to be dropped"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/domains.ex:202
+#, elixir-autogen, elixir-format
+msgid "Deadline"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/domains.ex:181
+#, elixir-autogen, elixir-format
+msgid "Proof missing"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/domains.ex:201
+#, elixir-autogen, elixir-format
+msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
+msgstr ""
+
+#: lib/vutuv/notifications/emailer.ex:832
+#, elixir-autogen, elixir-format
+msgid "Your organization page on vutuv is about to lose its verification"
+msgstr ""
+
+#: lib/vutuv/notifications/emailer.ex:853
+#, elixir-autogen, elixir-format
+msgid "Your organization page on vutuv is no longer public"
+msgstr ""
+
 #: lib/vutuv_web/live/job_posting_live/show.ex:176
 #, elixir-autogen, elixir-format
 msgid "Your posting"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -12632,6 +12632,36 @@ msgstr ""
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
+#: lib/vutuv/notifications/emailer.ex:835
+#, elixir-autogen, elixir-format
+msgid "A domain of your organization page on vutuv is about to be dropped"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/domains.ex:202
+#, elixir-autogen, elixir-format
+msgid "Deadline"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/domains.ex:181
+#, elixir-autogen, elixir-format
+msgid "Proof missing"
+msgstr ""
+
+#: lib/vutuv_web/live/organization_live/domains.ex:201
+#, elixir-autogen, elixir-format
+msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
+msgstr ""
+
+#: lib/vutuv/notifications/emailer.ex:832
+#, elixir-autogen, elixir-format
+msgid "Your organization page on vutuv is about to lose its verification"
+msgstr ""
+
+#: lib/vutuv/notifications/emailer.ex:853
+#, elixir-autogen, elixir-format
+msgid "Your organization page on vutuv is no longer public"
+msgstr ""
+
 #: lib/vutuv_web/live/job_posting_live/show.ex:176
 #, elixir-autogen, elixir-format
 msgid "Your posting"

--- a/test/vutuv/organizations_test.exs
+++ b/test/vutuv/organizations_test.exs
@@ -298,6 +298,165 @@ defmodule Vutuv.OrganizationsTest do
     end
   end
 
+  describe "owner notices on a failing domain proof" do
+    setup [:enable_verification]
+
+    # A member with an address to mail (the plain user factory has none).
+    defp owner_with_email(locale) do
+      user = insert(:activated_user, locale: locale)
+      insert(:email, user: user)
+      user
+    end
+
+    # Verifies `organization` via DNS, consumes the operator's "verified" notice,
+    # then makes the TXT record vanish so the next re-check fails.
+    defp break_proof(organization, domain) do
+      stub_dns(domain.verification_token)
+      {:ok, _organization} = Organizations.verify_dns(organization, domain)
+      assert_email_sent(fn email -> assert email.subject =~ "Firmenseite verifiziert" end)
+      Application.put_env(:vutuv, :organizations_dns_resolver, fn _host -> [] end)
+      Repo.get!(OrganizationDomain, domain.id)
+    end
+
+    defp expire_grace(domain) do
+      past = NaiveDateTime.add(NaiveDateTime.utc_now(), -3600) |> NaiveDateTime.truncate(:second)
+
+      domain
+      |> OrganizationDomain.check_changeset(%{grace_deadline_at: past})
+      |> Repo.update!()
+    end
+
+    test "the grace window warns the owner, naming the deadline and the domains page" do
+      user = owner_with_email("de")
+      address = Vutuv.Accounts.first_email_value(user)
+
+      {:ok, %{organization: organization, domain: domain}} =
+        Organizations.create_pending_organization(user, @valid, "dns")
+
+      domain = break_proof(organization, domain)
+
+      assert :grace_started = Organizations.recheck_domain(domain)
+      deadline = Repo.get!(OrganizationDomain, domain.id).grace_deadline_at
+
+      assert_email_sent(fn email ->
+        assert [{_name, ^address}] = email.to
+        assert email.subject =~ "verliert bald ihre Verifizierung"
+        # The owner is told which domain broke, by when, and where to fix it:
+        # the owner's domains page, never the admin dashboard they cannot open.
+        refute email.text_body =~ "admin/organizations"
+        assert email.text_body =~ domain.domain
+        assert email.text_body =~ Calendar.strftime(deadline, "%d.%m.%Y")
+        assert email.text_body =~ "organizations/#{organization.slug}/domains"
+        assert email.html_body =~ "organizations/#{organization.slug}/domains"
+      end)
+    end
+
+    test "the warning goes out once per grace window, not on every re-check" do
+      user = owner_with_email("de")
+
+      {:ok, %{organization: organization, domain: domain}} =
+        Organizations.create_pending_organization(user, @valid, "dns")
+
+      domain = break_proof(organization, domain)
+
+      assert :grace_started = Organizations.recheck_domain(domain)
+      assert_email_sent(fn email -> assert email.subject =~ "Verifizierung" end)
+
+      # A second failing check inside the window is the same, already-reported
+      # problem: nagging weekly would train the owner to ignore the mail.
+      assert :in_grace = Organizations.recheck_domain(Repo.get!(OrganizationDomain, domain.id))
+      refute_email_sent()
+    end
+
+    test "losing the last verified domain tells the owner the page is offline" do
+      user = owner_with_email("de")
+      address = Vutuv.Accounts.first_email_value(user)
+
+      {:ok, %{organization: organization, domain: domain}} =
+        Organizations.create_pending_organization(user, @valid, "dns")
+
+      domain = break_proof(organization, domain)
+      assert :grace_started = Organizations.recheck_domain(domain)
+      assert_email_sent(fn email -> assert email.subject =~ "Verifizierung" end)
+
+      assert :demoted_organization =
+               Organizations.recheck_domain(
+                 expire_grace(Repo.get!(OrganizationDomain, domain.id))
+               )
+
+      # The operator notice stays first (it is the existing behaviour); the
+      # owner's is the new second message.
+      assert_email_sent(fn email ->
+        assert email.subject =~ "nicht mehr verifiziert"
+        assert email.text_body =~ "admin/organizations"
+      end)
+
+      assert_email_sent(fn email ->
+        assert [{_name, ^address}] = email.to
+        assert email.subject =~ "nicht mehr öffentlich"
+        assert email.text_body =~ organization.name
+        assert email.text_body =~ "organizations/#{organization.slug}/domains"
+      end)
+    end
+
+    test "every owner is warned, in their own locale; other role holders are not" do
+      owner = owner_with_email("de")
+      second_owner = owner_with_email("en")
+      recruiter = owner_with_email("de")
+
+      {:ok, %{organization: organization, domain: domain}} =
+        Organizations.create_pending_organization(owner, @valid, "dns")
+
+      {:ok, _} = Organizations.add_role(organization, second_owner, "owner", owner)
+      {:ok, _} = Organizations.add_role(organization, recruiter, "recruiter", owner)
+
+      domain = break_proof(organization, domain)
+      assert :grace_started = Organizations.recheck_domain(domain)
+
+      # Owners in role order (creator first), each in their own locale.
+      assert_email_sent(fn email ->
+        assert email.subject =~ "verliert bald ihre Verifizierung"
+      end)
+
+      assert_email_sent(fn email ->
+        assert email.subject =~ "is about to lose its verification"
+      end)
+
+      # Only an owner can manage domains, so a recruiter gets no call to action.
+      refute_email_sent()
+    end
+
+    test "a non-last domain failing still warns, without claiming the page goes offline" do
+      user = owner_with_email("de")
+
+      {:ok, %{organization: organization, domain: primary}} =
+        Organizations.create_pending_organization(user, @valid, "dns")
+
+      stub_dns(primary.verification_token)
+      {:ok, _} = Organizations.verify_dns(organization, primary)
+      assert_email_sent(fn email -> assert email.subject =~ "Firmenseite verifiziert" end)
+
+      {:ok, second} = Organizations.add_domain(organization, "second.example.org", "dns")
+      stub_dns(second.verification_token)
+      # Re-read the page (as the domains LiveView does) so `verified_at` is set
+      # and the already-sent "verified" operator notice is not sent a second time.
+      {:ok, _} = Organizations.verify_dns(Repo.get!(Organization, organization.id), second)
+
+      Application.put_env(:vutuv, :organizations_dns_resolver, fn _host -> [] end)
+
+      assert :grace_started =
+               Organizations.recheck_domain(Repo.get!(OrganizationDomain, primary.id))
+
+      assert_email_sent(fn email ->
+        # The page keeps its other verified domain, so neither the subject nor
+        # the body may threaten an outage that is not coming.
+        refute email.text_body =~ "nicht mehr öffentlich sichtbar"
+        assert email.subject =~ "Eine Domain Ihrer Firmenseite auf vutuv entfällt bald"
+        assert email.text_body =~ primary.domain
+      end)
+    end
+  end
+
   describe "domains_due_for_recheck/1 (weekly cutoff)" do
     test "a domain checked within the past week is not due; older than a week is" do
       user = insert(:activated_user)

--- a/test/vutuv_web/organization_management_test.exs
+++ b/test/vutuv_web/organization_management_test.exs
@@ -103,6 +103,45 @@ defmodule VutuvWeb.OrganizationManagementTest do
       assert Organizations.primary_domain(organization).domain == "acme.de"
     end
 
+    test "a domain in its grace window says so and offers the proof again", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      organization = active_organization_for(owner)
+      primary = Organizations.primary_domain(organization)
+
+      # The proof vanished; the weekly re-check opened the grace window.
+      Application.put_env(:vutuv, :organizations_dns_resolver, fn _host -> [] end)
+      assert :grace_started = Organizations.recheck_domain(primary)
+      deadline = Organizations.get_domain(organization, primary.id).grace_deadline_at
+
+      {:ok, _view, html} = live(conn, ~p"/organizations/#{organization.slug}/domains")
+
+      # The warning email links here, so the page must not greet the owner with a
+      # bare green "Verified" pill that contradicts it.
+      assert html =~ "Proof missing"
+      assert html =~ Calendar.strftime(deadline, "%Y-%m-%d")
+
+      # And the record to re-publish is right there, with the button to re-check.
+      assert html =~ "vutuv-organization-verify=#{primary.verification_token}"
+      assert html =~ "verify-#{primary.id}"
+    end
+
+    test "restoring the proof during grace clears the warning", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      organization = active_organization_for(owner)
+      primary = Organizations.primary_domain(organization)
+
+      Application.put_env(:vutuv, :organizations_dns_resolver, fn _host -> [] end)
+      assert :grace_started = Organizations.recheck_domain(primary)
+
+      {:ok, view, _html} = live(conn, ~p"/organizations/#{organization.slug}/domains")
+      stub_dns(primary.verification_token)
+
+      html = view |> element("#verify-#{primary.id}") |> render_click()
+
+      refute html =~ "Proof missing"
+      assert Organizations.get_domain(organization, primary.id).grace_deadline_at == nil
+    end
+
     test "removing the last verified domain is refused", %{conn: conn} do
       {conn, owner} = create_and_login_user(conn)
       organization = active_organization_for(owner)


### PR DESCRIPTION
**TL;DR** A failing organization domain proof only mailed the operator, and that notice links to `/admin/organizations`. The owners, the only people who can fix it, heard nothing. They do now, at grace start and at demotion.

**Where:** `Vutuv.Organizations` (`handle_recheck_failure/2`, `demote_domain/2`), `Vutuv.Notifications.Emailer`, `VutuvWeb.OrganizationLive.Domains`

**Now:** the weekly re-check fails, a 7-day grace window opens silently, and when it expires the page falls back to `pending` and off the public web. The only message sent is `organization_unverified_notice/2` to `:operator_recipient`, pointing at the admin oversight dashboard the page's own staff cannot open.

**Want:** the owners are told, in time to act.

## What this adds

Two member-facing mails (de + en, text + HTML), both linking to `/organizations/:slug/domains`:

- **Grace start** (`organization_domain_grace_email/5`) sent **once per window**. The `:in_grace` re-checks stay silent, since a weekly nag is how a warning mail gets filtered away. Subject and body branch on whether it is the page's last verified domain, so a page with other verified proofs is not told it is about to go offline.
- **Demotion** (`organization_page_unverified_email/4`) sent alongside the unchanged operator notice.

Recipients are **owners only** (`Organizations.owners/1`), each in their own locale: domains are an owner-only power (`can_manage_domains?/2`), so an admin or recruiter would get a call to action they cannot follow. Transactional, like the job-expiry reminder, so no opt-out.

The domains page is where both mails land, so it had to stop contradicting them: a domain in its grace window shows an amber "Proof missing" pill plus the deadline instead of a bare green "Verified", and the verification panel (the record to publish + "Verify now") now renders for a grace-window domain too, not only a never-verified one.

## Tests

Five new context tests (warn at grace start with the deadline and the owner link, never the admin URL; once per window; demotion mails owner *and* operator; every owner in their own locale while a recruiter gets nothing; a non-last domain warns without threatening an outage) and two LiveView tests for the domains page. `mix precommit` green: 5099 passed.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01DMBgHGB18YRf2miCKFtBrh
