### PR TITLE
Bump to 7.163.0 after a version collision on main

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.162.0",
+      version: "7.163.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
#1121 (code block language labels and syntax highlighting, #1106 + #1107) was branched while main still read 7.161.0 and bumped to 7.162.0. #1119 claimed that number first and merged in the meantime, so my squash landed the whole feature without moving the version at all: 7.162.0 now names two unrelated changes and its release tag is ambiguous.

This is the number the feature should have had. Minor rather than patch, since that is what a new user-facing capability gets.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01BvQXug8GXXiPyfrUV9z7Pr