### PR TITLE
Ask before a reload throws away a post draft (#1148)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -464,6 +464,38 @@ const Hooks = {
       this._tops = null
     },
   },
+  // Ask before a reload throws a draft away (issue #1148). Hitting F5 or Cmd+R
+  // with half a post in the composer used to wipe it without a word; now the
+  // browser's own "Leave site?" dialog gets in the way first. That dialog is
+  // the only one on offer — its wording and buttons belong to the browser, and
+  // it appears only after the member has interacted with the page, which typing
+  // a post is — so the whole job here is to arm it at the right moments.
+  //
+  // The right moments are decided on the server: PostLive.Composer knows both
+  // what is in the form and what the post looked like when it opened, and
+  // stamps the verdict on data-draft-unsaved. Reading one attribute keeps this
+  // handler cheap, and (more to the point) keeps "is this worth asking about?"
+  // in one place instead of splitting it between Elixir and a DOM walk here.
+  //
+  // Only *browser*-initiated unloads reach this — reload, tab close, Back, a
+  // link to another site. A LiveView navigation never unloads the document, so
+  // it never prompts; a save that redirects releases the guard server-side
+  // before it navigates (see handle_save_result/2).
+  DraftGuard: {
+    mounted() {
+      this.guard = (event) => {
+        if (this.el.dataset.draftUnsaved !== "true") return
+        // preventDefault() is the modern way to ask for the dialog; returnValue
+        // is what Chrome/Edge < 119 and older Safari still look at.
+        event.preventDefault()
+        event.returnValue = true
+      }
+      window.addEventListener("beforeunload", this.guard)
+    },
+    destroyed() {
+      window.removeEventListener("beforeunload", this.guard)
+    },
+  },
   // Drag-to-reorder for the post composer's photo strip (issue #1104). The
   // sibling of Reorder above, with two differences that matter: the strip is a
   // wrapping grid, so the drop target is found by distance to a tile's centre

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -203,6 +203,39 @@ ActivityPub **`featured` collection** and pushed to their followers as
 profile they render — same anonymous-public gate, see
 `docs/architecture/fediverse.md`.
 
