### PR TITLE
Answer a reply that came from another network (#1070)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -159,6 +159,18 @@ config :vutuv, :fediverse_note_refresh, true
 config :vutuv, :fediverse_note_retention_days, 183
 config :vutuv, :fediverse_note_refresh_days, 7
 
+# How long a post whose picture the AI image scan has not judged yet waits before
+# it federates anyway (issue #1070). The scan normally settles within seconds and
+# releases the post at once, so this is the CEILING, not the usual wait: it is
+# what happens when the scanner is down, and then the post goes out without the
+# unvetted picture rather than not at all.
+config :vutuv, :fediverse_image_hold_seconds, 90
+
+# How many answers to other networks one member may send per hour (issue #1070).
+# The one place a member's own action makes vutuv POST to a server that never
+# followed them, so it is metered; sized for a conversation, not a script.
+config :vutuv, :fediverse_outbound_reply_limit, 30
+
 # Whether the daily GenServer that prunes the account-activity log runs (off in
 # tests, same sandbox reasoning; tests call
 # Vutuv.AccountEvents.delete_expired/0 directly).

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -174,6 +174,21 @@ if config_env() == :prod do
     config :vutuv, :fediverse_note_refresh_days, String.to_integer(String.trim(days))
   end
 
+  # How many answers to other networks one member may send per hour (issue
+  # #1070). The one place a member's own action makes this installation POST to a
+  # server that never followed them, so the operator has to be able to meter it.
+  if limit = System.get_env("FEDIVERSE_OUTBOUND_REPLY_LIMIT") do
+    config :vutuv, :fediverse_outbound_reply_limit, String.to_integer(String.trim(limit))
+  end
+
+  # How long a post whose picture the AI image scan has not judged yet waits
+  # before it federates without it (issue #1070). The ceiling, not the usual
+  # wait — the post normally goes out the moment the scan settles. An
+  # installation running the scanner on slow hardware raises it.
+  if seconds = System.get_env("FEDIVERSE_IMAGE_HOLD_SECONDS") do
+    config :vutuv, :fediverse_image_hold_seconds, String.to_integer(String.trim(seconds))
+  end
+
   # How long the account-activity log keeps an event (issue #1087). It holds
   # devices, IP addresses and what changed when, so how long that may be kept is
   # the operator's call; one year is what vutuv.de runs.

--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -119,6 +119,8 @@ Everything else has a default (the vutuv.de production value):
 | `FEDIVERSE_INBOUND_CAPS` | `600,60` | `host,actor`: how many rows one remote server, and one remote account, may store here per hour. Anything past the budget is dropped for that hour. The floor under the operator blocklist at `/admin/fediverse`, since it also bounds servers nobody has blocked yet |
 | `FEDIVERSE_NOTE_RETENTION_DAYS` | `183` | How long a reply written on another network may be held here at the very most, in days. It is deleted when the clock runs out whatever else happens, so this is the promise your privacy page can make. Only applies once a member switches replies on (off by default) |
 | `FEDIVERSE_NOTE_REFRESH_DAYS` | `7` | How stale a stored reply may get before vutuv asks its origin server whether it is still published there. Still there means the text is refreshed and the retention clock starts again; gone (or locked away) means it is deleted at once; unreachable changes nothing. Replies sent to a member privately are never re-checked |
+| `FEDIVERSE_OUTBOUND_REPLY_LIMIT` | `30` | How many answers to other networks one member may send per hour. This is the one place a member's own action makes your installation POST to a server that never followed them, so it is metered: the budget is the backstop against a compromised account relaying. Sized for somebody holding a conversation, so it only ever bites automation. Answering is only possible where a reply from that server already sits on a vutuv post, so the targets are always people who wrote here first |
+| `FEDIVERSE_IMAGE_HOLD_SECONDS` | `90` | How long a post whose picture the AI image scan has not judged yet waits before it federates **without** the picture. This is a ceiling, not the usual wait: the post goes out the moment the scan settles, normally within seconds. It only bites when the scanner is down, and then the choice is "the post without its picture" over "no post at all". Raise it if you run image moderation on slow hardware; irrelevant when `MODERATE_IMAGES` is off |
 | `ACCOUNT_EVENT_RETENTION_DAYS` | `365` | How long the **account-activity log** keeps an event, in days (see `docs/architecture/account-activity.md`). It records what changed on an account, when, from which coarse device (never an IP address), and how it was confirmed, so it is personal data with a clock on it: a year covers the "this happened months ago and I only noticed now" support case without becoming a permanent movement profile. The daily sweeper deletes anything older |
 | `FETCH_BOOK_METADATA` | `true` | `false` turns the catalogue lookups behind post **book reviews** off (the composer's ISBN → title/author/year prefill, the cover image, page count and publisher from Open Library, and an audiobook's running time). The review feature itself keeps working — members type the fields by hand and the card renders without a cover or those details. Set it on installations that must not call out (intranets) |
 | `DNB_SRU_URL` | `https://services.dnb.de/sru/dnb` | Where an **audiobook's running time** is looked up by ISBN: an SRU endpoint answering MARC21-xml (the Deutsche Nationalbibliothek by default — Open Library records no durations). Point it at another catalogue's SRU endpoint, or set it **empty** (`DNB_SRU_URL=`) to switch that one lookup off while the rest of the book metadata keeps working |
@@ -553,6 +555,37 @@ at all — they never signed up here and cannot practically be asked:
 If you run an installation where holding third-party text is not acceptable at
 all, leave it as it is: members have to switch it on themselves, and
 `FEDIVERSE_ENABLED=false` turns the whole of federation off.
+
+**Answering those replies.** A member who takes part in the Fediverse can answer
+a **public** reply that came from another network, from the reply's own card in the
+conversation. Any member who federates can answer, not only the author of the post
+it sits under. The answer is an ordinary public vutuv post that also travels to the
+person answered and to the answerer's Fediverse followers, and the page says so
+before they write a word, so nobody publishes to another network by accident. A
+member who has not switched federation on is shown what the setting does and a
+link to it rather than a disabled button.
+
+A reply that was addressed to a member alone cannot be answered: doing it publicly
+would publish half of an exchange its author meant for one person.
+
+This is the only case where your installation sends something to a server that
+never asked for it, so two things bound it. The target is never freely chosen —
+there has to be a stored reply from that server on a vutuv post first, so the
+person answered is always somebody who wrote here — and each member has an hourly
+budget (`FEDIVERSE_OUTBOUND_REPLY_LIMIT`) as the backstop against a compromised
+account being used to relay. Blocking a server at `/admin/fediverse` also stops
+answers going to it. Editing or deleting such an answer tells the person answered
+too, for as long as the answer exists here — which is why a small delivery address
+is kept alongside it even after the six-month copy of their reply is gone.
+
+**Posts with pictures reach other networks a moment later.** A picture is
+invisible until image moderation has judged it, so a post carrying one waits for
+that verdict before it federates — otherwise the other network would receive the
+text and never the picture. Normally that is a few seconds. If the scanner is down,
+the post goes out after `FEDIVERSE_IMAGE_HOLD_SECONDS` (90) **without** the
+unvetted picture, on the grounds that a post without its picture beats no post.
+A rejected picture settles the post the same way. None of this applies when
+`MODERATE_IMAGES` is off.
 
 **Followers who leave without saying so.** Somebody on another server who
 unfollows, or who deletes their account and whose server announces it, disappears

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -190,6 +190,79 @@ every endpoint 404s and nothing is delivered.
     renders as a closed lid. The member also gets a notification: the
     `fediverse_reply` kind, sourced **straight from the notes table**, so
     deleting a note deletes its notification with no second place to remember.
+- **Answering a reply that came from another network** (issue #1070, the one
+  place a member's own action makes vutuv POST to a server that never followed
+  them): the "Reply" link on a remote reply's card opens
+  `/system/fediverse/reply/:id` (`VutuvWeb.PostLive.RemoteReply`) — the reply
+  above, the ordinary post composer below, and a line stating plainly, *before*
+  the member types, that the answer goes to that person on their own server and to
+  the member's Fediverse followers and is a public vutuv post as well. Nobody
+  should publish to another network by accident.
+  - **Underneath it is an ordinary reply.** `Posts.create_remote_reply/3` writes
+    the same `PostReply` row to the vutuv post the note answers, so local
+    threading, the parent-author notification, the public reply count and the edit
+    window are untouched, plus a `Vutuv.Posts.PostRemoteReply` sidecar recording
+    the *other* thing it answers. The conversation renderer reads that sidecar to
+    hang the answer **under** the remote card rather than beside it (the forest
+    would otherwise make them siblings).
+  - **The sidecar carries its own copy of the target** — `in_reply_to_uri`,
+    `actor_uri`, `inbox_uri`, `handle` — because a note is a cache that expires
+    six months out or is taken down before that, while the member's answer lives
+    on and an `Update`/`Delete` still has to reach the person answered. `note_id`
+    nilifies for that reason instead of cascading. The inbox itself was captured
+    when the note was stored (the inbox had already fetched and verified that
+    actor document to check the signature), so answering costs no network call.
+  - **The activity**: `inReplyTo` is the remote note's own id, not the vutuv post
+    underneath (that note already points back at our post, so this is what threads
+    the answer correctly over there); the answered actor joins `cc` beside the
+    usual public audience; and a `Mention` tag plus a leading linked `@user@host`
+    in the outgoing HTML is what gets them notified. The `Mention` is built from
+    the **stored** actor URI, never parsed out of the member's typed text — parsing
+    would let anyone mint a verified-looking Mention at an actor nobody checked,
+    which is mention spam with our signature on it. The handle is added on the wire
+    only: on vutuv the answer shows a "Replying to" line, so a member who has never
+    heard of Mastodon never types a handle in a foreign format.
+  - **Who may answer**: any member who federates, not only the author of the post
+    the note sits under — the conversation is on their post either way, and the
+    answer is delivered from the answerer's own actor to their own followers.
+    `Fediverse.check_remote_reply/2` holds the gates and **names** which one
+    refused, because `:not_federating` is the one the member can act on: the page
+    turns it into an explanation and a link to `/settings/fediverse` rather than a
+    dead end. Hiding the link from them instead would leave them no way to find out
+    the capability exists.
+  - **Public replies only** in v1, and the operator blocklist stops answers going
+    to a shut-out server (a block is both ears and mouth shut). Plus an hourly
+    per-member budget (`:fediverse_outbound_reply_limit`, 30) as the backstop
+    against a compromised account relaying: the shape of the feature already bounds
+    it hard, since an answer needs a stored reply on a vutuv post first, so the
+    targets are people who wrote here and never a list an attacker picks.
+  - **The inbox is vetted twice.** An actor document names its own inbox and
+    whoever runs that server writes the document, so a hostile one can point its
+    inbox at a third party and turn a member's answer into a signed POST there (the
+    classic ActivityPub inbox redirect). `Fediverse.own_inbox/1` therefore refuses
+    an inbox that is not https on the actor's **own host** before it is ever
+    stored — the same rule the inbox already applies to a signature's `keyId` — and
+    `attempt/2` re-checks every row at send time (https, not internal, not
+    blocked).
+- **Holding a post back until its pictures are vetted** (issue #1070): a post's
+  images are invisible until the AI scan releases them
+  (`Vutuv.Moderation.ImageScans`), so a Note built the instant the post commits
+  carries no attachment for them and nothing would ever send the picture. Such a
+  post is now enqueued with a short hold and a `rebuild_from` marker
+  (`fediverse_deliveries`), and the deliverer re-renders it when it goes out.
+  `Fediverse.images_settled/1`, called from
+  `Vutuv.Moderation.ImageSubjects.apply_approved/1` **and** `apply_rejected/1`
+  (a rejected picture settles the post just as an approved one does — it then
+  federates without it, which is what vetting first means), pulls the row forward
+  the moment the last picture on the post has a verdict, which is the normal case
+  and usually a few seconds. `:fediverse_image_hold_seconds` (90) is the
+  **ceiling**, not the usual wait: it is what happens when the scanner is down, and
+  then the post goes out without the unvetted picture rather than not at all.
+  `activity_json` still holds a complete, valid activity for a held row, so a
+  release that knows nothing of `rebuild_from` delivers that instead of choking —
+  the worst a deploy window can do is federate one post without its picture. The
+  rebuild re-checks the gates too, so a post deleted or made non-public during the
+  hold never goes out.
 - **The operator's safety floor** (issue #1067): anyone can run an ActivityPub
   server, so before anything a remote sends is stored, two independent levers
   sit in front of it. The **blocklist**
@@ -377,10 +450,13 @@ a link out instead), **boost rosters** (who re-shared stays a number), inline
 rather than a vutuv post — that conversation lives on its author's server, and
 following it would mean storing arbitrary third-party threads.
 
