### PR TITLE
Ask who may download the original photo, next to the licence

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -636,19 +636,37 @@ with JS off those links are plain hrefs to the full-size image.
 `PostLive.Composer.photo_panel/1`): a `caption` (shown to everyone; distinct
 from `alt`, which describes the picture for people who cannot see it), a
 **camera-settings** switch (renders from the DB columns — the served files stay
-metadata-stripped) and an **original download** switch with its one follow-up,
-which file (see [images.md](images.md)). The panel expands below the strip
-rather than floating — a popover on a phone covers what it is about and has
-nowhere to put a follow-up. In photo mode the caption and the camera switch
-move out of the panel to under the tile itself (the panel drops them there —
-two same-name inputs would corrupt the submit); the alt input renders in the
-panel in both modes. An "apply to all photos" shortcut copies the two
-switches (never the texts: a caption describes one picture).
+metadata-stripped) and, for a set of several photos, the **download override**
+with its one follow-up, which file (see [images.md](images.md)). The panel
+expands below the strip rather than floating — a popover on a phone covers what
+it is about and has nowhere to put a follow-up. In photo mode the caption and
+the camera switch move out of the panel to under the tile itself (the panel
+drops them there — two same-name inputs would corrupt the submit); the alt
+input renders in the panel in both modes. An "apply to all photos" shortcut
+copies the two switches (never the texts: a caption describes one picture).
 
-**Per post**, one `Vutuv.Posts.PhotoLicense` from a fixed vocabulary (`arr`
-default, CC BY / BY-SA / BY-NC / CC0 4.0). The select appears only once a photo
-is attached; the last pick is remembered on `users.default_post_license` and
-pre-selected next time, so a professional sets it once. It renders as a line
+**Per post**, the two questions about the pictures themselves, asked as a
+labeled pair below the photos in both modes and only once a photo is attached.
+
+The first is **what a visitor can save**: the served AVIF versions only (the
+default), the full-resolution original with its metadata removed, or the
+uploaded file byte for byte. The columns behind it are per photo
+(`download_original` + `download_exact`), but the select answers for the whole
+set, because that is how a photographer decides it — a single photo therefore
+gets no switch in its panel at all, and a set whose photos disagree (a panel
+override, an older post) reads "Different per photo" rather than claiming an
+answer nobody gave. The select carries its own `phx-change` instead of riding
+the form's `validate`: every keystroke replays the whole form, and a replayed
+value would push the select's answer back over a per-photo choice just made in
+the panel. Picking the exact file names the location it hands over when any
+photo carries one, and a format `Vutuv.Uploads.MetadataStrip` cannot take apart
+says so up front rather than quietly serving an uncleaned file under the
+cleaned label (`Posts.update_image_settings/2` forces the exact file there).
+
+The second is the licence: one `Vutuv.Posts.PhotoLicense` from a fixed
+vocabulary (`arr` default, CC BY / BY-SA / BY-NC / CC0 4.0). The last pick is
+remembered on `users.default_post_license` and pre-selected next time, so a
+professional sets it once. It renders as a line
 under the photos **only when it grants something** — a rights notice on every
 picture in the app teaches people to stop reading the one that matters. It also
 reaches machines: the agent-format siblings carry the SPDX id, and the JSON-LD

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -59,6 +59,7 @@ defmodule VutuvWeb.PostLive.Composer do
   alias Vutuv.Posts.PostDraft
   alias Vutuv.Posts.PostImage
   alias Vutuv.Posts.PostReview
+  alias Vutuv.Uploads.Spec
   alias VutuvWeb.ErrorHelpers
   alias VutuvWeb.PostComponents
 
@@ -373,6 +374,66 @@ defmodule VutuvWeb.PostLive.Composer do
   defp open_photo(_images, nil), do: nil
   defp open_photo(images, id), do: Enum.find(images, &(&1.id == id))
 
