### PR TITLE
Fix the German translations across the whole catalog

### DIFF
--- a/lib/vutuv/notifications/emailer.ex
+++ b/lib/vutuv/notifications/emailer.ex
@@ -757,7 +757,7 @@ defmodule Vutuv.Notifications.Emailer do
       :verified,
       organization,
       domain,
-      "vutuv: Firmenseite verifiziert - #{organization.name}"
+      "vutuv: Organisationsseite verifiziert - #{organization.name}"
     )
   end
 
@@ -767,7 +767,7 @@ defmodule Vutuv.Notifications.Emailer do
       :unverified,
       organization,
       domain,
-      "vutuv: Firmenseite nicht mehr verifiziert - #{organization.name}"
+      "vutuv: Organisationsseite nicht mehr verifiziert - #{organization.name}"
     )
   end
 

--- a/lib/vutuv_web/templates/email/organization_domain_grace_de.text.eex
+++ b/lib/vutuv_web/templates/email/organization_domain_grace_de.text.eex
@@ -1,6 +1,6 @@
 <%= email_greeting(@user) %>,
 
-der Domain-Nachweis Ihrer Firmenseite "<%= @organization_name %>" lässt sich nicht mehr
+der Domain-Nachweis Ihrer Organisationsseite "<%= @organization_name %>" lässt sich nicht mehr
 abrufen. Betroffen ist die Domain <%= @domain %>.
 
 Wir prüfen den Nachweis wöchentlich, und Sie haben bis zum

--- a/lib/vutuv_web/templates/email/organization_operator_notice_de.text.eex
+++ b/lib/vutuv_web/templates/email/organization_operator_notice_de.text.eex
@@ -1,11 +1,11 @@
-<%= cond do %><% @kind == :verified -> %>Eine Firmenseite wurde soeben über die Domain <%= @domain.domain %> verifiziert und ist jetzt öffentlich.<% @kind == :domain_dropped -> %>Eine Firmenseite hat die Domain <%= @domain.domain %> verloren (sie war nach der Prüfung nicht mehr nachweisbar). Die Seite bleibt über ihre übrigen Domains verifiziert und öffentlich.<% true -> %>Eine Firmenseite hat ihre letzte verifizierte Domain (<%= @domain.domain %>) verloren und steht wieder auf "pending". Sie ist nicht mehr öffentlich sichtbar.<% end %>
+<%= cond do %><% @kind == :verified -> %>Eine Organisationsseite wurde soeben über die Domain <%= @domain.domain %> verifiziert und ist jetzt öffentlich.<% @kind == :domain_dropped -> %>Eine Organisationsseite hat die Domain <%= @domain.domain %> verloren (sie war nach der Prüfung nicht mehr nachweisbar). Die Seite bleibt über ihre übrigen Domains verifiziert und öffentlich.<% true -> %>Eine Organisationsseite hat ihre letzte verifizierte Domain (<%= @domain.domain %>) verloren und steht wieder auf "pending". Sie ist nicht mehr öffentlich sichtbar.<% end %>
 
-Firma:      <%= @organization.name %>
-Seite:      <%= @page_url %>
-Domain:     <%= @domain.domain %> (<%= @domain.method %>)
-Verwaltung: <%= @admin_url %>
+Organisation: <%= @organization.name %>
+Seite:        <%= @page_url %>
+Domain:       <%= @domain.domain %> (<%= @domain.method %>)
+Verwaltung:   <%= @admin_url %>
 
-Diese Nachricht dient der Kontrolle neuer bzw. auffälliger Firmenseiten,
+Diese Nachricht dient der Kontrolle neuer bzw. auffälliger Organisationsseiten,
 solange das Volumen gering ist.
 
 <%= render "_footer.text" %>

--- a/lib/vutuv_web/templates/email/organization_page_unverified_de.text.eex
+++ b/lib/vutuv_web/templates/email/organization_page_unverified_de.text.eex
@@ -1,6 +1,6 @@
 <%= email_greeting(@user) %>,
 
-Ihre Firmenseite "<%= @organization_name %>" hat ihre letzte verifizierte Domain verloren
+Ihre Organisationsseite "<%= @organization_name %>" hat ihre letzte verifizierte Domain verloren
 und steht wieder auf "Verifizierung ausstehend". Sie ist damit nicht mehr öffentlich
 sichtbar. Betroffen ist die Domain <%= @domain %>.
 

--- a/lib/vutuv_web/templates/email_body/organization_domain_grace_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/organization_domain_grace_de.html.heex
@@ -1,7 +1,7 @@
-<.email_layout preheader="Der Domain-Nachweis Ihrer Firmenseite fehlt" locale={@locale}>
+<.email_layout preheader="Der Domain-Nachweis Ihrer Organisationsseite fehlt" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
-    der Domain-Nachweis Ihrer Firmenseite „{@organization_name}" lässt sich nicht mehr abrufen.
+    der Domain-Nachweis Ihrer Organisationsseite „{@organization_name}" lässt sich nicht mehr abrufen.
     Betroffen ist die Domain <strong>{@domain}</strong>. Wir prüfen den Nachweis wöchentlich, und
     Sie haben bis zum <strong>{Calendar.strftime(@deadline, "%d.%m.%Y")}</strong> Zeit, ihn
     wiederherzustellen.

--- a/lib/vutuv_web/templates/email_body/organization_operator_notice_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/organization_operator_notice_de.html.heex
@@ -1,25 +1,25 @@
-<.email_layout preheader="vutuv Firmenseite" locale="de">
+<.email_layout preheader="vutuv Organisationsseite" locale="de">
   <%= cond do %>
     <% @kind == :verified -> %>
       <.email_p>
-        Eine Firmenseite wurde soeben über die Domain <strong>{@domain.domain}</strong>
+        Eine Organisationsseite wurde soeben über die Domain <strong>{@domain.domain}</strong>
         verifiziert und ist jetzt öffentlich.
       </.email_p>
     <% @kind == :domain_dropped -> %>
       <.email_p>
-        Eine Firmenseite hat die Domain <strong>{@domain.domain}</strong>
+        Eine Organisationsseite hat die Domain <strong>{@domain.domain}</strong>
         verloren (sie war nach der Prüfung nicht mehr nachweisbar). Die Seite
         bleibt über ihre übrigen Domains verifiziert und öffentlich.
       </.email_p>
     <% true -> %>
       <.email_p>
-        Eine Firmenseite hat ihre letzte verifizierte Domain
+        Eine Organisationsseite hat ihre letzte verifizierte Domain
         (<strong>{@domain.domain}</strong>) verloren und steht wieder auf
         "pending". Sie ist nicht mehr öffentlich sichtbar.
       </.email_p>
   <% end %>
   <.email_p>
-    Firma: {@organization.name}<br /> Seite:
+    Organisation: {@organization.name}<br /> Seite:
     <.email_link href={@page_url}>{@page_url}</.email_link><br /> Domain: {@domain.domain}
     ({@domain.method})
   </.email_p>
