### PR TITLE
Set the pronunciation in brackets, and drop the speaker icon (#1112)

### DIFF
--- a/docs/architecture/profiles.md
+++ b/docs/architecture/profiles.md
@@ -22,11 +22,17 @@ view for everyone, and editing happens at `/settings/<section>`.
 ## Name pronunciation (issue #1112)
 
 `users.name_pronunciation` is free text (varchar(255), nullable) saying how the
-member's name is said out loud: "SHTEH-fahn VIN-ter-my-er", "rhymes with 'a
-fan'", IPA for the few who write it. It renders as a quiet line with a speaker
-glyph **directly under the name** in the profile header, above the availability
-pill and the tagline, because it belongs to the name and to nothing else on the
-page.
+member's name is said out loud: `[SHTEH-fahn VIN-ter-my-er]`, `[rhymes with 'a
+fan']`, IPA for those who write it. It renders as a quiet **monospace** line
+**directly under the name** in the profile header (tight against it, `mt-0.5`,
+so it reads as part of the name block), above the availability pill and the
+tagline, because it belongs to the name and to nothing else on the page.
+
+It carries **no icon**: a speaker glyph promises audio the page does not play.
+What marks the line as a transcription is the `[…]` the changeset guarantees
+plus the monospace face, which also keeps it distinct from the name above and
+the tagline below without a label word competing with either. An `sr-only`
+label carries the same meaning for anyone who cannot see that.
 
 It is deliberately a **quiet, optional** field. It is asked for on the Basics
 form (`/settings/profile`, in the "Your name" card) and **nowhere else** — the
@@ -38,8 +44,15 @@ means the feature is simply not there" is decided in one place and an untouched
 profile looks exactly as it did.
 
 **Validation** (all in `User.changeset/2`): whitespace folds to one line first
-(it renders as one), so a value that only overruns because of stray whitespace
-is fixed rather than refused; then a 255-character cap matching the column, and
+(it renders as one) and the value is wrapped in the transcription brackets —
+whichever of `[` / `]` is missing is **added**, never demanded and never
+doubled, so the member is not made to type punctuation to satisfy a rule (the
+phonemic `/…/` spelling is deliberately not recognised as a delimiter of its
+own: `/ˈʃtɛfan/` becomes `[/ˈʃtɛfan/]` rather than silently rewriting what was
+written). Both run before the length check, so a value that only overruns
+because of stray whitespace is fixed rather than refused; then a 255-character
+cap matching the column — checked on the **stored** value, brackets included,
+which is why the form's `maxlength` is 255 too — and
 a rule that the value must actually pronounce something — at least one letter
 (stricter than `Tag.punctuation_only?/1`, where a symbol like "C#" is a real
 name) and not the bare web/email address a spam sign-up drops into every free

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -19,11 +19,13 @@ defmodule Vutuv.Accounts.User do
     field(:nickname, :string)
     field(:honorific_prefix, :string)
     field(:honorific_suffix, :string)
-    # How to say the name out loud (issue #1112), free text: "SHTEH-fahn
-    # VIN-ter-my-er", "rhymes with 'a fan'", IPA for the few who write it. It is
-    # a deliberately quiet field — set on the profile basics form, never asked
-    # for at sign-up — and nil on nearly every account, which is why the profile
-    # renders the line only when it is present (`name_pronunciation/1`).
+    # How to say the name out loud (issue #1112), free text stored in the square
+    # brackets a transcription is written in (the changeset adds them):
+    # "[SHTEH-fahn VIN-ter-my-er]", "[rhymes with 'a fan']", IPA for those who
+    # write it. It is a deliberately quiet field — set on the profile basics
+    # form, never asked for at sign-up — and nil on nearly every account, which
+    # is why the profile renders the line only when it is present
+    # (`name_pronunciation/1`).
     field(:name_pronunciation, :string)
     field(:gender, :string)
     # The member's job-availability signal (issue #870), shown as a badge next

--- a/lib/vutuv/accounts/user.ex
+++ b/lib/vutuv/accounts/user.ex
@@ -623,7 +623,8 @@ defmodule Vutuv.Accounts.User do
   end
 
   # A pronunciation is one spoken line, so fold every run of whitespace (a
-  # pasted line break included) into a single space and trim the ends. This runs
+  # pasted line break included) into a single space and trim the ends, then put
+  # the value in the square brackets a transcription is written in. Both run
   # *before* the length check on purpose: a value that only overruns 255 because
   # of stray whitespace is fixed rather than refused. An emptied field folds to
   # nil, which is what "I don't want this shown" means — `cast/3`'s own
@@ -636,9 +637,22 @@ defmodule Vutuv.Accounts.User do
       value ->
         case value |> String.replace(~r/\s+/u, " ") |> String.trim() do
           "" -> put_change(changeset, :name_pronunciation, nil)
-          normalized -> put_change(changeset, :name_pronunciation, normalized)
+          normalized -> put_change(changeset, :name_pronunciation, bracket(normalized))
         end
     end
+  end
+
+  # `[…]` is how a phonetic transcription is written, and the brackets are what
+  # tell a reader that the string is one rather than a nickname or a spelling —
+  # which matters all the more now that the line carries no other label. So the
+  # form does not *demand* them: whichever bracket is missing is simply added,
+  # and a member who typed them keeps exactly what they typed (no doubling).
+  # Deliberately literal about the brackets Stefan asked for: the phonemic
+  # `/…/` spelling is not treated as a delimiter of its own, so `/ˈʃtɛfan/`
+  # becomes `[/ˈʃtɛfan/]` rather than silently changing what the member wrote.
+  defp bracket(value) do
+    value = if String.starts_with?(value, "["), do: value, else: "[" <> value
+    if String.ends_with?(value, "]"), do: value, else: value <> "]"
   end
 
   # What a pronunciation may not be. Two ways a value carries no pronunciation

--- a/lib/vutuv_web/templates/user/edit.html.heex
+++ b/lib/vutuv_web/templates/user/edit.html.heex
@@ -164,13 +164,13 @@ lands here). --%>
         <div class="sm:col-span-2">
           <%= label f, :name_pronunciation, gettext("Name pronunciation"), class: "block text-sm font-medium text-slate-900 dark:text-white" %>
           <%= text_input f, :name_pronunciation,