+  ## The post-wide download answer (issue #1104 follow-up)
+
+  # What a visitor can save, as one value for the whole set: the served
+  # versions the page shows, the full-resolution original with its metadata
+  # removed, or the uploaded file byte for byte. The choice is per photo in
+  # the database (and the panel still edits it there), but it is asked once
+  # per post — a photographer decides "may my originals be downloaded" for a
+  # set, not for picture three of nine.
+  @download_choices ~w(none clean exact)
+
+  defp download_choice(%{download_original: false}), do: "none"
+  defp download_choice(%{download_exact: true}), do: "exact"
+  defp download_choice(_settings), do: "clean"
+
+  # `"mixed"` is a reading, not a choice: a post whose photos disagree (a
+  # per-photo override in the panel, or an older post opened for editing) must
+  # not have the select claim an answer nobody gave.
+  defp download_selection(photos, images) do
+    images
+    |> Enum.map(&download_choice(photo_settings(photos, &1)))
+    |> Enum.uniq()
+    |> case do
+      [] -> "none"
+      [one] -> one
+      _differing -> "mixed"
+    end
+  end
+
+  defp apply_download_choice(socket, choice) when choice in @download_choices do
+    settings = download_settings(choice)
+
+    photos =
+      Map.new(socket.assigns.photos, fn {id, current} -> {id, Map.merge(current, settings)} end)
+
+    assign(socket, :photos, photos)
+  end
+
+  defp apply_download_choice(socket, _mixed_or_unknown), do: socket
+
+  defp download_settings("none"), do: %{download_original: false, download_exact: false}
+  defp download_settings("clean"), do: %{download_original: true, download_exact: false}
+  defp download_settings("exact"), do: %{download_original: true, download_exact: true}
+
+  # How many of the photos carry the place they were taken. Only `has_gps` is
+  # stored (never the coordinates), which is all the warning needs.
+  defp located_photos(images), do: Enum.count(images, & &1.has_gps)
+
+  # A format `Vutuv.Uploads.MetadataStrip` cannot take apart is handed out as
+  # it is, whatever "metadata removed" says — `Posts.update_image_settings/2`
+  # forces the exact file at save time rather than breaking the promise, so
+  # the composer says so up front.
+  defp uncleanable?(images),
+    do: Enum.any?(images, &(not Vutuv.PostImageStore.cleanable?(&1)))
+
+  # "AVIF" — the served format names itself, so the select cannot advertise a
+  # format the pipeline no longer produces.
+  defp served_format do
+    Spec.served_ext() |> String.trim_leading(".") |> String.upcase()
+  end
+
   defp update_photo(socket, id, fun) do
     case Map.fetch(socket.assigns.photos, id) do
       :error ->
@@ -639,6 +700,15 @@ defmodule VutuvWeb.PostLive.Composer do
      socket
      |> update_photo(id, &Map.put(&1, :download_exact, exact == "true"))
      |> schedule_draft_save()}
+  end
+
+  # The post-wide download select. It carries its own `phx-change` rather than
+  # riding the form's `validate`, so it speaks only when the author actually
+  # turns it: every keystroke replays the whole form, and a replayed value
+  # would push the select's answer back over a per-photo choice just made in
+  # the panel. `validate` therefore ignores `post[download]` on purpose.
+  def handle_event("download-choice", %{"post" => %{"download" => choice}}, socket) do
+    {:noreply, apply_download_choice(socket, choice)}
   end
 
   # Copies one photo's four choices onto every other photo of the post. The
@@ -1139,6 +1209,11 @@ defmodule VutuvWeb.PostLive.Composer do
 
   @impl true
   def render(assigns) do
