### PR TITLE
Index the public-visibility gate (#838)

### DIFF
--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -124,3 +124,45 @@ unavailable" page (`VutuvWeb.ErrorHTML`, `profile_unavailable.html`) that does
 not reveal *why*. The separate `/api/2.0` JSON API keeps its own 404 for hidden
 accounts — it is not an agent-format sibling and follows problem+json
 conventions.
+
+## The public-visibility gate, and the index behind it
+
+"Is this member publicly visible" is one predicate, spelled once in
+`Vutuv.Moderation.Query`: `account_confirmed_row(u) and not
+account_hidden_row(u)`. Roughly 55 query sites across 13 modules filter on it —
+search, the follower / following / connection lists, the tag pages, the member
+directory, the fediverse actor — so it is the single most-evaluated condition
+in the app.
+
+It comes in two spellings, and picking the wrong one is a performance bug:
+
+- **`account_hidden_row(u)`** takes an already-joined users row and reads its
+  columns. **Use this whenever the users row is in scope** (a join or the main
+  binding), which is nearly always.
+- **`account_hidden(user_id)`** is a correlated `EXISTS` against the users PK,
+  for the case where the users row is *not* joined — `Vutuv.Posts` scoping a
+  post by its author is the real example. It costs one subquery per candidate
+  row, and because it sits outside the row's own predicate it also splits the
+  gate in two, which stops the index below from applying.
+
+The index is `users_visible_index`: a partial index on `users (id)` whose
+predicate is the static half of the gate (confirmed, not frozen, not
+deactivated, not unreachable). It exists because the gate is far more selective
+than the table size suggests — on the production data only ~9% of members pass
+it, the rest being legacy accounts that never confirmed their email — so
+without it every gated query read the whole `users` heap to find a small set.
+
+Two things to know when touching this:
+
+- The `suspended_until > now()` arm is deliberately **not** in the index
+  predicate: `now()` is not immutable, so Postgres rejects it there. It stays a
+  filter on the rows the index returns. The implication still holds, because
+  the query's WHERE is the index predicate *and* the suspension test, which only
+  narrows it.
+- Postgres uses a partial index only when it can **prove** the query predicate
+  implies the index predicate, and it fails silently — a gate that drifts from
+  the index just goes back to full scans, with nothing in the logs.
+  `test/vutuv/moderation/visibility_index_test.exs` is the tripwire: it plans a
+  query built from the two macros with sequential scans disabled and fails if
+  the index no longer serves it. Change the gate and that test tells you to ship
+  a migration recreating the index.

--- a/lib/vutuv/social/follow.ex
+++ b/lib/vutuv/social/follow.ex
@@ -14,7 +14,7 @@ defmodule Vutuv.Social.Follow do
 
   use VutuvWeb, :model
 
-  import Vutuv.Moderation.Query, only: [account_hidden: 1, account_confirmed_row: 1]
+  import Vutuv.Moderation.Query, only: [account_hidden_row: 1, account_confirmed_row: 1]
 
   schema "follows" do
     belongs_to(:follower, Vutuv.Accounts.User)
@@ -76,9 +76,14 @@ defmodule Vutuv.Social.Follow do
         limit: ^n
       )
 
+    # `account_hidden_row/1`, not the correlated `account_hidden/1`: both users
+    # rows are already joined above, so the row-bound twin reads the columns
+    # the planner has instead of running an EXISTS per candidate row — and it
+    # puts the whole gate (confirmed AND not hidden) in one predicate, which is
+    # what lets `users_visible_index` apply.
     case listed do
-      :follower -> Ecto.Query.from([follower: u] in query, where: not account_hidden(u.id))
-      :followee -> Ecto.Query.from([followee: u] in query, where: not account_hidden(u.id))
+      :follower -> Ecto.Query.from([follower: u] in query, where: not account_hidden_row(u))
+      :followee -> Ecto.Query.from([followee: u] in query, where: not account_hidden_row(u))
     end
   end
 end

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -384,7 +384,7 @@ defmodule Vutuv.Tags do
   renderer's no-hashtag path stays query-free.
   """
   def linkable_slugs(slugs) when is_list(slugs) do
-    import Vutuv.Moderation.Query, only: [account_hidden: 1, account_confirmed_row: 1]
+    import Vutuv.Moderation.Query, only: [account_hidden_row: 1, account_confirmed_row: 1]
 
     case slugs |> Enum.map(&String.downcase/1) |> Enum.uniq() do
       [] ->
@@ -395,7 +395,7 @@ defmodule Vutuv.Tags do
           join: ut in assoc(t, :user_tags),
           join: u in assoc(ut, :user),
           where: t.slug in ^normalized,
-          where: account_confirmed_row(u) and not account_hidden(u.id),
+          where: account_confirmed_row(u) and not account_hidden_row(u),
           distinct: true,
           select: t.slug
         )
@@ -518,7 +518,7 @@ defmodule Vutuv.Tags do
   popular pool unchanged.
   """
   def people_for_followed_tags(%User{} = user, limit) do