@@ -28,7 +28,7 @@
     <.email_link href={@admin_url}>{@admin_url}</.email_link>
   </.email_p>
   <.email_muted>
-    Diese Nachricht dient der Kontrolle neuer bzw. auffälliger Firmenseiten,
+    Diese Nachricht dient der Kontrolle neuer bzw. auffälliger Organisationsseiten,
     solange das Volumen gering ist.
   </.email_muted>
 </.email_layout>

--- a/lib/vutuv_web/templates/email_body/organization_page_unverified_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/organization_page_unverified_de.html.heex
@@ -1,7 +1,7 @@
-<.email_layout preheader="Ihre Firmenseite ist nicht mehr öffentlich" locale={@locale}>
+<.email_layout preheader="Ihre Organisationsseite ist nicht mehr öffentlich" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>
-    Ihre Firmenseite „{@organization_name}" hat ihre letzte verifizierte Domain verloren
+    Ihre Organisationsseite „{@organization_name}" hat ihre letzte verifizierte Domain verloren
     (<strong>{@domain}</strong>) und steht wieder auf „Verifizierung ausstehend". Sie ist damit
     nicht mehr öffentlich sichtbar.
   </.email_p>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.159.2",
+      version: "7.159.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -152,7 +152,7 @@ msgstr "Kontakt"
 
 #: web/controllers/user_controller.ex:276
 msgid "Couldn't follow back to %{name}."
-msgstr "Konnte nicht zu %{name} zurückfolgen."
+msgstr "%{name} konnte nicht zurückgefolgt werden."
 
 #: lib/vutuv_web/components/post_components.ex:1271
 #: lib/vutuv_web/components/ui.ex:2967
@@ -365,7 +365,7 @@ msgstr "Deutsch"
 
 #: web/templates/page/index.html.eex:24
 msgid "Get started now. It only takes 30 seconds."
-msgstr "Ihr gratis Account ist in nicht mal 30 Sekunden fertig."
+msgstr "Ihr Gratis-Konto ist in nicht mal 30 Sekunden fertig."
 
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:4
@@ -501,7 +501,7 @@ msgstr "Spitzname"
 
 #: web/templates/user/show.html.eex:208
 msgid "No Followers yet!"
-msgstr "Noch keine Followers!"
+msgstr "Noch keine Follower!"
 
 #: web/templates/page/index.html.eex:16
 msgid "No expensive premium accounts! Read more about it in"
@@ -509,7 +509,7 @@ msgstr "Keine teuren Premium-Accounts. Lesen Sie mehr in"
 
 #: web/templates/user/show.html.eex:222
 msgid "Not following anyone yet!"
-msgstr "Keine"
+msgstr "Sie folgen noch niemandem!"
 
 #: lib/vutuv_web/templates/phone_number/show.html.heex:21
 #, elixir-autogen
@@ -666,7 +666,7 @@ msgstr "Anzeigen"
 #: lib/vutuv_web/templates/page/index.html.heex:153
 #, elixir-autogen
 msgid "Sign up for a free account"
-msgstr "Gratis Account erstellen"
+msgstr "Gratis-Konto erstellen"
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:51
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:24
@@ -708,8 +708,8 @@ msgstr "Profile von %{name}"
 #, elixir-autogen, elixir-format
 msgid "Profile created successfully. BTW: Did you know that the vutuv repo is hosted on GitHub? https://github.com/wintermeyer/vutuv"
 msgstr ""
-"Profil wurde erstellt. Wussten Sie, dass der vutuv Source-Code auf GitHub "
-"gehostet wird? https://github.com/wintermeyer/vutuv"
+"Profil wurde erstellt. Wussten Sie, dass der Quellcode von vutuv auf GitHub "
+"liegt? https://github.com/wintermeyer/vutuv"
 
 #: lib/vutuv_web/controllers/social_media_account_controller.ex:79
 #, elixir-autogen, elixir-format
@@ -774,7 +774,8 @@ msgstr "URL"
 #: web/controllers/user_controller.ex:43
 msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr ""
-"Der User %{name} wurde angelegt. Eine E-Mail mit einem PIN wurde verschickt."
+"Der Benutzer %{name} wurde angelegt. Eine E-Mail mit einer PIN wurde "
+"verschickt."
 
 #: lib/vutuv_web/controllers/user_controller.ex:314
 #, elixir-autogen
@@ -901,7 +902,7 @@ msgstr "Ein Lebenslaufeintrag wurde erstellt."
 #: lib/vutuv_web/controllers/work_experience_controller.ex:234
 #, elixir-autogen
 msgid "Work experience deleted successfully."
-msgstr "Ein Lebenlaufseintrag wurde gelöscht"
+msgstr "Ein Lebenslaufeintrag wurde gelöscht."
 
 #: lib/vutuv_web/controllers/work_experience_controller.ex:174
 #, elixir-autogen
@@ -924,7 +925,7 @@ msgstr ""
 
 #: web/controllers/user_controller.ex:272
 msgid "You follow back %{name}."
-msgstr "Sie folgen %{name}."
+msgstr "Sie folgen %{name} jetzt zurück."
 
 #: lib/vutuv_web/live/init_assigns.ex:52
 #: lib/vutuv_web/live/post_live/feed.ex:59
@@ -965,8 +966,8 @@ msgstr ""
 msgid "An email has been sent with your login link. Once you login, you'll be logged in for the next 90 days on this device, or until you log out."
 msgstr ""
 "Eine E-Mail mit einem Login-Link ist unterwegs. Wenn Sie sich damit "
-"eingeloggt haben bleiben Sie auf diesem Browser für 90 Tage eingeloggt. "
-"Natürlich können Sie sicher jederzeit manuell ausloggen (links oben)."
+"angemeldet haben, bleiben Sie auf diesem Gerät für 90 Tage angemeldet. "
+"Natürlich können Sie sich jederzeit manuell abmelden."
 
 #: lib/vutuv/magic_link_helpers.ex:87, lib/vutuv/magic_link_helpers.ex:106
 msgid "An error occured"
@@ -980,15 +981,15 @@ msgstr "Der Zeitstempel dieses Login-Links ist abgelaufen."
 #: lib/vutuv_web/templates/session/pin_user_login.html.heex:2
 #, elixir-autogen
 msgid "Please check your INBOX."
-msgstr "Bitte überprüfen Sie Ihr E-Mail Postfach."
+msgstr "Bitte überprüfen Sie Ihr E-Mail-Postfach."
 
 #: lib/vutuv_web/templates/page/pin_new_registration.html.heex:17
 #: lib/vutuv_web/templates/session/pin_user_login.html.heex:15
 #, elixir-autogen
 msgid "Please check your spam folder in case you don't find the email in your inbox."
 msgstr ""
-"Bitte überprüfen Sie Ihren SPAM Ordner, falls Sie keine E-Mail in Ihrer "
-"INBOX vorfinden."
+"Bitte überprüfen Sie Ihren Spam-Ordner, falls Sie keine E-Mail in Ihrem "
+"Posteingang vorfinden."
 
 #: lib/vutuv_web/templates/phone_number/form_content.html.heex:6
 #, elixir-autogen