-            class: input_class(f, :name_pronunciation),
+            class: [input_class(f, :name_pronunciation), "font-mono"],
             maxlength: "255",
-            placeholder: gettext("e.g. SHTEH-fahn VIN-ter-my-er"),
+            placeholder: gettext("e.g. [SHTEH-fahn VIN-ter-my-er]"),
             "aria-invalid": f.errors[:name_pronunciation] && "true" %>
           <p :if={!f.errors[:name_pronunciation]} class="mt-1 text-sm text-slate-600 dark:text-slate-400">
             {gettext(
-              "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows under your name on your profile; leave it empty and nothing is shown."
+              "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
             )}
           </p>
           <%= error_tag f, :name_pronunciation %>

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -198,23 +198,24 @@ the resulting ~200px rail width. --%>
             </.card_menu>
           </div>
         </div>
-        <%!-- How to say the name (issue #1112), the line directly under it,
-        because it belongs to the name and to nothing else on this page. Shown
-        only when the member wrote one — on nearly every profile this renders
-        nothing at all, which is the point: it is help where help is needed, not
-        a field everyone has to fill in. The speaker glyph does the labelling
-        (no label word competing with the tagline below), so the row carries an
-        sr-only name for anyone who can't see it. --%>
+        <%!-- How to say the name (issue #1112), the line directly under it (and
+        tight against it, `mt-0.5`, so it reads as part of the name block rather
+        than as another fact). Shown only when the member wrote one — on nearly
+        every profile this renders nothing at all, which is the point: it is
+        help where help is needed, not a field everyone has to fill in.
+
+        No icon: a speaker glyph promises audio we do not play. What marks the
+        line as a transcription instead is the `[…]` the changeset guarantees
+        plus the monospace face — the notation look, and distinct from the name
+        above and the tagline below without a label word competing with either.
+        The sr-only label carries the meaning for anyone who can't see that. --%>
         <% pronunciation = Vutuv.Accounts.User.name_pronunciation(@user) %>
         <p
           :if={pronunciation}
           id="profile-pronunciation"
           data-name-pronunciation
-          class="mt-1 flex items-center gap-1.5 text-sm text-slate-600 dark:text-slate-400"
+          class="mt-0.5 font-mono text-sm text-slate-600 dark:text-slate-400"
         >
-          <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M11 5 6.5 9H3v6h3.5L11 19V5Zm4.5 3.5a5 5 0 0 1 0 7m2.8-9.8a9 9 0 0 1 0 12.6" />
-          </svg>
           <span class="sr-only">{gettext("Name pronunciation")}:</span>
           <span class="breakwrap">{pronunciation}</span>
         </p>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.164.0",
+      version: "7.164.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -17325,13 +17325,14 @@ msgstr "Aussprache des Namens"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen, elixir-format
-msgid "e.g. SHTEH-fahn VIN-ter-my-er"
-msgstr "z. B. SCHTEH-fan WIN-ter-mei-er"
+msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
+msgstr "z. B. [SCHTEH-fan WIN-ter-mei-er]"
 
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen, elixir-format
-msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows under your name on your profile; leave it empty and nothing is shown."
+msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 "Optional. Schreiben Sie Ihren Namen so, wie er klingt, damit ihn jemand beim "
-"ersten Anruf richtig ausspricht. Er steht auf Ihrem Profil unter Ihrem Namen; "
-"bleibt das Feld leer, wird nichts angezeigt."
+"ersten Anruf richtig ausspricht. Er steht auf Ihrem Profil unter Ihrem Namen, "
+"in eckigen Klammern, wie eine Lautschrift geschrieben wird; die Klammern "
+"ergänzen wir für Sie. Bleibt das Feld leer, wird nichts angezeigt."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -16546,10 +16546,10 @@ msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen, elixir-format
-msgid "e.g. SHTEH-fahn VIN-ter-my-er"
+msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen, elixir-format
-msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows under your name on your profile; leave it empty and nothing is shown."
+msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -16544,10 +16544,10 @@ msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:170
 #, elixir-autogen, elixir-format
-msgid "e.g. SHTEH-fahn VIN-ter-my-er"
+msgid "e.g. [SHTEH-fahn VIN-ter-my-er]"
 msgstr ""
 
 #: lib/vutuv_web/templates/user/edit.html.heex:174
 #, elixir-autogen, elixir-format
-msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows under your name on your profile; leave it empty and nothing is shown."
+msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""

--- a/test/vutuv/accounts_test.exs
+++ b/test/vutuv/accounts_test.exs
@@ -278,13 +278,45 @@ defmodule Vutuv.AccountsTest do
   # cases are the empty one (stays absent, nothing renders) and the values that
   # pronounce nothing at all.
   describe "name pronunciation" do
-    test "stores a pronunciation hint" do
+    test "stores a pronunciation hint in the transcription brackets" do
       user = insert(:user)
-      hint = "SHTEH-fahn VIN-ter-my-er"
 
-      assert {:ok, updated} = Accounts.update_user(user, %{"name_pronunciation" => hint})
-      assert updated.name_pronunciation == hint
-      assert User.name_pronunciation(updated) == hint
+      assert {:ok, updated} =
+               Accounts.update_user(user, %{"name_pronunciation" => "SHTEH-fahn VIN-ter-my-er"})
+
+      assert updated.name_pronunciation == "[SHTEH-fahn VIN-ter-my-er]"
+      assert User.name_pronunciation(updated) == "[SHTEH-fahn VIN-ter-my-er]"
+    end
+
+    # The brackets are what tell a reader the line is a transcription, so they
+    # are added rather than demanded — whichever one is missing, and never a
+    # second copy of one the member already typed.
+    test "adds only the bracket that is missing" do
+      user = insert(:user)
+
+      for {typed, stored} <- [
+            {"[ˈʃtɛfan]", "[ˈʃtɛfan]"},
+            {"[ˈʃtɛfan", "[ˈʃtɛfan]"},
+            {"ˈʃtɛfan]", "[ˈʃtɛfan]"},
+            {"ˈʃtɛfan", "[ˈʃtɛfan]"},
+            # The phonemic /…/ spelling is not a delimiter we recognise, so it
+            # is kept verbatim inside the brackets rather than rewritten.
+            {"/ˈʃtɛfan/", "[/ˈʃtɛfan/]"}
+          ] do
+        assert {:ok, updated} = Accounts.update_user(user, %{"name_pronunciation" => typed})
+        assert updated.name_pronunciation == stored
+      end
+    end
+
+    test "empty brackets pronounce nothing and are refused" do
+      user = insert(:user)
+
+      for value <- ["[]", "["] do
+        assert {:error, changeset} =
+                 Accounts.update_user(user, %{"name_pronunciation" => value})
+
+        assert "must spell out how the name sounds" in errors_on(changeset).name_pronunciation
+      end
     end
 
     test "an empty field stays empty and reads as absent" do
@@ -312,7 +344,7 @@ defmodule Vutuv.AccountsTest do
                  "name_pronunciation" => "  SHTEH-fahn \n\n  VIN-ter-my-er  "
                })
 