-    import Vutuv.Moderation.Query, only: [account_hidden: 1, account_confirmed_row: 1]
+    import Vutuv.Moderation.Query, only: [account_hidden_row: 1, account_confirmed_row: 1]
 
     case followed_tag_ids(user) do
       [] ->
@@ -534,10 +534,10 @@ defmodule Vutuv.Tags do
             # clause, so a hidden/unconfirmed endorser leaves `endorser` NULL and
             # drops out of `count(endorser.id)`.
             left_join: endorser in assoc(e, :user),
-            on: account_confirmed_row(endorser) and not account_hidden(endorser.id),
+            on: account_confirmed_row(endorser) and not account_hidden_row(endorser),
             where: ut.tag_id in ^tag_ids,
             where: u.id != ^user.id,
-            where: account_confirmed_row(u) and not account_hidden(u.id),
+            where: account_confirmed_row(u) and not account_hidden_row(u),
             group_by: u.id,
             order_by: fragment("count(?) DESC", endorser.id),
             limit: ^limit,

--- a/lib/vutuv/tags/tag.ex
+++ b/lib/vutuv/tags/tag.ex
@@ -307,7 +307,7 @@ defmodule Vutuv.Tags.Tag do
   # Same visibility gate as search/most-followed (unactivated + moderation-
   # hidden accounts never surface), same narrow listing-row select.
   defp most_endorsed_in_tag(source, tag) do