@@ -1092,17 +1093,17 @@ msgstr "Geschlecht auswählen"
 #: lib/vutuv/notifications/emailer.ex:212
 #, elixir-autogen
 msgid "Confirm your account deletion"
-msgstr "PIN zum Löschen eines vutuv Accounts"
+msgstr "PIN zum Löschen eines vutuv-Kontos"
 
 #: lib/vutuv/notifications/emailer.ex:206
 #, elixir-autogen
 msgid "Confirm your email"
-msgstr "Weitere E-Mail Adresse für einen vutuv Account verifizieren"
+msgstr "Weitere E-Mail-Adresse für ein vutuv-Konto bestätigen"
 
 #: lib/vutuv/notifications/emailer.ex:194
 #, elixir-autogen
 msgid "Confirm your vutuv account"
-msgstr "vutuv Account einrichten"
+msgstr "vutuv-Konto einrichten"
 
 #: lib/vutuv/notifications/emailer.ex:200
 #, elixir-autogen
@@ -1272,8 +1273,8 @@ msgstr "Alle Tags"
 #, elixir-autogen
 msgid "An email has been sent with your PIN. Once you enter your PIN below, you'll be logged in for the next 90 days on this device, or until you log out."
 msgstr ""
-"Wir haben Ihnen eine E-Mail mit Ihrem PIN geschickt. Sobald Sie den PIN "
-"unten eingeben, bleiben Sie auf diesem Gerät für 90 Tage eingeloggt, oder "
+"Wir haben Ihnen eine E-Mail mit Ihrer PIN geschickt. Sobald Sie die PIN "
+"unten eingeben, bleiben Sie auf diesem Gerät für 90 Tage angemeldet, oder "
 "bis Sie sich abmelden."
 
 #: lib/vutuv_web/templates/admin/tag/edit.html.heex:2
@@ -1480,7 +1481,7 @@ msgstr "Tags"
 #: lib/vutuv_web/controllers/username_controller.ex:215
 #, elixir-autogen
 msgid "Too many incorrect attempts."
-msgstr "Zu viele fehlerhafter Versuche."
+msgstr "Zu viele fehlerhafte Versuche."
 
 #: web/templates/tag/single_card.html.eex:28
 msgid "Url"
@@ -1494,9 +1495,9 @@ msgstr "URLs"
 #, elixir-autogen
 msgid "Your account has been created, and an email with a PIN has been sent. No passwords to remember! Once you enter your PIN below, you'll be logged in on this device for the next 90 days, or until you log out."
 msgstr ""
-"Ihr Account wurde erstellt. Eine E-Mail mit Ihrem PIN ist unterwegs. Wir "
-"arbeiten ohne Passwörter. Wenn Sie den PIN eingegeben haben, sind Sie für 90"
-" Tage auf diesem Browser eingelogt."
+"Ihr Konto wurde erstellt. Eine E-Mail mit Ihrer PIN ist unterwegs. Wir "
+"arbeiten ohne Passwörter. Wenn Sie die PIN eingegeben haben, bleiben Sie auf "
+"diesem Gerät für 90 Tage angemeldet."
 
 #: lib/vutuv_web/templates/page/pin_new_registration.html.heex:13
 #: lib/vutuv_web/templates/session/pin_user_login.html.heex:11
@@ -1614,7 +1615,7 @@ msgstr "Verwandte Tags anzeigen"
 
 #: web/templates/user_tag/index.html.eex:25
 msgid "tag name"
-msgstr "Tag Name"
+msgstr "Tag-Name"
 
 #: lib/vutuv/notifications/emailer.ex:252
 #, elixir-autogen
@@ -1624,8 +1625,8 @@ msgstr "verifizierter Account"
 #: web/templates/page/new_registration.html.eex:16
 msgid "You'll receive an email with a login link."
 msgstr ""
-"Sie bekommen in den nächsten Sekunden/Minuten eine E-Mail mit einem Login "
-"Link."
+"Sie bekommen in den nächsten Sekunden oder Minuten eine E-Mail mit einem "
+"Login-Link."
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:776
 #: lib/vutuv_web/live/job_board_live.ex:360
@@ -1911,21 +1912,21 @@ msgstr "Verifiziertes Profil"
 #, elixir-autogen, elixir-format
 msgid "WARNING: There is no turning back from this. Your account is deleted as soon as you submit the PIN."
 msgstr ""
-"ACHTUNG: Dieser Schritt kann nicht rückgängig gemacht werden. Ihr Konto wird"
-" gelöscht, sobald Sie den PIN absenden."
+"ACHTUNG: Dieser Schritt kann nicht rückgängig gemacht werden. Ihr Konto wird "
+"gelöscht, sobald Sie die PIN absenden."
 
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "We sent a PIN to your email address. Enter it below to permanently delete your account."
 msgstr ""
-"Wir haben einen PIN an Ihre E-Mail-Adresse geschickt. Geben Sie ihn unten "
+"Wir haben eine PIN an Ihre E-Mail-Adresse geschickt. Geben Sie sie unten "
 "ein, um Ihr Konto endgültig zu löschen."
 
 #: lib/vutuv_web/templates/email/confirm.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
-"Wir haben einen PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie ihn "
+"Wir haben eine PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie sie "
 "unten ein, um die Adresse zu bestätigen."
 
 #: lib/vutuv_web/live/post_live/feed.ex:757
@@ -2330,8 +2331,8 @@ msgstr "Wird gespeichert…"
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
-msgstr[0] "Zeige %{formatted} neuen Beitrag"
-msgstr[1] "Zeige %{formatted} neue Beiträge"
+msgstr[0] "%{formatted} neuen Beitrag anzeigen"
+msgstr[1] "%{formatted} neue Beiträge anzeigen"
 
 #: lib/vutuv_web/live/post_live/edit.ex:36
 #: lib/vutuv_web/live/post_live/reply.ex:30
@@ -2752,7 +2753,7 @@ msgstr "Willkommen zurück, %{name}!"
 #: lib/vutuv_web/controllers/session_controller.ex:268
 #, elixir-autogen, elixir-format
 msgid "A new PIN is on its way to your email."
-msgstr "Ein neuer PIN ist unterwegs zu Ihrer E-Mail-Adresse."
+msgstr "Eine neue PIN ist unterwegs zu Ihrer E-Mail-Adresse."
 
 #: lib/vutuv_web/controllers/session_controller.ex:106
 #, elixir-autogen, elixir-format
@@ -4649,13 +4650,13 @@ msgstr "Unzustellbar"
 #, elixir-autogen, elixir-format
 msgid "You can search for a name, email, or tag, or for words in public posts."
 msgstr ""
-"Sie können nach Namen (Vor- und Nachname), E-Mail Adressen, Tags oder nach "
+"Sie können nach Namen (Vor- und Nachname), E-Mail-Adressen, Tags oder nach "
 "Wörtern in öffentlichen Beiträgen suchen."
 
 #: lib/vutuv_web/live/search_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Search for people by name, email, or username."
