### PR TITLE
Stop keeping an IP address in the account-activity log (#1087)

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -119,7 +119,7 @@ Everything else has a default (the vutuv.de production value):
 | `FEDIVERSE_INBOUND_CAPS` | `600,60` | `host,actor`: how many rows one remote server, and one remote account, may store here per hour. Anything past the budget is dropped for that hour. The floor under the operator blocklist at `/admin/fediverse`, since it also bounds servers nobody has blocked yet |
 | `FEDIVERSE_NOTE_RETENTION_DAYS` | `183` | How long a reply written on another network may be held here at the very most, in days. It is deleted when the clock runs out whatever else happens, so this is the promise your privacy page can make. Only applies once a member switches replies on (off by default) |
 | `FEDIVERSE_NOTE_REFRESH_DAYS` | `7` | How stale a stored reply may get before vutuv asks its origin server whether it is still published there. Still there means the text is refreshed and the retention clock starts again; gone (or locked away) means it is deleted at once; unreachable changes nothing. Replies sent to a member privately are never re-checked |
-| `ACCOUNT_EVENT_RETENTION_DAYS` | `365` | How long the **account-activity log** keeps an event, in days (see `docs/architecture/account-activity.md`). It records what changed on an account, when, from which coarse device and IP, and how it was confirmed, so it is personal data with a clock on it: a year covers the "this happened months ago and I only noticed now" support case without becoming a permanent movement profile. The daily sweeper deletes anything older |
+| `ACCOUNT_EVENT_RETENTION_DAYS` | `365` | How long the **account-activity log** keeps an event, in days (see `docs/architecture/account-activity.md`). It records what changed on an account, when, from which coarse device (never an IP address), and how it was confirmed, so it is personal data with a clock on it: a year covers the "this happened months ago and I only noticed now" support case without becoming a permanent movement profile. The daily sweeper deletes anything older |
 | `FETCH_BOOK_METADATA` | `true` | `false` turns the catalogue lookups behind post **book reviews** off (the composer's ISBN → title/author/year prefill, the cover image, page count and publisher from Open Library, and an audiobook's running time). The review feature itself keeps working — members type the fields by hand and the card renders without a cover or those details. Set it on installations that must not call out (intranets) |
 | `DNB_SRU_URL` | `https://services.dnb.de/sru/dnb` | Where an **audiobook's running time** is looked up by ISBN: an SRU endpoint answering MARC21-xml (the Deutsche Nationalbibliothek by default — Open Library records no durations). Point it at another catalogue's SRU endpoint, or set it **empty** (`DNB_SRU_URL=`) to switch that one lookup off while the rest of the book metadata keeps working |
 | `AMAZON_DOMAIN` | `www.amazon.de` | The store a book review card's shop link points at (`https://<domain>/dp/<isbn10>`). Set your regional store (`www.amazon.com`, …) — or an **empty** value (`AMAZON_DOMAIN=`) to remove the shop link entirely |
@@ -442,15 +442,18 @@ Every security-relevant change to an account is recorded: signing in (and with
 which factor), a username rename, an email address added or removed, the
 visibility switches, a new passkey or authenticator app, a token minted, a
 LinkedIn import applied. Each entry carries the exact time (to the second), the
-request IP and a coarse device summary ("Chrome on macOS"), plus the acting
-admin when the change was not the member's own doing.
+coarse device summary ("Chrome on macOS"), plus the acting admin when the change
+was not the member's own doing. It deliberately keeps **no IP address**: the
+member's question is "was that me?", which the device, the time and the
+confirming factor answer, and a year of addresses per account is a movement
+profile with no support value.
 
 - **Members read their own** at `/settings/activity`, and see the last few
   entries on `/settings/security`. Every row ends in a "Not you?" link back to
   the security page, where they can sign every other device out.
 - **You read all of them** at **`/admin` → Account activity**
   (`/admin/activity`): filter by member (name, @handle or email), search over
-  device, IP or detail, filter by kind, sort by time, member or kind. This is
+  device or detail, filter by kind, sort by time, member or kind. This is
   where a support mail that says "my username is different and I did not do
   that" gets answered.
 

--- a/docs/architecture/account-activity.md
+++ b/docs/architecture/account-activity.md
@@ -22,7 +22,6 @@ changeset:
 | `actor_user_id` | who did it, **only** when that was somebody else (an admin) |
 | `kind` | what happened, from a closed vocabulary |
 | `factor` | how it was confirmed: `passkey` / `authenticator` / `list_code` / `pin` / `session` / `admin` |
-| `ip_address` | the request IP as `RemoteIp` resolves it |
 | `device` | the **coarse** summary (`"Chrome on macOS"`), never the raw User-Agent |
 | `details` | a small per-kind map, key-whitelisted |
 | `inserted_at` | UTC, **microsecond** precision |
@@ -31,12 +30,22 @@ The precision is deliberate. Support has to be able to say "you changed this at
 14:32:07", and two changes inside the same second must still have an order —
 which second-resolution timestamps (what the rest of the app stores) cannot give.
 
+**There is no IP address.** The first cut kept one; it is gone. For the member
+the question is "was that me?", and the device summary, the exact time and the
+confirming factor answer it — while a year of IP addresses per account is a
+movement profile nobody asked us to keep, sitting in a table an admin page and
+every backup can read. (`user_sessions` still stores one per signed-in device:
+that is the devices list and the new-device security email, a different feature
+with its own lifetime.) Removing it took two releases, per the N-1 migration
+rule: one that stopped writing and reading the column and nulled what was
+already there, then one that dropped it.
+
 ## What may never be in it
 
 Not the value of anything secret or guessable-and-private. No PIN, token,
 passkey material, TOTP secret or one-time list code — those never reach the
 module. No muted word (a filter row records its *kind*, never the pattern), no
-message, no address. **Email addresses are stored masked**
+message, no postal address, no IP address. **Email addresses are stored masked**
 (`AccountEvents.mask_email/1`: `an***@example.com`), enough for the owner to
 recognize which of their addresses it was and not enough for a leaked backup or
 an admin screen to harvest one.
@@ -73,9 +82,8 @@ The hooks, by area:
   basics save.
 - **Privacy and reach** — the visibility, notification and Fediverse settings
   saves; blocking and unblocking (recorded at the `Vutuv.Social` chokepoint, so
-  it covers the /blocks form, the profile menu and the report flow alike — which
-  is also why those rows carry no request IP: two of the three have a socket,
-  not a conn); adding and removing a content filter.
+  it covers the /blocks form, the profile menu and the report flow alike);
+  adding and removing a content filter.
 - **Data** — the GDPR download, an applied LinkedIn import.
 - **Apps** — an access token minted or revoked, a connected app disconnected.
 - **Somebody else acting** — an admin freeze/unfreeze, a restore, an identity
@@ -95,8 +103,8 @@ Two readers, one query builder.
 **The member** — `/settings/activity` (`VutuvWeb.AccountActivityLive`), in the
 Account group of the settings menu. Newest first, one row per event reading as a
 sentence with a to-the-second `<.local_time precision="second">` stamp, the
-device and IP it came from, how it was confirmed, and an amber "Not by you"
-marker when `actor_user_id` is set. Search over device / IP / factor / details,
+device it came from, how it was confirmed, and an amber "Not by you"
+marker when `actor_user_id` is set. Search over device / factor / details,
 a kind filter offering only the kinds that actually occur, sorting by time (both
 ways) and by kind, numbered paging. **Every row ends in a quiet "Not you?" link
 into `/settings/security`** — a log you cannot act on is a curiosity, not a