+## A reload asks before it eats a draft (issue #1148)
+
+Hitting F5 or Cmd+R halfway through a post used to wipe it without a word. Now
+the browser's own "Leave site?" dialog gets in the way first. That dialog is
+the only one available — `beforeunload` cannot be styled, worded or replaced,
+and browsers only raise it once the member has interacted with the page (typing
+a post counts) — so the whole design question is *when* to arm it.
+
+`PostLive.Composer` answers that server-side and stamps the verdict on its root
+element as `data-draft-unsaved`; the tiny `DraftGuard` hook in `assets/js/app.js`
+reads that one attribute when the browser is about to leave. Keeping the decision
+in Elixir is the point: the composer already holds both halves of it — what is in
+the form now (`@body`, `@tags_value`, `@images`, `@review`, kept current by the
+form's ordinary `phx-change`) and what the post looked like when it opened.
+
+The comparison is `unsaved?/1`, and it is deliberately **not** `drafting?/1`:
+the edit page opens full of the stored post, so "there is text in it" would arm
+the guard on every visit, and a prompt that fires when nothing is at stake is one
+people learn to click away. A quote the reply page seeded (`initial_body`) counts
+as part of the opening state too — the reader did not type it, and it comes back
+from the URL on a reload.
+
+Two things the guard deliberately does not do. It never fires on a **LiveView
+navigation**, because no document unload happens there; it catches reloads, tab
+closes, Back and links off the site. And a **successful save releases it**
+(`:saved?`, set in `handle_save_result/2` before the redirect): the permalink the
+composer navigates to is a controller page, so LiveView's `live_redirect` degrades
+into a full page load, and without the release the author would be asked to
+confirm leaving the post they just published. LiveView pushes a component's diff
+*ahead* of its redirect, so the released marker reaches the browser in time —
+verified in a browser, not only in the tests (`composer_draft_guard_test.exs`
+covers the marker; the release-before-redirect ordering is a browser fact).
+
 ## Editing closes (the edit window)
 
 An edit rewrites what other people already put their name to: like "I love

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -165,6 +165,9 @@ defmodule VutuvWeb.PostLive.Composer do
     |> assign(:user_search, "")
     |> assign(:user_results, [])
     |> assign(:error, nil)
+    # Released once the post is saved, so the unload guard (`unsaved?/1`) stops
+    # asking about content that is now safely in the database.
+    |> assign(:saved?, false)
     |> allow_upload(:images,
       accept: Vutuv.PostImageStore.extension_whitelist(),
       max_entries: Posts.max_images_per_post(),
@@ -577,6 +580,39 @@ defmodule VutuvWeb.PostLive.Composer do
   defp drafting?(assigns),
     do: assigns.body != "" or assigns.tags_value != "" or assigns.images != []
 
+  # What a reload would throw away (issue #1148) — the answer the `DraftGuard`
+  # hook turns into the browser's "Leave site?" prompt. Deliberately *not*
+  # `drafting?/1`: on the edit page the composer opens full of the stored post,
+  # so "there is text in it" would arm the guard on every visit, and a prompt
+  # that fires when nothing is at stake is one people learn to click away.
+  # What counts is the difference between the form and the state it opened in.
+  #
+  # A quote the reply page seeded (`initial_body`) is part of that opening
+  # state: the reader did not type it, and it comes back from the URL anyway.
+  # Audience, licence and the per-photo settings are left out — nobody sets
+  # them without also having content, which is caught here already.
+  defp unsaved?(%{saved?: true}), do: false
+
+  defp unsaved?(assigns), do: composer_state(assigns) != opened_state(assigns)
+
+  defp composer_state(assigns) do
+    %{
+      body: assigns.body,
+      tags: assigns.tags_value,
+      image_ids: Enum.map(assigns.images, & &1.id),
+      review: assigns.review
+    }
+  end
+
+  defp opened_state(%{post: post} = assigns) do
+    %{
+      body: (post && post.body) || assigns[:initial_body] || "",
+      tags: tags_value(post),
+      image_ids: Enum.map(post_images(post), & &1.id),
+      review: review_values(post)
+    }
+  end
+
   # Re-adopts photos LiveView form recovery hands back after a reconnect: the
   # composer's socket state died with the old socket, but the pending rows
   # survived, and the hidden `post[image_ids][]` inputs rode the recovered
@@ -683,6 +719,15 @@ defmodule VutuvWeb.PostLive.Composer do
   defp save_post(%{post: post}, attrs), do: Posts.update_post(post, attrs)
 
   defp handle_save_result({:ok, post}, socket) do
+    # The post is in the database, so there is nothing left to warn about —
+    # release the unload guard before we hand over. The three navigating
+    # branches below need this: the permalink they push to is a controller
+    # page, so LiveView's `live_redirect` degrades into a full page load, and
+    # a still-armed guard would greet the author with "Leave site?" for the
+    # post they just published. LiveView pushes a component's diff *before*
+    # its redirect, so the browser sees the released marker in time.
+    socket = assign(socket, :saved?, true)
+
     cond do
       socket.assigns.post ->
         {:noreply, push_navigate(socket, to: Posts.path(post))}
@@ -698,7 +743,8 @@ defmodule VutuvWeb.PostLive.Composer do
 
       true ->
         # The feed prepends the new post via its own {:new_post, …} broadcast;
-        # the composer just resets (audience choice sticks).
+        # the composer just resets (audience choice sticks) and re-arms for
+        # whatever gets typed next — it is empty now, so it stays quiet.
         {:noreply,
          socket
          |> assign(:body, "")
@@ -709,6 +755,7 @@ defmodule VutuvWeb.PostLive.Composer do
          |> assign(:photos, %{})
          |> assign(:open_photo, nil)
          |> assign(:text_open?, false)
+         |> assign(:saved?, false)
          |> assign(:error, nil)}
     end
   end
@@ -925,7 +972,18 @@ defmodule VutuvWeb.PostLive.Composer do
   @impl true
   def render(assigns) do
     ~H"""
-    <div id={@id} data-composer-mode={@mode}>
+    <%!-- `data-draft-unsaved` is the whole unload guard (issue #1148): the
+    `DraftGuard` hook in app.js reads it when the browser is about to leave the
+    page and, while it says "true", asks the member first. The decision is made
+    here rather than by inspecting the DOM because the composer already holds
+    both halves of it — what is in the form now, and what the post looked like
+    when it opened. --%>
+    <div
+      id={@id}
+      data-composer-mode={@mode}
+      phx-hook="DraftGuard"
+      data-draft-unsaved={to_string(unsaved?(assigns))}
+    >
       <.card>
         <.form
           for={to_form(%{}, as: :post)}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.167.0",
+      version: "7.168.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/composer_draft_guard_test.exs
+++ b/test/vutuv_web/live/composer_draft_guard_test.exs
@@ -1,0 +1,166 @@
+defmodule VutuvWeb.ComposerDraftGuardTest do
+  @moduledoc """
+  The composer's unsaved-draft guard (issue #1148). The composer marks itself
+  `data-draft-unsaved` whenever its content differs from what it opened with,
+  and the `DraftGuard` hook in `assets/js/app.js` turns that marker into the
+  browser's own "Leave site?" prompt on a reload or a tab close. So the marker
+  is the whole server-side contract, and these tests pin it down: an untouched
+  composer must stay quiet (a guard that fires on every page is a guard people
+  learn to click away), and anything the author put in by hand must arm it.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Posts
+
+  # The composer's marker, read off its root element.
+  defp guard(live) do
+    html = live |> element("#composer") |> render()
+
+    case Regex.run(~r/data-draft-unsaved="([^"]*)"/, html, capture: :all_but_first) do
+      [value] -> value
+      nil -> flunk("the composer renders no data-draft-unsaved marker")
+    end
+  end
+
+  describe "the feed composer" do
+    test "an untouched composer has nothing to lose", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      assert guard(live) == "false"
+    end
+
+    test "typed text arms the guard", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "half a thought"}})
+      |> render_change()
+
+      assert guard(live) == "true"
+    end
+
+    test "tags alone arm the guard", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "", "tags" => "elixir"}})
+      |> render_change()
+
+      assert guard(live) == "true"
+    end
+
+    test "deleting the text again disarms it", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "half a thought"}})
+      |> render_change()
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => ""}})
+      |> render_change()
+
+      assert guard(live) == "false"
+    end
+
+    test "posting empties the composer and disarms the guard", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "a whole thought", "tags" => "elixir"}})
+      |> render_submit()
+
+      assert guard(live) == "false"
+    end
+  end
+
+  describe "the edit page" do
+    test "a prefilled composer is not a draft until it is changed", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, post} = Posts.create_post(user, %{body: "as published", tags: "elixir"})
+
+      {:ok, live, _html} = live(conn, ~p"/posts/#{post.id}/edit")
+
+      assert guard(live) == "false"
+    end
+
+    test "changing the body arms the guard", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, post} = Posts.create_post(user, %{body: "as published"})
+
+      {:ok, live, _html} = live(conn, ~p"/posts/#{post.id}/edit")
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "as published, plus a sentence"}})
+      |> render_change()
+
+      assert guard(live) == "true"
+    end
+
+    test "changing the tags arms the guard", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, post} = Posts.create_post(user, %{body: "as published", tags: "elixir"})
+
+      {:ok, live, _html} = live(conn, ~p"/posts/#{post.id}/edit")
+
+      live
+      |> form("#composer-form", %{
+        "post" => %{"body" => "as published", "tags" => "elixir, phoenix"}
+      })
+      |> render_change()
+
+      assert guard(live) == "true"
+    end
+
+    test "typing the original text back disarms it", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, post} = Posts.create_post(user, %{body: "as published"})
+
+      {:ok, live, _html} = live(conn, ~p"/posts/#{post.id}/edit")
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "typo"}})
+      |> render_change()
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "as published"}})
+      |> render_change()
+
+      assert guard(live) == "false"
+    end
+  end
+
+  describe "the reply page" do
+    test "a quoted passage the reader never typed is not an unsaved draft", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      author = insert(:user, email_confirmed?: true)
+      {:ok, parent} = Posts.create_post(author, %{body: "a passage worth answering"})
+
+      {:ok, live, html} =
+        live(conn, ~p"/posts/#{parent.id}/reply?quote=a+passage+worth+answering")
+
+      # The quote really is in the editor — it is just not the reader's own
+      # work, and it comes back from the URL on a reload.
+      assert html =~ "a passage worth answering"
+      assert guard(live) == "false"
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "> a passage worth answering\n\nAgreed."}})
+      |> render_change()
+
+      assert guard(live) == "true"
+    end
+  end
+end


