### PR TITLE
Attach the notification actor after the limit, not before

### DIFF
--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -651,15 +651,30 @@ defmodule Vutuv.Activity do
     ]
   end
 
+  # The actor join deliberately happens **after** the order/limit, via a
+  # subquery. Joining users straight onto the follows rows makes Postgres build
+  # the whole candidate set first — for a member with many followers that means
+  # hash-joining the entire users table (a full scan on every notification
+  # page) only to discard all but `limit` of the result. Ordering and limiting
+  # the cheap follows rows first and attaching the actor to the survivors turns
+  # it into `limit` primary-key lookups: measured 9.4 ms -> 0.6 ms on the
+  # production data. `connection_items/3` below is the same shape.
   defp follower_items(user_id, limit, cursor) do
-    from(c in Follow,
-      where: c.followee_id == ^user_id,
-      join: f in assoc(c, :follower),
-      order_by: [desc: c.inserted_at, desc: c.id],
-      limit: ^limit,
-      select: {c.id, c.inserted_at, struct(f, ^User.listing_fields())}
+    newest =
+      from(c in Follow,
+        where: c.followee_id == ^user_id,
+        order_by: [desc: c.inserted_at, desc: c.id],
+        limit: ^limit,
+        select: %{id: c.id, at: c.inserted_at, actor_id: c.follower_id}
+      )
+      |> at_or_before(cursor)
+
+    from(e in subquery(newest),
+      join: f in User,
+      on: f.id == e.actor_id,
+      order_by: [desc: e.at, desc: e.id],
+      select: {e.id, e.at, struct(f, ^User.listing_fields())}
     )
-    |> at_or_before(cursor)
     |> Repo.all()
     |> Enum.map(fn {id, at, follower} ->
       actor_item("follower-#{id}", "follower", at, follower)
@@ -693,12 +708,10 @@ defmodule Vutuv.Activity do
   # separate connection record any more, so a one-way follow simply does not
   # surface here (it is a `follower_items/3` entry instead).
   defp connection_items(user_id, limit, cursor) do
-    query =
+    mutual =
       from(out in Follow,
         join: back in Follow,
         on: back.follower_id == out.followee_id and back.followee_id == out.follower_id,
-        join: u in User,
-        on: u.id == out.followee_id,
         where: out.follower_id == ^user_id,
         order_by: [
           desc: fragment("GREATEST(?, ?)", out.inserted_at, back.inserted_at),
@@ -709,21 +722,29 @@ defmodule Vutuv.Activity do
           id: type(fragment("GREATEST(?, ?)", out.id, back.id), Vutuv.UUIDv7),
           at:
             type(fragment("GREATEST(?, ?)", out.inserted_at, back.inserted_at), :naive_datetime),
-          friend: struct(u, ^User.listing_fields())
+          actor_id: out.followee_id
         }
       )
 
-    query =
+    mutual =
       if cursor,
         do:
           where(
-            query,
+            mutual,
             [out, back],
             fragment("GREATEST(?, ?)", out.inserted_at, back.inserted_at) <= ^cursor.at
           ),
-        else: query
+        else: mutual
 
-    query
+    # Same two-step shape as `follower_items/3`: the users join is kept out of
+    # the ordered/limited half so it runs over `limit` rows, not every mutual
+    # follow (measured 6.0 ms -> 0.8 ms).
+    from(e in subquery(mutual),
+      join: u in User,
+      on: u.id == e.actor_id,
+      order_by: [desc: e.at, desc: e.id],
+      select: %{id: e.id, at: e.at, friend: struct(u, ^User.listing_fields())}
+    )
     |> Repo.all()
     |> Enum.map(fn %{id: id, at: at, friend: friend} ->
       actor_item("connection-#{id}", "connection", at, friend)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.159.4",
+      version: "7.159.5",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/activity_test.exs
+++ b/test/vutuv/activity_test.exs
@@ -658,6 +658,76 @@ defmodule Vutuv.ActivityTest do
       assert Enum.map(page2.entries, & &1.kind) == ["like"]
       refute page2.more?
     end
+
+    # The follower and connection sources attach their actor *after* ordering
+    # and limiting (joining users first made Postgres scan the whole table to
+    # build a candidate set it then threw away). These pin what that shape can
+    # get wrong: the order must survive the two-step query, and the actor must
+    # still be the other person rather than the reader.
+    test "connection events come newest-first, honour the limit and walk the cursor" do
+      me = insert(:user)
+
+      # A connection is timestamped GREATEST(out, back), so both edges of each
+      # pair are back-dated to the same instant to pin the event's position.
+      for {name, at} <- [
+            {"Oldest", ~N[2021-01-01 12:00:00]},
+            {"Middle", ~N[2022-01-01 12:00:00]},
+            {"Newest", ~N[2023-01-01 12:00:00]}
+          ] do
+        friend = insert(:user, first_name: name, last_name: "Friend")
+
+        for edge <- [
+              insert(:follow, follower: me, followee: friend),
+              insert(:follow, follower: friend, followee: me)
+            ],
+            do: backdate_connection(edge, at)
+      end
+
+      page1 = Activity.notifications_page(me.id, limit: 2, kinds: ["connection"])
+
+      assert Enum.map(page1.entries, & &1.actor_name) == ["Newest Friend", "Middle Friend"]
+      assert page1.more?
+
+      page2 =
+        Activity.notifications_page(me.id,
+          limit: 2,
+          kinds: ["connection"],
+          cursor: page1.next_cursor
+        )
+
+      assert Enum.map(page2.entries, & &1.actor_name) == ["Oldest Friend"]
+      refute page2.more?
+
+      # ... and the same feed by numbered page.
+      assert Activity.notifications_page(me.id, limit: 2, page: 2, kinds: ["connection"])
+             |> Map.fetch!(:entries)
+             |> Enum.map(& &1.actor_name) == ["Oldest Friend"]
+    end
+
+    test "follower events name the follower, not the reader, past the limit" do
+      me = insert(:user)
+
+      for {name, at} <- [
+            {"Oldest", ~N[2021-01-01 12:00:00]},
+            {"Middle", ~N[2022-01-01 12:00:00]},
+            {"Newest", ~N[2023-01-01 12:00:00]}
+          ] do
+        follower = insert(:user, first_name: name, last_name: "Follower")
+        backdate_connection(insert(:follow, follower: follower, followee: me), at)
+      end
+
+      page = Activity.notifications_page(me.id, limit: 2, kinds: ["follower"])
+
+      assert Enum.map(page.entries, & &1.actor_name) == ["Newest Follower", "Middle Follower"]
+
+      assert Activity.notifications_page(me.id,
+               limit: 2,
+               kinds: ["follower"],
+               cursor: page.next_cursor
+             )
+             |> Map.fetch!(:entries)
+             |> Enum.map(& &1.actor_name) == ["Oldest Follower"]
+    end
   end
 
   describe "activity_summary/2" do


### PR DESCRIPTION
**TL;DR** The notification feed's follower and connection sources joined the actor's `users` row *before* the ORDER BY / LIMIT, so every notification page carried a full sequential scan of `users`. Attaching the actor after the limit does 8–12× less I/O on page 1 with byte-identical results. **Not merged yet — the wall-clock gain is smaller than it first looked, so this is Stefan's call.**

## The bug

`follower_items/3` and `connection_items/3` both built their candidate set with the users join already attached. For a member with 664 followers that meant hash-joining the entire 60k-row `users` table to produce 664 rows, then discarding all but the 51 the page asked for:

```
Limit (rows=51)
  Sort
    Hash Join
      Seq Scan on users  (60,527 rows)   <-- the whole cost
      Index Scan on follows_followee_id_index  (664 rows, 0.055 ms)
```

Both now order and limit the cheap `follows` rows in a subquery and attach the actor to the survivors, so the users side becomes `limit` primary-key lookups (Postgres memoizes them).

## Numbers, honestly

Wall-clock, both shapes **interleaved in one process** so machine drift lands on both arms equally, median of 61 runs after 25 warm-ups:

| fetch depth | source | before | after | |
|---|---|---|---|---|
| page 1 (51) | follower | 0.98 ms | 0.56 ms | 1.7× |
| page 1 (51) | connection | 1.65 ms | 1.26 ms | 1.3× |
| page 10 (501) | follower | 2.66 ms | 2.40 ms | 1.1× |
| page 10 (501) | connection | 5.85 ms | 5.47 ms | 1.1× |

Buffers touched, which does not depend on cache state:

| | before | after |
|---|---|---|
| follower, page 1 | 1,843 | **223** |
| connection, page 1 | 3,693 | **302** |
| follower, page 10 | 1,843 | 2,023 |
| connection, page 10 | 3,693 | 1,889 |

The common case does 8–12× less I/O; a deep offset page is a wash.

**Why the wall-clock gain is modest today:** 14 MB of `users` fits in shared_buffers, and a hot sequential scan is mostly CPU. The point is the *shape* — the old cost was proportional to total membership no matter how many followers the reader has, the new one is proportional to the page size. At 500k members the old query gets ~8× worse while this one stays flat, and on a cold or evicted cache the old plan already costs ~10 ms.

A correction worth recording: an earlier draft of this work quoted 16× and 7×. Those came from a short warm-up on a cold cache and did not survive a drift-immune re-measurement. The giveaway was that queries I had not touched (`notifications_count`, the unread badge) also "changed" 2× between runs.

## Also worth knowing

`notifications_page` turned out **not to be slow** in steady state: ~5–9 ms of DB time across 16 queries, flat profile, no outlier left after this. The 15 sources run sequentially and could be parallelised, but that needs `Ecto.Adapters.SQL.Sandbox` ownership handling for every `async: true` test that touches notifications — a lot of test risk for ~10 ms. I did not do it.

## Tests

Two new tests pin what this shape can get wrong — the order surviving the two-step query, and the actor still being the other person rather than the reader — across the limit, the cursor and a numbered page. They were written against the old code and passed there first, so they pin behaviour rather than the new implementation.

`mix precommit` green: 5,164 tests, credo `--strict`, format.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