-msgstr "Suchen Sie Personen nach Name, E-Mail Adresse oder Benutzername."
+msgstr "Suchen Sie Personen nach Name, E-Mail-Adresse oder Benutzername."
 
 #: lib/vutuv_web/live/search_live.ex:258
 #, elixir-autogen, elixir-format
@@ -6677,8 +6678,8 @@ msgstr "Aufheben"
 #, elixir-autogen, elixir-format
 msgid "Confirmed members whose every email address bounced, so they can no longer receive a login PIN. Hidden from other members until an address works again. Thaw to lift the freeze."
 msgstr ""
-"Bestätigte Mitglieder, deren sämtliche E-Mail-Adressen unzustellbar sind und"
-" die daher keinen Login-PIN mehr empfangen können. Für andere Mitglieder "
+"Bestätigte Mitglieder, deren sämtliche E-Mail-Adressen unzustellbar sind und "
+"die daher keine Login-PIN mehr empfangen können. Für andere Mitglieder "
 "verborgen, bis eine Adresse wieder funktioniert. Auftauen hebt die Sperre "
 "auf."
 
@@ -6775,7 +6776,7 @@ msgstr "Noch keine Zustellbarkeitsereignisse."
 #, elixir-autogen, elixir-format
 msgid "Not getting the PIN? That email address may no longer be working. If you have added other addresses to your vutuv account, try logging in with one of those instead."
 msgstr ""
-"Kein PIN erhalten? Diese E-Mail-Adresse funktioniert möglicherweise nicht "
+"Keine PIN erhalten? Diese E-Mail-Adresse funktioniert möglicherweise nicht "
 "mehr. Wenn Sie Ihrem vutuv-Konto weitere Adressen hinzugefügt haben, melden "
 "Sie sich stattdessen mit einer davon an."
 
@@ -6942,8 +6943,7 @@ msgstr ""
 #: lib/vutuv_web/templates/post/teaser.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Follow each other to connect with %{name} and read it."
-msgstr ""
-"Folgt euch gegenseitig, um mit %{name} vernetzt zu sein und ihn zu lesen."
+msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 
 #: lib/vutuv_web/templates/post/teaser.html.heex:40
 #, elixir-autogen, elixir-format
@@ -6968,33 +6968,33 @@ msgstr "@%{handle} nicht mehr stummschalten"
 #: lib/vutuv_web/components/ui.ex:1806
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
-msgstr "Folgt dir nicht"
+msgstr "Folgt Ihnen nicht"
 
 #: lib/vutuv_web/components/ui.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Follows you"
-msgstr "Folgt dir"
+msgstr "Folgt Ihnen"
 
 #: lib/vutuv_web/components/ui.ex:1790
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
-msgstr "Dieses Mitglied folgt dir nicht"
+msgstr "Dieses Mitglied folgt Ihnen nicht"
 
 #: lib/vutuv_web/components/ui.ex:1741
 #: lib/vutuv_web/components/ui.ex:1790
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
-msgstr "Dieses Mitglied folgt dir"
+msgstr "Dieses Mitglied folgt Ihnen"
 
 #: lib/vutuv_web/components/ui.ex:1739
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
-msgstr "Ihr folgt euch"
+msgstr "Sie folgen einander"
 
 #: lib/vutuv_web/components/ui.ex:1740
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
-msgstr "Du folgst diesem Mitglied"
+msgstr "Sie folgen diesem Mitglied"
 
 #: lib/vutuv_web/controllers/admin/newsletter_controller.ex:152
 #, elixir-autogen, elixir-format
@@ -7468,7 +7468,7 @@ msgstr "Diese Zielgruppe wurde nicht gefunden."
 msgid "Their members are removed from this one (e.g. exclude the test group to send to \"the rest\")."
 msgstr ""
 "Ihre Mitglieder werden aus dieser entfernt (z. B. die Testgruppe abziehen, "
-"um an „den Rest\" zu senden)."
+"um an „den Rest“ zu senden)."
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:945
 #, elixir-autogen, elixir-format
@@ -7697,7 +7697,7 @@ msgstr "Sie können das jederzeit in Ihren Einstellungen wieder aktivieren."
 #: lib/vutuv_web/views/unsubscribe_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "the vutuv newsletter"
-msgstr "den vutuv Newsletter"
+msgstr "den vutuv-Newsletter"
 
 #: lib/vutuv_web/views/unsubscribe_html.ex:13
 #, elixir-autogen, elixir-format
@@ -7858,7 +7858,7 @@ msgstr "Der vutuv-Newsfeed von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:922
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
-msgstr "Dein Feed ist leer."
+msgstr "Ihr Feed ist leer."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:925
 #, elixir-autogen, elixir-format
@@ -8348,7 +8348,7 @@ msgstr "Identität verifiziert"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
-msgstr "Falscher PIN"
+msgstr "Falsche PIN"
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:145
 #: lib/vutuv_web/live/admin/user_detail_live.ex:114
@@ -8826,7 +8826,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Import your LinkedIn profile data into your vutuv profile. From your export we can fill in:"
 msgstr ""
-"Importieren Sie die Daten Ihres LinkedIn-Profils in Ihr vutuv Profil. Aus "
+"Importieren Sie die Daten Ihres LinkedIn-Profils in Ihr vutuv-Profil. Aus "
 "Ihrem Export können wir übernehmen:"
 
 #: lib/vutuv_web/templates/import/new.html.heex:110
@@ -9169,13 +9169,13 @@ msgstr "Ihr Fediverse-Handle"
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
-msgstr "Dieser PIN wurde bereits verwendet."
+msgstr "Diese PIN wurde bereits verwendet."
 
 #: lib/vutuv_web/controllers/session_controller.ex:324
 #, elixir-autogen, elixir-format
 msgid "This PIN was already used. If that was you, you are already signed in."
 msgstr ""
-"Dieser PIN wurde bereits verwendet. Falls Sie das waren, sind Sie bereits "
+"Diese PIN wurde bereits verwendet. Falls Sie das waren, sind Sie bereits "
 "angemeldet."
 
 #: lib/vutuv_web/templates/education/form_content.html.heex:17
@@ -11357,7 +11357,7 @@ msgstr "Standard der Installation (%{value})"
 #: lib/vutuv_web/controllers/settings_controller.ex:619
 #, elixir-autogen, elixir-format
 msgid "Map preferences reset to the site defaults."
-msgstr "Karten-Einstellungen auf die Standardwerte zurückgesetzt."
+msgstr "Karteneinstellungen auf die Standardwerte zurückgesetzt."
 
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:57
 #, elixir-autogen, elixir-format
@@ -11479,8 +11479,8 @@ msgstr ""
 msgid "Auto-generated screenshots for single-link posts: watch the capture queue and browse the gallery of finished shots, each linked to its post."
 msgstr ""
 "Automatisch erzeugte Screenshots für Beiträge mit einem einzelnen Link: "