-      assert updated.name_pronunciation == "SHTEH-fahn VIN-ter-my-er"
+      assert updated.name_pronunciation == "[SHTEH-fahn VIN-ter-my-er]"
     end
 
     test "refuses a value that pronounces nothing" do
@@ -331,9 +363,11 @@ defmodule Vutuv.AccountsTest do
       hint = "like the 'stefan' in stefan.fm"
 
       assert {:ok, updated} = Accounts.update_user(user, %{"name_pronunciation" => hint})
-      assert updated.name_pronunciation == hint
+      assert updated.name_pronunciation == "[#{hint}]"
     end
 
+    # The cap is the column's, so it is checked on the value that is stored —
+    # brackets included, which is why the form stops typing at 255 too.
     test "refuses more than 255 characters" do
       user = insert(:user)
 
@@ -341,6 +375,11 @@ defmodule Vutuv.AccountsTest do
                Accounts.update_user(user, %{"name_pronunciation" => String.duplicate("a", 256)})
 
       assert "should be at most 255 character(s)" in errors_on(changeset).name_pronunciation
+
+      assert {:ok, updated} =
+               Accounts.update_user(user, %{"name_pronunciation" => String.duplicate("a", 253)})
+
+      assert String.length(updated.name_pronunciation) == 255
     end
 
     # The verified badge vouches for the written name, not for how it sounds,

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -28,7 +28,7 @@ defmodule VutuvWeb.AgentDocsDriftTest do
         # The spoken-name hint (issue #1112): the profile shows it under the
         # name, so every agent format must carry it too — it is worth the most
         # to a reader that says the name out loud.
