### PR TITLE
Engaging with a post marks its notifications as read

### DIFF
--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -142,10 +142,44 @@ organizations share the handle namespace but have no feed.
 you, and a mention supersedes the quieter "thread" event for the same reply. So
 a single post never produces two notifications for the same reader.
 
-The only stored state derived-feed-wise is the `users.notifications_read_at`
-read marker behind the unread badge; `post_mentions` and
-`handle_change_notifications` are the two event tables written for a feed kind
-rather than read from one that already existed.
+`post_mentions` and `handle_change_notifications` are the two event tables
+written for a feed kind rather than read from one that already existed.
+
+### Read state: one marker plus per-post exceptions
+
+Derived-feed-wise, read state is stored in exactly two places.
+
+`users.notifications_read_at` is the **marker**: everything up to here has been
+seen. `Activity.mark_notifications_read/1` bumps it when the member opens
+/notifications, and anchors it to the newest *event* rather than the wall clock,
+so an event landing in the same second is not swallowed (the event tables keep
+second precision and the unread filter is a strict `>`).
+
+`notification_post_reads` holds the **per-post exceptions**, written by
+`Activity.mark_post_seen/2` when a member answers, likes, bookmarks or reposts a
+post. Nobody does any of those four to a post they have not read, so whatever
+the feed has to say about that post is news they already have — and the badge is
+supposed to mean "things you have not looked at", not "things since your last
+visit to /notifications". Before this, you could read an answer in the feed,
+reply to it, and the badge would still insist on one unread notification until
+you opened the page and dismissed it by hand.
+
+The chokepoints are `Vutuv.Posts`'s `engage/4` (like / bookmark / repost, on the
+idempotent repeat too) and `do_create_reply/4` (the parent). Marking broadcasts
+`:notifications_changed`, the shell's recount-from-source signal, rather than
+decrementing a tally, so the badge cannot drift.
+
+Which events a seen post clears is `Activity.subject_post_id/1`, and it is
+deliberately narrow — only the three kinds whose subject is somebody *else's*
+post: the answer to your post ("reply"), the answer elsewhere in your thread
+("thread") and the post that named you ("mention"). A "like" names your own
+post, and bookmarking or reposting your own post says nothing about having seen
+who liked it, so those keep waiting for a real visit. Only the **unread tally**
+consults the table (`unread_notification_count/1`); `notifications_count/2` and
+the feed itself do not, so the row stays listed and the pager's total is
+unchanged — /notifications remains the log of what happened, it just stops
+calling that row new. The page marks those rows with one extra query per page
+(`Activity.seen_post_ids/2`), so the list and the badge tell one story.
 
 ### The notifications page (2026-07 redesign)
 
@@ -183,7 +217,9 @@ Around the list:
 
 * **Unread highlighting**: events newer than the previous visit's read marker
   get a tint + coral dot and a "N new notifications" header line; the visit
-  itself still advances `users.notifications_read_at` and clears the bell.
+  itself still advances `users.notifications_read_at` and clears the bell. A row
+  whose post the reader already engaged with is exempt (see the read-state
+  section above) — it is listed, plain.
 * **Filter tabs** (all / posts / people / more) restrict the feed server-side
   via `Activity.notifications_page/2`'s `kinds:` option (only the matching
   source queries run, so pagination stays exact) and live in the URL

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -16,17 +16,28 @@ defmodule Vutuv.Activity do
   thread the user writes in a "thread" one —, `post_mentions` — a post naming
   the user by `@handle` is a "mention" event —, `post_likes`, and the announced
   CV rows behind `Vutuv.Profiles.CvUpdates`) instead of being
