### PR TITLE
Bump to 7.162.0 after a version collision on main

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.161.0",
+      version: "7.162.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
**TL;DR** #1116 and #1117 merged minutes apart and both carried `7.161.0`, so two deploys report the same version. This claims `7.162.0`.

**Why it slipped through:** both branched off `7.160.1` and made the identical `mix.exs` edit, so the squash merges did not conflict. Versions drive the release tag and the `/about`-style surfaces, so they need to stay monotonic and unique.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_016STn6WsDCvvjxyUb7ynX4f
