### PR TITLE
Quote a marked passage into a reply (#1114)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -160,6 +160,74 @@ window.addEventListener("resize", () => {
   previewClampResizeTimer = setTimeout(sweepPreviewClamps, 150)
 })
 
+// Quote a passage into a reply (issue #1114). Mark part of a post, press that
+// post's Reply control, and the reply page opens with the marked text already
+// in the composer as a blockquote. No new chrome: the selection rides along on
+// the Reply link the card already has, as a `quote` query parameter that
+// VutuvWeb.Markdown.blockquote/1 normalizes and caps server-side.
+//
+// The server marks the two halves — `data-post-body` on a post's prose, and
+// `data-quote-reply` on the enclosing card naming its Reply control. Thread
+// cards nest, so resolving the card from the SELECTION (innermost marked
+// ancestor) rather than from the link is what keeps a marked reply from
+// quoting itself into its parent's answer.
+const QUOTE_MAX = 500
+
+// What was selected when the pointer went down. The browser collapses a
+// selection as part of the default action of pointerdown, i.e. before the
+// link's click event ever fires, so by click time it is already gone.
+let pendingQuote = null
+
+function selectionQuote() {
+  const selection = window.getSelection()
+  if (!selection || selection.isCollapsed) return null
+
+  const text = selection.toString().trim()
+  if (!text) return null
+
+  const anchor = selection.anchorNode
+  const start = anchor && (anchor.nodeType === 1 ? anchor : anchor.parentElement)
+  const body = start && start.closest("[data-post-body]")
+  const card = body && body.closest("[data-quote-reply]")
+  if (!card) return null
+
+  return { text: text.slice(0, QUOTE_MAX), replyId: card.dataset.quoteReply }
+}
+
+// Capture, so a handler that stops propagation can't rob us of the selection.
+document.addEventListener(
+  "pointerdown",
+  () => {
+    pendingQuote = selectionQuote()
+  },
+  true
+)
+
+document.addEventListener(
+  "click",
+  (e) => {
+    // A keyboard activation fires no pointerdown and leaves the selection
+    // standing, so the live selection is tried first and the remembered one is
+    // the fallback for the mouse/touch path.
+    const quote = selectionQuote() || pendingQuote
+    pendingQuote = null
+    if (!quote) return
+
+    const link = e.target.closest("a[href]")
+    if (!link || link.id !== quote.replyId) return
+
+    const href = link.getAttribute("href")
+    const url = new URL(href, window.location.origin)
+    url.searchParams.set("quote", quote.text)
+    link.setAttribute("href", url.pathname + url.search)
+    // Put the plain href back once the navigation is under way: a click the
+    // browser does not follow (opening in a new tab) would otherwise leave this
+    // card's Reply link pointing at a stale quote.
+    setTimeout(() => link.setAttribute("href", href), 0)
+  },
+  true
+)
+
 // Hooks. MarkdownEditor is the Milkdown WYSIWYG composer (posts + messages).
 // LocalTime localizes timestamps (see above). ScrollBottom keeps a chat thread
 // pinned to its newest message.