-  persisted per notification — which makes it automatically retroactive. The only stored
-  state is `users.notifications_read_at`, the read marker behind the unread
-  badge; `mark_notifications_read/1` bumps it and broadcasts. Older events are
-  reached via `notifications_page/2`, a timestamp-cursor pagination that backs
-  the "Load more" button.
+  persisted per notification — which makes it automatically retroactive. Older
+  events are reached via `notifications_page/2`, a timestamp-cursor pagination
+  that backs the "Load more" button.
+
+  Read state is stored in two places, and they answer different questions:
+
+    * `users.notifications_read_at` is the **marker**: everything up to here
+      has been seen. `mark_notifications_read/1` bumps it and broadcasts, which
+      is what opening /notifications does.
+    * `notification_post_reads` holds the **per-post** exceptions written by
+      `mark_post_seen/2`: the member answered, liked, bookmarked or reposted
+      that post, so what the feed has to say about it is old news even though
+      the marker still sits behind it. Only the unread tally consults them —
+      the page keeps listing those events, it just stops calling them new.
   """
   import Ecto.Query
   require Logger
 
   alias Vutuv.Accounts.HandleChangeNotification
   alias Vutuv.Accounts.User
+  alias Vutuv.Activity.NotificationPostRead
+  alias Vutuv.Engagement
   alias Vutuv.Fediverse.Note
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Notifications.Emailer
@@ -186,6 +197,67 @@ defmodule Vutuv.Activity do
     from(t in subquery(union), select: max(t.ts))
     |> Repo.one()
   end
+
+  @doc """
+  Record that `user_id` has seen `post_id`, so the notifications *about* that
+  post stop counting as unread (`notification_post_reads`).
+
+  Called from `Vutuv.Posts` whenever a member answers, likes, bookmarks or
+  reposts a post: all four are deliberate acts on a post they were looking at,
+  which makes "you were mentioned here" or "somebody answered this" news they
+  already have. Idempotent (the four actions are toggles that may fire again),
+  and a no-op for a missing member or post.
+
+  The badge is not decremented here — `:notifications_changed` tells the shell
+  to recount from the source, the same way a silently removed event does, so
+  the two can never drift. Only a fresh mark broadcasts; the repeat changes
+  nothing to recount.
+  """
+  def mark_post_seen(nil, _post_id), do: :ok
+  def mark_post_seen(_user_id, nil), do: :ok
+
+  def mark_post_seen(user_id, post_id) when is_binary(user_id) and is_binary(post_id) do
+    case Engagement.insert_if_new(
+           NotificationPostRead,
+           %{user_id: user_id, post_id: post_id},
+           [:user_id, :post_id]
+         ) do
+      {:inserted, _row} -> broadcast(user_id, :notifications_changed)
+      :exists -> :ok
+    end
+  end
+
+  @doc """
+  Which of `post_ids` the member has already seen (`mark_post_seen/2`), as a
+  `MapSet`. One query for a whole notifications page, so its rows can render
+  the individually-read ones as read; empty in, empty out.
+  """
+  def seen_post_ids(_user_id, []), do: MapSet.new()
+  def seen_post_ids(nil, _post_ids), do: MapSet.new()
+
+  def seen_post_ids(user_id, post_ids) do
+    from(s in NotificationPostRead,
+      where: s.user_id == ^user_id and s.post_id in ^post_ids,
+      select: s.post_id
+    )
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  @doc """
+  The post a feed item is *about* — the one the member would engage with to
+  prove they have seen it, and the key `mark_post_seen/2` marks.
+
+  Only the three kinds whose subject is somebody else's post have one: the
+  answer to your post, the answer elsewhere in your thread, and the post that
+  named you. A "like" names your own post instead, and engaging with your own
+  post says nothing about having seen who liked it, so it has none.
+  """
+  def subject_post_id(%{kind: kind} = item) when kind in ~w(reply thread),
+    do: Map.get(item, :reply_post_id)
+
+  def subject_post_id(%{kind: "mention"} = item), do: Map.get(item, :post_id)
+  def subject_post_id(_item), do: nil
 
   @doc "Tell a user's shell their messages were just read (clears the badge)."
   def mark_messages_read(user_id), do: broadcast(user_id, :messages_read)
@@ -584,17 +656,23 @@ defmodule Vutuv.Activity do
   def notifications_count(user_id, kinds \\ nil)
   def notifications_count(nil, _kinds), do: 0
 
-  def notifications_count(user_id, kinds), do: total_count(user_id, nil, kinds)
+  def notifications_count(user_id, kinds), do: total_count(user_id, nil, kinds, false)
 
   @doc """
   How many feed events are newer than the user's read marker (all of them when
