### PR TITLE
Bump to 7.164.0 after a version collision on main

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.163.0",
+      version: "7.164.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
**TL;DR** Two commits on `main` both carry 7.163.0. Bumping so the version stays monotonic.

**Where:** `mix.exs`
**Now:** `a4a03ff2` (#1122's own collision fix) and `092430d9` (reply quoting, #1120) are both 7.163.0.
**Want:** the next commit on `main` reports 7.164.0.

The quote branch was rebased and re-bumped correctly off `origin/main`, but #1122 merged during its four-minute CI run, and an identical `version:` line merges without a conflict, so neither git nor CI saw the clash. Third time today, so I have sharpened my own rule to re-check `origin/main`'s version immediately before pressing merge, not only at rebase time.

Same one-line fix as #1119 and #1122.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01H6dRXwvHciTBK8fd9CNJSu