### PR TITLE
Show the pinned post on other networks (#1110)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -28,7 +28,8 @@ every endpoint 404s and nothing is delivered.
   (`Vutuv.Fediverse.Keys`), created lazily on opt-in. The documents are built
   by `VutuvWeb.Fediverse.Docs`; URLs hang off the member so no root slug is
   burned: `/:username/actor` (id), `.../inbox`, `.../followers` and
-  `.../outbox` (count-only collections). The actor also carries
+  `.../outbox` (count-only collections) and `.../collections/featured` (the
+  pinned post, see the post-lifecycle bullet below). The actor also carries
   **`alsoKnownAs`** (issue #986) — the account URIs a member is migrating
   *from* (`users.also_known_as`, set on `/settings/fediverse/move`, one per line).
   A remote server that moves a member's followers *to* vutuv checks this before
@@ -300,6 +301,28 @@ every endpoint 404s and nothing is delivered.
   The Note carries the member-rendered HTML with absolutized links, and image
   attachments via the public post-image proxy URLs. A public post's permalink
   answers an AP Accept with the Note (remote servers dereference ids).
+- **The pinned post** (issue #1110): the post a member pins to their profile
+  is published as the ActivityPub **`featured` collection**, which is how
+  Mastodon and friends show a pin at the top of the profile *they* render. The
+  actor names it unconditionally (`"featured": <actor-url>/collections/featured`
+  — an actor that only sometimes carries the field would make a remote profile
+  depend on when it was last fetched), and `GET` on it answers an
+  `OrderedCollection` whose `orderedItems` embed the **full Note**, the shape
+  Mastodon serves, so no second fetch is needed. It is strictly the
+  **anonymous public** view (`Fediverse.featured_posts/1` → `Posts.pinned_post(user, nil)`):
+  the collection is served unauthenticated, so a pin that is restricted, frozen
+  or otherwise not public is simply not in it, exactly as it is absent from the
+  profile's `.md` sibling. Pinning also **pushes**: `Add { object: <note-url>,
+  target: <featured-url> }` goes to every follower inbox so a remote profile
+  updates right away instead of at its next actor refresh, releasing sends
+  `Remove`, and replacing one pin with another sends both halves. Those two
+  name different posts, so the remote end state is the same whichever arrives
+  first — worth knowing, because the delivery queue drains concurrently and
+  promises no order. A `Remove` fires even for a pin that
+  was never public — a post that stopped being public must still be able to
+  leave a remote profile — while an `Add` never does. Deleting the pinned post
+  needs no `Remove`: the pin nulls itself in the database (`ON DELETE SET
+  NULL`) and the post's own `Delete(Tombstone)` takes the remote copy with it.
 - **Account deletion** (`Vutuv.Accounts.delete_user/1`, issue #985): a
   federating member's followers are told their actor is gone with an actor
   `Delete { object: <actor-url> }`. The follower rows *are* the delivery

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -197,6 +197,12 @@ the pinned entry first with `pinned: true` (md/txt append "(pinned post)")
 and drops it from the timeline list, and a pin that is restricted, frozen or
 invisible to the viewer is simply absent, in every format.
 
+Other networks see the pin too: for a federating member it is published as the
+ActivityPub **`featured` collection** and pushed to their followers as
+`Add`/`Remove`, so Mastodon and friends show the same post at the top of the
+profile they render — same anonymous-public gate, see
+`docs/architecture/fediverse.md`.
+
 ## Editing closes (the edit window)
 
 An edit rewrites what other people already put their name to: like "I love

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -453,6 +453,23 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc """
+  What the `featured` collection holds (issue #1110): the member's pinned post
+  when the **anonymous public** may see it, else nothing. A list, because that
+  is the collection's shape — one entry today.
+
+  Anonymous is the right viewer here and not a simplification: the collection
+  is served unauthenticated to every remote server, so a pin that is
+  restricted, frozen or hidden must be absent from it exactly as it is absent
+  from the `.md` sibling of the profile. Preloaded for `Docs.note/2`.
+  """
+  def featured_posts(%User{} = user) do
+    case Posts.pinned_post(user, nil) do
+      %Post{} = post -> [Repo.preload(post, Docs.note_preloads())]
+      nil -> []
+    end
+  end
+
+  @doc """
   The distinct inboxes a member's activities go to: one per server where the
   remote declared a sharedInbox (however many followers live there), else the
   per-actor inbox.
@@ -1727,6 +1744,48 @@ defmodule Vutuv.Fediverse do
          true <- federated?(author),
          [_ | _] = inboxes <- delivery_inboxes(reposter) do
       enqueue(reposter, inboxes, builder.(post, author, reposter))
+    else
+      _ -> :skip
+    end
+  end
+
+  ## The pinned post as the `featured` collection (issue #1110)
+
+  @doc """
+  The member pinned a post -> `Add` it to their `featured` collection, so a
+  remote profile shows the pin right away instead of at its next actor
+  refresh. Only for a pin the anonymous public may see: the collection is
+  served unauthenticated, so a restricted or frozen post never goes into it —
+  and then nothing is sent either.
+  """
+  def federate_pin(%Post{} = post, %User{} = user) do
+    # The public-visibility check sits behind the federation gates on purpose:
+    # it costs a query, and for the overwhelming majority (members who do not
+    # federate at all) there is nothing to decide.
+    pin_activity(user, fn user ->
+      if Posts.visible_to?(post, nil), do: Docs.add_featured_activity(post, user)
+    end)
+  end
+
+  @doc """
+  The pin was released or replaced -> `Remove` from the collection. Takes the
+  bare post id: the post may be restricted, deleted or simply replaced by the
+  time this runs, and a `Remove` naming an id the remote does not have pinned
+  is a harmless no-op there. Sent whenever the member federates, so a post
+  that stopped being public still leaves the remote profile.
+  """
+  def federate_unpin(post_id, %User{} = user) when is_binary(post_id),
+    do: pin_activity(user, &Docs.remove_featured_activity(post_id, &1))
+
+  # A builder returning nil means "nothing to send after all" (a pin the public
+  # may not see), so it lands on the same :skip as every other closed gate.
+  defp pin_activity(%User{} = user, builder) do
+    with true <- enabled?(),
+         true <- federated?(user),
+         false <- moved?(user),
+         [_ | _] = inboxes <- delivery_inboxes(user),
+         activity when is_map(activity) <- builder.(user) do
+      enqueue(user, inboxes, activity)
     else
       _ -> :skip
     end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1729,26 +1729,63 @@ defmodule Vutuv.Posts do
   structural rather than something the code has to keep true. `post` must be
   the member's own (the caller resolves it owner-scoped); someone else's is
   rejected rather than pinned.
+
+  A federating member's pin also travels: the replaced post (if any) is
+  `Remove`d from their ActivityPub `featured` collection and the new one
+  `Add`ed, so other networks show the same pin (issue #1110).
   """
-  def pin_to_profile(%User{id: author_id} = author, %Post{id: post_id, user_id: author_id}) do
+  def pin_to_profile(
+        %User{id: author_id} = author,
+        %Post{id: post_id, user_id: author_id} = post
+      ) do
+    replaced_id = author.pinned_post_id
+
     author
     |> Ecto.Changeset.change(pinned_post_id: post_id)
     # Guards the race where the post is deleted between resolving the owner and
     # this write: the FK fails cleanly instead of persisting a dangling pointer.
     |> Ecto.Changeset.foreign_key_constraint(:pinned_post_id)
     |> Repo.update()
+    |> case do
+      {:ok, user} = ok ->
+        # A replacement sends both halves: the old post leaves the collection
+        # and the new one joins it. The two name different posts, so the remote
+        # end state is the same whichever arrives first (the queue drains
+        # concurrently and does not promise an order).
+        if replaced_id && replaced_id != post_id do
+          Vutuv.Fediverse.federate_unpin(replaced_id, user)
+        end
+
+        Vutuv.Fediverse.federate_pin(%{post | user: user}, user)
+        ok
+
+      error ->
+        error
+    end
   end
 
   def pin_to_profile(%User{}, %Post{}), do: {:error, :not_author}
 
   @doc """
   Clears `author`'s pinned post, so their profile leads with the newest entry
-  again. Idempotent — unpinning when nothing is pinned is a no-op update.
+  again, and `Remove`s it from a federating member's `featured` collection.
+  Idempotent — unpinning when nothing is pinned is a no-op update that sends
+  nothing.
   """
   def unpin_from_profile(%User{} = author) do
+    released_id = author.pinned_post_id
+
     author
     |> Ecto.Changeset.change(pinned_post_id: nil)
     |> Repo.update()
+    |> case do
+      {:ok, user} = ok ->
+        if released_id, do: Vutuv.Fediverse.federate_unpin(released_id, user)
+        ok
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -4,7 +4,8 @@ defmodule VutuvWeb.FediverseController do
 
     * `GET /.well-known/webfinger` — how Mastodon's search turns
       `@handle@host` into an actor URL,
-    * `GET /:slug/actor` (+ `/followers`, `/outbox`) — the member's
+    * `GET /:slug/actor` (+ `/followers`, `/outbox`,
+      `/collections/featured` — the pinned post, issue #1110) — the member's
       machine-readable identity,
     * `POST /:slug/actor/inbox` — receives signed `Follow`/`Undo` activities,
       the reactions and replies other networks send back (`Like`/`Announce`,
@@ -81,6 +82,16 @@ defmodule VutuvWeb.FediverseController do
         "type" => "OrderedCollection",
         "totalItems" => Fediverse.public_post_count(user)
       })
+    end)
+  end
+
+  # The pinned post (issue #1110), the collection Mastodon and friends read to
+  # show a pin at the top of the profile they render. Strictly the **anonymous
+  # public** view — a pin that is restricted, frozen or otherwise not public is
+  # simply not in it, exactly as it is absent from the agent formats.
+  def featured(conn, %{"slug" => slug}) do
+    with_federated_user(conn, slug, fn user ->
+      send_activity_json(conn, Docs.featured_collection(user, Fediverse.featured_posts(user)))
     end)
   end
 

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -10,10 +10,11 @@ defmodule VutuvWeb.Fediverse.Docs do
 
   URL scheme (all under the member, so nothing new burns a root slug):
 
-      /:username/actor            the actor document (id)
-      /:username/actor/inbox      POST target for Follow/Undo
-      /:username/actor/followers  count-only collection
-      /:username/actor/outbox     count-only collection
+      /:username/actor                       the actor document (id)
+      /:username/actor/inbox                 POST target for Follow/Undo
+      /:username/actor/followers             count-only collection
+      /:username/actor/outbox                count-only collection
+      /:username/actor/collections/featured  the pinned post (issue #1110)
   """
 
   alias Vutuv.Fediverse.Actor
@@ -40,6 +41,13 @@ defmodule VutuvWeb.Fediverse.Docs do
   def actor_url(user), do: "#{base()}/#{user.username}/actor"
   def key_id(user), do: actor_url(user) <> "#main-key"
   def note_url(user, post_id), do: "#{base()}/#{user.username}/posts/#{post_id}"
+
+  @doc """
+  The `featured` collection: the member's pinned post (issue #1110), which is
+  how Mastodon and friends show a pinned post at the top of the profile they
+  render. The path is the one those servers already expect.
+  """
+  def featured_url(user), do: actor_url(user) <> "/collections/featured"
 
   @doc """
   The member's Fediverse address without the leading `@`
@@ -70,6 +78,11 @@ defmodule VutuvWeb.Fediverse.Docs do
       "inbox" => actor_url <> "/inbox",
       "outbox" => actor_url <> "/outbox",
       "followers" => actor_url <> "/followers",
+      # Where a remote server looks for the pinned post (issue #1110). Always
+      # advertised, even with nothing pinned: the collection is then simply
+      # empty, and an actor that only sometimes names the field would make the
+      # profile a remote server renders depend on when it last fetched.
+      "featured" => featured_url(user),
       "manuallyApprovesFollowers" => false,
       "published" => iso8601(user.inserted_at),
       "publicKey" => %{
@@ -199,6 +212,49 @@ defmodule VutuvWeb.Fediverse.Docs do
   # Announce the repost sent.
   defp announce_id(%Post{id: post_id}, author, reposter),
     do: note_url(author, post_id) <> "#announce-" <> reposter.username
+
+  @doc """
+  The `featured` collection document (issue #1110): the member's pinned post
+  as a full Note, so a remote server can render it without a second fetch —
+  the shape Mastodon serves and expects. `posts` is a list (empty = nothing
+  pinned, or a pin the anonymous public may not see), so the collection can
+  grow past one entry without changing the document.
+  """
+  def featured_collection(user, posts) when is_list(posts) do
+    %{
+      "@context" => "https://www.w3.org/ns/activitystreams",
+      "id" => featured_url(user),
+      "type" => "OrderedCollection",
+      "totalItems" => length(posts),
+      "orderedItems" => Enum.map(posts, &note(&1, user))
+    }
+  end
+
+  @doc """
+  Add(Note -> featured): the member pinned a post (issue #1110). Sent to the
+  follower inboxes so a remote profile shows the pin without waiting for its
+  next actor refresh; the collection itself stays the authority.
+  """
+  def add_featured_activity(%Post{id: post_id}, user), do: featured_activity("Add", post_id, user)
+
+  @doc """
+  Remove(Note -> featured): the pin was released or replaced. Takes the bare
+  post id, because the row is often already gone (or replaced) by the time
+  this is built.
+  """
+  def remove_featured_activity(post_id, user) when is_binary(post_id),
+    do: featured_activity("Remove", post_id, user)
+
+  # Both carry the Note's **id** rather than the object: the receiving server
+  # already knows the post (it was delivered as a Create), and the collection
+  # is what it re-reads when it wants the full thing.
+  defp featured_activity(type, post_id, user) do
+    note_url = note_url(user, post_id)
+
+    user
+    |> envelope(type, note_url <> "##{String.downcase(type)}-featured", note_url)
+    |> Map.put("target", featured_url(user))
+  end
 
   @doc "Accept(Follow): the answer that seals a remote follow."
   def accept_activity(user, follow_object) do

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -131,6 +131,8 @@ defmodule VutuvWeb.Router do
     get("/:slug/actor", FediverseController, :actor)
     get("/:slug/actor/followers", FediverseController, :followers)
     get("/:slug/actor/outbox", FediverseController, :outbox)
+    # The pinned post (issue #1110), at the path other servers already look for.
+    get("/:slug/actor/collections/featured", FediverseController, :featured)
     post("/:slug/actor/inbox", FediverseController, :inbox)
     # Deploy readiness probe (see VutuvWeb.HealthController). No pipeline:
     # it is hit by curl on localhost and must not depend on sessions or

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.163.1",
+      version: "7.164.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_test.exs
+++ b/test/vutuv/fediverse_test.exs
@@ -9,6 +9,7 @@ defmodule Vutuv.FediverseTest do
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Delivery
   alias Vutuv.Fediverse.Follower
+  alias Vutuv.Posts
   alias VutuvWeb.Fediverse.Docs
 
   defp stub_remote(fun) do
@@ -269,6 +270,118 @@ defmodule Vutuv.FediverseTest do
 
       assert :skip == Fediverse.federate_new_post(insert(:post, user: user))
       assert Repo.aggregate(Delivery, :count) == 0
+    end
+  end
+
+  describe "the pinned post as the featured collection (issue #1110)" do
+    # A federating member with one remote follower — the shape every pin
+    # activity needs before anything is enqueued.
+    defp follower_of(user) do
+      {:ok, _} =
+        Fediverse.add_follower(user, %{
+          actor_uri: "https://social.example/users/alice",
+          inbox_uri: "https://social.example/inbox"
+        })
+
+      user
+    end
+
+    # The post's own Create is already in the queue by the time it is pinned
+    # (the member has a follower), so every assertion below starts from empty.
+    defp queued_after_clearing(fun) do
+      Repo.delete_all(Delivery)
+      result = fun.()
+      # Ordered by the UUID v7 id, i.e. by insertion: an unordered Repo.all/1
+      # returns the rows in whatever order Postgres likes, which made this
+      # flaky.
+      {result, Repo.all(from(d in Delivery, order_by: d.id, select: d.activity_json))}
+    end
+
+    test "featured_posts/1 holds the pinned post, and only a public one" do
+      user = federated_user()
+      post = create_post!(user, %{body: "my best work"})
+
+      assert Fediverse.featured_posts(user) == []
+
+      {:ok, user} = Posts.pin_to_profile(user, post)
+      assert [%{id: id}] = Fediverse.featured_posts(user)
+      assert id == post.id
+
+      # A restricted pin is not served to the anonymous collection at all.
+      restricted =
+        create_post!(user, %{body: "members only", denials: [%{"wildcard" => "logged_out"}]})
+
+      {:ok, user} = Posts.pin_to_profile(user, restricted)
+      assert Fediverse.featured_posts(user) == []
+    end
+
+    test "pinning sends Add, releasing sends Remove" do
+      user = federated_user() |> follower_of()
+      {:ok, _actor} = Fediverse.ensure_actor(user)
+      post = create_post!(user, %{body: "pin me"})
+
+      {{:ok, user}, [add]} = queued_after_clearing(fn -> Posts.pin_to_profile(user, post) end)
+
+      assert add =~ ~s("type":"Add")
+      assert add =~ Docs.note_url(user, post.id)
+      assert add =~ Docs.featured_url(user)
+
+      {_result, [remove]} = queued_after_clearing(fn -> Posts.unpin_from_profile(user) end)
+
+      assert remove =~ ~s("type":"Remove")
+      assert remove =~ Docs.note_url(user, post.id)
+      assert remove =~ Docs.featured_url(user)
+    end
+
+    test "replacing a pin removes the old one and adds the new one" do
+      user = federated_user() |> follower_of()
+      {:ok, _actor} = Fediverse.ensure_actor(user)
+      first = create_post!(user, %{body: "first"})
+      second = create_post!(user, %{body: "second"})
+      {:ok, user} = Posts.pin_to_profile(user, first)
+
+      {_result, activities} = queued_after_clearing(fn -> Posts.pin_to_profile(user, second) end)
+
+      # Both halves go out: the old post leaves the collection, the new one
+      # joins it. They name different posts, so the remote end state is the
+      # same whichever arrives first (the queue drains concurrently).
+      assert [remove, add] = activities
+      assert remove =~ ~s("type":"Remove")
+      assert remove =~ first.id
+      assert add =~ ~s("type":"Add")
+      assert add =~ second.id
+    end
+
+    test "a restricted pin is never announced, but releasing it still is" do
+      user = federated_user() |> follower_of()
+      {:ok, _actor} = Fediverse.ensure_actor(user)
+
+      hidden =
+        create_post!(user, %{body: "members only", denials: [%{"wildcard" => "logged_out"}]})
+
+      {{:ok, user}, queued} = queued_after_clearing(fn -> Posts.pin_to_profile(user, hidden) end)
+      assert queued == []
+
+      # The Remove goes out regardless: a post that stopped being public must
+      # still be able to leave a remote profile.
+      {_result, [remove]} = queued_after_clearing(fn -> Posts.unpin_from_profile(user) end)
+      assert remove =~ ~s("type":"Remove")
+    end
+
+    test "a member who does not federate (or has moved out) sends nothing" do
+      plain = insert(:activated_user)
+      post = create_post!(plain, %{body: "no federation here"})
+
+      moved = federated_user(moved_to: "https://mastodon.example/users/newme") |> follower_of()
+      moved_post = create_post!(moved, %{body: "already left"})
+
+      {_result, queued} =
+        queued_after_clearing(fn ->
+          {:ok, _} = Posts.pin_to_profile(plain, post)
+          {:ok, _} = Posts.pin_to_profile(moved, moved_post)
+        end)
+
+      assert queued == []
     end
   end
 

--- a/test/vutuv_web/controllers/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/fediverse_controller_test.exs
@@ -185,6 +185,16 @@ defmodule VutuvWeb.FediverseControllerTest do
       assert body["movedTo"] == @remote_actor
     end
 
+    test "advertises the featured collection (#1110)", %{conn: conn} do
+      user = federated_user()
+
+      body = conn |> get("/#{user.username}/actor") |> Map.fetch!(:resp_body) |> Jason.decode!()
+
+      # Always named, even with nothing pinned — an actor that only sometimes
+      # carries the field would make a remote profile depend on fetch timing.
+      assert body["featured"] == Docs.featured_url(user)
+    end
+
     test "followers and outbox are count-only collections", %{conn: conn} do
       user = federated_user()
 
@@ -198,6 +208,61 @@ defmodule VutuvWeb.FediverseControllerTest do
         conn |> recycle() |> get("/#{user.username}/actor/outbox") |> Map.fetch!(:resp_body)
 
       assert Jason.decode!(outbox)["type"] == "OrderedCollection"
+    end
+  end
+
+  describe "GET /:slug/actor/collections/featured (issue #1110)" do
+    defp featured(conn, user) do
+      conn |> get("/#{user.username}/actor/collections/featured") |> Map.fetch!(:resp_body)
+    end
+
+    test "is an empty OrderedCollection while nothing is pinned", %{conn: conn} do
+      user = federated_user()
+      _post = create_post!(user, %{body: "not pinned"})
+
+      body = conn |> featured(user) |> Jason.decode!()
+
+      assert body["type"] == "OrderedCollection"
+      assert body["id"] == Docs.featured_url(user)
+      assert body["totalItems"] == 0
+      assert body["orderedItems"] == []
+    end
+
+    test "carries the pinned post as a full Note", %{conn: conn} do
+      user = federated_user()
+      post = create_post!(user, %{body: "the one I am proud of"})
+      {:ok, _} = Vutuv.Posts.pin_to_profile(user, post)
+
+      body = conn |> featured(user) |> Jason.decode!()
+
+      assert body["totalItems"] == 1
+      assert [note] = body["orderedItems"]
+      assert note["type"] == "Note"
+      assert note["id"] == Docs.note_url(user, post.id)
+      # Embedded in full, so a remote server renders it without a second fetch.
+      assert note["content"] =~ "the one I am proud of"
+      assert note["attributedTo"] == Docs.actor_url(user)
+    end
+
+    test "a pin the anonymous public may not see is absent", %{conn: conn} do
+      user = federated_user()
+
+      hidden =
+        create_post!(user, %{body: "members only", denials: [%{"wildcard" => "logged_out"}]})
+
+      {:ok, _} = Vutuv.Posts.pin_to_profile(user, hidden)
+
+      body = conn |> featured(user) |> Jason.decode!()
+
+      assert body["totalItems"] == 0
+      refute body |> Jason.encode!() =~ "members only"
+    end
+
+    test "404s without the opt-in", %{conn: conn} do
+      user = insert(:activated_user)
+
+      conn = get(conn, "/#{user.username}/actor/collections/featured")
+      assert conn.status == 404
     end
   end
 


### PR DESCRIPTION
**TL;DR** The profile pin (#1110) now reaches other networks: it is published as the ActivityPub `featured` collection and pushed to followers as `Add`/`Remove`, so Mastodon and friends show the same pinned post at the top of the profile they render.

**Where:** `VutuvWeb.Fediverse.Docs` (actor field, collection, Add/Remove), `VutuvWeb.FediverseController.featured/2` + route `/:slug/actor/collections/featured`, `Vutuv.Fediverse.featured_posts/1` + `federate_pin/2` / `federate_unpin/2`, hooked into `Vutuv.Posts.pin_to_profile/2` and `unpin_from_profile/1`.

**Design decisions worth reviewing**
- **The actor names the collection unconditionally.** One that only carries `featured` while something is pinned would make a remote profile depend on when it last fetched; an always-present, sometimes-empty collection is honest at every moment.
- **The collection embeds the full Note**, the shape Mastodon serves, so a remote server renders the pin without a second fetch.
- **Strictly the anonymous public view** (`Posts.pinned_post(user, nil)`): the collection is served unauthenticated, so a restricted, frozen or otherwise non-public pin is simply not in it, the same gate the profile's `.md` sibling uses.
- **Pinning pushes as well as publishes**, so a remote profile updates immediately instead of at its next actor refresh. A replacement sends both halves; they name different posts, so the remote end state is the same whichever arrives first (the queue drains concurrently and promises no order).
- **`Remove` fires even for a pin that was never public** — a post that stopped being public must still be able to leave a remote profile — while `Add` never does.
- **Deleting the pinned post needs no `Remove`:** the pin nulls itself (`ON DELETE SET NULL`) and the post's own `Delete(Tombstone)` takes the remote copy with it.

**Tested:** the actor advertises `featured`; the collection is empty / carries the full Note / hides a non-public pin / 404s without the opt-in; `Add` on pin, `Remove` on release, both on a replacement, nothing for a restricted pin, nothing for a member who does not federate or has moved out. Full `mix precommit` green (5395 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_016STn6WsDCvvjxyUb7ynX4f