-  the marker is NULL). Zero for a logged-out visitor.
+  the marker is NULL) **and** not about a post the member has already seen.
+  Zero for a logged-out visitor.
+
+  The second half is what makes the badge mean "things you have not looked at"
+  rather than "things since your last visit to /notifications": answering,
+  liking, bookmarking or reposting a post marks it seen (`mark_post_seen/2`)
+  and its event drops out of the tally right there in the feed.
   """
   def unread_notification_count(nil), do: 0
 
   def unread_notification_count(user_id) do
     read_at = Repo.one(from(u in User, where: u.id == ^user_id, select: u.notifications_read_at))
-    total_count(user_id, read_at)
+    total_count(user_id, read_at, nil, true)
   end
 
   # The feed sources are counted in a single round trip: each count is a
@@ -606,9 +684,14 @@ defmodule Vutuv.Activity do
   #
   # `kinds` picks the subset to count, mirroring `kind_sources/1`; the sum is
   # built with dynamics so the filtered case stays one query too.
-  defp total_count(user_id, read_at, kinds \\ nil) do
+  #
+  # `unread?` additionally drops the events whose post the member has already
+  # engaged with (`mark_post_seen/2`). It is deliberately not derived from
+  # `read_at` — that one is nil for a member who never opened /notifications,
+  # who still wants the per-post exceptions applied.
+  defp total_count(user_id, read_at, kinds, unread?) do
     counts =
-      for {kind, count} <- kind_counts(user_id, read_at),
+      for {kind, count} <- kind_counts(user_id, read_at, unread?),
           kinds == nil or kind in kinds,
           do: count
 
@@ -630,14 +713,14 @@ defmodule Vutuv.Activity do
   # count-side twin of `kind_sources/1`, so a `kinds:` filter narrows the feed
   # and its total the same way. `report_protection` is two queries (severed and
   # restored), matching the one source that emits both.
-  defp kind_counts(user_id, read_at) do
+  defp kind_counts(user_id, read_at, unread?) do
     [
       {"follower", count_followers(user_id, read_at)},
       {"endorsement", count_endorsements(user_id, read_at)},
       {"connection", count_connections(user_id, read_at)},
-      {"reply", count_replies(user_id, read_at)},
-      {"thread", count_thread_replies(user_id, read_at)},
-      {"mention", count_mentions(user_id, read_at)},
+      {"reply", count_replies(user_id, read_at, unread?)},
+      {"thread", count_thread_replies(user_id, read_at, unread?)},
+      {"mention", count_mentions(user_id, read_at, unread?)},
       {"fediverse_reply", count_fediverse_replies(user_id, read_at)},
       {"like", count_likes(user_id, read_at)},
       {"organization_role", count_organization_roles(user_id, read_at)},
@@ -1282,25 +1365,39 @@ defmodule Vutuv.Activity do
     end
   end
 
-  defp count_replies(user_id, read_at) do
+  defp count_replies(user_id, read_at, unread? \\ false) do
     from(r in PostReply,
       join: reply in assoc(r, :post),
       where: r.parent_author_id == ^user_id and reply.user_id != ^user_id,
       select: %{count: count()}
     )
     |> since(read_at)
+    |> unless_seen(user_id, unread?)
   end
 
-  defp count_thread_replies(user_id, read_at) do
+  defp count_thread_replies(user_id, read_at, unread?) do
     thread_replies(user_id)
     |> select([thread_ref: r], %{count: count()})
     |> since(read_at)
+    |> unless_seen(user_id, unread?)
   end
 
-  defp count_mentions(user_id, read_at) do
+  defp count_mentions(user_id, read_at, unread?) do
     mention_events(user_id)
     |> select([mention: m], %{count: count()})
     |> since(read_at)
+    |> unless_seen(user_id, unread?)
+  end
+
+  # Drops the events whose subject post the member has already engaged with.
+  # All three affected sources key on `post_id` of their first binding — the
+  # answer for a reply / thread event, the naming post for a mention — which is
+  # exactly what `mark_post_seen/2` writes, so one clause covers them.
+  defp unless_seen(query, _user_id, false), do: query
+
+  defp unless_seen(query, user_id, true) do
+    seen = from(s in NotificationPostRead, where: s.user_id == ^user_id, select: s.post_id)
+    where(query, [event], event.post_id not in subquery(seen))
   end
 
   # No self-like filter: a member cannot like their own post (enforced in

--- a/lib/vutuv/activity/notification_post_read.ex
+++ b/lib/vutuv/activity/notification_post_read.ex
@@ -1,0 +1,19 @@
+defmodule Vutuv.Activity.NotificationPostRead do
+  @moduledoc """
+  One member has seen one post — the per-item read mark behind
+  `Vutuv.Activity.mark_post_seen/2`.
+
+  Written when the member answers, likes, bookmarks or reposts the post, since
+  none of those happen to a post nobody looked at. The unread notification tally
+  then skips every event whose subject is that post.
+  """
+
+  use VutuvWeb, :model
+
+  schema "notification_post_reads" do
+    belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:post, Vutuv.Posts.Post)
+
+    timestamps()
+  end
+end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -221,6 +221,9 @@ defmodule Vutuv.Posts do
       case insert_post(changeset, image_ids, parent, note) do
         {:ok, post} ->
           post = preload_post(post)
+          # Answering a post is the clearest possible proof of having read it,
+          # so any notification about the parent stops counting as unread.
+          Vutuv.Activity.mark_post_seen(author.id, parent.id)
           broadcast_new_post(post)
           broadcast_reply(parent, post)
           sync_mentions(post)
@@ -918,6 +921,12 @@ defmodule Vutuv.Posts do
 
   defp engage(schema, kind, %User{} = user, %Post{} = post) do
     if visible_to?(post, user) do
+      # Liking, bookmarking or reposting a post is proof the member read it, so
+      # whatever the notifications feed has to say about that post is old news
+      # — including on the idempotent repeat, which is still a member acting on
+      # a post in front of them.
+      Vutuv.Activity.mark_post_seen(user.id, post.id)
+
       case Vutuv.Engagement.insert_if_new(
              schema,
              %{user_id: user.id, post_id: post.id},

--- a/lib/vutuv_web/live/notification_live/groups.ex
+++ b/lib/vutuv_web/live/notification_live/groups.ex
@@ -37,7 +37,9 @@ defmodule VutuvWeb.NotificationLive.Groups do
   member's time), `:actors` (distinct, newest first), `:actor_count`,
   `:tags` (endorsement groups: chronological), `:item` (the newest raw item,
   for kind-specific fields and post previews) and `:unread?` - true when any
-  member is newer than `read_marker` (nil marker = everything unread).
+  member is newer than `read_marker` (nil marker = everything unread) and not
+  already marked `:seen?` by the caller (the reader engaged with the post the
+  item is about, see `Vutuv.Activity.mark_post_seen/2`).
   """
   def sections(items, read_marker) do
     items