-"Beobachte die Aufnahme-Warteschlange und durchstöbere die Galerie fertiger "
-"Screenshots, jeder mit einem Link zum Beitrag."
+"Beobachten Sie die Aufnahme-Warteschlange und durchstöbern Sie die Galerie "
+"fertiger Screenshots, jeder mit einem Link zum Beitrag."
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:105
 #, elixir-autogen, elixir-format
@@ -12125,8 +12125,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Domain added. Publish the record or file, then verify it."
 msgstr ""
-"Domain hinzugefügt. Veröffentliche den Eintrag oder die Datei und "
-"verifiziere sie dann."
+"Domain hinzugefügt. Veröffentlichen Sie den Eintrag oder die Datei und "
+"starten Sie dann die Verifizierung."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:129
 #, elixir-autogen, elixir-format
@@ -12167,15 +12167,15 @@ msgstr "Einfrieren"
 #, elixir-autogen, elixir-format
 msgid "Freeze this page? It disappears for the public but stays visible to its owner."
 msgstr ""
-"Diese Seite einfrieren? Sie verschwindet für die Öffentlichkeit, bleibt aber"
-" für den Inhaber sichtbar."
+"Diese Seite einfrieren? Sie verschwindet für die Öffentlichkeit, bleibt aber "
+"für den Besitzer sichtbar."
 
 #: lib/vutuv_web/live/organization_live/roles.ex:155
 #, elixir-autogen, elixir-format
 msgid "Give members a role on this page. Owners manage the team and domains, admins edit the page, recruiters post jobs."
 msgstr ""
-"Gib Mitgliedern eine Rolle auf dieser Seite. Inhaber verwalten Team und "
-"Domains, Administratoren bearbeiten die Seite, Recruiter schalten "
+"Geben Sie Mitgliedern eine Rolle auf dieser Seite. Besitzer verwalten Team "
+"und Domains, Administratoren bearbeiten die Seite, Recruiter schalten "
 "Stellenanzeigen."
 
 #: lib/vutuv_web/live/organization_live/domains.ex:189
@@ -12515,11 +12515,13 @@ msgstr[1] ""
 msgid "%{count} alias matches another verified organization and is flagged for review. Open an organization below to see it."
 msgid_plural "%{count} aliases match another verified organization and are flagged for review. Open an organization below to see them."
 msgstr[0] ""
-"%{count} Alias stimmt mit einer anderen verifizierten Organisation überein und "
-"wurde zur Prüfung markiert. Öffne unten eine Organisation, um ihn zu sehen."
+"%{count} Alias stimmt mit einer anderen verifizierten Organisation überein "
+"und wurde zur Prüfung markiert. Öffnen Sie unten eine Organisation, um ihn "
+"zu sehen."
 msgstr[1] ""
-"%{count} Aliasse stimmen mit anderen verifizierten Organisationen überein und wurden"
-" zur Prüfung markiert. Öffne unten eine Organisation, um sie zu sehen."
+"%{count} Aliasse stimmen mit anderen verifizierten Organisationen überein "
+"und wurden zur Prüfung markiert. Öffnen Sie unten eine Organisation, um sie "
+"zu sehen."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:353
 #, elixir-autogen, elixir-format
@@ -12547,8 +12549,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "An organization must keep at least one owner, so the last owner cannot be changed."
 msgstr ""
-"Eine Organisation muss mindestens einen Inhaber behalten, daher kann der letzte "
-"Inhaber nicht geändert werden."
+"Eine Organisation muss mindestens einen Besitzer behalten, daher kann der "
+"letzte Besitzer nicht geändert werden."
 
 #: lib/vutuv_web/live/organization_live/new.ex:82
 #, elixir-autogen, elixir-format
@@ -12651,12 +12653,13 @@ msgstr "Keine gespeicherten Organisationen passen zu Ihrer Suche."
 #: lib/vutuv_web/live/post_live/saved.ex:597
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Organizations you bookmark show up here."
-msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
+msgstr "Hier ist noch nichts. Organisationen mit Lesezeichen erscheinen hier."
 
 #: lib/vutuv_web/live/post_live/saved.ex:594
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Organizations you like show up here."
-msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
+msgstr ""
+"Hier ist noch nichts. Organisationen, die Ihnen gefallen, erscheinen hier."
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:269
 #, elixir-autogen, elixir-format
@@ -12666,28 +12669,28 @@ msgstr "Organisations-Aufsicht öffnen"
 #: lib/vutuv_web/live/admin/organization_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Organization archived."
-msgstr "Organisation"
+msgstr "Organisation archiviert."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Organization deleted."
-msgstr "Organisation"
+msgstr "Organisation gelöscht."
 
 #: lib/vutuv_web/live/admin/organization_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Organization frozen."
-msgstr "Organisation"
+msgstr "Organisation eingefroren."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:267
 #: lib/vutuv_web/live/organization_live/new.ex:110
 #, elixir-autogen, elixir-format
 msgid "Organization name"
-msgstr "Organisation"
+msgstr "Name der Organisation"
 
 #: lib/vutuv_web/views/admin/moderation_html.ex:29
 #, elixir-autogen, elixir-format
 msgid "Organization page"
-msgstr "Organisation"
+msgstr "Organisationsseite"
 
 #: lib/vutuv_web/live/admin/organization_live.ex:25
 #: lib/vutuv_web/live/admin/organization_live.ex:188
@@ -12695,17 +12698,17 @@ msgstr "Organisation"
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:264
 #, elixir-autogen, elixir-format
 msgid "Organization pages"
-msgstr "Organisation"
+msgstr "Organisationsseiten"
 
 #: lib/vutuv_web/live/notification_live/index.ex:904
 #, elixir-autogen, elixir-format
 msgid "Organization role"
-msgstr "Organisation"
+msgstr "Organisationsrolle"
 
 #: lib/vutuv_web/live/admin/organization_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Organization unfrozen."
-msgstr "Organisation"
+msgstr "Organisation wieder freigegeben."
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
 #: lib/vutuv_web/components/ui.ex:3256
@@ -12740,7 +12743,7 @@ msgstr "Bitte loggen Sie sich ein, um eine Organisationsseite zu beanspruchen."
 #: lib/vutuv_web/live/organization_live/index.ex:83
 #, elixir-autogen, elixir-format
 msgid "Search organizations"
-msgstr "Tags durchsuchen"
+msgstr "Organisationen durchsuchen"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:67
 #, elixir-autogen, elixir-format
@@ -12811,22 +12814,22 @@ msgstr "Ihre Organisationsseite wurde aktualisiert."
 #: lib/vutuv_web/live/notification_live/index.ex:1065
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
-msgstr "hat dir eine Rolle bei %{company} gegeben."
+msgstr "hat Ihnen eine Rolle bei %{organization} gegeben."
 
 #: lib/vutuv_web/live/notification_live/index.ex:1062
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
-msgstr "hat dich zum Recruiter für %{company} gemacht."
+msgstr "hat Sie zum Recruiter für %{organization} gemacht."
 
 #: lib/vutuv_web/live/notification_live/index.ex:1059
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
-msgstr "hat dich zum Administrator von %{company} gemacht."
+msgstr "hat Sie zum Administrator von %{organization} gemacht."
 
 #: lib/vutuv_web/live/notification_live/index.ex:1056
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
-msgstr "hat dich zum Inhaber von %{company} gemacht."
+msgstr "hat Sie zum Besitzer von %{organization} gemacht."
 
 #: lib/vutuv_web/live/organization_live/edit.ex:431
 #, elixir-autogen, elixir-format
