### PR TITLE
Point at the Fediverse card from the Profiles card (#1111)

### DIFF
--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -807,8 +807,11 @@ the resulting ~200px rail width. --%>
     It closes the page: the profile itself is what a visitor came for, and this
     is the "take me with you" footer under it. `order-3` keeps it last on a
     phone too, where every card is one flex child of a single column and the
-    rail's utility footer sits at `order-2`. --%>
-    <.card :if={@fediverse} id="profile-fediverse" class="order-3 md:order-none">
+    rail's utility footer sits at `order-2`. Two links jump straight here — the
+    Profiles card's shortcut row and the remote-follow controller's error
+    redirect — so `scroll-mt-24` keeps the sticky top bar off the card's title
+    when the browser lands on the anchor. --%>
+    <.card :if={@fediverse} id="profile-fediverse" class="order-3 scroll-mt-24 md:order-none">
       <.section_title>{gettext("Fediverse")}</.section_title>
 
       <%= if @fediverse.moved_to do %>
@@ -1071,8 +1074,10 @@ the resulting ~200px rail width. --%>
     </.card>
 
     <% smas_count = Enum.count(@user.social_media_accounts) %>
+    <%!-- @fediverse joins the card's render condition: a member who federates
+    but lists no other account still has one address worth showing here. --%>
     <.card
-      :if={smas_count > 0 or @as_owner?}
+      :if={smas_count > 0 or @fediverse != nil or @as_owner?}
       id="profile-social-media"
     >
       <.section_header title={gettext("Profiles")} />
@@ -1089,6 +1094,35 @@ the resulting ~200px rail width. --%>
         accounts={@user.social_media_accounts}
         social_feed_loading={@social_feed_loading}
       />
+
+      <%!-- The member's Fediverse address, in the one card a visitor scans for
+      "where else is this person" (issue #1111). The full explanation — copy
+      button, remote-follow tool, or the forwarding address of a member who
+      moved away — closes the page, and repeating that here would say the same
+      thing twice on one screen; so this is a single row that names the address
+      and jumps to it. Its own heading, unlike the two buckets above (whose
+      labels appear only when both are present): this row is not an account on
+      another site but the member's account right here, seen from the outside,
+      and naming the network is what makes that legible. --%>
+      <div :if={@fediverse} class={smas_count > 0 && "mt-6"}>
+        <h3 class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          {gettext("Fediverse")}
+        </h3>
+        <a
+          id="profile-fediverse-shortcut"
+          href="#profile-fediverse"
+          class="group flex items-center gap-2.5 py-1.5 text-sm text-slate-700 transition hover:text-brand-700 dark:text-slate-200"
+        >
+          <.detail_icon
+            name="globe"
+            class="h-4 w-4 shrink-0 text-slate-400 transition group-hover:text-brand-600 dark:text-slate-500 dark:group-hover:text-brand-300"
+          />
+          <span class="truncate font-medium">{@fediverse.moved_handle || @fediverse.handle}</span>
+          <span class="ml-auto shrink-0 text-xs text-slate-500 dark:text-slate-400">
+            {gettext("Follow")} ›
+          </span>
+        </a>
+      </div>
 
       <.manage_footer
         href={~p"/#{@user}/social_media_accounts"}

--- a/lib/vutuv_web/views/user_html.ex
+++ b/lib/vutuv_web/views/user_html.ex
@@ -533,6 +533,19 @@ defmodule VutuvWeb.UserHTML do
     """
   end
 
+  # The globe the app already uses for "another network" (the admin dashboard's
+  # Fediverse tile), drawn as a circle plus two meridians rather than one path,
+  # so it stays crisp at 16px next to the brand glyphs of the Profiles card.
+  def detail_icon(%{name: "globe"} = assigns) do
+    ~H"""
+    <svg class={@class} fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="12" cy="12" r="8.5" />
+      <path stroke-linecap="round" d="M3.5 12h17" />
+      <path d="M12 3.5c2.3 2.3 3.7 5.3 3.7 8.5s-1.4 6.2-3.7 8.5c-2.3-2.3-3.7-5.3-3.7-8.5S9.7 5.8 12 3.5Z" />
+    </svg>
+    """
+  end
+
   def detail_icon(assigns) do
     ~H"""
     <svg class={@class} fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24" aria-hidden="true">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.160.0",
+      version: "7.160.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/user_profile_fediverse_test.exs
+++ b/test/vutuv_web/live/user_profile_fediverse_test.exs
@@ -15,6 +15,7 @@ defmodule VutuvWeb.UserProfileFediverseTest do
   @card "#profile-fediverse"
   @handle "#profile-fediverse-handle"
   @form "#remote-follow-form"
+  @shortcut "#profile-fediverse-shortcut"
 
   defp federating_member(attrs \\ []) do
     insert_activated_user(Keyword.merge([fediverse_followers?: true], attrs))
@@ -115,6 +116,54 @@ defmodule VutuvWeb.UserProfileFediverseTest do
       assert view
              |> element(@form)
              |> render() =~ ~s|action="/#{user.username}/fediverse/follow"|
+    end
+  end
+
+  describe "the shortcut in the Profiles card" do
+    test "names the address and points at the card", %{conn: conn} do
+      user = federating_member()
+
+      {:ok, view, _html} = live(conn, ~p"/#{user}")
+
+      assert has_element?(view, "#profile-social-media " <> @shortcut)
+      assert view |> element(@shortcut) |> render() =~ Docs.handle(user)
+      assert view |> element(@shortcut) |> render() =~ ~s|href="#profile-fediverse"|
+    end
+
+    test "does not repeat the card's tools", %{conn: conn} do
+      user = federating_member()
+
+      {:ok, view, _html} = live(conn, ~p"/#{user}")
+
+      # The point of the shortcut is that the explanation, the copy button and
+      # the remote-follow form exist once, at the foot of the page. A second
+      # copy up here would be the heavy version this replaced.
+      refute has_element?(view, "#profile-social-media #remote-follow-form")
+      refute has_element?(view, "#profile-social-media [data-copy]")
+    end
+
+    test "the card it points at clears the sticky top bar", %{conn: conn} do
+      user = federating_member()
+
+      {:ok, view, _html} = live(conn, ~p"/#{user}")
+
+      assert has_element?(view, "#profile-fediverse.scroll-mt-24")
+    end
+
+    test "shows the forwarding address once the member moved away", %{conn: conn} do
+      user = federating_member(moved_to: "https://social.example/users/greta")
+
+      {:ok, view, _html} = live(conn, ~p"/#{user}")
+
+      assert view |> element(@shortcut) |> render() =~ "@greta@social.example"
+    end
+
+    test "is absent for a member who does not federate", %{conn: conn} do
+      user = insert_activated_user()
+
+      {:ok, view, _html} = live(conn, ~p"/#{user}")
+
+      refute has_element?(view, @shortcut)
     end
   end
 


### PR DESCRIPTION
Closes #1111.

A member's Fediverse address only lived in the card that closes the profile, so a visitor arriving from Mastodon had to scroll past every section to reach the one thing they came for.

**The lighter call.** The full card stays where it is, once, at the foot of the page: it needs room for the explanation, the copy button and the remote-follow form, and a card that size does not belong in a rail of one-line entries. What the Profiles card gets is a single row that names the address and links to `#profile-fediverse`.

- Own "Fediverse" heading, unlike the two buckets above it (whose labels only appear when both are present): this row is not an account on another site, it is the member's account right here seen from the outside, and naming the network is what makes that legible.
- Shows the forwarding address when the member moved their account away, so the row stays truthful in that state.
- The card gains `scroll-mt-24`, so the sticky top bar does not cover its title when the browser lands on the anchor. The remote-follow controller's error redirect targets the same anchor and gets that fix for free.
- The Profiles card now also renders for a member who federates but lists no other account, which used to be an empty rail slot.

Tests in `user_profile_fediverse_test.exs` cover the row, the moved state, the absence for a non-federating member, and that the card's tools are not duplicated up in the rail.

Version bumped to 7.160.1.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01PwkKz9jfVnAeZPSDZQqwv5
