### PR TITLE
Keep the post composer open when it holds a draft (#1130)

### DIFF
--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -265,6 +265,8 @@ defmodule VutuvWeb.PostLive.Composer do
   # post changeset. So both handlers take the whole payload.
   @impl true
   def handle_event("validate", %{"post" => params} = payload, socket) do
+    drafting_before? = drafting?(socket.assigns)
+
     # New posts publish public (there is no audience picker); the fallback to the
     # current preset keeps an edited restricted post from silently downgrading to
     # public as the author types.
@@ -290,7 +292,7 @@ defmodule VutuvWeb.PostLive.Composer do
         socket
       end
 
-    {:noreply, socket}
+    {:noreply, announce_draft(socket, drafting_before?)}
   end
 
   def handle_event("deny-user", %{"id" => id}, socket) do
@@ -515,6 +517,38 @@ defmodule VutuvWeb.PostLive.Composer do
     |> save_post(attrs)
     |> handle_save_result(socket)
   end
+
+  # Anything the author has already put into the composer by hand. Attached
+  # photos are deliberately left out: they live in assigns a re-mount drops
+  # anyway, so they can never be the thing that needs rescuing.
+  defp drafting?(assigns), do: assigns.body != "" or assigns.tags_value != ""
+
+  # Tell the feed that this composer holds a draft (issue #1130).
+  #
+  # The feed keeps its composer collapsed behind a "Write a post" trigger and
+  # holds that open/shut state in plain socket assigns, so every re-mount starts
+  # collapsed — and a websocket reconnect is a re-mount. A tab left in the
+  # background long enough gets one: the browser throttles the heartbeat, the
+  # socket times out, and rejoining on return re-mounts the feed. LiveView's
+  # form recovery then replays this very `validate` with the half-typed text
+  # still sitting in the DOM, so the draft comes back but the panel does not:
+  # the author returns from looking something up and the form is simply gone,
+  # with the text hidden inside it. Announcing the first content lets the feed
+  # re-open the panel in the same round trip.
+  #
+  # Only the feed composer announces. The edit, reply and remote-reply pages
+  # render the composer unconditionally, so they have nothing to re-open (and no
+  # handler for the message).
+  defp announce_draft(socket, drafting_before?) do
+    if not drafting_before? and drafting?(socket.assigns) and feed_composer?(socket.assigns) do
+      send(self(), {:composer_drafting, socket.assigns.id})
+    end
+
+    socket
+  end
+
+  defp feed_composer?(assigns),
+    do: is_nil(assigns.post) and is_nil(assigns.parent) and is_nil(assigns.remote_note)
 
   # Answering a reply from another network goes through its own context function:
   # it writes the sidecar that carries the answer out to that network, and it

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -453,6 +453,17 @@ defmodule VutuvWeb.PostLive.Feed do
     {:noreply, refresh_shown_post(socket, post_id)}
   end
 
+  # The composer says it holds a draft, so show it (issue #1130). Two moments
+  # send this: the first characters of a normal compose (the panel is already
+  # open, so the assign is a no-op), and the `validate` LiveView's form recovery
+  # replays after a reconnect — which is the one that matters. A reconnect
+  # re-mounts this LiveView, and `composer_open?` is plain socket state, so the
+  # panel collapses while the text stays in it: the author comes back to their
+  # tab, finds the form gone and has no reason to believe the draft survived.
+  def handle_info({:composer_drafting, _id}, socket) do
+    {:noreply, assign(socket, :composer_open?, true)}
+  end
+
   def handle_info(_other, socket), do: {:noreply, socket}
 
   # Swap in the post's now-screenshot-carrying copy and re-stream the entry in
@@ -634,7 +645,9 @@ defmodule VutuvWeb.PostLive.Feed do
           <%!-- Collapsed by default: the shared avatar-card trigger (see
           <.composer_trigger>), revealed via phx-click. The composer stays
           mounted (just hidden) so a half-typed draft survives a background
-          feed re-render; posting or the composer's corner ✕ collapses it. --%>
+          feed re-render; posting or the composer's corner ✕ collapses it. A
+          reconnect re-mounts this LiveView and would collapse it under a draft,
+          so a drafting composer re-opens itself (:composer_drafting). --%>
           <.composer_trigger
             :if={!@composer_open?}
             viewer={@current_user}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.165.0",
+      version: "7.165.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -632,6 +632,51 @@ defmodule VutuvWeb.PostFeedLiveTest do
       assert has_element?(live, "#open-composer")
       assert has_element?(live, "#composer-panel.hidden")
     end
+
+    test "a half-typed draft brings the composer back after a reconnect", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      # What a reconnect does (issue #1130): the feed re-mounts, so the composer
+      # starts collapsed again, while LiveView's form recovery replays the
+      # composer's phx-change with the half-typed text still sitting in the DOM.
+      # This is that second half — a collapsed feed receiving a `validate` that
+      # carries a body. The draft has to bring the panel back, or the author
+      # returns to their tab and finds the form gone with the text inside it.
+      assert has_element?(live, "#composer-panel.hidden")
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "half-typed draft"}})
+      |> render_change()
+
+      refute has_element?(live, "#composer-panel.hidden")
+      refute has_element?(live, "#open-composer")
+    end
+
+    test "typed tags alone bring the composer back too", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "", "tags" => "elixir"}})
+      |> render_change()
+
+      refute has_element?(live, "#composer-panel.hidden")
+    end
+
+    test "an empty composer stays collapsed", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      # Nothing typed, nothing to rescue: a recovered empty form must not pop
+      # the composer open under a reader who never opened it.
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "", "tags" => ""}})
+      |> render_change()
+
+      assert has_element?(live, "#composer-panel.hidden")
+      assert has_element?(live, "#open-composer")
+    end
   end
 
   describe "who to follow rail" do