@@ -169,6 +171,11 @@ defmodule VutuvWeb.NotificationLive.Groups do
       "anon-#{:erlang.phash2(item[:actor_name])}"
   end
 
+  # An item the reader already engaged with (`:seen?`, set by the page from
+  # `Vutuv.Activity.mark_post_seen/2`) is read whatever the marker says: they
+  # answered, liked, bookmarked or reposted the post it is about, and the shell
+  # badge stopped counting it there and then.
+  defp unread?(%{seen?: true}, _read_marker), do: false
   defp unread?(_item, nil), do: true
 
   defp unread?(item, read_marker),

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -211,8 +211,26 @@ defmodule VutuvWeb.NotificationLive.Index do
     socket
     |> assign(:page, page)
     |> assign(:total, total)
-    |> assign(:items, with_post_previews(feed.entries, user))
+    |> assign(:items, feed.entries |> with_seen_flags(user) |> with_post_previews(user))
     |> assign_sections()
+  end
+
+  # Rows the reader has already dealt with out in the feed: they answered,
+  # liked, bookmarked or reposted the post the row is about, so
+  # `Vutuv.Activity.mark_post_seen/2` recorded it and the shell's badge stopped
+  # counting it. They stay listed — the page is the log of what happened — they
+  # just no longer render as new, so the list and the badge tell one story. One
+  # query per page.
+  defp with_seen_flags(entries, viewer) do
+    seen =
+      entries
+      |> Enum.map(&Activity.subject_post_id/1)
+      |> Enum.reject(&is_nil/1)
+      |> then(&Activity.seen_post_ids(viewer.id, &1))
+
+    Enum.map(entries, fn entry ->
+      Map.put(entry, :seen?, MapSet.member?(seen, Activity.subject_post_id(entry)))
+    end)
   end
 
   defp assign_sections(socket) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.164.1",