+    # Read off the per-photo state rather than kept beside it, so the select
+    # and the panel can never disagree about what is in force.
+    assigns =
+      assign(assigns, :download_choice, download_selection(assigns.photos, assigns.images))
+
     ~H"""
     <div id={@id} data-composer-mode={@mode}>
       <.card>
@@ -1411,30 +1486,95 @@ defmodule VutuvWeb.PostLive.Composer do
             myself={@myself}
           />
 
-          <%!-- Who may reuse the photos — one quiet labeled row, at home with
-          the photos it is about instead of loose in the button row (where it
-          read as a control about nothing, issue #1104 feedback). --%>
-          <div :if={@images != []} class="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1">
-            <label
-              for={"#{@id}-license"}
-              class="text-sm font-medium text-slate-600 dark:text-slate-400"
-            >
-              {gettext("Licence")}
-            </label>
-            <select
-              name="post[license]"
-              id={"#{@id}-license"}
-              title={gettext("Who may reuse these photos")}
-              class={[input_class(), "h-9 w-auto max-w-full py-0 text-sm"]}
-            >
-              <option
-                :for={license <- PhotoLicense.values()}
-                value={license}
-                selected={@license == license}
+          <%!-- The two questions about the pictures themselves — who may reuse
+          them, and what a visitor can actually save — as one quiet labeled
+          pair, at home with the photos they are about instead of loose in the
+          button row (where they read as controls about nothing, issue #1104
+          feedback). --%>
+          <div :if={@images != []} class="mt-3 space-y-2">
+            <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <label
+                for={"#{@id}-license"}
+                class="text-sm font-medium text-slate-600 dark:text-slate-400"
               >
-                {PhotoLicense.label(license)}
-              </option>
-            </select>
+                {gettext("Licence")}
+              </label>
+              <select
+                name="post[license]"
+                id={"#{@id}-license"}
+                title={gettext("Who may reuse these photos")}
+                class={[input_class(), "h-9 w-auto max-w-full py-0 text-sm"]}
+              >
+                <option
+                  :for={license <- PhotoLicense.values()}
+                  value={license}
+                  selected={@license == license}
+                >
+                  {PhotoLicense.label(license)}
+                </option>
+              </select>
+            </div>
+
+            <%!-- The download question used to be reachable only by tapping a
+            photo, where nobody found it (the same complaint that moved the
+            camera switch out of the panel). It belongs here: what a visitor
+            gets is the licence's practical half, and it is one answer for the
+            whole set. The panel keeps the per-photo override, so a post whose
+            photos disagree reads "Different per photo" rather than pretending
+            the set agrees. --%>
+            <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <label
+                for={"#{@id}-download"}
+                class="text-sm font-medium text-slate-600 dark:text-slate-400"
+              >
+                {gettext("Download")}
+              </label>
+              <select
+                name="post[download]"
+                id={"#{@id}-download"}
+                phx-change="download-choice"
+                phx-target={@myself}
+                title={gettext("What a visitor can save")}
+                class={[input_class(), "h-9 w-auto max-w-full py-0 text-sm"]}
+              >
+                <option value="none" selected={@download_choice == "none"}>
+                  {gettext("Web versions only (%{format})", format: served_format())}
+                </option>
+                <option value="clean" selected={@download_choice == "clean"}>
+                  {gettext("Original, metadata removed")}
+                </option>
+                <option value="exact" selected={@download_choice == "exact"}>
+                  {gettext("Original, exactly as uploaded")}
+                </option>
+                <option :if={@download_choice == "mixed"} value="mixed" selected>
+                  {gettext("Different per photo")}
+                </option>
+              </select>
+            </div>
+
+            <%!-- The two things that make the choice an informed one, each
+            shown at the moment it applies rather than as a standing notice
+            nobody reads. --%>
+            <p
+              :if={@download_choice == "exact" and located_photos(@images) > 0}
+              class="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800"
+              data-download-gps-warning
+            >
+              {ngettext(
+                "This photo carries the location it was taken at, and the exact file hands it over.",
+                "Some of these photos carry the location they were taken at, and the exact file hands it over.",
+                located_photos(@images)
+              )}
+            </p>
+            <p
+              :if={@download_choice == "clean" and uncleanable?(@images)}
+              class="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800"
+              data-download-clean-notice
+            >
+              {gettext(
+                "A file whose format cannot be cleaned is handed out exactly as uploaded."
+              )}
+            </p>
           </div>
 
           <%!-- Photo mode: the optional words come after the pictures, folded
@@ -2019,6 +2159,11 @@ defmodule VutuvWeb.PostLive.Composer do
   switch reveals the choice of file and, when the photo carries a location,
   warns about it at the moment the exact file is picked.
 
+  The download switch is the **override** of the post-wide answer the select
+  beside the licence gives, so it renders only for a set of several photos
+  (`many?`) — with one photo the two controls would be the same state asked
+  twice on the same screen.
+
   Photo mode moves two things out of here to where they are seen (issue
   #1104 follow-up): `caption?` drops the caption input (it sits under every
   tile there, and a second input of the same name would corrupt the submit)
@@ -2121,8 +2266,11 @@ defmodule VutuvWeb.PostLive.Composer do
           </label>
         </div>
 
-        <%!-- Original download, and the one follow-up it reveals. --%>
-        <div>
+        <%!-- The per-photo override of the post-wide download answer, and the
+        one follow-up it reveals. With a single photo there is nothing to
+        override — the select beside the licence IS that photo's answer — so
+        the block stays away rather than offering the same state twice. --%>
+        <div :if={@many?}>
           <label class="flex items-start gap-2 text-sm text-slate-700 dark:text-slate-200">
             <input
               type="checkbox"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.169.0",
+      version: "7.170.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -17625,3 +17625,40 @@ msgstr "Fotos und Text dieses Entwurfs verwerfen?"
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Weiter, wo Sie aufgehört haben."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1424
+#, elixir-autogen, elixir-format
+msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
+msgstr "Eine Datei, deren Format sich nicht säubern lässt, wird exakt so weitergegeben, wie sie hochgeladen wurde."
+
+#: lib/vutuv_web/live/post_live/composer.ex:1399
+#, elixir-autogen, elixir-format
+msgid "Different per photo"
+msgstr "Pro Foto verschieden"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1396
+#, elixir-autogen, elixir-format
+msgid "Original, exactly as uploaded"
+msgstr "Original, exakt wie hochgeladen"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1393
+#, elixir-autogen, elixir-format
+msgid "Original, metadata removed"
+msgstr "Original, ohne Metadaten"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1390
+#, elixir-autogen, elixir-format
+msgid "Web versions only (%{format})"
+msgstr "Nur Web-Versionen (%{format})"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1386
+#, elixir-autogen, elixir-format
+msgid "What a visitor can save"
+msgstr "Was Besucher speichern können"
+
+#: lib/vutuv_web/live/post_live/composer.ex:1412
+#, elixir-autogen, elixir-format
+msgid "This photo carries the location it was taken at, and the exact file hands it over."
+msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
+msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exakte Datei gibt ihn weiter."
+msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -16856,3 +16856,40 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1424
+#, elixir-autogen, elixir-format
+msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1399
+#, elixir-autogen, elixir-format
+msgid "Different per photo"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1396
+#, elixir-autogen, elixir-format
+msgid "Original, exactly as uploaded"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1393
+#, elixir-autogen, elixir-format
+msgid "Original, metadata removed"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1390
+#, elixir-autogen, elixir-format
+msgid "Web versions only (%{format})"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1386
+#, elixir-autogen, elixir-format
+msgid "What a visitor can save"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1412
+#, elixir-autogen, elixir-format
+msgid "This photo carries the location it was taken at, and the exact file hands it over."
+msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -16854,3 +16854,40 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1424
+#, elixir-autogen, elixir-format
+msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1399
+#, elixir-autogen, elixir-format
+msgid "Different per photo"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1396
+#, elixir-autogen, elixir-format
+msgid "Original, exactly as uploaded"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1393
+#, elixir-autogen, elixir-format
+msgid "Original, metadata removed"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1390
+#, elixir-autogen, elixir-format
+msgid "Web versions only (%{format})"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1386
+#, elixir-autogen, elixir-format
+msgid "What a visitor can save"
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/composer.ex:1412
+#, elixir-autogen, elixir-format
+msgid "This photo carries the location it was taken at, and the exact file hands it over."
+msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
+msgstr[0] ""
+msgstr[1] ""

--- a/test/vutuv_web/live/photo_composer_test.exs
+++ b/test/vutuv_web/live/photo_composer_test.exs
@@ -130,6 +130,14 @@ defmodule VutuvWeb.PhotoComposerTest do
     |> render_click()
   end
 
+  # The post-wide download select carries its own phx-change (not the form's),
+  # so a test drives it through the element rather than through `form/3`.
+  defp choose_download(live, choice) do
+    live
+    |> element("#composer-download")
+    |> render_change(%{"post" => %{"download" => choice}})
+  end
+
   defp reload(image), do: Repo.get(PostImage, image.id)
 
   # The post the composer just saved, with its photos in stored order (the
@@ -210,11 +218,29 @@ defmodule VutuvWeb.PhotoComposerTest do
       refute has_element?(live, "input[data-photo-camera-switch][disabled]")
     end
 
+    test "one photo gets no download switch: the post-wide select is its answer", %{
+      live: live,
+      user: user
+    } do
+      # Two controls for one state on one screen is the duplicate the photo
+      # grid keeps being cleaned of; the panel's switch is the OVERRIDE, so it
+      # only means something once there is a set to differ from.
+      image = upload_photo!(live, user)
+      open_panel(live, image)
+
+      refute has_element?(live, "input[data-photo-download-switch]")
+
+      upload_photo!(live, user)
+
+      assert has_element?(live, "input[data-photo-download-switch]")
+    end
+
     test "the exact-file choice appears only once a download is offered", %{
       live: live,
       user: user
     } do
       image = upload_photo!(live, user)
+      upload_photo!(live, user)
       open_panel(live, image)
 
       refute render(live) =~ "The file exactly as I uploaded it"
@@ -232,6 +258,7 @@ defmodule VutuvWeb.PhotoComposerTest do
     } do
       image = upload_photo!(live, user, exif: [{"exif-ifd3-GPSLatitude", "50/1 56/1 0/1"}])
       assert image.has_gps
+      upload_photo!(live, user)
 
       open_panel(live, image)
       toggle(live, image, "download_original")
@@ -251,6 +278,7 @@ defmodule VutuvWeb.PhotoComposerTest do
     test "a photo with no location never warns, whatever is picked", %{live: live, user: user} do
       image = upload_photo!(live, user)
       refute image.has_gps
+      upload_photo!(live, user)
 
       open_panel(live, image)
       toggle(live, image, "download_original")
@@ -764,6 +792,126 @@ defmodule VutuvWeb.PhotoComposerTest do
       post = only_post(user)
       assert post.license == "cc-by-4.0"
       assert Vutuv.Accounts.User |> Repo.get(user.id) |> Posts.default_license() == "cc-by-4.0"
+    end
+  end
+
+  describe "the download choice" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      %{conn: conn, user: user}
+    end
+
+    test "it sits beside the licence in both modes, not behind a photo", %{
+      conn: conn,
+      user: user
+    } do
+      # Tapping a photo to find out whether the original can be downloaded is
+      # exactly the hunt the photo grid was meant to end, so the question is
+      # asked where the licence is asked.
+      live = open_photo_composer(conn)
+      upload_photo!(live, user)
+
+      assert has_element?(live, "#composer-download")
+
+      live |> form("#composer-form", %{"post" => %{"mode" => "text"}}) |> render_change()
+
+      assert has_element?(live, "#composer-download")
+    end
+
+    test "no photos, no question", %{conn: conn} do
+      live = open_composer(conn)
+
+      refute has_element?(live, "#composer-download")
+    end
+
+    test "the web versions are all a visitor gets until the author says otherwise", %{
+      conn: conn,
+      user: user
+    } do
+      live = open_photo_composer(conn)
+      image = upload_photo!(live, user)
+
+      assert has_element?(live, ~s(#composer-download option[value="none"][selected]))
+
+      live |> form("#composer-form", %{"post" => %{"mode" => "photos"}}) |> render_submit()
+
+      assert %{download_original: false, download_exact: false} = reload(image)
+    end
+
+    test "offering the original answers for the whole set at once", %{conn: conn, user: user} do
+      live = open_photo_composer(conn)
+      first = upload_photo!(live, user)
+      second = upload_photo!(live, user)
+
+      choose_download(live, "clean")
+      live |> form("#composer-form", %{"post" => %{"mode" => "photos"}}) |> render_submit()
+
+      assert %{download_original: true, download_exact: false} = reload(first)
+      assert %{download_original: true, download_exact: false} = reload(second)
+    end
+
+    test "the exact file is its own answer", %{conn: conn, user: user} do
+      live = open_photo_composer(conn)
+      image = upload_photo!(live, user)
+
+      choose_download(live, "exact")
+      live |> form("#composer-form", %{"post" => %{"mode" => "photos"}}) |> render_submit()
+
+      assert %{download_original: true, download_exact: true} = reload(image)
+    end
+
+    test "a location is called out at the moment the exact file is picked", %{
+      conn: conn,
+      user: user
+    } do
+      live = open_photo_composer(conn)
+      image = upload_photo!(live, user, exif: [{"exif-ifd3-GPSLatitude", "50/1 56/1 0/1"}])
+      assert image.has_gps
+
+      choose_download(live, "clean")
+      refute has_element?(live, "[data-download-gps-warning]")
+
+      choose_download(live, "exact")
+      assert has_element?(live, "[data-download-gps-warning]")
+
+      choose_download(live, "none")
+      refute has_element?(live, "[data-download-gps-warning]")
+    end
+
+    test "a set without a location never warns", %{conn: conn, user: user} do
+      live = open_photo_composer(conn)
+      upload_photo!(live, user)
+
+      choose_download(live, "exact")
+
+      refute has_element?(live, "[data-download-gps-warning]")
+    end
+
+    test "a per-photo override reads as such, and no keystroke quietly undoes it", %{
+      conn: conn,
+      user: user
+    } do
+      live = open_photo_composer(conn)
+      first = upload_photo!(live, user)
+      second = upload_photo!(live, user)
+
+      open_panel(live, first)
+      toggle(live, first, "download_original")
+
+      # The set now disagrees, and the select says so rather than claiming an
+      # answer nobody gave.
+      assert has_element?(live, ~s(#composer-download option[value="mixed"][selected]))
+
+      # A validate carrying the select's stale value (every keystroke does)
+      # must not push that value back onto the photos.
+      live
+      |> element("#composer-form")
+      |> render_change(%{"post" => %{"mode" => "photos", "download" => "none"}})
+
+      live |> form("#composer-form", %{"post" => %{"mode" => "photos"}}) |> render_submit()
+
+      assert %{download_original: true} = reload(first)
+      assert %{download_original: false} = reload(second)
     end
   end
 


### PR DESCRIPTION
**TL;DR** The photo composer now asks, right under the licence, whether visitors get the original file or only the AVIF versions the page serves. The per-photo columns shipped with #1104, but the switch was only reachable by tapping a photo, so the question read as missing.

## What changed

A labelled `Download` select under `Lizenz`, in both composer modes, once a photo is attached:

- **Nur Web-Versionen (AVIF)** (default)
- **Original, ohne Metadaten** (full resolution, location and serial numbers stripped)
- **Original, exakt wie hochgeladen** (byte for byte)

One answer covers the whole set, because that is how a photographer decides it; it writes every photo's `download_original` / `download_exact`. The per-photo panel keeps the override for a set of several photos and drops it for a single photo, where the two controls would be the same state asked twice on one screen. A set whose photos disagree reads "Pro Foto verschieden" instead of claiming an answer nobody gave.

The select carries its own `phx-change` rather than riding the form's `validate`: every keystroke replays the whole form, and a replayed value would push the select's answer back over a choice just made in the panel.

Two notices appear only when they apply: the location warning when the exact file is picked and a photo carries one, and the "this format cannot be cleaned" line, so the composer never promises a cleaned file the download route would refuse (`Posts.update_image_settings/2` forces the exact file there).

## Verification

- New tests in `photo_composer_test.exs` (default, whole set, exact file, location warning, "different per photo" surviving a keystroke); `mix precommit` green.
- Browser smoke test on a German QA account: the select renders in German, "Original, exakt wie hochgeladen" lands as `download_original=t, download_exact=t`, and `/post_images/<token>/original.orig` then answers 200.
- German translations added to all three catalogs (surgical, no `gettext.extract`); `docs/architecture/posts-and-feed.md` updated.

**Deploy:** hot (no migrations, no config or dependency changes). **Version:** 7.170.0.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_011SL9FZTsuBpgq5WasLJRLN