--- a/assets/js/markdown_editor.js
+++ b/assets/js/markdown_editor.js
@@ -266,6 +266,7 @@ export const MarkdownEditor = {
 
     this.editor = await editor.create()
 
+    this.ensureTrailingParagraph()
     this.applyState()
     this.wireToolbar()
     this.wireSubmitShortcut()
@@ -283,7 +284,11 @@ export const MarkdownEditor = {
     if (serverMd === this.lastPushed) return
     this.lastPushed = serverMd
     this.source.value = serverMd
-    if (this.mode !== "source") this.setEditorMarkdown(serverMd)
+
+    if (this.mode !== "source") {
+      this.setEditorMarkdown(serverMd)
+      this.ensureTrailingParagraph()
+    }
   },
 
   // Re-stamp the hook's view state onto the (server-managed) root. Cheap and
@@ -388,6 +393,26 @@ export const MarkdownEditor = {
       (whole, sigil, handle) =>
         handle.includes("\\_") ? sigil + handle.replace(/\\_/g, "_") : whole
     )
+  },
+
+  // ProseMirror offers no place to put the cursor after a trailing block that
+  // owns its content: click below a blockquote, a table or a code block and the
+  // cursor lands INSIDE it. That is fatal for a seeded quote (issue #1114) — the
+  // whole document is one blockquote, so the answer would be typed into the
+  // quotation. Append an empty paragraph so there is somewhere to write, and do
+  // it after every seed rather than in a plugin: a plugin's appendTransaction
+  // never sees the editor's initial state, which is exactly the state that needs
+  // it. The paragraph costs nothing in the stored source — Milkdown serializes
+  // it as the `<br />` artifact `normalizeMarkdown` already drops.
+  ensureTrailingParagraph() {
+    this.editor?.action((ctx) => {
+      const view = ctx.get(editorViewCtx)
+      const { state } = view
+      const paragraph = state.schema.nodes.paragraph
+      const last = state.doc.lastChild
+      if (!paragraph || !last || last.type === paragraph) return
+      view.dispatch(state.tr.insert(state.doc.content.size, paragraph.create()))
+    })
   },
 
   setEditorMarkdown(markdown) {

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -297,6 +297,26 @@ Replying works on **public** parents only (the reply button on restricted posts
 is disabled, like repost) and pins the parent's audience open like reposts do.
 Replies to replies are allowed.
 
+**Quoting a passage** (issue #1114). Marking part of a post and then pressing
+that post's Reply opens the composer with the marked text already in it as a
+Markdown blockquote, so a long post can be answered point by point. The whole
+mechanism is the Reply link the card already has — no floating menu, no new
+route, nothing stored: `assets/js/app.js` reads the selection at click time and
+appends it as a `quote` query parameter, and `VutuvWeb.PostLive.Reply` runs that
+untrusted string through `VutuvWeb.Markdown.blockquote/1` (trim each line, keep
+the quote marker across blank lines, cap at 500 characters cut back to the last
+whole word) into the composer's `initial_body`. The server marks the two halves
+the client needs: `data-post-body` on a post's prose and `data-quote-reply` on
+the enclosing card, naming its Reply control by id. Because thread cards nest,
+the card is resolved from the **selection** (innermost marked ancestor), not
+from the link — otherwise a marked reply would quote itself into its parent's
+answer. A restricted post carries no marker (its Reply control is a dead span),
+and the reply page's own parent preview passes `quotable={false}`, since its
+Reply link leads back to the page being composed on and would discard the draft.
+The quote is plain Markdown in the answer's body; the attribution is the reply
+card itself, which already shows the post it answers with its author's avatar
+and a link to it.
+
 **A post is rendered by one shared component everywhere**
 (`VutuvWeb.PostComponents`): `post_thread_entry/1` shows a reply as a **nested
 conversation** — the posts it answers are stacked **above** it as full cards

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -86,6 +86,14 @@ defmodule VutuvWeb.PostComponents do
     doc: ":card stands alone; :flat embeds inside an existing card (profile Posts section)"
   )
 
+  attr(:quotable, :boolean,
+    default: true,
+    doc:
+      "let a text selection inside this card's body ride along to the reply page " <>
+        "as a quote (issue #1114). Set false where the Reply link leads back to " <>
+        "the page the reader is already composing on"
+  )
+
   attr(:conn_or_socket, :any,
     required: true,
     doc: "@conn (dead pages) or @socket (LiveViews) — anchors the embedded live action bar"
@@ -1259,7 +1267,12 @@ defmodule VutuvWeb.PostComponents do
 
   defp render_post_card_inner(assigns) do
     ~H"""
-    <div>
+    <%!-- data-quote-reply names this card's Reply control, so a text selection
+    inside its body can ride along to the reply page as a quote (issue #1114,
+    wired in app.js). It sits on the card, not on the body, because thread cards
+    nest: the INNERMOST marked ancestor of the selection is the post that was
+    marked. Absent on a restricted post, whose Reply control is a dead span. --%>
+    <div data-quote-reply={@quotable and not @restricted? and "#{@actions_id}-reply"}>
       <%!-- The owner's freezer notice: only the author (and admins) still see
       a reported post; everyone else gets nothing, not even a tombstone. --%>
       <.frozen_banner :if={@frozen? and @author?} class="mb-3 rounded-lg px-3 py-2 text-xs">
@@ -1431,6 +1444,7 @@ defmodule VutuvWeb.PostComponents do
               beside-the-text reading as the preview, at the same width. --%>
               <div
                 :if={@mode == :full and @post.body != ""}
+                data-post-body
                 class="markdown markdown--post mt-2 text-slate-800 dark:text-slate-200"
                 {style_attrs(@body_style)}
               >
@@ -1750,6 +1764,7 @@ defmodule VutuvWeb.PostComponents do
             "markdown markdown--post text-slate-800 dark:text-slate-200"
           ]}
           data-clamp-body
+          data-post-body
           {style_attrs(@body_style)}
         >
           <%!-- The floated media is the clamp block's FIRST child so the body text

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -2,7 +2,8 @@ defmodule VutuvWeb.PostLive.Composer do
   @moduledoc """
   The post composer, used by the feed (new posts), the edit page and the
   reply page (pass `parent` to create the post as a reply via
-  `Vutuv.Posts.create_reply/3`).
+  `Vutuv.Posts.create_reply/3`, and `initial_body` to open it with text
+  already in the editor).
 
   **Images upload eagerly**: the moment a file is picked it is processed
   (`Vutuv.Posts.create_pending_image/3` — AVIF versions, private original)
@@ -55,7 +56,17 @@ defmodule VutuvWeb.PostLive.Composer do
   @impl true
   def update(assigns, socket) do
     socket =
-      assign(socket, Map.take(assigns, [:id, :current_user, :post, :parent, :remote_note]))
+      assign(
+        socket,
+        Map.take(assigns, [
+          :id,
+          :current_user,
+          :post,
+          :parent,
+          :remote_note,
+          :initial_body
+        ])
+      )
 
     socket =
       if socket.assigns[:composer_ready?] do
@@ -84,7 +95,10 @@ defmodule VutuvWeb.PostLive.Composer do
       :audience_locked?,
       post != nil and (Posts.has_reposts?(post) or Posts.has_replies?(post))
     )