@@ -121,8 +129,7 @@ particular view is shareable and the back button restores it.
 
 ## Retention
 
-The log is personal data — devices, IP addresses, what changed when — so it ages
-out. `Vutuv.AccountEvents.Sweeper` deletes rows past
+The log is personal data — devices, what changed when — so it ages out. `Vutuv.AccountEvents.Sweeper` deletes rows past
 `AccountEvents.retention_days/0` daily; the default is **365 days**, settable per
 installation via `ACCOUNT_EVENT_RETENTION_DAYS`. A year covers the "this
 happened months ago and I only noticed now" support case without turning the

--- a/lib/vutuv/account_events.ex
+++ b/lib/vutuv/account_events.ex
@@ -10,18 +10,25 @@ defmodule Vutuv.AccountEvents do
 
   Who (`user_id`), what (`kind`), when (`inserted_at`, **microsecond**
   resolution so two changes in one second still have an order), the confirming
-  factor, the request IP, a **coarse** device summary and a small `details` map.
+  factor, a **coarse** device summary and a small `details` map.
   `actor_user_id` is set only when somebody else did it — an admin acting for
   support — which is what makes "that wasn't me" answerable at a glance.
+
+  **No IP address.** It was in the first cut and is deliberately gone: for the
+  member the question is "was that me?", which the device summary, the time and
+  the confirming factor answer, while a year of IPs per account is a movement
+  profile nobody asked us to keep. (`user_sessions` still stores one per
+  signed-in device — that is the devices list and the new-device security email,
+  a different feature with its own lifetime.)
 
   ## What a row must never hold
 
   Not the value of anything secret or guessable-and-private. No PIN, token,
   passkey material, TOTP secret or one-time list code — those never even reach
-  this module. No muted word, no message, no address. Email addresses are
-  stored **masked** (`mask_email/1`: `an***@example.com`), enough for the owner
-  to recognize which of their addresses it was, not enough for a leaked backup
-  or an admin screen to harvest one.
+  this module. No muted word, no message, no postal address, no IP address.
+  Email addresses are stored **masked** (`mask_email/1`: `an***@example.com`),
+  enough for the owner to recognize which of their addresses it was, not enough
+  for a leaked backup or an admin screen to harvest one.
 
   That rule is enforced structurally rather than by discipline: `@kinds` is the
   **whole** vocabulary, each kind declares exactly which `details` keys it may
@@ -51,8 +58,8 @@ defmodule Vutuv.AccountEvents do
 
   Rows older than `retention_days/0` (365 by default,
   `ACCOUNT_EVENT_RETENTION_DAYS`) are deleted by `Vutuv.AccountEvents.Sweeper`.
-  The log is personal data: it rides along in the GDPR export
-  (`Vutuv.Export`) and cascades away with the account.
+  The log is still personal data without the IP: it rides along in the GDPR
+  export (`Vutuv.Export`) and cascades away with the account.
   """
 
   import Ecto.Query
@@ -160,10 +167,10 @@ defmodule Vutuv.AccountEvents do
 
   `opts`:
 
-    * `:conn` — a `Plug.Conn`, to take the request IP and the coarse device
-      summary from (never the raw User-Agent).
-    * `:ip` / `:device` — the same two, when there is no conn (a LiveView
-      socket, a background job).
+    * `:conn` — a `Plug.Conn`, to take the coarse device summary from (never
+      the raw User-Agent, and never the IP — see the moduledoc).
+    * `:device` — the same, when there is no conn (a LiveView socket, a
+      background job).
     * `:factor` — how the member proved it was them, one of `factors/0`.
     * `:actor` — the `%User{}` who did it, when that is **not** the account's
       owner (an admin). Left out for the member's own actions.
@@ -178,13 +185,10 @@ defmodule Vutuv.AccountEvents do
   def record(%User{id: user_id}, kind, opts), do: record(user_id, kind, opts)
 
   def record(user_id, kind, opts) when is_binary(user_id) do
-    {ip, device} = source(opts)
-
     attrs = %{
       kind: kind,
       factor: opts[:factor],
-      ip_address: ip,
-      device: device,
+      device: device(opts),
       details: opts[:details] || %{}
     }
 
@@ -207,22 +211,16 @@ defmodule Vutuv.AccountEvents do
 
   def record(_user, _kind, _opts), do: :ok
 
-  # The request's own two facts. The device is deliberately the coarse summary
+  # The one request fact the log keeps. Deliberately the coarse summary
   # ("Chrome on macOS") the signed-in-devices list already shows, not the raw
   # User-Agent: the log should say which of your devices it was, not carry a
   # fingerprint for a year.
-  defp source(opts) do
+  defp device(opts) do
     case opts[:conn] do
-      %Plug.Conn{} = conn ->
-        {client_ip(conn), conn |> Plug.Conn.get_req_header("user-agent") |> device_summary()}
-
-      _ ->
-        {opts[:ip], opts[:device]}
+      %Plug.Conn{} = conn -> conn |> Plug.Conn.get_req_header("user-agent") |> device_summary()
+      _ -> opts[:device]
     end
   end
-
-  defp client_ip(%Plug.Conn{remote_ip: nil}), do: nil
-  defp client_ip(%Plug.Conn{remote_ip: ip}), do: ip |> :inet.ntoa() |> to_string()
 
   defp device_summary([ua | _]), do: Sessions.device_summary(ua)
   defp device_summary(_none), do: nil
@@ -391,7 +389,6 @@ defmodule Vutuv.AccountEvents do
           at: e.inserted_at,
           kind: e.kind,
           factor: e.factor,
-          ip_address: e.ip_address,
           device: e.device,
           by_someone_else: not is_nil(e.actor_user_id),
           details: e.details
@@ -444,8 +441,8 @@ defmodule Vutuv.AccountEvents do
     where(
       query,
       [event: e],
-      ilike(e.kind, ^like) or ilike(e.ip_address, ^like) or ilike(e.device, ^like) or
-        ilike(e.factor, ^like) or ilike(fragment("CAST(? AS text)", e.details), ^like)
+      ilike(e.kind, ^like) or ilike(e.device, ^like) or ilike(e.factor, ^like) or
+        ilike(fragment("CAST(? AS text)", e.details), ^like)
     )
   end
 

--- a/lib/vutuv/account_events/account_event.ex
+++ b/lib/vutuv/account_events/account_event.ex
@@ -11,7 +11,10 @@ defmodule Vutuv.AccountEvents.AccountEvent do
   What a row may hold is decided by `Vutuv.AccountEvents`, not here: the kind
   must be a declared one and every `details` key must be whitelisted for that
   kind, which is what keeps secrets and private values out of a table that a
-  backup, an admin page and a support conversation all touch.
+  backup, an admin page and a support conversation all touch. There is
+  deliberately **no IP address** — the `ip_address` column is dropped in the
+  release after this one (an N-1-safe expand/contract), and nothing reads or
+  writes it any more.
   """
 
   use VutuvWeb, :model
@@ -24,7 +27,6 @@ defmodule Vutuv.AccountEvents.AccountEvent do
 
     field(:kind, :string)
     field(:factor, :string)
-    field(:ip_address, :string)
     field(:device, :string)
     field(:details, :map, default: %{})
 