-        name_pronunciation: "GRAY-ta GRAY-dee-ent",
+        name_pronunciation: "[GRAY-ta GRAY-dee-ent]",
         gender: "female",
         birthdate: ~D[1991-04-23],
         employment_status: "looking",
@@ -184,7 +184,7 @@ defmodule VutuvWeb.AgentDocsDriftTest do
       "Greta Gradient",
       "bridges between humans and agents",
       # how the name is said out loud (issue #1112)
-      "GRAY-ta GRAY-dee-ent",
+      "[GRAY-ta GRAY-dee-ent]",
       # experience
       "Bridge Engineer",
       "Span AG",
@@ -432,7 +432,7 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert body =~ "IMPP;TYPE=telegram:https://t.me/gretachats"
     # How the name is said (issue #1112): vCard 3.0 has no standard property for
     # a free-text hint, so it rides as an X- extension right below FN.
-    assert body =~ "X-PHONETIC-NAME:GRAY-ta GRAY-dee-ent"
+    assert body =~ "X-PHONETIC-NAME:[GRAY-ta GRAY-dee-ent]"
   end
 
   test "a member without a pronunciation gets no phonetic line in the vCard" do

--- a/test/vutuv_web/controllers/user_controller_test.exs
+++ b/test/vutuv_web/controllers/user_controller_test.exs
@@ -824,7 +824,9 @@ defmodule VutuvWeb.UserControllerTest do
       html = conn |> get(~p"/settings/profile") |> html_response(200)
 
       assert html =~ "Name pronunciation"