+      version: "7.165.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260726084957_create_notification_post_reads.exs
+++ b/priv/repo/migrations/20260726084957_create_notification_post_reads.exs
@@ -1,0 +1,27 @@
+defmodule Vutuv.Repo.Migrations.CreateNotificationPostReads do
+  use Ecto.Migration
+
+  # "This member has demonstrably seen that post." Written when they answer,
+  # like, bookmark or repost it — four actions nobody performs on a post they
+  # have not read.
+  #
+  # The notifications feed is derived at read time and its only stored state is
+  # the single `users.notifications_read_at` marker, which can say "everything
+  # up to here" and nothing else. This table is the per-item exception: it lets
+  # the unread tally skip the events the member has already dealt with out in
+  # the feed, without moving the marker past everything else.
+  #
+  # One row per (member, post); the pair is unique because the four actions are
+  # idempotent toggles and each of them may fire more than once. Both sides
+  # cascade — a deleted post or member leaves nothing behind.
+  def change do
+    create table(:notification_post_reads) do
+      add(:user_id, references(:users, on_delete: :delete_all), null: false)
+      add(:post_id, references(:posts, on_delete: :delete_all), null: false)
+
+      timestamps()
+    end
+
+    create(unique_index(:notification_post_reads, [:user_id, :post_id]))
+  end
+end