@@ -13374,7 +13377,7 @@ msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
 #: lib/vutuv/notifications/emailer.ex:835
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
-msgstr "Eine Domain Ihrer Firmenseite auf vutuv entfällt bald"
+msgstr "Eine Domain Ihrer Organisationsseite auf vutuv entfällt bald"
 
 #: lib/vutuv_web/live/organization_live/domains.ex:202
 #, elixir-autogen, elixir-format
@@ -13394,12 +13397,12 @@ msgstr "Der Nachweis dieser Domain war bei der letzten Prüfung nicht abrufbar. 
 #: lib/vutuv/notifications/emailer.ex:832
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
-msgstr "Ihre Firmenseite auf vutuv verliert bald ihre Verifizierung"
+msgstr "Ihre Organisationsseite auf vutuv verliert bald ihre Verifizierung"
 
 #: lib/vutuv/notifications/emailer.ex:853
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
-msgstr "Ihre Firmenseite auf vutuv ist nicht mehr öffentlich"
+msgstr "Ihre Organisationsseite auf vutuv ist nicht mehr öffentlich"
 
 #: lib/vutuv_web/live/job_posting_live/show.ex:176
 #, elixir-autogen, elixir-format
@@ -13628,7 +13631,7 @@ msgstr "Noch keine Stellenanzeigen."
 #: lib/vutuv_web/live/job_board_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "No matching positions. Try adjusting the filters."
-msgstr "Keine passenden Stellen. Passe die Filter an."
+msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:382
 #: lib/vutuv_web/agent_docs/markdown.ex:394
@@ -13654,7 +13657,7 @@ msgstr "Stelle ausschreiben"
 #: lib/vutuv_web/live/job_board_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Post the first one"
-msgstr "Veröffentliche die erste"
+msgstr "Veröffentlichen Sie die erste"
 
 #: lib/vutuv_web/live/job_board_live.ex:354
 #, elixir-autogen, elixir-format
@@ -13854,8 +13857,8 @@ msgstr "—"
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
-msgstr[0] "%{count} neuer Treffer für deine gespeicherten Suchen"
-msgstr[1] "%{count} neue Treffer für deine gespeicherten Suchen"
+msgstr[0] "%{count} neuer Treffer für Ihre gespeicherten Suchen"
+msgstr[1] "%{count} neue Treffer für Ihre gespeicherten Suchen"
 
 #: lib/vutuv_web/components/saved_search_components.ex:96
 #, elixir-autogen, elixir-format
@@ -13880,7 +13883,9 @@ msgstr "Diese gespeicherte Suche löschen?"
 #: lib/vutuv_web/templates/saved_search_alert/done.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Done. Your saved search \"%{label}\" will no longer e-mail you."
-msgstr "Erledigt. Deine gespeicherte Suche „%{label}“ schickt dir keine E-Mails mehr."
+msgstr ""
+"Erledigt. Ihre gespeicherte Suche „%{label}“ schickt Ihnen keine E-Mails "
+"mehr."
 
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:51
 #, elixir-autogen, elixir-format
@@ -13922,7 +13927,10 @@ msgstr "Ältere"
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Save a search on the job board or on the people search, then let vutuv e-mail you when a new match appears. Daily searches are checked every day; weekly ones once a week."
-msgstr "Speichere eine Suche in der Stellenbörse oder in der Personensuche, und vutuv schickt dir eine E-Mail, sobald es einen neuen Treffer gibt. Tägliche Suchen werden jeden Tag geprüft, wöchentliche einmal pro Woche."
+msgstr ""
+"Speichern Sie eine Suche in der Stellenbörse oder in der Personensuche, und "
+"vutuv schickt Ihnen eine E-Mail, sobald es einen neuen Treffer gibt. "
+"Tägliche Suchen werden jeden Tag geprüft, wöchentliche einmal pro Woche."
 
 #: lib/vutuv_web/components/saved_search_components.ex:103
 #: lib/vutuv_web/components/saved_search_components.ex:124
@@ -13952,7 +13960,8 @@ msgstr "Suche gespeichert."
 #: lib/vutuv_web/templates/saved_search_alert/show.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
-msgstr "E-Mail-Benachrichtigungen für deine gespeicherte Suche „%{label}“ stoppen?"
+msgstr ""
+"E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:518
@@ -13980,17 +13989,21 @@ msgstr "Wöchentliche E-Mail"
 #: lib/vutuv_web/components/saved_search_components.ex:39
 #, elixir-autogen, elixir-format
 msgid "You already have the maximum number of saved searches."
-msgstr "Du hast bereits die maximale Anzahl gespeicherter Suchen erreicht."
+msgstr "Sie haben bereits die maximale Anzahl gespeicherter Suchen erreicht."
 
 #: lib/vutuv_web/templates/saved_search_alert/done.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "You can turn its alerts back on, or delete the search, in your settings at any time."
-msgstr "Du kannst die Benachrichtigungen jederzeit in deinen Einstellungen wieder aktivieren oder die Suche löschen."
+msgstr ""
+"Sie können die Benachrichtigungen jederzeit in Ihren Einstellungen wieder "
+"aktivieren oder die Suche löschen."
 
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:9
 #, elixir-autogen, elixir-format
 msgid "You have no saved searches yet. Look for the \"Save search\" button on the"
-msgstr "Du hast noch keine gespeicherten Suchen. Klicke auf „Suche speichern“ in der"
+msgstr ""
+"Sie haben noch keine gespeicherten Suchen. Klicken Sie auf „Suche speichern“ "
+"in der"
 
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:11
 #, elixir-autogen, elixir-format
@@ -14026,7 +14039,9 @@ msgstr "E-Mails zu gespeicherten Suchen"
 #: lib/vutuv_web/templates/saved_search_alert/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "The search itself is kept. Only its e-mails stop, and you can turn them back on in your settings."
-msgstr "Die Suche selbst bleibt erhalten. Nur ihre E-Mails werden gestoppt, und du kannst sie in deinen Einstellungen jederzeit wieder aktivieren."
+msgstr ""
+"Die Suche selbst bleibt erhalten. Nur ihre E-Mails werden gestoppt, und Sie "
+"können sie in Ihren Einstellungen jederzeit wieder aktivieren."
 
 #: lib/vutuv/saved_searches.ex:263
 #, elixir-autogen, elixir-format
@@ -14041,7 +14056,7 @@ msgstr "Stellenanzeigen in Ihrem Namen veröffentlichen, bearbeiten und schließ
 #: lib/vutuv/api_auth/scopes.ex:68
 #, elixir-autogen, elixir-format
 msgid "Read job postings and organization pages visible to you"
