### PR TITLE
Write down the LiveView reconnect trap from #1130 as a rule

### DIFF
--- a/.claude/rules/phoenix.md
+++ b/.claude/rules/phoenix.md
@@ -26,3 +26,11 @@ paths:
   the UserLive route would point to the `AppWeb.Admin.UserLive` module
 
 - `Phoenix.View` no longer is needed or included with Phoenix, don't use it
+
+## LiveView guidelines
+
+- **UI state a member can lose must not live only in socket assigns: a reconnect re-mounts the LiveView and resets it.** A websocket reconnect runs `mount/3` again, so every plain assign drops back to its initial value, and reconnects are ordinary, not exotic: a tab left in the background has its heartbeat throttled by the browser until the transport times out, and a network blip or a blue/green deploy does the same. What makes the resulting bug so confusing is an asymmetry: LiveView's **form recovery** replays a form's `phx-change` with the values still sitting in the DOM, so everything *inside* a form comes back on the server, while the socket state that merely *wraps* that form (an open/collapsed flag, a wizard step, a revealed-section set, a "show more" toggle) does not. The member sees their text intact and the form gone. This shipped as issue #1130: the feed's `composer_open?` collapsed the composer under a half-typed post, so returning from looking something up looked like the draft had been thrown away. So whenever you add a reveal / step / expand flag to a LiveView, ask what it looks like after a re-mount, and derive it from something that survives one (a recovered form field, `handle_params` and the URL, the DB) instead of leaving it at its mount default. In #1130 the composer announces its first content to the feed, which re-opens the panel from the recovered `validate` in the same round trip.
+
+- **Reproduce a reconnect in five seconds instead of waiting for a throttled tab**: in the browser console, `liveSocket.disconnect()` then `liveSocket.connect()`. And to tell a real server re-render from morphdom simply leaving the DOM alone, stamp a client-only sentinel on the attribute first (`el.dataset.someValue = "SENTINEL"`) and watch whether the rejoin overwrites it with the real value. That is what proved form recovery, rather than a stale DOM, was restoring the #1130 draft.
+
+- **Private helpers dropped between two `handle_event/3` (or `handle_info/2`) clauses split the clause group** and fail `compile --warnings-as-errors`, which is a `mix precommit` failure. Put them below the last clause of the group.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.165.1",
+      version: "7.165.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
**TL;DR** Records the bug class behind #1130 in `.claude/rules/phoenix.md`, so the next LiveView reveal/step/expand flag does not reintroduce it. Docs only, no code change.

#1130 (the feed composer disappearing with a half-typed post inside it) was not specific to the composer. Any UI flag held only in socket assigns has the same hole: a reconnect re-mounts the LiveView and resets it, and reconnects are ordinary rather than exotic. What makes the bug hard to recognise is the asymmetry with LiveView's form recovery, which replays a form's `phx-change` from the DOM and therefore restores everything inside the form while the flag wrapping it stays at its mount default. The member sees the text intact and the form gone, which reads as data loss.

Three bullets, under a new "LiveView guidelines" heading:

1. Derive losable UI state from something that survives a re-mount (a recovered form field, `handle_params` and the URL, the DB) instead of leaving it at its mount default.
2. Force a reconnect from the browser console (`liveSocket.disconnect(); liveSocket.connect()`) rather than waiting for a throttled tab, and use a client-only sentinel attribute to tell a real server re-render from morphdom leaving the DOM alone. Both are what made the #1130 diagnosis quick.
3. Private helpers dropped between two `handle_event/3` clauses split the clause group and fail `compile --warnings-as-errors`. The #1130 fix walked into this.

The file is `paths:`-scoped to `lib/**/*.ex`, so it loads exactly when someone is editing a LiveView. `mix precommit` green.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01WDJdtgUsoGvE9EoHXocMxh