### PR DESCRIPTION
Closes #1148.

Hitting F5 or Cmd+R with half a post in the composer wiped it without a word. Now the browser's own "Leave site?" dialog gets in the way first. That dialog is the only one on offer (`beforeunload` cannot be styled, worded or replaced, and browsers raise it only after the member has interacted with the page, which typing a post is), so the whole design question is *when* to arm it.

The composer answers that server-side and stamps the verdict on its root element as `data-draft-unsaved`; a small `DraftGuard` hook in `app.js` reads that one attribute when the browser is about to leave. Keeping the decision in Elixir is the point: `PostLive.Composer` already holds both halves of it, what is in the form now and what the post looked like when it opened.

Comparing the two, rather than asking "is there text in it", is what keeps the guard from crying wolf: the edit page opens full of the stored post, so the naive check would prompt on every visit, and a prompt that fires when nothing is at stake is one people learn to click away. A quote the reply page seeded (`initial_body`) counts as opening state too, since the reader did not type it and it comes back from the URL anyway.

Two things it deliberately does not do:

- It never fires on a **LiveView navigation** (no document unload happens there). It catches reloads, tab closes, Back and links off the site.
- A **successful save releases it** before the redirect. The permalink the composer navigates to is a controller page, so LiveView's `live_redirect` degrades into a full page load, and a still-armed guard would ask the author to confirm leaving the post they just published.

The issue's snippet is the right API; what it needed was a condition and a release, which is where the work went.

## Verification

`mix precommit` green (5489 tests). New `composer_draft_guard_test.exs` covers the marker across the feed, the edit page and the reply page, in both directions.

Smoke-tested in a real browser, because the release-before-redirect ordering is a browser fact the test harness cannot see: with a draft in the feed composer the guard armed, clearing the text disarmed it, the prefilled edit page stayed quiet, and at the *real* unload of the post-save redirect the marker had already flipped to released.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01QAYRhkuNwjJhB8MzmapzGL