@@ -39,11 +41,10 @@ defmodule Vutuv.AccountEvents.AccountEvent do
   """
   def changeset(event, attrs) do
     event
-    |> cast(attrs, [:kind, :factor, :ip_address, :device, :details])
+    |> cast(attrs, [:kind, :factor, :device, :details])
     |> validate_required([:kind])
     |> validate_inclusion(:kind, AccountEvents.kinds())
     |> validate_inclusion(:factor, AccountEvents.factors())
-    |> validate_length(:ip_address, max: 100)
     |> validate_length(:device, max: 200)
     |> validate_details()
   end

--- a/lib/vutuv_web/live/account_activity_live.ex
+++ b/lib/vutuv_web/live/account_activity_live.ex
@@ -114,9 +114,9 @@ defmodule VutuvWeb.AccountActivityLive do
   # sort is not a filter: it hides nothing.
   defp filtered?(filters), do: filters.q != nil or filters.kind != nil
 
-  # The "Where from" column folds away below `sm`: the device and IP also ride
-  # under the sentence on a phone, and keeping the column would push the
-  # timestamp — the fact the page exists for — off the card edge.
+  # The "Device" column folds away below `sm`: the device also rides under the
+  # sentence on a phone, and keeping the column would push the timestamp — the
+  # fact the page exists for — off the card edge.
   @source_column_class "hidden sm:table-cell"
 
   defp source_column_class, do: @source_column_class
@@ -144,13 +144,6 @@ defmodule VutuvWeb.AccountActivityLive do
   defp range_first(_page, _per_page, _total), do: 0
 
   defp range_last(page, per_page, total), do: min(page * per_page, total)
-
-  # The device and the IP as one muted line. Either can be missing (an event
-  # recorded off a request has neither), so the line collapses rather than
-  # rendering a stray separator.
-  defp source_line(event) do
-    [event.device, event.ip_address] |> Enum.reject(&(&1 in [nil, ""])) |> Enum.join(" · ")
-  end
 
   @impl true
   def render(assigns) do
@@ -207,7 +200,7 @@ defmodule VutuvWeb.AccountActivityLive do
                   value={@filters.q}
                   phx-debounce="250"
                   autocomplete="off"
-                  placeholder={gettext("device, IP address or detail")}
+                  placeholder={gettext("device or detail")}
                   class={input_class()}
                 />
               </div>
@@ -269,7 +262,7 @@ defmodule VutuvWeb.AccountActivityLive do
                         {header}{sort_caret(@filters, col)}
                       </button>
                     </th>
-                    <th class={source_column_class()}>{gettext("Where from")}</th>
+                    <th class={source_column_class()}>{gettext("Device")}</th>
                     <th><span class="sr-only">{gettext("Was this you?")}</span></th>
                   </tr>
                 </thead>
@@ -309,20 +302,17 @@ defmodule VutuvWeb.AccountActivityLive do
                       >
                         {gettext("Not by you")}
                       </span>
-                      <%!-- On a phone the "Where from" column is folded away, so
-                      its content rides here instead of being lost. --%>
+                      <%!-- On a phone the "Device" column is folded away, so its
+                      content rides here instead of being lost. --%>
                       <span
-                        :if={source_line(event) != ""}
+                        :if={event.device}
                         class="block text-xs text-slate-600 sm:hidden dark:text-slate-400"
                       >
-                        {source_line(event)}
+                        {event.device}
                       </span>
                     </td>
                     <td class={[source_column_class(), "align-top text-slate-600 dark:text-slate-400"]}>
-                      <span :if={event.device} class="block">{event.device}</span>
-                      <span :if={event.ip_address} class="block break-all text-xs">
-                        {event.ip_address}
-                      </span>
+                      {event.device}
                     </td>
                     <td class="whitespace-nowrap align-top text-right">
                       <.link

--- a/lib/vutuv_web/live/admin/activity_live.ex
+++ b/lib/vutuv_web/live/admin/activity_live.ex
@@ -195,7 +195,7 @@ defmodule VutuvWeb.Admin.ActivityLive do
       <section class="card">
         <p class="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
           {gettext(
-            "What changed on which account, when, from where and how it was confirmed - the same log every member sees for themselves. Opening it is recorded in your own activity log."
+            "What changed on which account, when, from which device and how it was confirmed - the same log every member sees for themselves. Opening it is recorded in your own activity log."
           )}
         </p>
 
@@ -237,7 +237,7 @@ defmodule VutuvWeb.Admin.ActivityLive do
               value={@filters.q}
               phx-debounce="250"
               autocomplete="off"
-              placeholder={gettext("device, IP address or detail")}
+              placeholder={gettext("device or detail")}
               class={input_class()}
             />
           </div>
@@ -293,7 +293,7 @@ defmodule VutuvWeb.Admin.ActivityLive do
                     {header}{sort_caret(@filters, col)}
                   </button>
                 </th>
-                <th>{gettext("Where from")}</th>
+                <th>{gettext("Device")}</th>
               </tr>
             </thead>
             <tbody id="activity-events">
@@ -346,10 +346,7 @@ defmodule VutuvWeb.Admin.ActivityLive do
                   </span>
                 </td>
                 <td class="align-top text-slate-600 dark:text-slate-400">
-                  <span :if={event.device} class="block">{event.device}</span>
-                  <span :if={event.ip_address} class="block break-all text-xs">
-                    {event.ip_address}
-                  </span>
+                  {event.device}
                 </td>
               </tr>
             </tbody>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.159.0",
+      version: "7.159.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -635,7 +635,7 @@ msgstr "Öffentlich"
 msgid "Save"
 msgstr "Speichern"
 
-#: lib/vutuv_web/live/account_activity_live.ex:201
+#: lib/vutuv_web/live/account_activity_live.ex:194
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:244
@@ -5586,7 +5586,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/components/ui.ex:3533
 #: lib/vutuv_web/components/ui.ex:3597
 #: lib/vutuv_web/controllers/settings_controller.ex:53
-#: lib/vutuv_web/live/account_activity_live.ex:162
+#: lib/vutuv_web/live/account_activity_live.ex:155
 #: lib/vutuv_web/live/fediverse_followers_live.ex:185
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
@@ -7167,7 +7167,7 @@ msgstr "Filter"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:212
 #: lib/vutuv_web/agent_docs/text.ex:200
-#: lib/vutuv_web/live/account_activity_live.ex:219
+#: lib/vutuv_web/live/account_activity_live.ex:212
 #: lib/vutuv_web/live/admin/activity_live.ex:249
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
@@ -8279,7 +8279,7 @@ msgstr "Alle Registrierungen"
 msgid "Awaiting verification"
 msgstr "Prüfung ausstehend"
 
-#: lib/vutuv_web/live/account_activity_live.ex:241
+#: lib/vutuv_web/live/account_activity_live.ex:234
 #: lib/vutuv_web/live/admin/activity_live.ex:269
 #: lib/vutuv_web/live/admin/user_live.ex:209
 #: lib/vutuv_web/live/fediverse_followers_live.ex:278
@@ -8855,7 +8855,7 @@ msgstr "Weitere Profil-Bereiche"
 
 #: lib/vutuv_web/components/ui.ex:3327
 #: lib/vutuv_web/controllers/settings_controller.ex:97
-#: lib/vutuv_web/live/account_activity_live.ex:375
+#: lib/vutuv_web/live/account_activity_live.ex:365
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/totp/new.html.heex:5
@@ -13893,7 +13893,7 @@ msgid "Email me"
 msgstr "Benachrichtige mich"
 
 #: lib/vutuv_web/components/saved_search_components.ex:62
-#: lib/vutuv_web/live/account_activity_live.ex:223
+#: lib/vutuv_web/live/account_activity_live.ex:216
 #: lib/vutuv_web/live/admin/activity_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Everything"
@@ -16620,8 +16620,8 @@ msgstr "Dazu passt kein Follower. Versuchen Sie eine kürzere Suche, oder setzen
 msgid "Show only followers from this server"
 msgstr "Nur Follower von diesem Server zeigen"
 
-#: lib/vutuv_web/live/account_activity_live.ex:341
-#: lib/vutuv_web/live/admin/activity_live.ex:360
+#: lib/vutuv_web/live/account_activity_live.ex:331
+#: lib/vutuv_web/live/admin/activity_live.ex:357
 #: lib/vutuv_web/live/fediverse_followers_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Showing %{first}-%{last} of %{total}."
@@ -16806,9 +16806,9 @@ msgstr "API-Token widerrufen"
 
 #: lib/vutuv_web/components/ui.ex:3331
 #: lib/vutuv_web/live/account_activity_live.ex:40
-#: lib/vutuv_web/live/account_activity_live.ex:161
-#: lib/vutuv_web/live/account_activity_live.ex:162
-#: lib/vutuv_web/live/account_activity_live.ex:167
+#: lib/vutuv_web/live/account_activity_live.ex:154
+#: lib/vutuv_web/live/account_activity_live.ex:155
+#: lib/vutuv_web/live/account_activity_live.ex:160
 #: lib/vutuv_web/live/admin/activity_live.ex:41
 #: lib/vutuv_web/live/admin/activity_live.ex:190
 #: lib/vutuv_web/live/admin/activity_live.ex:191
@@ -16872,7 +16872,7 @@ msgstr "Von %{name}"
 msgid "CV update notifications"
 msgstr "Benachrichtigungen zu Lebenslauf-Änderungen"
 
-#: lib/vutuv_web/live/account_activity_live.ex:301
+#: lib/vutuv_web/live/account_activity_live.ex:294
 #: lib/vutuv_web/live/admin/activity_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
@@ -16913,7 +16913,7 @@ msgstr "E-Mail-Adresse entfernt"
 msgid "Endorsement emails"
 msgstr "E-Mails zu Empfehlungen"
 
-#: lib/vutuv_web/live/account_activity_live.ex:176
+#: lib/vutuv_web/live/account_activity_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Every change to your account: what changed, exactly when, from which device, and how it was confirmed. If a line surprises you, follow the link at the end of it."
 msgstr "Jede Änderung an Ihrem Konto: was geändert wurde, wann genau, von welchem Gerät und wie es bestätigt wurde. Wenn Sie eine Zeile überrascht, folgen Sie dem Link an ihrem Ende."
@@ -16958,7 +16958,7 @@ msgstr "Filter entfernt"
 msgid "Identity verified"
 msgstr "Identität verifiziert"
 
-#: lib/vutuv_web/live/account_activity_live.ex:359
+#: lib/vutuv_web/live/account_activity_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "If something here was not you"
 msgstr "Wenn etwas hier nicht von Ihnen war"
@@ -16968,7 +16968,7 @@ msgstr "Wenn etwas hier nicht von Ihnen war"
 msgid "Import applied"
 msgstr "Import übernommen"
 
-#: lib/vutuv_web/live/account_activity_live.ex:372
+#: lib/vutuv_web/live/account_activity_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "It is part of your data download, and it is deleted with your account."
 msgstr "Es ist Teil Ihres Datendownloads und wird mit Ihrem Konto gelöscht."
@@ -17003,23 +17003,23 @@ msgstr "E-Mails zu neuen Followern"
 msgid "No account activity has been recorded yet."
 msgstr "Es wurde noch keine Kontoaktivität aufgezeichnet."
 
-#: lib/vutuv_web/live/account_activity_live.ex:310
+#: lib/vutuv_web/live/account_activity_live.ex:303
 #: lib/vutuv_web/templates/settings/security.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "Not by you"
 msgstr "Nicht von Ihnen"
 
-#: lib/vutuv_web/live/account_activity_live.ex:332
+#: lib/vutuv_web/live/account_activity_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "Not you?"
 msgstr "Nicht Sie?"
 
-#: lib/vutuv_web/live/account_activity_live.ex:183
+#: lib/vutuv_web/live/account_activity_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. The next time you sign in or change a setting, it will be listed here."
 msgstr "Hier ist noch nichts. Wenn Sie sich das nächste Mal anmelden oder eine Einstellung ändern, steht es hier."
 
-#: lib/vutuv_web/live/account_activity_live.ex:250
+#: lib/vutuv_web/live/account_activity_live.ex:243
 #: lib/vutuv_web/live/admin/activity_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
@@ -17090,7 +17090,7 @@ msgstr "Einstellungen vom Support geändert"
 msgid "Show only this member"
 msgstr "Nur dieses Mitglied anzeigen"
 
-#: lib/vutuv_web/live/account_activity_live.ex:361
+#: lib/vutuv_web/live/account_activity_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Sign every other device out, then check which passkeys, codes and email addresses your account has. All of it is on the sign-in & security page."
 msgstr "Melden Sie alle anderen Geräte ab und prüfen Sie dann, welche Passkeys, Codes und E-Mail-Adressen Ihr Konto hat. Das alles finden Sie auf der Seite Anmeldung & Sicherheit."
@@ -17105,7 +17105,7 @@ msgstr "Angemeldet"
 msgid "Signed out"
 msgstr "Abgemeldet"
 
-#: lib/vutuv_web/live/account_activity_live.ex:366
+#: lib/vutuv_web/live/account_activity_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "This log keeps one day of history."
 msgid_plural "This log keeps %{formatted} days of history."
@@ -17137,7 +17137,7 @@ msgstr "Benutzername geändert"
 msgid "Visibility settings changed"
 msgstr "Sichtbarkeitseinstellungen geändert"
 
-#: lib/vutuv_web/live/account_activity_live.ex:273
+#: lib/vutuv_web/live/account_activity_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Was this you?"
 msgstr "Waren Sie das?"
@@ -17146,11 +17146,6 @@ msgstr "Waren Sie das?"
 #, elixir-autogen, elixir-format
 msgid "What changed on an account, when, from where and how it was confirmed - the answer to \"I didn't do anything!\". Opening it is recorded in your own log."
 msgstr "Was sich an einem Konto geändert hat, wann, von wo und wie es bestätigt wurde: die Antwort auf \"Ich habe doch nichts gemacht!\". Dass Sie es öffnen, wird in Ihrem eigenen Protokoll festgehalten."
-
-#: lib/vutuv_web/live/admin/activity_live.ex:197
-#, elixir-autogen, elixir-format
-msgid "What changed on which account, when, from where and how it was confirmed - the same log every member sees for themselves. Opening it is recorded in your own activity log."
-msgstr "Was sich an welchem Konto geändert hat, wann, von wo und wie es bestätigt wurde: dasselbe Protokoll, das jedes Mitglied für sich selbst sieht. Dass Sie es öffnen, wird in Ihrem eigenen Aktivitätsprotokoll festgehalten."
 
 #: lib/vutuv_web/templates/settings/security.html.heex:39
 #, elixir-autogen, elixir-format
@@ -17168,13 +17163,7 @@ msgstr "Was sich an Ihrem Konto geändert hat, und wann"
 msgid "What happened"
 msgstr "Was geschehen ist"
 
-#: lib/vutuv_web/live/account_activity_live.ex:272
-#: lib/vutuv_web/live/admin/activity_live.ex:296
-#, elixir-autogen, elixir-format
-msgid "Where from"
-msgstr "Von wo"
-
-#: lib/vutuv_web/live/admin/activity_live.ex:382
+#: lib/vutuv_web/live/admin/activity_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "a deleted account"
 msgstr "einem gelöschten Konto"
@@ -17193,12 +17182,6 @@ msgstr "ein Wort oder eine Wortgruppe"
 #, elixir-autogen, elixir-format
 msgid "by the site operators"
 msgstr "durch den Betreiber"
-
-#: lib/vutuv_web/live/account_activity_live.ex:210
-#: lib/vutuv_web/live/admin/activity_live.ex:240
-#, elixir-autogen, elixir-format
-msgid "device, IP address or detail"
-msgstr "Gerät, IP-Adresse oder Detail"
 
 #: lib/vutuv_web/views/account_event_text.ex:138
 #, elixir-autogen, elixir-format
@@ -17239,3 +17222,20 @@ msgstr "mit einem per E-Mail geschickten PIN"
 #, elixir-autogen, elixir-format
 msgid "with your authenticator app"
 msgstr "mit Ihrer Authenticator-App"
+
+#: lib/vutuv_web/live/account_activity_live.ex:265
+#: lib/vutuv_web/live/admin/activity_live.ex:296
+#, elixir-autogen, elixir-format
+msgid "Device"
+msgstr "Gerät"
+
+#: lib/vutuv_web/live/admin/activity_live.ex:197
+#, elixir-autogen, elixir-format
+msgid "What changed on which account, when, from which device and how it was confirmed - the same log every member sees for themselves. Opening it is recorded in your own activity log."
+msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wie es bestätigt wurde: dasselbe Protokoll, das jedes Mitglied für sich selbst sieht. Dass Sie es öffnen, wird in Ihrem eigenen Aktivitätsprotokoll festgehalten."
+
+#: lib/vutuv_web/live/account_activity_live.ex:203
+#: lib/vutuv_web/live/admin/activity_live.ex:240
+#, elixir-autogen, elixir-format
+msgid "device or detail"
+msgstr "Gerät oder Detail"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:201
+#: lib/vutuv_web/live/account_activity_live.ex:194
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:244
@@ -5350,7 +5350,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3533
 #: lib/vutuv_web/components/ui.ex:3597
 #: lib/vutuv_web/controllers/settings_controller.ex:53
-#: lib/vutuv_web/live/account_activity_live.ex:162
+#: lib/vutuv_web/live/account_activity_live.ex:155
 #: lib/vutuv_web/live/fediverse_followers_live.ex:185
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
@@ -6860,7 +6860,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:212
 #: lib/vutuv_web/agent_docs/text.ex:200
-#: lib/vutuv_web/live/account_activity_live.ex:219
+#: lib/vutuv_web/live/account_activity_live.ex:212
 #: lib/vutuv_web/live/admin/activity_live.ex:249
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
@@ -7909,7 +7909,7 @@ msgstr ""
 msgid "Awaiting verification"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:241
+#: lib/vutuv_web/live/account_activity_live.ex:234
 #: lib/vutuv_web/live/admin/activity_live.ex:269
 #: lib/vutuv_web/live/admin/user_live.ex:209
 #: lib/vutuv_web/live/fediverse_followers_live.ex:278
@@ -8431,7 +8431,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3327
 #: lib/vutuv_web/controllers/settings_controller.ex:97
-#: lib/vutuv_web/live/account_activity_live.ex:375
+#: lib/vutuv_web/live/account_activity_live.ex:365
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/totp/new.html.heex:5
@@ -13190,7 +13190,7 @@ msgid "Email me"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:62
-#: lib/vutuv_web/live/account_activity_live.ex:223
+#: lib/vutuv_web/live/account_activity_live.ex:216
 #: lib/vutuv_web/live/admin/activity_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Everything"
@@ -15875,8 +15875,8 @@ msgstr ""
 msgid "Show only followers from this server"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:341
-#: lib/vutuv_web/live/admin/activity_live.ex:360
+#: lib/vutuv_web/live/account_activity_live.ex:331
+#: lib/vutuv_web/live/admin/activity_live.ex:357
 #: lib/vutuv_web/live/fediverse_followers_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Showing %{first}-%{last} of %{total}."
@@ -16061,9 +16061,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3331
 #: lib/vutuv_web/live/account_activity_live.ex:40
-#: lib/vutuv_web/live/account_activity_live.ex:161
-#: lib/vutuv_web/live/account_activity_live.ex:162
-#: lib/vutuv_web/live/account_activity_live.ex:167
+#: lib/vutuv_web/live/account_activity_live.ex:154
+#: lib/vutuv_web/live/account_activity_live.ex:155
+#: lib/vutuv_web/live/account_activity_live.ex:160
 #: lib/vutuv_web/live/admin/activity_live.ex:41
 #: lib/vutuv_web/live/admin/activity_live.ex:190
 #: lib/vutuv_web/live/admin/activity_live.ex:191
@@ -16127,7 +16127,7 @@ msgstr ""
 msgid "CV update notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:301
+#: lib/vutuv_web/live/account_activity_live.ex:294
 #: lib/vutuv_web/live/admin/activity_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
@@ -16168,7 +16168,7 @@ msgstr ""
 msgid "Endorsement emails"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:176
+#: lib/vutuv_web/live/account_activity_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Every change to your account: what changed, exactly when, from which device, and how it was confirmed. If a line surprises you, follow the link at the end of it."
 msgstr ""
@@ -16213,7 +16213,7 @@ msgstr ""
 msgid "Identity verified"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:359
+#: lib/vutuv_web/live/account_activity_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "If something here was not you"
 msgstr ""
@@ -16223,7 +16223,7 @@ msgstr ""
 msgid "Import applied"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:372
+#: lib/vutuv_web/live/account_activity_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "It is part of your data download, and it is deleted with your account."
 msgstr ""
@@ -16258,23 +16258,23 @@ msgstr ""
 msgid "No account activity has been recorded yet."
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:310
+#: lib/vutuv_web/live/account_activity_live.ex:303
 #: lib/vutuv_web/templates/settings/security.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "Not by you"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:332
+#: lib/vutuv_web/live/account_activity_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "Not you?"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:183
+#: lib/vutuv_web/live/account_activity_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. The next time you sign in or change a setting, it will be listed here."
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:250
+#: lib/vutuv_web/live/account_activity_live.ex:243
 #: lib/vutuv_web/live/admin/activity_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
@@ -16345,7 +16345,7 @@ msgstr ""
 msgid "Show only this member"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:361
+#: lib/vutuv_web/live/account_activity_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Sign every other device out, then check which passkeys, codes and email addresses your account has. All of it is on the sign-in & security page."
 msgstr ""
@@ -16360,7 +16360,7 @@ msgstr ""
 msgid "Signed out"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:366
+#: lib/vutuv_web/live/account_activity_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "This log keeps one day of history."
 msgid_plural "This log keeps %{formatted} days of history."
@@ -16392,7 +16392,7 @@ msgstr ""
 msgid "Visibility settings changed"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:273
+#: lib/vutuv_web/live/account_activity_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Was this you?"
 msgstr ""
@@ -16400,11 +16400,6 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "What changed on an account, when, from where and how it was confirmed - the answer to \"I didn't do anything!\". Opening it is recorded in your own log."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/activity_live.ex:197
-#, elixir-autogen, elixir-format
-msgid "What changed on which account, when, from where and how it was confirmed - the same log every member sees for themselves. Opening it is recorded in your own activity log."
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/security.html.heex:39
@@ -16423,13 +16418,7 @@ msgstr ""
 msgid "What happened"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:272
-#: lib/vutuv_web/live/admin/activity_live.ex:296
-#, elixir-autogen, elixir-format
-msgid "Where from"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/activity_live.ex:382
+#: lib/vutuv_web/live/admin/activity_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "a deleted account"
 msgstr ""
@@ -16447,12 +16436,6 @@ msgstr ""
 #: lib/vutuv_web/views/account_event_text.ex:139
 #, elixir-autogen, elixir-format
 msgid "by the site operators"
-msgstr ""
-
-#: lib/vutuv_web/live/account_activity_live.ex:210
-#: lib/vutuv_web/live/admin/activity_live.ex:240
-#, elixir-autogen, elixir-format
-msgid "device, IP address or detail"
 msgstr ""
 
 #: lib/vutuv_web/views/account_event_text.ex:138
@@ -16493,4 +16476,21 @@ msgstr ""
 #: lib/vutuv_web/views/account_event_text.ex:135
 #, elixir-autogen, elixir-format
 msgid "with your authenticator app"
+msgstr ""
+
+#: lib/vutuv_web/live/account_activity_live.ex:265
+#: lib/vutuv_web/live/admin/activity_live.ex:296
+#, elixir-autogen, elixir-format
+msgid "Device"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/activity_live.ex:197
+#, elixir-autogen, elixir-format
+msgid "What changed on which account, when, from which device and how it was confirmed - the same log every member sees for themselves. Opening it is recorded in your own activity log."
+msgstr ""
+
+#: lib/vutuv_web/live/account_activity_live.ex:203
+#: lib/vutuv_web/live/admin/activity_live.ex:240
+#, elixir-autogen, elixir-format
+msgid "device or detail"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:201
+#: lib/vutuv_web/live/account_activity_live.ex:194
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
 #: lib/vutuv_web/live/admin/user_live.ex:244
@@ -5348,7 +5348,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3533
 #: lib/vutuv_web/components/ui.ex:3597
 #: lib/vutuv_web/controllers/settings_controller.ex:53
-#: lib/vutuv_web/live/account_activity_live.ex:162
+#: lib/vutuv_web/live/account_activity_live.ex:155
 #: lib/vutuv_web/live/fediverse_followers_live.ex:185
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
@@ -6858,7 +6858,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:212
 #: lib/vutuv_web/agent_docs/text.ex:200
-#: lib/vutuv_web/live/account_activity_live.ex:219
+#: lib/vutuv_web/live/account_activity_live.ex:212
 #: lib/vutuv_web/live/admin/activity_live.ex:249
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
@@ -7907,7 +7907,7 @@ msgstr ""
 msgid "Awaiting verification"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:241
+#: lib/vutuv_web/live/account_activity_live.ex:234
 #: lib/vutuv_web/live/admin/activity_live.ex:269
 #: lib/vutuv_web/live/admin/user_live.ex:209
 #: lib/vutuv_web/live/fediverse_followers_live.ex:278
@@ -8429,7 +8429,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3327
 #: lib/vutuv_web/controllers/settings_controller.ex:97
-#: lib/vutuv_web/live/account_activity_live.ex:375
+#: lib/vutuv_web/live/account_activity_live.ex:365
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/totp/new.html.heex:5
@@ -13188,7 +13188,7 @@ msgid "Email me"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:62
-#: lib/vutuv_web/live/account_activity_live.ex:223
+#: lib/vutuv_web/live/account_activity_live.ex:216
 #: lib/vutuv_web/live/admin/activity_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Everything"
@@ -15873,8 +15873,8 @@ msgstr ""
 msgid "Show only followers from this server"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:341
-#: lib/vutuv_web/live/admin/activity_live.ex:360
+#: lib/vutuv_web/live/account_activity_live.ex:331
+#: lib/vutuv_web/live/admin/activity_live.ex:357
 #: lib/vutuv_web/live/fediverse_followers_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Showing %{first}-%{last} of %{total}."
@@ -16059,9 +16059,9 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3331
 #: lib/vutuv_web/live/account_activity_live.ex:40
-#: lib/vutuv_web/live/account_activity_live.ex:161
-#: lib/vutuv_web/live/account_activity_live.ex:162
-#: lib/vutuv_web/live/account_activity_live.ex:167
+#: lib/vutuv_web/live/account_activity_live.ex:154
+#: lib/vutuv_web/live/account_activity_live.ex:155
+#: lib/vutuv_web/live/account_activity_live.ex:160
 #: lib/vutuv_web/live/admin/activity_live.ex:41
 #: lib/vutuv_web/live/admin/activity_live.ex:190
 #: lib/vutuv_web/live/admin/activity_live.ex:191
@@ -16125,7 +16125,7 @@ msgstr ""
 msgid "CV update notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:301
+#: lib/vutuv_web/live/account_activity_live.ex:294
 #: lib/vutuv_web/live/admin/activity_live.ex:338
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirmed"
@@ -16166,7 +16166,7 @@ msgstr ""
 msgid "Endorsement emails"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:176
+#: lib/vutuv_web/live/account_activity_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Every change to your account: what changed, exactly when, from which device, and how it was confirmed. If a line surprises you, follow the link at the end of it."
 msgstr ""
@@ -16211,7 +16211,7 @@ msgstr ""
 msgid "Identity verified"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:359
+#: lib/vutuv_web/live/account_activity_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "If something here was not you"
 msgstr ""
@@ -16221,7 +16221,7 @@ msgstr ""
 msgid "Import applied"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:372
+#: lib/vutuv_web/live/account_activity_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "It is part of your data download, and it is deleted with your account."
 msgstr ""
@@ -16256,23 +16256,23 @@ msgstr ""
 msgid "No account activity has been recorded yet."
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:310
+#: lib/vutuv_web/live/account_activity_live.ex:303
 #: lib/vutuv_web/templates/settings/security.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "Not by you"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:332
+#: lib/vutuv_web/live/account_activity_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "Not you?"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:183
+#: lib/vutuv_web/live/account_activity_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. The next time you sign in or change a setting, it will be listed here."
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:250
+#: lib/vutuv_web/live/account_activity_live.ex:243
 #: lib/vutuv_web/live/admin/activity_live.ex:275
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
@@ -16343,7 +16343,7 @@ msgstr ""
 msgid "Show only this member"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:361
+#: lib/vutuv_web/live/account_activity_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Sign every other device out, then check which passkeys, codes and email addresses your account has. All of it is on the sign-in & security page."
 msgstr ""
@@ -16358,7 +16358,7 @@ msgstr ""
 msgid "Signed out"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:366
+#: lib/vutuv_web/live/account_activity_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "This log keeps one day of history."
 msgid_plural "This log keeps %{formatted} days of history."
@@ -16390,7 +16390,7 @@ msgstr ""
 msgid "Visibility settings changed"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:273
+#: lib/vutuv_web/live/account_activity_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Was this you?"
 msgstr ""
@@ -16398,11 +16398,6 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:106
 #, elixir-autogen, elixir-format
 msgid "What changed on an account, when, from where and how it was confirmed - the answer to \"I didn't do anything!\". Opening it is recorded in your own log."
-msgstr ""
-
-#: lib/vutuv_web/live/admin/activity_live.ex:197
-#, elixir-autogen, elixir-format
-msgid "What changed on which account, when, from where and how it was confirmed - the same log every member sees for themselves. Opening it is recorded in your own activity log."
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/security.html.heex:39
@@ -16421,13 +16416,7 @@ msgstr ""
 msgid "What happened"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:272
-#: lib/vutuv_web/live/admin/activity_live.ex:296
-#, elixir-autogen, elixir-format
-msgid "Where from"
-msgstr ""
-
-#: lib/vutuv_web/live/admin/activity_live.ex:382
+#: lib/vutuv_web/live/admin/activity_live.ex:379
 #, elixir-autogen, elixir-format, fuzzy
 msgid "a deleted account"
 msgstr ""
@@ -16445,12 +16434,6 @@ msgstr ""
 #: lib/vutuv_web/views/account_event_text.ex:139
 #, elixir-autogen, elixir-format
 msgid "by the site operators"
-msgstr ""
-
-#: lib/vutuv_web/live/account_activity_live.ex:210
-#: lib/vutuv_web/live/admin/activity_live.ex:240
-#, elixir-autogen, elixir-format
-msgid "device, IP address or detail"
 msgstr ""
 
 #: lib/vutuv_web/views/account_event_text.ex:138
@@ -16491,4 +16474,21 @@ msgstr ""
 #: lib/vutuv_web/views/account_event_text.ex:135
 #, elixir-autogen, elixir-format
 msgid "with your authenticator app"
+msgstr ""
+
+#: lib/vutuv_web/live/account_activity_live.ex:265
+#: lib/vutuv_web/live/admin/activity_live.ex:296
+#, elixir-autogen, elixir-format
+msgid "Device"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/activity_live.ex:197
+#, elixir-autogen, elixir-format, fuzzy
+msgid "What changed on which account, when, from which device and how it was confirmed - the same log every member sees for themselves. Opening it is recorded in your own activity log."
+msgstr ""
+
+#: lib/vutuv_web/live/account_activity_live.ex:203
+#: lib/vutuv_web/live/admin/activity_live.ex:240
+#, elixir-autogen, elixir-format
+msgid "device or detail"
 msgstr ""

--- a/priv/repo/migrations/20260725155214_clear_account_event_ip_addresses.exs
+++ b/priv/repo/migrations/20260725155214_clear_account_event_ip_addresses.exs
@@ -1,0 +1,19 @@
+defmodule Vutuv.Repo.Migrations.ClearAccountEventIpAddresses do
+  use Ecto.Migration
+
+  # The account-activity log no longer keeps an IP address (issue #1087's first
+  # cut did). Step 1 of the expand/contract: this release's code neither writes
+  # nor reads the column, and this wipes what the previous release stored, so the
+  # data is gone the moment the deploy lands rather than waiting for the drop.
+  #
+  # N-1 safe: the release still serving traffic during the migration selects the
+  # column and simply reads NULL. The column itself is dropped one release later
+  # (DropAccountEventIpAddresses) — dropping it here would 500 that release.
+  def up do
+    execute("UPDATE account_events SET ip_address = NULL")
+  end
+
+  # Deliberately irreversible: the addresses are deleted, and a down migration
+  # that pretended otherwise would be a lie.
+  def down, do: :ok
+end

--- a/test/vutuv/account_events_test.exs
+++ b/test/vutuv/account_events_test.exs
@@ -17,18 +17,12 @@ defmodule Vutuv.AccountEventsTest do
     test "stores who, what, when, from where and how it was confirmed" do
       user = insert(:user)
 
-      :ok =
-        AccountEvents.record(user, "signed_in",
-          factor: "passkey",
-          ip: "203.0.113.4",
-          device: "Chrome on macOS"
-        )
+      :ok = AccountEvents.record(user, "signed_in", factor: "passkey", device: "Chrome on macOS")
 
       assert [event] = Repo.all(AccountEvent)
       assert event.user_id == user.id
       assert event.kind == "signed_in"
       assert event.factor == "passkey"
-      assert event.ip_address == "203.0.113.4"
       assert event.device == "Chrome on macOS"
       assert event.actor_user_id == nil
       assert %DateTime{} = event.inserted_at
@@ -59,7 +53,7 @@ defmodule Vutuv.AccountEventsTest do
       assert event.actor_user_id == admin.id
     end
 
-    test "takes the IP and a COARSE device summary from a conn, never the raw User-Agent" do
+    test "takes a COARSE device summary from a conn, never the raw User-Agent or the IP" do
       user = insert(:user)
 
       ua =
@@ -73,9 +67,11 @@ defmodule Vutuv.AccountEventsTest do
       :ok = AccountEvents.record(user, "signed_in", conn: conn)
 
       assert [event] = Repo.all(AccountEvent)
-      assert event.ip_address == "203.0.113.9"
       assert event.device == "Chrome on macOS"
       refute event.device =~ "AppleWebKit"
+      # The conn knows the address; the log deliberately does not keep it.
+      refute Map.has_key?(event, :ip_address)
+      refute inspect(event) =~ "203.0.113.9"
     end
 
     test "an undeclared kind is refused (and never raises on the caller)" do
@@ -131,17 +127,20 @@ defmodule Vutuv.AccountEventsTest do
       user = insert(:user)
       other = insert(:user)
 
-      :ok = AccountEvents.record(user, "signed_in", factor: "pin", ip: "203.0.113.1")
+      :ok = AccountEvents.record(user, "signed_in", factor: "pin", device: "Firefox on Linux")
       :ok = AccountEvents.record(user, "passkey_added", details: %{nickname: "Work laptop"})
-      :ok = AccountEvents.record(other, "signed_in", ip: "198.51.100.7")
+      :ok = AccountEvents.record(other, "signed_in", device: "Safari on iPhone")
 
       %{user: user, other: other}
     end
 
     test "only the member's own events", %{user: user} do
       assert AccountEvents.count(user, AccountEvents.filters(%{})) == 2
-      ips = user |> AccountEvents.page(AccountEvents.filters(%{})) |> Enum.map(& &1.ip_address)
-      refute "198.51.100.7" in ips
+
+      devices =
+        user |> AccountEvents.page(AccountEvents.filters(%{})) |> Enum.map(& &1.device)
+
+      refute "Safari on iPhone" in devices
     end
 
     test "newest first by default", %{user: user} do
@@ -166,9 +165,9 @@ defmodule Vutuv.AccountEventsTest do
       assert AccountEvents.count(user, filters) == 2
     end
 
-    test "searches the IP, the factor and the details", %{user: user} do
+    test "searches the device, the factor and the details", %{user: user} do
       assert [%{kind: "signed_in"}] =
-               AccountEvents.page(user, AccountEvents.filters(%{"q" => "203.0.113"}))
+               AccountEvents.page(user, AccountEvents.filters(%{"q" => "Firefox"}))
 
       assert [%{kind: "signed_in"}] =
                AccountEvents.page(user, AccountEvents.filters(%{"q" => "pin"}))
@@ -251,12 +250,15 @@ defmodule Vutuv.AccountEventsTest do
   describe "the log is personal data" do
     test "rides along in the GDPR export" do
       user = insert(:user)
-      :ok = AccountEvents.record(user, "signed_in", factor: "pin", ip: "203.0.113.1")
+      :ok = AccountEvents.record(user, "signed_in", factor: "pin", device: "Chrome on macOS")
 
       assert %{account_events: [entry]} = Vutuv.Export.build(user)
       assert entry.kind == "signed_in"
       assert entry.factor == "pin"
+      assert entry.device == "Chrome on macOS"
       assert entry.by_someone_else == false
+      # Nothing to export: the log does not keep an IP address.
+      refute Map.has_key?(entry, :ip_address)
     end
 
     test "is deleted with the account" do

--- a/test/vutuv_web/account_event_hooks_test.exs
+++ b/test/vutuv_web/account_event_hooks_test.exs
@@ -23,7 +23,9 @@ defmodule VutuvWeb.AccountEventHooksTest do
   end
 
   describe "signing in and out" do
-    test "an emailed-PIN login is recorded with its factor, device and IP", %{conn: conn} do
+    test "an emailed-PIN login is recorded with its factor and device, not its IP", %{
+      conn: conn
+    } do
       user = insert(:user, email_confirmed?: true)
       insert(:email, value: "hook-login@example.com", user: user)
 
@@ -36,7 +38,7 @@ defmodule VutuvWeb.AccountEventHooksTest do
       assert [event] = events(user, "signed_in")
       assert event.factor == "pin"
       assert event.device == "Safari on iPhone"
-      assert event.ip_address
+      refute Map.has_key?(event, :ip_address)
     end
 
     test "logging out is recorded too", %{conn: conn} do

--- a/test/vutuv_web/live/account_activity_live_test.exs
+++ b/test/vutuv_web/live/account_activity_live_test.exs
@@ -37,7 +37,6 @@ defmodule VutuvWeb.AccountActivityLiveTest do
       :ok =
         AccountEvents.record(user, "username_changed",
           factor: "passkey",
-          ip: "203.0.113.55",
           device: "Firefox on Linux",
           details: %{from: "old_name", to: "new_name"}
         )
@@ -55,7 +54,11 @@ defmodule VutuvWeb.AccountActivityLiveTest do
       # them and the client rewrite is told to keep them.
       assert html =~ ~s(data-localtime="second")
       assert html =~ "Firefox on Linux"
-      assert html =~ "203.0.113.55"
+
+      # The IP was dropped from the log, so no row can show one. Scoped to the
+      # rows: a page-wide match would trip over any dotted number in the chrome.
+      refute live |> element("#activity-events") |> render() =~
+               ~r/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/
     end
 
     test "every row offers the way out", %{conn: conn} do
@@ -78,7 +81,7 @@ defmodule VutuvWeb.AccountActivityLiveTest do
       assert_patched(live, ~p"/settings/activity?kind=passkey_added")
     end
 
-    test "search matches the device, the IP and the details", %{conn: conn} do
+    test "search matches the device and the details", %{conn: conn} do
       {:ok, live, _html} = live(conn, ~p"/settings/activity")
 
       live |> element("#activity-filter") |> render_change(%{"q" => "Work laptop"})
@@ -86,7 +89,7 @@ defmodule VutuvWeb.AccountActivityLiveTest do
       assert rows =~ "Passkey added"
       refute rows =~ "Username changed"
 
-      live |> element("#activity-filter") |> render_change(%{"q" => "203.0.113.55"})
+      live |> element("#activity-filter") |> render_change(%{"q" => "Firefox on Linux"})
       rows = live |> element("#activity-events") |> render()
       assert rows =~ "Username changed"
       refute rows =~ "Passkey added"
@@ -122,11 +125,11 @@ defmodule VutuvWeb.AccountActivityLiveTest do
 
     test "only the member's own events, never another account's", %{conn: conn, user: user} do
       stranger = insert(:user)
-      :ok = AccountEvents.record(stranger, "signed_in", ip: "198.51.100.99")
+      :ok = AccountEvents.record(stranger, "signed_in", device: "Opera on Windows")
 
       {:ok, live_view, _html} = live(conn, ~p"/settings/activity")
 
-      refute live_view |> element("#activity-events") |> render() =~ "198.51.100.99"
+      refute live_view |> element("#activity-events") |> render() =~ "Opera on Windows"
       assert AccountEvents.count(user, AccountEvents.filters(%{})) == 3
     end
   end

--- a/test/vutuv_web/live/admin/activity_live_test.exs
+++ b/test/vutuv_web/live/admin/activity_live_test.exs
@@ -41,7 +41,7 @@ defmodule VutuvWeb.Admin.ActivityLiveTest do
       bert = insert(:user, username: "admin-log-bert", first_name: "Bert")
 
       :ok = AccountEvents.record(anna, "passkey_added", details: %{nickname: "Anna's phone"})
-      :ok = AccountEvents.record(bert, "totp_enabled", ip: "198.51.100.42")
+      :ok = AccountEvents.record(bert, "totp_enabled", device: "Opera on Windows")
 
       %{conn: conn, admin: admin, anna: anna, bert: bert}
     end
@@ -75,10 +75,10 @@ defmodule VutuvWeb.Admin.ActivityLiveTest do
       assert_patched(live, ~p"/admin/activity?member=admin-log-bert")
     end
 
-    test "search matches the IP", %{conn: conn} do
+    test "search matches the device", %{conn: conn} do
       {:ok, live, _html} = live(conn, ~p"/admin/activity")
 
-      live |> element("#activity-filter") |> render_change(%{"q" => "198.51.100.42"})
+      live |> element("#activity-filter") |> render_change(%{"q" => "Opera on Windows"})
 
       rows = live |> element("#activity-events") |> render()
       assert rows =~ "admin-log-bert"


### PR DESCRIPTION
Follow-up to #1097.

The log shipped with the request IP on every row. It is not worth keeping: the member's question is "was that me?", and the coarse device summary, the exact time and the confirming factor answer it. What the IP adds is a year of addresses per account, sitting in a table an admin page, every backup and every support conversation can read — a movement profile nobody asked us to keep, in the one place built to be safe to leak.

## This PR (deploy 1 of 2)

- Nothing writes or reads `account_events.ip_address` any more: the column is off the schema, off both activity pages, out of the search, out of the GDPR export.
- A migration **nulls what the previous release stored**, so the addresses are gone the moment this deploy lands rather than waiting for the drop.
- "Where from" becomes "Device"; the search placeholder loses "IP address".

## Deploy 2 (separate PR, right after this one is live)

The `ip_address` column itself. It cannot go here: under the blue/green N-1 rule the release still serving traffic during the migration selects that column, so dropping it now would 500 it.

## Not touched

`user_sessions` keeps its own IP per signed-in device — that is the signed-in-devices list and the new-device security email (#794, #786), a different feature with its own lifetime and its own reason to know where a login came from. Say the word if you want that gone too; it is a separate decision.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_015TuYrPu1TVk8huerAbErc7