### PR TITLE
Say the name right: optional pronunciation on the profile (#1112)

### DIFF
--- a/docs/architecture/profiles.md
+++ b/docs/architecture/profiles.md
@@ -19,6 +19,43 @@ inert (the profile ignores it).
 The profile-section pages behave the same way: `/:slug/<section>` IS the public
 view for everyone, and editing happens at `/settings/<section>`.
 
+## Name pronunciation (issue #1112)
+
+`users.name_pronunciation` is free text (varchar(255), nullable) saying how the
+member's name is said out loud: "SHTEH-fahn VIN-ter-my-er", "rhymes with 'a
+fan'", IPA for the few who write it. It renders as a quiet line with a speaker
+glyph **directly under the name** in the profile header, above the availability
+pill and the tagline, because it belongs to the name and to nothing else on the
+page.
+
+It is deliberately a **quiet, optional** field. It is asked for on the Basics
+form (`/settings/profile`, in the "Your name" card) and **nowhere else** — the
+sign-up form never mentions it, since it is not one of the few things a new
+member must decide. It is `nil` on nearly every account, and everything that
+renders it goes through `Vutuv.Accounts.User.name_pronunciation/1`, the one seam
+that folds a stored `""` (an older row, an API write) into `nil` — so "blank
+means the feature is simply not there" is decided in one place and an untouched
+profile looks exactly as it did.
+
+**Validation** (all in `User.changeset/2`): whitespace folds to one line first
+(it renders as one), so a value that only overruns because of stray whitespace
+is fixed rather than refused; then a 255-character cap matching the column, and
+a rule that the value must actually pronounce something — at least one letter
+(stricter than `Tag.punctuation_only?/1`, where a symbol like "C#" is a real
+name) and not the bare web/email address a spam sign-up drops into every free
+text field (`Vutuv.WebAddress.link_only?/1`, the same whole-value rule the
+tagline uses, so a hint that *mentions* an address stays valid). The field is
+**not** in `@identity_fields`: it says how the verified name *sounds*, not who
+the member is, so editing it does not revoke a verified badge.
+
+It reaches every sibling format — `ProfileDoc` carries `name_pronunciation`, the
+md/txt renderers lead the fact list with it (an agent reading a profile aloud is
+where the hint is worth the most), JSON/XML get it for free, and the vCard emits
+it as `X-PHONETIC-NAME` below `FN` (vCard 3.0 has no standard property: `SOUND`
+is a recorded audio file, and Apple's `X-PHONETIC-FIRST-NAME`/`-LAST-NAME` pair
+would need us to guess which half of a free-text hint is which). It is writable
+over `PATCH /api/2.0/me` and included in the GDPR export.
+
 ## Birthday visibility (General Info card)
 
 A member enters their birthday on the Basics form but chooses **how much of it

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -1277,8 +1277,8 @@ defmodule Vutuv.Accounts do
   # account flags (email_confirmed?, notification_emails?) are deliberately not
   # on it.
   @profile_fields ~w(headline first_name last_name middle_name nickname
-                     honorific_prefix honorific_suffix gender birthdate
-                     locale noindex? noai?)
+                     honorific_prefix honorific_suffix name_pronunciation
+                     gender birthdate locale noindex? noai?)
 
   @doc """
   Updates only the plain profile fields (see `@profile_fields`) — the

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -19,6 +19,12 @@ defmodule Vutuv.Accounts.User do
     field(:nickname, :string)
     field(:honorific_prefix, :string)
     field(:honorific_suffix, :string)
+    # How to say the name out loud (issue #1112), free text: "SHTEH-fahn
+    # VIN-ter-my-er", "rhymes with 'a fan'", IPA for the few who write it. It is
+    # a deliberately quiet field — set on the profile basics form, never asked
+    # for at sign-up — and nil on nearly every account, which is why the profile
+    # renders the line only when it is present (`name_pronunciation/1`).
+    field(:name_pronunciation, :string)
     field(:gender, :string)
     # The member's job-availability signal (issue #870), shown as a badge next
     # to the tagline on the profile. nil = not specified (the default, no
@@ -381,7 +387,7 @@ defmodule Vutuv.Accounts.User do
   # :email_confirmed? is NOT here either: it flips only via the login-PIN path
   # (Accounts.activate_user/1, its own narrow cast) — castable, it would let a
   # registration self-activate without ever proving control of an email.
-  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix gender birthdate birthdate_visibility locale tag_list)a
+  @optional_fields ~w(noindex? noai? notification_emails? dm_email_each_message? dm_email_delay_minutes email_on_endorsement? email_on_follower? newsletter_emails? saved_search_emails? cv_update_notifications? thread_notifications? show_online_status? show_mastodon_feed? show_code_stats? fediverse_followers? fediverse_reactions? fediverse_replies? also_known_as_input map_google? map_openstreetmap? map_apple? default_map_service post_lines_desktop post_lines_mobile post_hyphenate_desktop post_hyphenate_mobile notification_post_lines headline employment_status employment_status_visibility desired_salary_min desired_salary_currency desired_salary_period desired_salary_visibility desired_workplace_types first_name last_name middle_name nickname honorific_prefix honorific_suffix name_pronunciation gender birthdate birthdate_visibility locale tag_list)a
 
   # The job-availability values a member can advertise (issue #870), other
   # than the "not specified" default which is stored as nil. The single source
@@ -538,6 +544,9 @@ defmodule Vutuv.Accounts.User do
     |> validate_length(:nickname, max: 50)
     |> validate_length(:honorific_prefix, max: 50)
     |> validate_length(:honorific_suffix, max: 50)
+    |> normalize_name_pronunciation()
+    |> validate_length(:name_pronunciation, max: 255)
+    |> validate_name_pronunciation()
     |> validate_length(:gender, max: 50)
     |> validate_length(:headline, max: 255)
     # The tagline may only mention handles that exist (relaxed for the import).
@@ -607,11 +616,66 @@ defmodule Vutuv.Accounts.User do
     end)
   end
 
+  # A pronunciation is one spoken line, so fold every run of whitespace (a
+  # pasted line break included) into a single space and trim the ends. This runs
+  # *before* the length check on purpose: a value that only overruns 255 because
+  # of stray whitespace is fixed rather than refused. An emptied field folds to
+  # nil, which is what "I don't want this shown" means — `cast/3`'s own
+  # empty_values only catch a literal "".
+  defp normalize_name_pronunciation(changeset) do
+    case get_change(changeset, :name_pronunciation) do
+      nil ->
+        changeset
+
+      value ->
+        case value |> String.replace(~r/\s+/u, " ") |> String.trim() do
+          "" -> put_change(changeset, :name_pronunciation, nil)
+          normalized -> put_change(changeset, :name_pronunciation, normalized)
+        end
+    end
+  end
+
+  # What a pronunciation may not be. Two ways a value carries no pronunciation
+  # at all, refused with the same "say the name" nudge:
+  #
+  #   * no letter anywhere ("---", "???", "123"). A pronunciation is written in
+  #     letters — unlike a tag, where a symbol like "C#" or an emoji is a name
+  #     people really use, so this is stricter than `Tag.punctuation_only?/1`.
+  #   * nothing but a web or email address, the billboard a spam sign-up puts
+  #     into every free-text field — the same `Vutuv.WebAddress` whole-value
+  #     rule the tagline uses, so a hint that *mentions* one ("wie in
+  #     example.com") stays valid.
+  defp validate_name_pronunciation(changeset) do
+    validate_change(changeset, :name_pronunciation, fn :name_pronunciation, value ->
+      if Regex.match?(~r/\p{L}/u, value) and not WebAddress.link_only?(value),
+        do: [],
+        else: [name_pronunciation: "must spell out how the name sounds"]
+    end)
+  end
+
+  @doc """
+  The member's spoken-name hint (issue #1112), or `nil` when they never set one.
+
+  The single seam the profile, the CV/vCard and the agent documents read, so
+  "blank means the feature is simply not there" is decided in exactly one place
+  — a stored `""` (an older row, an API write) reads as absent, like a `nil`.
+  """
+  def name_pronunciation(%__MODULE__{name_pronunciation: value}) do
+    case value do
+      nil -> nil
+      value -> if String.trim(value) == "", do: nil, else: value
+    end
+  end
+
   # Every identity detail the verified badge vouches for: the legal name parts,
   # the nickname, the honorific titles, the gender and the birthday. An admin
   # checked these against the member's ID, so changing any of them invalidates
   # that check. Deliberately broad ("sicher ist sicher") — even a nickname,
   # title or gender edit shifts the verified identity, so it re-opens it.
+  # `name_pronunciation` is the one name-adjacent field deliberately left out:
+  # it says how the verified name *sounds*, not who the member is, so no ID
+  # check is invalidated by fixing it — and a badge that dropped over a spelling
+  # hint would just teach members to leave the hint wrong.
   @identity_fields ~w(first_name middle_name last_name nickname
     honorific_prefix honorific_suffix gender birthdate)a
 

--- a/lib/vutuv/export.ex
+++ b/lib/vutuv/export.ex
@@ -222,6 +222,7 @@ defmodule Vutuv.Export do
       nickname: user.nickname,
       honorific_prefix: user.honorific_prefix,
       honorific_suffix: user.honorific_suffix,
+      name_pronunciation: user.name_pronunciation,
       gender: user.gender,
       birthdate: user.birthdate,
       headline: user.headline,

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -427,6 +427,10 @@ defmodule VutuvWeb.AgentDocs.Markdown do
 
   defp profile_facts(doc) do
     [
+      # First fact, like the profile's first line under the name: a reader that
+      # says the name out loud should meet the pronunciation before anything else.
+      doc.name_pronunciation &&
+        "- #{gettext("Name pronunciation")}: #{doc.name_pronunciation}",
       doc.verified && "- " <> gettext("Verified profile: yes"),
       doc.employment_status &&
         "- #{gettext("Employment status")}: #{User.employment_status_label(doc.employment_status)}",
@@ -437,13 +441,22 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       fediverse_fact(doc[:fediverse]),
       count_facts(doc.counts),
       doc.gender && "- #{gettext("Gender")}: #{User.gender_gettext(doc.gender)}",
-      doc.birthdate && "- #{gettext("Birthday")}: #{doc.birthdate}",
-      doc.birthday_month_day && "- #{gettext("Birthday")}: #{doc.birthday_month_day}",
-      doc.age && "- #{gettext("Age")}: #{doc.age}"
+      birthday_facts(doc)
     ]
     |> List.flatten()
     |> Enum.filter(& &1)
     |> Enum.join("\n\n")
+  end
+
+  # The birthday granularity the member chose (`User.birthdate_mode/1`) puts at
+  # most one of these three in the doc, so they travel as one group — and keep
+  # `profile_facts/1` inside Credo's complexity budget.
+  defp birthday_facts(doc) do
+    [
+      doc.birthdate && "- #{gettext("Birthday")}: #{doc.birthdate}",
+      doc.birthday_month_day && "- #{gettext("Birthday")}: #{doc.birthday_month_day}",
+      doc.age && "- #{gettext("Age")}: #{doc.age}"
+    ]
   end
 
   # The member's Fediverse address, the same fact the profile's Fediverse card

--- a/lib/vutuv_web/agent_docs/profile_doc.ex
+++ b/lib/vutuv_web/agent_docs/profile_doc.ex
@@ -94,6 +94,11 @@ defmodule VutuvWeb.AgentDocs.ProfileDoc do
       nickname: user.nickname,
       honorific_prefix: user.honorific_prefix,
       honorific_suffix: user.honorific_suffix,
+      # How the name is said out loud (issue #1112), exactly as the profile
+      # shows it under the name. nil for nearly every member, and the md/txt
+      # renderers drop the line then — an agent reading a profile aloud is one
+      # of the places this hint is worth the most.
+      name_pronunciation: User.name_pronunciation(user),
       username: user.username,
       verified: user.identity_verified?,
       # The job-availability signal (issue #870), the machine value nil /

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -423,6 +423,9 @@ defmodule VutuvWeb.AgentDocs.Text do
 
   defp profile_facts(doc) do
     [
+      # First fact, like the profile's first line under the name (see the
+      # Markdown renderer).
+      doc.name_pronunciation && "#{gettext("Name pronunciation")}: #{doc.name_pronunciation}",
       doc.verified && gettext("Verified profile: yes"),
       doc.employment_status &&
         "#{gettext("Employment status")}: #{User.employment_status_label(doc.employment_status)}",
@@ -433,13 +436,21 @@ defmodule VutuvWeb.AgentDocs.Text do
       fediverse_fact(doc[:fediverse]),
       count_facts(doc.counts),
       doc.gender && "#{gettext("Gender")}: #{User.gender_gettext(doc.gender)}",
-      doc.birthdate && "#{gettext("Birthday")}: #{doc.birthdate}",
-      doc.birthday_month_day && "#{gettext("Birthday")}: #{doc.birthday_month_day}",
-      doc.age && "#{gettext("Age")}: #{doc.age}"
+      birthday_facts(doc)
     ]
     |> List.flatten()
     |> Enum.filter(& &1)
     |> Enum.join("\n")
+  end
+
+  # One group, for the same reason as the Markdown renderer's twin: at most one
+  # of the three is present, and it keeps `profile_facts/1` simple enough.
+  defp birthday_facts(doc) do
+    [
+      doc.birthdate && "#{gettext("Birthday")}: #{doc.birthdate}",
+      doc.birthday_month_day && "#{gettext("Birthday")}: #{doc.birthday_month_day}",
+      doc.age && "#{gettext("Age")}: #{doc.age}"
+    ]
   end
 
   # The member's Fediverse address, the same fact the profile's Fediverse card

--- a/lib/vutuv_web/agent_docs/v_card.ex
+++ b/lib/vutuv_web/agent_docs/v_card.ex
@@ -31,6 +31,7 @@ defmodule VutuvWeb.AgentDocs.VCard do
       sanitize(doc.honorific_suffix) <>
       "\nFN:" <>
       sanitize(doc.name) <>
+      phonetic_name(doc) <>
       bday(doc) <>
       "\nORG:#{organization(doc)}" <>
       "\nTITLE:#{title(doc)}" <>
@@ -64,6 +65,19 @@ defmodule VutuvWeb.AgentDocs.VCard do
 
     if(name == "", do: "profile", else: name) <> "_vcard.vcf"
   end
+
+  # How to say the name (issue #1112), right below FN because that is where it
+  # belongs and where the profile shows it. vCard 3.0 has no standard property
+  # for it: `SOUND` is a recorded audio file, and the Apple/Google
+  # `X-PHONETIC-FIRST-NAME` / `-LAST-NAME` pair would need us to guess which
+  # part of a free-text hint is the first name and which the last. So it rides
+  # as a single self-describing `X-PHONETIC-NAME` extension — no client turns it
+  # into a field, but the fact travels with the card instead of being dropped on
+  # export. Omitted entirely when the member wrote none, like BDAY.
+  defp phonetic_name(%{name_pronunciation: hint}) when is_binary(hint),
+    do: "\nX-PHONETIC-NAME:" <> sanitize(hint)
+
+  defp phonetic_name(_doc), do: ""
 
   # vCard 3.0 BDAY takes an ISO date (YYYY-MM-DD); doc.birthdate is a raw Date
   # or nil. The full date is already public in every other format (the HTML

--- a/lib/vutuv_web/templates/user/edit.html.heex
+++ b/lib/vutuv_web/templates/user/edit.html.heex
@@ -156,6 +156,25 @@ lands here). --%>
           <%= text_input f, :honorific_suffix, class: input_class(), placeholder: gettext("e.g. Jr. or PhD") %>
           <%= error_tag f, :honorific_suffix %>
         </div>
+        <%!-- How the name is said out loud (issue #1112). Full width, last in
+        the card: it belongs to the name, but it is the one field almost nobody
+        fills in, so it must not push the name inputs around. It is asked for
+        here and nowhere else — never at sign-up — and an empty field simply
+        adds nothing to the profile. --%>
+        <div class="sm:col-span-2">
+          <%= label f, :name_pronunciation, gettext("Name pronunciation"), class: "block text-sm font-medium text-slate-900 dark:text-white" %>
+          <%= text_input f, :name_pronunciation,
+            class: input_class(f, :name_pronunciation),
+            maxlength: "255",
+            placeholder: gettext("e.g. SHTEH-fahn VIN-ter-my-er"),
+            "aria-invalid": f.errors[:name_pronunciation] && "true" %>
+          <p :if={!f.errors[:name_pronunciation]} class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+            {gettext(
+              "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows under your name on your profile; leave it empty and nothing is shown."
+            )}
+          </p>
+          <%= error_tag f, :name_pronunciation %>
+        </div>
       </div>
     </.card>
 

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -198,6 +198,26 @@ the resulting ~200px rail width. --%>
             </.card_menu>
           </div>
         </div>
+        <%!-- How to say the name (issue #1112), the line directly under it,
+        because it belongs to the name and to nothing else on this page. Shown
+        only when the member wrote one — on nearly every profile this renders
+        nothing at all, which is the point: it is help where help is needed, not
+        a field everyone has to fill in. The speaker glyph does the labelling
+        (no label word competing with the tagline below), so the row carries an
+        sr-only name for anyone who can't see it. --%>
+        <% pronunciation = Vutuv.Accounts.User.name_pronunciation(@user) %>
+        <p
+          :if={pronunciation}
+          id="profile-pronunciation"
+          data-name-pronunciation
+          class="mt-1 flex items-center gap-1.5 text-sm text-slate-600 dark:text-slate-400"
+        >
+          <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M11 5 6.5 9H3v6h3.5L11 19V5Zm4.5 3.5a5 5 0 0 1 0 7m2.8-9.8a9 9 0 0 1 0 12.6" />
+          </svg>
+          <span class="sr-only">{gettext("Name pronunciation")}:</span>
+          <span class="breakwrap">{pronunciation}</span>
+        </p>
         <%!-- Employment-status pill (issue #870): pulled up to sit on its own
         line right below the name, so the job-availability signal ("Looking for
         a job" / "Open to offers") reads immediately under who the member is,

--- a/lib/vutuv_web/views/account_event_text.ex
+++ b/lib/vutuv_web/views/account_event_text.ex
@@ -148,6 +148,7 @@ defmodule VutuvWeb.AccountEventText do
   def field_label("first_name"), do: gettext("First name")
   def field_label("last_name"), do: gettext("Last name")
   def field_label("headline"), do: gettext("Tagline")
+  def field_label("name_pronunciation"), do: gettext("Name pronunciation")
   def field_label("birthdate"), do: gettext("Date of birth")
   def field_label("gender"), do: gettext("Gender")
   def field_label("avatar"), do: gettext("Photo")

--- a/lib/vutuv_web/views/error_helpers.ex
+++ b/lib/vutuv_web/views/error_helpers.ex
@@ -112,6 +112,8 @@ defmodule VutuvWeb.ErrorHelpers do
         "errors",
         "\"%{tag}\" is a web address, not a tag. Please describe yourself with words."
       ),
+      # Vutuv.Accounts.User, the spoken-name hint (issue #1112).
+      dgettext_noop("errors", "must spell out how the name sounds"),
       # Vutuv.Tags.Tag, a name of punctuation only.
       dgettext_noop("errors", "must not be only punctuation"),
       dgettext_noop("errors", "\"%{tag}\" is only punctuation, not a tag."),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.162.0",
+      version: "7.163.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/dev_docs/reference.md
+++ b/priv/dev_docs/reference.md
@@ -69,7 +69,8 @@ auth $API/users/wintermeyer
 
 Scope: `profile:write`. Updates the plain profile fields: `headline`,
 `first_name`, `middle_name`, `last_name`, `nickname`, `honorific_prefix`,
-`honorific_suffix`, `gender`, `birthdate` (ISO date), `locale`,
+`honorific_suffix`, `name_pronunciation` (how the name is said out loud, max
+255 characters), `gender`, `birthdate` (ISO date), `locale`,
 `noindex?` (search-engine opt-out), `noai?` (AI/LLM opt-out). Returns the
 fresh profile. The username and email addresses are deliberately **not**
 writable over the API.

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -17313,3 +17313,25 @@ msgstr "Nicht mehr angeheftet. Der Beitrag ist wieder ein normaler Beitrag."
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr "angehefteter Beitrag"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:431
+#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/templates/user/edit.html.heex:166
+#: lib/vutuv_web/templates/user/show.html.heex:216
+#: lib/vutuv_web/views/account_event_text.ex:151
+#, elixir-autogen, elixir-format
+msgid "Name pronunciation"
+msgstr "Aussprache des Namens"
+
+#: lib/vutuv_web/templates/user/edit.html.heex:170
+#, elixir-autogen, elixir-format
+msgid "e.g. SHTEH-fahn VIN-ter-my-er"
+msgstr "z. B. SCHTEH-fan WIN-ter-mei-er"
+
+#: lib/vutuv_web/templates/user/edit.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows under your name on your profile; leave it empty and nothing is shown."
+msgstr ""
+"Optional. Schreiben Sie Ihren Namen so, wie er klingt, damit ihn jemand beim "
+"ersten Anruf richtig ausspricht. Er steht auf Ihrem Profil unter Ihrem Namen; "
+"bleibt das Feld leer, wird nichts angezeigt."

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -236,3 +236,8 @@ msgstr "„%{uri}“ ist keine gültige https-Kontoadresse."
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr "Bitte geben Sie höchstens %{max} Konten an."
+
+#: lib/vutuv_web/views/error_helpers.ex:114
+#, elixir-autogen, elixir-format
+msgid "must spell out how the name sounds"
+msgstr "muss beschreiben, wie der Name klingt"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -16534,3 +16534,22 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:431
+#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/templates/user/edit.html.heex:166
+#: lib/vutuv_web/templates/user/show.html.heex:216
+#: lib/vutuv_web/views/account_event_text.ex:151
+#, elixir-autogen, elixir-format
+msgid "Name pronunciation"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/edit.html.heex:170
+#, elixir-autogen, elixir-format
+msgid "e.g. SHTEH-fahn VIN-ter-my-er"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/edit.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows under your name on your profile; leave it empty and nothing is shown."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -16532,3 +16532,22 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:431
+#: lib/vutuv_web/agent_docs/text.ex:427
+#: lib/vutuv_web/templates/user/edit.html.heex:166
+#: lib/vutuv_web/templates/user/show.html.heex:216
+#: lib/vutuv_web/views/account_event_text.ex:151
+#, elixir-autogen, elixir-format
+msgid "Name pronunciation"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/edit.html.heex:170
+#, elixir-autogen, elixir-format
+msgid "e.g. SHTEH-fahn VIN-ter-my-er"
+msgstr ""
+
+#: lib/vutuv_web/templates/user/edit.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows under your name on your profile; leave it empty and nothing is shown."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -234,3 +234,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:114
+#, elixir-autogen, elixir-format
+msgid "must spell out how the name sounds"
+msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -237,3 +237,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Please list at most %{max} accounts."
 msgstr ""
+
+#: lib/vutuv_web/views/error_helpers.ex:114
+#, elixir-autogen, elixir-format
+msgid "must spell out how the name sounds"
+msgstr ""

--- a/priv/repo/migrations/20260726081706_add_name_pronunciation_to_users.exs
+++ b/priv/repo/migrations/20260726081706_add_name_pronunciation_to_users.exs
@@ -1,0 +1,17 @@
+defmodule Vutuv.Repo.Migrations.AddNamePronunciationToUsers do
+  use Ecto.Migration
+
+  # How to say this member's name out loud (issue #1112) — the one thing a
+  # written name cannot carry, and what makes a first phone call go right.
+  # Free text in a plain varchar(255): almost nobody writes IPA, and the member
+  # knows best whether "SHTEH-fahn" or "rhymes with 'a fan'" helps a caller more.
+  #
+  # Nullable, and empty on nearly every profile by design: the profile renders
+  # the line only when it is filled, so an untouched account looks exactly as it
+  # did. A plain column addition, so it is N-1 compatible on its own.
+  def change do
+    alter table(:users) do
+      add(:name_pronunciation, :string)
+    end
+  end
+end

--- a/test/vutuv/accounts_test.exs
+++ b/test/vutuv/accounts_test.exs
@@ -274,6 +274,85 @@ defmodule Vutuv.AccountsTest do
     end
   end
 
+  # The spoken-name hint (issue #1112). Optional everywhere, so the interesting
+  # cases are the empty one (stays absent, nothing renders) and the values that
+  # pronounce nothing at all.
+  describe "name pronunciation" do
+    test "stores a pronunciation hint" do
+      user = insert(:user)
+      hint = "SHTEH-fahn VIN-ter-my-er"
+
+      assert {:ok, updated} = Accounts.update_user(user, %{"name_pronunciation" => hint})
+      assert updated.name_pronunciation == hint
+      assert User.name_pronunciation(updated) == hint
+    end
+
+    test "an empty field stays empty and reads as absent" do
+      user = insert(:user)
+
+      assert {:ok, updated} = Accounts.update_user(user, %{"name_pronunciation" => "   "})
+      assert is_nil(updated.name_pronunciation)
+      assert is_nil(User.name_pronunciation(updated))
+    end
+
+    test "clearing a stored pronunciation removes it" do
+      user = insert(:user, name_pronunciation: "SHTEH-fahn")
+
+      assert {:ok, updated} = Accounts.update_user(user, %{"name_pronunciation" => ""})
+      assert is_nil(updated.name_pronunciation)
+    end
+
+    # It is one spoken line, so a pasted paragraph collapses instead of
+    # breaking the profile line it renders into.
+    test "folds whitespace into one line" do
+      user = insert(:user)
+
+      assert {:ok, updated} =
+               Accounts.update_user(user, %{
+                 "name_pronunciation" => "  SHTEH-fahn \n\n  VIN-ter-my-er  "
+               })
+
+      assert updated.name_pronunciation == "SHTEH-fahn VIN-ter-my-er"
+    end
+
+    test "refuses a value that pronounces nothing" do
+      user = insert(:user)
+
+      for value <- ["---", "???", "123", "https://www.example-shop.com/", "kontakt@example.com"] do
+        assert {:error, changeset} =
+                 Accounts.update_user(user, %{"name_pronunciation" => value})
+
+        assert "must spell out how the name sounds" in errors_on(changeset).name_pronunciation
+      end
+    end
+
+    test "accepts a hint that names a sound-alike with a dot in it" do
+      user = insert(:user)
+      hint = "like the 'stefan' in stefan.fm"
+
+      assert {:ok, updated} = Accounts.update_user(user, %{"name_pronunciation" => hint})
+      assert updated.name_pronunciation == hint
+    end
+
+    test "refuses more than 255 characters" do
+      user = insert(:user)
+
+      assert {:error, changeset} =
+               Accounts.update_user(user, %{"name_pronunciation" => String.duplicate("a", 256)})
+
+      assert "should be at most 255 character(s)" in errors_on(changeset).name_pronunciation
+    end
+
+    # The verified badge vouches for the written name, not for how it sounds,
+    # so fixing the hint must not cost the badge (unlike a name edit).
+    test "keeps a verified badge" do
+      user = insert(:user, identity_verified?: true)
+
+      assert {:ok, updated} = Accounts.update_user(user, %{"name_pronunciation" => "SHTEH-fahn"})
+      assert updated.identity_verified?
+    end
+  end
+
   describe "login_pins uniqueness" do
     test "rejects a second login pin for the same user and type" do
       user = insert(:user)

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -25,6 +25,10 @@ defmodule VutuvWeb.AgentDocsDriftTest do
         # drift-checked against the agent formats like every other public fact.
         fediverse_followers?: true,
         headline: "Builds bridges between humans and agents",
+        # The spoken-name hint (issue #1112): the profile shows it under the
+        # name, so every agent format must carry it too — it is worth the most
+        # to a reader that says the name out loud.
+        name_pronunciation: "GRAY-ta GRAY-dee-ent",
         gender: "female",
         birthdate: ~D[1991-04-23],
         employment_status: "looking",
@@ -179,6 +183,8 @@ defmodule VutuvWeb.AgentDocsDriftTest do
       # identity card
       "Greta Gradient",
       "bridges between humans and agents",
+      # how the name is said out loud (issue #1112)
+      "GRAY-ta GRAY-dee-ent",
       # experience
       "Bridge Engineer",
       "Span AG",
@@ -424,6 +430,17 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert body =~ "URL:"
     # The online messenger (issue #949) rides as an IMPP line with its deep link.
     assert body =~ "IMPP;TYPE=telegram:https://t.me/gretachats"
+    # How the name is said (issue #1112): vCard 3.0 has no standard property for
+    # a free-text hint, so it rides as an X- extension right below FN.
+    assert body =~ "X-PHONETIC-NAME:GRAY-ta GRAY-dee-ent"
+  end
+
+  test "a member without a pronunciation gets no phonetic line in the vCard" do
+    user = insert_activated_user(username: "no_phonetics", first_name: "Plain")
+
+    body = get(build_conn(), "/#{user.username}.vcf").resp_body
+
+    refute body =~ "X-PHONETIC-NAME"
   end
 
   test "post permalink: body, author, replies and engagement in every format", %{post: post} do

--- a/test/vutuv_web/controllers/user_controller_test.exs
+++ b/test/vutuv_web/controllers/user_controller_test.exs
@@ -815,6 +815,79 @@ defmodule VutuvWeb.UserControllerTest do
     assert html =~ "e.g. Jr. or PhD"
   end
 
+  # The spoken-name hint (issue #1112). It is a settings-only field: asked for
+  # on the profile basics form, never at sign-up, and invisible on a profile
+  # until the member writes one.
+  describe "name pronunciation" do
+    test "the Basics form offers the field with an example", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      html = conn |> get(~p"/settings/profile") |> html_response(200)
+
+      assert html =~ "Name pronunciation"
+      assert html =~ "e.g. SHTEH-fahn VIN-ter-my-er"
+      # The browser stops typing at the column width, so the cap is felt before
+      # the server has to refuse the save.
+      assert html =~ ~s(maxlength="255")
+    end
+
+    test "saving it from the Basics form shows it under the name on the profile", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      conn =
+        put(conn, ~p"/settings/profile", user: %{"name_pronunciation" => "SHTEH-fahn"})
+
+      assert redirected_to(conn) == ~p"/#{Repo.get!(User, user.id)}"
+
+      html = conn |> recycle() |> get(~p"/#{user}") |> html_response(200)
+
+      assert html =~ "SHTEH-fahn"
+      assert html =~ ~s(id="profile-pronunciation")
+    end
+
+    test "a profile without one renders no pronunciation row at all", %{conn: conn} do
+      user = insert_activated_user()
+
+      html = conn |> get(~p"/#{user}") |> html_response(200)
+
+      refute html =~ ~s(id="profile-pronunciation")
+      refute html =~ "Name pronunciation"
+    end
+
+    test "a value that pronounces nothing re-renders the form with the error", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      conn = put(conn, ~p"/settings/profile", user: %{"name_pronunciation" => "???"})
+
+      assert html_response(conn, 422) =~ "must spell out how the name sounds"
+      assert is_nil(Repo.get!(User, user.id).name_pronunciation)
+    end
+
+    # vutuv is a German site, so a new field with no German msgstr renders as an
+    # English island for most real visitors — which no English-only check sees.
+    test "the field is German for a German visitor", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      html =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/settings/profile")
+        |> html_response(200)
+
+      assert html =~ "Aussprache des Namens"
+      assert html =~ "damit ihn jemand beim ersten Anruf richtig ausspricht"
+    end
+
+    # It is deliberately hidden away in the settings: the sign-up form asks for
+    # the few things a new member must decide, and this is not one of them.
+    test "the registration form never asks for it", %{conn: conn} do
+      html = conn |> get(~p"/") |> html_response(200)
+
+      refute html =~ "name_pronunciation"
+      refute html =~ "Name pronunciation"
+    end
+  end
+
   test "the Tagline field carries a live character counter capped at 255 (#873)", %{conn: conn} do
     {conn, _user} = create_and_login_user(conn)
     html = conn |> get(~p"/settings/profile") |> html_response(200)


### PR DESCRIPTION
Closes #1112.

Names get mangled on first phone calls, and the written form carries no hint about how they sound. Members can now write one themselves, and it shows as a quiet line directly under their name on the profile.

The design is deliberately small, because that is what makes it worth having:

- **Settings only.** An optional field in the "Your name" card of `/settings/profile`, and nowhere else. The sign-up flow never asks for it, since a new member has enough to decide already.
- **Blank does nothing.** While the field is empty, no line, no placeholder, no prompt. On nearly every profile it will stay blank and cost nothing; on the few where it is filled it saves the awkward opening of a call. Everything reads it through `User.name_pronunciation/1`, the one seam that also folds a stored `""` into "absent".
- **On the profile it sits under the name**, above the availability pill and the tagline, with a speaker glyph doing the labelling (plus an sr-only label).

**Validation** keeps it a pronunciation rather than a second tagline: the value folds to one line first (so a value that only overruns because of stray whitespace is fixed rather than refused), is capped at the column's 255 characters, and must actually pronounce something: at least one letter, and not the bare web or email address a spam sign-up drops into every free text field (the same whole-value `Vutuv.WebAddress` rule the tagline uses, so a hint that merely *mentions* an address stays valid). It is deliberately **not** an identity field: it says how the verified name sounds, not who the member is, so editing it does not revoke a verified badge, which would only teach members to leave the hint wrong.

**Every sibling format carries it**, since an agent reading a profile aloud is where the hint is worth the most: the Markdown and text documents lead their fact list with it, JSON and XML get it from the doc map, and the vCard emits `X-PHONETIC-NAME` below `FN` (vCard 3.0 has no standard property: `SOUND` is a recorded audio file, and Apple's phonetic first/last pair would need us to guess which half of a free-text hint is which). It is also writable over `PATCH /api/2.0/me` and part of the GDPR export.

**Migration** is a plain nullable column addition, so it is N-1 compatible on its own.

**Tests**: model-level (stores, clears, folds whitespace, refuses "---" / "???" / a bare address / over 255, keeps a verified badge), web-level (the form offers the field, saving it shows the line, a profile without one renders no row at all, an invalid value re-renders with the error, the sign-up form never asks for it, and the field is German for a German visitor), plus the agent-format drift test and both vCard directions. Smoke-tested in a browser: the line renders under the name as intended.

An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.

https://claude.ai/code/session_01Fr6kxj3ypgyPGME2EtU555