-      assert html =~ "e.g. SHTEH-fahn VIN-ter-my-er"
+      # The example carries the transcription brackets, so the convention is
+      # visible before the member finds out the server adds them.
+      assert html =~ "e.g. [SHTEH-fahn VIN-ter-my-er]"
       # The browser stops typing at the column width, so the cap is felt before
       # the server has to refuse the save.
       assert html =~ ~s(maxlength="255")
@@ -840,8 +842,22 @@ defmodule VutuvWeb.UserControllerTest do
 
       html = conn |> recycle() |> get(~p"/#{user}") |> html_response(200)
 
-      assert html =~ "SHTEH-fahn"
+      assert html =~ "[SHTEH-fahn]"
       assert html =~ ~s(id="profile-pronunciation")
+    end
+
+    # A speaker glyph would promise audio the page cannot play, so the brackets
+    # and the monospace face are what mark the line as a transcription.
+    test "the profile line is monospaced and carries no audio icon", %{conn: conn} do
+      user = insert_activated_user(name_pronunciation: "[ˈʃtɛfan]")
+
+      html = conn |> get(~p"/#{user}") |> html_response(200)
+
+      [row] = Regex.run(~r|<p[^>]*id="profile-pronunciation".*?</p>|s, html)
+
+      assert row =~ "font-mono"
+      assert row =~ "[ˈʃtɛfan]"
+      refute row =~ "<svg"
     end
 
     test "a profile without one renders no pronunciation row at all", %{conn: conn} do
@@ -876,6 +892,7 @@ defmodule VutuvWeb.UserControllerTest do
 
       assert html =~ "Aussprache des Namens"
       assert html =~ "damit ihn jemand beim ersten Anruf richtig ausspricht"
+      assert html =~ "eckigen Klammern"
     end
 
     # It is deliberately hidden away in the settings: the sign-up form asks for


### PR DESCRIPTION
Follow-up to #1124 (issue #1112). Four corrections to the pronunciation line, all about making it read as what it is: a transcription.

**Brackets are guaranteed by the changeset.** Whichever of `[` or `]` is missing is *added* to the trimmed value rather than demanded, so nobody has to type punctuation to satisfy a rule and nobody gets an error for not knowing about it; a member who typed them keeps exactly what they typed, with no doubling. The phonemic `/…/` spelling is deliberately **not** recognised as a delimiter of its own, so `/ˈʃtɛfan/` becomes `[/ˈʃtɛfan/]` rather than silently rewriting what the member wrote. The brackets count towards the stored 255, since that is what the column limits; the form's `maxlength` stays 255 for the same reason.

**The line is monospace.** With the brackets it reads as notation at a glance, and it stays clearly distinct from the name above and the tagline below without a label word competing with either. The input carries the same face, so what you type looks like what will be shown.

**The speaker icon is gone.** It promised audio that nothing here plays, which is precisely the wrong hint on a field about how a name sounds. The brackets and the monospace face do the labelling for a sighted reader; the `sr-only` label still carries it for everyone else.

**The line sits tighter under the name** (`mt-0.5`), so it reads as part of the name block rather than as one more fact about the member.

Tests cover each bracket case (neither, one, both, `/…/` kept verbatim), that `[]` and `[` still fail the "pronounces nothing" rule, that the cap is checked on the stored value including the brackets, and that the profile row is monospaced and carries no `<svg>`. The agent-format drift test and the vCard assertion carry the bracketed value now. Verified in a browser: the IPA glyphs render in the monospace stack and the brackets show.

An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.

https://claude.ai/code/session_01Fr6kxj3ypgyPGME2EtU555