--- a/test/vutuv/engagement_marks_notifications_read_test.exs
+++ b/test/vutuv/engagement_marks_notifications_read_test.exs
@@ -1,0 +1,211 @@
+defmodule Vutuv.EngagementMarksNotificationsReadTest do
+  @moduledoc """
+  Answering, liking, bookmarking or reposting a post marks the notifications
+  *about that post* as read (`Vutuv.Activity.mark_post_seen/2`).
+
+  The bell badge is supposed to mean "things you have not looked at". Before
+  this, it meant "things since your last visit to /notifications": you could
+  read an answer in the feed, reply to it, and the badge still insisted there
+  was one unread notification until you opened the page and dismissed it by
+  hand. Four actions settle the question of whether a post was read — nobody
+  answers, likes, bookmarks or reposts a post they have not looked at — so each
+  of them now clears what the feed had to say about it.
+
+  Deliberately narrow (see `Activity.subject_post_id/1`): only the three kinds
+  whose subject is somebody *else's* post can be cleared this way. A "like"
+  names your own post, and reposting or bookmarking your own post tells us
+  nothing about whether you saw who liked it, so those keep waiting for a real
+  visit to /notifications.
+  """
+  use Vutuv.DataCase, async: true
+
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Activity
+  alias Vutuv.Posts
+
+  # A member whose handle can appear as `@handle` in a body (the factory's
+  # default `user-1` is not mentionable, see Factory.unique_username/1).
+  defp mentionable(attrs \\ []) do
+    insert(:activated_user, Keyword.put_new(attrs, :username, unique_username()))
+  end
+
+  # My post, somebody else's answer to it: one unread "reply" notification.
+  defp answered_post do
+    me = insert(:user)
+    other = insert(:user)
+    mine = insert(:post, user: me)
+    answer = insert(:post, user: other)
+    insert(:post_reply, post: answer, parent_post: mine, parent_author: me)
+
+    {me, answer}
+  end
+
+  describe "engaging with the post a notification is about" do
+    test "answering it clears the notification" do
+      {me, answer} = answered_post()
+      assert Activity.unread_notification_count(me.id) == 1
+
+      {:ok, _reply} = Posts.create_reply(me, answer, %{body: "Thanks!"})
+
+      assert Activity.unread_notification_count(me.id) == 0
+    end
+
+    test "liking it clears the notification" do
+      {me, answer} = answered_post()
+
+      :ok = Posts.like_post(me, answer)
+
+      assert Activity.unread_notification_count(me.id) == 0
+    end
+
+    test "bookmarking it clears the notification" do
+      {me, answer} = answered_post()
+
+      :ok = Posts.bookmark_post(me, answer)
+
+      assert Activity.unread_notification_count(me.id) == 0
+    end
+
+    test "reposting it clears the notification" do
+      {me, answer} = answered_post()
+
+      :ok = Posts.repost_post(me, answer)
+
+      assert Activity.unread_notification_count(me.id) == 0
+    end
+
+    test "undoing the engagement does not make it unread again" do
+      # Reading cannot be undone: unliking says "I take that back", not
+      # "I never saw it".
+      {me, answer} = answered_post()
+
+      :ok = Posts.like_post(me, answer)
+      :ok = Posts.unlike_post(me, answer)
+
+      assert Activity.unread_notification_count(me.id) == 0
+    end
+
+    test "a mention stops counting once the post that named me is liked" do
+      author = mentionable()
+      me = mentionable()
+
+      post = create_post!(author, %{body: "Ask @#{me.username} about it."})
+      assert Activity.unread_notification_count(me.id) == 1
+
+      :ok = Posts.like_post(me, post)
+
+      assert Activity.unread_notification_count(me.id) == 0
+    end
+
+    test "a thread event stops counting once its reply is answered" do
+      me = insert(:user)
+      first_replier = insert(:user)
+      root = insert(:post, user: me)
+      first = insert(:post, user: first_replier)
+      insert(:post_reply, post: first, parent_post: root, parent_author: me, root_post: root)
+      nested = insert(:post, user: insert(:user))
+
+      insert(:post_reply,
+        post: nested,
+        parent_post: first,
+        parent_author: first_replier,
+        root_post: root
+      )
+
+      # One direct reply to my post + one answer elsewhere in my thread.
+      assert Activity.unread_notification_count(me.id) == 2
+
+      {:ok, _reply} = Posts.create_reply(me, nested, %{body: "Good point."})
+
+      # Only the thread event goes; the unanswered direct reply stays unread.
+      assert Activity.unread_notification_count(me.id) == 1
+    end
+
+    test "only the engaged post's notification goes, the rest stay unread" do
+      {me, answer} = answered_post()
+      insert(:follow, follower: insert(:user), followee: me)
+      second = insert(:post, user: insert(:user))
+      insert(:post_reply, post: second, parent_post: insert(:post, user: me), parent_author: me)
+
+      assert Activity.unread_notification_count(me.id) == 3
+
+      :ok = Posts.like_post(me, answer)
+
+      assert Activity.unread_notification_count(me.id) == 2
+    end
+  end
+
+  describe "what the notifications page still shows" do
+    test "the row stays in the feed and in the pager's total" do
+      # Read is not deleted: /notifications remains the log of what happened,
+      # it just stops calling that row new.
+      {me, answer} = answered_post()
+      :ok = Posts.like_post(me, answer)
+
+      assert [%{kind: "reply"}] = Activity.notifications_page(me.id, limit: 50).entries
+      assert Activity.notifications_count(me.id) == 1
+    end
+
+    test "the row is marked as the subject post, so the page can render it read" do
+      {me, answer} = answered_post()
+      [item] = Activity.notifications_page(me.id, limit: 50).entries
+
+      assert Activity.subject_post_id(item) == answer.id
+      assert Activity.seen_post_ids(me.id, [answer.id]) |> Enum.to_list() == []
+
+      :ok = Posts.like_post(me, answer)
+
+      assert Activity.seen_post_ids(me.id, [answer.id]) |> Enum.to_list() == [answer.id]
+    end
+
+    test "a like on my own post has no subject post to clear" do
+      # The deliberate limit: nothing I can do to my own post proves I saw who
+      # liked it, so that badge waits for a real visit to /notifications.
+      me = insert(:user)
+      mine = insert(:post, user: me)
+      :ok = Posts.like_post(insert(:user), mine)
+
+      [item] = Activity.notifications_page(me.id, limit: 50).entries
+      assert item.kind == "like"
+      assert Activity.subject_post_id(item) == nil
+
+      :ok = Posts.bookmark_post(me, mine)
+
+      assert Activity.unread_notification_count(me.id) == 1
+    end
+  end
+
+  describe "mark_post_seen/2" do
+    test "tells the member's open sessions to recount their badge" do
+      me = insert(:user)
+      post = insert(:post, user: insert(:user))
+      Activity.subscribe(me.id)
+
+      Activity.mark_post_seen(me.id, post.id)
+
+      assert_receive :notifications_changed
+    end
+
+    test "is idempotent" do
+      {me, answer} = answered_post()
+
+      Activity.mark_post_seen(me.id, answer.id)
+      Activity.mark_post_seen(me.id, answer.id)
+
+      assert Activity.seen_post_ids(me.id, [answer.id]) |> Enum.to_list() == [answer.id]
+    end
+
+    test "a nil member or post is a no-op" do
+      post = insert(:post, user: insert(:user))
+      assert Activity.mark_post_seen(nil, post.id) == :ok
+      assert Activity.mark_post_seen(Vutuv.UUIDv7.generate(), nil) == :ok
+    end
+
+    test "seen_post_ids/2 asks nothing for an empty list or a logged-out visitor" do
+      me = insert(:user)
+      assert Activity.seen_post_ids(me.id, []) |> Enum.to_list() == []
+      assert Activity.seen_post_ids(nil, [Vutuv.UUIDv7.generate()]) |> Enum.to_list() == []
+    end
+  end
+end

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -731,6 +731,26 @@ defmodule VutuvWeb.NotificationLiveTest do
       assert Vutuv.Activity.unread_notification_count(user.id) == 0
     end
 
