### PR TITLE
Photo mode: findable camera switch, one caption, a real discard

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -206,3 +206,4 @@ the browser within ~2s; if they ever don't, suspect that watcher first.
 - Don't reskin legacy pages per-template — edit `components.css`.
 - Don't invent new bespoke colours; stay on brand / accent / slate.
 - No em-dashes in UI copy (project-wide rule).
+- **Everything must work on a phone, and too-small UX elements are a problem** (Stefan, 2026-07-26): every interactive control a member must hit on a phone gets a finger-sized target (aim ~40px; a compact variant is acceptable only where the space genuinely cannot fit it, like the text-strip photo tiles), inputs keep their full `input_class()` size (a shrunken input is a shrunken touch target), and a feature that only works with hover or drag needs a touch path (the ◀ ▶ arrows beside HTML5 drag are the model). When in doubt, judge the mobile rendering first, not the desktop one.

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -504,15 +504,23 @@ of two ways — `@mode`, `"text"` or `"photos"`; nothing about the stored post
 differs.
 
 **Text mode** is the classic layout: editor first, a compact thumbnail strip
-below, caption/alt behind each tile's ⚙ panel. **Photo mode** leads with a
-dropzone (the grid is a `phx-drop-target`), renders the photos as a large
-grid whose caption and alt inputs sit visibly under every tile (the ⚙ panel
-keeps only camera/download), adds more photos via a tile in the grid, and
-folds the text editor behind one "Add text (optional)" button — a non-empty
-body keeps it open, so recovered text can never hide. The book/film review
-triggers and the bottom-row picker are text-mode-only; the licence row sits
-with the photos in both modes. The cover badge appears only from the second
-photo on (with one photo there is no order to mark).
+below, caption/alt behind each tile's ⚙ panel. **Photo mode** opens with a
+one-line explainer of what the mode is, leads with a dropzone (the grid is a
+`phx-drop-target`), renders the photos as a large grid, adds more photos via
+a tile in the grid, and folds the text editor behind one "Add text
+(optional)" button — a non-empty body keeps it open, so recovered text can
+never hide. Under every tile sit the things a photographer looks for and
+would not find behind the ⚙: **one caption input** (it doubles as the
+accessible name via `photo_alt/1`, so the alt input stays an opt-in
+refinement in the panel rather than a second required-looking field) and,
+when the file carries camera facts, the **"Show camera settings" switch with
+the very line visitors would see**. **Tapping the photo itself opens its
+options panel** (alt, download) — the scrim's ⚙ stays as the labeled,
+keyboard-reachable control, but the picture is the target people actually
+try. The book/film review triggers and the bottom-row picker are
+text-mode-only; the licence row sits with the photos in both modes. The
+cover badge appears only from the second photo on, and the amber ALT nudge
+only while a photo has **neither** caption nor alt.
 
 The mode is a **radio pair inside the form** (`post[mode]`, the segmented
 control at the top), so switching is an ordinary `validate` and LiveView form
@@ -521,6 +529,13 @@ offers the pill (text-first) and a camera button (photos-first) — the feed
 sends `set_mode` via `send_update`, where the camera always gets its way and
 the pill never rearranges a held draft; editing a photo-only post (images,
 empty body) derives photo mode; replies are text-only (no switch).
+
+**The ✕ means two different things by mode.** A text draft survives a close
+(issue #1135 — the composer only collapses). Photo mode's ✕ is a real
+**discard** behind a confirm: the pending rows are deleted on the spot
+(`discard-draft` → `{:composer_discarded, id}` to the feed), because
+collapsing over invisible uploaded photos meant the next "Write a post"
+surprised people with last week's pictures.
 
 **Photos survive a reconnect.** The attached rows ride the form as hidden
 `post[image_ids][]` inputs; a re-mounted composer re-adopts the recovered,
@@ -593,10 +608,11 @@ from `alt`, which describes the picture for people who cannot see it), a
 metadata-stripped) and an **original download** switch with its one follow-up,
 which file (see [images.md](images.md)). The panel expands below the strip
 rather than floating — a popover on a phone covers what it is about and has
-nowhere to put a follow-up. In photo mode the two texts move out of the panel
-to inline inputs under every tile (the panel drops them there — two same-name
-inputs would corrupt the submit). An "apply to all photos" shortcut copies the
-two switches (never the texts: a caption describes one picture).
+nowhere to put a follow-up. In photo mode the caption and the camera switch
+move out of the panel to under the tile itself (the panel drops them there —
+two same-name inputs would corrupt the submit); the alt input renders in the
+panel in both modes. An "apply to all photos" shortcut copies the two
+switches (never the texts: a caption describes one picture).
 
 **Per post**, one `Vutuv.Posts.PhotoLicense` from a fixed vocabulary (`arr`
 default, CC BY / BY-SA / BY-NC / CC0 4.0). The select appears only once a photo

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -211,6 +211,14 @@ defmodule VutuvWeb.PostLive.Composer do
   defp photo_setting(photos, %PostImage{} = image, key),
     do: photos |> photo_settings(image) |> Map.fetch!(key)
 
+  # Whether the photo has an accessible name: an alt, or the caption that
+  # `PostComponents.photo_alt/1` falls back to. The amber ALT nudge shows
+  # only while it has neither — a photo with a caption is not undescribed.
+  defp photo_described?(photos, %PostImage{} = image) do
+    settings = photo_settings(photos, image)
+    settings.alt != "" or settings.caption != ""
+  end
+
   defp open_photo(_images, nil), do: nil
   defp open_photo(images, id), do: Enum.find(images, &(&1.id == id))
 
@@ -543,6 +551,21 @@ defmodule VutuvWeb.PostLive.Composer do
     {:noreply, cancel_upload(socket, :images, ref)}
   end
 
+  # Photo mode's ✕: a real discard, not a collapse. Closing over invisible
+  # uploaded photos meant the next "Write a post" surprised people with last
+  # week's pictures, so the pending rows die now (their files with them), the
+  # form resets, and the feed collapses the panel. Only the feed composer
+  # renders the ✕, so the host always has the handle_info.
+  def handle_event("discard-draft", _params, socket) do
+    Enum.each(socket.assigns.images, fn image ->
+      if is_nil(image.post_id), do: Posts.delete_pending_image(image)
+    end)
+
+    send(self(), {:composer_discarded, socket.assigns.id})
+
+    {:noreply, reset_composer(socket)}
+  end
+
   def handle_event("save", %{"post" => params} = payload, socket) do
     # The submitted texts are the truth (a keystroke may not have round-tripped
     # through `validate` yet), so merge them before writing.
@@ -743,20 +766,8 @@ defmodule VutuvWeb.PostLive.Composer do
 
       true ->
         # The feed prepends the new post via its own {:new_post, …} broadcast;
-        # the composer just resets (audience choice sticks) and re-arms for
-        # whatever gets typed next — it is empty now, so it stays quiet.
-        {:noreply,
-         socket
-         |> assign(:body, "")
-         |> assign(:tags_value, "")
-         |> assign(:review, @empty_review)
-         |> assign(:review_lookup_error, nil)
-         |> assign(:images, [])
-         |> assign(:photos, %{})
-         |> assign(:open_photo, nil)
-         |> assign(:text_open?, false)
-         |> assign(:saved?, false)
-         |> assign(:error, nil)}
+        # the composer just resets (audience choice sticks).
+        {:noreply, reset_composer(socket)}
     end
   end
 
@@ -766,6 +777,24 @@ defmodule VutuvWeb.PostLive.Composer do
 
   defp handle_save_result({:error, reason}, socket) do
     {:noreply, assign(socket, :error, save_error_message(reason))}
+  end
+
+  # Back to an empty form: after a successful post, and after photo mode's ✕
+  # discards a draft. Mode and audience choice stick on purpose, and the
+  # unload guard re-arms for whatever gets typed next (`saved?` back to
+  # false, issue #1148) — the form is empty now, so it stays quiet.
+  defp reset_composer(socket) do
+    socket
+    |> assign(:body, "")
+    |> assign(:tags_value, "")
+    |> assign(:review, @empty_review)
+    |> assign(:review_lookup_error, nil)
+    |> assign(:images, [])
+    |> assign(:photos, %{})
+    |> assign(:open_photo, nil)
+    |> assign(:text_open?, false)
+    |> assign(:saved?, false)
+    |> assign(:error, nil)
   end
 
   defp save_error_message(:invalid_denials), do: gettext("The audience selection is not valid.")
@@ -1018,17 +1047,42 @@ defmodule VutuvWeb.PostLive.Composer do
               </.mode_tab>
             </div>
 
+            <%!-- The ✕ means two different things by mode, and says so via
+            its tooltip: a TEXT draft survives a close (issue #1135 — the
+            composer only collapses, `close-composer` bubbling to the feed),
+            while a PHOTO draft is really discarded (`discard-draft`, handled
+            here): collapsing over invisible uploaded photos meant the next
+            "Write a post" surprised people with last week's pictures. The
+            confirm guards the destructive half, and only when there is
+            something to lose. --%>
             <button
               :if={@post == nil and @parent == nil and @remote_note == nil}
               type="button"
-              phx-click="close-composer"
-              aria-label={gettext("Close")}
-              title={gettext("Close")}
-              class="-mr-2 -mt-1 ml-auto rounded-lg px-2 py-1 text-sm font-semibold text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+              phx-click={if @mode == "photos", do: "discard-draft", else: "close-composer"}
+              phx-target={if @mode == "photos", do: @myself}
+              data-confirm={
+                if @mode == "photos" and drafting?(assigns),
+                  do: gettext("Discard the photos and text of this draft?")
+              }
+              aria-label={if @mode == "photos", do: gettext("Discard draft"), else: gettext("Close")}
+              title={if @mode == "photos", do: gettext("Discard draft"), else: gettext("Close")}
+              class="-mr-2 -mt-1 ml-auto rounded-lg px-3 py-2 text-sm font-semibold text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
             >
               ✕
             </button>
           </div>