-Replying **back** to somebody on another network from vutuv is not built either:
-it would mean delivering to servers that never followed us and sending a member's
-words somewhere they did not choose, which deserves its own decision. The card
-links to the original instead.
+Replying **back** to somebody on another network is built now (issue #1070, see
+the outbound-replies bullet above) — for **public** replies only. A reply
+addressed to the member alone still cannot be answered: answering it publicly
+would publish half of an exchange its author asked to keep to one person, and
+answering it privately would mean a new kind of vutuv post that has to be
+invisible in the feed, on the profile, in the thread, in the agent formats and in
+the data export. That is its own feature; the card links to the original instead.
 
 The operator blocklist and the
 inbound caps that were the condition for storing anything shipped alongside it

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -47,6 +47,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostDenial
+  alias Vutuv.Posts.PostRemoteReply
   alias Vutuv.RateLimiter
   alias Vutuv.RemoteHtml
   alias Vutuv.Repo
@@ -617,6 +618,15 @@ defmodule Vutuv.Fediverse do
   @inbound_actor_limit 60
   @inbound_window_ms :timer.hours(1)
 
+  # Answers a member may send out to other networks per hour (issue #1070). Set
+  # for a person holding a conversation, not for a script: a real exchange is a
+  # handful of messages, so this only ever bites automation.
+  @outbound_reply_limit 30
+
+  # How long a post with an unvetted picture is held before it federates without
+  # it. The ceiling, not the normal wait — see `image_hold_seconds/0`.
+  @image_hold_seconds 90
+
   @doc "Every blocked remote server, newest first, with who blocked it."
   def list_blocked_instances do
     Repo.all(from(b in BlockedInstance, order_by: [desc: b.id], preload: [:blocked_by]))
@@ -1169,6 +1179,7 @@ defmodule Vutuv.Fediverse do
           actor_uri: actor.uri,
           origin_url: presence(object["url"]),
           in_reply_to_uri: object["inReplyTo"],
+          inbox_uri: own_inbox(actor),
           handle: actor.handle,
           display_name: actor.name,
           content_text: text,
@@ -1183,6 +1194,39 @@ defmodule Vutuv.Fediverse do
         |> Repo.insert()
     end
   end
+
+  @doc """
+  The inbox a remote actor may be answered at: their own, and only when it sits
+  on the **same host** as the actor id (issue #1070).
+
+  An actor document names its own inbox, and that document is written by whoever
+  runs the server. A hostile one can point its inbox at a third party and use a
+  member's reply to make vutuv deliver a signed POST there, which is the classic
+  ActivityPub inbox redirect. The inbox path already refuses a `keyId` served by
+  another host (`same_authority?/2` in `VutuvWeb.FediverseController`); this is
+  the same rule for the delivery target.
+
+  Returns `nil` when the document names a foreign, malformed or missing inbox, so
+  the answer is simply not delivered to it rather than delivered somewhere the
+  actor does not control.
+  """
+  def own_inbox(%{uri: actor_uri, inbox: inbox}) when is_binary(inbox) do
+    if same_host?(actor_uri, inbox), do: inbox
+  end
+
+  def own_inbox(_actor), do: nil
+
+  defp same_host?(a, b) when is_binary(a) and is_binary(b) do
+    case {URI.parse(a), URI.parse(b)} do
+      {%URI{host: host}, %URI{host: host, scheme: "https"}} when is_binary(host) and host != "" ->
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  defp same_host?(_a, _b), do: false
 
   # How the note was addressed, read from `to`/`cc` on **both** the Create and
   # the Note (servers put the audience on either). Only the public collection
@@ -1454,10 +1498,77 @@ defmodule Vutuv.Fediverse do
   # instances reject anonymous GETs). federated?/1 guaranteed the actor exists.
   defp signer(user), do: signer_for(user, get_actor(user))
 
+  ## Answering another network (issue #1070)
+
+  @doc """
+  Whether `author` may answer the stored remote reply `note`, and when not, which
+  gate refused. `:ok`, or `{:error, reason}` with one of:
+
+    * `:fediverse_disabled` — the installation switch is off.
+    * `:note_not_public` — the reply was addressed to the member alone. Answering
+      it would mean publishing half of a private exchange, so v1 does not offer
+      it at all; the card links to the original instead.
+    * `:not_federating` — the member has not switched Fediverse participation on
+      (or their account is not in good standing). **The one refusal the member can
+      do something about**, which is why it is named separately: the reply page
+      turns it into an explanation and a link to `/settings/fediverse` rather than
+      a dead end.
+    * `:moved` — the member redirected their Fediverse followers to another
+      account, so nothing of theirs federates any more.
+    * `:instance_blocked` — the operator shut that server out. A block is both
+      ears and mouth shut, so it stops answers going the other way too.
+
+  Any federating member may answer, not only the author of the post the note sits
+  under: the conversation is on their post either way, and an answer is delivered
+  from the answerer's own actor to their own followers.
+
+  Deliberately free of side effects, so a render can ask it as safely as a write.
+  The outbound budget is claimed separately (`claim_reply_budget/1`).
+  """
+  def check_remote_reply(%User{} = author, %Note{} = note) do
+    cond do
+      not enabled?() -> {:error, :fediverse_disabled}
+      not Note.public?(note) -> {:error, :note_not_public}
+      not federated?(author) -> {:error, :not_federating}
+      moved?(author) -> {:error, :moved}
+      instance_blocked?(note.actor_uri) -> {:error, :instance_blocked}
+      true -> :ok
+    end
+  end
+
+  @doc """
+  Claims one slot from the member's hourly budget for answers that leave for
+  another network. `:ok`, or `{:error, :reply_capped}`.
+
+  This is the one place a member's own action makes vutuv POST to a server that
+  never followed them, so it is metered. The shape of the feature already bounds
+  it hard (an answer needs a stored reply on a vutuv post first, so the targets
+  are people who wrote here, never a list an attacker picks), and this is the
+  backstop for the rest: a compromised account cannot turn the installation into
+  a relay faster than the budget allows.
+
+  Consuming, so only the write path calls it.
+  """
+  def claim_reply_budget(%User{id: user_id}) do
+    case RateLimiter.hit(
+           {:fediverse_outbound_reply, user_id},
+           outbound_reply_limit(),
+           @inbound_window_ms
+         ) do
+      :ok -> :ok
+      _ -> {:error, :reply_capped}
+    end
+  end
+
+  @doc "How many answers per hour one member may send to other networks."
+  def outbound_reply_limit,
+    do: Application.get_env(:vutuv, :fediverse_outbound_reply_limit, @outbound_reply_limit)
+
   ## Federating posts (called from Vutuv.Posts after commit)
 
   @doc "A freshly published post -> Create(Note) to every follower inbox."