-msgstr "Für Sie sichtbare Stellenanzeigen und Unternehmensseiten lesen"
+msgstr "Für Sie sichtbare Stellenanzeigen und Organisationsseiten lesen"
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:39
 #, elixir-autogen, elixir-format
@@ -14179,7 +14194,9 @@ msgstr "Geprüft, alles in Ordnung: Markierung entfernen"
 #: lib/vutuv_web/live/organization_live/edit.ex:181
 #, elixir-autogen, elixir-format
 msgid "This page has job postings, so it cannot be deleted. Ask an admin to archive it instead."
-msgstr "Diese Seite hat Stellenanzeigen und kann deshalb nicht gelöscht werden. Bitte einen Admin, sie stattdessen zu archivieren."
+msgstr ""
+"Diese Seite hat Stellenanzeigen und kann deshalb nicht gelöscht werden. "
+"Bitten Sie einen Admin, sie stattdessen zu archivieren."
 
 #: lib/vutuv_web/live/admin/user_detail_live.ex:126
 #, elixir-autogen, elixir-format
@@ -14400,7 +14417,10 @@ msgstr "Eigene Beiträge"
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
-msgstr "Beiträge mit einem Tag, dem du folgst, landen in deinem Feed, und passende Personen tauchen in deinen Vorschlägen auf. Einem Tag folgst du auf seiner Seite."
+msgstr ""
+"Beiträge mit einem Tag, dem Sie folgen, landen in Ihrem Feed, und passende "
+"Personen tauchen in Ihren Vorschlägen auf. Einem Tag folgen Sie auf seiner "
+"Seite."
 
 #: lib/vutuv_web/components/ui.ex:3301
 #: lib/vutuv_web/controllers/settings_controller.ex:437
@@ -14419,7 +14439,9 @@ msgstr "#%{tag} entfolgen"
 #: lib/vutuv_web/live/job_board_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Looking for a role that goes by several titles? Separate them with a comma and we show postings that match any of them."
-msgstr "Ein Beruf mit mehreren möglichen Titeln? Trenne sie mit Komma, dann zeigen wir Anzeigen, die zu einem davon passen."
+msgstr ""
+"Ein Beruf mit mehreren möglichen Titeln? Trennen Sie sie mit Komma, dann "
+"zeigen wir Anzeigen, die zu einem davon passen."
 
 #: lib/vutuv_web/live/job_board_live.ex:424
 #, elixir-autogen, elixir-format
@@ -14575,7 +14597,7 @@ msgstr "Hörbuch"
 #: lib/vutuv_web/live/post_live/composer.ex:725
 #, elixir-autogen, elixir-format
 msgid "Author(s)"
-msgstr "Autor/in"
+msgstr "Autor(en)"
 
 #: lib/vutuv_web/live/post_live/composer.ex:787
 #, elixir-autogen, elixir-format
@@ -14639,7 +14661,7 @@ msgstr "Nachschlagen"
 #: lib/vutuv_web/live/post_live/composer.ex:702
 #, elixir-autogen, elixir-format
 msgid "Looking up…"
-msgstr "Schlage nach …"
+msgstr "Wird nachgeschlagen …"
 
 #: lib/vutuv_web/live/post_live/composer.ex:249
 #, elixir-autogen, elixir-format
@@ -14681,7 +14703,7 @@ msgstr "Streaming"
 #: lib/vutuv_web/live/post_live/composer.ex:743
 #, elixir-autogen, elixir-format
 msgid "Watched as… (optional)"
-msgstr "Wie gesehen? (optional)"
+msgstr "Gesehen als … (optional)"
 
 #: lib/vutuv_web/live/post_live/composer.ex:757
 #, elixir-autogen, elixir-format
@@ -15055,7 +15077,7 @@ msgstr "Verfügbarkeit"
 #, elixir-autogen, elixir-format
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
-"Ihr automatisch zugewiesener vutuv-Username ist {handle}. Sie können ihn "
+"Ihr automatisch zugewiesener vutuv-Benutzername ist {handle}. Sie können ihn "
 "jederzeit unter {url} ändern."
 
 #: lib/vutuv/notifications/emailer.ex:894
@@ -15134,14 +15156,18 @@ msgstr ""
 msgid "%{formatted} account is currently in the moderation freezer, newest freeze first."
 msgid_plural "%{formatted} accounts are currently in the moderation freezer, newest freeze first."
 msgstr[0] ""
+"%{formatted} Konto ist zurzeit von der Moderation eingefroren, neueste "
+"Einfrierung zuerst."
 msgstr[1] ""
+"%{formatted} Konten sind zurzeit von der Moderation eingefroren, neueste "
+"Einfrierung zuerst."
 
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "%{formatted} account is in the moderation freezer."
 msgid_plural "%{formatted} accounts are in the moderation freezer."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%{formatted} Konto ist von der Moderation eingefroren."
+msgstr[1] "%{formatted} Konten sind von der Moderation eingefroren."
 
 #: lib/vutuv_web/controllers/admin/account_controller.ex:105
 #, elixir-autogen, elixir-format
@@ -16106,7 +16132,7 @@ msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 #: lib/vutuv_web/components/ui.ex:3257
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
-msgstr "Firmenseiten, die Sie verwalten"
+msgstr "Organisationsseiten, die Sie verwalten"
 
 #: lib/vutuv_web/components/ui.ex:3258
 #, elixir-autogen, elixir-format
@@ -16678,12 +16704,16 @@ msgstr "Code von Ihrer Kennwortliste"
 #: lib/vutuv_web/views/username_html.ex:30
 #, elixir-autogen, elixir-format
 msgid "We sent a PIN to %{email}. Any of your other codes works here too."
-msgstr "Wir haben einen PIN an %{email} geschickt. Ihre anderen Codes funktionieren hier ebenfalls."
+msgstr ""
+"Wir haben eine PIN an %{email} geschickt. Ihre anderen Codes funktionieren "
+"hier ebenfalls."
 
 #: lib/vutuv_web/views/username_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Your authenticator app or one-time code list, or a PIN we email you."
-msgstr "Ihre Authenticator-App, Ihre Kennwortliste oder ein PIN, den wir Ihnen per E-Mail schicken."
+msgstr ""
+"Ihre Authenticator-App, Ihre Kennwortliste oder eine PIN, die wir Ihnen per "
+"E-Mail schicken."
 
 #: lib/vutuv_web/templates/username/confirm.html.heex:20
 #, elixir-autogen, elixir-format
@@ -16743,7 +16773,7 @@ msgstr "PIN senden an"
 #: lib/vutuv_web/views/username_html.ex:107
 #, elixir-autogen, elixir-format
 msgid "Send a new PIN"
-msgstr "Neuen PIN senden"
+msgstr "Neue PIN senden"
 
 #: lib/vutuv_web/views/username_html.ex:107
 #, elixir-autogen, elixir-format