+
+          <%!-- One line saying what this mode IS, for everyone who lands here
+          from the camera button without a mental model of the two modes. --%>
+          <p
+            :if={@mode == "photos"}
+            data-photo-mode-hint
+            class="mb-3 text-xs text-slate-600 dark:text-slate-400"
+          >
+            {gettext(
+              "A photo post shows your pictures big and first; text is optional. For a post that is mainly text, switch to \"Text\"."
+            )}
+          </p>
 
           <%!-- Text mode leads with the editor. Photo mode renders the same
           editor below the photos instead (one instance at a time, so the ids
@@ -1061,7 +1115,7 @@ defmodule VutuvWeb.PostLive.Composer do
                 index={index}
                 count={length(@images)}
                 open?={@open_photo == image.id}
-                alt_missing?={photo_setting(@photos, image, :alt) == ""}
+                alt_missing?={photo_described?(@photos, image) == false}
                 myself={@myself}
               />
             </div>
@@ -1092,28 +1146,51 @@ defmodule VutuvWeb.PostLive.Composer do
                 index={index}
                 count={length(@images)}
                 open?={@open_photo == image.id}
-                alt_badge?={false}
-                alt_missing?={photo_setting(@photos, image, :alt) == ""}
+                alt_missing?={photo_described?(@photos, image) == false}
+                roomy?
                 myself={@myself}
               />
 
               <div class="mt-1.5 space-y-1.5">
+                <%!-- One visible text per photo: the caption. It doubles as
+                the accessible name when no alt is written (photo_alt/1), so
+                the alt input can stay an opt-in refinement in the panel
+                instead of a second required-looking field. Full input size
+                on purpose: a shrunken input is a shrunken touch target. --%>
                 <input
                   type="text"
                   name={"photo[#{image.id}][caption]"}
                   value={photo_setting(@photos, image, :caption)}
                   phx-debounce="300"
-                  placeholder={gettext("Caption, shown under the photo (optional)")}
-                  class={[input_class(), "px-2.5 py-1.5 text-xs"]}
+                  placeholder={gettext("Caption (optional)")}
+                  class={input_class()}
                 />
-                <input
-                  type="text"
-                  name={"photo[#{image.id}][alt]"}
-                  value={photo_setting(@photos, image, :alt)}
-                  phx-debounce="300"
-                  placeholder={gettext("Describe the photo for people who can't see it")}
-                  class={[input_class(), "px-2.5 py-1.5 text-xs"]}
-                />
+
+                <%!-- The photographer's marquee switch, right where the photo
+                is — behind the tile's ⚙ nobody found it. Only rendered when
+                the file actually carries camera facts, and it shows the very
+                line visitors would see. --%>
+                <label
+                  :if={PostImage.camera_info?(image)}
+                  data-photo-camera-inline={image.id}
+                  class="flex items-start gap-2 py-1 text-sm text-slate-700 dark:text-slate-200"
+                >
+                  <input
+                    type="checkbox"
+                    checked={photo_setting(@photos, image, :show_camera_info)}
+                    phx-click="photo-toggle"
+                    phx-value-id={image.id}
+                    phx-value-field="show_camera_info"
+                    phx-target={@myself}
+                    class={checkbox_class()}
+                  />
+                  <span class="min-w-0">
+                    <span class="font-semibold">{gettext("Show camera settings")}</span>
+                    <span class="mt-0.5 block text-xs text-slate-600 dark:text-slate-400">
+                      {PostComponents.camera_line(image)}
+                    </span>
+                  </span>
+                </label>
               </div>
             </div>
 
@@ -1176,7 +1253,8 @@ defmodule VutuvWeb.PostLive.Composer do
             image={open_photo(@images, @open_photo)}
             settings={photo_settings(@photos, open_photo(@images, @open_photo))}
             many?={length(@images) > 1}
-            texts?={@mode == "text"}
+            caption?={@mode == "text"}
+            camera?={@mode == "text"}
             insert?={@mode == "text"}
             id={"#{@id}-photo-panel"}
             myself={@myself}
@@ -1559,7 +1637,7 @@ defmodule VutuvWeb.PostLive.Composer do
   defp mode_tab(assigns) do
     ~H"""
     <label class={[
-      "cursor-pointer whitespace-nowrap rounded-md px-3 py-1",
+      "cursor-pointer whitespace-nowrap rounded-md px-3 py-1.5",
       "has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-brand-500",
       (@active &&
          "bg-white font-semibold text-brand-700 shadow-sm dark:bg-slate-900 dark:text-brand-100") ||
@@ -1605,12 +1683,16 @@ defmodule VutuvWeb.PostLive.Composer do
   # sits here rather than on the outer cell so a drag in the grid's caption
   # inputs selects text instead of starting a photo drag; the PhotoStrip hook
   # finds the reorder unit via closest("[data-photo-tile]") either way.
+  # `roomy?` grows the scrim buttons to finger size — the photo-mode tiles
+  # have the width for it, while the text strip's small tiles (3-5 per row)
+  # would overflow; too-small touch targets are a standing mobile complaint.
   attr(:image, :any, required: true)
   attr(:index, :integer, required: true)
   attr(:count, :integer, required: true)
   attr(:open?, :boolean, required: true)
   attr(:alt_badge?, :boolean, default: true)
   attr(:alt_missing?, :boolean, required: true)
+  attr(:roomy?, :boolean, default: false)
   attr(:myself, :any, required: true)
 
   defp photo_frame(assigns) do
@@ -1622,7 +1704,19 @@ defmodule VutuvWeb.PostLive.Composer do
         (@open? && "ring-2 ring-brand-500") || "ring-slate-200 dark:ring-slate-800"
       ]}
     >
-      <img src={PostImage.url(@image, "thumb")} alt="" class="h-full w-full object-cover" />
+      <%!-- The picture itself opens its options panel: it is the biggest
+      target on screen and the first thing people try, where the scrim's ⚙
+      (kept as the labeled, keyboard-reachable control) goes unseen. The
+      binding sits on the img, not the frame, so the scrim buttons don't
+      double-fire it through bubbling. --%>
+      <img
+        src={PostImage.url(@image, "thumb")}
+        alt=""
+        phx-click="photo-open"
+        phx-value-id={@image.id}
+        phx-target={@myself}
+        class="h-full w-full cursor-pointer object-cover"
+      />
 
       <%!-- The hero marker. A number on every tile would be noise; what the
       author needs to know is which photo leads — and with a single photo
@@ -1650,7 +1744,10 @@ defmodule VutuvWeb.PostLive.Composer do
       <%!-- Controls sit on a scrim at the bottom of the tile: always visible
       on touch (where there is no hover), so nothing is undiscoverable on a
       phone. --%>
-      <div class="absolute inset-x-0 bottom-0 flex items-center justify-between gap-0.5 bg-slate-900/60 px-1 py-1">
+      <div class={[
+        "absolute inset-x-0 bottom-0 flex items-center justify-between bg-slate-900/60",
+        (@roomy? && "gap-1 px-1.5 py-1") || "gap-0.5 px-1 py-1"
+      ]}>
         <button
           type="button"
           phx-click="photo-move"
@@ -1659,7 +1756,7 @@ defmodule VutuvWeb.PostLive.Composer do
           phx-target={@myself}
           disabled={@index == 0}
           aria-label={gettext("Move photo earlier")}
-          class="rounded px-1 text-xs text-white disabled:opacity-30"
+          class={[scrim_button_class(@roomy?), "disabled:opacity-30"]}
         >
           ◀
         </button>
@@ -1670,7 +1767,7 @@ defmodule VutuvWeb.PostLive.Composer do
           phx-target={@myself}
           aria-label={gettext("Photo options")}
           title={gettext("Photo options")}
-          class="rounded px-1 text-xs text-white hover:bg-white/20"
+          class={[scrim_button_class(@roomy?), "hover:bg-white/20"]}
         >
           ⚙
         </button>
@@ -1681,7 +1778,7 @@ defmodule VutuvWeb.PostLive.Composer do
           phx-target={@myself}
           aria-label={gettext("Remove photo")}
           title={gettext("Remove photo")}
-          class="rounded px-1 text-xs text-white hover:bg-white/20"
+          class={[scrim_button_class(@roomy?), "hover:bg-white/20"]}
         >
           ✕
         </button>
@@ -1693,7 +1790,7 @@ defmodule VutuvWeb.PostLive.Composer do
           phx-target={@myself}
           disabled={@index == @count - 1}
           aria-label={gettext("Move photo later")}
-          class="rounded px-1 text-xs text-white disabled:opacity-30"
+          class={[scrim_button_class(@roomy?), "disabled:opacity-30"]}
         >
           ▶
         </button>
@@ -1701,6 +1798,11 @@ defmodule VutuvWeb.PostLive.Composer do
     </div>
     """
   end
+
+  # The tile scrim's button recipe: finger-sized in the photo grid (roomy),
+  # compact in the text strip whose small tiles cannot fit four 40px targets.
+  defp scrim_button_class(true), do: "rounded-md px-2.5 py-1.5 text-sm text-white"
+  defp scrim_button_class(false), do: "rounded px-1 text-xs text-white"
 
   # The outline camera glyph (heroicons "camera") for the dropzone and the
   # add-more tile — an SVG rather than the 📷 emoji so it takes the text
@@ -1747,15 +1849,19 @@ defmodule VutuvWeb.PostLive.Composer do
   switch reveals the choice of file and, when the photo carries a location,
   warns about it at the moment the exact file is picked.
 
-  `texts?` drops the caption/alt inputs (photo mode renders them under every
-  tile, and a second input of the same name would corrupt the submit);
+  Photo mode moves two things out of here to where they are seen (issue
+  #1104 follow-up): `caption?` drops the caption input (it sits under every
+  tile there, and a second input of the same name would corrupt the submit)
+  and `camera?` drops the camera block (the inline row under the tile owns
+  it). The alt input always renders here — one opt-in refinement, one place.
   `insert?` drops the "Insert into text" action (photo mode may have no
   editor on screen to insert into).
   """
   attr(:image, :any, required: true)
   attr(:settings, :map, required: true)
   attr(:many?, :boolean, required: true)
-  attr(:texts?, :boolean, default: true)
+  attr(:caption?, :boolean, default: true)
+  attr(:camera?, :boolean, default: true)
   attr(:insert?, :boolean, default: true)
   attr(:id, :string, required: true)
   attr(:myself, :any, required: true)
@@ -1780,7 +1886,7 @@ defmodule VutuvWeb.PostLive.Composer do
         />
         <div class="min-w-0 flex-1 space-y-2">
           <input
-            :if={@texts?}
+            :if={@caption?}
             type="text"
             name={"photo[#{@image.id}][caption]"}
             value={@settings.caption}
@@ -1789,7 +1895,6 @@ defmodule VutuvWeb.PostLive.Composer do
             class={input_class()}
           />
           <input
-            :if={@texts?}
             type="text"
             name={"photo[#{@image.id}][alt]"}
             value={@settings.alt}
@@ -1797,9 +1902,6 @@ defmodule VutuvWeb.PostLive.Composer do
             placeholder={gettext("Describe the photo for people who can't see it")}
             class={input_class()}
           />
-          <p :if={not @texts?} class="text-sm text-slate-600 dark:text-slate-400">
-            {gettext("Caption and description live under the photo itself.")}
-          </p>
         </div>
         <button
           type="button"
@@ -1814,8 +1916,10 @@ defmodule VutuvWeb.PostLive.Composer do
 
       <div class="mt-4 space-y-3">
         <%!-- Camera info. The switch is disabled when there is nothing to
-        show, and says so — a dead toggle with no explanation reads as a bug. --%>
-        <div>
+        show, and says so — a dead toggle with no explanation reads as a bug.
+        Photo mode drops the whole block: the inline row under the tile owns
+        the switch there. --%>
+        <div :if={@camera?}>
           <label class={[
             "flex items-start gap-2 text-sm",
             (@camera_info? && "text-slate-700 dark:text-slate-200") ||

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -471,6 +471,12 @@ defmodule VutuvWeb.PostLive.Feed do
     {:noreply, assign(socket, :composer_open?, true)}
   end
 
+  # Photo mode's ✕ discarded the draft inside the component; the panel
+  # collapses with it (the component cannot reach this assign itself).
+  def handle_info({:composer_discarded, _id}, socket) do
+    {:noreply, assign(socket, :composer_open?, false)}
+  end
+
   def handle_info(_other, socket), do: {:noreply, socket}
 
   # Swap in the post's now-screenshot-carrying copy and re-stream the entry in

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.168.0",
+      version: "7.168.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -613,7 +613,7 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1353
+#: lib/vutuv_web/live/post_live/composer.ex:1489
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -623,7 +623,7 @@ msgstr "Öffentlich"
 
 #: lib/vutuv_web/components/ui.ex:2863
 #: lib/vutuv_web/live/organization_live/edit.ex:339
-#: lib/vutuv_web/live/post_live/composer.ex:1362
+#: lib/vutuv_web/live/post_live/composer.ex:1498
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:95
@@ -1698,9 +1698,9 @@ msgstr "Schauen Sie in Ihr Postfach"
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:967
-#: lib/vutuv_web/live/post_live/composer.ex:968
-#: lib/vutuv_web/live/post_live/composer.ex:1750
+#: lib/vutuv_web/live/post_live/composer.ex:1067
+#: lib/vutuv_web/live/post_live/composer.ex:1068
+#: lib/vutuv_web/live/post_live/composer.ex:1910
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1938,7 +1938,7 @@ msgstr ""
 "Wir haben eine PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie sie "
 "unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:823
+#: lib/vutuv_web/live/post_live/feed.ex:829
 #: lib/vutuv_web/templates/user/show.html.heex:1429
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2152,12 +2152,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:1313
+#: lib/vutuv_web/live/post_live/composer.ex:1449
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1470
+#: lib/vutuv_web/live/post_live/composer.ex:1606
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
@@ -2168,7 +2168,7 @@ msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1107
+#: lib/vutuv_web/live/post_live/composer.ex:1242
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2191,7 +2191,7 @@ msgid "Edit post"
 msgstr "Beitrag bearbeiten"
 
 #: lib/vutuv_web/live/post_live/feed.ex:85
-#: lib/vutuv_web/live/post_live/feed.ex:650
+#: lib/vutuv_web/live/post_live/feed.ex:656
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:116
@@ -2209,12 +2209,12 @@ msgstr "Folgen Sie %{name}, um ihn zu lesen."
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1446
+#: lib/vutuv_web/live/post_live/composer.ex:1582
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1374
+#: lib/vutuv_web/live/post_live/composer.ex:1510
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
@@ -2225,41 +2225,41 @@ msgstr "Diesen Beitrag verbergen vor…"
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1416
+#: lib/vutuv_web/live/post_live/composer.ex:1552
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:766
-#: lib/vutuv_web/live/post_live/composer.ex:814
+#: lib/vutuv_web/live/post_live/composer.ex:842
+#: lib/vutuv_web/live/post_live/composer.ex:890
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:764
+#: lib/vutuv_web/live/post_live/feed.ex:770
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:742
+#: lib/vutuv_web/live/post_live/composer.ex:818
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1406
+#: lib/vutuv_web/live/post_live/composer.ex:1542
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1396
+#: lib/vutuv_web/live/post_live/composer.ex:1532
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1362
+#: lib/vutuv_web/live/post_live/composer.ex:1498
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2303,7 +2303,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:1432
+#: lib/vutuv_web/live/post_live/composer.ex:1568
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2319,12 +2319,12 @@ msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1360
+#: lib/vutuv_web/live/post_live/composer.ex:1496
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:719
+#: lib/vutuv_web/live/post_live/feed.ex:725
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2338,12 +2338,12 @@ msgstr[1] "%{formatted} neue Beiträge anzeigen"
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:839
+#: lib/vutuv_web/live/post_live/composer.ex:915
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:724
+#: lib/vutuv_web/live/post_live/composer.ex:800
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
@@ -2353,12 +2353,12 @@ msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1918
+#: lib/vutuv_web/live/post_live/composer.ex:2080
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
@@ -2372,12 +2372,12 @@ msgstr "Upload fehlgeschlagen."
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1531
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1532
+#: lib/vutuv_web/live/post_live/composer.ex:1668
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
@@ -2413,17 +2413,17 @@ msgstr "Personen, denen Sie nicht folgen"
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1183
+#: lib/vutuv_web/live/post_live/composer.ex:1319
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr "Tags, durch Komma oder Leerzeichen getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1908
+#: lib/vutuv_web/live/post_live/composer.ex:2070
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1912
+#: lib/vutuv_web/live/post_live/composer.ex:2074
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
@@ -2535,7 +2535,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1648
-#: lib/vutuv_web/live/post_live/feed.ex:812
+#: lib/vutuv_web/live/post_live/feed.ex:818
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2571,13 +2571,13 @@ msgstr "Antworten"
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:727
-#: lib/vutuv_web/live/post_live/composer.ex:1350
+#: lib/vutuv_web/live/post_live/composer.ex:803
+#: lib/vutuv_web/live/post_live/composer.ex:1486
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empfängerkreis nicht einschränken."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1477
+#: lib/vutuv_web/live/post_live/composer.ex:1613
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
@@ -2832,7 +2832,7 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:672
+#: lib/vutuv_web/live/post_live/feed.ex:678
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2890,7 +2890,7 @@ msgstr "Noch keine Vernetzungen."
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1386
+#: lib/vutuv_web/live/post_live/composer.ex:1522
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
@@ -4727,7 +4727,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:769
+#: lib/vutuv_web/live/post_live/feed.ex:775
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -5535,7 +5535,7 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:745
+#: lib/vutuv_web/live/post_live/composer.ex:821
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
@@ -5657,7 +5657,7 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:1548
 #: lib/vutuv_web/components/post_components.ex:1929
 #: lib/vutuv_web/live/notification_live/index.ex:601
-#: lib/vutuv_web/live/post_live/feed.ex:884
+#: lib/vutuv_web/live/post_live/feed.ex:890
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr "Beitrag ansehen"
@@ -5757,7 +5757,7 @@ msgstr "Personen, die nicht mit Ihnen interagieren können."
 msgid "Personal tokens for the vutuv API."
 msgstr "Persönliche Tokens für die vutuv-API."
 
-#: lib/vutuv_web/live/post_live/composer.ex:959
+#: lib/vutuv_web/live/post_live/composer.ex:1046
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -8886,13 +8886,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:851
-#: lib/vutuv_web/live/post_live/feed.ex:852
+#: lib/vutuv_web/live/post_live/feed.ex:857
+#: lib/vutuv_web/live/post_live/feed.ex:858
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:846
+#: lib/vutuv_web/live/post_live/feed.ex:852
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -13824,7 +13824,7 @@ msgid "Search title, poster or organization"
 msgstr "Titel, Ersteller oder Organisation suchen"
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1255
+#: lib/vutuv_web/live/post_live/composer.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
@@ -14346,7 +14346,7 @@ msgstr "Volle Breite"
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1887
+#: lib/vutuv_web/live/post_live/composer.ex:2049
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
@@ -14410,14 +14410,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3301
 #: lib/vutuv_web/controllers/settings_controller.ex:437
-#: lib/vutuv_web/live/post_live/feed.ex:798
+#: lib/vutuv_web/live/post_live/feed.ex:804
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:813
+#: lib/vutuv_web/live/post_live/feed.ex:819
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -14580,19 +14580,19 @@ msgstr "hat %{count} neue Einträge im Lebenslauf:"
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1263
+#: lib/vutuv_web/live/post_live/composer.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Author(s)"
 msgstr "Autor(en)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1331
+#: lib/vutuv_web/live/post_live/composer.ex:1467
 #, elixir-autogen, elixir-format
 msgid "Book"
 msgstr "Buch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:933
 #: lib/vutuv_web/components/post_components.ex:2741
-#: lib/vutuv_web/live/post_live/composer.ex:1209
+#: lib/vutuv_web/live/post_live/composer.ex:1345
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
@@ -14607,7 +14607,7 @@ msgstr "Kino"
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1263
+#: lib/vutuv_web/live/post_live/composer.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Director"
 msgstr "Regie"
@@ -14617,39 +14617,39 @@ msgstr "Regie"
 msgid "E-book"
 msgstr "E-Book"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1343
+#: lib/vutuv_web/live/post_live/composer.ex:1479
 #, elixir-autogen, elixir-format
 msgid "Film"
 msgstr "Film"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:933
 #: lib/vutuv_web/components/post_components.ex:2740
-#: lib/vutuv_web/live/post_live/composer.ex:1208
+#: lib/vutuv_web/live/post_live/composer.ex:1344
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1229
+#: lib/vutuv_web/live/post_live/composer.ex:1365
 #, elixir-autogen, elixir-format
 msgid "IMDb link or ID"
 msgstr "IMDb-Link oder -ID"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1230
+#: lib/vutuv_web/live/post_live/composer.ex:1366
 #, elixir-autogen, elixir-format
 msgid "ISBN"
 msgstr "ISBN"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1243
+#: lib/vutuv_web/live/post_live/composer.ex:1379
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1240
+#: lib/vutuv_web/live/post_live/composer.ex:1376
 #, elixir-autogen, elixir-format
 msgid "Looking up…"
 msgstr "Wird nachgeschlagen …"
 
-#: lib/vutuv_web/live/post_live/composer.ex:416
+#: lib/vutuv_web/live/post_live/composer.ex:427
 #, elixir-autogen, elixir-format
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr "Zu dieser ISBN wurde nichts gefunden. Bitte füllen Sie die Felder selbst aus."
@@ -14659,24 +14659,24 @@ msgstr "Zu dieser ISBN wurde nichts gefunden. Bitte füllen Sie die Felder selbs
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1282
+#: lib/vutuv_web/live/post_live/composer.ex:1418
 #, elixir-autogen, elixir-format
 msgid "Read as… (optional)"
 msgstr "Gelesen als … (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1218
+#: lib/vutuv_web/live/post_live/composer.ex:1354
 #, elixir-autogen, elixir-format
 msgid "Remove review"
 msgstr "Besprechung entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1327
-#: lib/vutuv_web/live/post_live/composer.ex:1328
+#: lib/vutuv_web/live/post_live/composer.ex:1463
+#: lib/vutuv_web/live/post_live/composer.ex:1464
 #, elixir-autogen, elixir-format
 msgid "Review a book"
 msgstr "Ein Buch besprechen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1339
-#: lib/vutuv_web/live/post_live/composer.ex:1340
+#: lib/vutuv_web/live/post_live/composer.ex:1475
+#: lib/vutuv_web/live/post_live/composer.ex:1476
 #, elixir-autogen, elixir-format
 msgid "Review a film"
 msgstr "Einen Film besprechen"
@@ -14686,17 +14686,17 @@ msgstr "Einen Film besprechen"
 msgid "Streaming"
 msgstr "Streaming"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1281
+#: lib/vutuv_web/live/post_live/composer.ex:1417
 #, elixir-autogen, elixir-format
 msgid "Watched as… (optional)"
 msgstr "Gesehen als … (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1295
+#: lib/vutuv_web/live/post_live/composer.ex:1431
 #, elixir-autogen, elixir-format
 msgid "With an ISBN, the post shows the book cover and a shop link automatically."
 msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1275
+#: lib/vutuv_web/live/post_live/composer.ex:1411
 #: lib/vutuv_web/templates/education/form_content.html.heex:47
 #: lib/vutuv_web/templates/education/form_content.html.heex:48
 #: lib/vutuv_web/templates/education/form_content.html.heex:67
@@ -15113,13 +15113,13 @@ msgstr "Erwähnung"
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:732
+#: lib/vutuv_web/live/post_live/composer.ex:808
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten: jemand hat ihn geliked, geteilt oder beantwortet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:735
+#: lib/vutuv_web/live/post_live/composer.ex:811
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -17317,7 +17317,7 @@ msgstr ""
 "in eckigen Klammern, wie eine Lautschrift geschrieben wird; die Klammern "
 "ergänzen wir für Sie. Bleibt das Feld leer, wird nichts angezeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1900
+#: lib/vutuv_web/live/post_live/composer.ex:2062
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Diese Einstellungen für alle Fotos übernehmen"
@@ -17347,19 +17347,17 @@ msgstr "CC BY-SA 4.0 (Namensnennung, gleiche Bedingungen)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1048
-#: lib/vutuv_web/live/post_live/composer.ex:1730
+#: lib/vutuv_web/live/post_live/composer.ex:1894
 #, elixir-autogen, elixir-format
 msgid "Caption, shown under the photo (optional)"
 msgstr "Bildunterschrift, erscheint unter dem Foto (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:1729
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Titelbild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1056
-#: lib/vutuv_web/live/post_live/composer.ex:1739
+#: lib/vutuv_web/live/post_live/composer.ex:1902
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
@@ -17371,37 +17369,37 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 msgid "Download the original"
 msgstr "Original herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1095
+#: lib/vutuv_web/live/post_live/composer.ex:1230
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr "Zum Umsortieren ziehen. Das erste Foto führt die Galerie an."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1849
+#: lib/vutuv_web/live/post_live/composer.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr "Alle Metadaten bleiben erhalten, auch alles, was Ihre Kamera hineingeschrieben hat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1806
+#: lib/vutuv_web/live/post_live/composer.ex:1968
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Alle dürfen dieses Foto herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1808
+#: lib/vutuv_web/live/post_live/composer.ex:1970
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Volle Auflösung, direkt aus dem Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1827
+#: lib/vutuv_web/live/post_live/composer.ex:1989
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1603
+#: lib/vutuv_web/live/post_live/composer.ex:1758
 #, elixir-autogen, elixir-format
 msgid "Move photo earlier"
 msgstr "Foto nach vorne schieben"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1637
+#: lib/vutuv_web/live/post_live/composer.ex:1792
 #, elixir-autogen, elixir-format
 msgid "Move photo later"
 msgstr "Foto nach hinten schieben"
@@ -17411,7 +17409,7 @@ msgstr "Foto nach hinten schieben"
 msgid "Next photo"
 msgstr "Nächstes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1585
+#: lib/vutuv_web/live/post_live/composer.ex:1737
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
@@ -17443,8 +17441,8 @@ msgstr "Foto %{n} von %{total}"
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1613
-#: lib/vutuv_web/live/post_live/composer.ex:1614
+#: lib/vutuv_web/live/post_live/composer.ex:1768
+#: lib/vutuv_web/live/post_live/composer.ex:1769
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
@@ -17461,49 +17459,50 @@ msgstr "Fotos:"
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1624
-#: lib/vutuv_web/live/post_live/composer.ex:1625
+#: lib/vutuv_web/live/post_live/composer.ex:1779
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1829
+#: lib/vutuv_web/live/post_live/composer.ex:1991
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qualität unverändert."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1778
+#: lib/vutuv_web/live/post_live/composer.ex:1188
+#: lib/vutuv_web/live/post_live/composer.ex:1940
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:757
+#: lib/vutuv_web/live/post_live/composer.ex:833
 #: lib/vutuv_web/live/post_live/remote_reply.ex:87
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1847
+#: lib/vutuv_web/live/post_live/composer.ex:2009
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Die Datei genau so, wie ich sie hochgeladen habe"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1786
+#: lib/vutuv_web/live/post_live/composer.ex:1948
 #, elixir-autogen, elixir-format
 msgid "This file carries no camera information."
 msgstr "Diese Datei enthält keine Kameradaten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1870
+#: lib/vutuv_web/live/post_live/composer.ex:2032
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen Sie das Foto, wenn Sie das nicht möchten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1862
+#: lib/vutuv_web/live/post_live/composer.ex:2024
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:760
+#: lib/vutuv_web/live/post_live/composer.ex:836
 #: lib/vutuv_web/live/post_live/remote_reply.ex:84
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
@@ -17524,12 +17523,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1140
+#: lib/vutuv_web/live/post_live/composer.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Wer diese Fotos weiterverwenden darf"
 
-#: lib/vutuv_web/live/post_live/composer.ex:752
+#: lib/vutuv_web/live/post_live/composer.ex:828
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
@@ -17539,7 +17538,7 @@ msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke gesc
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:763
+#: lib/vutuv_web/live/post_live/composer.ex:839
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
@@ -17554,53 +17553,69 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr "© Alle Rechte vorbehalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1071
+#: lib/vutuv_web/live/post_live/composer.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Fotos hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1165
+#: lib/vutuv_web/live/post_live/composer.ex:1301
 #, elixir-autogen, elixir-format
 msgid "Add text (optional)"
 msgstr "Text hinzufügen (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1743
-#, elixir-autogen, elixir-format
-msgid "Caption and description live under the photo itself."
-msgstr "Bildunterschrift und Beschreibung stehen direkt unter dem Foto."
-
-#: lib/vutuv_web/live/post_live/composer.ex:1135
+#: lib/vutuv_web/live/post_live/composer.ex:1271
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:679
-#: lib/vutuv_web/live/post_live/feed.ex:680
+#: lib/vutuv_web/live/post_live/feed.ex:685
+#: lib/vutuv_web/live/post_live/feed.ex:686
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:952
+#: lib/vutuv_web/live/post_live/composer.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Post type"
 msgstr "Beitragsart"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1082
+#: lib/vutuv_web/live/post_live/composer.ex:1217
 #, elixir-autogen, elixir-format
 msgid "Select photos, or drag them here"
 msgstr "Fotos auswählen oder hierher ziehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:956
+#: lib/vutuv_web/live/post_live/composer.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Text"
 msgstr "Text"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1531
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Text (optional)"
 msgstr "Text (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1085
+#: lib/vutuv_web/live/post_live/composer.ex:1220
 #, elixir-autogen, elixir-format
 msgid "Up to %{max} photos per post"
 msgstr "Bis zu %{max} Fotos pro Beitrag"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1165
+#, elixir-autogen, elixir-format
+msgid "Caption (optional)"
+msgstr "Bildunterschrift (optional)"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1082
+#, elixir-autogen, elixir-format
+msgid "A photo post shows your pictures big and first; text is optional. For a post that is mainly text, switch to \"Text\"."
+msgstr "Ein Foto-Beitrag zeigt Ihre Bilder groß und zuerst; Text ist optional. Für einen Beitrag, der vor allem Text ist, wechseln Sie zu \"Text\"."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1067
+#: lib/vutuv_web/live/post_live/composer.ex:1068
+#, elixir-autogen, elixir-format
+msgid "Discard draft"
+msgstr "Entwurf verwerfen"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1065
+#, elixir-autogen, elixir-format
+msgid "Discard the photos and text of this draft?"
+msgstr "Fotos und Text dieses Entwurfs verwerfen?"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1353
+#: lib/vutuv_web/live/post_live/composer.ex:1489
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -623,7 +623,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2863
 #: lib/vutuv_web/live/organization_live/edit.ex:339
-#: lib/vutuv_web/live/post_live/composer.ex:1362
+#: lib/vutuv_web/live/post_live/composer.ex:1498
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:95
@@ -1664,9 +1664,9 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:967
-#: lib/vutuv_web/live/post_live/composer.ex:968
-#: lib/vutuv_web/live/post_live/composer.ex:1750
+#: lib/vutuv_web/live/post_live/composer.ex:1067
+#: lib/vutuv_web/live/post_live/composer.ex:1068
+#: lib/vutuv_web/live/post_live/composer.ex:1910
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:823
+#: lib/vutuv_web/live/post_live/feed.ex:829
 #: lib/vutuv_web/templates/user/show.html.heex:1429
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2107,12 +2107,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:1313
+#: lib/vutuv_web/live/post_live/composer.ex:1449
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1470
+#: lib/vutuv_web/live/post_live/composer.ex:1606
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2123,7 +2123,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1107
+#: lib/vutuv_web/live/post_live/composer.ex:1242
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2146,7 +2146,7 @@ msgid "Edit post"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:85
-#: lib/vutuv_web/live/post_live/feed.ex:650
+#: lib/vutuv_web/live/post_live/feed.ex:656
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:116
@@ -2164,12 +2164,12 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1446
+#: lib/vutuv_web/live/post_live/composer.ex:1582
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1374
+#: lib/vutuv_web/live/post_live/composer.ex:1510
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
@@ -2180,39 +2180,39 @@ msgstr ""
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1416
+#: lib/vutuv_web/live/post_live/composer.ex:1552
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:766
-#: lib/vutuv_web/live/post_live/composer.ex:814
+#: lib/vutuv_web/live/post_live/composer.ex:842
+#: lib/vutuv_web/live/post_live/composer.ex:890
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:764
+#: lib/vutuv_web/live/post_live/feed.ex:770
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:742
+#: lib/vutuv_web/live/post_live/composer.ex:818
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1406
+#: lib/vutuv_web/live/post_live/composer.ex:1542
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1396
+#: lib/vutuv_web/live/post_live/composer.ex:1532
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1362
+#: lib/vutuv_web/live/post_live/composer.ex:1498
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2256,7 +2256,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:1432
+#: lib/vutuv_web/live/post_live/composer.ex:1568
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2270,12 +2270,12 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1360
+#: lib/vutuv_web/live/post_live/composer.ex:1496
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:719
+#: lib/vutuv_web/live/post_live/feed.ex:725
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2289,12 +2289,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:839
+#: lib/vutuv_web/live/post_live/composer.ex:915
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:724
+#: lib/vutuv_web/live/post_live/composer.ex:800
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2304,12 +2304,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1918
+#: lib/vutuv_web/live/post_live/composer.ex:2080
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2323,12 +2323,12 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1531
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1532
+#: lib/vutuv_web/live/post_live/composer.ex:1668
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
@@ -2364,17 +2364,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1183
+#: lib/vutuv_web/live/post_live/composer.ex:1319
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1908
+#: lib/vutuv_web/live/post_live/composer.ex:2070
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1912
+#: lib/vutuv_web/live/post_live/composer.ex:2074
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2486,7 +2486,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1648
-#: lib/vutuv_web/live/post_live/feed.ex:812
+#: lib/vutuv_web/live/post_live/feed.ex:818
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2522,13 +2522,13 @@ msgstr ""
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:727
-#: lib/vutuv_web/live/post_live/composer.ex:1350
+#: lib/vutuv_web/live/post_live/composer.ex:803
+#: lib/vutuv_web/live/post_live/composer.ex:1486
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1477
+#: lib/vutuv_web/live/post_live/composer.ex:1613
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2779,7 +2779,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:672
+#: lib/vutuv_web/live/post_live/feed.ex:678
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1386
+#: lib/vutuv_web/live/post_live/composer.ex:1522
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -4552,7 +4552,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:769
+#: lib/vutuv_web/live/post_live/feed.ex:775
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5306,7 +5306,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:745
+#: lib/vutuv_web/live/post_live/composer.ex:821
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5426,7 +5426,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1548
 #: lib/vutuv_web/components/post_components.ex:1929
 #: lib/vutuv_web/live/notification_live/index.ex:601
-#: lib/vutuv_web/live/post_live/feed.ex:884
+#: lib/vutuv_web/live/post_live/feed.ex:890
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:959
+#: lib/vutuv_web/live/post_live/composer.ex:1046
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -8465,13 +8465,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:851
-#: lib/vutuv_web/live/post_live/feed.ex:852
+#: lib/vutuv_web/live/post_live/feed.ex:857
+#: lib/vutuv_web/live/post_live/feed.ex:858
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:846
+#: lib/vutuv_web/live/post_live/feed.ex:852
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -13126,7 +13126,7 @@ msgid "Search title, poster or organization"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1255
+#: lib/vutuv_web/live/post_live/composer.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -13634,7 +13634,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1887
+#: lib/vutuv_web/live/post_live/composer.ex:2049
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13693,14 +13693,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3301
 #: lib/vutuv_web/controllers/settings_controller.ex:437
-#: lib/vutuv_web/live/post_live/feed.ex:798
+#: lib/vutuv_web/live/post_live/feed.ex:804
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:813
+#: lib/vutuv_web/live/post_live/feed.ex:819
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13861,19 +13861,19 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1263
+#: lib/vutuv_web/live/post_live/composer.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Author(s)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1331
+#: lib/vutuv_web/live/post_live/composer.ex:1467
 #, elixir-autogen, elixir-format
 msgid "Book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:933
 #: lib/vutuv_web/components/post_components.ex:2741
-#: lib/vutuv_web/live/post_live/composer.ex:1209
+#: lib/vutuv_web/live/post_live/composer.ex:1345
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
@@ -13888,7 +13888,7 @@ msgstr ""
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1263
+#: lib/vutuv_web/live/post_live/composer.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Director"
 msgstr ""
@@ -13898,39 +13898,39 @@ msgstr ""
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1343
+#: lib/vutuv_web/live/post_live/composer.ex:1479
 #, elixir-autogen, elixir-format
 msgid "Film"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:933
 #: lib/vutuv_web/components/post_components.ex:2740
-#: lib/vutuv_web/live/post_live/composer.ex:1208
+#: lib/vutuv_web/live/post_live/composer.ex:1344
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1229
+#: lib/vutuv_web/live/post_live/composer.ex:1365
 #, elixir-autogen, elixir-format
 msgid "IMDb link or ID"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1230
+#: lib/vutuv_web/live/post_live/composer.ex:1366
 #, elixir-autogen, elixir-format
 msgid "ISBN"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1243
+#: lib/vutuv_web/live/post_live/composer.ex:1379
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1240
+#: lib/vutuv_web/live/post_live/composer.ex:1376
 #, elixir-autogen, elixir-format
 msgid "Looking up…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:416
+#: lib/vutuv_web/live/post_live/composer.ex:427
 #, elixir-autogen, elixir-format
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
@@ -13940,24 +13940,24 @@ msgstr ""
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1282
+#: lib/vutuv_web/live/post_live/composer.ex:1418
 #, elixir-autogen, elixir-format
 msgid "Read as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1218
+#: lib/vutuv_web/live/post_live/composer.ex:1354
 #, elixir-autogen, elixir-format
 msgid "Remove review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1327
-#: lib/vutuv_web/live/post_live/composer.ex:1328
+#: lib/vutuv_web/live/post_live/composer.ex:1463
+#: lib/vutuv_web/live/post_live/composer.ex:1464
 #, elixir-autogen, elixir-format
 msgid "Review a book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1339
-#: lib/vutuv_web/live/post_live/composer.ex:1340
+#: lib/vutuv_web/live/post_live/composer.ex:1475
+#: lib/vutuv_web/live/post_live/composer.ex:1476
 #, elixir-autogen, elixir-format
 msgid "Review a film"
 msgstr ""
@@ -13967,17 +13967,17 @@ msgstr ""
 msgid "Streaming"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1281
+#: lib/vutuv_web/live/post_live/composer.ex:1417
 #, elixir-autogen, elixir-format
 msgid "Watched as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1295
+#: lib/vutuv_web/live/post_live/composer.ex:1431
 #, elixir-autogen, elixir-format
 msgid "With an ISBN, the post shows the book cover and a shop link automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1275
+#: lib/vutuv_web/live/post_live/composer.ex:1411
 #: lib/vutuv_web/templates/education/form_content.html.heex:47
 #: lib/vutuv_web/templates/education/form_content.html.heex:48
 #: lib/vutuv_web/templates/education/form_content.html.heex:67
@@ -14377,13 +14377,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:732
+#: lib/vutuv_web/live/post_live/composer.ex:808
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:735
+#: lib/vutuv_web/live/post_live/composer.ex:811
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -16548,7 +16548,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1900
+#: lib/vutuv_web/live/post_live/composer.ex:2062
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16578,19 +16578,17 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1048
-#: lib/vutuv_web/live/post_live/composer.ex:1730
+#: lib/vutuv_web/live/post_live/composer.ex:1894
 #, elixir-autogen, elixir-format
 msgid "Caption, shown under the photo (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:1729
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1056
-#: lib/vutuv_web/live/post_live/composer.ex:1739
+#: lib/vutuv_web/live/post_live/composer.ex:1902
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16602,37 +16600,37 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1095
+#: lib/vutuv_web/live/post_live/composer.ex:1230
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1849
+#: lib/vutuv_web/live/post_live/composer.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1806
+#: lib/vutuv_web/live/post_live/composer.ex:1968
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1808
+#: lib/vutuv_web/live/post_live/composer.ex:1970
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1827
+#: lib/vutuv_web/live/post_live/composer.ex:1989
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1603
+#: lib/vutuv_web/live/post_live/composer.ex:1758
 #, elixir-autogen, elixir-format
 msgid "Move photo earlier"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1637
+#: lib/vutuv_web/live/post_live/composer.ex:1792
 #, elixir-autogen, elixir-format
 msgid "Move photo later"
 msgstr ""
@@ -16642,7 +16640,7 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1585
+#: lib/vutuv_web/live/post_live/composer.ex:1737
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16674,8 +16672,8 @@ msgstr ""
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1613
-#: lib/vutuv_web/live/post_live/composer.ex:1614
+#: lib/vutuv_web/live/post_live/composer.ex:1768
+#: lib/vutuv_web/live/post_live/composer.ex:1769
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
@@ -16692,49 +16690,50 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1624
-#: lib/vutuv_web/live/post_live/composer.ex:1625
+#: lib/vutuv_web/live/post_live/composer.ex:1779
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1829
+#: lib/vutuv_web/live/post_live/composer.ex:1991
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1778
+#: lib/vutuv_web/live/post_live/composer.ex:1188
+#: lib/vutuv_web/live/post_live/composer.ex:1940
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:757
+#: lib/vutuv_web/live/post_live/composer.ex:833
 #: lib/vutuv_web/live/post_live/remote_reply.ex:87
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1847
+#: lib/vutuv_web/live/post_live/composer.ex:2009
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1786
+#: lib/vutuv_web/live/post_live/composer.ex:1948
 #, elixir-autogen, elixir-format
 msgid "This file carries no camera information."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1870
+#: lib/vutuv_web/live/post_live/composer.ex:2032
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1862
+#: lib/vutuv_web/live/post_live/composer.ex:2024
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:760
+#: lib/vutuv_web/live/post_live/composer.ex:836
 #: lib/vutuv_web/live/post_live/remote_reply.ex:84
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
@@ -16755,12 +16754,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1140
+#: lib/vutuv_web/live/post_live/composer.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:752
+#: lib/vutuv_web/live/post_live/composer.ex:828
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16770,7 +16769,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:763
+#: lib/vutuv_web/live/post_live/composer.ex:839
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16785,53 +16784,69 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1071
+#: lib/vutuv_web/live/post_live/composer.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1165
+#: lib/vutuv_web/live/post_live/composer.ex:1301
 #, elixir-autogen, elixir-format
 msgid "Add text (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1743
-#, elixir-autogen, elixir-format
-msgid "Caption and description live under the photo itself."
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1135
+#: lib/vutuv_web/live/post_live/composer.ex:1271
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:679
-#: lib/vutuv_web/live/post_live/feed.ex:680
+#: lib/vutuv_web/live/post_live/feed.ex:685
+#: lib/vutuv_web/live/post_live/feed.ex:686
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:952
+#: lib/vutuv_web/live/post_live/composer.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Post type"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1082
+#: lib/vutuv_web/live/post_live/composer.ex:1217
 #, elixir-autogen, elixir-format
 msgid "Select photos, or drag them here"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:956
+#: lib/vutuv_web/live/post_live/composer.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Text"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1531
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Text (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1085
+#: lib/vutuv_web/live/post_live/composer.ex:1220
 #, elixir-autogen, elixir-format
 msgid "Up to %{max} photos per post"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1165
+#, elixir-autogen, elixir-format
+msgid "Caption (optional)"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1082
+#, elixir-autogen, elixir-format
+msgid "A photo post shows your pictures big and first; text is optional. For a post that is mainly text, switch to \"Text\"."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1067
+#: lib/vutuv_web/live/post_live/composer.ex:1068
+#, elixir-autogen, elixir-format
+msgid "Discard draft"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1065
+#, elixir-autogen, elixir-format
+msgid "Discard the photos and text of this draft?"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -611,7 +611,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1353
+#: lib/vutuv_web/live/post_live/composer.ex:1489
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -621,7 +621,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2863
 #: lib/vutuv_web/live/organization_live/edit.ex:339
-#: lib/vutuv_web/live/post_live/composer.ex:1362
+#: lib/vutuv_web/live/post_live/composer.ex:1498
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:95
@@ -1662,9 +1662,9 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:967
-#: lib/vutuv_web/live/post_live/composer.ex:968
-#: lib/vutuv_web/live/post_live/composer.ex:1750
+#: lib/vutuv_web/live/post_live/composer.ex:1067
+#: lib/vutuv_web/live/post_live/composer.ex:1068
+#: lib/vutuv_web/live/post_live/composer.ex:1910
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1893,7 +1893,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:823
+#: lib/vutuv_web/live/post_live/feed.ex:829
 #: lib/vutuv_web/templates/user/show.html.heex:1429
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2105,12 +2105,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:1313
+#: lib/vutuv_web/live/post_live/composer.ex:1449
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1470
+#: lib/vutuv_web/live/post_live/composer.ex:1606
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1107
+#: lib/vutuv_web/live/post_live/composer.ex:1242
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2144,7 +2144,7 @@ msgid "Edit post"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:85
-#: lib/vutuv_web/live/post_live/feed.ex:650
+#: lib/vutuv_web/live/post_live/feed.ex:656
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:116
@@ -2162,12 +2162,12 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1446
+#: lib/vutuv_web/live/post_live/composer.ex:1582
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1374
+#: lib/vutuv_web/live/post_live/composer.ex:1510
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
@@ -2178,39 +2178,39 @@ msgstr ""
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1416
+#: lib/vutuv_web/live/post_live/composer.ex:1552
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:766
-#: lib/vutuv_web/live/post_live/composer.ex:814
+#: lib/vutuv_web/live/post_live/composer.ex:842
+#: lib/vutuv_web/live/post_live/composer.ex:890
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:764
+#: lib/vutuv_web/live/post_live/feed.ex:770
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:742
+#: lib/vutuv_web/live/post_live/composer.ex:818
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1406
+#: lib/vutuv_web/live/post_live/composer.ex:1542
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1396
+#: lib/vutuv_web/live/post_live/composer.ex:1532
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1362
+#: lib/vutuv_web/live/post_live/composer.ex:1498
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2254,7 +2254,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:1432
+#: lib/vutuv_web/live/post_live/composer.ex:1568
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2268,12 +2268,12 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1360
+#: lib/vutuv_web/live/post_live/composer.ex:1496
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:719
+#: lib/vutuv_web/live/post_live/feed.ex:725
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2287,12 +2287,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:839
+#: lib/vutuv_web/live/post_live/composer.ex:915
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:724
+#: lib/vutuv_web/live/post_live/composer.ex:800
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2302,12 +2302,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1918
+#: lib/vutuv_web/live/post_live/composer.ex:2080
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2321,12 +2321,12 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1531
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1532
+#: lib/vutuv_web/live/post_live/composer.ex:1668
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
@@ -2362,17 +2362,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1183
+#: lib/vutuv_web/live/post_live/composer.ex:1319
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1908
+#: lib/vutuv_web/live/post_live/composer.ex:2070
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1912
+#: lib/vutuv_web/live/post_live/composer.ex:2074
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1648
-#: lib/vutuv_web/live/post_live/feed.ex:812
+#: lib/vutuv_web/live/post_live/feed.ex:818
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2520,13 +2520,13 @@ msgstr ""
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:727
-#: lib/vutuv_web/live/post_live/composer.ex:1350
+#: lib/vutuv_web/live/post_live/composer.ex:803
+#: lib/vutuv_web/live/post_live/composer.ex:1486
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1477
+#: lib/vutuv_web/live/post_live/composer.ex:1613
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2777,7 +2777,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:672
+#: lib/vutuv_web/live/post_live/feed.ex:678
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2833,7 +2833,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1386
+#: lib/vutuv_web/live/post_live/composer.ex:1522
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -4550,7 +4550,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:769
+#: lib/vutuv_web/live/post_live/feed.ex:775
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5304,7 +5304,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:745
+#: lib/vutuv_web/live/post_live/composer.ex:821
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5424,7 +5424,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1548
 #: lib/vutuv_web/components/post_components.ex:1929
 #: lib/vutuv_web/live/notification_live/index.ex:601
-#: lib/vutuv_web/live/post_live/feed.ex:884
+#: lib/vutuv_web/live/post_live/feed.ex:890
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr ""
@@ -5523,7 +5523,7 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:959
+#: lib/vutuv_web/live/post_live/composer.ex:1046
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -8463,13 +8463,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:851
-#: lib/vutuv_web/live/post_live/feed.ex:852
+#: lib/vutuv_web/live/post_live/feed.ex:857
+#: lib/vutuv_web/live/post_live/feed.ex:858
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:846
+#: lib/vutuv_web/live/post_live/feed.ex:852
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -13124,7 +13124,7 @@ msgid "Search title, poster or organization"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1255
+#: lib/vutuv_web/live/post_live/composer.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -13632,7 +13632,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1887
+#: lib/vutuv_web/live/post_live/composer.ex:2049
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13691,14 +13691,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3301
 #: lib/vutuv_web/controllers/settings_controller.ex:437
-#: lib/vutuv_web/live/post_live/feed.ex:798
+#: lib/vutuv_web/live/post_live/feed.ex:804
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:813
+#: lib/vutuv_web/live/post_live/feed.ex:819
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13859,19 +13859,19 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1263
+#: lib/vutuv_web/live/post_live/composer.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Author(s)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1331
+#: lib/vutuv_web/live/post_live/composer.ex:1467
 #, elixir-autogen, elixir-format
 msgid "Book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:933
 #: lib/vutuv_web/components/post_components.ex:2741
-#: lib/vutuv_web/live/post_live/composer.ex:1209
+#: lib/vutuv_web/live/post_live/composer.ex:1345
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
@@ -13886,7 +13886,7 @@ msgstr ""
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1263
+#: lib/vutuv_web/live/post_live/composer.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Director"
 msgstr ""
@@ -13896,39 +13896,39 @@ msgstr ""
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1343
+#: lib/vutuv_web/live/post_live/composer.ex:1479
 #, elixir-autogen, elixir-format
 msgid "Film"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:933
 #: lib/vutuv_web/components/post_components.ex:2740
-#: lib/vutuv_web/live/post_live/composer.ex:1208
+#: lib/vutuv_web/live/post_live/composer.ex:1344
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1229
+#: lib/vutuv_web/live/post_live/composer.ex:1365
 #, elixir-autogen, elixir-format
 msgid "IMDb link or ID"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1230
+#: lib/vutuv_web/live/post_live/composer.ex:1366
 #, elixir-autogen, elixir-format
 msgid "ISBN"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1243
+#: lib/vutuv_web/live/post_live/composer.ex:1379
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1240
+#: lib/vutuv_web/live/post_live/composer.ex:1376
 #, elixir-autogen, elixir-format
 msgid "Looking up…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:416
+#: lib/vutuv_web/live/post_live/composer.ex:427
 #, elixir-autogen, elixir-format
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
@@ -13938,24 +13938,24 @@ msgstr ""
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1282
+#: lib/vutuv_web/live/post_live/composer.ex:1418
 #, elixir-autogen, elixir-format
 msgid "Read as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1218
+#: lib/vutuv_web/live/post_live/composer.ex:1354
 #, elixir-autogen, elixir-format
 msgid "Remove review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1327
-#: lib/vutuv_web/live/post_live/composer.ex:1328
+#: lib/vutuv_web/live/post_live/composer.ex:1463
+#: lib/vutuv_web/live/post_live/composer.ex:1464
 #, elixir-autogen, elixir-format
 msgid "Review a book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1339
-#: lib/vutuv_web/live/post_live/composer.ex:1340
+#: lib/vutuv_web/live/post_live/composer.ex:1475
+#: lib/vutuv_web/live/post_live/composer.ex:1476
 #, elixir-autogen, elixir-format
 msgid "Review a film"
 msgstr ""
@@ -13965,17 +13965,17 @@ msgstr ""
 msgid "Streaming"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1281
+#: lib/vutuv_web/live/post_live/composer.ex:1417
 #, elixir-autogen, elixir-format
 msgid "Watched as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1295
+#: lib/vutuv_web/live/post_live/composer.ex:1431
 #, elixir-autogen, elixir-format
 msgid "With an ISBN, the post shows the book cover and a shop link automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1275
+#: lib/vutuv_web/live/post_live/composer.ex:1411
 #: lib/vutuv_web/templates/education/form_content.html.heex:47
 #: lib/vutuv_web/templates/education/form_content.html.heex:48
 #: lib/vutuv_web/templates/education/form_content.html.heex:67
@@ -14375,13 +14375,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:732
+#: lib/vutuv_web/live/post_live/composer.ex:808
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:735
+#: lib/vutuv_web/live/post_live/composer.ex:811
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -16546,7 +16546,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1900
+#: lib/vutuv_web/live/post_live/composer.ex:2062
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16576,19 +16576,17 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1048
-#: lib/vutuv_web/live/post_live/composer.ex:1730
+#: lib/vutuv_web/live/post_live/composer.ex:1894
 #, elixir-autogen, elixir-format
 msgid "Caption, shown under the photo (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:1729
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1056
-#: lib/vutuv_web/live/post_live/composer.ex:1739
+#: lib/vutuv_web/live/post_live/composer.ex:1902
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16600,37 +16598,37 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1095
+#: lib/vutuv_web/live/post_live/composer.ex:1230
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1849
+#: lib/vutuv_web/live/post_live/composer.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1806
+#: lib/vutuv_web/live/post_live/composer.ex:1968
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1808
+#: lib/vutuv_web/live/post_live/composer.ex:1970
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1827
+#: lib/vutuv_web/live/post_live/composer.ex:1989
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1603
+#: lib/vutuv_web/live/post_live/composer.ex:1758
 #, elixir-autogen, elixir-format
 msgid "Move photo earlier"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1637
+#: lib/vutuv_web/live/post_live/composer.ex:1792
 #, elixir-autogen, elixir-format
 msgid "Move photo later"
 msgstr ""
@@ -16640,7 +16638,7 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1585
+#: lib/vutuv_web/live/post_live/composer.ex:1737
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16672,8 +16670,8 @@ msgstr ""
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1613
-#: lib/vutuv_web/live/post_live/composer.ex:1614
+#: lib/vutuv_web/live/post_live/composer.ex:1768
+#: lib/vutuv_web/live/post_live/composer.ex:1769
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
@@ -16690,49 +16688,50 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1624
-#: lib/vutuv_web/live/post_live/composer.ex:1625
+#: lib/vutuv_web/live/post_live/composer.ex:1779
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1829
+#: lib/vutuv_web/live/post_live/composer.ex:1991
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1778
+#: lib/vutuv_web/live/post_live/composer.ex:1188
+#: lib/vutuv_web/live/post_live/composer.ex:1940
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:757
+#: lib/vutuv_web/live/post_live/composer.ex:833
 #: lib/vutuv_web/live/post_live/remote_reply.ex:87
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1847
+#: lib/vutuv_web/live/post_live/composer.ex:2009
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1786
+#: lib/vutuv_web/live/post_live/composer.ex:1948
 #, elixir-autogen, elixir-format
 msgid "This file carries no camera information."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1870
+#: lib/vutuv_web/live/post_live/composer.ex:2032
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1862
+#: lib/vutuv_web/live/post_live/composer.ex:2024
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:760
+#: lib/vutuv_web/live/post_live/composer.ex:836
 #: lib/vutuv_web/live/post_live/remote_reply.ex:84
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
@@ -16753,12 +16752,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1140
+#: lib/vutuv_web/live/post_live/composer.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:752
+#: lib/vutuv_web/live/post_live/composer.ex:828
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16768,7 +16767,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:763
+#: lib/vutuv_web/live/post_live/composer.ex:839
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16783,53 +16782,69 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1071
+#: lib/vutuv_web/live/post_live/composer.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1165
+#: lib/vutuv_web/live/post_live/composer.ex:1301
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add text (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1743
-#, elixir-autogen, elixir-format
-msgid "Caption and description live under the photo itself."
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1135
+#: lib/vutuv_web/live/post_live/composer.ex:1271
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:679
-#: lib/vutuv_web/live/post_live/feed.ex:680
+#: lib/vutuv_web/live/post_live/feed.ex:685
+#: lib/vutuv_web/live/post_live/feed.ex:686
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:952
+#: lib/vutuv_web/live/post_live/composer.ex:1039
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post type"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1082
+#: lib/vutuv_web/live/post_live/composer.ex:1217
 #, elixir-autogen, elixir-format
 msgid "Select photos, or drag them here"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:956
+#: lib/vutuv_web/live/post_live/composer.ex:1043
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Text"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1531
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Text (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1085
+#: lib/vutuv_web/live/post_live/composer.ex:1220
 #, elixir-autogen, elixir-format
 msgid "Up to %{max} photos per post"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1165
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Caption (optional)"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1082
+#, elixir-autogen, elixir-format
+msgid "A photo post shows your pictures big and first; text is optional. For a post that is mainly text, switch to \"Text\"."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1067
+#: lib/vutuv_web/live/post_live/composer.ex:1068
+#, elixir-autogen, elixir-format
+msgid "Discard draft"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1065
+#, elixir-autogen, elixir-format
+msgid "Discard the photos and text of this draft?"
 msgstr ""

--- a/test/vutuv_web/live/photo_composer_test.exs
+++ b/test/vutuv_web/live/photo_composer_test.exs
@@ -115,7 +115,11 @@ defmodule VutuvWeb.PhotoComposerTest do
   end
 
   defp open_panel(live, image) do
-    live |> element(~s([phx-click="photo-open"][phx-value-id="#{image.id}"])) |> render_click()
+    # The scrim's ⚙ specifically — the tile's img opens the panel too now,
+    # so a bare [phx-click=photo-open] selector matches two elements.
+    live
+    |> element(~s(button[phx-click="photo-open"][phx-value-id="#{image.id}"]))
+    |> render_click()
   end
 
   defp toggle(live, image, field) do
@@ -323,7 +327,7 @@ defmodule VutuvWeb.PhotoComposerTest do
       refute has_element?(live, ~s(#composer-form textarea[name="post[body]"]))
     end
 
-    test "photo mode shows caption and description with every photo, no panel needed", %{
+    test "photo mode shows one caption per photo; the alt text lives in the panel", %{
       conn: conn,
       user: user
     } do
@@ -331,18 +335,94 @@ defmodule VutuvWeb.PhotoComposerTest do
       image = upload_photo!(live, user)
 
       assert has_element?(live, ~s(input[name="photo[#{image.id}][caption]"]))
-      assert has_element?(live, ~s(input[name="photo[#{image.id}][alt]"]))
-      # The panel still exists for the rarer switches, but must not render a
-      # second caption field (two same-name inputs corrupt the submit).
+      # One visible text per photo: the caption already serves as the
+      # accessible name when no alt is written, so the alt input is the
+      # panel's opt-in refinement rather than a second required-looking field.
+      refute has_element?(live, ~s(input[name="photo[#{image.id}][alt]"]))
+
       open_panel(live, image)
 
       assert has_element?(live, "#composer-photo-panel")
+      assert has_element?(live, ~s(input[name="photo[#{image.id}][alt]"]))
 
+      # The open panel must not render a second caption field (two same-name
+      # inputs corrupt the submit).
       assert live
              |> render()
              |> then(fn html ->
                length(String.split(html, ~s(name="photo[#{image.id}][caption]"))) == 2
              end)
+    end
+
+    test "a photo carrying camera facts offers the publish switch right under its tile", %{
+      conn: conn,
+      user: user
+    } do
+      live = open_photo_composer(conn)
+
+      image =
+        upload_photo!(live, user,
+          exif: [
+            {"exif-ifd0-Make", "Canon"},
+            {"exif-ifd0-Model", "Canon EOS R6"},
+            {"exif-ifd2-FocalLength", "50/1"},
+            {"exif-ifd2-FNumber", "18/10"},
+            {"exif-ifd2-ExposureTime", "1/200"},
+            {"exif-ifd2-ISOSpeedRatings", "400"}
+          ]
+        )
+
+      assert has_element?(live, ~s([data-photo-camera-inline="#{image.id}"]))
+      assert render(live) =~ "Canon EOS R6 · 50 mm · f/1.8 · 1/200 s · ISO 400"
+
+      live
+      |> element(~s([data-photo-camera-inline="#{image.id}"] input[phx-click="photo-toggle"]))
+      |> render_click()
+
+      live |> form("#composer-form", %{"post" => %{"mode" => "photos"}}) |> render_submit()
+
+      assert %{show_camera_info: true} = reload(image)
+    end
+
+    test "a photo without camera facts gets no camera row", %{conn: conn, user: user} do
+      live = open_photo_composer(conn)
+      image = upload_photo!(live, user)
+
+      refute has_element?(live, ~s([data-photo-camera-inline="#{image.id}"]))
+    end
+
+    test "tapping the photo itself opens its options panel", %{conn: conn, user: user} do
+      # The ⚙ in the tile scrim is real but nobody sees it; the picture is the
+      # biggest target on screen and the first thing people try.
+      live = open_photo_composer(conn)
+      image = upload_photo!(live, user)
+
+      refute has_element?(live, "#composer-photo-panel")
+
+      live |> element(~s([data-photo-tile="#{image.id}"] img)) |> render_click()
+
+      assert has_element?(live, "#composer-photo-panel")
+    end
+
+    test "the alt nudge shows only while a photo has neither caption nor description", %{
+      conn: conn,
+      user: user
+    } do
+      live = open_photo_composer(conn)
+      image = upload_photo!(live, user)
+
+      assert has_element?(live, ~s([data-photo-alt-missing="#{image.id}"]))
+
+      # A caption gives the photo its accessible name (photo_alt/1 falls back
+      # to it), so the nudge is satisfied without the panel.
+      live
+      |> form("#composer-form", %{
+        "post" => %{"mode" => "photos"},
+        "photo" => %{image.id => %{"caption" => "Zugfenster"}}
+      })
+      |> render_change()
+
+      refute has_element?(live, ~s([data-photo-alt-missing="#{image.id}"]))
     end
 
     test "the licence stays with the photos in photo mode", %{conn: conn, user: user} do
@@ -414,17 +494,57 @@ defmodule VutuvWeb.PhotoComposerTest do
       assert has_element?(live, ~s(#composer[data-composer-mode="text"]))
     end
 
-    test "the pill never rearranges the composer under a held photo draft", %{
+    test "the photo ✕ discards everything: rows deleted, form empty, panel collapsed", %{
       conn: conn,
       user: user
     } do
       live = open_photo_composer(conn)
-      upload_photo!(live, user)
+      image = upload_photo!(live, user)
+
+      live
+      |> form("#composer-form", %{
+        "post" => %{"mode" => "photos"},
+        "photo" => %{image.id => %{"caption" => "Gleich weg"}}
+      })
+      |> render_change()
+
+      live |> element(~s(button[phx-click="discard-draft"])) |> render_click()
+
+      # The pending row (and with it the stored files) is gone, the panel is
+      # collapsed, and reopening starts fresh and text-first.
+      assert reload(image) == nil
+      assert has_element?(live, "#composer-panel.hidden")
+
+      live |> element("#open-composer") |> render_click()
+
+      assert has_element?(live, ~s(#composer[data-composer-mode="text"]))
+      refute has_element?(live, "[data-photo-tile]")
+    end
+
+    test "the text ✕ keeps the draft (issue #1135), only photo mode discards", %{
+      conn: conn,
+      user: _user
+    } do
+      live = open_composer(conn)
+
+      live
+      |> form("#composer-form", %{"post" => %{"mode" => "text", "body" => "Halb getippt."}})
+      |> render_change()
 
       live |> element(~s(button[phx-click="close-composer"])) |> render_click()
       live |> element("#open-composer") |> render_click()
 
-      assert has_element?(live, ~s(#composer[data-composer-mode="photos"]))
+      assert render(live) =~ "Halb getippt."
+    end
+
+    test "photo mode explains itself in one line", %{conn: conn, user: _user} do
+      live = open_photo_composer(conn)
+
+      assert has_element?(live, "[data-photo-mode-hint]")
+
+      live |> form("#composer-form", %{"post" => %{"mode" => "text"}}) |> render_change()
+
+      refute has_element?(live, "[data-photo-mode-hint]")
     end
 
     test "a photo-only post saves from photo mode", %{conn: conn, user: user} do
@@ -432,7 +552,10 @@ defmodule VutuvWeb.PhotoComposerTest do
       image = upload_photo!(live, user)
 
       # No body field at all: the editor is folded away, which is the point —
-      # the form still submits (the caption inputs are in the photo grid).
+      # the form still submits (the caption input is in the photo grid, the
+      # alt refinement in the opened panel).
+      open_panel(live, image)
+
       live
       |> form("#composer-form", %{
         "post" => %{"mode" => "photos"},

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -412,8 +412,10 @@ defmodule VutuvWeb.PostFeedLiveTest do
       [image] = Vutuv.Repo.all(PostImage)
       refute has_element?(live, ~s([phx-click="insert-inline"]))
 
+      # The scrim's ⚙ specifically — the tile's img opens the panel too, so a
+      # bare [phx-click=photo-open] selector matches two elements.
       live
-      |> element(~s([phx-click="photo-open"][phx-value-id="#{image.id}"]))
+      |> element(~s(button[phx-click="photo-open"][phx-value-id="#{image.id}"]))
       |> render_click()
 
       live


### PR DESCRIPTION
**TL;DR** Follow-up to #1146 from live feedback: the camera-data switch moves out of the hidden ⚙ to right under the tile, each photo shows one caption field (alt becomes the panel's opt-in refinement), tapping the photo opens its panel, the ✕ really discards a photo draft, and touch targets grow to phone size.

**Where:** `VutuvWeb.PostLive.Composer` (+ feed `handle_info`, `design.md` mobile rule)
**Now:** camera switch invisible behind the tile ⚙; two stacked text inputs per photo read as duplicate alt fields; ✕ only collapsed, so a "closed" photo draft kept its uploads invisibly; scrim buttons too small for fingers.
**Want / done:**
- One caption input per photo; it already doubles as the accessible name (`photo_alt/1`), so the alt input moved to the ⚙ panel as an opt-in. ALT nudge only when neither text exists.
- "Show camera settings" switch inline under the tile whenever the file carries camera facts, previewing the exact visitor-facing line.
- Tapping the photo opens its options panel (⚙ stays as the labeled, keyboard path).
- Photo-mode ✕ = discard behind a confirm (pending rows deleted, form reset, feed collapses via `{:composer_discarded, id}`); text drafts still survive their close (#1135).
- One-line mode explainer; finger-sized scrim buttons, full-height caption input, taller mode tabs (Stefan's mobile rule, now a design.md Don't).

Verified in a real browser; 5485 tests green.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_011SL9FZTsuBpgq5WasLJRLN