-  def federate_new_post(%Post{} = post), do: maybe_federate(post, &Docs.create_activity/2)
+  def federate_new_post(%Post{} = post),
+    do: maybe_federate(post, &Docs.create_activity/2, "post_create")
 
   @doc """
   An edited post -> Update(Note); one whose audience closed -> Delete, so
@@ -1468,36 +1579,129 @@ defmodule Vutuv.Fediverse do
     if Posts.restricted?(post) do
       federate_post_delete(post)
     else
-      maybe_federate(post, &Docs.update_activity/2)
+      maybe_federate(post, &Docs.update_activity/2, "post_update")
     end
   end
 
   @doc "A deleted post -> Delete(Tombstone) (best effort)."
-  def federate_post_delete(%Post{id: post_id, user_id: user_id}) do
+  def federate_post_delete(%Post{id: post_id, user_id: user_id} = post) do
     with true <- enabled?(),
          %User{} = user <- Repo.get(User, user_id),
          true <- federated?(user),
          false <- moved?(user),
-         [_ | _] = inboxes <- delivery_inboxes(user) do
+         [_ | _] = inboxes <- recipients(user, post) do
       enqueue(user, inboxes, Docs.delete_activity(post_id, user))
     else
       _ -> :skip
     end
   end
 
-  defp maybe_federate(%Post{} = post, builder) do
+  defp maybe_federate(%Post{} = post, builder, kind) do
     with true <- enabled?(),
          %User{} = user <- Repo.get(User, post.user_id),
          true <- federated?(user),
          false <- moved?(user),
          false <- Posts.restricted?(post),
-         [_ | _] = inboxes <- delivery_inboxes(user) do
-      post = Repo.preload(post, [:images, :review, reply_ref: [:parent_author]])
-      enqueue(user, inboxes, builder.(post, user))
+         post = Repo.preload(post, Docs.note_preloads()),
+         [_ | _] = inboxes <- recipients(user, post) do
+      enqueue(user, inboxes, builder.(post, user), hold_opts(post, kind))
     else
       _ -> :skip
     end
   end
+
+  ## Holding a post back until its pictures are vetted (issue #1070)
+
+  @doc """
+  How long a post with an unvetted picture waits before it federates anyway.
+
+  A post's images are invisible until the AI scan releases them
+  (`Vutuv.Moderation.ImageScans`), so a Note built the instant the post commits
+  carries no attachment for them and nothing would ever send the picture. The
+  post is therefore held, and released the moment the scan settles — usually a few
+  seconds later, through `images_settled/1`.
+
+  This is the **ceiling**, not the normal wait: it is what happens when the
+  scanner is down, and then the post goes out without the picture rather than not
+  at all. Configurable (`:fediverse_image_hold_seconds`) so tests do not sit on a
+  real clock.
+  """
+  def image_hold_seconds,
+    do: Application.get_env(:vutuv, :fediverse_image_hold_seconds, @image_hold_seconds)
+
+  # A post with nothing pending goes out now, exactly as before. One waiting on a
+  # picture is enqueued with a complete, valid activity anyway (so a release that
+  # knows nothing of `rebuild_from` still delivers something sane) plus the marker
+  # that tells this release to re-render it at send time.
+  defp hold_opts(%Post{} = post, kind) do
+    if Posts.awaiting_image_release?(post) do
+      [
+        delay_seconds: image_hold_seconds(),
+        rebuild_from: "#{kind}:#{post.id}"
+      ]
+    else
+      []
+    end
+  end
+
+  @doc """
+  The AI scan settled every picture on this post: send any held delivery now
+  instead of waiting out `image_hold_seconds/0`.
+
+  Called from `Vutuv.Moderation.ImageSubjects` on both outcomes, because a
+  rejected picture settles the post just as an approved one does — the post then
+  federates without it, which is the whole point of vetting first.
+
+  Nothing to do when a *second* picture on the same post is still pending: the
+  post waits for the last one.
+  """
+  def images_settled(post_id) when is_binary(post_id) do
+    if enabled?() and not Posts.awaiting_image_release?(post_id) do
+      release_held_deliveries(post_id)
+    end
+
+    :ok
+  end
+
+  def images_settled(_post_id), do: :ok
+
+  defp release_held_deliveries(post_id) do
+    now = DateTime.utc_now(:second)
+    markers = Enum.map(["post_create", "post_update"], &"#{&1}:#{post_id}")
+
+    {count, _} =
+      from(d in Delivery, where: d.rebuild_from in ^markers and d.next_attempt_at > ^now)
+      |> Repo.update_all(set: [next_attempt_at: now])
+
+    if count > 0, do: Deliverer.nudge()
+    count
+  end
+
+  @doc """
+  Every inbox one of a member's post activities goes to: the servers that
+  followed them, plus — when the post answers a reply from another network
+  (issue #1070) — the inbox of the person answered.
+
+  That last one is the only inbox vutuv ever posts to without having been asked,
+  which is why the address is vetted before it is ever stored (`own_inbox/1`
+  refuses an inbox on a host the actor does not control) and re-vetted per row at
+  send time (`attempt/2`: https, not internal, not a blocked server).
+
+  A member with no Fediverse followers at all still reaches the person they
+  answered, so the empty-follower case is not "nothing to do" any more.
+  """
+  def recipients(%User{} = user, %Post{} = post) do
+    (delivery_inboxes(user) ++ answered_inbox(post)) |> Enum.uniq()
+  end
+
+  # Read off the struct, never re-queried: on the delete path the sidecar row has
+  # already cascaded away with the post, and the preloaded association is the only
+  # copy of the address left (see `Vutuv.Posts.delete_post/1`).
+  defp answered_inbox(%Post{remote_reply_ref: %PostRemoteReply{inbox_uri: inbox}})
+       when is_binary(inbox),
+       do: [inbox]
+
+  defp answered_inbox(%Post{}), do: []
 
   @doc """
   A member reposts another member's public post -> `Announce` to the reposter's
@@ -1533,10 +1737,11 @@ defmodule Vutuv.Fediverse do
     enqueue(user, [inbox_uri], Docs.accept_activity(user, follow_object))
   end
 
-  defp enqueue(user, inboxes, activity) do
+  defp enqueue(user, inboxes, activity, opts \\ []) do
     json = Jason.encode!(activity)
     now = DateTime.utc_now(:second)
     stamp = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    due = DateTime.add(now, Keyword.get(opts, :delay_seconds, 0))
 
     rows =
       Enum.map(inboxes, fn inbox ->
@@ -1545,8 +1750,9 @@ defmodule Vutuv.Fediverse do
           user_id: user.id,
           inbox_uri: inbox,
           activity_json: json,
+          rebuild_from: Keyword.get(opts, :rebuild_from),
           attempts: 0,
-          next_attempt_at: now,
+          next_attempt_at: due,
           inserted_at: stamp,
           updated_at: stamp
         }
@@ -1674,16 +1880,40 @@ defmodule Vutuv.Fediverse do
          false <- Vutuv.Ssrf.resolves_to_internal?(host),
          # A server the operator blocked while this row waited in the queue must
          # not be delivered to either — a block is both ears and mouth shut.
-         false <- instance_blocked?(delivery.inbox_uri) do
+         false <- instance_blocked?(delivery.inbox_uri),
+         {:ok, delivery} <- rebuilt(delivery, user) do
       post_activity(delivery, user, actor)
     else
-      # No key, a non-https inbox, an internal target or a blocked server:
-      # undeliverable for good, so the row goes instead of clogging the queue.
+      # No key, a non-https inbox, an internal target, a blocked server, or a
+      # post that is gone or no longer public: undeliverable for good, so the row
+      # goes instead of clogging the queue.
       _ -> Repo.delete(delivery)
     end
   end
 
   defp attempt(%Delivery{} = delivery, _actor), do: Repo.delete(delivery)
+
+  # A held row re-renders its activity now, so a picture the AI scan released
+  # while it waited rides along (issue #1070). The gates are re-checked at the
+  # same time: the post may have been deleted or had its audience closed during
+  # the hold, and then this delivery must not go out at all.
+  defp rebuilt(%Delivery{rebuild_from: nil} = delivery, _user), do: {:ok, delivery}
+
+  defp rebuilt(%Delivery{rebuild_from: marker} = delivery, user) do
+    with [kind, post_id] <- String.split(marker, ":", parts: 2),
+         builder when is_function(builder) <- rebuild_builder(kind),
+         %Post{} = post <- Posts.get_post(post_id),
+         false <- Posts.restricted?(post) do
+      post = Repo.preload(post, Docs.note_preloads())
+      {:ok, %{delivery | activity_json: Jason.encode!(builder.(post, user))}}
+    else
+      _ -> :drop
+    end
+  end
+
+  defp rebuild_builder("post_create"), do: &Docs.create_activity/2
+  defp rebuild_builder("post_update"), do: &Docs.update_activity/2
+  defp rebuild_builder(_kind), do: nil
 
   defp post_activity(delivery, user, actor) do
     case ap_post(

--- a/lib/vutuv/fediverse/delivery.ex
+++ b/lib/vutuv/fediverse/delivery.ex
@@ -5,6 +5,13 @@ defmodule Vutuv.Fediverse.Delivery do
   key when `Vutuv.Fediverse.Deliverer` sends it. Mirrors the webhook queue:
   exponential backoff on failure, dropped after repeated failure, row deleted
   on success.
+
+  `rebuild_from` marks the one row that does **not** send the copy built at
+  enqueue time (issue #1070): a post whose picture the AI scan had not released
+  yet is held briefly and re-rendered when it goes out, so the picture rides
+  along. `activity_json` still holds a complete, valid activity for such a row, so
+  a release that does not know this column delivers that instead of choking — the
+  worst a deploy window can do is federate one post without its picture.
   """
 
   use VutuvWeb, :model
@@ -12,6 +19,7 @@ defmodule Vutuv.Fediverse.Delivery do
   schema "fediverse_deliveries" do
     field(:inbox_uri, :string)
     field(:activity_json, :string)
+    field(:rebuild_from, :string)
     field(:attempts, :integer, default: 0)
     field(:next_attempt_at, :utc_datetime)
     field(:last_error, :string)

--- a/lib/vutuv/fediverse/note.ex
+++ b/lib/vutuv/fediverse/note.ex
@@ -17,6 +17,11 @@ defmodule Vutuv.Fediverse.Note do
       the cap is well defined in characters.
     * `audience` — how it was addressed. Only `"public"` is public; the other
       three render to the addressed member alone (issue #1071).
+    * `inbox_uri` — where an answer to this reply is delivered (issue #1070).
+      Free to keep: the inbox verifies every delivery against the sender's
+      freshly fetched actor document, which carries it, so storing it here means
+      answering costs no network call on the member's request path. Nullable,
+      since notes stored before issue #1070 have none.
     * `received_at` / `checked_at` / `expires_at` — the retention triple.
 
   There is no avatar column and there never will be: the card renders initials
@@ -62,6 +67,7 @@ defmodule Vutuv.Fediverse.Note do
     field(:actor_uri, :string)
     field(:origin_url, :string)
     field(:in_reply_to_uri, :string)
+    field(:inbox_uri, :string)
     field(:handle, :string)
     field(:display_name, :string)
     field(:content_text, :string)
@@ -118,6 +124,7 @@ defmodule Vutuv.Fediverse.Note do
       :actor_uri,
       :origin_url,
       :in_reply_to_uri,
+      :inbox_uri,
       :handle,
       :display_name,
       :content_text,
@@ -140,6 +147,7 @@ defmodule Vutuv.Fediverse.Note do
     |> validate_length(:actor_uri, max: @max_uri_bytes, count: :bytes)
     |> validate_length(:origin_url, max: @max_uri_bytes, count: :bytes)
     |> validate_length(:in_reply_to_uri, max: @max_uri_bytes, count: :bytes)
+    |> validate_length(:inbox_uri, max: @max_uri_bytes, count: :bytes)
     |> validate_length(:handle, max: 255)
     |> validate_length(:display_name, max: 255)
     |> validate_length(:content_text, max: @max_content)

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -236,6 +236,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
             Vutuv.Organizations.release_logo(Repo.get!(OrganizationImage, scan.subject_id))
         end
 
+        settle_post_federation(kind, scan.subject_id)
         broadcast(scan, :approved)
         :ok
 
@@ -323,6 +324,7 @@ defmodule Vutuv.Moderation.ImageSubjects do
         # announced once it is released (no quarantine move — covers are
         # served through the authorizing proxy, which checks this state).
         Vutuv.Posts.broadcast_review_cover_ready(review.post_id)
+        Vutuv.Fediverse.images_settled(review.post_id)
         :ok
 
       _ ->
@@ -366,6 +368,9 @@ defmodule Vutuv.Moderation.ImageSubjects do
         config.store.delete(image.token)
         Repo.delete(image, allow_stale: true)
         clear_gallery_references(kind, image)
+        # A rejected picture settles the post just as an approved one does: it
+        # federates now, without the picture, which is what vetting first means.
+        settle_post_federation(kind, image)
         broadcast(scan, :rejected)
         :ok
     end
@@ -436,12 +441,35 @@ defmodule Vutuv.Moderation.ImageSubjects do
     case cleared do
       {1, _} ->
         Vutuv.ReviewCover.delete_files(%PostReview{id: scan.subject_id})
+        # The cover is settled (as gone), so a post held for it federates now.
+        case Repo.get(PostReview, scan.subject_id) do
+          %PostReview{post_id: post_id} -> Vutuv.Fediverse.images_settled(post_id)
+          nil -> :ok
+        end
+
         :ok
 
       _ ->
         :stale
     end
   end
+
+  # A post picture reaching a verdict is what releases a post held back from
+  # federating (issue #1070). Takes the image row when it still exists (the
+  # rejection path has just deleted it, so the id would no longer resolve) or its
+  # id when it does. Only `post_image` matters here — the other gallery kinds do
+  # not federate.
+  defp settle_post_federation("post_image", %PostImage{post_id: post_id}),
+    do: Vutuv.Fediverse.images_settled(post_id)
+
+  defp settle_post_federation("post_image", subject_id) when is_binary(subject_id) do
+    case Repo.get(PostImage, subject_id) do
+      %PostImage{post_id: post_id} -> Vutuv.Fediverse.images_settled(post_id)
+      nil -> :ok
+    end
+  end
+
+  defp settle_post_federation(_kind, _subject), do: :ok
 
   # An organization's `logo` column points at its image token; a rejected logo
   # must not leave a dangling pointer behind.

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -45,6 +45,7 @@ defmodule Vutuv.Posts do
   import Vutuv.SearchText, only: [escape_like: 1, normalize_search: 1, name_ilike: 3]
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse.Note
   alias Vutuv.Mentions
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Pages
@@ -55,6 +56,7 @@ defmodule Vutuv.Posts do
   alias Vutuv.Posts.PostImage
   alias Vutuv.Posts.PostLike
   alias Vutuv.Posts.PostMention
+  alias Vutuv.Posts.PostRemoteReply
   alias Vutuv.Posts.PostReply
   alias Vutuv.Posts.PostRepost
   alias Vutuv.Posts.PostReview
@@ -166,7 +168,37 @@ defmodule Vutuv.Posts do
   reference nilifies, on account deletion the author reference too (see
   `Vutuv.Posts.PostReply`).
   """
-  def create_reply(%User{} = author, %Post{} = parent, attrs) do
+  def create_reply(%User{} = author, %Post{} = parent, attrs),
+    do: do_create_reply(author, parent, attrs, nil)
+
+  @doc """
+  Creates a reply to a reply that came from **another network** (issue #1070).
+
+  Underneath it is an ordinary `create_reply/3` to the vutuv post the remote note
+  answers, so local threading, the parent-author notification, the public reply
+  count and the edit window behave exactly as for any other reply. On top it
+  writes the `Vutuv.Posts.PostRemoteReply` sidecar, which is what makes the
+  outgoing activity carry an `inReplyTo` into that other network, a `Mention` of
+  the person answered, and their inbox among its recipients.
+
+  Any member may answer a note, not only the author of the post it sits under, so
+  long as they federate: `Vutuv.Fediverse.check_remote_reply/2` holds that gate
+  (plus the installation switch, public-notes-only, the operator blocklist and an
+  outbound rate limit) and names which one refused, so the caller can tell a
+  member who simply has not switched federation on from a hard no.
+  """
+  def create_remote_reply(%User{} = author, %Note{} = note, attrs) do
+    with :ok <- Vutuv.Fediverse.check_remote_reply(author, note),
+         :ok <- Vutuv.Fediverse.claim_reply_budget(author),
+         %Post{} = parent <- get_post(note.post_id) do
+      do_create_reply(author, parent, attrs, note)
+    else
+      nil -> {:error, :not_visible}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp do_create_reply(%User{} = author, %Post{} = parent, attrs, note) do
     image_ids = parse_ids(fetch(attrs, :image_ids) || [])
 
     with :ok <- check_reply_allowed(author, parent),
@@ -176,7 +208,7 @@ defmodule Vutuv.Posts do
          # params are dropped, so the public reply count and the parent-author
          # notification only ever concern content the author can see (issue #774).
          {:ok, changeset} <- build_changeset(%Post{user_id: author.id}, attrs, [], image_ids) do
-      case insert_post(changeset, image_ids, parent) do
+      case insert_post(changeset, image_ids, parent, note) do
         {:ok, post} ->
           post = preload_post(post)
           broadcast_new_post(post)
@@ -285,7 +317,11 @@ defmodule Vutuv.Posts do
   parent's fresh reply count is re-broadcast.
   """
   def delete_post(%Post{} = post) do
-    post = Repo.preload(post, [:images, :screenshot, :review])
+    # `:remote_reply_ref` is loaded before the delete on purpose: the sidecar row
+    # cascades away with the post, but the Delete(Tombstone) still has to reach
+    # the person on the other network who was answered (issue #1070). The
+    # in-memory struct is the only place that address is left afterwards.
+    post = Repo.preload(post, [:images, :screenshot, :review, :remote_reply_ref])
     parent_id = reply_parent_id(post.id)
 
     case Repo.delete(post) do
@@ -363,9 +399,10 @@ defmodule Vutuv.Posts do
 
   # Stamps the Berlin-day publication date (the archive coordinate; the same
   # calendar day the rendered timestamps use) and commits the post, its image
-  # claims and — for a reply — the PostReply row in one transaction, so post
-  # and reference land (or roll back) together.
-  defp insert_post(changeset, image_ids, parent \\ nil) do
+  # claims and — for a reply — the PostReply row (plus, when it answers another
+  # network, the PostRemoteReply sidecar) in one transaction, so post and
+  # references land (or roll back) together.
+  defp insert_post(changeset, image_ids, parent \\ nil, note \\ nil) do
     Repo.transaction(fn ->
       changeset
       |> Ecto.Changeset.change(published_on: Vutuv.BerlinTime.today())
@@ -374,12 +411,32 @@ defmodule Vutuv.Posts do
         {:ok, post} ->
           attach_images!(post, image_ids)
           insert_reply_ref!(post, parent)
+          insert_remote_reply_ref!(post, note)
           post
 
         {:error, changeset} ->
           Repo.rollback(changeset)
       end
     end)
+  end
+
+  defp insert_remote_reply_ref!(_post, nil), do: :ok
+
+  # Everything delivery needs is copied here now, while the note is still on
+  # hand: the note is a cache that expires (or is taken down), and an `Update` or
+  # `Delete` of this answer has to keep reaching the person who was answered long
+  # after that. Hence the copies, and hence `note_id` nilifying rather than
+  # cascading the answer away with its target.
+  defp insert_remote_reply_ref!(%Post{} = post, %Note{} = note) do
+    %PostRemoteReply{post_id: post.id}
+    |> PostRemoteReply.changeset(%{
+      note_id: note.id,
+      in_reply_to_uri: note.object_uri,
+      actor_uri: note.actor_uri,
+      inbox_uri: note.inbox_uri,
+      handle: Note.display_handle(note)
+    })
+    |> Repo.insert!()
   end
 
   defp insert_reply_ref!(_post, nil), do: :ok
@@ -2474,6 +2531,10 @@ defmodule Vutuv.Posts do
       # The book/film review sidecar (nil for ordinary posts) — the card
       # renders it wherever the post renders, so it always travels along.
       :review,
+      # Present only on an answer to a reply from another network (issue #1070).
+      # The conversation renderer reads it to hang such an answer under the
+      # remote card it answers rather than beside it.
+      :remote_reply_ref,
       denials: [:denied_user],
       tags: from(t in Tag, order_by: t.name),
       reply_ref: [
@@ -2556,6 +2617,42 @@ defmodule Vutuv.Posts do
     do: Enum.filter(images, &ImageScans.released?(&1.moderation))
 
   def released_images(_not_loaded), do: []
+
+  @doc """
+  Whether any picture on this post is still waiting for the AI image scan.
+
+  What federation asks before it sends a post to other networks (issue #1070): a
+  Note built while an image is in limbo carries no attachment for it, and nothing
+  would ever re-send it, so the picture would simply be missing over there. The
+  answer covers both kinds of picture a post can carry — its attached images and
+  a book review's fetched cover.
+
+  Takes an id (a fresh read, which is what the scan-settled hook needs) or a post
+  whose `:images` and `:review` are already loaded.
+  """
+  def awaiting_image_release?(post_id) when is_binary(post_id) do
+    case UUIDv7.with_cast(post_id, &Repo.get(Post, &1)) do
+      nil -> false
+      post -> post |> Repo.preload([:images, :review]) |> awaiting_image_release?()
+    end
+  end
+
+  def awaiting_image_release?(%Post{} = post) do
+    pending_images?(post.images) or pending_cover?(post.review)
+  end
+
+  defp pending_images?(images) when is_list(images),
+    do: Enum.any?(images, &(not ImageScans.released?(&1.moderation)))
+
+  defp pending_images?(_not_loaded), do: false
+
+  # A cover that was fetched but not yet judged. A review with no cover at all,
+  # or one whose fetch failed, is not something to wait for.
+  defp pending_cover?(%PostReview{cover_status: "ready", cover: cover} = review)
+       when is_binary(cover),
+       do: not ImageScans.released?(review.cover_moderation)
+
+  defp pending_cover?(_review), do: false
 
   @doc "Deletes a pending (unattached) image: row and files."
   def delete_pending_image(%PostImage{post_id: nil} = image) do

--- a/lib/vutuv/posts/post.ex
+++ b/lib/vutuv/posts/post.ex
@@ -26,6 +26,11 @@ defmodule Vutuv.Posts.Post do
     # Present iff this post is a reply; survives parent deletion (see PostReply).
     has_one(:reply_ref, Vutuv.Posts.PostReply, foreign_key: :post_id)
 
+    # Present iff this reply also answers a reply from another network (issue
+    # #1070). Rides alongside `reply_ref`, never instead of it, and carries its
+    # own copy of the delivery target so it outlives the cached remote note.
+    has_one(:remote_reply_ref, Vutuv.Posts.PostRemoteReply, foreign_key: :post_id)
+
     has_many(:denials, Vutuv.Posts.PostDenial, on_replace: :delete)
     has_many(:images, Vutuv.Posts.PostImage, preload_order: [asc: :position])
 

--- a/lib/vutuv/posts/post_remote_reply.ex
+++ b/lib/vutuv/posts/post_remote_reply.ex
@@ -1,0 +1,61 @@
+defmodule Vutuv.Posts.PostRemoteReply do
+  @moduledoc """
+  One vutuv post that answers a reply written on another network (issue #1070).
+
+  The sidecar to `Vutuv.Posts.PostReply`, not a replacement for it: such an
+  answer is still an ordinary reply to the vutuv post underneath, so local
+  threading, the reply notification, the public reply count and the edit window
+  all keep working untouched. This row records the *other* thing it answers, and
+  it is what makes the outgoing `Create(Note)` carry an `inReplyTo` pointing into
+  the other network plus a `Mention` of the person being answered.
+
+  **Why it holds its own copy of the target.** A stored remote reply is a cache:
+  it is collected six months out (`Vutuv.Fediverse.NoteSweeper`), and a takedown
+  or an upstream delete can remove it long before that. The member's own answer
+  lives on, and editing or deleting it has to keep reaching the person who was
+  answered. So `note_id` nilifies rather than cascading, and everything delivery
+  needs is copied here at creation time:
+
+    * `in_reply_to_uri` — the remote note's own id, what `inReplyTo` names.
+    * `actor_uri` — who was answered. The `Mention` tag is built from **this**,
+      never from parsing the member's typed text, so a member cannot make vutuv
+      notify an actor nobody verified.
+    * `inbox_uri` — where the answer is delivered, copied from the note (which
+      captured it from the actor document the inbox had already verified). Only
+      ever an inbox on the actor's own host (`Vutuv.Fediverse.own_inbox/1`).
+      Nullable: a note stored before issue #1070 carries none, and then only the
+      member's own followers receive the answer.
+    * `handle` — the `@user@host` the answer's "Replying to" line shows and the
+      outgoing `Mention` names. Cosmetic, remote-supplied, so capped.
+  """
+
+  use VutuvWeb, :model
+
+  # Remote URIs are unbounded in theory; cap them in bytes like
+  # `Vutuv.Fediverse.Note` does, so a hostile value fails the changeset rather
+  # than the insert.
+  @max_uri_bytes 2_048
+
+  schema "post_remote_replies" do
+    belongs_to(:post, Vutuv.Posts.Post)
+    belongs_to(:note, Vutuv.Fediverse.Note)
+
+    field(:in_reply_to_uri, :string)
+    field(:actor_uri, :string)
+    field(:inbox_uri, :string)
+    field(:handle, :string)
+
+    timestamps()
+  end
+
+  def changeset(%__MODULE__{} = remote_reply, attrs) do
+    remote_reply
+    |> cast(attrs, [:note_id, :in_reply_to_uri, :actor_uri, :inbox_uri, :handle])
+    |> validate_required([:in_reply_to_uri, :actor_uri])
+    |> validate_length(:in_reply_to_uri, max: @max_uri_bytes, count: :bytes)
+    |> validate_length(:actor_uri, max: @max_uri_bytes, count: :bytes)
+    |> validate_length(:inbox_uri, max: @max_uri_bytes, count: :bytes)
+    |> validate_length(:handle, max: 255)
+    |> unique_constraint(:post_id)
+  end
+end

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -32,6 +32,7 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Posts
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.PostRemoteReply
   alias Vutuv.Posts.PostReview
   alias Vutuv.Posts.PostScreenshot
   alias Vutuv.ReviewCover
@@ -767,6 +768,10 @@ defmodule VutuvWeb.PostComponents do
       |> assign(:initials, name_initials(note.display_name || note.handle))
       |> assign(:public?, Note.public?(note))
       |> assign(:warned?, Note.warned?(note))
+      # Only a public reply can be answered (issue #1070): a private one would
+      # mean publishing half of an exchange its author asked to keep to one
+      # person, so v1 does not offer it at all.
+      |> assign(:can_reply?, not is_nil(assigns.viewer) and Note.public?(note))
 
     ~H"""
     <article data-fediverse-reply={@note.id} data-audience={@note.audience}>
@@ -869,6 +874,21 @@ defmodule VutuvWeb.PostComponents do
               rel="nofollow noopener noreferrer"
               class="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
             >{gettext("View the original")}</a>
+            <%!-- Answering is the one action on a remote reply that exists, so it
+            sits here in the open beside where the reply came from. The card still
+            has no action bar: liking or resharing something on somebody else's
+            server is not a thing, and an absent row still beats a dead one. Shown
+            to every signed-in member on a public reply — the page behind it is
+            what explains a member who does not federate why they cannot send
+            (issue #1070). --%>
+            <span :if={@can_reply?}>
+              ·
+              <.link
+                navigate={~p"/system/fediverse/reply/#{@note.id}"}
+                data-remote-reply-link={@note.id}
+                class="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+              >{gettext("Reply")}</.link>
+            </span>
           </p>
         </div>
       </div>
@@ -1088,11 +1108,36 @@ defmodule VutuvWeb.PostComponents do
   defp merge_remote_nodes(children, notes, post, viewer) do
     owner? = match?(%User{}, viewer) and viewer.id == post.user_id
 
-    remote_nodes =
-      Enum.map(notes, &%{note: &1, owner?: owner?, children: []})
+    # An answer to one of these notes (issue #1070) is, underneath, an ordinary
+    # reply to the same vutuv post — so `thread_forest/1` made it a *sibling* of
+    # the note it answers. Move it under the note, which is where the reader
+    # expects it and what the note's own server shows too.
+    {answers, siblings} = Enum.split_with(children, &(answered_note_id(&1) in note_ids(notes)))
 
-    Enum.sort_by(children ++ remote_nodes, &node_time/1, {:asc, NaiveDateTime})
+    remote_nodes =
+      Enum.map(notes, fn note ->
+        %{
+          note: note,
+          owner?: owner?,
+          children:
+            answers
+            |> Enum.filter(&(answered_note_id(&1) == note.id))
+            |> Enum.sort_by(&node_time/1, {:asc, NaiveDateTime})
+        }
+      end)
+
+    Enum.sort_by(siblings ++ remote_nodes, &node_time/1, {:asc, NaiveDateTime})
   end
+
+  defp note_ids(notes), do: Enum.map(notes, & &1.id)
+
+  # Which remote reply this node answers, or nil for every ordinary post. An
+  # un-preloaded association is a truthy `NotLoaded`, so it is matched away
+  # rather than treated as an answer.
+  defp answered_note_id(%{post: %{remote_reply_ref: %PostRemoteReply{note_id: note_id}}}),
+    do: note_id
+
+  defp answered_note_id(_node), do: nil
 
   defp node_time(%{note: note}), do: DateTime.to_naive(note.received_at)
   defp node_time(%{post: post}), do: post.inserted_at

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -252,11 +252,18 @@ defmodule VutuvWeb.FediverseController do
   defp reaction_kind("Announce"), do: "announce"
 
   # What a stored reply keeps about its author: the actor URI (the takedown and
-  # dedupe key) plus the two cosmetic display strings. No avatar — the card
+  # dedupe key), the two cosmetic display strings, and the inbox an answer goes
+  # to (issue #1070 — we hold the verified actor document right here, so keeping
+  # its inbox spares the reply path a network call). No avatar — the card
   # renders initials and links out, so vutuv never hosts a third party's
   # picture.
   defp remote_author(remote) do
-    %{uri: remote.id, handle: remote.preferred_username, name: remote.name}
+    %{
+      uri: remote.id,
+      handle: remote.preferred_username,
+      name: remote.name,
+      inbox: remote.inbox
+    }
   end
 
   defp follower_attrs(remote) do

--- a/lib/vutuv_web/controllers/post_controller.ex
+++ b/lib/vutuv_web/controllers/post_controller.ex
@@ -270,7 +270,7 @@ defmodule VutuvWeb.PostController do
 
   # The ActivityPub rendering of a public post (see Vutuv.Fediverse).
   defp send_note(conn, author, post) do
-    post = Repo.preload(post, [:images, :review, reply_ref: [:parent_author]])
+    post = Repo.preload(post, FediverseDocs.note_preloads())
 
     note =
       post

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -20,12 +20,22 @@ defmodule VutuvWeb.Fediverse.Docs do
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.PostRemoteReply
   alias Vutuv.Posts.PostReview
   alias Vutuv.ReviewCover
   alias VutuvWeb.PostComponents
   alias VutuvWeb.UserHelpers
 
   @public "https://www.w3.org/ns/activitystreams#Public"
+
+  # Everything note/2 reads off a post. Kept here, beside the builder that needs
+  # it, because two call sites load it (the delivery queue and the permalink's
+  # ActivityPub rendering) and a field added to the Note must not silently render
+  # as `NotLoaded` at one of them.
+  @note_preloads [:images, :review, :remote_reply_ref, reply_ref: [:parent_author]]
+
+  @doc "The associations `note/2` needs loaded on a post."
+  def note_preloads, do: @note_preloads
 
   def actor_url(user), do: "#{base()}/#{user.username}/actor"
   def key_id(user), do: actor_url(user) <> "#main-key"
@@ -205,18 +215,68 @@ defmodule VutuvWeb.Fediverse.Docs do
 
   @doc "The Note a public post federates as."
   def note(%Post{} = post, user) do
+    remote = remote_target(post)
+
     %{
       "id" => note_url(user, post.id),
       "type" => "Note",
       "attributedTo" => actor_url(user),
-      "content" => content_html(post),
+      "content" => content_html(post, remote),
       "published" => iso8601(post.inserted_at),
       "to" => [@public],
-      "cc" => [actor_url(user) <> "/followers"],
+      "cc" => cc(user, remote),
       "url" => note_url(user, post.id)
     }
-    |> put_in_reply_to(post)
+    |> put_in_reply_to(post, remote)
+    |> put_tag(remote)
     |> put_attachments(post)
+  end
+
+  # The reply from another network this post answers, when it answers one
+  # (issue #1070). An un-preloaded association is a truthy `NotLoaded`, so it is
+  # matched away explicitly rather than treated as "no target".
+  defp remote_target(%Post{remote_reply_ref: %PostRemoteReply{} = ref}), do: ref
+  defp remote_target(%Post{}), do: nil
+
+  # A public answer is addressed like any other public post, plus the person it
+  # answers. Naming them in `cc` (rather than `to`) is what Mastodon does for a
+  # public reply: the post stays public, and the mentioned actor is delivered to
+  # directly so it lands in their notifications.
+  defp cc(user, nil), do: [actor_url(user) <> "/followers"]
+
+  defp cc(user, %PostRemoteReply{actor_uri: actor_uri}),
+    do: [actor_url(user) <> "/followers", actor_uri]
+
+  # The `Mention` tag is what makes the remote server notify the person answered
+  # and thread the reply under theirs.
+  #
+  # It is built from the **stored** actor URI, never from parsing the member's
+  # typed text. Parsing would let anyone put `@someone@anywhere` in a post body
+  # and have vutuv mint a verified-looking Mention at an actor nobody ever
+  # checked, which is mention spam with our signature on it.
+  defp put_tag(note, nil), do: note
+
+  defp put_tag(note, %PostRemoteReply{} = ref) do
+    Map.put(note, "tag", [
+      %{
+        "type" => "Mention",
+        "href" => ref.actor_uri,
+        "name" => mention_handle(ref)
+      }
+    ])
+  end
+
+  # How the answered account is written: the `@user@host` captured with the note.
+  # Falls back to the bare host when the remote document carried no
+  # `preferredUsername` (the same fallback `Vutuv.Fediverse.Note` makes).
+  defp mention_handle(%PostRemoteReply{handle: handle}) when is_binary(handle) and handle != "",
+    do: handle
+
+  defp mention_handle(%PostRemoteReply{actor_uri: actor_uri}) do
+    case URI.parse(actor_uri) do
+      %URI{host: host} when is_binary(host) and host != "" -> "@" <> host
+      _ -> actor_uri
+    end
   end
 
   defp envelope(user, type, id, object) do
@@ -236,14 +296,33 @@ defmodule VutuvWeb.Fediverse.Docs do
   # sidecar is rendered INTO the content: the Note is one more rendering of
   # the post (like the agent docs), so a Mastodon reader gets the reviewed
   # work's facts even though remote software knows nothing of review cards.
-  defp content_html(post) do
+  defp content_html(post, remote) do
     body_html =
       post.body
       |> VutuvWeb.Markdown.render_post(images(post))
       |> Phoenix.HTML.safe_to_string()
 
-    (body_html <> PostComponents.review_content_html(post))
+    (mention_html(remote) <> body_html <> PostComponents.review_content_html(post))
     |> absolutize()
+  end
+
+  # The answered account, written into the outgoing HTML the way these networks
+  # write a reply: a leading linked `@user@host`.
+  #
+  # It is added **here, on the wire, only** — the member's stored body does not
+  # carry it. On vutuv the answer shows a "Replying to" line instead, so a member
+  # who has never heard of Mastodon does not have to type a handle in a foreign
+  # format, and their post does not read like a foreign one. The handle is remote
+  # supplied, so it is escaped.
+  defp mention_html(nil), do: ""
+
+  defp mention_html(%PostRemoteReply{} = ref) do
+    handle =
+      ref |> mention_handle() |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
+
+    href = ref.actor_uri |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
+
+    ~s(<p><span class="h-card"><a href="#{href}" class="u-url mention">#{handle}</a></span></p>)
   end
 
   # Remote servers are anonymous viewers: only AI-released images may render
@@ -260,9 +339,18 @@ defmodule VutuvWeb.Fediverse.Docs do
     VutuvWeb.Markdown.absolutize_html(html, base())
   end
 
-  # inReplyTo only when the parent's author federates too — otherwise the id
-  # would not resolve as ActivityPub and remote servers could drop the post.
-  defp put_in_reply_to(note, post) do
+  # An answer to a reply from another network points at **that** note (issue
+  # #1070), not at the vutuv post underneath: the remote note already carries its
+  # own `inReplyTo` back to our post, so this is what puts the answer in the right
+  # place in the conversation on the other server. The URI is the durable copy
+  # from the sidecar, so it still resolves after the cached note is collected.
+  defp put_in_reply_to(note, _post, %PostRemoteReply{in_reply_to_uri: uri}),
+    do: Map.put(note, "inReplyTo", uri)
+
+  # Otherwise inReplyTo only when the parent's author federates too — a
+  # non-federating author serves no Note at that id, and remote servers could
+  # drop the post over an id that does not resolve.
+  defp put_in_reply_to(note, post, nil) do
     case reply_parent(post) do
       nil -> note
       {parent_author, parent_id} -> Map.put(note, "inReplyTo", note_url(parent_author, parent_id))

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -31,6 +31,7 @@ defmodule VutuvWeb.PostLive.Composer do
   use VutuvWeb, :live_component
 
   alias Vutuv.BookMetadata
+  alias Vutuv.Fediverse.Note
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
@@ -53,7 +54,8 @@ defmodule VutuvWeb.PostLive.Composer do
 
   @impl true
   def update(assigns, socket) do
-    socket = assign(socket, Map.take(assigns, [:id, :current_user, :post, :parent]))
+    socket =
+      assign(socket, Map.take(assigns, [:id, :current_user, :post, :parent, :remote_note]))
 
     socket =
       if socket.assigns[:composer_ready?] do
@@ -72,6 +74,9 @@ defmodule VutuvWeb.PostLive.Composer do
     socket
     |> assign(:composer_ready?, true)
     |> assign_new(:parent, fn -> nil end)
+    # Set when this composer answers a reply from another network (issue #1070);
+    # it then saves through Posts.create_remote_reply/3 instead.
+    |> assign_new(:remote_note, fn -> nil end)
     # Reposted or answered posts carry other people's shares and replies:
     # the audience is pinned to public (Posts.update_post/2 enforces it; the
     # select disappears).
@@ -303,20 +308,31 @@ defmodule VutuvWeb.PostLive.Composer do
       image_ids: Enum.map(socket.assigns.images, & &1.id)
     }
 
-    socket.assigns.post
-    |> save_post(socket.assigns.current_user, attrs, socket.assigns.parent)
+    socket.assigns
+    |> save_post(attrs)
     |> handle_save_result(socket)
   end
 
-  defp save_post(nil, author, attrs, %Post{} = parent),
+  # Answering a reply from another network goes through its own context function:
+  # it writes the sidecar that carries the answer out to that network, and it
+  # holds the federation gates (issue #1070).
+  defp save_post(%{post: nil, remote_note: %Note{} = note, current_user: author}, attrs),
+    do: Posts.create_remote_reply(author, note, attrs)
+
+  defp save_post(%{post: nil, parent: %Post{} = parent, current_user: author}, attrs),
     do: Posts.create_reply(author, parent, attrs)
 
-  defp save_post(nil, author, attrs, nil), do: Posts.create_post(author, attrs)
-  defp save_post(post, _author, attrs, _parent), do: Posts.update_post(post, attrs)
+  defp save_post(%{post: nil, current_user: author}, attrs), do: Posts.create_post(author, attrs)
+  defp save_post(%{post: post}, attrs), do: Posts.update_post(post, attrs)
 
   defp handle_save_result({:ok, post}, socket) do
     cond do
       socket.assigns.post ->
+        {:noreply, push_navigate(socket, to: Posts.path(post))}
+
+      socket.assigns[:remote_note] ->
+        # An answer to a remote reply has no `parent` assign of its own, so its
+        # own permalink is the way back into that conversation.
         {:noreply, push_navigate(socket, to: Posts.path(post))}
 
       socket.assigns.parent ->
@@ -368,6 +384,24 @@ defmodule VutuvWeb.PostLive.Composer do
 
   defp save_error_message(reason) when reason in [:restricted, :not_visible],
     do: gettext("You can no longer reply to this post.")
+
+  # Answering another network (issue #1070). `:not_federating` is handled by the
+  # page before the composer ever renders, so these are the states that can only
+  # appear between opening the form and pressing Save.
+  defp save_error_message(:reply_capped),
+    do:
+      gettext(
+        "You have sent a lot of answers to other networks in the past hour. Please try again later."
+      )
+
+  defp save_error_message(:instance_blocked),
+    do: gettext("That server is blocked on this site, so no answer can be sent to it.")
+
+  defp save_error_message(:note_not_public),
+    do: gettext("This reply was sent to you alone, so it cannot be answered publicly.")
+
+  defp save_error_message(reason) when reason in [:not_federating, :moved, :fediverse_disabled],
+    do: gettext("Your Fediverse settings do not allow sending an answer right now.")
 
   defp save_error_message(_too_many_images) do
     gettext("No more than %{max} images per post.", max: Posts.max_images_per_post())

--- a/lib/vutuv_web/live/post_live/remote_reply.ex
+++ b/lib/vutuv_web/live/post_live/remote_reply.ex
@@ -1,0 +1,159 @@
+defmodule VutuvWeb.PostLive.RemoteReply do
+  @moduledoc """
+  Answering a reply that came from another network (issue #1070) — the sibling of
+  `VutuvWeb.PostLive.Reply`: the reply being answered above (read-only, in its own
+  remote card) and the same composer below.
+
+  Two things it does that the local reply page does not.
+
+  **It says where the words are going.** A member who has never heard of Mastodon
+  must not discover afterwards that their answer left the site, so the page states
+  it plainly before they type: the answer goes to that person on their own server
+  and to the member's Fediverse followers, and it is a public post on vutuv too.
+
+  **It explains a refusal instead of hiding the action.** The "Reply" link shows
+  on every public remote reply for every signed-in member, including one who has
+  not switched Fediverse participation on — hiding it would leave them with no way
+  to find out that the capability exists. So `:not_federating` is not a dead end
+  here: the page explains what the setting does and links to `/settings/fediverse`.
+  Every other refusal is a hard no and sends them back with a plain-language
+  reason.
+  """
+
+  use VutuvWeb, :live_view
+
+  import VutuvWeb.PostComponents
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Posts
+
+  on_mount({VutuvWeb.Live.InitAssigns, :require_login})
+
+  @impl true
+  def mount(%{"id" => id}, _session, socket) do
+    viewer = socket.assigns.current_user
+    note = Fediverse.get_note(id)
+
+    if note && visible?(note, viewer) do
+      {:ok, assign_gate(socket, note, viewer)}
+    else
+      {:ok, not_found(socket)}
+    end
+  end
+
+  # The same rule `Vutuv.Fediverse.list_notes/2` enforces for the thread: a public
+  # reply is everybody's, a private one is its addressee's alone. Answering a
+  # private one is refused separately (`:note_not_public`) — this is only about
+  # whether the page may show it at all, so existence never leaks.
+  defp visible?(%Note{} = note, viewer) do
+    Note.public?(note) or
+      match?(%Posts.Post{user_id: id} when id == viewer.id, Posts.get_post(note.post_id))
+  end
+
+  defp assign_gate(socket, %Note{} = note, viewer) do
+    socket =
+      socket
+      |> assign(:page_title, gettext("Reply to %{handle}", handle: Note.display_handle(note)))
+      |> assign(:note, note)
+      |> assign(:post, Posts.get_post(note.post_id))
+
+    case Fediverse.check_remote_reply(viewer, note) do
+      :ok ->
+        assign(socket, :refusal, nil)
+
+      # The one refusal the member can act on, so it gets the page rather than a
+      # redirect.
+      {:error, :not_federating} ->
+        assign(socket, :refusal, :not_federating)
+
+      {:error, reason} ->
+        socket
+        |> put_flash(:error, refusal_message(reason))
+        |> redirect(to: Posts.path(socket.assigns.post))
+    end
+  end
+
+  defp not_found(socket) do
+    socket
+    |> put_flash(:error, gettext("Sorry, that page could not be found."))
+    |> redirect(to: ~p"/")
+  end
+
+  defp refusal_message(:note_not_public),
+    do: gettext("This reply was sent to you alone, so it cannot be answered publicly.")
+
+  defp refusal_message(:instance_blocked),
+    do: gettext("That server is blocked on this site, so no answer can be sent to it.")
+
+  defp refusal_message(:moved),
+    do:
+      gettext(
+        "You moved your Fediverse account to another server, so answers are no longer sent from here."
+      )
+
+  defp refusal_message(_disabled),
+    do: gettext("This site does not take part in the Fediverse.")
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="remote-reply" class="py-6">
+      <div class="mx-auto max-w-2xl space-y-4">
+        <h1 class="text-2xl font-bold text-slate-800 dark:text-slate-100">
+          {gettext("Reply to %{handle}", handle: Note.display_handle(@note))}
+        </h1>
+
+        <.card>
+          <.remote_reply_card note={@note} viewer={@current_user} />
+        </.card>
+
+        <%= if @refusal == :not_federating do %>
+          <.card>
+            <h2 class="mb-2 text-base font-semibold text-slate-900 dark:text-white">
+              {gettext("Turn on Fediverse participation to answer")}
+            </h2>
+            <p class="mb-3 text-sm text-slate-600 dark:text-slate-400">
+              {gettext(
+                "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
+              )}
+            </p>
+            <.button navigate={~p"/settings/fediverse"}>
+              {gettext("Open Fediverse settings")}
+            </.button>
+          </.card>
+        <% else %>
+          <%!-- Said before they type, not after they send: the whole point of the
+          page is that nobody publishes to another network by accident. --%>
+          <p
+            data-remote-reply-notice
+            class="rounded-lg bg-brand-50 px-4 py-3 text-sm text-brand-800 dark:bg-brand-900/30 dark:text-brand-100"
+          >
+            {gettext(
+              "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well.",
+              handle: Note.display_handle(@note)
+            )}
+          </p>
+
+          <.live_component
+            module={VutuvWeb.PostLive.Composer}
+            id="composer"
+            current_user={@current_user}
+            post={nil}
+            parent={nil}
+            remote_note={@note}
+          />
+        <% end %>
+
+        <.link
+          :if={@post}
+          href={Posts.path(@post)}
+          class="text-sm font-semibold text-brand-600 hover:text-brand-700"
+        >
+          {gettext("Back to the conversation")}
+        </.link>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -427,6 +427,11 @@ defmodule VutuvWeb.Router do
       live("/posts/:id/edit", PostLive.Edit, :edit)
       live("/posts/:id/reply", PostLive.Reply, :new)
 
+      # Answering a reply that came from another network (issue #1070). Under
+      # /system/ rather than a new root word, which profiles own; "system" is
+      # already reserved, so this burns no handle.
+      live("/system/fediverse/reply/:id", PostLive.RemoteReply, :new)
+
       # The private likes / bookmarks lists (reserved slugs too).
       live("/likes", PostLive.Saved, :likes)
       live("/bookmarks", PostLive.Saved, :bookmarks)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.159.5",
+      version: "7.160.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260725172940_add_fediverse_note_inbox.exs
+++ b/priv/repo/migrations/20260725172940_add_fediverse_note_inbox.exs
@@ -1,0 +1,18 @@
+defmodule Vutuv.Repo.Migrations.AddFediverseNoteInbox do
+  use Ecto.Migration
+
+  # Where an answer to this reply has to be delivered (issue #1070).
+  #
+  # The inbox is already in hand when the note is stored: the inbox verifies
+  # every delivery's signature against the sender's freshly fetched actor
+  # document, which carries it, and then throws it away. Keeping it means
+  # replying costs no network call on the member's request path.
+  #
+  # Nullable on purpose: notes stored before this column existed have none, and
+  # a reply to one of those resolves the inbox on demand instead.
+  def change do
+    alter table(:fediverse_notes) do
+      add(:inbox_uri, :string)
+    end
+  end
+end

--- a/priv/repo/migrations/20260725173005_create_post_remote_replies.exs
+++ b/priv/repo/migrations/20260725173005_create_post_remote_replies.exs
@@ -1,0 +1,36 @@
+defmodule Vutuv.Repo.Migrations.CreatePostRemoteReplies do
+  use Ecto.Migration
+
+  # One vutuv post that answers a reply written on another network (issue
+  # #1070). The sidecar to `post_replies`: the answer is still an ordinary reply
+  # to the vutuv post underneath (so local threading, notifications, counts and
+  # the edit window are untouched), and this row records the *other* thing it
+  # answers.
+  #
+  # Why it carries its own copy of the target instead of reading the note row:
+  # a note is collected after six months (`Vutuv.Fediverse.NoteSweeper`) or taken
+  # down before that, while the member's own reply lives on. An `Update` or a
+  # `Delete(Tombstone)` has to keep reaching the person who was answered, so the
+  # delivery address cannot live only in a row that expires. `note_id` nilifies
+  # for that reason rather than cascading the answer away.
+  def change do
+    create table(:post_remote_replies) do
+      add(:post_id, references(:posts, on_delete: :delete_all), null: false)
+      add(:note_id, references(:fediverse_notes, on_delete: :nilify_all))
+
+      # The durable copy of who was answered and where the answer goes.
+      add(:in_reply_to_uri, :string, null: false)
+      add(:actor_uri, :string, null: false)
+      add(:inbox_uri, :string)
+      add(:handle, :string)
+
+      timestamps()
+    end
+
+    # One sidecar per answer.
+    create(unique_index(:post_remote_replies, [:post_id]))
+    # "Which answers belong to this note" — the thread renderer nests each
+    # answer under the note it responds to.
+    create(index(:post_remote_replies, [:note_id]))
+  end
+end

--- a/priv/repo/migrations/20260725173151_add_delivery_rebuild_from.exs
+++ b/priv/repo/migrations/20260725173151_add_delivery_rebuild_from.exs
@@ -1,0 +1,23 @@
+defmodule Vutuv.Repo.Migrations.AddDeliveryRebuildFrom do
+  use Ecto.Migration
+
+  # Lets a queued delivery re-render its activity at send time instead of
+  # sending the copy built when it was enqueued.
+  #
+  # Why: a post's images are invisible until the AI scan releases them
+  # (`Vutuv.Moderation.ImageScans`), so a Create built at commit time carries no
+  # attachment and the picture never reaches the other network. Such a post is
+  # now enqueued with a short hold and this marker; the deliverer rebuilds the
+  # Note when the hold expires, or earlier when the scan settles and pulls the
+  # row forward.
+  #
+  # `activity_json` deliberately stays NOT NULL and keeps holding a complete,
+  # valid activity. A release that does not know this column simply sends that
+  # copy, so the worst a deploy window can do is federate one post without its
+  # picture, never crash on a half-built row.
+  def change do
+    alter table(:fediverse_deliveries) do
+      add(:rebuild_from, :string)
+    end
+  end
+end

--- a/test/vutuv/fediverse_image_hold_test.exs
+++ b/test/vutuv/fediverse_image_hold_test.exs
@@ -1,0 +1,156 @@
+defmodule Vutuv.FediverseImageHoldTest do
+  @moduledoc """
+  A post whose picture the AI scan has not judged yet waits before it federates
+  (issue #1070), so the picture goes out with it instead of never going out at
+  all.
+
+  The two things worth pinning down: the hold is released the moment the scan
+  settles (which is the normal case, a few seconds), and the ceiling is only what
+  happens when the scanner never answers — then the post federates without the
+  picture rather than not at all.
+
+  async: false — flips the global `:fediverse_image_hold_seconds`.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Moderation.ImageScans
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostImage
+
+  setup do
+    user = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+
+    {:ok, _follower} =
+      Fediverse.add_follower(user, %{
+        actor_uri: "https://follower.example/users/f",
+        inbox_uri: "https://follower.example/inbox"
+      })
+
+    {:ok, user: user}
+  end
+
+  defp pending_image!(post), do: insert(:post_image, post: post, moderation: "pending")
+
+  defp release!(%PostImage{} = image),
+    do: image |> Ecto.Changeset.change(moderation: "approved") |> Repo.update!()
+
+  describe "a post with a picture still in limbo" do
+    test "is held back, carrying the marker that re-renders it later", %{user: user} do
+      post = insert(:post, user: user, body: "Mit Bild")
+      pending_image!(post)
+
+      assert :ok == Fediverse.federate_new_post(post)
+
+      assert [%Delivery{} = delivery] = Repo.all(Delivery)
+      assert delivery.rebuild_from == "post_create:#{post.id}"
+      # Not due yet: the scan gets its chance first.
+      assert DateTime.compare(delivery.next_attempt_at, DateTime.utc_now()) == :gt
+      # Still a complete activity, so a release that knows nothing of the marker
+      # delivers this rather than choking on a half-built row.
+      assert delivery.activity_json =~ ~s("type":"Create")
+    end
+
+    test "goes out at once once the scan settles", %{user: user} do
+      post = insert(:post, user: user, body: "Mit Bild")
+      image = pending_image!(post)
+      assert :ok == Fediverse.federate_new_post(post)
+
+      release!(image)
+      assert :ok == Fediverse.images_settled(post.id)
+
+      assert [%Delivery{next_attempt_at: due}] = Repo.all(Delivery)
+      assert DateTime.compare(due, DateTime.utc_now()) != :gt
+    end
+
+    test "keeps waiting while a second picture is still pending", %{user: user} do
+      post = insert(:post, user: user, body: "Zwei Bilder")
+      first = pending_image!(post)
+      _second = pending_image!(post)
+      assert :ok == Fediverse.federate_new_post(post)
+
+      release!(first)
+      :ok = Fediverse.images_settled(post.id)
+
+      # The post waits for the last picture, not the first.
+      assert [%Delivery{next_attempt_at: due}] = Repo.all(Delivery)
+      assert DateTime.compare(due, DateTime.utc_now()) == :gt
+    end
+  end
+
+  describe "a post with nothing pending" do
+    test "federates immediately, with no marker", %{user: user} do
+      post = insert(:post, user: user, body: "Nur Text")
+
+      assert :ok == Fediverse.federate_new_post(post)
+
+      assert [%Delivery{rebuild_from: nil, next_attempt_at: due}] = Repo.all(Delivery)
+      assert DateTime.compare(due, DateTime.utc_now()) != :gt
+    end
+
+    test "counts an already released picture as nothing pending", %{user: user} do
+      post = insert(:post, user: user, body: "Mit fertigem Bild")
+      insert(:post_image, post: post, moderation: "approved")
+
+      assert :ok == Fediverse.federate_new_post(post)
+      assert [%Delivery{rebuild_from: nil}] = Repo.all(Delivery)
+    end
+  end
+
+  describe "awaiting_image_release?/1" do
+    test "is true only while a picture is unjudged", %{user: user} do
+      post = insert(:post, user: user, body: "Mit Bild")
+      image = pending_image!(post)
+
+      assert Posts.awaiting_image_release?(post.id)
+
+      release!(image)
+      refute Posts.awaiting_image_release?(post.id)
+    end
+
+    test "a rejected picture counts as settled, not as pending", %{user: user} do
+      post = insert(:post, user: user, body: "Mit Bild")
+      image = pending_image!(post)
+
+      # A rejection deletes the row, which is what the real path does; either way
+      # the post is no longer waiting on anybody.
+      Repo.delete!(image)
+      refute Posts.awaiting_image_release?(post.id)
+    end
+
+    test "an unknown post is not waiting for anything" do
+      refute Posts.awaiting_image_release?(Vutuv.UUIDv7.generate())
+    end
+
+    test "released?/1 is the single source of the verdict" do
+      # Guards against the hold and the renderer drifting apart: both ask this.
+      assert ImageScans.released?("approved")
+      refute ImageScans.released?("pending")
+    end
+  end
+
+  describe "the hold ceiling" do
+    test "is what the post waits, and it is configurable", %{user: user} do
+      Application.put_env(:vutuv, :fediverse_image_hold_seconds, 5)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_image_hold_seconds) end)
+
+      assert Fediverse.image_hold_seconds() == 5
+
+      post = insert(:post, user: user, body: "Mit Bild")
+      pending_image!(post)
+      before = DateTime.utc_now(:second)
+
+      assert :ok == Fediverse.federate_new_post(post)
+
+      assert [%Delivery{next_attempt_at: due}] = Repo.all(Delivery)
+      assert DateTime.diff(due, before) <= 5
+      assert DateTime.diff(due, before) > 0
+    end
+
+    test "defaults to 90 seconds" do
+      assert Fediverse.image_hold_seconds() == 90
+    end
+  end
+end

--- a/test/vutuv/fediverse_notes_test.exs
+++ b/test/vutuv/fediverse_notes_test.exs
@@ -58,7 +58,56 @@ defmodule Vutuv.FediverseNotesTest do
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
-  defp remote(uri \\ @actor), do: %{uri: uri, handle: "alice", name: "Alice Anders"}
+  # The actor document the inbox verified the delivery against, reduced to what
+  # a stored note keeps. `inbox:` is what an answer would be delivered to
+  # (issue #1070); pass it explicitly to test the same-host rule.
+  defp remote(uri \\ @actor, opts \\ []) do
+    %{
+      uri: uri,
+      handle: "alice",
+      name: "Alice Anders",
+      inbox: Keyword.get(opts, :inbox, default_inbox(uri))
+    }
+  end
+
+  defp default_inbox(uri), do: uri <> "/inbox"
+
+  describe "the inbox an answer would go to (issue #1070)" do
+    test "is captured from the verified actor document", %{user: user, note_url: note_url} do
+      assert :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+
+      assert [%Note{inbox_uri: inbox}] = Repo.all(Note)
+      assert inbox == "#{@actor}/inbox"
+    end
+
+    test "is refused when the actor names an inbox on another host", %{
+      user: user,
+      note_url: note_url
+    } do
+      author = remote(@actor, inbox: "https://victim.example/inbox")
+
+      assert :ok = Fediverse.record_reply(user, create_activity(note_url), author)
+
+      # The classic ActivityPub inbox redirect: whoever runs social.example
+      # writes that document, so a foreign inbox would turn a member's answer
+      # into a signed POST at a third party. Not stored, so not delivered to.
+      assert [%Note{inbox_uri: nil}] = Repo.all(Note)
+    end
+
+    test "is refused when the actor names a plain-http inbox", %{user: user, note_url: note_url} do
+      author = remote(@actor, inbox: "http://social.example/users/alice/inbox")
+
+      assert :ok = Fediverse.record_reply(user, create_activity(note_url), author)
+      assert [%Note{inbox_uri: nil}] = Repo.all(Note)
+    end
+
+    test "is absent when the document carried none", %{user: user, note_url: note_url} do
+      author = remote(@actor, inbox: nil)
+
+      assert :ok = Fediverse.record_reply(user, create_activity(note_url), author)
+      assert [%Note{inbox_uri: nil}] = Repo.all(Note)
+    end
+  end
 
   describe "record_reply/3 — the gates" do
     test "stores a public reply to the member's own post", %{

--- a/test/vutuv/posts_remote_replies_test.exs
+++ b/test/vutuv/posts_remote_replies_test.exs
@@ -1,0 +1,264 @@
+defmodule Vutuv.PostsRemoteRepliesTest do
+  @moduledoc """
+  Answering a reply that came from another network (issue #1070).
+
+  async: false — the outbound reply budget lives in the shared
+  `Vutuv.RateLimiter` ETS table, which the SQL sandbox does not roll back.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostRemoteReply
+
+  @actor "https://social.example/users/alice"
+  @inbox "https://social.example/users/alice/inbox"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+
+    author = insert(:activated_user, fediverse_followers?: true, fediverse_replies?: true)
+    post = create_post!(author, %{"body" => "Federated far and wide."})
+
+    {:ok, author: author, post: post, note: insert_note!(post)}
+  end
+
+  # A stored public reply from another network, the way the inbox writes one.
+  defp insert_note!(post, attrs \\ %{}) do
+    now = DateTime.utc_now(:second)
+
+    %Note{post_id: post.id}
+    |> Note.changeset(
+      Map.merge(
+        %{
+          object_uri: "#{@actor}/statuses/#{System.unique_integer([:positive])}",
+          actor_uri: @actor,
+          inbox_uri: @inbox,
+          handle: "alice",
+          display_name: "Alice Anders",
+          content_text: "Guter Punkt.",
+          audience: "public",
+          received_at: now,
+          checked_at: now,
+          expires_at: DateTime.add(now, 183 * 86_400)
+        },
+        attrs
+      )
+    )
+    |> Repo.insert!()
+  end
+
+  describe "create_remote_reply/3" do
+    test "creates an ordinary reply plus the sidecar naming what it answers", %{
+      author: author,
+      post: post,
+      note: note
+    } do
+      assert {:ok, reply} =
+               Posts.create_remote_reply(author, note, %{"body" => "Danke, freut mich!"})
+
+      # Underneath it is a normal reply to the vutuv post, so local threading,
+      # the reply count and the edit window are untouched.
+      reply = Repo.preload(reply, [:reply_ref, :remote_reply_ref])
+      assert reply.reply_ref.parent_post_id == post.id
+      assert reply.reply_ref.parent_author_id == author.id
+
+      # On top, the record of the other thing it answers.
+      assert %PostRemoteReply{} = ref = reply.remote_reply_ref
+      assert ref.note_id == note.id
+      assert ref.in_reply_to_uri == note.object_uri
+      assert ref.actor_uri == @actor
+      assert ref.inbox_uri == @inbox
+      assert ref.handle == "@alice@social.example"
+    end
+
+    test "a member who is not the post's author may answer too", %{note: note} do
+      stranger = insert(:activated_user, fediverse_followers?: true)
+
+      assert {:ok, reply} =
+               Posts.create_remote_reply(stranger, note, %{"body" => "Sehe ich auch so."})
+
+      assert reply.user_id == stranger.id
+    end
+
+    test "keeps the delivery target after the note is collected", %{author: author, note: note} do
+      assert {:ok, reply} = Posts.create_remote_reply(author, note, %{"body" => "Bis bald."})
+
+      # The note is a cache: it expires six months out, or a takedown removes it.
+      Repo.delete!(note)
+
+      ref = Repo.get_by!(PostRemoteReply, post_id: reply.id)
+      # note_id nilifies, but everything an Update/Delete needs is still here.
+      assert is_nil(ref.note_id)
+      assert ref.in_reply_to_uri
+      assert ref.actor_uri == @actor
+      assert ref.inbox_uri == @inbox
+    end
+  end
+
+  describe "create_remote_reply/3 — the gates" do
+    test "refuses a member who has not switched federation on", %{note: note} do
+      plain = insert(:activated_user)
+
+      assert {:error, :not_federating} =
+               Posts.create_remote_reply(plain, note, %{"body" => "Hallo"})
+
+      assert [] = Repo.all(PostRemoteReply)
+    end
+
+    test "refuses a reply that was addressed to the member alone", %{author: author, post: post} do
+      private = insert_note!(post, %{audience: "direct"})
+
+      assert {:error, :note_not_public} =
+               Posts.create_remote_reply(author, private, %{"body" => "Hallo"})
+    end
+
+    test "refuses a member who moved their account away", %{author: author, note: note} do
+      {:ok, moved} =
+        author
+        |> Ecto.Changeset.change(moved_to: "https://elsewhere.example/users/a")
+        |> Repo.update()
+
+      assert {:error, :moved} = Posts.create_remote_reply(moved, note, %{"body" => "Hallo"})
+    end
+
+    test "refuses once the operator blocked that server", %{author: author, note: note} do
+      admin = insert(:activated_user)
+      {:ok, _blocked} = Fediverse.block_instance(%{"host" => "social.example"}, admin)
+
+      # A block is both ears and mouth shut, so it stops answers going out too.
+      assert {:error, :instance_blocked} =
+               Posts.create_remote_reply(author, note, %{"body" => "Hallo"})
+    end
+
+    test "refuses past the member's hourly budget", %{author: author, post: post} do
+      # One slot, so the second answer is over budget whatever the default is.
+      Application.put_env(:vutuv, :fediverse_outbound_reply_limit, 1)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_outbound_reply_limit) end)
+
+      assert {:ok, _first} =
+               Posts.create_remote_reply(author, insert_note!(post), %{"body" => "Eins"})
+
+      assert {:error, :reply_capped} =
+               Posts.create_remote_reply(author, insert_note!(post), %{"body" => "Zwei"})
+    end
+
+    test "refuses while the installation switch is off", %{author: author, note: note} do
+      Application.put_env(:vutuv, :fediverse_enabled, false)
+      on_exit(fn -> Application.put_env(:vutuv, :fediverse_enabled, true) end)
+
+      assert {:error, :fediverse_disabled} =
+               Posts.create_remote_reply(author, note, %{"body" => "Hallo"})
+    end
+  end
+
+  describe "what leaves for the other network" do
+    setup %{author: author} do
+      {:ok, _actor} = Fediverse.ensure_actor(author)
+
+      {:ok, _follower} =
+        Fediverse.add_follower(author, %{
+          actor_uri: "https://follower.example/users/f",
+          inbox_uri: "https://follower.example/inbox"
+        })
+
+      :ok
+    end
+
+    test "reaches the answered person's inbox as well as the member's followers", %{
+      author: author,
+      note: note
+    } do
+      assert {:ok, _reply} = Posts.create_remote_reply(author, note, %{"body" => "Danke!"})
+
+      inboxes = Delivery |> Repo.all() |> Enum.map(& &1.inbox_uri) |> Enum.sort()
+      assert inboxes == ["https://follower.example/inbox", @inbox]
+    end
+
+    test "carries inReplyTo into the other network and a Mention of its author", %{
+      author: author,
+      note: note
+    } do
+      assert {:ok, _reply} = Posts.create_remote_reply(author, note, %{"body" => "Danke!"})
+
+      activity =
+        Delivery
+        |> Repo.all()
+        |> Enum.find(&(&1.inbox_uri == @inbox))
+        |> Map.fetch!(:activity_json)
+        |> Jason.decode!()
+
+      object = activity["object"]
+      # The answer points at the remote note, not at the vutuv post underneath:
+      # that note already points back at our post, so this is what threads the
+      # answer correctly on the other server.
+      assert object["inReplyTo"] == note.object_uri
+
+      # The Mention is what makes them notified. Built from the stored actor URI.
+      assert [%{"type" => "Mention", "href" => @actor, "name" => "@alice@social.example"}] =
+               object["tag"]
+
+      # Addressed to them by name on top of the usual public audience.
+      assert @actor in object["cc"]
+      assert object["to"] == ["https://www.w3.org/ns/activitystreams#Public"]
+
+      # The handle is written into the outgoing HTML the way these networks do,
+      # linked to the actor.
+      assert object["content"] =~
+               ~s(<a href="#{@actor}" class="u-url mention">@alice@social.example</a>)
+
+      assert object["content"] =~ "Danke!"
+    end
+
+    test "the member's own stored body never carries the foreign handle", %{
+      author: author,
+      note: note
+    } do
+      assert {:ok, reply} = Posts.create_remote_reply(author, note, %{"body" => "Danke!"})
+
+      # On vutuv the answer shows a "Replying to" line instead, so a member who
+      # has never heard of Mastodon does not type handles in a foreign format.
+      assert reply.body == "Danke!"
+      refute reply.body =~ "@alice"
+    end
+
+    test "still reaches the answered person when the member has no followers", %{note: note} do
+      lonely = insert(:activated_user, fediverse_followers?: true)
+      {:ok, _actor} = Fediverse.ensure_actor(lonely)
+
+      assert {:ok, _reply} = Posts.create_remote_reply(lonely, note, %{"body" => "Auch von mir."})
+
+      assert [%Delivery{inbox_uri: @inbox}] = Repo.all(Delivery)
+    end
+
+    test "deleting the answer tells the answered person too", %{author: author, note: note} do
+      assert {:ok, reply} = Posts.create_remote_reply(author, note, %{"body" => "Danke!"})
+      Repo.delete_all(Delivery)
+
+      assert {:ok, _deleted} = Posts.delete_post(reply)
+
+      deliveries = Repo.all(Delivery)
+      assert @inbox in Enum.map(deliveries, & &1.inbox_uri)
+
+      activity = deliveries |> Enum.find(&(&1.inbox_uri == @inbox)) |> Map.fetch!(:activity_json)
+      assert activity =~ ~s("type":"Delete")
+    end
+
+    test "an answer whose note carried no usable inbox goes to followers only", %{
+      author: author,
+      post: post
+    } do
+      # A note stored before issue #1070, or one whose server named an inbox it
+      # does not control (own_inbox/1 refused it).
+      note = insert_note!(post, %{inbox_uri: nil})
+
+      assert {:ok, _reply} = Posts.create_remote_reply(author, note, %{"body" => "Hallo"})
+
+      assert [%Delivery{inbox_uri: "https://follower.example/inbox"}] = Repo.all(Delivery)
+    end
+  end
+end

--- a/test/vutuv_web/live/remote_reply_page_test.exs
+++ b/test/vutuv_web/live/remote_reply_page_test.exs
@@ -1,0 +1,221 @@
+defmodule VutuvWeb.RemoteReplyPageTest do
+  @moduledoc """
+  Answering a reply that came from another network (issue #1070), from the
+  member's side: who is offered the action, what a member who does not federate is
+  told instead of being stonewalled, and that the answer lands back in the
+  conversation nested under the reply it answers.
+
+  async: false — the outbound reply budget lives in the shared
+  `Vutuv.RateLimiter` ETS table, which the SQL sandbox does not roll back.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Posts
+
+  @actor "https://social.example/users/alice"
+  @inbox "https://social.example/users/alice/inbox"
+
+  setup %{conn: conn} do
+    Vutuv.RateLimiter.reset()
+    {conn, user} = create_and_login_user(conn)
+
+    user
+    |> Ecto.Changeset.change(%{fediverse_followers?: true, fediverse_replies?: true})
+    |> Repo.update!()
+
+    # Re-read: the struct `register_user` returned predates the PIN login that
+    # confirmed the address, and `Fediverse.federated?/1` reads
+    # `email_confirmed?`.
+    user = Repo.get!(Vutuv.Accounts.User, user.id)
+
+    post = create_post!(user, %{body: "Reachable from anywhere."})
+
+    {:ok, conn: conn, user: user, post: post, note: note!(post)}
+  end
+
+  defp note!(post, attrs \\ []) do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(%Note{
+      post_id: post.id,
+      object_uri: "#{@actor}/statuses/#{System.unique_integer([:positive])}",
+      actor_uri: @actor,
+      inbox_uri: @inbox,
+      origin_url: "https://social.example/@alice/1",
+      handle: "alice",
+      display_name: "Alice Anders",
+      content_text: "Sturdier than they look.",
+      audience: Keyword.get(attrs, :audience, "public"),
+      received_at: now,
+      checked_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+  end
+
+  describe "the page a federating member gets" do
+    test "shows the reply, the composer, and where the words are going", %{
+      conn: conn,
+      note: note
+    } do
+      {:ok, _view, html} = live(conn, ~p"/system/fediverse/reply/#{note.id}")
+
+      assert html =~ "Sturdier than they look."
+      assert html =~ "data-remote-reply-notice"
+      # Said before they type: nobody should publish to another network by
+      # accident.
+      assert html =~ "@alice@social.example"
+      assert html =~ "your Fediverse followers"
+      refute html =~ "Turn on Fediverse participation"
+    end
+
+    test "sends the answer and lands back in the conversation", %{conn: conn, note: note} do
+      {:ok, view, _html} = live(conn, ~p"/system/fediverse/reply/#{note.id}")
+
+      view
+      |> form("#composer-form", %{"post" => %{"body" => "Danke, Alice!"}})
+      |> render_submit()
+
+      reply = Posts.Post |> Repo.get_by!(body: "Danke, Alice!") |> Repo.preload(:user)
+      assert_redirect(view, Posts.path(reply))
+
+      # The sidecar that carries it out to the other network.
+      ref = Repo.get_by!(Vutuv.Posts.PostRemoteReply, post_id: reply.id)
+      assert ref.note_id == note.id
+      assert ref.inbox_uri == @inbox
+    end
+  end
+
+  describe "a member who has not switched federation on" do
+    setup do
+      # A fresh conn: the outer setup already sent a response on its own, and a
+      # second login through it would reconfigure an already-sent session.
+      {conn, plain} =
+        build_conn()
+        |> Plug.Test.init_test_session(%{})
+        |> create_and_login_user(registration_attrs("plain"))
+
+      {:ok, plain_conn: conn, plain: plain}
+    end
+
+    test "is told what the setting does and where it is", %{plain_conn: conn, note: note} do
+      {:ok, _view, html} = live(conn, ~p"/system/fediverse/reply/#{note.id}")
+
+      # Not a dead end: the capability is explained and the setting is one click
+      # away.
+      assert html =~ "Turn on Fediverse participation"
+      assert html =~ ~s(href="/settings/fediverse")
+      # And no composer, so there is nothing to fill in that could not be sent.
+      refute html =~ "phx-submit=\"save\""
+    end
+
+    test "still sees the reply they cannot answer yet", %{plain_conn: conn, note: note} do
+      {:ok, _view, html} = live(conn, ~p"/system/fediverse/reply/#{note.id}")
+      assert html =~ "Sturdier than they look."
+    end
+  end
+
+  describe "what is refused outright" do
+    test "a reply addressed to the member alone", %{conn: conn, post: post} do
+      private = note!(post, audience: "direct")
+
+      assert {:error, {:redirect, %{to: to, flash: flash}}} =
+               live(conn, ~p"/system/fediverse/reply/#{private.id}")
+
+      assert to == Posts.path(post)
+      assert flash["error"] =~ "sent to you alone"
+    end
+
+    test "an unknown reply, without saying whether it ever existed", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/", flash: flash}}} =
+               live(conn, ~p"/system/fediverse/reply/#{Vutuv.UUIDv7.generate()}")
+
+      assert flash["error"] =~ "could not be found"
+    end
+
+    test "a private reply on somebody else's post is not even shown", %{post: post} do
+      private = note!(post, audience: "direct")
+
+      {other_conn, _stranger} =
+        build_conn()
+        |> Plug.Test.init_test_session(%{})
+        |> create_and_login_user(registration_attrs("nosy"))
+
+      # The addressee alone may see it, so for anybody else it does not exist —
+      # the same rule list_notes/2 enforces in the thread.
+      assert {:error, {:redirect, %{to: "/"}}} =
+               live(other_conn, ~p"/system/fediverse/reply/#{private.id}")
+
+      assert Repo.get(Note, private.id)
+      assert post
+    end
+  end
+
+  describe "where the answer ends up in the conversation" do
+    test "nested under the reply it answers, not beside it", %{
+      conn: conn,
+      user: user,
+      post: post,
+      note: note
+    } do
+      {:ok, answer} = Posts.create_remote_reply(user, note, %{"body" => "Danke, Alice!"})
+
+      html = conn |> get(Posts.path(post)) |> html_response(200)
+
+      # Underneath, the answer is an ordinary reply to `post`, so the forest would
+      # have made it a *sibling* of the remote card. It belongs under it.
+      assert html =~ "Danke, Alice!"
+      assert has_children?(html, note), "the remote card should carry the answer as its child"
+      assert answer.id
+    end
+
+    test "an ordinary reply to the same post stays beside the remote card", %{
+      conn: conn,
+      user: user,
+      post: post,
+      note: note
+    } do
+      {:ok, _plain} = Posts.create_reply(user, post, %{"body" => "Eine ganz normale Antwort."})
+
+      html = conn |> get(Posts.path(post)) |> html_response(200)
+
+      # Both are shown, and only an answer carrying the sidecar is moved under the
+      # remote card — a plain reply to the same post stays its sibling.
+      assert html =~ "Eine ganz normale Antwort."
+      assert html =~ ~s(data-fediverse-reply="#{note.id}")
+      refute has_children?(html, note)
+    end
+  end
+
+  # Whether the thread drew the remote card as a node that has answers under it.
+  # That connector span is rendered `:if={node.children != []}` immediately before
+  # the card, so its presence right there is the rendered proof of nesting —
+  # `[^>]*` cannot cross the span's own tag, so it cannot match some other node's
+  # connector further up the page.
+  defp has_children?(html, note) do
+    marker = Regex.escape("top-9 h-[calc(100%-2.25rem)] w-0.5")
+
+    pattern =
+      Regex.compile!(
+        marker <> ~s([^>]*>\\s*</span>\\s*<article data-fediverse-reply="#{note.id}"),
+        "s"
+      )
+
+    html =~ pattern
+  end
+
+  describe "the Reply link on the card" do
+    test "is offered on a public reply", %{conn: conn, post: post, note: note} do
+      html = conn |> get(Posts.path(post)) |> html_response(200)
+      assert html =~ "data-remote-reply-link=\"#{note.id}\""
+    end
+
+    test "is absent for a logged-out visitor", %{post: post} do
+      html = build_conn() |> get(Posts.path(post)) |> html_response(200)
+      refute html =~ "data-remote-reply-link"
+    end
+  end
+end


### PR DESCRIPTION
Closes #1070.

Since #1069 a reply written on Mastodon under a member's public post is stored and shown in the conversation, but there was no way to answer it, so vutuv showed half a dialogue and sent people elsewhere to finish it. This closes the loop for **public** replies.

## What a member sees

A "Reply" link on the remote reply's own card, next to where it came from. It opens a page showing the reply above and the ordinary post composer below, with one line stating **before they type** that the answer goes to that person on their own server and to their Fediverse followers, and that it is a public vutuv post as well. Nobody should publish to another network by accident.

Any federating member may answer, not only the author of the post it sits under. A member who has not switched federation on gets an explanation of what the setting does plus a link to `/settings/fediverse`, not a disabled button, so the capability is discoverable instead of hidden.

The answer then hangs **under** the reply it answers in the conversation.

## How it works

An answer is an ordinary reply to the vutuv post underneath, so local threading, the parent-author notification, the public reply count and the edit window all keep working untouched. A new `post_remote_replies` sidecar records the other thing it answers, and the outgoing `Create(Note)` gains an `inReplyTo` pointing at the remote note, the answered actor in `cc`, and a `Mention` tag.

The sidecar carries its own copy of the target (`in_reply_to_uri`, `actor_uri`, `inbox_uri`, `handle`) because a stored note is a cache that expires after six months or is taken down sooner, while the member's answer lives on and an `Update`/`Delete` still has to reach the person answered. The inbox is captured when the note is stored, since the inbox had already fetched and verified that actor document to check the signature, so answering costs no network call on the request path.

The `@user@host` handle is written into the outgoing HTML **only**: on vutuv the answer shows a "Replying to" line, so a member who has never heard of Mastodon never types a handle in a foreign format.

## Public replies only

Answering a reply addressed to a member alone would publish half of an exchange its author meant for one person. Doing it privately would need a new kind of vutuv post that has to be invisible in the feed, on the profile, in the thread, in the agent formats and in the data export. That deserves its own decision, so the card keeps linking to the original.

## Security

- **Metered.** This is the only place a member's own action makes vutuv POST to a server that never followed us, so each member has an hourly budget (`FEDIVERSE_OUTBOUND_REPLY_LIMIT`, 30). The shape of the feature already bounds it hard: an answer needs a stored reply on a vutuv post first, so the person answered is always somebody who wrote here, never a list an attacker picks.
- **Inbox redirect closed.** An actor document is written by whoever runs that server, so a hostile one could point its inbox at a third party and turn a member's answer into a signed POST there. `own_inbox/1` now refuses an inbox that is not https on the actor's **own host** before it is ever stored, the same rule the inbox already applies to a signature's `keyId`, and `attempt/2` re-checks every row at send time.
- **The `Mention` is built from the stored actor URI**, never parsed out of the member's typed text. Parsing would let anyone mint a verified-looking Mention at an actor nobody checked.
- The operator blocklist stops answers going to a shut-out server, and the usual `federated?`/`moved?`/`restricted?` gates apply.

## Also: posts wait for their pictures

A post's images are invisible until the AI scan releases them, so a Note built the instant the post commits carried **no attachment** and the picture never reached the other network at all. This was a pre-existing gap that bit hardest on a reply where the picture is the answer.

Such a post is now enqueued with a short hold and re-rendered when it goes out, released the moment the last picture has a verdict (approved *or* rejected, since a rejection settles the post too). `FEDIVERSE_IMAGE_HOLD_SECONDS` (90) is the **ceiling** for a scanner that never answers, and then the post federates without the unvetted picture rather than not at all. A held row still stores a complete, valid activity, so a release mid-deploy that does not know the new column delivers that instead of choking: the worst a deploy window can do is federate one post without its picture.

## Migrations

Three, all plain additions and N-1 safe: `fediverse_notes.inbox_uri`, the `post_remote_replies` table, `fediverse_deliveries.rebuild_from`.

## Tests

`mix precommit` green, 5205 tests. New coverage for the gates (including the four refusals by name), what actually leaves for the other network (`inReplyTo`, `Mention`, `cc`, the injected handle, followers **plus** the answered inbox, and delete reaching them too), the delivery target surviving the note's collection, the same-host inbox rule, the image hold and its release, and the UI (the gate page for a non-federating member, the private-reply refusals, and both directions of the thread nesting).

## Still needs doing by hand

The **privacy page** is per-installation content in the database (`/admin/legal`), so it is not in this diff. It needs a sentence that a small delivery address is kept alongside a member's own answer for as long as that answer exists, so editing or deleting it can still reach the person answered after the six-month copy of their reply is gone.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01HavjqF5qDdPK4XFxWDjEJ3