-    import Vutuv.Moderation.Query, only: [account_hidden: 1, account_confirmed_row: 1]
+    import Vutuv.Moderation.Query, only: [account_hidden_row: 1, account_confirmed_row: 1]
 
     Repo.all(
       from(u in source,
@@ -319,9 +319,9 @@ defmodule Vutuv.Tags.Tag do
         # unconfirmed endorser leaves `endorser` NULL and drops out of
         # count(endorser.id) — the ranking then agrees with the counts shown.
         left_join: endorser in assoc(e, :user),
-        on: account_confirmed_row(endorser) and not account_hidden(endorser.id),
+        on: account_confirmed_row(endorser) and not account_hidden_row(endorser),
         where: us.tag_id == ^tag.id,
-        where: account_confirmed_row(u) and not account_hidden(u.id),
+        where: account_confirmed_row(u) and not account_hidden_row(u),
         # most endorsed (by visible endorsers only)
         order_by: fragment("count(?) DESC", endorser.id),
         group_by: u.id,

--- a/lib/vutuv/tags/user_tag.ex
+++ b/lib/vutuv/tags/user_tag.ex
@@ -37,7 +37,7 @@ defmodule Vutuv.Tags.UserTag do
   state) add `preload(:endorsements)` themselves.
   """
   def ordered_by_endorsements(query \\ __MODULE__) do
-    import Vutuv.Moderation.Query, only: [account_hidden: 1, account_confirmed_row: 1]
+    import Vutuv.Moderation.Query, only: [account_hidden_row: 1, account_confirmed_row: 1]
 
     from(u in query,
       left_join: e in assoc(u, :endorsements),
@@ -49,7 +49,7 @@ defmodule Vutuv.Tags.UserTag do
       left_join: endorser in assoc(e, :user),
       on:
         account_confirmed_row(endorser) and
-          not account_hidden(endorser.id),
+          not account_hidden_row(endorser),
       left_join: t in assoc(u, :tag),
       # `desc: t.honor?` sorts true (honor) before false, so admin badges lead.
       order_by: [desc: t.honor?, desc: count(endorser.id), asc: t.slug],

--- a/lib/vutuv/tags/user_tag_endorsement.ex
+++ b/lib/vutuv/tags/user_tag_endorsement.ex
@@ -31,11 +31,11 @@ defmodule Vutuv.Tags.UserTagEndorsement do
   `Vutuv.Tags.UserTag.ordered_by_endorsements/0`.
   """
   def visible(query \\ __MODULE__) do
-    import Vutuv.Moderation.Query, only: [account_hidden: 1, account_confirmed_row: 1]
+    import Vutuv.Moderation.Query, only: [account_hidden_row: 1, account_confirmed_row: 1]
 
     from(e in query,
       join: u in assoc(e, :user),
-      where: account_confirmed_row(u) and not account_hidden(u.id)
+      where: account_confirmed_row(u) and not account_hidden_row(u)
     )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.159.3",
+      version: "7.159.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260725170422_add_users_visibility_partial_index.exs
+++ b/priv/repo/migrations/20260725170422_add_users_visibility_partial_index.exs
@@ -1,0 +1,42 @@
+defmodule Vutuv.Repo.Migrations.AddUsersVisibilityPartialIndex do
+  use Ecto.Migration
+
+  # The "is this member publicly visible" gate — `account_confirmed_row/1 and
+  # not account_hidden_row/1` from `Vutuv.Moderation.Query` — guards ~55 query
+  # sites across 13 modules (search, the follower/following/connection lists,
+  # the tag pages, the directory, the fediverse actor). It has never had an
+  # index, so every one of those queries read the whole users table.
+  #
+  # That is far more wasteful than the row count suggests: on the production
+  # data only 5,549 of 60,527 members pass the gate (9%) — the other 91% are
+  # legacy accounts that never confirmed their email. Each gated query was
+  # scanning 14 MB of heap to find a set that fits in a few index pages.
+  #
+  # The predicate deliberately leaves out the `suspended_until > now()` arm:
+  # `now()` is not immutable, so it cannot appear in an index predicate. It
+  # stays a cheap filter on the rows the index returns, and Postgres still
+  # proves the implication (the query's WHERE is this predicate AND the
+  # suspension test, which only narrows it) — verified on the production copy:
+  # the planner picks this index for the gated queries and drops the seq scan.
+  #
+  # Keep the predicate in step with those two macros. If a future hidden state
+  # joins the gate and this index is not updated, the implication no longer
+  # holds and every gated query silently falls back to the seq scan — which is
+  # what `test/vutuv/moderation/visibility_index_test.exs` fails on.
+  #
+  # Plain (non-concurrent) create, like the other index migrations here: users
+  # is a 14 MB table, so the build takes well under a second.
+  def up do
+    execute("""
+    CREATE INDEX users_visible_index ON users (id)
+    WHERE ("email_confirmed?" IS NULL OR "email_confirmed?")
+      AND frozen_at IS NULL
+      AND deactivated_at IS NULL
+      AND unreachable_at IS NULL
+    """)
+  end
+
+  def down do
+    execute("DROP INDEX users_visible_index")
+  end
+end

--- a/test/vutuv/moderation/visibility_index_test.exs
+++ b/test/vutuv/moderation/visibility_index_test.exs
@@ -1,0 +1,62 @@
+defmodule Vutuv.Moderation.VisibilityIndexTest do
+  @moduledoc """
+  Guards `users_visible_index` (migration
+  `20260725170422_add_users_visibility_partial_index`) against drift.
+
+  The partial index spells the public-visibility gate a second time, in SQL,
+  so Postgres can serve the ~55 query sites that filter on
+  `account_confirmed_row(u) and not account_hidden_row(u)` from an index
+  instead of reading all 60k users rows. Postgres only uses a partial index
+  when it can *prove* the query's WHERE implies the index predicate — and it
+  proves nothing loudly: if the two ever drift apart, every gated query
+  quietly falls back to a sequential scan and only a profiler notices.
+
+  So this asserts the implication itself rather than any timing: with
+  sequential scans disabled, a query built from the two macros must still be
+  planned onto the index. Change the gate and this fails until the migration's
+  predicate follows.
+  """
+
+  use Vutuv.DataCase, async: true
+
+  import Vutuv.Moderation.Query, only: [account_confirmed_row: 1, account_hidden_row: 1]
+
+  alias Vutuv.Accounts.User
+
+  @index "users_visible_index"
+
+  test "the visibility gate is still covered by #{@index}" do
+    query = from(u in User, where: account_confirmed_row(u) and not account_hidden_row(u))
+
+    assert plan_for(query) =~ @index,
+           """
+           The public-visibility gate is no longer served by #{@index}.
+
+           `account_confirmed_row/1` / `account_hidden_row/1` in
+           Vutuv.Moderation.Query changed so that Postgres can no longer prove
+           the query predicate implies the index predicate, so every gated
+           query (search, the follow lists, the tag pages, the directory) is
+           back to a full scan of users.
+
+           Fix: add a migration that recreates #{@index} with a predicate
+           matching the new gate. Remember `now()` and friends cannot appear in
+           an index predicate — leave time-dependent arms (the suspension
+           window) out, they only narrow the query and the proof still holds.
+
+           Plan was:
+           #{plan_for(query)}
+           """
+  end
+
+  # The planner would rather scan a small test table than use any index, so
+  # sequential scans are ruled out first: what is left tells us whether the
+  # index is *usable*, which is the property under test. SET LOCAL keeps it
+  # inside the sandbox transaction.
+  defp plan_for(query) do
+    Repo.query!("SET LOCAL enable_seqscan = off")
+    {sql, params} = Repo.to_sql(:all, query)
+
+    Repo.query!("EXPLAIN " <> sql, params).rows
+    |> Enum.map_join("\n", &hd/1)
+  end
+end


### PR DESCRIPTION
**TL;DR** The public-visibility gate that guards ~55 query sites had no index, so every one of them read the whole `users` table. One 192 kB partial index plus nine `account_hidden/1` → `account_hidden_row/1` swaps makes the follower lists, search operators, tag pages and directory 2–4× faster. Closes #838, whose three proposals I measured and rejected.

## What was wrong

`account_confirmed_row(u) and not account_hidden_row(u)` is the single most-evaluated condition in the app — search, the follower/following/connection lists, the tag pages, the member directory, the fediverse actor. It was unindexed.

On the production data only **5,549 of 60,527 members (9%)** pass it; the rest are legacy accounts that never confirmed their email. So each gated query scanned 14 MB of heap to find a set that fits in a few index pages.

Nine sites made it worse by spelling the gate with the correlated `account_hidden/1` on a users row they had **already joined** — an `EXISTS` per candidate row, and because the check sat outside the row's own predicate it split the gate in two, which stopped the index from applying at all. `account_hidden_row/1`'s docstring already recommended the row-bound form for exactly this case. The two remaining `account_hidden/1` uses in `Vutuv.Posts` are correct — no users row is in scope there.

## Numbers

Measured against a copy of the production database, best of two independent passes:

| | before | after | |
|---|---|---|---|
| followers-list SQL | 9.5 ms | 1.5 ms | **6.5×** |
| `followee_count` SQL | 24 ms | 1.8 ms | **13×** |
| `vorname:` / `nachname:` search | 6.2 ms | 1.6 ms | **3.8×** |
| tag page (`recommended_users/1`) | 6.2 ms | 2.2 ms | **2.8×** |
| `/:slug/following` | 20.7 ms | 7.8 ms | **2.6×** |
| directory A–Z overview | 7.8 ms | 3.4 ms | **2.3×** |
| `/:slug/followers` | 10.6 ms | 5.4 ms | **1.9×** |

Rendering `/:slug/followers` went from **9 sequential scans of `users`, reading 544,743 rows, to none**.

## Why the index can drift, and the tripwire

Postgres uses a partial index only when it can *prove* the query predicate implies the index predicate — and it fails silently: a gate that drifts from the index just reverts to full scans with nothing in the logs. `test/vutuv/moderation/visibility_index_test.exs` plans a query built from the two macros with sequential scans disabled and fails if the index no longer serves it, so the next change to the gate gets told to ship a migration. (Verified it fails for the right reason by dropping the index.)

The `suspended_until > now()` arm is deliberately left out of the index predicate — `now()` is not immutable — and it only narrows the query, so the proof still holds.

## Deploy safety

Plain additive index, N-1 compatible, no column or type changes. Build took under a second on the 60k-row table.

## On #838's three proposals — all rejected

1. **Denormalized follower/followee/connection counters.** The worst-case account (664 followers, 2,695 followees) now costs 1.2 / 2.1 / 1.2 ms. The 7 ms outlier the issue was reacting to was this missing index, not the counting. Denormalized columns would have to be re-derived on every moderation state change (freeze, suspend, deactivate, unreachable bounce) — the drift the issue itself flagged — to buy nothing.
2. **`post_likes.post_author_id`.** The whole table holds **223 rows** in production; the busiest author has 119 likes across all their posts, and the notifications "like" source measures 0.9 ms. A denormalized column, a backfill and two deploys to save well under a millisecond is not a trade worth making. The `post_replies.parent_author_id` precedent makes it a small change if that ever changes.
3. **`users` name indexes for `vorname:` / `nachname:`.** Superseded, and the diagnosis was wrong: the operators were slow because of the gate's full scan that ran first, not a missing name index. They are ~1.6 ms now with no name-specific index and no trigram GIN (which would have cost ~10 MB and write amplification on every name edit).

`mix precommit` green: 5,162 tests, credo `--strict`, format.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