### PR DESCRIPTION
Closes #1130.

**TL;DR** The feed's composer collapses on every LiveView re-mount, so a reconnect (a tab backgrounded long enough for the heartbeat to be throttled) hides a half-typed post behind the "Write a post" trigger. A composer that holds a draft now re-opens itself.

### What actually happens

`composer_open?` lives in the feed LiveView's socket assigns, and `mount/3` sets it to `false`. A websocket reconnect re-mounts the LiveView, so the panel collapses. The draft is not lost: LiveView's form recovery replays the composer's `phx-change` with the text still in the DOM, so the server gets the body back. Only the open state does not come back, which is exactly why it reads as "the form vanished but the text is still in there".

Verified in a browser: open `/feed`, open the composer, type, then `liveSocket.disconnect(); liveSocket.connect()`. Before: `#composer-panel` gains `hidden` while `data-mde-value` still holds the draft. After: the panel stays open with the draft in it.

The reporter guessed the periodic feed refresh (the 5-minute "Who to follow" reshuffle) was the trigger. It is not, but the conclusion was right: something re-renders the page and the form goes away.

### The fix

The composer announces its first content to the feed (`{:composer_drafting, id}`), and the feed re-opens the panel. On a reconnect the recovered `validate` carries the draft, so the panel comes back in the same round trip.

Unchanged on purpose:

- an empty composer still collapses on a reconnect (nothing is at stake)
- the corner close button still shuts a composer that holds a draft, with no re-open loop
- posting still collapses it
- only the feed composer announces; the edit, reply and remote-reply pages render the composer unconditionally

Attached photos are left out of the "is there a draft" test: they live in assigns a re-mount drops anyway.

### Tests

Three new cases in `post_feed_live_test.exs` covering the recovery `validate` on a collapsed feed: a body brings the panel back, tags alone bring it back, an empty form leaves it collapsed. `mix precommit` green.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01WDJdtgUsoGvE9EoHXocMxh