+    test "a reply I already answered is listed but not marked unread", %{conn: conn} do
+      # The row stays - the page is the log of what happened - but answering the
+      # reply out in the feed already settled it, so it must not read as new
+      # here either, or the page and the bell badge would tell two stories.
+      {conn, user} = create_and_login_user(conn)
+      backdate_welcome_note(user, ~N[2016-11-24 12:00:00])
+      set_read_marker(user, ~N[2016-11-25 00:00:00])
+
+      mine = insert(:post, user: user)
+      answer = insert(:post, user: insert(:user))
+      insert(:post_reply, post: answer, parent_post: mine, parent_author: user)
+
+      {:ok, _reply} = Vutuv.Posts.create_reply(user, answer, %{body: "Thanks!"})
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+
+      assert has_element?(live, ~s([data-notification-row][data-kind="reply"]))
+      refute has_element?(live, ~s([data-notification-row][data-kind="reply"][data-unread]))
+    end
+
     test "redirects a logged-out visitor to the login", %{conn: conn} do
       assert {:error, {:redirect, %{to: "/login"}}} = live(conn, ~p"/notifications")
     end


### PR DESCRIPTION
**TL;DR** Answering, liking, bookmarking or reposting a post now marks the notifications *about that post* as read, so the bell badge counts what you have not looked at instead of what happened since your last visit to /notifications.

**Now:** you read an answer in your feed, reply to it, and the badge still says 1 unread until you open /notifications and dismiss it by hand. The only read state was the single `users.notifications_read_at` marker, which can say "everything up to here" and nothing else.

**Want:** four actions settle whether a post was read, because nobody performs them on a post they have not looked at. Each one records the post as seen (new `notification_post_reads` table, one row per member/post pair, both sides cascading) and the unread tally skips the events about it. The badge recounts from the source over the existing `:notifications_changed` signal rather than decrementing a tally, so it cannot drift.

**Scope — deliberately narrow, server-side only.** Only the three kinds whose subject is somebody *else's* post can be cleared this way (`Activity.subject_post_id/1`): the answer to your post, the answer elsewhere in your thread, and the post that named you. A "like" names your own post, and bookmarking or reposting your own post says nothing about having seen who liked it, so those keep waiting for a real visit. Nothing depends on JavaScript or on what scrolled past a viewport — this is not meant to cover every case, only the ones that are beyond doubt.

**What the page still shows:** only the unread count consults the new table, so the row stays listed and the pager's total is unchanged. /notifications remains the log of what happened, it just stops calling that row new — and it marks those rows in one extra query per page, so the list and the badge tell one story.

**Where:** `Vutuv.Activity.mark_post_seen/2` (the write), `Vutuv.Posts`' `engage/4` + `do_create_reply/4` (the chokepoints), `unread_notification_count/1` (the filter), `VutuvWeb.NotificationLive.Index` + `Groups` (the rendering). Docs in `docs/architecture/realtime.md`.

**Migration:** plain new table, N-1 safe. Version 7.165.0.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01CEw4ffSThZPjNkwustwMTh
