### PR TITLE
Photo-mode tiles load the aspect-preserving feed version

### DIFF
--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -1726,7 +1726,16 @@ defmodule VutuvWeb.PostLive.Composer do
         title={gettext("Photo options")}
         class="block h-full w-full cursor-pointer rounded-lg focus-visible:ring-2 focus-visible:ring-brand-500"
       >
-        <img src={PostImage.url(@image, "thumb")} alt="" class="h-full w-full object-cover" />
+        <%!-- The natural-ratio frame needs the aspect-preserving `feed`
+        version: `thumb` is itself a 320×320 centre crop (Vutuv.Uploads.Spec),
+        so inside a portrait frame it would show a cut of a cut — exactly the
+        "still not the full picture" complaint the frame was meant to fix.
+        The square strip keeps the light thumb. --%>
+        <img
+          src={PostImage.url(@image, if(@natural?, do: "feed", else: "thumb"))}
+          alt=""
+          class="h-full w-full object-cover"
+        />
       </button>
 
       <div class="pointer-events-none absolute left-1 top-1 flex flex-col items-start gap-1">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.168.2",
+      version: "7.168.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/photo_composer_test.exs
+++ b/test/vutuv_web/live/photo_composer_test.exs
@@ -428,6 +428,10 @@ defmodule VutuvWeb.PhotoComposerTest do
     } do
       # A photographer judges the upload by the full frame; the square crop
       # belongs to the compact text-mode strip alone. The test JPEG is 90×60.
+      # The frame's shape alone is not enough: the `thumb` version is itself a
+      # 320×320 centre crop (`Vutuv.Uploads.Spec`), so a natural-ratio frame
+      # around it still shows a cut — the tile must load the aspect-preserving
+      # `feed` version.
       live = open_photo_composer(conn)
       image = upload_photo!(live, user)
 
@@ -435,6 +439,15 @@ defmodule VutuvWeb.PhotoComposerTest do
                live,
                ~s([data-photo-tile="#{image.id}"] [style*="aspect-ratio: 90 / 60"])
              )
+
+      assert has_element?(live, ~s([data-photo-tile="#{image.id}"] img[src$="/feed.avif"]))
+    end
+
+    test "the text-mode strip keeps its square thumbs", %{conn: conn, user: user} do
+      live = open_composer(conn)
+      image = upload_photo!(live, user)
+
+      assert has_element?(live, ~s([data-photo-tile="#{image.id}"] img[src$="/thumb.avif"]))
     end
 
     test "the alt nudge shows only while a photo has neither caption nor description", %{


### PR DESCRIPTION
**TL;DR** The natural-ratio tiles from #1151 still cropped: the frame had the photo's shape, but the image inside was the square-cropped `thumb` version. Photo mode now loads the aspect-preserving `feed` version; the text strip keeps the light square thumb.

**Where:** `VutuvWeb.PostLive.Composer.photo_frame/1`
**Now:** `thumb` is a 320×320 centre crop (`Vutuv.Uploads.Spec`), so a portrait frame showed a cut of a cut — the editor preview still wasn't the full picture (Stefan, with a real photograph).
**Want / done:** photo mode (`natural?`) loads `feed` (`box_down 1200`, aspect-preserving); verified with corner-marked test frames, all four corners visible on portrait and landscape tiles.

5498 tests green.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_011SL9FZTsuBpgq5WasLJRLN