### PR TITLE
Drop the account-activity log's ip_address column (#1087)

### DIFF
--- a/docs/architecture/account-activity.md
+++ b/docs/architecture/account-activity.md
@@ -37,8 +37,8 @@ movement profile nobody asked us to keep, sitting in a table an admin page and
 every backup can read. (`user_sessions` still stores one per signed-in device:
 that is the devices list and the new-device security email, a different feature
 with its own lifetime.) Removing it took two releases, per the N-1 migration
-rule: one that stopped writing and reading the column and nulled what was
-already there, then one that dropped it.
+rule: v7.159.1 stopped writing and reading the column and nulled what was
+already there, v7.159.2 dropped it.
 
 ## What may never be in it
 

--- a/lib/vutuv/account_events/account_event.ex
+++ b/lib/vutuv/account_events/account_event.ex
@@ -12,9 +12,8 @@ defmodule Vutuv.AccountEvents.AccountEvent do
   must be a declared one and every `details` key must be whitelisted for that
   kind, which is what keeps secrets and private values out of a table that a
   backup, an admin page and a support conversation all touch. There is
-  deliberately **no IP address** — the `ip_address` column is dropped in the
-  release after this one (an N-1-safe expand/contract), and nothing reads or
-  writes it any more.
+  deliberately **no IP address** — the `ip_address` column was removed
+  across v7.159.1 and v7.159.2 (an N-1-safe expand/contract).
   """
 
   use VutuvWeb, :model

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.159.1",
+      version: "7.159.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260725160420_drop_account_event_ip_addresses.exs
+++ b/priv/repo/migrations/20260725160420_drop_account_event_ip_addresses.exs
@@ -1,0 +1,17 @@
+defmodule Vutuv.Repo.Migrations.DropAccountEventIpAddresses do
+  use Ecto.Migration
+
+  # Step 2 of the expand/contract that took the IP address out of the
+  # account-activity log (issue #1087). The previous release already stopped
+  # writing and reading this column and nulled every value in it
+  # (ClearAccountEventIpAddresses), so the release still serving traffic while
+  # this runs never touches it and the drop is N-1 safe.
+  #
+  # `change` rather than up/down: the rollback re-adds an empty nullable column,
+  # which is exactly the state the previous release is happy with.
+  def change do
+    alter table(:account_events) do
+      remove(:ip_address, :string)
+    end
+  end
+end


### PR DESCRIPTION
Deploy 2 of 2, following #1098.

v7.159.1 stopped writing and reading `account_events.ip_address` and nulled every value in it. The release still serving traffic while this migration runs therefore never touches the column, which is what makes the drop N-1 safe — and nothing is deleted here that was not already emptied a release ago.

That closes out the removal: the account-activity log now keeps what changed, exactly when, from which coarse device and how it was confirmed, and no addresses.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_015TuYrPu1TVk8huerAbErc7