@@ -16753,17 +16783,17 @@ msgstr "PIN per E-Mail schicken"
 #: lib/vutuv_web/views/username_html.ex:115
 #, elixir-autogen, elixir-format
 msgid "The PIN goes to %{email}."
-msgstr "Der PIN geht an %{email}."
+msgstr "Die PIN geht an %{email}."
 
 #: lib/vutuv_web/views/username_html.ex:34
 #, elixir-autogen, elixir-format
 msgid "We sent a PIN to %{email}."
-msgstr "Wir haben einen PIN an %{email} geschickt."
+msgstr "Wir haben eine PIN an %{email} geschickt."
 
 #: lib/vutuv_web/views/username_html.ex:42
 #, elixir-autogen, elixir-format
 msgid "Ask for a PIN first, then enter it here."
-msgstr "Fordern Sie zuerst einen PIN an und geben Sie ihn hier ein."
+msgstr "Fordern Sie zuerst eine PIN an und geben Sie sie hier ein."
 
 #: lib/vutuv_web/views/account_event_text.ex:91
 #, elixir-autogen, elixir-format
@@ -17216,7 +17246,7 @@ msgstr "mit einem Passkey"
 #: lib/vutuv_web/views/account_event_text.ex:137
 #, elixir-autogen, elixir-format
 msgid "with an emailed PIN"
-msgstr "mit einem per E-Mail geschickten PIN"
+msgstr "mit einer per E-Mail geschickten PIN"
 
 #: lib/vutuv_web/views/account_event_text.ex:135
 #, elixir-autogen, elixir-format

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -26,13 +26,13 @@ msgid "is reserved"
 msgstr "ist reserviert"
 
 msgid "does not match confirmation"
-msgstr ""
+msgstr "stimmt nicht mit der Bestätigung überein"
 
 msgid "is still associated to this entry"
-msgstr ""
+msgstr "ist noch mit diesem Eintrag verknüpft"
 
 msgid "are still associated to this entry"
-msgstr ""
+msgstr "sind noch mit diesem Eintrag verknüpft"
 
 msgid "should be %{count} character(s)"
 msgid_plural "should be %{count} character(s)"

--- a/test/vutuv/organizations_test.exs
+++ b/test/vutuv/organizations_test.exs
@@ -232,7 +232,7 @@ defmodule Vutuv.OrganizationsTest do
       domain = Repo.get!(OrganizationDomain, domain.id)
       # Consume the "verified" operator notice so the demote assertion below
       # matches the second message, not this one.
-      assert_email_sent(fn email -> assert email.subject =~ "Firmenseite verifiziert" end)
+      assert_email_sent(fn email -> assert email.subject =~ "Organisationsseite verifiziert" end)
 
       # The record vanishes.
       Application.put_env(:vutuv, :organizations_dns_resolver, fn _host -> [] end)
@@ -313,7 +313,7 @@ defmodule Vutuv.OrganizationsTest do
     defp break_proof(organization, domain) do
       stub_dns(domain.verification_token)
       {:ok, _organization} = Organizations.verify_dns(organization, domain)
-      assert_email_sent(fn email -> assert email.subject =~ "Firmenseite verifiziert" end)
+      assert_email_sent(fn email -> assert email.subject =~ "Organisationsseite verifiziert" end)
       Application.put_env(:vutuv, :organizations_dns_resolver, fn _host -> [] end)
       Repo.get!(OrganizationDomain, domain.id)
     end
@@ -434,7 +434,7 @@ defmodule Vutuv.OrganizationsTest do
 
       stub_dns(primary.verification_token)
       {:ok, _} = Organizations.verify_dns(organization, primary)
-      assert_email_sent(fn email -> assert email.subject =~ "Firmenseite verifiziert" end)
+      assert_email_sent(fn email -> assert email.subject =~ "Organisationsseite verifiziert" end)
 
       {:ok, second} = Organizations.add_domain(organization, "second.example.org", "dns")
       stub_dns(second.verification_token)
@@ -451,7 +451,7 @@ defmodule Vutuv.OrganizationsTest do
         # The page keeps its other verified domain, so neither the subject nor
         # the body may threaten an outage that is not coming.
         refute email.text_body =~ "nicht mehr öffentlich sichtbar"
-        assert email.subject =~ "Eine Domain Ihrer Firmenseite auf vutuv entfällt bald"
+        assert email.subject =~ "Eine Domain Ihrer Organisationsseite auf vutuv entfällt bald"
         assert email.text_body =~ primary.domain
       end)
     end


### PR DESCRIPTION
**TL;DR** An audit of all ~2,950 German entries: four notifications were silently rendering in English, eight organization strings were translated as the bare word "Organisation", and 22 strings had drifted into the informal du. 96 fixes, msgstr only.

## Bugs gettext hid

**Four organization-role notifications rendered in English.** `made you an owner of %{organization}.` and its three siblings had `%{company}` in the German, but `notification_live/index.ex` binds `organization:`. Gettext cannot resolve the binding, so it falls back to the English msgid. No test could see it.

**Eight organization strings were the bare word "Organisation".** `Organization archived.` / `deleted.` / `frozen.` / `unfrozen.` / `name` / `page` / `pages` / `role` — flash messages and headings showing one stray noun. Alongside them `Search organizations` read *"Tags durchsuchen"* and two bookmark empty-states talked about Beitraege instead of Organisationen.

**Five entries were untranslated** (two moderation-freezer plurals, three Ecto errors), and `Not following anyone yet!` was the single word *"Keine"*. Plus outright errors: *"Zu viele fehlerhafter Versuche"*, *"Lebenlaufseintrag"*, *"Noch keine Followers"*, *"eingelogt"*, *"koennen Sie sicher jederzeit"* (→ sich).

## Consistency

- **22 strings had drifted to "du"** — now all Sie, per the project's standing rule. The only remaining "du" is the sample handle `@du:matrix.org`.
- **PIN is feminine throughout.** The catalog was split 11 masculine / 10 feminine; Stefan picked "die PIN".
- **An organization's owner is "Besitzer"** — what the role badge itself renders, and what all 14 moderation strings use. Four strings had drifted to "Inhaber".
- **The organization emails now say "Organisationsseite", not "Firmenseite"** — the feature also covers schools, associations and public authorities. Subjects, both body formats and the operator notice's label column changed together, so subject and body cannot disagree.
- Compound hyphens (*"E-Mail Postfach"*, *"SPAM Ordner"*, *"vutuv Account"*, *"Login Link"*), and one German opening quote that was closed with a straight one.

## How this was checked

Five passes: a structural scan (fuzzy / empty / doubled / orphaned msgid), a placeholder diff between msgid and msgstr (this is what caught the `%{company}` bug), an address-form scan, an orthography grep, and a full read of every msgid/msgstr pair. Recipe is in the session notes.

**Only msgstr values changed** — no msgid, `.pot` or `en.po` was touched, so the catalogs stay in sync and no extract/merge churn rides along. `mix precommit` green (5161 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_011mjkddRAK5cfh9hfaXRVwF