-    |> assign(:body, (post && post.body) || "")
+    # `initial_body` opens the composer with text already in it — the reply
+    # page seeds a Markdown blockquote when the reader marked part of the post
+    # before pressing Reply (issue #1114). An edited post's own body wins.
+    |> assign(:body, (post && post.body) || socket.assigns[:initial_body] || "")
     |> assign(:review, review_values(post))
     |> assign(:review_lookup_error, nil)
     |> assign(:tags_value, tags_value(post))

--- a/lib/vutuv_web/live/post_live/reply.ex
+++ b/lib/vutuv_web/live/post_live/reply.ex
@@ -4,6 +4,15 @@ defmodule VutuvWeb.PostLive.Reply do
   as the feed. Only visible, **public** parents can be answered
   (`Vutuv.Posts.create_reply/3` enforces the same rule); everything else is
   sent away with the unknown-id flash, so existence never leaks.
+
+  **Quoting a passage** (issue #1114): a reader who marks part of a post before
+  pressing Reply arrives here with that text in the `quote` parameter, and the
+  composer opens with it as a Markdown blockquote. The selection is client-side
+  by nature, so `assets/js/app.js` puts it on the Reply link at click time; the
+  parameter is untrusted text like any other and goes through
+  `VutuvWeb.Markdown.blockquote/1`, which normalizes and caps it. Nothing here
+  ties the quote to the parent — the reply card already names the post it
+  answers, with its author's avatar and a link to it.
   """
 
   use VutuvWeb, :live_view
@@ -11,11 +20,12 @@ defmodule VutuvWeb.PostLive.Reply do
   import VutuvWeb.PostComponents
 
   alias Vutuv.Posts
+  alias VutuvWeb.Markdown
 
   on_mount({VutuvWeb.Live.InitAssigns, :require_login})
 
   @impl true
-  def mount(%{"id" => id}, _session, socket) do
+  def mount(%{"id" => id} = params, _session, socket) do
     user = socket.assigns.current_user
     parent = Posts.get_post(id)
 
@@ -23,7 +33,8 @@ defmodule VutuvWeb.PostLive.Reply do
       {:ok,
        socket
        |> assign(:page_title, gettext("Reply"))
-       |> assign(:parent, parent)}
+       |> assign(:parent, parent)
+       |> assign(:initial_body, Markdown.blockquote(params["quote"]))}
     else
       {:ok,
        socket
@@ -41,7 +52,16 @@ defmodule VutuvWeb.PostLive.Reply do
           {gettext("Reply to %{handle}", handle: "@" <> @parent.user.username)}
         </h1>
 
-        <.post_card post={@parent} viewer={@current_user} mode={:preview} conn_or_socket={@socket} />
+        <%!-- quotable={false}: this card's own Reply link leads back to this
+        page, so arming it would let a second selection reload the page and
+        throw away whatever has been typed below. --%>
+        <.post_card
+          post={@parent}
+          viewer={@current_user}
+          mode={:preview}
+          conn_or_socket={@socket}
+          quotable={false}
+        />
 
         <.live_component
           module={VutuvWeb.PostLive.Composer}
@@ -49,6 +69,7 @@ defmodule VutuvWeb.PostLive.Reply do
           current_user={@current_user}
           post={nil}
           parent={@parent}
+          initial_body={@initial_body}
         />
 
         <.link

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -46,6 +46,9 @@ defmodule VutuvWeb.Markdown do
   # code spans — as one capture, so `Regex.split(include_captures: true)`
   # alternates non-code / code chunks. Used by `map_outside_code/2`.
   @code_region ~r/(```[\s\S]*?```|~~~[\s\S]*?~~~|``[^`]*``|`[^`\n]*`)/
+  # How much of a text selection a reply may quote (issue #1114). A paragraph
+  # fits; marking half the page does not, and the excerpt rides in a URL.
+  @quote_max_length 500
   # When a whole block would overflow the preview, keep a word-cut of it (so a
   # one-line intro above a long block doesn't leave a one-line preview) — but
   # only if at least this many characters of budget remain, else just stop.
@@ -209,6 +212,64 @@ defmodule VutuvWeb.Markdown do
     |> Enum.map(&String.trim/1)
     |> Enum.reject(&(&1 == ""))
     |> Enum.join("\n")
+  end
+
+  @doc """
+  Turn a plain-text excerpt into Markdown **blockquote source** — what the reply
+  composer opens with when the reader marked part of the post before pressing
+  Reply (issue #1114).
+
+  The excerpt comes from a browser text selection, so it arrives with the DOM's
+  own line breaks and indentation: each line is trimmed and prefixed with the
+  quote marker, and a blank line keeps the quote open across a paragraph break
+  instead of ending it. The whole excerpt is capped at #{@quote_max_length}
+  characters — cut back to the last whole word and closed with an ellipsis — so
+  one selection can neither fill the answer nor bloat the URL that carries it.
+  The trailing blank line puts the cursor below the quote, where the answer goes.
+
+  Returns `nil` when there is nothing to quote, so a raw query parameter can be
+  passed straight in.
+  """
+  def blockquote(text) when is_binary(text) do
+    case text |> String.trim() |> cut_excerpt() do
+      "" ->
+        nil
+
+      excerpt ->
+        excerpt
+        |> String.split(["\r\n", "\n", "\r"])
+        |> Enum.map_join("\n", &quote_line/1)
+        |> Kernel.<>("\n\n")
+    end
+  end
+
+  def blockquote(_), do: nil
+
+  # A blank line inside a blockquote ends it, so an empty line keeps the marker
+  # and becomes a paragraph break within the quote.
+  defp quote_line(line) do
+    case String.trim(line) do
+      "" -> ">"
+      trimmed -> "> " <> trimmed
+    end
+  end
+
+  # Cut back to the last whitespace so the quote never ends mid-word; a single
+  # run too long to cut back (a pasted token, a language that doesn't space its
+  # words) is cut hard rather than thrown away. The `s` flag lets the greedy
+  # `.*` reach across line breaks, so the last word of a multi-line selection is
+  # the one dropped.
+  defp cut_excerpt(text) do
+    if String.length(text) <= @quote_max_length do
+      text
+    else
+      cut = String.slice(text, 0, @quote_max_length)
+
+      case Regex.run(~r/^(.*)\s\S*$/su, cut, capture: :all_but_first) do
+        [head] -> head <> " …"
+        nil -> cut <> " …"
+      end
+    end
   end
 
   # The escapes Earmark and the sanitizer emit. `&amp;` goes last: decoding it

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.162.0",
+      version: "7.163.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -22,6 +22,36 @@ defmodule VutuvWeb.PostFeedLiveTest do
     end
   end
 
+  describe "quoting a passage into a reply (#1114)" do
+    test "a card names its own Reply control, so a selection can ride along", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, _post} = Posts.create_post(user, %{body: "a passage worth answering"})
+
+      {:ok, _live, html} = live(conn, ~p"/feed")
+
+      # The card points at the Reply control by id and marks the prose the
+      # selection has to come from — app.js needs both halves to fire.
+      assert [reply_id] = Regex.run(~r/data-quote-reply="([^"]+)"/, html, capture: :all_but_first)
+      assert html =~ ~s(id="#{reply_id}")
+      assert html =~ "data-post-body"
+    end
+
+    test "a restricted post is not armed — its Reply control is a dead span", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      {:ok, _post} =
+        Posts.create_post(user, %{
+          body: "not for everyone",
+          denials: [%{"wildcard" => "logged_out"}]
+        })
+
+      {:ok, _live, html} = live(conn, ~p"/feed")
+
+      assert html =~ "not for everyone"
+      refute html =~ "data-quote-reply"
+    end
+  end
+
   describe "engagement query batching" do
     test "feed engagement queries do not grow with post count", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)

--- a/test/vutuv_web/live/post_reply_live_test.exs
+++ b/test/vutuv_web/live/post_reply_live_test.exs
@@ -69,6 +69,43 @@ defmodule VutuvWeb.PostReplyLiveTest do
       assert Posts.list_replies(parent, author) == []
     end
 
+    test "opens the composer with the marked passage as a quote", %{conn: conn} do
+      # Issue #1114: app.js puts the reader's text selection on the Reply link,
+      # and the composer opens with it quoted, ready to be answered under.
+      {conn, _user} = create_and_login_user(conn)
+      parent = create_post!(other_user(), %{body: "one claim. another claim."})
+
+      {:ok, _live, html} =
+        live(conn, ~p"/posts/#{parent.id}/reply?#{[quote: "another claim."]}")
+
+      assert html =~ "&gt; another claim."
+    end
+
+    test "submitting the seeded quote posts it as the reply's body", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      parent = create_post!(other_user(), %{body: "the question"})
+
+      {:ok, live, _html} = live(conn, ~p"/posts/#{parent.id}/reply?#{[quote: "the question"]}")
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "> the question\n\nmy answer"}})
+      |> render_submit()
+
+      assert [reply] = Posts.list_replies(parent, user)
+      assert reply.body == "> the question\n\nmy answer"
+    end
+
+    test "the parent preview is not armed for quoting, so a draft cannot be lost", %{conn: conn} do
+      # This card's own Reply link leads back to this page; arming it would let a
+      # second selection reload the page over whatever has been typed below.
+      {conn, _user} = create_and_login_user(conn)
+      parent = create_post!(other_user(), %{body: "the original"})
+
+      {:ok, _live, html} = live(conn, ~p"/posts/#{parent.id}/reply")
+
+      refute html =~ "data-quote-reply"
+    end
+
     test "submitting creates the reply and returns to the parent", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       parent = create_post!(other_user(), %{body: "the question"})

--- a/test/vutuv_web/markdown_quote_test.exs
+++ b/test/vutuv_web/markdown_quote_test.exs
@@ -1,0 +1,48 @@
+defmodule VutuvWeb.MarkdownQuoteTest do
+  @moduledoc """
+  `VutuvWeb.Markdown.blockquote/1` — the Markdown source the reply composer
+  opens with when the reader selected part of a post before pressing Reply
+  (issue #1114). The excerpt comes from a browser text selection, so the tests
+  cover the shapes a selection really has: stray indentation, blank lines, and
+  a reader who marked half the page.
+  """
+  use ExUnit.Case, async: true
+
+  alias VutuvWeb.Markdown
+
+  test "wraps the selection in a blockquote and leaves a line for the answer" do
+    assert Markdown.blockquote("the point I answer") == "> the point I answer\n\n"
+  end
+
+  test "quotes every line and keeps a paragraph break inside the quote" do
+    assert Markdown.blockquote("first line\n\nsecond line") ==
+             "> first line\n>\n> second line\n\n"
+  end
+
+  test "drops the indentation a DOM selection carries along" do
+    assert Markdown.blockquote("  \n  indented  \n\t tabbed\n") == "> indented\n> tabbed\n\n"
+  end
+
+  test "an empty selection is nil, so a bare query parameter can be passed in" do
+    assert Markdown.blockquote("") == nil
+    assert Markdown.blockquote("   \n  ") == nil
+    assert Markdown.blockquote(nil) == nil
+  end
+
+  test "caps a long selection at the last whole word" do
+    quoted = Markdown.blockquote(String.duplicate("wort ", 200))
+
+    assert String.starts_with?(quoted, "> wort wort")
+    assert String.ends_with?(quoted, " …\n\n")
+    # The cap plus the quote marker and the ellipsis, nothing near the 1000
+    # characters that went in.
+    assert String.length(quoted) < 520
+  end
+
+  test "cuts a word too long to cut back rather than dropping it" do
+    quoted = Markdown.blockquote(String.duplicate("a", 700))
+
+    assert String.starts_with?(quoted, "> " <> String.duplicate("a", 500))
+    assert String.ends_with?(quoted, "…\n\n")
+  end
+end


### PR DESCRIPTION
**TL;DR** Mark part of a post, press that post's **Reply**, and the composer opens with the marked text already in it as a blockquote. Closes #1114.

**Where:** `assets/js/app.js`, `VutuvWeb.Markdown.blockquote/1`, `VutuvWeb.PostLive.Reply`, `VutuvWeb.PostComponents.post_card/1`
**Now:** answering one point of a long post means retyping it by hand.
**Want:** select the sentence, hit Reply, write the answer under the quote.

## How it works

No floating menu, no new route, nothing stored. The selection rides on the Reply link the card already has:

```
select text in a post  ->  click Reply  ->  /posts/<id>/reply?quote=<text>
                                             |
                                             VutuvWeb.Markdown.blockquote/1
                                             |
                                             composer opens with "> …"
```

`app.js` reads the selection at click time (the browser collapses it on `pointerdown`, so the pointerdown pass remembers it; a keyboard activation still has the live one). The reply page runs that untrusted string through `VutuvWeb.Markdown.blockquote/1`: trim each line, keep the quote marker across blank lines so a paragraph break stays inside the quote, cap at 500 characters cut back to the last whole word.

The server marks the two halves the client needs: `data-post-body` on a post's prose and `data-quote-reply` on the enclosing card, naming its Reply control by id. Thread cards nest, so the card is resolved from the **selection** (innermost marked ancestor), not from the link. Otherwise a marked reply would quote itself into its parent's answer.

Two places deliberately stay unarmed: a **restricted post** (its Reply control is a dead span) and the reply page's **own parent preview**, whose Reply link leads back to the page being composed on and would throw the draft away.

## About the avatar and the link

The issue asks the blockquote to carry the quoted member's avatar and a link to the post. It already does, one level up: the reply card names the post it answers, with that author's avatar and the thread connector into it. So the attribution needs no per-blockquote metadata and the stored body stays plain Markdown, which keeps the agent-format siblings, the fediverse copy and the RSS rendering untouched.

## Editor bug fixed on the way

Found smoke-testing this: a document whose last node is a blockquote leaves ProseMirror nowhere to put the cursor, so clicking below the quote typed the answer **into** the quotation. The Milkdown hook now appends an empty trailing paragraph after every seed, which also unsticks a body ending in a table or a code block. It costs nothing in the stored source (Milkdown serializes it as the `<br />` artifact `normalizeMarkdown` already drops).

## Verification

`mix precommit` green (5255 tests). New coverage: `markdown_quote_test.exs` for the excerpt shapes a selection really has, plus reply-page and feed-card tests for the seeding and the two unarmed cases.

Smoke-tested in a real browser, since the whole trigger is client-side and no ConnTest can reach it: real drag selection on a post permalink, real click on Reply, quote in the URL, blockquote in the WYSIWYG editor, answer typed below it, reply posted and rendered under its parent. Also verified the negative case, a selection inside the nested reply followed by a click on the **parent's** Reply, which correctly carries no quote.

## Not in scope

A reply that came from another network (`remote_reply_card`) is not armed yet. Same three lines if we want it, but it is a different card and its Reply link is a live navigation, so I kept it out of this change.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01H6dRXwvHciTBK8fd9CNJSu
