### PR TITLE
Name who reacted from another network, and say so (#1068)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -3,9 +3,10 @@
 People on Mastodon and other ActivityPub servers can follow an opted-in
 member and receive their **public** posts. Federation is outbound-first by
 design, and what comes back is accepted in two tiers, each with its own switch:
-a bare **count** of favourites and re-shares (issue #1068, on by default) and,
-behind a second and deliberately separate opt-in, the **replies** people out
-there write under a member's post (issues #1069 and #1071, off by default). The
+the **favourites and re-shares** people out there give a post, as their account
+address and nothing else (issue #1068, on by default) and, behind a second and
+deliberately separate opt-in, the **replies** they write under it (issues #1069
+and #1071, off by default — that tier stores their words). The
 inbox otherwise processes only `Follow`, `Undo(Follow)`, the remote actor's own
 lifecycle (`Update` / `Delete`) and an author's `Update`/`Delete` of a reply they
 sent us; everything else is acknowledged (202) and dropped. Everything lives in
@@ -99,29 +100,49 @@ every endpoint 404s and nothing is delivered.
 - **Reactions from other networks** (issue #1068, the one inbound thing that is
   stored): a `Like` or `Announce` naming a member's public Note becomes one row
   in `fediverse_reactions` (`Vutuv.Fediverse.Reaction`) — `post_id`,
-  `actor_uri`, `kind`, `received_at` and **nothing else**. No display name, no
-  avatar, no text: vutuv can never obtain consent from a stranger on another
-  server, so what makes this lawful is storing almost nothing about them plus a
-  deletion path that really works. The actor URI earns its place twice over:
-  each person counts once (unique on `(post_id, actor_uri, kind)`) and an
-  upstream `Undo` can find its row. `record_reaction/4` holds every gate in
-  order — the installation switch, the member federates and has not switched
-  the counts off (`users.fediverse_reactions?`, on by default, `/settings/
-  fediverse`; switching it off calls `drop_reactions/1`), the object really is
-  one of *their* public Note URLs, and the sender is within its inbound cap —
-  and the inbox answers the same 202 whatever it decides, so a misdirected
-  activity learns nothing. `remove_reaction/4` is deliberately **un**gated: an
-  upstream withdrawal is the deletion path, so it must not depend on a switch
-  still being on. Rows live exactly as long as the post (FK cascade, so a post
-  delete and an account delete both take them), like a vutuv like; there is no
-  separate expiry. The count rides the existing engagement select
-  (`Vutuv.Posts.engagement_count_select/1` → `:fediverse_reactions`), so it is
-  batched with the other counters, ticks live through `{:post_counters, …}`
-  (`broadcast_post_counters/1`) and reaches `VutuvWeb.AgentDocs.PostDoc` as
-  `fediverse_reaction_count`. It renders as its **own** labelled line under the
-  vutuv counters, never folded into them: a hostile server can then inflate
-  only its own line, and the reader sees which world answered. Public and
-  hidden at zero.
+  `actor_uri`, `handle`, `kind`, `received_at` and **nothing else**. No display
+  name, no avatar, no text: vutuv can never obtain consent from a stranger on
+  another server, so what makes this lawful is storing almost nothing about them
+  plus a deletion path that really works. The two stored identifiers are one and
+  the same account address in two notations — `handle` is the actor document's
+  `preferredUsername`, which the inbox has in hand anyway from the fetch that
+  verifies the signature, so naming the account costs no extra request. The
+  actor URI earns its place three times over: each person counts once (unique on
+  `(post_id, actor_uri, kind)`), an upstream `Undo` finds its row, and the post
+  can say who answered. `record_reaction/4` holds every gate in order — the
+  installation switch, the member federates and has not switched reactions off
+  (`users.fediverse_reactions?`, on by default, `/settings/fediverse`; switching
+  it off calls `drop_reactions/1`), the object really is one of *their* public
+  Note URLs, and the sender is within its inbound cap — and the inbox answers
+  the same 202 whatever it decides, so a misdirected activity learns nothing.
+  `remove_reaction/4` is deliberately **un**gated: an upstream withdrawal is the
+  deletion path, so it must not depend on a switch still being on. Rows live
+  exactly as long as the post (FK cascade, so a post delete and an account
+  delete both take them), like a vutuv like; there is no separate expiry.
+  - The count **and the newest few accounts** ride the existing engagement
+    select (`Vutuv.Posts.engagement_count_select/1` → `:fediverse_reactions`
+    plus a `json_agg` of `:fediverse_reaction_actors`, capped at 4 rows), so
+    both are batched with the other counters, tick live through
+    `{:post_counters, …}` (`broadcast_post_counters/1`) and reach
+    `VutuvWeb.AgentDocs.PostDoc` as `fediverse_reaction_count` and
+    `fediverse_reactions`. The cap lives in SQL so a post with a thousand boosts
+    cannot drag a thousand rows into a feed card; the count stays the true total
+    behind the "+N more" tail.
+  - It renders as its **own** line under the vutuv counters, never folded into
+    them: a hostile server can then inflate only its own line, and the reader
+    sees which world answered. Each account is a chip — the heart or re-share
+    glyph the vutuv action bar uses for the same act, the `@handle@host`
+    (`Vutuv.Fediverse.Handle`, shared with the follower list and the reply
+    cards), linking **out** to the account, since there is no vutuv profile
+    behind it. Public, like the counts always were: both acts are published
+    under the actor's own name on their own server, and the reply cards below
+    already name their authors the same way. Hidden at zero.
+  - A new reaction also **notifies the author** (`fediverse_reaction`, the
+    notification kind shaped exactly like `fediverse_reply`): derived straight
+    from the reaction rows, so an `Undo`, a deleted post or the member switching
+    reactions off deletes the notification with the row and there is no second
+    place that has to remember to forget. Rows merge per post *and* per kind —
+    a favourite and a re-share are different news.
 - **Replies from other networks** (issues #1069 and #1071, the first content
   vutuv stores that its own members did not write): a `Create(Note)` whose
   `inReplyTo` names one of a member's public posts becomes a row in
@@ -340,7 +361,7 @@ every endpoint 404s and nothing is delivered.
 - **The member's two pages.** `/settings/fediverse` answers one question for
   someone who has never heard the word: do I take part at all. Plain-language
   explainer, the three things that happen if you do, the on/off switch, the
-  reaction-count switch, then — once on — the handle (with the shared
+  reactions switch, then — once on — the handle (with the shared
   `data-copy` button, since copying it is the action people come for) and who
   followed. **`/settings/fediverse/move`** holds account migration, **both
   directions on one page** (`Umzug zu vutuv` = the `alsoKnownAs` aliases,
@@ -445,7 +466,7 @@ account.
 
 Because leaving now really does ask other servers to forget the member,
 switching off also **drops their follower rows** (`drop_followers/1`, the
-symmetry `drop_reactions/1` already had for the reaction counts): those servers
+symmetry `drop_reactions/1` already had for the reactions): those servers
 drop the follow at their end, so a kept row would only be a relationship that
 exists nowhere else.
 

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -39,6 +39,7 @@ defmodule Vutuv.Activity do
   alias Vutuv.Activity.NotificationPostRead
   alias Vutuv.Engagement
   alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.Reaction
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Notifications.Emailer
   alias Vutuv.Organizations.Organization
@@ -443,6 +444,34 @@ defmodule Vutuv.Activity do
   end
 
   @doc ~S"""
+  Convenience: a "favourited / shared your post from another network"
+  notification (issue #1068) — the answer coming back from Mastodon and its
+  kin, now stored as a `Vutuv.Fediverse.Reaction`.
+
+  Same shape as `notify_fediverse_reply/3`, and for the same reason: the live
+  push only, with the reaction row itself as the durable half that
+  `fediverse_reaction_items/3` derives the feed entry from. An upstream `Undo`
+  deletes the row, and the notification goes with it — there is no second place
+  that has to remember to forget.
+
+  `reaction_kind` rides along because the sentence turns on it: a favourite and
+  a re-share are not the same news.
+  """
+  def notify_fediverse_reaction(%User{} = user, post, reaction) do
+    notify(
+      user.id,
+      Map.merge(remote_actor_fields(reaction), %{
+        kind: "fediverse_reaction",
+        text: "reacted to your post from another network.",
+        post_id: post.id,
+        reaction_id: reaction.id,
+        reaction_kind: reaction.kind,
+        at: reaction.received_at
+      })
+    )
+  end
+
+  @doc ~S"""
   Convenience: a "mentioned you in a post" notification for a member the post's
   body names by `@handle`. `post_id` is that post — written by the actor, not by
   the recipient, so the row links it under the **author's** profile.
@@ -613,6 +642,7 @@ defmodule Vutuv.Activity do
       {"thread", &thread_items(user_id, &1, &2)},
       {"mention", &mention_items(user_id, &1, &2)},
       {"fediverse_reply", &fediverse_reply_items(user_id, &1, &2)},
+      {"fediverse_reaction", &fediverse_reaction_items(user_id, &1, &2)},
       {"like", &like_items(user_id, &1, &2)},
       {"organization_role", &organization_role_items(user_id, &1, &2)},
       {"moderation", &moderation_items(user_id, &1, &2)},
@@ -722,6 +752,7 @@ defmodule Vutuv.Activity do
       {"thread", count_thread_replies(user_id, read_at, unread?)},
       {"mention", count_mentions(user_id, read_at, unread?)},
       {"fediverse_reply", count_fediverse_replies(user_id, read_at)},
+      {"fediverse_reaction", count_fediverse_reactions(user_id, read_at)},
       {"like", count_likes(user_id, read_at)},
       {"organization_role", count_organization_roles(user_id, read_at)},
       {"cv_update", count_cv_updates(user_id, read_at)},
@@ -953,6 +984,50 @@ defmodule Vutuv.Activity do
     user_id
     |> fediverse_reply_events()
     |> select([note: n], %{count: count()})
+    |> note_since(read_at)
+  end
+
+  # Favourites and re-shares from other networks (issue #1068), sourced straight
+  # from the reaction rows for the same reason the replies are: an upstream
+  # `Undo`, a deleted post or a member switching the counts off deletes the row,
+  # and the notification goes with it.
+  defp fediverse_reaction_items(user_id, limit, cursor) do
+    user_id
+    |> fediverse_reaction_events()
+    |> order_by([note: r], desc: r.received_at, desc: r.id)
+    |> limit(^limit)
+    |> select([note: r], r)
+    |> note_at_or_before(cursor)
+    |> Repo.all()
+    |> Enum.map(fn reaction ->
+      reaction
+      |> remote_actor_fields()
+      |> Map.merge(%{
+        id: "fediverse_reaction-#{reaction.id}",
+        kind: "fediverse_reaction",
+        at: DateTime.to_naive(reaction.received_at),
+        post_id: reaction.post_id,
+        reaction_id: reaction.id,
+        reaction_kind: reaction.kind
+      })
+    end)
+  end
+
+  # Named `:note` like the reply source so both share `note_at_or_before/2` and
+  # `note_since/2` — the same `received_at` boundary conversion, one copy.
+  defp fediverse_reaction_events(user_id) do
+    from(r in Reaction,
+      as: :note,
+      join: p in Post,
+      on: p.id == r.post_id,
+      where: p.user_id == ^user_id
+    )
+  end
+
+  defp count_fediverse_reactions(user_id, read_at) do
+    user_id
+    |> fediverse_reaction_events()
+    |> select([note: r], %{count: count()})
     |> note_since(read_at)
   end
 
@@ -1305,6 +1380,21 @@ defmodule Vutuv.Activity do
       actor_avatar: nil,
       actor_handle: Note.display_handle(note),
       actor_url: note.actor_uri
+    }
+  end
+
+  # A reaction knows no display name (we deliberately never stored one), so the
+  # `@handle@host` is both the name and the handle.
+  defp remote_actor_fields(%Reaction{} = reaction) do
+    handle = Reaction.display_handle(reaction)
+
+    %{
+      actor_id: nil,
+      actor_name: handle,
+      actor_param: nil,
+      actor_avatar: nil,
+      actor_handle: handle,
+      actor_url: reaction.actor_uri
     }
   end
 

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -783,23 +783,45 @@ defmodule Vutuv.Fediverse do
   else is `:skip` — the inbox acknowledges and drops it either way, so a
   misdirected activity never tells the sender what happened.
 
+  `actor` is the remote actor as `%{uri:, handle:}` (the inbox has the fetched
+  document in hand), or a bare URI string when there is no handle to keep.
+
   Broadcasts the post's counters afterwards, so an open action bar ticks over
-  without a reload.
+  without a reload, and tells the author — a favourite or a boost from out
+  there is news exactly like a vutuv like, and until it notified nothing the
+  count simply crept up unseen.
   """
-  def record_reaction(%User{} = user, object, kind, actor_uri) when kind in ~w(like announce) do
+  def record_reaction(%User{} = user, object, kind, actor) when kind in ~w(like announce) do
+    %{uri: actor_uri} = actor = actor_attrs(actor)
+
     with true <- enabled?(),
          true <- federated?(user),
          true <- user.fediverse_reactions?,
          %Post{} = post <- resolve_own_note(user, object),
          false <- Posts.restricted?(post),
          :ok <- check_inbound_cap(actor_uri),
-         {:ok, _} <- insert_reaction(post, actor_uri, kind) do
+         {:ok, reaction} <- insert_reaction(post, actor, kind) do
       Posts.broadcast_post_counters(post.id)
+      notify_reaction(user, post, reaction)
       :ok
     else
       _ -> :skip
     end
   end
+
+  # Both call shapes as one map. A bare URI is what an `Undo` and the tests
+  # carry; the inbox passes the actor document's `preferredUsername` along.
+  defp actor_attrs(uri) when is_binary(uri), do: %{uri: uri, handle: nil}
+  defp actor_attrs(%{uri: uri} = actor), do: %{uri: uri, handle: actor[:handle]}
+  defp actor_attrs(other), do: %{uri: other, handle: nil}
+
+  # Only a genuinely new row is news: a redelivery of a Like we already hold
+  # must not ring the bell a second time (`insert_reaction/3` reports it as
+  # `:exists`).
+  defp notify_reaction(user, post, %Reaction{} = reaction),
+    do: Activity.notify_fediverse_reaction(user, post, reaction)
+
+  defp notify_reaction(_user, _post, :exists), do: :ok
 
   @doc """
   Removes a reaction the remote side took back (`Undo(Like)` / `Undo(Announce)`).
@@ -844,15 +866,47 @@ defmodule Vutuv.Fediverse do
     count
   end
 
-  defp insert_reaction(post, actor_uri, kind) do
-    %Reaction{post_id: post.id}
-    |> Reaction.changeset(%{
-      actor_uri: actor_uri,
-      kind: kind,
-      received_at: DateTime.utc_now(:second)
-    })
-    |> Repo.insert(on_conflict: :nothing, conflict_target: [:post_id, :actor_uri, :kind])
+  # Validated by the changeset, written by `insert_all` — because the caller
+  # has to know whether this delivery was *new*. `Repo.insert(on_conflict:
+  # :nothing)` cannot say: the v7 id is minted in Elixir, so the struct it hands
+  # back looks identical whether the row landed or collided. `insert_all`'s row
+  # count is the honest answer, and `:exists` is what keeps a redelivery from
+  # notifying twice.
+  defp insert_reaction(post, actor, kind) do
+    changeset =
+      %Reaction{post_id: post.id}
+      |> Reaction.changeset(%{
+        actor_uri: actor.uri,
+        # Cosmetic, remote-supplied and hostile: cut it to a column's worth
+        # rather than lose the whole reaction to an over-long one.
+        handle: truncate_handle(actor.handle),
+        kind: kind,
+        received_at: DateTime.utc_now(:second)
+      })
+
+    with {:ok, reaction} <- Ecto.Changeset.apply_action(changeset, :insert) do
+      row = %{
+        id: UUIDv7.generate(),
+        post_id: post.id,
+        actor_uri: reaction.actor_uri,
+        handle: reaction.handle,
+        kind: reaction.kind,
+        received_at: reaction.received_at
+      }
+
+      case Repo.insert_all(Reaction, [row],
+             on_conflict: :nothing,
+             conflict_target: [:post_id, :actor_uri, :kind],
+             returning: true
+           ) do
+        {0, _} -> {:ok, :exists}
+        {1, [inserted]} -> {:ok, inserted}
+      end
+    end
   end
+
+  defp truncate_handle(handle) when is_binary(handle), do: String.slice(handle, 0, 255)
+  defp truncate_handle(_handle), do: nil
 
   # The post behind an activity's `object`, but only when it is a Note URL we
   # serve for *this* member. A URL naming somebody else's post, a foreign host,

--- a/lib/vutuv/fediverse/follower.ex
+++ b/lib/vutuv/fediverse/follower.ex
@@ -16,6 +16,8 @@ defmodule Vutuv.Fediverse.Follower do
 
   use VutuvWeb, :model
 
+  alias Vutuv.Fediverse.Handle
+
   # Remote URIs are unbounded in theory; cap generously (they are `text`
   # columns) so a hostile payload cannot store megabytes.
   @max_uri 2_048
@@ -52,15 +54,13 @@ defmodule Vutuv.Fediverse.Follower do
   end
 
   @doc """
-  The `@user@host` Fediverse handle to show the member. Uses the captured
-  `handle` (the remote `preferredUsername`) when present, else the last path
-  segment of the actor URI; the host is always the actor URI's host. This is a
-  best-effort display label — the linked `actor_uri` is the canonical target.
+  The `@user@host` Fediverse handle to show the member. A best-effort display
+  label — the linked `actor_uri` is the canonical target — built by the shared
+  `Vutuv.Fediverse.Handle`, so a follower, a reply and a reaction never write
+  the same person two different ways on one page.
   """
-  def display_handle(%__MODULE__{actor_uri: actor_uri} = follower) do
-    uri = URI.parse(actor_uri)
-    "@#{follower.handle || derive_username(uri)}@#{uri.host}"
-  end
+  def display_handle(%__MODULE__{actor_uri: actor_uri} = follower),
+    do: Handle.display(follower.handle, actor_uri)
 
   @doc """
   The remote server this follower lives on, as the follower browser's Server
@@ -72,13 +72,5 @@ defmodule Vutuv.Fediverse.Follower do
       nil -> ""
       host -> String.downcase(host)
     end
-  end
-
-  defp derive_username(%URI{path: path}) do
-    (path || "")
-    |> String.split("/", trim: true)
-    |> List.last()
-    |> to_string()
-    |> String.trim_leading("@")
   end
 end

--- a/lib/vutuv/fediverse/handle.ex
+++ b/lib/vutuv/fediverse/handle.ex
@@ -1,0 +1,80 @@
+defmodule Vutuv.Fediverse.Handle do
+  @moduledoc """
+  How vutuv names an account that lives on another server: `@handle@host`, the
+  form every one of those networks uses.
+
+  One module because two different tables need the same answer — a stored reply
+  (`Vutuv.Fediverse.Note`) and a stored reaction (`Vutuv.Fediverse.Reaction`) —
+  and a reader must not see the same person written two ways on one page.
+
+  The handle we store is the actor document's `preferredUsername`. When there is
+  none (a row written before we kept it, or a server that omits it) the account
+  URI still carries a usable name: every implementation puts it in the last path
+  segment — Mastodon and Pleroma `/users/alice`, Lemmy `/u/alice`, Friendica
+  `/profile/alice`, some servers `/@alice`.
+
+  Deriving it is a **display** fallback and nothing more. It is guesswork: a
+  server that puts an opaque id there gives an opaque name, which is why the
+  chip is always a link to the account URI — that one is canonical. Where the
+  segment is not even shaped like a name (empty, a path we cannot read) the bare
+  host is shown instead, because the host is always true.
+  """
+
+  # Shaped like a name at all: one path segment, no whitespace, no separators,
+  # and short enough not to be a wall of text in a chip.
+  @username ~r/^[A-Za-z0-9_.-]{1,64}$/
+
+  @doc """
+  `@handle@host` for a stored `handle` (may be nil) and the account's URI.
+
+  Falls back to the URI's last path segment, then to `@host` alone, and finally
+  — for a URI we cannot even parse a host out of — to the stored handle or nil.
+  """
+  def display(handle, actor_uri) do
+    case {present(handle) || derive(actor_uri), host(actor_uri)} do
+      {nil, nil} -> nil
+      {name, nil} -> "@" <> name
+      {nil, host} -> "@" <> host
+      {name, host} -> "@" <> name <> "@" <> host
+    end
+  end
+
+  @doc "The server an account URI names, or nil."
+  def host(uri) when is_binary(uri) do
+    case URI.parse(uri) do
+      %URI{host: host} when is_binary(host) and host != "" -> host
+      _ -> nil
+    end
+  end
+
+  def host(_uri), do: nil
+
+  # The last path segment, when it reads like a username. A leading "@" is part
+  # of the URL style (`/@alice`), not part of the name.
+  defp derive(uri) when is_binary(uri) do
+    uri
+    |> URI.parse()
+    |> Map.get(:path)
+    |> to_string()
+    |> String.split("/", trim: true)
+    |> List.last()
+    |> to_string()
+    |> String.trim_leading("@")
+    |> username()
+  end
+
+  defp derive(_uri), do: nil
+
+  defp username(candidate) do
+    if Regex.match?(@username, candidate), do: candidate
+  end
+
+  defp present(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp present(_value), do: nil
+end

--- a/lib/vutuv/fediverse/note.ex
+++ b/lib/vutuv/fediverse/note.ex
@@ -30,6 +30,8 @@ defmodule Vutuv.Fediverse.Note do
 
   use VutuvWeb, :model
 
+  alias Vutuv.Fediverse.Handle
+
   @audiences ~w(public followers direct unknown)
 
   # Remote URIs are unbounded in theory. Cap them in **bytes**, because
@@ -92,26 +94,14 @@ defmodule Vutuv.Fediverse.Note do
 
   @doc """
   How the card names the author: `@handle@host`, the form every one of these
-  networks uses. Falls back to the bare host when the remote document carried no
-  `preferredUsername`.
+  networks uses. Shared with the follower list and the reaction chips
+  (`Vutuv.Fediverse.Handle`), so one person reads the same way everywhere.
   """
-  def display_handle(%__MODULE__{handle: handle, actor_uri: actor_uri}) do
-    case {handle, host(actor_uri)} do
-      {_, nil} -> handle
-      {nil, host} -> "@#{host}"
-      {handle, host} -> "@#{handle}@#{host}"
-    end
-  end
+  def display_handle(%__MODULE__{handle: handle, actor_uri: actor_uri}),
+    do: Handle.display(handle, actor_uri)
 
   @doc "The server this note came from, for the card's footer and the ledger."
-  def host(uri) when is_binary(uri) do
-    case URI.parse(uri) do
-      %URI{host: host} when is_binary(host) and host != "" -> host
-      _ -> nil
-    end
-  end
-
-  def host(_), do: nil
+  defdelegate host(uri), to: Handle
 
   @doc "Where a human reads the original: the note's own page, or its id."
   def origin(%__MODULE__{origin_url: url}) when is_binary(url) and url != "", do: url

--- a/lib/vutuv/fediverse/reaction.ex
+++ b/lib/vutuv/fediverse/reaction.ex
@@ -3,18 +3,24 @@ defmodule Vutuv.Fediverse.Reaction do
   One remote reaction to a member's post (issue #1068): somebody on another
   network favourited (`like`) or re-shared (`announce`) it.
 
-  **Counts only.** No display name, no avatar, no text — the actor URI is stored
-  for exactly two reasons: so each remote person counts once, and so an upstream
-  `Undo` can find its row. That minimalism is the point: vutuv can never obtain
-  consent from a stranger on another server, so what makes this lawful is
-  storing almost nothing about them and deleting it the moment they, the post or
-  the account go.
+  **An account address and what they did — nothing more.** No display name, no
+  avatar, no text. `actor_uri` earns its place three times over: each remote
+  person counts once, an upstream `Undo` finds its row, and the post says who
+  answered instead of only that somebody did. `handle` is the same address in
+  the notation those networks write it in (`@handle@host`), captured from the
+  actor document the inbox fetches anyway to verify the signature.
+
+  That minimalism is the point: vutuv can never obtain consent from a stranger
+  on another server, so what makes this lawful is storing almost nothing about
+  them and deleting it the moment they, the post or the account go.
 
   The row's lifetime is the post's lifetime (the FK cascades), exactly like a
   vutuv like. There is no separate expiry.
   """
 
   use VutuvWeb, :model
+
+  alias Vutuv.Fediverse.Handle
 
   @kinds ~w(like announce)
 
@@ -29,18 +35,29 @@ defmodule Vutuv.Fediverse.Reaction do
 
   schema "fediverse_reactions" do
     field(:actor_uri, :string)
+    field(:handle, :string)
     field(:kind, :string)
     field(:received_at, :utc_datetime)
 
     belongs_to(:post, Vutuv.Posts.Post)
   end
 
+  @doc """
+  How the post names this person: `@handle@host`. Falls back to the actor URI's
+  last path segment (rows stored before the handle was kept), then to the bare
+  host. Shared with the reply cards and the follower list.
+  """
+  def display_handle(%__MODULE__{handle: handle, actor_uri: actor_uri}),
+    do: Handle.display(handle, actor_uri)
+
   def changeset(%__MODULE__{} = reaction, attrs) do
     reaction
-    |> cast(attrs, [:actor_uri, :kind, :received_at])
+    |> cast(attrs, [:actor_uri, :handle, :kind, :received_at])
     |> validate_required([:actor_uri, :kind, :received_at])
     |> validate_inclusion(:kind, @kinds)
     |> validate_length(:actor_uri, max: @max_uri_bytes, count: :bytes)
+    # Remote-supplied and cosmetic: keep a column's worth, never let it 22001.
+    |> validate_length(:handle, max: 255)
     |> unique_constraint([:post_id, :actor_uri, :kind])
   end
 end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1045,6 +1045,30 @@ defmodule Vutuv.Posts do
             "(SELECT count(*) FROM fediverse_reactions fr WHERE fr.post_id = ?)",
             unquote(post).id
           ),
+        # ...and WHO they were. A bare number told the author nothing: their
+        # post had travelled somewhere and there was no way to see where or to
+        # whom (issue #1068 shipped the count alone). Each entry is the stored
+        # account address and the verb, which is the whole row — there is
+        # nothing else about these people to show.
+        #
+        # Capped here rather than in the renderer: a post with a thousand boosts
+        # must not drag a thousand rows into every feed card, and the count
+        # above already carries the true total for the "+N more" tail. Rides the
+        # engagement select so it is batched with the counters, reaches the
+        # `{:post_counters, …}` broadcast, and needs no second round trip on any
+        # page that already loads engagement.
+        fediverse_reaction_actors:
+          fragment(
+            """
+            (SELECT coalesce(json_agg(a ORDER BY a.received_at DESC, a.id DESC), '[]'::json)
+               FROM (SELECT fr.id, fr.kind, fr.actor_uri, fr.handle, fr.received_at
+                       FROM fediverse_reactions fr
+                      WHERE fr.post_id = ?
+                      ORDER BY fr.received_at DESC, fr.id DESC
+                      LIMIT 4) a)
+            """,
+            unquote(post).id
+          ),
         # Replies written on other networks (issue #1069), on their own figure
         # for the same reason. **Public ones only**: a reply addressed to the
         # member alone (issue #1071) must not move a number anybody else can
@@ -1071,6 +1095,7 @@ defmodule Vutuv.Posts do
         reposts: 0,
         replies: 0,
         fediverse_reactions: 0,
+        fediverse_reaction_actors: [],
         fediverse_replies: 0
       }
   end

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -912,7 +912,8 @@ defmodule VutuvWeb.AgentDocs.Markdown do
 
       count ->
         vutuv_counts <>
-          " · " <> gettext("Reactions from other networks") <> ": #{count}"
+          " · " <>
+          gettext("Reactions from other networks") <> ": #{count}#{reaction_names(doc)}"
     end
     |> then(fn line ->
       case doc[:fediverse_reply_count] || 0 do
@@ -921,6 +922,21 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       end
     end)
   end
+
+  # The accounts behind those reactions, the same ones the HTML line names as
+  # chips. Parenthesised after the count so the figure stays first and a doc for
+  # a post nobody reacted to is unchanged.
+  defp reaction_names(doc) do
+    case doc[:fediverse_reactions] || [] do
+      [] -> ""
+      entries -> " (" <> Enum.map_join(entries, ", ", &reaction_name/1) <> ")"
+    end
+  end
+
+  defp reaction_name(%{kind: "announce", handle: handle}),
+    do: gettext("%{handle} shared this", handle: handle)
+
+  defp reaction_name(%{handle: handle}), do: gettext("%{handle} liked this", handle: handle)
 
   @doc """
   The post's review sidecar as one fact line (what the HTML review card

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -12,6 +12,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   use Gettext, backend: VutuvWeb.Gettext
 
   alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Handle
   alias Vutuv.Fediverse.Note
   alias Vutuv.Posts
   alias Vutuv.Posts.PhotoLicense
@@ -83,6 +84,10 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # Favourites and re-shares from OTHER networks (issue #1068), the same
       # separate figure the HTML shows on its own line under the vutuv counters.
       fediverse_reaction_count: engagement.fediverse_reactions,
+      # ...and the accounts behind the newest few of them, exactly the chips the
+      # HTML line names — same rows, same cap, so the two cannot drift. The
+      # count above stays the true total.
+      fediverse_reactions: reaction_entries(engagement),
       fediverse_reply_count: engagement.fediverse_replies,
       # The replies written on other networks that the HTML thread weaves in
       # (issue #1069). **Public ones only, on every path** — note the hardcoded
@@ -193,6 +198,24 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
         received_at: note.received_at,
         content_warning: note.summary,
         text: note.content_text
+      }
+    end)
+  end
+
+  # One reaction from another network as a doc entry: the account address in
+  # both notations and what they did. That is the entire stored row — there is
+  # no name, no avatar and no text to add.
+  defp reaction_entries(engagement) do
+    engagement
+    |> Map.get(:fediverse_reaction_actors, [])
+    |> List.wrap()
+    |> Enum.map(fn row ->
+      %{
+        handle: Handle.display(row["handle"], row["actor_uri"]),
+        network: Handle.host(row["actor_uri"]),
+        url: row["actor_uri"],
+        kind: row["kind"],
+        received_at: row["received_at"]
       }
     end)
   end

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -27,6 +27,7 @@ defmodule VutuvWeb.PostComponents do
   import VutuvWeb.UserHelpers, only: [full_name: 1]
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse.Handle
   alias Vutuv.Fediverse.Note
   alias Vutuv.Isbn
   alias Vutuv.Moderation.ImageScans
@@ -3009,63 +3010,115 @@ defmodule VutuvWeb.PostComponents do
     <.fediverse_line
       :if={@engagement}
       reactions={@engagement.fediverse_reactions}
+      actors={Map.get(@engagement, :fediverse_reaction_actors, [])}
       replies={Map.get(@engagement, :fediverse_replies, 0)}
     />
     """
   end
 
-  # What other networks did with this post (issues #1068 and #1069): labelled
-  # counts on their OWN line under the vutuv counters, never folded into them. A
-  # member who publishes outward otherwise gets no feedback at all, and keeping
-  # the figures separate means a hostile remote server can inflate only its own
-  # line — and the reader can see which world answered. Public, because both are
-  # aggregates with no identity attached; the reply figure counts **public**
-  # replies only, so a note addressed to the member alone (issue #1071) never
-  # moves a number a stranger can read. Renders nothing while both are zero, so
-  # a post nobody out there touched stays clean.
+  # What other networks did with this post (issues #1068 and #1069): its OWN
+  # line under the vutuv counters, never folded into them. A member who
+  # publishes outward otherwise gets no feedback at all, and keeping the figures
+  # separate means a hostile remote server can inflate only its own line — the
+  # reader can see which world answered.
+  #
+  # It **names** the accounts that reacted, one chip each, rather than reporting
+  # a bare number: "1 reaction from other networks" told the author that their
+  # post had travelled somewhere, and nothing whatsoever about where or to whom,
+  # which is not transparency but a rumour. A chip carries the whole stored row
+  # — the account address and the verb — and links out to the account, since
+  # there is no vutuv profile behind it. Public, like the counts always were:
+  # both a favourite and a re-share are acts those networks publish under the
+  # actor's own name, and the reply cards below already name their authors the
+  # same way.
+  #
+  # The reply figure stays a count (the replies themselves render as cards on
+  # the permalink) and counts **public** ones only, so a note addressed to the
+  # member alone (issue #1071) never moves a number a stranger can read.
+  # Renders nothing while everything is zero, so a post nobody out there touched
+  # stays clean.
   attr(:reactions, :integer, required: true)
+  attr(:actors, :list, required: true, doc: "the newest few reaction rows, JSON-decoded")
   attr(:replies, :integer, required: true)
 
   defp fediverse_line(%{reactions: reactions, replies: replies} = assigns)
        when reactions > 0 or replies > 0 do
-    assigns = assign(assigns, :text, fediverse_line_text(reactions, replies))
+    shown = shown_reaction_actors(assigns.actors, reactions)
+
+    assigns =
+      assigns
+      |> assign(:shown, shown)
+      |> assign(:more, reactions - length(shown))
 
     ~H"""
     <div
-      class="mt-2 border-t border-slate-100 pt-2 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-400"
+      class="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-slate-100 pt-2 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-400"
       data-fediverse-reactions={@reactions}
       data-fediverse-replies={@replies}
     >
-      <span aria-hidden="true" class="mr-1">🌐</span>{@text}
+      <span class="inline-flex items-center gap-1">
+        <span aria-hidden="true">🌐</span>{gettext("From other networks")}
+      </span>
+
+      <a
+        :for={actor <- @shown}
+        href={actor.uri}
+        target="_blank"
+        rel="nofollow noopener noreferrer"
+        data-fediverse-reaction={actor.kind}
+        title={reaction_title(actor)}
+        class="inline-flex min-h-8 max-w-full items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-200 hover:text-brand-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-brand-300"
+      >
+        <%!-- The same two glyphs the vutuv action bar above uses for the same
+              two acts, so "shared" and "favourited" read identically whichever
+              world they came from. --%>
+        <.icon_repost :if={actor.kind == "announce"} class="h-3.5 w-3.5 shrink-0" />
+        <.icon_heart :if={actor.kind != "announce"} filled?={false} class="h-3.5 w-3.5 shrink-0" />
+        <span class="sr-only">{reaction_title(actor)}</span>
+        <span aria-hidden="true" class="break-all">{actor.handle}</span>
+      </a>
+
+      <span :if={@more > 0} data-fediverse-reactions-more={@more}>
+        {gettext("+%{count} more", count: compact_count(@more))}
+      </span>
+
+      <span :if={@replies > 0} class="inline-flex items-center gap-1">
+        <.icon_reply class="h-3.5 w-3.5 shrink-0" />{reply_phrase(@replies)}
+      </span>
     </div>
     """
   end
 
   defp fediverse_line(assigns), do: ~H""
 
-  # One **whole** sentence per case, never a line assembled from fragments: the
-  # figures go in as placeholders so a translator owns the word order (German
-  # would otherwise be at the mercy of where the English happens to put "from
-  # other networks"). The noun phrases are their own ngettext calls, because
-  # only they need the singular/plural split.
-  defp fediverse_line_text(reactions, 0), do: gettext_from_networks(reaction_phrase(reactions))
-  defp fediverse_line_text(0, replies), do: gettext_from_networks(reply_phrase(replies))
+  # The rows the SQL cap handed us (`Vutuv.Posts.engagement_count_select/1`
+  # fetches a few more than a card should show), normalised out of their
+  # JSON string keys. Showing every fetched row when the total fits keeps the
+  # common "one boost" case whole; past that one slot goes to the "+N" tail so
+  # the count and the chips always add up.
+  defp shown_reaction_actors(actors, total) when is_list(actors) do
+    actors = Enum.map(actors, &reaction_actor/1)
 
-  defp fediverse_line_text(reactions, replies) do
-    gettext("%{reactions} and %{replies} from other networks",
-      reactions: reaction_phrase(reactions),
-      replies: reply_phrase(replies)
-    )
+    if total > length(actors), do: Enum.take(actors, length(actors) - 1), else: actors
   end
 
-  defp gettext_from_networks(phrase),
-    do: gettext("%{count} from other networks", count: phrase)
+  defp shown_reaction_actors(_actors, _total), do: []
 
-  defp reaction_phrase(count) do
-    ngettext("%{formatted} reaction", "%{formatted} reactions", count,
-      formatted: compact_count(count)
-    )
+  defp reaction_actor(%{"actor_uri" => uri} = row) do
+    %{
+      uri: uri,
+      kind: row["kind"],
+      handle: Handle.display(row["handle"], uri)
+    }
   end
+
+  # What the chip says to a screen reader and on hover — the sentence the glyph
+  # alone cannot carry.
+  defp reaction_title(%{kind: "announce", handle: handle}),
+    do: gettext("%{handle} shared this", handle: handle)
+
+  defp reaction_title(%{handle: handle}),
+    do: gettext("%{handle} liked this", handle: handle)
 
   defp reply_phrase(count) do
     ngettext("%{formatted} reply", "%{formatted} replies", count, formatted: compact_count(count))

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -180,14 +180,17 @@ defmodule VutuvWeb.FediverseController do
   end
 
   # Somebody on another network favourited (`Like`) or re-shared (`Announce`)
-  # one of the member's public posts (issue #1068). Stored as a bare counter
-  # row — no name, no text, no picture — so the member sees that their post
-  # travelled. Every gate lives in `Fediverse.record_reaction/4`; whatever it
-  # decides, the answer is the same 202, so a misdirected activity never tells
-  # the sender which of the conditions it failed.
+  # one of the member's public posts (issue #1068). Stored as their account
+  # address and what they did — no display name, no text, no picture — so the
+  # member sees that their post travelled and by whom. The handle rides along
+  # from the actor document this request already fetched to check the
+  # signature, so naming them costs no second request. Every gate lives in
+  # `Fediverse.record_reaction/4`; whatever it decides, the answer is the same
+  # 202, so a misdirected activity never tells the sender which of the
+  # conditions it failed.
   defp perform(conn, user, %{"type" => type, "object" => object}, remote)
        when type in ["Like", "Announce"] do
-    Fediverse.record_reaction(user, object, reaction_kind(type), remote.id)
+    Fediverse.record_reaction(user, object, reaction_kind(type), reacting_actor(remote))
     send_resp(conn, 202, "")
   end
 
@@ -268,6 +271,14 @@ defmodule VutuvWeb.FediverseController do
   # its inbox spares the reply path a network call). No avatar — the card
   # renders initials and links out, so vutuv never hosts a third party's
   # picture.
+  # A reaction keeps the account address alone: the URI and the same address in
+  # the `@handle@host` notation. Deliberately not `remote_author/1` — a
+  # favourite is not a text somebody wrote, so their display name has no job
+  # here.
+  defp reacting_actor(remote) do
+    %{uri: remote.id, handle: remote.preferred_username}
+  end
+
   defp remote_author(remote) do
     %{
       uri: remote.id,

--- a/lib/vutuv_web/live/notification_live/groups.ex
+++ b/lib/vutuv_web/live/notification_live/groups.ex
@@ -14,6 +14,8 @@ defmodule VutuvWeb.NotificationLive.Groups do
     * one endorser's **endorsements** - "endorsed you for Elixir and Phoenix."
     * **thread** events of the same thread - "Anna and Ben replied in a
       thread you posted in."
+    * **reactions from other networks** to the same post, per kind -
+      "@anna@chaos.social and @ben@social.example shared your post."
 
   Direct replies, mentions and every rarer kind (moderation, CV updates,
   handle changes, ...) stay one row per event - each carries its own content.
@@ -95,6 +97,12 @@ defmodule VutuvWeb.NotificationLive.Groups do
   defp group_key(%{kind: "thread", root_post_id: root_id}) when is_binary(root_id),
     do: {:thread, root_id}
 
+  # Reactions from other networks merge per post *and per kind*: a favourite and
+  # a re-share are different news, and one row can only carry one verb.
+  defp group_key(%{kind: "fediverse_reaction", post_id: post_id, reaction_kind: reaction_kind})
+       when is_binary(post_id) and is_binary(reaction_kind),
+       do: {:fediverse_reaction, post_id, reaction_kind}
+
   defp group_key(%{kind: "follower"}), do: :follower
   defp group_key(%{kind: "connection"}), do: :connection
   defp group_key(%{kind: "endorsement"} = item), do: {:endorsement, actor_key(item)}
@@ -120,6 +128,10 @@ defmodule VutuvWeb.NotificationLive.Groups do
   defp group_id({:single, id}, _day, _newest), do: id
   defp group_id({:like, post_id}, day, _newest), do: "like-#{post_id}-#{day_key(day)}"
   defp group_id({:thread, root_id}, day, _newest), do: "thread-#{root_id}-#{day_key(day)}"
+
+  defp group_id({:fediverse_reaction, post_id, reaction_kind}, day, _newest),
+    do: "fediverse-reaction-#{reaction_kind}-#{post_id}-#{day_key(day)}"
+
   defp group_id(:follower, day, _newest), do: "follower-#{day_key(day)}"
   defp group_id(:connection, day, _newest), do: "connection-#{day_key(day)}"
 

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -74,7 +74,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   # `kinds:` option keeps. "all" passes nil (every source).
   @filters %{
     "all" => nil,
-    "posts" => ~w(reply thread mention like fediverse_reply),
+    "posts" => ~w(reply thread mention like fediverse_reply fediverse_reaction),
     "people" => ~w(follower connection endorsement),
     "other" =>
       ~w(organization_role moderation image_rejected report_protection handle_change cv_update
@@ -863,7 +863,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   # Event kinds that share the brand badge colour, so the class string lives
   # in one place.
   @brand_kind_classes "bg-brand-50 text-brand-700 dark:bg-brand-900/40 dark:text-brand-100"
-  @brand_kinds ~w(follower reply thread mention connection report_protection organization_role handle_change cv_update fediverse_reply)
+  @brand_kinds ~w(follower reply thread mention connection report_protection organization_role handle_change cv_update fediverse_reply fediverse_reaction)
 
   defp kind_classes("endorsement"),
     do: "bg-emerald-50 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-300"
@@ -894,6 +894,10 @@ defmodule VutuvWeb.NotificationLive.Index do
   # A reply written on another network (issue #1069) — the same globe the
   # post card's "from other networks" line uses, so one glyph means one thing.
   defp kind_glyph("fediverse_reply"), do: "🌐"
+  # A favourite or a re-share from out there (issue #1068) — same globe, since
+  # "this came from another network" is the one thing the glyph has to say; the
+  # sentence beside it names the verb.
+  defp kind_glyph("fediverse_reaction"), do: "🌐"
   # "connection" is the vernetzt (mutual-follow) event; the handshake glyph.
   defp kind_glyph("connection"), do: "🤝"
   defp kind_glyph("moderation"), do: "⚑"
@@ -915,6 +919,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   defp kind_label("mention"), do: gettext("Mention")
   defp kind_label("like"), do: gettext("Like")
   defp kind_label("fediverse_reply"), do: gettext("Reply from another network")
+  defp kind_label("fediverse_reaction"), do: gettext("Reaction from another network")
   defp kind_label("connection"), do: gettext("Connection")
   defp kind_label("moderation"), do: gettext("Moderation")
   defp kind_label("image_rejected"), do: gettext("Image review")
@@ -950,7 +955,37 @@ defmodule VutuvWeb.NotificationLive.Index do
 
   defp group_text(%{kind: "thread", actor_count: count}), do: thread_text(count)
 
+  defp group_text(%{kind: "fediverse_reaction", actor_count: count, item: item}),
+    do: fediverse_reaction_text(item[:reaction_kind], count)
+
   defp group_text(%{item: item}), do: notification_text(item)
+
+  # German conjugates the verb across the actor count (hat/haben) where English
+  # does not, so both branches go through ngettext even when the two English
+  # forms read the same — the same trick `thread_text/1` uses.
+  defp fediverse_reaction_text("announce", count) do
+    ngettext(
+      "shared your post on another network.",
+      "shared your post on another network.",
+      count
+    )
+  end
+
+  defp fediverse_reaction_text("like", count) do
+    ngettext(
+      "liked your post on another network.",
+      "liked your post on another network.",
+      count
+    )
+  end
+
+  defp fediverse_reaction_text(_kind, count) do
+    ngettext(
+      "reacted to your post from another network.",
+      "reacted to your post from another network.",
+      count
+    )
+  end
 
   # The English tail is number-blind ("A and B replied in..."), but German
   # conjugates the verb (hat/haben), so the actor count goes through ngettext
@@ -1042,7 +1077,7 @@ defmodule VutuvWeb.NotificationLive.Index do
   # vutuv unless they choose otherwise, and a private reply (issue #1071) has no
   # public page to open anyway.
   defp primary_target(%{kind: kind} = n, viewer)
-       when kind in ["reply", "like", "fediverse_reply"] do
+       when kind in ["reply", "like", "fediverse_reply", "fediverse_reaction"] do
     if is_binary(n[:post_id]) and viewer != nil, do: ~p"/#{viewer}/posts/#{n.post_id}"
   end
 
@@ -1064,6 +1099,12 @@ defmodule VutuvWeb.NotificationLive.Index do
 
   defp notification_text(%{kind: "fediverse_reply"}),
     do: gettext("replied to your post from another network.")
+
+  # Live-pushed reactions land here (no group context yet): one actor. The verb
+  # is the whole point of the news, so `fediverse_reaction_text/2` owns both
+  # sentences and this and the grouped row share them.
+  defp notification_text(%{kind: "fediverse_reaction"} = n),
+    do: fediverse_reaction_text(n[:reaction_kind], 1)
 
   # Live-pushed thread events land here (no group context yet): one actor.
   defp notification_text(%{kind: "thread"}), do: thread_text(1)

--- a/lib/vutuv_web/live/post_live/action_bar.ex
+++ b/lib/vutuv_web/live/post_live/action_bar.ex
@@ -97,8 +97,10 @@ defmodule VutuvWeb.PostLive.ActionBar do
               replies: replies,
               # Issues #1068 and #1069: a reaction or a reply from another
               # network arrives without any viewer of ours acting, so this is the
-              # only path that updates the two remote figures.
+              # only path that updates the two remote figures — and, since the
+              # reactions line names the accounts behind them, the chips too.
               fediverse_reactions: payload.fediverse_reactions,
+              fediverse_reaction_actors: payload.fediverse_reaction_actors,
               fediverse_replies: payload.fediverse_replies
           })
         end

--- a/lib/vutuv_web/templates/settings/fediverse.html.heex
+++ b/lib/vutuv_web/templates/settings/fediverse.html.heex
@@ -63,16 +63,19 @@ subpage now (/settings/fediverse/move), linked from the footer below. --%>
           )}
         </.setting_toggle>
 
-        <%!-- Reaction counts (issue #1068): the answer coming back. Only
-              meaningful once posts are actually going out, so it shows with the
-              rest of the "you are taking part" block. --%>
+        <%!-- Reactions (issue #1068): the answer coming back. Only meaningful
+              once posts are actually going out, so it shows with the rest of
+              the "you are taking part" block. The wording names what is stored
+              about a stranger, because that is the part a member is deciding
+              about — and it has to stay true to the line under the post, which
+              names those accounts rather than merely counting them. --%>
         <.setting_toggle
           :if={Vutuv.Fediverse.federated?(@user)}
-          label={gettext("Count reactions from other networks")}
+          label={gettext("Show reactions from other networks")}
         >
           <:checkbox><%= checkbox f, :fediverse_reactions?, class: checkbox_class() %></:checkbox>
           {gettext(
-            "Show under each of your posts how many people out there liked or shared it. A number only, visible to everyone who sees the post. Switching it off deletes what is stored for it."
+            "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
           )}
         </.setting_toggle>
 

--- a/lib/vutuv_web/views/account_event_text.ex
+++ b/lib/vutuv_web/views/account_event_text.ex
@@ -170,7 +170,7 @@ defmodule VutuvWeb.AccountEventText do
   def field_label("cv_update_notifications?"), do: gettext("CV update notifications")
   def field_label("thread_notifications?"), do: gettext("Thread notifications")
   def field_label("fediverse_followers?"), do: gettext("Fediverse participation")
-  def field_label("fediverse_reactions?"), do: gettext("Fediverse reaction counts")
+  def field_label("fediverse_reactions?"), do: gettext("Fediverse reactions")
   def field_label("fediverse_replies?"), do: gettext("Fediverse replies")
   def field_label("also_known_as_input"), do: gettext("Fediverse aliases")
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.170.0",
+      version: "7.171.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -116,7 +116,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:86
 #: lib/vutuv_web/templates/report/new.html.heex:103
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:213
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:216
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:50
@@ -154,7 +154,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:1412
+#: lib/vutuv_web/components/post_components.ex:1413
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -195,6 +195,7 @@ msgid "Disable"
 msgstr "Inaktivieren"
 
 #: lib/vutuv_web/live/cv_live.ex:439
+#: lib/vutuv_web/live/post_live/composer.ex:1530
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:303
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -202,7 +203,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:1377
+#: lib/vutuv_web/components/post_components.ex:1378
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -613,7 +614,7 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1640
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -623,10 +624,10 @@ msgstr "Öffentlich"
 
 #: lib/vutuv_web/components/ui.ex:2863
 #: lib/vutuv_web/live/organization_live/edit.ex:339
-#: lib/vutuv_web/live/post_live/composer.ex:1649
+#: lib/vutuv_web/live/post_live/composer.ex:1789
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:95
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:98
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:73
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
@@ -658,7 +659,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:906
+#: lib/vutuv_web/components/post_components.ex:907
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -803,7 +804,7 @@ msgstr "User wurde verifiziert."
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:169
-#: lib/vutuv_web/live/notification_live/index.ex:925
+#: lib/vutuv_web/live/notification_live/index.ex:930
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1694,13 +1695,13 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/post_components.ex:1854
+#: lib/vutuv_web/components/post_components.ex:1855
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1217
-#: lib/vutuv_web/live/post_live/composer.ex:1218
-#: lib/vutuv_web/live/post_live/composer.ex:2071
+#: lib/vutuv_web/live/post_live/composer.ex:1292
+#: lib/vutuv_web/live/post_live/composer.ex:1293
+#: lib/vutuv_web/live/post_live/composer.ex:2225
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1824,7 +1825,7 @@ msgstr "Nachrichten"
 msgid "Network"
 msgstr "Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:330
+#: lib/vutuv_web/components/post_components.ex:331
 #: lib/vutuv_web/components/ui.ex:3077
 #: lib/vutuv_web/live/admin/user_live.ex:311
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
@@ -1975,17 +1976,17 @@ msgstr "folgt"
 msgid "submit a bug report"
 msgstr "einen Fehlerbericht erstellen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:946
+#: lib/vutuv_web/live/notification_live/index.ex:951
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr "hat Sie für %{tag} empfohlen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:941
+#: lib/vutuv_web/live/notification_live/index.ex:946
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr "ist jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:936
+#: lib/vutuv_web/live/notification_live/index.ex:941
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
@@ -2152,12 +2153,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:1600
+#: lib/vutuv_web/live/post_live/composer.ex:1740
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1757
+#: lib/vutuv_web/live/post_live/composer.ex:1897
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
@@ -2168,7 +2169,7 @@ msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1393
+#: lib/vutuv_web/live/post_live/composer.ex:1468
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2178,7 +2179,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:1409
+#: lib/vutuv_web/components/post_components.ex:1410
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2209,29 +2210,29 @@ msgstr "Folgen Sie %{name}, um ihn zu lesen."
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1733
+#: lib/vutuv_web/live/post_live/composer.ex:1873
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1661
+#: lib/vutuv_web/live/post_live/composer.ex:1801
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:1363
-#: lib/vutuv_web/components/post_components.ex:1365
+#: lib/vutuv_web/components/post_components.ex:1364
+#: lib/vutuv_web/components/post_components.ex:1366
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1703
+#: lib/vutuv_web/live/post_live/composer.ex:1843
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:980
-#: lib/vutuv_web/live/post_live/composer.ex:1028
+#: lib/vutuv_web/live/post_live/composer.ex:1050
+#: lib/vutuv_web/live/post_live/composer.ex:1098
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
@@ -2243,23 +2244,23 @@ msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:956
+#: lib/vutuv_web/live/post_live/composer.ex:1026
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1693
+#: lib/vutuv_web/live/post_live/composer.ex:1833
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1683
+#: lib/vutuv_web/live/post_live/composer.ex:1823
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1649
+#: lib/vutuv_web/live/post_live/composer.ex:1789
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2270,7 +2271,7 @@ msgstr "Posten"
 msgid "Post deleted successfully."
 msgstr "Beitrag erfolgreich gelöscht."
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:107
+#: lib/vutuv_web/agent_docs/post_doc.ex:112
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/user_controller.ex:76
@@ -2286,24 +2287,24 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1792
-#: lib/vutuv_web/components/post_components.ex:1796
+#: lib/vutuv_web/components/post_components.ex:1793
+#: lib/vutuv_web/components/post_components.ex:1797
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:1793
+#: lib/vutuv_web/components/post_components.ex:1794
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:873
+#: lib/vutuv_web/components/post_components.ex:874
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:1719
+#: lib/vutuv_web/live/post_live/composer.ex:1859
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2319,7 +2320,7 @@ msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1647
+#: lib/vutuv_web/live/post_live/composer.ex:1787
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
@@ -2338,12 +2339,12 @@ msgstr[1] "%{formatted} neue Beiträge anzeigen"
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1054
+#: lib/vutuv_web/live/post_live/composer.ex:1124
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:938
+#: lib/vutuv_web/live/post_live/composer.ex:1008
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
@@ -2353,12 +2354,12 @@ msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2240
+#: lib/vutuv_web/live/post_live/composer.ex:2397
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2241
+#: lib/vutuv_web/live/post_live/composer.ex:2398
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
@@ -2372,37 +2373,37 @@ msgstr "Upload fehlgeschlagen."
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:1958
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1819
+#: lib/vutuv_web/live/post_live/composer.ex:1959
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:1360
+#: lib/vutuv_web/components/post_components.ex:1361
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:2921
+#: lib/vutuv_web/components/post_components.ex:2922
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:2925
+#: lib/vutuv_web/components/post_components.ex:2926
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:2923
+#: lib/vutuv_web/components/post_components.ex:2924
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:2924
+#: lib/vutuv_web/components/post_components.ex:2925
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2413,17 +2414,17 @@ msgstr "Personen, denen Sie nicht folgen"
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1470
+#: lib/vutuv_web/live/post_live/composer.ex:1610
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr "Tags, durch Komma oder Leerzeichen getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2231
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2235
+#: lib/vutuv_web/live/post_live/composer.ex:2392
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
@@ -2443,7 +2444,7 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3002
+#: lib/vutuv_web/components/post_components.ex:3003
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2462,18 +2463,18 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:3094
+#: lib/vutuv_web/components/post_components.ex:3147
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
-#: lib/vutuv_web/live/notification_live/index.ex:916
+#: lib/vutuv_web/live/notification_live/index.ex:920
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:906
-#: lib/vutuv_web/components/post_components.ex:3103
+#: lib/vutuv_web/components/post_components.ex:3156
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2493,12 +2494,12 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:2991
+#: lib/vutuv_web/components/post_components.ex:2992
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:3002
+#: lib/vutuv_web/components/post_components.ex:3003
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2507,23 +2508,23 @@ msgstr "Nur öffentliche Beiträge können repostet werden."
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:2988
+#: lib/vutuv_web/components/post_components.ex:2989
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:2406
+#: lib/vutuv_web/components/post_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2988
+#: lib/vutuv_web/components/post_components.ex:2989
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:3094
+#: lib/vutuv_web/components/post_components.ex:3147
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2546,43 +2547,43 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:3143
+#: lib/vutuv_web/components/post_components.ex:3196
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/components/post_components.ex:319
+#: lib/vutuv_web/components/post_components.ex:320
 #: lib/vutuv_web/live/notification_live/index.ex:858
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:941
-#: lib/vutuv_web/components/post_components.ex:3126
-#: lib/vutuv_web/components/post_components.ex:3127
-#: lib/vutuv_web/live/notification_live/index.ex:913
+#: lib/vutuv_web/components/post_components.ex:942
+#: lib/vutuv_web/components/post_components.ex:3179
+#: lib/vutuv_web/components/post_components.ex:3180
+#: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1331
+#: lib/vutuv_web/components/post_components.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:941
-#: lib/vutuv_web/live/post_live/composer.ex:1637
+#: lib/vutuv_web/live/post_live/composer.ex:1011
+#: lib/vutuv_web/live/post_live/composer.ex:1777
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empfängerkreis nicht einschränken."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1764
+#: lib/vutuv_web/live/post_live/composer.ex:1904
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1061
+#: lib/vutuv_web/live/notification_live/index.ex:1096
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
@@ -2594,12 +2595,12 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1326
+#: lib/vutuv_web/components/post_components.ex:1327
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:1320
+#: lib/vutuv_web/components/post_components.ex:1321
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2890,7 +2891,7 @@ msgstr "Noch keine Vernetzungen."
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1673
+#: lib/vutuv_web/live/post_live/composer.ex:1813
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
@@ -2913,7 +2914,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:2922
+#: lib/vutuv_web/components/post_components.ex:2923
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -2923,22 +2924,22 @@ msgstr "Personen, mit denen Sie nicht vernetzt sind"
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:926
+#: lib/vutuv_web/live/notification_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:918
+#: lib/vutuv_web/live/notification_live/index.ex:923
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:912
+#: lib/vutuv_web/live/notification_live/index.ex:916
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:915
 #: lib/vutuv_web/templates/user/show.html.heex:800
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2951,7 +2952,7 @@ msgstr[1] "Follower"
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Willkommen bei vutuv, %{name}!"
 
-#: lib/vutuv_web/live/notification_live/index.ex:943
+#: lib/vutuv_web/live/notification_live/index.ex:948
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr "gefällt Ihr Beitrag."
@@ -2983,12 +2984,12 @@ msgstr "(gelöschtes Konto)"
 msgid "(no text)"
 msgstr "(kein Text)"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1091
+#: lib/vutuv_web/live/notification_live/index.ex:1132
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde bestätigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1092
+#: lib/vutuv_web/live/notification_live/index.ex:1133
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
@@ -3103,7 +3104,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:919
+#: lib/vutuv_web/live/notification_live/index.ex:924
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3192,7 +3193,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:1296
+#: lib/vutuv_web/components/post_components.ex:1297
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3271,8 +3272,8 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:883
-#: lib/vutuv_web/components/post_components.ex:1433
+#: lib/vutuv_web/components/post_components.ex:884
+#: lib/vutuv_web/components/post_components.ex:1434
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3560,12 +3561,12 @@ msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1094
+#: lib/vutuv_web/live/notification_live/index.ex:1135
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt gelöscht; der Fall ist abgeschlossen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1093
+#: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
@@ -3575,7 +3576,7 @@ msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
 msgid "Your content was reported"
 msgstr "Ihr Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1095
+#: lib/vutuv_web/live/notification_live/index.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3770,7 +3771,7 @@ msgstr "Verlauf"
 msgid "Open the profile"
 msgstr "Profil öffnen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1119
+#: lib/vutuv_web/live/notification_live/index.ex:1160
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3797,7 +3798,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:921
+#: lib/vutuv_web/live/notification_live/index.ex:926
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -3879,7 +3880,7 @@ msgstr "Bestätigt"
 msgid "Waiting for the owner"
 msgstr "Wartet auf den Besitzer"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1124
+#: lib/vutuv_web/live/notification_live/index.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -3981,7 +3982,7 @@ msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:966
+#: lib/vutuv_web/agent_docs/markdown.ex:982
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -4029,7 +4030,7 @@ msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:894
-#: lib/vutuv_web/agent_docs/markdown.ex:1043
+#: lib/vutuv_web/agent_docs/markdown.ex:1059
 #: lib/vutuv_web/agent_docs/text.ex:622
 #: lib/vutuv_web/agent_docs/text.ex:666
 #, elixir-autogen, elixir-format
@@ -4058,7 +4059,7 @@ msgstr "Mitglieder mit den meisten Followern"
 msgid "People %{name} follows"
 msgstr "Wem %{name} folgt"
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:108
+#: lib/vutuv_web/agent_docs/post_doc.ex:113
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr "Beitragsarchiv von %{name}"
@@ -4805,7 +4806,7 @@ msgstr ""
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
-#: lib/vutuv_web/components/post_components.ex:316
+#: lib/vutuv_web/components/post_components.ex:317
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/notification_live/index.ex:776
@@ -5535,7 +5536,7 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:959
+#: lib/vutuv_web/live/post_live/composer.ex:1029
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
@@ -5653,9 +5654,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:1496
-#: lib/vutuv_web/components/post_components.ex:1548
-#: lib/vutuv_web/components/post_components.ex:1929
+#: lib/vutuv_web/components/post_components.ex:1497
+#: lib/vutuv_web/components/post_components.ex:1549
+#: lib/vutuv_web/components/post_components.ex:1930
 #: lib/vutuv_web/live/notification_live/index.ex:601
 #: lib/vutuv_web/live/post_live/feed.ex:894
 #, elixir-autogen, elixir-format
@@ -5757,7 +5758,7 @@ msgstr "Personen, die nicht mit Ihnen interagieren können."
 msgid "Personal tokens for the vutuv API."
 msgstr "Persönliche Tokens für die vutuv-API."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1196
+#: lib/vutuv_web/live/post_live/composer.ex:1271
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -6474,7 +6475,7 @@ msgid "Previous day"
 msgstr "Vorheriger Tag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:906
-#: lib/vutuv_web/components/post_components.ex:318
+#: lib/vutuv_web/components/post_components.ex:319
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
@@ -6946,7 +6947,7 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:1430
+#: lib/vutuv_web/components/post_components.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6956,7 +6957,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:1429
+#: lib/vutuv_web/components/post_components.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7663,6 +7664,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
+#: lib/vutuv_web/components/post_components.ex:3082
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7851,17 +7853,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:971
+#: lib/vutuv_web/agent_docs/markdown.ex:987
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Ihr Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:974
+#: lib/vutuv_web/agent_docs/markdown.ex:990
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:981
+#: lib/vutuv_web/agent_docs/markdown.ex:997
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -9152,12 +9154,12 @@ msgstr ""
 msgid "Fediverse settings saved."
 msgstr "Fediverse-Einstellungen gespeichert."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:179
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr "Social-Media-Konten verwalten"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
@@ -9278,7 +9280,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:2409
+#: lib/vutuv_web/components/post_components.ex:2410
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -10441,7 +10443,7 @@ msgstr "Dauerhafter Profillink"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:121
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
 #: lib/vutuv_web/templates/totp/new.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:894
 #: lib/vutuv_web/templates/username/new.html.heex:27
@@ -10450,8 +10452,8 @@ msgstr "Schließen"
 msgid "Copied"
 msgstr "Kopiert"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:120
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:123
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:127
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
 #: lib/vutuv_web/templates/user/show.html.heex:893
@@ -12697,7 +12699,7 @@ msgstr "Organisationsseite"
 msgid "Organization pages"
 msgstr "Organisationsseiten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:922
+#: lib/vutuv_web/live/notification_live/index.ex:927
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisationsrolle"
@@ -12808,22 +12810,22 @@ msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
 msgid "Your organization page was updated."
 msgstr "Ihre Organisationsseite wurde aktualisiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1083
+#: lib/vutuv_web/live/notification_live/index.ex:1124
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr "hat Ihnen eine Rolle bei %{organization} gegeben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1080
+#: lib/vutuv_web/live/notification_live/index.ex:1121
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr "hat Sie zum Recruiter für %{organization} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1077
+#: lib/vutuv_web/live/notification_live/index.ex:1118
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr "hat Sie zum Administrator von %{organization} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1074
+#: lib/vutuv_web/live/notification_live/index.ex:1115
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr "hat Sie zum Besitzer von %{organization} gemacht."
@@ -13824,7 +13826,7 @@ msgid "Search title, poster or organization"
 msgstr "Titel, Ersteller oder Organisation suchen"
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1542
+#: lib/vutuv_web/live/post_live/composer.ex:1682
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
@@ -14217,7 +14219,7 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/live/notification_live/index.ex:920
+#: lib/vutuv_web/live/notification_live/index.ex:925
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -14304,7 +14306,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:923
+#: lib/vutuv_web/live/notification_live/index.ex:928
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -14316,7 +14318,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] "Wir haben %{formatted} Beitrag aktualisiert, der Ihren alten Handle erwähnt hat, und dessen Verfasser benachrichtigt."
 msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle erwähnt haben, und deren Verfasser benachrichtigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1133
+#: lib/vutuv_web/live/notification_live/index.ex:1174
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
@@ -14346,7 +14348,7 @@ msgstr "Volle Breite"
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2210
+#: lib/vutuv_web/live/post_live/composer.ex:2367
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
@@ -14380,22 +14382,22 @@ msgstr "Mobil (privat)"
 msgid "Work mobile"
 msgstr "Mobil (Arbeit)"
 
-#: lib/vutuv_web/components/post_components.ex:327
+#: lib/vutuv_web/components/post_components.ex:328
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Noch keine Beiträge."
 
-#: lib/vutuv_web/components/post_components.ex:329
+#: lib/vutuv_web/components/post_components.ex:330
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Noch keine Antworten."
 
-#: lib/vutuv_web/components/post_components.ex:328
+#: lib/vutuv_web/components/post_components.ex:329
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Noch keine Reposts."
 
-#: lib/vutuv_web/components/post_components.ex:317
+#: lib/vutuv_web/components/post_components.ex:318
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Eigene Beiträge"
@@ -14530,22 +14532,22 @@ msgstr[1] "Meine %{formatted} Follower darüber informieren"
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:924
+#: lib/vutuv_web/live/notification_live/index.ex:929
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1153
+#: lib/vutuv_web/live/notification_live/index.ex:1194
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr "hat eine neue Station im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1145
+#: lib/vutuv_web/live/notification_live/index.ex:1186
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr "hat eine neue Ausbildung im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1150
+#: lib/vutuv_web/live/notification_live/index.ex:1191
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr "hat ein neues Zertifikat im Lebenslauf: %{entry}"
@@ -14570,133 +14572,133 @@ msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folg
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1158
+#: lib/vutuv_web/live/notification_live/index.ex:1199
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:2784
+#: lib/vutuv_web/components/post_components.ex:2785
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1550
+#: lib/vutuv_web/live/post_live/composer.ex:1690
 #, elixir-autogen, elixir-format
 msgid "Author(s)"
 msgstr "Autor(en)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1618
+#: lib/vutuv_web/live/post_live/composer.ex:1758
 #, elixir-autogen, elixir-format
 msgid "Book"
 msgstr "Buch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:933
-#: lib/vutuv_web/components/post_components.ex:2741
-#: lib/vutuv_web/live/post_live/composer.ex:1496
+#: lib/vutuv_web/agent_docs/markdown.ex:949
+#: lib/vutuv_web/components/post_components.ex:2742
+#: lib/vutuv_web/live/post_live/composer.ex:1636
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:2785
+#: lib/vutuv_web/components/post_components.ex:2786
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:2787
+#: lib/vutuv_web/components/post_components.ex:2788
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1550
+#: lib/vutuv_web/live/post_live/composer.ex:1690
 #, elixir-autogen, elixir-format
 msgid "Director"
 msgstr "Regie"
 
-#: lib/vutuv_web/components/post_components.ex:2783
+#: lib/vutuv_web/components/post_components.ex:2784
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1630
+#: lib/vutuv_web/live/post_live/composer.ex:1770
 #, elixir-autogen, elixir-format
 msgid "Film"
 msgstr "Film"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:933
-#: lib/vutuv_web/components/post_components.ex:2740
-#: lib/vutuv_web/live/post_live/composer.ex:1495
+#: lib/vutuv_web/agent_docs/markdown.ex:949
+#: lib/vutuv_web/components/post_components.ex:2741
+#: lib/vutuv_web/live/post_live/composer.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1516
+#: lib/vutuv_web/live/post_live/composer.ex:1656
 #, elixir-autogen, elixir-format
 msgid "IMDb link or ID"
 msgstr "IMDb-Link oder -ID"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1517
+#: lib/vutuv_web/live/post_live/composer.ex:1657
 #, elixir-autogen, elixir-format
 msgid "ISBN"
 msgstr "ISBN"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1530
+#: lib/vutuv_web/live/post_live/composer.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1527
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Looking up…"
 msgstr "Wird nachgeschlagen …"
 
-#: lib/vutuv_web/live/post_live/composer.ex:586
+#: lib/vutuv_web/live/post_live/composer.ex:647
 #, elixir-autogen, elixir-format
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr "Zu dieser ISBN wurde nichts gefunden. Bitte füllen Sie die Felder selbst aus."
 
-#: lib/vutuv_web/components/post_components.ex:2782
+#: lib/vutuv_web/components/post_components.ex:2783
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1569
+#: lib/vutuv_web/live/post_live/composer.ex:1709
 #, elixir-autogen, elixir-format
 msgid "Read as… (optional)"
 msgstr "Gelesen als … (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1505
+#: lib/vutuv_web/live/post_live/composer.ex:1645
 #, elixir-autogen, elixir-format
 msgid "Remove review"
 msgstr "Besprechung entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1614
-#: lib/vutuv_web/live/post_live/composer.ex:1615
+#: lib/vutuv_web/live/post_live/composer.ex:1754
+#: lib/vutuv_web/live/post_live/composer.ex:1755
 #, elixir-autogen, elixir-format
 msgid "Review a book"
 msgstr "Ein Buch besprechen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1626
-#: lib/vutuv_web/live/post_live/composer.ex:1627
+#: lib/vutuv_web/live/post_live/composer.ex:1766
+#: lib/vutuv_web/live/post_live/composer.ex:1767
 #, elixir-autogen, elixir-format
 msgid "Review a film"
 msgstr "Einen Film besprechen"
 
-#: lib/vutuv_web/components/post_components.ex:2786
+#: lib/vutuv_web/components/post_components.ex:2787
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1568
+#: lib/vutuv_web/live/post_live/composer.ex:1708
 #, elixir-autogen, elixir-format
 msgid "Watched as… (optional)"
 msgstr "Gesehen als … (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1582
+#: lib/vutuv_web/live/post_live/composer.ex:1722
 #, elixir-autogen, elixir-format
 msgid "With an ISBN, the post shows the book cover and a shop link automatically."
 msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1562
+#: lib/vutuv_web/live/post_live/composer.ex:1702
 #: lib/vutuv_web/templates/education/form_content.html.heex:47
 #: lib/vutuv_web/templates/education/form_content.html.heex:48
 #: lib/vutuv_web/templates/education/form_content.html.heex:67
@@ -14712,34 +14714,34 @@ msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:2823
+#: lib/vutuv_web/components/post_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:2853
+#: lib/vutuv_web/components/post_components.ex:2854
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:2854
+#: lib/vutuv_web/components/post_components.ex:2855
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:2852
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:2812
+#: lib/vutuv_web/components/post_components.ex:2813
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:2859
+#: lib/vutuv_web/components/post_components.ex:2860
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14769,7 +14771,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2626
+#: lib/vutuv_web/components/post_components.ex:2627
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14797,27 +14799,27 @@ msgid "Last 30 days"
 msgstr "Letzte 30 Tage"
 
 #: lib/vutuv_web/live/notification_live/index.ex:763
-#: lib/vutuv_web/live/notification_live/index.ex:972
+#: lib/vutuv_web/live/notification_live/index.ex:1007
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/vutuv_web/live/notification_live/index.ex:939
+#: lib/vutuv_web/live/notification_live/index.ex:944
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "sind jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:934
+#: lib/vutuv_web/live/notification_live/index.ex:939
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "folgen Ihnen jetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:949
+#: lib/vutuv_web/live/notification_live/index.ex:954
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:2617
+#: lib/vutuv_web/components/post_components.ex:2618
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -15071,7 +15073,7 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1107
+#: lib/vutuv_web/live/notification_live/index.ex:1148
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
@@ -15079,12 +15081,12 @@ msgstr ""
 "familienfreundlich genug für ein Arbeitsumfeld. Sie kann sich irren, "
 "antworten Sie in dem Fall einfach auf unsere E-Mail."
 
-#: lib/vutuv_web/live/notification_live/index.ex:914
+#: lib/vutuv_web/live/notification_live/index.ex:918
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Thread-Antwort"
 
-#: lib/vutuv_web/live/notification_live/index.ex:959
+#: lib/vutuv_web/live/notification_live/index.ex:994
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -15103,23 +15105,23 @@ msgstr "Unterhaltung"
 msgid "Only part of this long conversation is shown."
 msgstr "Von dieser langen Unterhaltung wird nur ein Teil angezeigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:915
+#: lib/vutuv_web/live/notification_live/index.ex:919
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Erwähnung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1063
+#: lib/vutuv_web/live/notification_live/index.ex:1098
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:946
+#: lib/vutuv_web/live/post_live/composer.ex:1016
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten: jemand hat ihn geliked, geteilt oder beantwortet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:949
+#: lib/vutuv_web/live/post_live/composer.ex:1019
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -15215,14 +15217,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1076
+#: lib/vutuv_web/components/post_components.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1098
+#: lib/vutuv_web/components/post_components.ex:1099
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -15249,7 +15251,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:3102
+#: lib/vutuv_web/components/post_components.ex:3155
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15651,15 +15653,10 @@ msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
 msgid "none yet"
 msgstr "noch keiner"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:915
+#: lib/vutuv_web/agent_docs/markdown.ex:916
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken"
-
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:71
-#, elixir-autogen, elixir-format
-msgid "Count reactions from other networks"
-msgstr "Reaktionen aus anderen Netzwerken zählen"
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:39
 #: lib/vutuv_web/live/fediverse_followers_live.ex:183
@@ -15704,40 +15701,35 @@ msgstr "Am Fediverse teilnehmen"
 msgid "Off means your profile cannot be found there and nothing is sent. Posts already delivered may stay on those servers, beyond our reach."
 msgstr "Ausgeschaltet ist Ihr Profil dort nicht auffindbar und es wird nichts zugestellt. Bereits ausgelieferte Beiträge können auf jenen Servern verbleiben, außerhalb unseres Zugriffs."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:74
-#, elixir-autogen, elixir-format
-msgid "Show under each of your posts how many people out there liked or shared it. A number only, visible to everyone who sees the post. Switching it off deletes what is stored for it."
-msgstr "Zeigen Sie unter jedem Ihrer Beiträge, wie viele Menschen dort draußen ihn geliked oder geteilt haben. Nur eine Zahl, sichtbar für alle, die den Beitrag sehen. Ausschalten löscht, was dafür gespeichert ist."
-
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:107
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr "Geben Sie es weiter wie eine E-Mail-Adresse. Jeder bei Mastodon und Co. kann es in die Suche einfügen und Ihnen von dort folgen."
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:209
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:143
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr "Noch niemand. Posten Sie Ihr Handle dort, wo andere es sehen, dann tauchen die ersten Follower hier auf."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Related"
 msgstr "Verwandte Themen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:162
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Moving to or away from another Fediverse account?"
 msgstr "Ziehen Sie zu einem anderen Fediverse-Konto um oder von dort zu vutuv?"
 
 #: lib/vutuv_web/controllers/settings_controller.ex:222
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:168
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:171
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Move your account"
 msgstr "Konto umziehen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:172
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr "Sie möchten das Häkchen in Ihrem Mastodon-Profil? Das geht ohne Teilnahme hier: Ihr vutuv-Profil verlinkt Ihre eingetragenen Konten mit rel=\"me\"."
@@ -15793,7 +15785,7 @@ msgstr "Schicken Sie Ihre Fediverse-Follower zu einem anderen Konto. Sie werden 
 msgid "Back to Fediverse settings"
 msgstr "Zurück zu den Fediverse-Einstellungen"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:129
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower from other networks"
 msgid_plural "%{formatted} followers from other networks"
@@ -16392,13 +16384,13 @@ msgstr "Benutzernamen ändern"
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr "Dieser Link öffnet immer Ihr Profil, auch nachdem Sie Ihren Benutzernamen geändert haben. Er wird aus einer festen Id gebildet und geht bei einer Umbenennung nie kaputt. Für den Alltag ist die kurze Adresse oben freundlicher."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:223
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:226
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr "Verstanden, abschalten"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:221
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:224
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
@@ -16448,48 +16440,31 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:3062
-#, elixir-autogen, elixir-format
-msgid "%{count} from other networks"
-msgstr "%{count} aus anderen Netzwerken"
-
-#: lib/vutuv_web/components/post_components.ex:3065
-#, elixir-autogen, elixir-format
-msgid "%{formatted} reaction"
-msgid_plural "%{formatted} reactions"
-msgstr[0] "%{formatted} Reaktion"
-msgstr[1] "%{formatted} Reaktionen"
-
-#: lib/vutuv_web/components/post_components.ex:3071
+#: lib/vutuv_web/components/post_components.ex:3124
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3055
-#, elixir-autogen, elixir-format
-msgid "%{reactions} and %{replies} from other networks"
-msgstr "%{reactions} und %{replies} aus anderen Netzwerken"
-
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "A report deletes the reply right away, with no queue to work through. This is the trail, so a server that keeps showing up here can be blocked above. It holds no text and no links, only which server and which account (as a short digest)."
 msgstr "Eine Meldung löscht die Antwort sofort, es gibt keine Warteschlange. Dies ist die Spur dazu: Ein Server, der hier immer wieder auftaucht, lässt sich oben sperren. Festgehalten werden weder Text noch Links, nur welcher Server und welches Konto (als kurzer Prüfwert)."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:89
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem Beitrag, gekennzeichnet als aus einem anderen Netzwerk. Wir speichern eine Kopie für bis zu sechs Monate und prüfen ab und zu, ob sie dort noch veröffentlicht ist; löscht sie die Autorin oder der Autor, verschwindet auch unsere. Sie können jede einzelne Antwort entfernen, und wenn Sie das hier ausschalten, werden alle gelöscht."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1064
+#: lib/vutuv_web/agent_docs/markdown.ex:1080
 #: lib/vutuv_web/agent_docs/text.ex:680
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:840
-#: lib/vutuv_web/components/post_components.ex:921
+#: lib/vutuv_web/components/post_components.ex:841
+#: lib/vutuv_web/components/post_components.ex:922
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
@@ -16499,7 +16474,7 @@ msgstr "Aus einem anderen Netzwerk"
 msgid "Nobody has removed or reported a reply yet."
 msgstr "Bisher hat niemand eine Antwort entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:871
+#: lib/vutuv_web/components/post_components.ex:872
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16510,7 +16485,7 @@ msgid "Removed by the member"
 msgstr "Vom Mitglied entfernt"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:123
-#: lib/vutuv_web/agent_docs/markdown.ex:920
+#: lib/vutuv_web/agent_docs/markdown.ex:921
 #: lib/vutuv_web/agent_docs/text.ex:114
 #, elixir-autogen, elixir-format
 msgid "Replies from other networks"
@@ -16521,7 +16496,7 @@ msgstr "Antworten aus anderen Netzwerken"
 msgid "Replies taken down by members"
 msgstr "Von Mitgliedern entfernte Antworten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:917
+#: lib/vutuv_web/live/notification_live/index.ex:921
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr "Antwort aus einem anderen Netzwerk"
@@ -16531,7 +16506,7 @@ msgstr "Antwort aus einem anderen Netzwerk"
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:880
+#: lib/vutuv_web/components/post_components.ex:881
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16541,13 +16516,13 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:897
+#: lib/vutuv_web/components/post_components.ex:898
 #: lib/vutuv_web/live/notification_live/index.ex:497
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr "Nur an Sie gesendet, für niemanden sonst sichtbar"
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:86
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Show replies from other networks"
 msgstr "Antworten aus anderen Netzwerken anzeigen"
@@ -16572,8 +16547,8 @@ msgstr "Danke. Die Antwort wurde sofort gelöscht."
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1066
-#: lib/vutuv_web/components/post_components.ex:927
+#: lib/vutuv_web/agent_docs/markdown.ex:1082
+#: lib/vutuv_web/components/post_components.ex:928
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16588,12 +16563,12 @@ msgstr "Was"
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr "Sie haben heute schon viel gemeldet. Bitte versuchen Sie es morgen wieder."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1066
+#: lib/vutuv_web/live/notification_live/index.ex:1101
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr "hat aus einem anderen Netzwerk auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:149
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "All followers"
 msgstr "Alle Follower"
@@ -16940,11 +16915,6 @@ msgstr "Fediverse-Aliase"
 msgid "Fediverse participation"
 msgstr "Fediverse-Teilnahme"
 
-#: lib/vutuv_web/views/account_event_text.ex:173
-#, elixir-autogen, elixir-format
-msgid "Fediverse reaction counts"
-msgstr "Fediverse-Reaktionszahlen"
-
 #: lib/vutuv_web/views/account_event_text.ex:174
 #, elixir-autogen, elixir-format
 msgid "Fediverse replies"
@@ -17252,22 +17222,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:1308
+#: lib/vutuv_web/components/post_components.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:1396
+#: lib/vutuv_web/components/post_components.ex:1397
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:1404
+#: lib/vutuv_web/components/post_components.ex:1405
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:1390
+#: lib/vutuv_web/components/post_components.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17317,7 +17287,7 @@ msgstr ""
 "in eckigen Klammern, wie eine Lautschrift geschrieben wird; die Klammern "
 "ergänzen wir für Sie. Bleibt das Feld leer, wird nichts angezeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2223
+#: lib/vutuv_web/live/post_live/composer.ex:2380
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Diese Einstellungen für alle Fotos übernehmen"
@@ -17347,74 +17317,74 @@ msgstr "CC BY-SA 4.0 (Namensnennung, gleiche Bedingungen)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2055
+#: lib/vutuv_web/live/post_live/composer.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Caption, shown under the photo (optional)"
 msgstr "Bildunterschrift, erscheint unter dem Foto (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1891
+#: lib/vutuv_web/live/post_live/composer.ex:2040
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Titelbild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2063
+#: lib/vutuv_web/live/post_live/composer.ex:2217
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:994
+#: lib/vutuv_web/agent_docs/markdown.ex:1010
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:1858
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1381
+#: lib/vutuv_web/live/post_live/composer.ex:1456
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr "Zum Umsortieren ziehen. Das erste Foto führt die Galerie an."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2172
+#: lib/vutuv_web/live/post_live/composer.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr "Alle Metadaten bleiben erhalten, auch alles, was Ihre Kamera hineingeschrieben hat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2129
+#: lib/vutuv_web/live/post_live/composer.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Alle dürfen dieses Foto herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2131
+#: lib/vutuv_web/live/post_live/composer.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Volle Auflösung, direkt aus dem Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2150
+#: lib/vutuv_web/live/post_live/composer.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1928
+#: lib/vutuv_web/live/post_live/composer.ex:2077
 #, elixir-autogen, elixir-format
 msgid "Move photo earlier"
 msgstr "Foto nach vorne schieben"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1940
+#: lib/vutuv_web/live/post_live/composer.ex:2089
 #, elixir-autogen, elixir-format
 msgid "Move photo later"
 msgstr "Foto nach hinten schieben"
 
-#: lib/vutuv_web/components/post_components.ex:1856
+#: lib/vutuv_web/components/post_components.ex:1857
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1898
+#: lib/vutuv_web/live/post_live/composer.ex:2047
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:2273
+#: lib/vutuv_web/components/post_components.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr "Bisher sehen nur Sie diesen Beitrag."
@@ -17424,85 +17394,85 @@ msgstr "Bisher sehen nur Sie diesen Beitrag."
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2276
+#: lib/vutuv_web/components/post_components.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] "Unsere KI prüft das Foto. Sobald es durch ist, geht der Beitrag von selbst online."
 msgstr[1] "Unsere KI prüft die Fotos, %{done} von %{total} sind durch. Sobald das letzte durch ist, geht der Beitrag von selbst online."
 
-#: lib/vutuv_web/components/post_components.ex:2101
+#: lib/vutuv_web/components/post_components.ex:2102
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:1603
+#: lib/vutuv_web/components/post_components.ex:1604
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1875
-#: lib/vutuv_web/live/post_live/composer.ex:1876
+#: lib/vutuv_web/live/post_live/composer.ex:2015
+#: lib/vutuv_web/live/post_live/composer.ex:2016
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1027
+#: lib/vutuv_web/agent_docs/markdown.ex:1043
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:2310
+#: lib/vutuv_web/components/post_components.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/post_components.ex:1855
+#: lib/vutuv_web/components/post_components.ex:1856
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1911
-#: lib/vutuv_web/live/post_live/composer.ex:1912
+#: lib/vutuv_web/live/post_live/composer.ex:2060
+#: lib/vutuv_web/live/post_live/composer.ex:2061
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2152
+#: lib/vutuv_web/live/post_live/composer.ex:2309
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qualität unverändert."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1339
-#: lib/vutuv_web/live/post_live/composer.ex:2101
+#: lib/vutuv_web/live/post_live/composer.ex:1414
+#: lib/vutuv_web/live/post_live/composer.ex:2255
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:971
+#: lib/vutuv_web/live/post_live/composer.ex:1041
 #: lib/vutuv_web/live/post_live/remote_reply.ex:87
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2170
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Die Datei genau so, wie ich sie hochgeladen habe"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2109
+#: lib/vutuv_web/live/post_live/composer.ex:2263
 #, elixir-autogen, elixir-format
 msgid "This file carries no camera information."
 msgstr "Diese Datei enthält keine Kameradaten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2350
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen Sie das Foto, wenn Sie das nicht möchten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2185
+#: lib/vutuv_web/live/post_live/composer.ex:2342
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:974
+#: lib/vutuv_web/live/post_live/composer.ex:1044
 #: lib/vutuv_web/live/post_live/remote_reply.ex:84
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
@@ -17523,12 +17493,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1427
+#: lib/vutuv_web/live/post_live/composer.ex:1505
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Wer diese Fotos weiterverwenden darf"
 
-#: lib/vutuv_web/live/post_live/composer.ex:966
+#: lib/vutuv_web/live/post_live/composer.ex:1036
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
@@ -17538,7 +17508,7 @@ msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke gesc
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:977
+#: lib/vutuv_web/live/post_live/composer.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
@@ -17553,17 +17523,17 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr "© Alle Rechte vorbehalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1357
+#: lib/vutuv_web/live/post_live/composer.ex:1432
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Fotos hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1452
+#: lib/vutuv_web/live/post_live/composer.ex:1592
 #, elixir-autogen, elixir-format
 msgid "Add text (optional)"
 msgstr "Text hinzufügen (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1422
+#: lib/vutuv_web/live/post_live/composer.ex:1500
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Lizenz"
@@ -17574,91 +17544,154 @@ msgstr "Lizenz"
 msgid "Post photos"
 msgstr "Fotos posten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1189
+#: lib/vutuv_web/live/post_live/composer.ex:1264
 #, elixir-autogen, elixir-format
 msgid "Post type"
 msgstr "Beitragsart"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1368
+#: lib/vutuv_web/live/post_live/composer.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Select photos, or drag them here"
 msgstr "Fotos auswählen oder hierher ziehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1193
+#: lib/vutuv_web/live/post_live/composer.ex:1268
 #, elixir-autogen, elixir-format
 msgid "Text"
 msgstr "Text"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:1958
 #, elixir-autogen, elixir-format
 msgid "Text (optional)"
 msgstr "Text (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1371
+#: lib/vutuv_web/live/post_live/composer.ex:1446
 #, elixir-autogen, elixir-format
 msgid "Up to %{max} photos per post"
 msgstr "Bis zu %{max} Fotos pro Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1316
+#: lib/vutuv_web/live/post_live/composer.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Bildunterschrift (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1232
+#: lib/vutuv_web/live/post_live/composer.ex:1307
 #, elixir-autogen, elixir-format
 msgid "A photo post shows your pictures big and first; text is optional. For a post that is mainly text, switch to \"Text\"."
 msgstr "Ein Foto-Beitrag zeigt Ihre Bilder groß und zuerst; Text ist optional. Für einen Beitrag, der vor allem Text ist, wechseln Sie zu \"Text\"."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1163
-#: lib/vutuv_web/live/post_live/composer.ex:1217
-#: lib/vutuv_web/live/post_live/composer.ex:1218
+#: lib/vutuv_web/live/post_live/composer.ex:1238
+#: lib/vutuv_web/live/post_live/composer.ex:1292
+#: lib/vutuv_web/live/post_live/composer.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Entwurf verwerfen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1215
+#: lib/vutuv_web/live/post_live/composer.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr "Fotos und Text dieses Entwurfs verwerfen?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1156
+#: lib/vutuv_web/live/post_live/composer.ex:1231
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Weiter, wo Sie aufgehört haben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1424
+#: lib/vutuv_web/live/post_live/composer.ex:1574
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr "Eine Datei, deren Format sich nicht säubern lässt, wird exakt so weitergegeben, wie sie hochgeladen wurde."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1399
+#: lib/vutuv_web/live/post_live/composer.ex:1550
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Pro Foto verschieden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1396
+#: lib/vutuv_web/live/post_live/composer.ex:1547
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Original, exakt wie hochgeladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1393
+#: lib/vutuv_web/live/post_live/composer.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Original, ohne Metadaten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1390
+#: lib/vutuv_web/live/post_live/composer.ex:1541
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Nur Web-Versionen (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1386
+#: lib/vutuv_web/live/post_live/composer.ex:1537
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Was Besucher speichern können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1412
+#: lib/vutuv_web/live/post_live/composer.ex:1563
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
 msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exakte Datei gibt ihn weiter."
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
+
+#: lib/vutuv_web/agent_docs/markdown.ex:939
+#: lib/vutuv_web/components/post_components.ex:3121
+#, elixir-autogen, elixir-format
+msgid "%{handle} liked this"
+msgstr "%{handle} gefällt das"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:937
+#: lib/vutuv_web/components/post_components.ex:3118
+#, elixir-autogen, elixir-format
+msgid "%{handle} shared this"
+msgstr "%{handle} hat das geteilt"
+
+#: lib/vutuv_web/views/account_event_text.ex:173
+#, elixir-autogen, elixir-format
+msgid "Fediverse reactions"
+msgstr "Fediverse-Reaktionen"
+
+#: lib/vutuv_web/components/post_components.ex:3060
+#, elixir-autogen, elixir-format
+msgid "From other networks"
+msgstr "Aus anderen Netzwerken"
+
+#: lib/vutuv_web/live/notification_live/index.ex:922
+#, elixir-autogen, elixir-format
+msgid "Reaction from another network"
+msgstr "Reaktion aus einem anderen Netzwerk"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:74
+#, elixir-autogen, elixir-format
+msgid "Show reactions from other networks"
+msgstr "Reaktionen aus anderen Netzwerken anzeigen"
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
+msgstr ""
+"Zeigen Sie unter jedem Ihrer Beiträge, wem dort draußen er gefällt oder "
+"wer ihn geteilt hat, mit der Adresse des Kontos auf dem jeweiligen "
+"Server und einem Link dorthin. Sichtbar für alle, die den Beitrag sehen. "
+"Mehr speichern wir über diese Menschen nicht: keinen Namen, kein Bild, "
+"keinen Text. Ausschalten löscht, was dafür gespeichert ist."
+
+#: lib/vutuv_web/live/notification_live/index.ex:975
+#, elixir-autogen, elixir-format
+msgid "liked your post on another network."
+msgid_plural "liked your post on another network."
+msgstr[0] "gefällt Ihr Beitrag in einem anderen Netzwerk."
+msgstr[1] "gefällt Ihr Beitrag in einem anderen Netzwerk."
+
+#: lib/vutuv_web/live/notification_live/index.ex:983
+#, elixir-autogen, elixir-format
+msgid "reacted to your post from another network."
+msgid_plural "reacted to your post from another network."
+msgstr[0] "hat aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
+msgstr[1] "haben aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
+
+#: lib/vutuv_web/live/notification_live/index.ex:967
+#, elixir-autogen, elixir-format
+msgid "shared your post on another network."
+msgid_plural "shared your post on another network."
+msgstr[0] "hat Ihren Beitrag in einem anderen Netzwerk geteilt."
+msgstr[1] "haben Ihren Beitrag in einem anderen Netzwerk geteilt."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -118,7 +118,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:86
 #: lib/vutuv_web/templates/report/new.html.heex:103
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:213
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:216
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:50
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1412
+#: lib/vutuv_web/components/post_components.ex:1413
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -195,6 +195,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:439
+#: lib/vutuv_web/live/post_live/composer.ex:1530
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:303
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -202,7 +203,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1377
+#: lib/vutuv_web/components/post_components.ex:1378
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -613,7 +614,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1640
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -623,10 +624,10 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2863
 #: lib/vutuv_web/live/organization_live/edit.ex:339
-#: lib/vutuv_web/live/post_live/composer.ex:1649
+#: lib/vutuv_web/live/post_live/composer.ex:1789
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:95
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:98
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:73
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
@@ -658,7 +659,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:906
+#: lib/vutuv_web/components/post_components.ex:907
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -799,7 +800,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:169
-#: lib/vutuv_web/live/notification_live/index.ex:925
+#: lib/vutuv_web/live/notification_live/index.ex:930
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1660,13 +1661,13 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1854
+#: lib/vutuv_web/components/post_components.ex:1855
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1217
-#: lib/vutuv_web/live/post_live/composer.ex:1218
-#: lib/vutuv_web/live/post_live/composer.ex:2071
+#: lib/vutuv_web/live/post_live/composer.ex:1292
+#: lib/vutuv_web/live/post_live/composer.ex:1293
+#: lib/vutuv_web/live/post_live/composer.ex:2225
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1787,7 +1788,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:330
+#: lib/vutuv_web/components/post_components.ex:331
 #: lib/vutuv_web/components/ui.ex:3077
 #: lib/vutuv_web/live/admin/user_live.ex:311
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
@@ -1932,17 +1933,17 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:946
+#: lib/vutuv_web/live/notification_live/index.ex:951
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:941
+#: lib/vutuv_web/live/notification_live/index.ex:946
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:936
+#: lib/vutuv_web/live/notification_live/index.ex:941
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -2107,12 +2108,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:1600
+#: lib/vutuv_web/live/post_live/composer.ex:1740
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1757
+#: lib/vutuv_web/live/post_live/composer.ex:1897
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2123,7 +2124,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1393
+#: lib/vutuv_web/live/post_live/composer.ex:1468
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2133,7 +2134,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1409
+#: lib/vutuv_web/components/post_components.ex:1410
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2164,29 +2165,29 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1733
+#: lib/vutuv_web/live/post_live/composer.ex:1873
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1661
+#: lib/vutuv_web/live/post_live/composer.ex:1801
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1363
-#: lib/vutuv_web/components/post_components.ex:1365
+#: lib/vutuv_web/components/post_components.ex:1364
+#: lib/vutuv_web/components/post_components.ex:1366
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1703
+#: lib/vutuv_web/live/post_live/composer.ex:1843
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:980
-#: lib/vutuv_web/live/post_live/composer.ex:1028
+#: lib/vutuv_web/live/post_live/composer.ex:1050
+#: lib/vutuv_web/live/post_live/composer.ex:1098
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2196,23 +2197,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:956
+#: lib/vutuv_web/live/post_live/composer.ex:1026
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1693
+#: lib/vutuv_web/live/post_live/composer.ex:1833
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1683
+#: lib/vutuv_web/live/post_live/composer.ex:1823
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1649
+#: lib/vutuv_web/live/post_live/composer.ex:1789
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2223,7 +2224,7 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:107
+#: lib/vutuv_web/agent_docs/post_doc.ex:112
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/user_controller.ex:76
@@ -2239,24 +2240,24 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1792
-#: lib/vutuv_web/components/post_components.ex:1796
+#: lib/vutuv_web/components/post_components.ex:1793
+#: lib/vutuv_web/components/post_components.ex:1797
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1793
+#: lib/vutuv_web/components/post_components.ex:1794
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:873
+#: lib/vutuv_web/components/post_components.ex:874
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:1719
+#: lib/vutuv_web/live/post_live/composer.ex:1859
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2270,7 +2271,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1647
+#: lib/vutuv_web/live/post_live/composer.ex:1787
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2289,12 +2290,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1054
+#: lib/vutuv_web/live/post_live/composer.ex:1124
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:938
+#: lib/vutuv_web/live/post_live/composer.ex:1008
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2304,12 +2305,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2240
+#: lib/vutuv_web/live/post_live/composer.ex:2397
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2241
+#: lib/vutuv_web/live/post_live/composer.ex:2398
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2323,37 +2324,37 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:1958
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1819
+#: lib/vutuv_web/live/post_live/composer.ex:1959
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1360
+#: lib/vutuv_web/components/post_components.ex:1361
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2921
+#: lib/vutuv_web/components/post_components.ex:2922
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2925
+#: lib/vutuv_web/components/post_components.ex:2926
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2923
+#: lib/vutuv_web/components/post_components.ex:2924
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2924
+#: lib/vutuv_web/components/post_components.ex:2925
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2364,17 +2365,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1470
+#: lib/vutuv_web/live/post_live/composer.ex:1610
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2231
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2235
+#: lib/vutuv_web/live/post_live/composer.ex:2392
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2394,7 +2395,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3002
+#: lib/vutuv_web/components/post_components.ex:3003
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2413,18 +2414,18 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3094
+#: lib/vutuv_web/components/post_components.ex:3147
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
-#: lib/vutuv_web/live/notification_live/index.ex:916
+#: lib/vutuv_web/live/notification_live/index.ex:920
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:906
-#: lib/vutuv_web/components/post_components.ex:3103
+#: lib/vutuv_web/components/post_components.ex:3156
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2444,12 +2445,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2991
+#: lib/vutuv_web/components/post_components.ex:2992
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3002
+#: lib/vutuv_web/components/post_components.ex:3003
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2458,23 +2459,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2988
+#: lib/vutuv_web/components/post_components.ex:2989
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2406
+#: lib/vutuv_web/components/post_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2988
+#: lib/vutuv_web/components/post_components.ex:2989
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3094
+#: lib/vutuv_web/components/post_components.ex:3147
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2497,43 +2498,43 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3143
+#: lib/vutuv_web/components/post_components.ex:3196
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:319
+#: lib/vutuv_web/components/post_components.ex:320
 #: lib/vutuv_web/live/notification_live/index.ex:858
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:941
-#: lib/vutuv_web/components/post_components.ex:3126
-#: lib/vutuv_web/components/post_components.ex:3127
-#: lib/vutuv_web/live/notification_live/index.ex:913
+#: lib/vutuv_web/components/post_components.ex:942
+#: lib/vutuv_web/components/post_components.ex:3179
+#: lib/vutuv_web/components/post_components.ex:3180
+#: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1331
+#: lib/vutuv_web/components/post_components.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:941
-#: lib/vutuv_web/live/post_live/composer.ex:1637
+#: lib/vutuv_web/live/post_live/composer.ex:1011
+#: lib/vutuv_web/live/post_live/composer.ex:1777
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1764
+#: lib/vutuv_web/live/post_live/composer.ex:1904
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1061
+#: lib/vutuv_web/live/notification_live/index.ex:1096
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2545,12 +2546,12 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1326
+#: lib/vutuv_web/components/post_components.ex:1327
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1320
+#: lib/vutuv_web/components/post_components.ex:1321
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2835,7 +2836,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1673
+#: lib/vutuv_web/live/post_live/composer.ex:1813
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2858,7 +2859,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2922
+#: lib/vutuv_web/components/post_components.ex:2923
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2868,22 +2869,22 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:926
+#: lib/vutuv_web/live/notification_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:918
+#: lib/vutuv_web/live/notification_live/index.ex:923
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:912
+#: lib/vutuv_web/live/notification_live/index.ex:916
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:915
 #: lib/vutuv_web/templates/user/show.html.heex:800
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2896,7 +2897,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:943
+#: lib/vutuv_web/live/notification_live/index.ex:948
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2928,12 +2929,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1091
+#: lib/vutuv_web/live/notification_live/index.ex:1132
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1092
+#: lib/vutuv_web/live/notification_live/index.ex:1133
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3039,7 +3040,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:919
+#: lib/vutuv_web/live/notification_live/index.ex:924
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3119,7 +3120,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1296
+#: lib/vutuv_web/components/post_components.ex:1297
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3194,8 +3195,8 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:883
-#: lib/vutuv_web/components/post_components.ex:1433
+#: lib/vutuv_web/components/post_components.ex:884
+#: lib/vutuv_web/components/post_components.ex:1434
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3460,12 +3461,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1094
+#: lib/vutuv_web/live/notification_live/index.ex:1135
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1093
+#: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3475,7 +3476,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1095
+#: lib/vutuv_web/live/notification_live/index.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3659,7 +3660,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1119
+#: lib/vutuv_web/live/notification_live/index.ex:1160
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3684,7 +3685,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:921
+#: lib/vutuv_web/live/notification_live/index.ex:926
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3759,7 +3760,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1124
+#: lib/vutuv_web/live/notification_live/index.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -3849,7 +3850,7 @@ msgstr ""
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:966
+#: lib/vutuv_web/agent_docs/markdown.ex:982
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3897,7 +3898,7 @@ msgid "In reply to a deleted post."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:894
-#: lib/vutuv_web/agent_docs/markdown.ex:1043
+#: lib/vutuv_web/agent_docs/markdown.ex:1059
 #: lib/vutuv_web/agent_docs/text.ex:622
 #: lib/vutuv_web/agent_docs/text.ex:666
 #, elixir-autogen, elixir-format
@@ -3926,7 +3927,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:108
+#: lib/vutuv_web/agent_docs/post_doc.ex:113
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -4626,7 +4627,7 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:316
+#: lib/vutuv_web/components/post_components.ex:317
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/notification_live/index.ex:776
@@ -5306,7 +5307,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:959
+#: lib/vutuv_web/live/post_live/composer.ex:1029
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5422,9 +5423,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1496
-#: lib/vutuv_web/components/post_components.ex:1548
-#: lib/vutuv_web/components/post_components.ex:1929
+#: lib/vutuv_web/components/post_components.ex:1497
+#: lib/vutuv_web/components/post_components.ex:1549
+#: lib/vutuv_web/components/post_components.ex:1930
 #: lib/vutuv_web/live/notification_live/index.ex:601
 #: lib/vutuv_web/live/post_live/feed.ex:894
 #, elixir-autogen, elixir-format
@@ -5525,7 +5526,7 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1196
+#: lib/vutuv_web/live/post_live/composer.ex:1271
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -6220,7 +6221,7 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:906
-#: lib/vutuv_web/components/post_components.ex:318
+#: lib/vutuv_web/components/post_components.ex:319
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
@@ -6657,7 +6658,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1430
+#: lib/vutuv_web/components/post_components.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6667,7 +6668,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1429
+#: lib/vutuv_web/components/post_components.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7350,6 +7351,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
+#: lib/vutuv_web/components/post_components.ex:3082
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7524,17 +7526,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:971
+#: lib/vutuv_web/agent_docs/markdown.ex:987
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:974
+#: lib/vutuv_web/agent_docs/markdown.ex:990
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:981
+#: lib/vutuv_web/agent_docs/markdown.ex:997
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8702,12 +8704,12 @@ msgstr ""
 msgid "Fediverse settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:179
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr ""
@@ -8821,7 +8823,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2409
+#: lib/vutuv_web/components/post_components.ex:2410
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9928,7 +9930,7 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:121
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
 #: lib/vutuv_web/templates/totp/new.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:894
 #: lib/vutuv_web/templates/username/new.html.heex:27
@@ -9937,8 +9939,8 @@ msgstr ""
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:120
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:123
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:127
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
 #: lib/vutuv_web/templates/user/show.html.heex:893
@@ -12012,7 +12014,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:922
+#: lib/vutuv_web/live/notification_live/index.ex:927
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12115,22 +12117,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1083
+#: lib/vutuv_web/live/notification_live/index.ex:1124
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1080
+#: lib/vutuv_web/live/notification_live/index.ex:1121
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1077
+#: lib/vutuv_web/live/notification_live/index.ex:1118
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1074
+#: lib/vutuv_web/live/notification_live/index.ex:1115
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -13126,7 +13128,7 @@ msgid "Search title, poster or organization"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1542
+#: lib/vutuv_web/live/post_live/composer.ex:1682
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -13505,7 +13507,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:920
+#: lib/vutuv_web/live/notification_live/index.ex:925
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13592,7 +13594,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:923
+#: lib/vutuv_web/live/notification_live/index.ex:928
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13604,7 +13606,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1133
+#: lib/vutuv_web/live/notification_live/index.ex:1174
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13634,7 +13636,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2210
+#: lib/vutuv_web/live/post_live/composer.ex:2367
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13666,22 +13668,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:327
+#: lib/vutuv_web/components/post_components.ex:328
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:329
+#: lib/vutuv_web/components/post_components.ex:330
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:328
+#: lib/vutuv_web/components/post_components.ex:329
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:317
+#: lib/vutuv_web/components/post_components.ex:318
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13811,22 +13813,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:924
+#: lib/vutuv_web/live/notification_live/index.ex:929
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1153
+#: lib/vutuv_web/live/notification_live/index.ex:1194
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1145
+#: lib/vutuv_web/live/notification_live/index.ex:1186
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1150
+#: lib/vutuv_web/live/notification_live/index.ex:1191
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13851,133 +13853,133 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1158
+#: lib/vutuv_web/live/notification_live/index.ex:1199
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2784
+#: lib/vutuv_web/components/post_components.ex:2785
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1550
+#: lib/vutuv_web/live/post_live/composer.ex:1690
 #, elixir-autogen, elixir-format
 msgid "Author(s)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1618
+#: lib/vutuv_web/live/post_live/composer.ex:1758
 #, elixir-autogen, elixir-format
 msgid "Book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:933
-#: lib/vutuv_web/components/post_components.ex:2741
-#: lib/vutuv_web/live/post_live/composer.ex:1496
+#: lib/vutuv_web/agent_docs/markdown.ex:949
+#: lib/vutuv_web/components/post_components.ex:2742
+#: lib/vutuv_web/live/post_live/composer.ex:1636
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2785
+#: lib/vutuv_web/components/post_components.ex:2786
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2787
+#: lib/vutuv_web/components/post_components.ex:2788
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1550
+#: lib/vutuv_web/live/post_live/composer.ex:1690
 #, elixir-autogen, elixir-format
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2783
+#: lib/vutuv_web/components/post_components.ex:2784
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1630
+#: lib/vutuv_web/live/post_live/composer.ex:1770
 #, elixir-autogen, elixir-format
 msgid "Film"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:933
-#: lib/vutuv_web/components/post_components.ex:2740
-#: lib/vutuv_web/live/post_live/composer.ex:1495
+#: lib/vutuv_web/agent_docs/markdown.ex:949
+#: lib/vutuv_web/components/post_components.ex:2741
+#: lib/vutuv_web/live/post_live/composer.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1516
+#: lib/vutuv_web/live/post_live/composer.ex:1656
 #, elixir-autogen, elixir-format
 msgid "IMDb link or ID"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1517
+#: lib/vutuv_web/live/post_live/composer.ex:1657
 #, elixir-autogen, elixir-format
 msgid "ISBN"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1530
+#: lib/vutuv_web/live/post_live/composer.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1527
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Looking up…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:586
+#: lib/vutuv_web/live/post_live/composer.ex:647
 #, elixir-autogen, elixir-format
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2782
+#: lib/vutuv_web/components/post_components.ex:2783
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1569
+#: lib/vutuv_web/live/post_live/composer.ex:1709
 #, elixir-autogen, elixir-format
 msgid "Read as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1505
+#: lib/vutuv_web/live/post_live/composer.ex:1645
 #, elixir-autogen, elixir-format
 msgid "Remove review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1614
-#: lib/vutuv_web/live/post_live/composer.ex:1615
+#: lib/vutuv_web/live/post_live/composer.ex:1754
+#: lib/vutuv_web/live/post_live/composer.ex:1755
 #, elixir-autogen, elixir-format
 msgid "Review a book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1626
-#: lib/vutuv_web/live/post_live/composer.ex:1627
+#: lib/vutuv_web/live/post_live/composer.ex:1766
+#: lib/vutuv_web/live/post_live/composer.ex:1767
 #, elixir-autogen, elixir-format
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2786
+#: lib/vutuv_web/components/post_components.ex:2787
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1568
+#: lib/vutuv_web/live/post_live/composer.ex:1708
 #, elixir-autogen, elixir-format
 msgid "Watched as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1582
+#: lib/vutuv_web/live/post_live/composer.ex:1722
 #, elixir-autogen, elixir-format
 msgid "With an ISBN, the post shows the book cover and a shop link automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1562
+#: lib/vutuv_web/live/post_live/composer.ex:1702
 #: lib/vutuv_web/templates/education/form_content.html.heex:47
 #: lib/vutuv_web/templates/education/form_content.html.heex:48
 #: lib/vutuv_web/templates/education/form_content.html.heex:67
@@ -13993,34 +13995,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2823
+#: lib/vutuv_web/components/post_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2853
+#: lib/vutuv_web/components/post_components.ex:2854
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2854
+#: lib/vutuv_web/components/post_components.ex:2855
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2852
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2812
+#: lib/vutuv_web/components/post_components.ex:2813
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2859
+#: lib/vutuv_web/components/post_components.ex:2860
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14050,7 +14052,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2626
+#: lib/vutuv_web/components/post_components.ex:2627
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14078,27 +14080,27 @@ msgid "Last 30 days"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:763
-#: lib/vutuv_web/live/notification_live/index.ex:972
+#: lib/vutuv_web/live/notification_live/index.ex:1007
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:939
+#: lib/vutuv_web/live/notification_live/index.ex:944
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:934
+#: lib/vutuv_web/live/notification_live/index.ex:939
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:949
+#: lib/vutuv_web/live/notification_live/index.ex:954
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2617
+#: lib/vutuv_web/components/post_components.ex:2618
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14338,17 +14340,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1107
+#: lib/vutuv_web/live/notification_live/index.ex:1148
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:914
+#: lib/vutuv_web/live/notification_live/index.ex:918
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:959
+#: lib/vutuv_web/live/notification_live/index.ex:994
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14367,23 +14369,23 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:915
+#: lib/vutuv_web/live/notification_live/index.ex:919
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1063
+#: lib/vutuv_web/live/notification_live/index.ex:1098
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:946
+#: lib/vutuv_web/live/post_live/composer.ex:1016
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:949
+#: lib/vutuv_web/live/post_live/composer.ex:1019
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14472,14 +14474,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1076
+#: lib/vutuv_web/components/post_components.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1098
+#: lib/vutuv_web/components/post_components.ex:1099
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14506,7 +14508,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3102
+#: lib/vutuv_web/components/post_components.ex:3155
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14906,14 +14908,9 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:915
+#: lib/vutuv_web/agent_docs/markdown.ex:916
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:71
-#, elixir-autogen, elixir-format
-msgid "Count reactions from other networks"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:39
@@ -14959,40 +14956,35 @@ msgstr ""
 msgid "Off means your profile cannot be found there and nothing is sent. Posts already delivered may stay on those servers, beyond our reach."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:74
-#, elixir-autogen, elixir-format
-msgid "Show under each of your posts how many people out there liked or shared it. A number only, visible to everyone who sees the post. Switching it off deletes what is stored for it."
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:107
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:209
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:143
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Related"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:162
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
 #: lib/vutuv_web/controllers/settings_controller.ex:222
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:168
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:171
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Move your account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:172
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr ""
@@ -15048,7 +15040,7 @@ msgstr ""
 msgid "Back to Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:129
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower from other networks"
 msgid_plural "%{formatted} followers from other networks"
@@ -15647,13 +15639,13 @@ msgstr ""
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:223
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:226
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:221
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:224
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
@@ -15689,48 +15681,31 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3062
-#, elixir-autogen, elixir-format
-msgid "%{count} from other networks"
-msgstr ""
-
-#: lib/vutuv_web/components/post_components.ex:3065
-#, elixir-autogen, elixir-format
-msgid "%{formatted} reaction"
-msgid_plural "%{formatted} reactions"
-msgstr[0] ""
-msgstr[1] ""
-
-#: lib/vutuv_web/components/post_components.ex:3071
+#: lib/vutuv_web/components/post_components.ex:3124
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3055
-#, elixir-autogen, elixir-format
-msgid "%{reactions} and %{replies} from other networks"
-msgstr ""
-
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "A report deletes the reply right away, with no queue to work through. This is the trail, so a server that keeps showing up here can be blocked above. It holds no text and no links, only which server and which account (as a short digest)."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:89
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1064
+#: lib/vutuv_web/agent_docs/markdown.ex:1080
 #: lib/vutuv_web/agent_docs/text.ex:680
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:840
-#: lib/vutuv_web/components/post_components.ex:921
+#: lib/vutuv_web/components/post_components.ex:841
+#: lib/vutuv_web/components/post_components.ex:922
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
@@ -15740,7 +15715,7 @@ msgstr ""
 msgid "Nobody has removed or reported a reply yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:871
+#: lib/vutuv_web/components/post_components.ex:872
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15751,7 +15726,7 @@ msgid "Removed by the member"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:123
-#: lib/vutuv_web/agent_docs/markdown.ex:920
+#: lib/vutuv_web/agent_docs/markdown.ex:921
 #: lib/vutuv_web/agent_docs/text.ex:114
 #, elixir-autogen, elixir-format
 msgid "Replies from other networks"
@@ -15762,7 +15737,7 @@ msgstr ""
 msgid "Replies taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:917
+#: lib/vutuv_web/live/notification_live/index.ex:921
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15772,7 +15747,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:880
+#: lib/vutuv_web/components/post_components.ex:881
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15782,13 +15757,13 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:897
+#: lib/vutuv_web/components/post_components.ex:898
 #: lib/vutuv_web/live/notification_live/index.ex:497
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:86
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Show replies from other networks"
 msgstr ""
@@ -15813,8 +15788,8 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1066
-#: lib/vutuv_web/components/post_components.ex:927
+#: lib/vutuv_web/agent_docs/markdown.ex:1082
+#: lib/vutuv_web/components/post_components.ex:928
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15829,12 +15804,12 @@ msgstr ""
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1066
+#: lib/vutuv_web/live/notification_live/index.ex:1101
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:149
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "All followers"
 msgstr ""
@@ -16177,11 +16152,6 @@ msgstr ""
 msgid "Fediverse participation"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:173
-#, elixir-autogen, elixir-format
-msgid "Fediverse reaction counts"
-msgstr ""
-
 #: lib/vutuv_web/views/account_event_text.ex:174
 #, elixir-autogen, elixir-format
 msgid "Fediverse replies"
@@ -16489,22 +16459,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1308
+#: lib/vutuv_web/components/post_components.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1396
+#: lib/vutuv_web/components/post_components.ex:1397
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1404
+#: lib/vutuv_web/components/post_components.ex:1405
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1390
+#: lib/vutuv_web/components/post_components.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16548,7 +16518,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2223
+#: lib/vutuv_web/live/post_live/composer.ex:2380
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16578,74 +16548,74 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2055
+#: lib/vutuv_web/live/post_live/composer.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Caption, shown under the photo (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1891
+#: lib/vutuv_web/live/post_live/composer.ex:2040
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2063
+#: lib/vutuv_web/live/post_live/composer.ex:2217
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:994
+#: lib/vutuv_web/agent_docs/markdown.ex:1010
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:1858
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1381
+#: lib/vutuv_web/live/post_live/composer.ex:1456
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2172
+#: lib/vutuv_web/live/post_live/composer.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2129
+#: lib/vutuv_web/live/post_live/composer.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2131
+#: lib/vutuv_web/live/post_live/composer.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2150
+#: lib/vutuv_web/live/post_live/composer.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1928
+#: lib/vutuv_web/live/post_live/composer.ex:2077
 #, elixir-autogen, elixir-format
 msgid "Move photo earlier"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1940
+#: lib/vutuv_web/live/post_live/composer.ex:2089
 #, elixir-autogen, elixir-format
 msgid "Move photo later"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1856
+#: lib/vutuv_web/components/post_components.ex:1857
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1898
+#: lib/vutuv_web/live/post_live/composer.ex:2047
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2273
+#: lib/vutuv_web/components/post_components.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr ""
@@ -16655,85 +16625,85 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2276
+#: lib/vutuv_web/components/post_components.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2101
+#: lib/vutuv_web/components/post_components.ex:2102
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1603
+#: lib/vutuv_web/components/post_components.ex:1604
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1875
-#: lib/vutuv_web/live/post_live/composer.ex:1876
+#: lib/vutuv_web/live/post_live/composer.ex:2015
+#: lib/vutuv_web/live/post_live/composer.ex:2016
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1027
+#: lib/vutuv_web/agent_docs/markdown.ex:1043
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:2310
+#: lib/vutuv_web/components/post_components.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1855
+#: lib/vutuv_web/components/post_components.ex:1856
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1911
-#: lib/vutuv_web/live/post_live/composer.ex:1912
+#: lib/vutuv_web/live/post_live/composer.ex:2060
+#: lib/vutuv_web/live/post_live/composer.ex:2061
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2152
+#: lib/vutuv_web/live/post_live/composer.ex:2309
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1339
-#: lib/vutuv_web/live/post_live/composer.ex:2101
+#: lib/vutuv_web/live/post_live/composer.ex:1414
+#: lib/vutuv_web/live/post_live/composer.ex:2255
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:971
+#: lib/vutuv_web/live/post_live/composer.ex:1041
 #: lib/vutuv_web/live/post_live/remote_reply.ex:87
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2170
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2109
+#: lib/vutuv_web/live/post_live/composer.ex:2263
 #, elixir-autogen, elixir-format
 msgid "This file carries no camera information."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2350
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2185
+#: lib/vutuv_web/live/post_live/composer.ex:2342
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:974
+#: lib/vutuv_web/live/post_live/composer.ex:1044
 #: lib/vutuv_web/live/post_live/remote_reply.ex:84
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
@@ -16754,12 +16724,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1427
+#: lib/vutuv_web/live/post_live/composer.ex:1505
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:966
+#: lib/vutuv_web/live/post_live/composer.ex:1036
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16769,7 +16739,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:977
+#: lib/vutuv_web/live/post_live/composer.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16784,17 +16754,17 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1357
+#: lib/vutuv_web/live/post_live/composer.ex:1432
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1452
+#: lib/vutuv_web/live/post_live/composer.ex:1592
 #, elixir-autogen, elixir-format
 msgid "Add text (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1422
+#: lib/vutuv_web/live/post_live/composer.ex:1500
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr ""
@@ -16805,91 +16775,149 @@ msgstr ""
 msgid "Post photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1189
+#: lib/vutuv_web/live/post_live/composer.ex:1264
 #, elixir-autogen, elixir-format
 msgid "Post type"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1368
+#: lib/vutuv_web/live/post_live/composer.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Select photos, or drag them here"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1193
+#: lib/vutuv_web/live/post_live/composer.ex:1268
 #, elixir-autogen, elixir-format
 msgid "Text"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:1958
 #, elixir-autogen, elixir-format
 msgid "Text (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1371
+#: lib/vutuv_web/live/post_live/composer.ex:1446
 #, elixir-autogen, elixir-format
 msgid "Up to %{max} photos per post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1316
+#: lib/vutuv_web/live/post_live/composer.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1232
+#: lib/vutuv_web/live/post_live/composer.ex:1307
 #, elixir-autogen, elixir-format
 msgid "A photo post shows your pictures big and first; text is optional. For a post that is mainly text, switch to \"Text\"."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1163
-#: lib/vutuv_web/live/post_live/composer.ex:1217
-#: lib/vutuv_web/live/post_live/composer.ex:1218
+#: lib/vutuv_web/live/post_live/composer.ex:1238
+#: lib/vutuv_web/live/post_live/composer.ex:1292
+#: lib/vutuv_web/live/post_live/composer.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1215
+#: lib/vutuv_web/live/post_live/composer.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1156
+#: lib/vutuv_web/live/post_live/composer.ex:1231
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1424
+#: lib/vutuv_web/live/post_live/composer.ex:1574
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1399
+#: lib/vutuv_web/live/post_live/composer.ex:1550
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1396
+#: lib/vutuv_web/live/post_live/composer.ex:1547
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1393
+#: lib/vutuv_web/live/post_live/composer.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1390
+#: lib/vutuv_web/live/post_live/composer.ex:1541
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1386
+#: lib/vutuv_web/live/post_live/composer.ex:1537
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1412
+#: lib/vutuv_web/live/post_live/composer.ex:1563
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:939
+#: lib/vutuv_web/components/post_components.ex:3121
+#, elixir-autogen, elixir-format
+msgid "%{handle} liked this"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:937
+#: lib/vutuv_web/components/post_components.ex:3118
+#, elixir-autogen, elixir-format
+msgid "%{handle} shared this"
+msgstr ""
+
+#: lib/vutuv_web/views/account_event_text.ex:173
+#, elixir-autogen, elixir-format
+msgid "Fediverse reactions"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:3060
+#, elixir-autogen, elixir-format
+msgid "From other networks"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:922
+#, elixir-autogen, elixir-format
+msgid "Reaction from another network"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:74
+#, elixir-autogen, elixir-format
+msgid "Show reactions from other networks"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:975
+#, elixir-autogen, elixir-format
+msgid "liked your post on another network."
+msgid_plural "liked your post on another network."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:983
+#, elixir-autogen, elixir-format
+msgid "reacted to your post from another network."
+msgid_plural "reacted to your post from another network."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:967
+#, elixir-autogen, elixir-format
+msgid "shared your post on another network."
+msgid_plural "shared your post on another network."
 msgstr[0] ""
 msgstr[1] ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -116,7 +116,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
 #: lib/vutuv_web/templates/import/preview.html.heex:86
 #: lib/vutuv_web/templates/report/new.html.heex:103
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:213
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:216
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:26
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:24
 #: lib/vutuv_web/templates/user/edit.html.heex:50
@@ -152,7 +152,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1412
+#: lib/vutuv_web/components/post_components.ex:1413
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -193,6 +193,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:439
+#: lib/vutuv_web/live/post_live/composer.ex:1530
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:303
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -200,7 +201,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1377
+#: lib/vutuv_web/components/post_components.ex:1378
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -611,7 +612,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1640
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -621,10 +622,10 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2863
 #: lib/vutuv_web/live/organization_live/edit.ex:339
-#: lib/vutuv_web/live/post_live/composer.ex:1649
+#: lib/vutuv_web/live/post_live/composer.ex:1789
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:95
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:98
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:73
 #: lib/vutuv_web/templates/settings/notifications.html.heex:67
 #: lib/vutuv_web/templates/settings/preferences.html.heex:29
@@ -656,7 +657,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:906
+#: lib/vutuv_web/components/post_components.ex:907
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -797,7 +798,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
 #: lib/vutuv_web/live/admin/user_live.ex:169
-#: lib/vutuv_web/live/notification_live/index.ex:925
+#: lib/vutuv_web/live/notification_live/index.ex:930
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -1658,13 +1659,13 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1854
+#: lib/vutuv_web/components/post_components.ex:1855
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1217
-#: lib/vutuv_web/live/post_live/composer.ex:1218
-#: lib/vutuv_web/live/post_live/composer.ex:2071
+#: lib/vutuv_web/live/post_live/composer.ex:1292
+#: lib/vutuv_web/live/post_live/composer.ex:1293
+#: lib/vutuv_web/live/post_live/composer.ex:2225
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1785,7 +1786,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:330
+#: lib/vutuv_web/components/post_components.ex:331
 #: lib/vutuv_web/components/ui.ex:3077
 #: lib/vutuv_web/live/admin/user_live.ex:311
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
@@ -1930,17 +1931,17 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:946
+#: lib/vutuv_web/live/notification_live/index.ex:951
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:941
+#: lib/vutuv_web/live/notification_live/index.ex:946
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:936
+#: lib/vutuv_web/live/notification_live/index.ex:941
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
@@ -2105,12 +2106,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:1600
+#: lib/vutuv_web/live/post_live/composer.ex:1740
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1757
+#: lib/vutuv_web/live/post_live/composer.ex:1897
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2121,7 +2122,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1393
+#: lib/vutuv_web/live/post_live/composer.ex:1468
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2131,7 +2132,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1409
+#: lib/vutuv_web/components/post_components.ex:1410
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2162,29 +2163,29 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1733
+#: lib/vutuv_web/live/post_live/composer.ex:1873
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1661
+#: lib/vutuv_web/live/post_live/composer.ex:1801
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1363
-#: lib/vutuv_web/components/post_components.ex:1365
+#: lib/vutuv_web/components/post_components.ex:1364
+#: lib/vutuv_web/components/post_components.ex:1366
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1703
+#: lib/vutuv_web/live/post_live/composer.ex:1843
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:980
-#: lib/vutuv_web/live/post_live/composer.ex:1028
+#: lib/vutuv_web/live/post_live/composer.ex:1050
+#: lib/vutuv_web/live/post_live/composer.ex:1098
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2194,23 +2195,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:956
+#: lib/vutuv_web/live/post_live/composer.ex:1026
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1693
+#: lib/vutuv_web/live/post_live/composer.ex:1833
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1683
+#: lib/vutuv_web/live/post_live/composer.ex:1823
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1649
+#: lib/vutuv_web/live/post_live/composer.ex:1789
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2221,7 +2222,7 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:107
+#: lib/vutuv_web/agent_docs/post_doc.ex:112
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/user_controller.ex:76
@@ -2237,24 +2238,24 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1792
-#: lib/vutuv_web/components/post_components.ex:1796
+#: lib/vutuv_web/components/post_components.ex:1793
+#: lib/vutuv_web/components/post_components.ex:1797
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1793
+#: lib/vutuv_web/components/post_components.ex:1794
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:873
+#: lib/vutuv_web/components/post_components.ex:874
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:1719
+#: lib/vutuv_web/live/post_live/composer.ex:1859
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2268,7 +2269,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1647
+#: lib/vutuv_web/live/post_live/composer.ex:1787
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2287,12 +2288,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1054
+#: lib/vutuv_web/live/post_live/composer.ex:1124
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:938
+#: lib/vutuv_web/live/post_live/composer.ex:1008
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2302,12 +2303,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2240
+#: lib/vutuv_web/live/post_live/composer.ex:2397
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2241
+#: lib/vutuv_web/live/post_live/composer.ex:2398
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2321,37 +2322,37 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:1958
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1819
+#: lib/vutuv_web/live/post_live/composer.ex:1959
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1360
+#: lib/vutuv_web/components/post_components.ex:1361
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2921
+#: lib/vutuv_web/components/post_components.ex:2922
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2925
+#: lib/vutuv_web/components/post_components.ex:2926
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2923
+#: lib/vutuv_web/components/post_components.ex:2924
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2924
+#: lib/vutuv_web/components/post_components.ex:2925
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2362,17 +2363,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1470
+#: lib/vutuv_web/live/post_live/composer.ex:1610
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2231
+#: lib/vutuv_web/live/post_live/composer.ex:2388
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2235
+#: lib/vutuv_web/live/post_live/composer.ex:2392
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2392,7 +2393,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3002
+#: lib/vutuv_web/components/post_components.ex:3003
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2411,18 +2412,18 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3094
+#: lib/vutuv_web/components/post_components.ex:3147
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
-#: lib/vutuv_web/live/notification_live/index.ex:916
+#: lib/vutuv_web/live/notification_live/index.ex:920
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:906
-#: lib/vutuv_web/components/post_components.ex:3103
+#: lib/vutuv_web/components/post_components.ex:3156
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2442,12 +2443,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2991
+#: lib/vutuv_web/components/post_components.ex:2992
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3002
+#: lib/vutuv_web/components/post_components.ex:3003
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2456,23 +2457,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2988
+#: lib/vutuv_web/components/post_components.ex:2989
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2406
+#: lib/vutuv_web/components/post_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2988
+#: lib/vutuv_web/components/post_components.ex:2989
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3094
+#: lib/vutuv_web/components/post_components.ex:3147
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2495,43 +2496,43 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3143
+#: lib/vutuv_web/components/post_components.ex:3196
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:319
+#: lib/vutuv_web/components/post_components.ex:320
 #: lib/vutuv_web/live/notification_live/index.ex:858
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:941
-#: lib/vutuv_web/components/post_components.ex:3126
-#: lib/vutuv_web/components/post_components.ex:3127
-#: lib/vutuv_web/live/notification_live/index.ex:913
+#: lib/vutuv_web/components/post_components.ex:942
+#: lib/vutuv_web/components/post_components.ex:3179
+#: lib/vutuv_web/components/post_components.ex:3180
+#: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1331
+#: lib/vutuv_web/components/post_components.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:941
-#: lib/vutuv_web/live/post_live/composer.ex:1637
+#: lib/vutuv_web/live/post_live/composer.ex:1011
+#: lib/vutuv_web/live/post_live/composer.ex:1777
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1764
+#: lib/vutuv_web/live/post_live/composer.ex:1904
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1061
+#: lib/vutuv_web/live/notification_live/index.ex:1096
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
@@ -2543,12 +2544,12 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1326
+#: lib/vutuv_web/components/post_components.ex:1327
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1320
+#: lib/vutuv_web/components/post_components.ex:1321
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2833,7 +2834,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1673
+#: lib/vutuv_web/live/post_live/composer.ex:1813
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2856,7 +2857,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2922
+#: lib/vutuv_web/components/post_components.ex:2923
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2866,22 +2867,22 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:926
+#: lib/vutuv_web/live/notification_live/index.ex:931
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:918
+#: lib/vutuv_web/live/notification_live/index.ex:923
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:912
+#: lib/vutuv_web/live/notification_live/index.ex:916
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:911
+#: lib/vutuv_web/live/notification_live/index.ex:915
 #: lib/vutuv_web/templates/user/show.html.heex:800
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2894,7 +2895,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:943
+#: lib/vutuv_web/live/notification_live/index.ex:948
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2926,12 +2927,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1091
+#: lib/vutuv_web/live/notification_live/index.ex:1132
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1092
+#: lib/vutuv_web/live/notification_live/index.ex:1133
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -3037,7 +3038,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:919
+#: lib/vutuv_web/live/notification_live/index.ex:924
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3117,7 +3118,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1296
+#: lib/vutuv_web/components/post_components.ex:1297
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3192,8 +3193,8 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:883
-#: lib/vutuv_web/components/post_components.ex:1433
+#: lib/vutuv_web/components/post_components.ex:884
+#: lib/vutuv_web/components/post_components.ex:1434
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3458,12 +3459,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1094
+#: lib/vutuv_web/live/notification_live/index.ex:1135
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1093
+#: lib/vutuv_web/live/notification_live/index.ex:1134
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3473,7 +3474,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1095
+#: lib/vutuv_web/live/notification_live/index.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3657,7 +3658,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1119
+#: lib/vutuv_web/live/notification_live/index.ex:1160
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3682,7 +3683,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:921
+#: lib/vutuv_web/live/notification_live/index.ex:926
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3757,7 +3758,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1124
+#: lib/vutuv_web/live/notification_live/index.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -3847,7 +3848,7 @@ msgstr ""
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:966
+#: lib/vutuv_web/agent_docs/markdown.ex:982
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3895,7 +3896,7 @@ msgid "In reply to a deleted post."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:894
-#: lib/vutuv_web/agent_docs/markdown.ex:1043
+#: lib/vutuv_web/agent_docs/markdown.ex:1059
 #: lib/vutuv_web/agent_docs/text.ex:622
 #: lib/vutuv_web/agent_docs/text.ex:666
 #, elixir-autogen, elixir-format
@@ -3924,7 +3925,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:108
+#: lib/vutuv_web/agent_docs/post_doc.ex:113
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -4624,7 +4625,7 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:316
+#: lib/vutuv_web/components/post_components.ex:317
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/notification_live/index.ex:776
@@ -5304,7 +5305,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:959
+#: lib/vutuv_web/live/post_live/composer.ex:1029
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5420,9 +5421,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1496
-#: lib/vutuv_web/components/post_components.ex:1548
-#: lib/vutuv_web/components/post_components.ex:1929
+#: lib/vutuv_web/components/post_components.ex:1497
+#: lib/vutuv_web/components/post_components.ex:1549
+#: lib/vutuv_web/components/post_components.ex:1930
 #: lib/vutuv_web/live/notification_live/index.ex:601
 #: lib/vutuv_web/live/post_live/feed.ex:894
 #, elixir-autogen, elixir-format
@@ -5523,7 +5524,7 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1196
+#: lib/vutuv_web/live/post_live/composer.ex:1271
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -6218,7 +6219,7 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:906
-#: lib/vutuv_web/components/post_components.ex:318
+#: lib/vutuv_web/components/post_components.ex:319
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
@@ -6655,7 +6656,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1430
+#: lib/vutuv_web/components/post_components.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6665,7 +6666,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1429
+#: lib/vutuv_web/components/post_components.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7348,6 +7349,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
+#: lib/vutuv_web/components/post_components.ex:3082
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7522,17 +7524,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:971
+#: lib/vutuv_web/agent_docs/markdown.ex:987
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:974
+#: lib/vutuv_web/agent_docs/markdown.ex:990
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:981
+#: lib/vutuv_web/agent_docs/markdown.ex:997
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8700,12 +8702,12 @@ msgstr ""
 msgid "Fediverse settings saved."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:179
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:182
 #, elixir-autogen, elixir-format
 msgid "Manage social media accounts"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:105
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:108
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse handle"
 msgstr ""
@@ -8819,7 +8821,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2409
+#: lib/vutuv_web/components/post_components.ex:2410
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9926,7 +9928,7 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:121
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
 #: lib/vutuv_web/templates/totp/new.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:894
 #: lib/vutuv_web/templates/username/new.html.heex:27
@@ -9935,8 +9937,8 @@ msgstr ""
 msgid "Copied"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:120
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:124
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:123
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:127
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
 #: lib/vutuv_web/templates/user/show.html.heex:893
@@ -12010,7 +12012,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:922
+#: lib/vutuv_web/live/notification_live/index.ex:927
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12113,22 +12115,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1083
+#: lib/vutuv_web/live/notification_live/index.ex:1124
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1080
+#: lib/vutuv_web/live/notification_live/index.ex:1121
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1077
+#: lib/vutuv_web/live/notification_live/index.ex:1118
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1074
+#: lib/vutuv_web/live/notification_live/index.ex:1115
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -13124,7 +13126,7 @@ msgid "Search title, poster or organization"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1542
+#: lib/vutuv_web/live/post_live/composer.ex:1682
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -13503,7 +13505,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:920
+#: lib/vutuv_web/live/notification_live/index.ex:925
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13590,7 +13592,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:923
+#: lib/vutuv_web/live/notification_live/index.ex:928
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13602,7 +13604,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1133
+#: lib/vutuv_web/live/notification_live/index.ex:1174
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13632,7 +13634,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2210
+#: lib/vutuv_web/live/post_live/composer.ex:2367
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13664,22 +13666,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:327
+#: lib/vutuv_web/components/post_components.ex:328
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:329
+#: lib/vutuv_web/components/post_components.ex:330
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:328
+#: lib/vutuv_web/components/post_components.ex:329
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:317
+#: lib/vutuv_web/components/post_components.ex:318
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13809,22 +13811,22 @@ msgstr[1] ""
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:924
+#: lib/vutuv_web/live/notification_live/index.ex:929
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1153
+#: lib/vutuv_web/live/notification_live/index.ex:1194
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1145
+#: lib/vutuv_web/live/notification_live/index.ex:1186
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1150
+#: lib/vutuv_web/live/notification_live/index.ex:1191
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13849,133 +13851,133 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1158
+#: lib/vutuv_web/live/notification_live/index.ex:1199
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2784
+#: lib/vutuv_web/components/post_components.ex:2785
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1550
+#: lib/vutuv_web/live/post_live/composer.ex:1690
 #, elixir-autogen, elixir-format
 msgid "Author(s)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1618
+#: lib/vutuv_web/live/post_live/composer.ex:1758
 #, elixir-autogen, elixir-format
 msgid "Book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:933
-#: lib/vutuv_web/components/post_components.ex:2741
-#: lib/vutuv_web/live/post_live/composer.ex:1496
+#: lib/vutuv_web/agent_docs/markdown.ex:949
+#: lib/vutuv_web/components/post_components.ex:2742
+#: lib/vutuv_web/live/post_live/composer.ex:1636
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2785
+#: lib/vutuv_web/components/post_components.ex:2786
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2787
+#: lib/vutuv_web/components/post_components.ex:2788
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1550
+#: lib/vutuv_web/live/post_live/composer.ex:1690
 #, elixir-autogen, elixir-format
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2783
+#: lib/vutuv_web/components/post_components.ex:2784
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1630
+#: lib/vutuv_web/live/post_live/composer.ex:1770
 #, elixir-autogen, elixir-format
 msgid "Film"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:933
-#: lib/vutuv_web/components/post_components.ex:2740
-#: lib/vutuv_web/live/post_live/composer.ex:1495
+#: lib/vutuv_web/agent_docs/markdown.ex:949
+#: lib/vutuv_web/components/post_components.ex:2741
+#: lib/vutuv_web/live/post_live/composer.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1516
+#: lib/vutuv_web/live/post_live/composer.ex:1656
 #, elixir-autogen, elixir-format
 msgid "IMDb link or ID"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1517
+#: lib/vutuv_web/live/post_live/composer.ex:1657
 #, elixir-autogen, elixir-format
 msgid "ISBN"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1530
+#: lib/vutuv_web/live/post_live/composer.ex:1670
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1527
+#: lib/vutuv_web/live/post_live/composer.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Looking up…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:586
+#: lib/vutuv_web/live/post_live/composer.ex:647
 #, elixir-autogen, elixir-format
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2782
+#: lib/vutuv_web/components/post_components.ex:2783
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1569
+#: lib/vutuv_web/live/post_live/composer.ex:1709
 #, elixir-autogen, elixir-format
 msgid "Read as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1505
+#: lib/vutuv_web/live/post_live/composer.ex:1645
 #, elixir-autogen, elixir-format
 msgid "Remove review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1614
-#: lib/vutuv_web/live/post_live/composer.ex:1615
+#: lib/vutuv_web/live/post_live/composer.ex:1754
+#: lib/vutuv_web/live/post_live/composer.ex:1755
 #, elixir-autogen, elixir-format
 msgid "Review a book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1626
-#: lib/vutuv_web/live/post_live/composer.ex:1627
+#: lib/vutuv_web/live/post_live/composer.ex:1766
+#: lib/vutuv_web/live/post_live/composer.ex:1767
 #, elixir-autogen, elixir-format
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2786
+#: lib/vutuv_web/components/post_components.ex:2787
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1568
+#: lib/vutuv_web/live/post_live/composer.ex:1708
 #, elixir-autogen, elixir-format
 msgid "Watched as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1582
+#: lib/vutuv_web/live/post_live/composer.ex:1722
 #, elixir-autogen, elixir-format
 msgid "With an ISBN, the post shows the book cover and a shop link automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1562
+#: lib/vutuv_web/live/post_live/composer.ex:1702
 #: lib/vutuv_web/templates/education/form_content.html.heex:47
 #: lib/vutuv_web/templates/education/form_content.html.heex:48
 #: lib/vutuv_web/templates/education/form_content.html.heex:67
@@ -13991,34 +13993,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2823
+#: lib/vutuv_web/components/post_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2853
+#: lib/vutuv_web/components/post_components.ex:2854
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2854
+#: lib/vutuv_web/components/post_components.ex:2855
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2852
+#: lib/vutuv_web/components/post_components.ex:2853
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2812
+#: lib/vutuv_web/components/post_components.ex:2813
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2859
+#: lib/vutuv_web/components/post_components.ex:2860
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14048,7 +14050,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2626
+#: lib/vutuv_web/components/post_components.ex:2627
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14076,27 +14078,27 @@ msgid "Last 30 days"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:763
-#: lib/vutuv_web/live/notification_live/index.ex:972
+#: lib/vutuv_web/live/notification_live/index.ex:1007
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:939
+#: lib/vutuv_web/live/notification_live/index.ex:944
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:934
+#: lib/vutuv_web/live/notification_live/index.ex:939
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:949
+#: lib/vutuv_web/live/notification_live/index.ex:954
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2617
+#: lib/vutuv_web/components/post_components.ex:2618
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14336,17 +14338,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1107
+#: lib/vutuv_web/live/notification_live/index.ex:1148
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:914
+#: lib/vutuv_web/live/notification_live/index.ex:918
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:959
+#: lib/vutuv_web/live/notification_live/index.ex:994
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14365,23 +14367,23 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:915
+#: lib/vutuv_web/live/notification_live/index.ex:919
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1063
+#: lib/vutuv_web/live/notification_live/index.ex:1098
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:946
+#: lib/vutuv_web/live/post_live/composer.ex:1016
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:949
+#: lib/vutuv_web/live/post_live/composer.ex:1019
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14470,14 +14472,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1076
+#: lib/vutuv_web/components/post_components.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1098
+#: lib/vutuv_web/components/post_components.ex:1099
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14504,7 +14506,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3102
+#: lib/vutuv_web/components/post_components.ex:3155
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14904,14 +14906,9 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:915
+#: lib/vutuv_web/agent_docs/markdown.ex:916
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:71
-#, elixir-autogen, elixir-format
-msgid "Count reactions from other networks"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:39
@@ -14957,40 +14954,35 @@ msgstr ""
 msgid "Off means your profile cannot be found there and nothing is sent. Posts already delivered may stay on those servers, beyond our reach."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:74
-#, elixir-autogen, elixir-format
-msgid "Show under each of your posts how many people out there liked or shared it. A number only, visible to everyone who sees the post. Switching it off deletes what is stored for it."
-msgstr ""
-
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:107
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:209
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:143
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:159
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Related"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:162
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Moving to or away from another Fediverse account?"
 msgstr ""
 
 #: lib/vutuv_web/controllers/settings_controller.ex:222
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:168
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:171
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Move your account"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:172
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Want the checkmark on your Mastodon profile? That works without taking part here: your vutuv profile links your listed accounts with rel=\"me\"."
 msgstr ""
@@ -15046,7 +15038,7 @@ msgstr ""
 msgid "Back to Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:129
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower from other networks"
 msgid_plural "%{formatted} followers from other networks"
@@ -15645,13 +15637,13 @@ msgstr ""
 msgid "This link always opens your profile, even after you change your username. It is built from a fixed id, so it never breaks on a rename. For everyday sharing the short address above is friendlier."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:223
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:226
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "I understand, switch off"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:221
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:224
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "I understand, take part"
@@ -15687,48 +15679,31 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3062
-#, elixir-autogen, elixir-format, fuzzy
-msgid "%{count} from other networks"
-msgstr ""
-
-#: lib/vutuv_web/components/post_components.ex:3065
-#, elixir-autogen, elixir-format, fuzzy
-msgid "%{formatted} reaction"
-msgid_plural "%{formatted} reactions"
-msgstr[0] ""
-msgstr[1] ""
-
-#: lib/vutuv_web/components/post_components.ex:3071
+#: lib/vutuv_web/components/post_components.ex:3124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3055
-#, elixir-autogen, elixir-format
-msgid "%{reactions} and %{replies} from other networks"
-msgstr ""
-
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "A report deletes the reply right away, with no queue to work through. This is the trail, so a server that keeps showing up here can be blocked above. It holds no text and no links, only which server and which account (as a short digest)."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:89
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1064
+#: lib/vutuv_web/agent_docs/markdown.ex:1080
 #: lib/vutuv_web/agent_docs/text.ex:680
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:840
-#: lib/vutuv_web/components/post_components.ex:921
+#: lib/vutuv_web/components/post_components.ex:841
+#: lib/vutuv_web/components/post_components.ex:922
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
@@ -15738,7 +15713,7 @@ msgstr ""
 msgid "Nobody has removed or reported a reply yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:871
+#: lib/vutuv_web/components/post_components.ex:872
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15749,7 +15724,7 @@ msgid "Removed by the member"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:123
-#: lib/vutuv_web/agent_docs/markdown.ex:920
+#: lib/vutuv_web/agent_docs/markdown.ex:921
 #: lib/vutuv_web/agent_docs/text.ex:114
 #, elixir-autogen, elixir-format
 msgid "Replies from other networks"
@@ -15760,7 +15735,7 @@ msgstr ""
 msgid "Replies taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:917
+#: lib/vutuv_web/live/notification_live/index.ex:921
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
@@ -15770,7 +15745,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:880
+#: lib/vutuv_web/components/post_components.ex:881
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15780,13 +15755,13 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:897
+#: lib/vutuv_web/components/post_components.ex:898
 #: lib/vutuv_web/live/notification_live/index.ex:497
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:86
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Show replies from other networks"
 msgstr ""
@@ -15811,8 +15786,8 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1066
-#: lib/vutuv_web/components/post_components.ex:927
+#: lib/vutuv_web/agent_docs/markdown.ex:1082
+#: lib/vutuv_web/components/post_components.ex:928
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15827,12 +15802,12 @@ msgstr ""
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1066
+#: lib/vutuv_web/live/notification_live/index.ex:1101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "replied to your post from another network."
 msgstr ""
 
-#: lib/vutuv_web/templates/settings/fediverse.html.heex:149
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "All followers"
 msgstr ""
@@ -16175,11 +16150,6 @@ msgstr ""
 msgid "Fediverse participation"
 msgstr ""
 
-#: lib/vutuv_web/views/account_event_text.ex:173
-#, elixir-autogen, elixir-format
-msgid "Fediverse reaction counts"
-msgstr ""
-
 #: lib/vutuv_web/views/account_event_text.ex:174
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse replies"
@@ -16487,22 +16457,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1308
+#: lib/vutuv_web/components/post_components.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1396
+#: lib/vutuv_web/components/post_components.ex:1397
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1404
+#: lib/vutuv_web/components/post_components.ex:1405
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1390
+#: lib/vutuv_web/components/post_components.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16546,7 +16516,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2223
+#: lib/vutuv_web/live/post_live/composer.ex:2380
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16576,74 +16546,74 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2055
+#: lib/vutuv_web/live/post_live/composer.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Caption, shown under the photo (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1891
+#: lib/vutuv_web/live/post_live/composer.ex:2040
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2063
+#: lib/vutuv_web/live/post_live/composer.ex:2217
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:994
+#: lib/vutuv_web/agent_docs/markdown.ex:1010
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:1858
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1381
+#: lib/vutuv_web/live/post_live/composer.ex:1456
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2172
+#: lib/vutuv_web/live/post_live/composer.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2129
+#: lib/vutuv_web/live/post_live/composer.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2131
+#: lib/vutuv_web/live/post_live/composer.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2150
+#: lib/vutuv_web/live/post_live/composer.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1928
+#: lib/vutuv_web/live/post_live/composer.ex:2077
 #, elixir-autogen, elixir-format
 msgid "Move photo earlier"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1940
+#: lib/vutuv_web/live/post_live/composer.ex:2089
 #, elixir-autogen, elixir-format
 msgid "Move photo later"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1856
+#: lib/vutuv_web/components/post_components.ex:1857
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1898
+#: lib/vutuv_web/live/post_live/composer.ex:2047
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2273
+#: lib/vutuv_web/components/post_components.ex:2274
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this post so far."
 msgstr ""
@@ -16653,85 +16623,85 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2276
+#: lib/vutuv_web/components/post_components.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2101
+#: lib/vutuv_web/components/post_components.ex:2102
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1603
+#: lib/vutuv_web/components/post_components.ex:1604
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1875
-#: lib/vutuv_web/live/post_live/composer.ex:1876
+#: lib/vutuv_web/live/post_live/composer.ex:2015
+#: lib/vutuv_web/live/post_live/composer.ex:2016
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1027
+#: lib/vutuv_web/agent_docs/markdown.ex:1043
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:2310
+#: lib/vutuv_web/components/post_components.ex:2311
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1855
+#: lib/vutuv_web/components/post_components.ex:1856
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1911
-#: lib/vutuv_web/live/post_live/composer.ex:1912
+#: lib/vutuv_web/live/post_live/composer.ex:2060
+#: lib/vutuv_web/live/post_live/composer.ex:2061
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2152
+#: lib/vutuv_web/live/post_live/composer.ex:2309
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1339
-#: lib/vutuv_web/live/post_live/composer.ex:2101
+#: lib/vutuv_web/live/post_live/composer.ex:1414
+#: lib/vutuv_web/live/post_live/composer.ex:2255
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:971
+#: lib/vutuv_web/live/post_live/composer.ex:1041
 #: lib/vutuv_web/live/post_live/remote_reply.ex:87
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2170
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2109
+#: lib/vutuv_web/live/post_live/composer.ex:2263
 #, elixir-autogen, elixir-format
 msgid "This file carries no camera information."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2193
+#: lib/vutuv_web/live/post_live/composer.ex:2350
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2185
+#: lib/vutuv_web/live/post_live/composer.ex:2342
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:974
+#: lib/vutuv_web/live/post_live/composer.ex:1044
 #: lib/vutuv_web/live/post_live/remote_reply.ex:84
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
@@ -16752,12 +16722,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1427
+#: lib/vutuv_web/live/post_live/composer.ex:1505
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:966
+#: lib/vutuv_web/live/post_live/composer.ex:1036
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16767,7 +16737,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:977
+#: lib/vutuv_web/live/post_live/composer.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16782,17 +16752,17 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1357
+#: lib/vutuv_web/live/post_live/composer.ex:1432
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1452
+#: lib/vutuv_web/live/post_live/composer.ex:1592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add text (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1422
+#: lib/vutuv_web/live/post_live/composer.ex:1500
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Licence"
 msgstr ""
@@ -16803,91 +16773,149 @@ msgstr ""
 msgid "Post photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1189
+#: lib/vutuv_web/live/post_live/composer.ex:1264
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post type"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1368
+#: lib/vutuv_web/live/post_live/composer.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Select photos, or drag them here"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1193
+#: lib/vutuv_web/live/post_live/composer.ex:1268
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Text"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1818
+#: lib/vutuv_web/live/post_live/composer.ex:1958
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Text (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1371
+#: lib/vutuv_web/live/post_live/composer.ex:1446
 #, elixir-autogen, elixir-format
 msgid "Up to %{max} photos per post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1316
+#: lib/vutuv_web/live/post_live/composer.ex:1391
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1232
+#: lib/vutuv_web/live/post_live/composer.ex:1307
 #, elixir-autogen, elixir-format
 msgid "A photo post shows your pictures big and first; text is optional. For a post that is mainly text, switch to \"Text\"."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1163
-#: lib/vutuv_web/live/post_live/composer.ex:1217
-#: lib/vutuv_web/live/post_live/composer.ex:1218
+#: lib/vutuv_web/live/post_live/composer.ex:1238
+#: lib/vutuv_web/live/post_live/composer.ex:1292
+#: lib/vutuv_web/live/post_live/composer.ex:1293
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1215
+#: lib/vutuv_web/live/post_live/composer.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1156
+#: lib/vutuv_web/live/post_live/composer.ex:1231
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1424
+#: lib/vutuv_web/live/post_live/composer.ex:1574
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1399
+#: lib/vutuv_web/live/post_live/composer.ex:1550
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1396
+#: lib/vutuv_web/live/post_live/composer.ex:1547
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1393
+#: lib/vutuv_web/live/post_live/composer.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1390
+#: lib/vutuv_web/live/post_live/composer.ex:1541
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1386
+#: lib/vutuv_web/live/post_live/composer.ex:1537
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1412
+#: lib/vutuv_web/live/post_live/composer.ex:1563
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:939
+#: lib/vutuv_web/components/post_components.ex:3121
+#, elixir-autogen, elixir-format
+msgid "%{handle} liked this"
+msgstr ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:937
+#: lib/vutuv_web/components/post_components.ex:3118
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{handle} shared this"
+msgstr ""
+
+#: lib/vutuv_web/views/account_event_text.ex:173
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Fediverse reactions"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:3060
+#, elixir-autogen, elixir-format, fuzzy
+msgid "From other networks"
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:922
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Reaction from another network"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:74
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Show reactions from other networks"
+msgstr ""
+
+#: lib/vutuv_web/templates/settings/fediverse.html.heex:77
+#, elixir-autogen, elixir-format
+msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
+msgstr ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:975
+#, elixir-autogen, elixir-format
+msgid "liked your post on another network."
+msgid_plural "liked your post on another network."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:983
+#, elixir-autogen, elixir-format, fuzzy
+msgid "reacted to your post from another network."
+msgid_plural "reacted to your post from another network."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/live/notification_live/index.ex:967
+#, elixir-autogen, elixir-format
+msgid "shared your post on another network."
+msgid_plural "shared your post on another network."
 msgstr[0] ""
 msgstr[1] ""

--- a/priv/repo/migrations/20260726163251_add_handle_to_fediverse_reactions.exs
+++ b/priv/repo/migrations/20260726163251_add_handle_to_fediverse_reactions.exs
@@ -1,0 +1,23 @@
+defmodule Vutuv.Repo.Migrations.AddHandleToFediverseReactions do
+  use Ecto.Migration
+
+  # The remote account's `preferredUsername`, so a reaction can say WHO it came
+  # from instead of only that somebody, somewhere did something.
+  #
+  # This is not a new category of data about a stranger: `@handle@host` is the
+  # very account address `actor_uri` already holds, written the way those
+  # networks write it. The inbox has the value in hand anyway — it fetches the
+  # actor document to verify the HTTP signature before any row is written — so
+  # keeping it costs no extra request and no lookup on the render path.
+  # Deliberately still no display name, no avatar, no text.
+  #
+  # Nullable: rows stored before this migration have none, and
+  # `Vutuv.Fediverse.Handle` derives a usable name from the actor URI for them.
+  #
+  # A plain nullable column -> N-1 safe for the blue/green window.
+  def change do
+    alter table(:fediverse_reactions) do
+      add(:handle, :string)
+    end
+  end
+end

--- a/test/vutuv/fediverse_handle_test.exs
+++ b/test/vutuv/fediverse_handle_test.exs
@@ -1,0 +1,55 @@
+defmodule Vutuv.FediverseHandleTest do
+  @moduledoc """
+  How vutuv names an account on another server. One module answers this for
+  followers, replies and reactions alike, so the same person cannot read two
+  different ways on one page.
+  """
+  use ExUnit.Case, async: true
+
+  alias Vutuv.Fediverse.Handle
+
+  describe "display/2" do
+    test "prefers the handle the remote server told us" do
+      assert Handle.display("alice", "https://social.example/users/alice") ==
+               "@alice@social.example"
+
+      # The stored handle wins even where the URI would derive something else:
+      # `preferredUsername` is what that server calls the account.
+      assert Handle.display("alice", "https://social.example/users/12345") ==
+               "@alice@social.example"
+    end
+
+    test "derives a name from the account URI when none was stored" do
+      # The URL shapes these networks actually serve — a row written before the
+      # handle column existed still reads properly. This is the case the two
+      # reactions already in production fall into.
+      for uri <- [
+            "https://social.example/users/carol",
+            "https://social.example/@carol",
+            "https://social.example/u/carol",
+            "https://social.example/profile/carol"
+          ] do
+        assert Handle.display(nil, uri) == "@carol@social.example"
+      end
+    end
+
+    test "falls back to the bare server when the URI names nothing at all" do
+      assert Handle.display(nil, "https://social.example/") == "@social.example"
+      assert Handle.display("  ", "https://social.example/") == "@social.example"
+      assert Handle.display(nil, "https://social.example/a b c") == "@social.example"
+    end
+
+    test "survives a URI that is not one" do
+      assert Handle.display("alice", "not a uri") == "@alice"
+      assert Handle.display(nil, nil) == nil
+    end
+  end
+
+  describe "host/1" do
+    test "is the URI's host, or nil" do
+      assert Handle.host("https://social.example/users/alice") == "social.example"
+      assert Handle.host("gibberish") == nil
+      assert Handle.host(nil) == nil
+    end
+  end
+end

--- a/test/vutuv/fediverse_reactions_test.exs
+++ b/test/vutuv/fediverse_reactions_test.exs
@@ -52,7 +52,7 @@ defmodule Vutuv.FediverseReactionsTest do
       assert Fediverse.reaction_count(post.id) == 1
     end
 
-    test "stores nothing but the actor, the kind and when it arrived", %{
+    test "stores nothing but the account address, the kind and when it arrived", %{
       user: user,
       post: post,
       note: note
@@ -64,8 +64,52 @@ defmodule Vutuv.FediverseReactionsTest do
       assert row.actor_uri == @actor
       assert row.kind == "like"
       assert row.received_at
-      # The whole schema: no name, no avatar, no text about a third party.
-      assert Reaction.__schema__(:fields) == [:id, :actor_uri, :kind, :received_at, :post_id]
+      # The whole schema: an account address in two notations, and what they
+      # did. Still no display name, no avatar, no text about a third party.
+      assert Reaction.__schema__(:fields) ==
+               [:id, :actor_uri, :handle, :kind, :received_at, :post_id]
+    end
+
+    test "keeps the handle the inbox already fetched, so the post can name them", %{
+      user: user,
+      note: note
+    } do
+      assert :ok =
+               Fediverse.record_reaction(user, note, "announce", %{
+                 uri: @actor,
+                 handle: "alice"
+               })
+
+      assert [%Reaction{} = row] = Repo.all(Reaction)
+      assert row.actor_uri == @actor
+      assert row.handle == "alice"
+      assert Reaction.display_handle(row) == "@alice@social.example"
+    end
+
+    test "names them from the actor URI when the server sent no preferredUsername", %{
+      user: user,
+      note: note
+    } do
+      assert :ok = Fediverse.record_reaction(user, note, "like", %{uri: @actor, handle: nil})
+
+      assert [%Reaction{handle: nil} = row] = Repo.all(Reaction)
+      assert Reaction.display_handle(row) == "@alice@social.example"
+    end
+
+    test "a hostile handle is cut to a column's worth, and the reaction still counts", %{
+      user: user,
+      post: post,
+      note: note
+    } do
+      assert :ok =
+               Fediverse.record_reaction(user, note, "like", %{
+                 uri: @actor,
+                 handle: String.duplicate("a", 300)
+               })
+
+      assert [%Reaction{handle: handle}] = Repo.all(Reaction)
+      assert String.length(handle) == 255
+      assert Fediverse.reaction_count(post.id) == 1
     end
 
     test "ignores a post that is not the addressed member's", %{note: note} do
@@ -190,6 +234,62 @@ defmodule Vutuv.FediverseReactionsTest do
     end
   end
 
+  describe "the author hears about it" do
+    test "a new reaction pushes a notification naming the account and the verb", %{
+      user: user,
+      post: post,
+      note: note
+    } do
+      Vutuv.Activity.subscribe(user.id)
+
+      :ok = Fediverse.record_reaction(user, note, "announce", %{uri: @actor, handle: "alice"})
+
+      assert_receive {:new_notification, n}
+      assert n.kind == "fediverse_reaction"
+      assert n.reaction_kind == "announce"
+      assert n.post_id == post.id
+      assert n.actor_handle == "@alice@social.example"
+      # A stranger with no vutuv profile: linked out to, never into a profile
+      # route that does not exist.
+      assert n.actor_url == @actor
+      assert n.actor_param == nil
+      assert n.actor_avatar == nil
+    end
+
+    test "a redelivery of the same reaction does not ring twice", %{user: user, note: note} do
+      :ok = Fediverse.record_reaction(user, note, "like", @actor)
+
+      Vutuv.Activity.subscribe(user.id)
+      :ok = Fediverse.record_reaction(user, note, "like", @actor)
+
+      refute_receive {:new_notification, _}
+    end
+
+    test "it joins the derived feed and the unread badge", %{user: user, post: post, note: note} do
+      :ok = Fediverse.record_reaction(user, note, "announce", %{uri: @actor, handle: "alice"})
+
+      assert Vutuv.Activity.unread_notification_count(user.id) == 1
+
+      assert %{entries: [entry]} =
+               Vutuv.Activity.notifications_page(user.id, kinds: ["fediverse_reaction"])
+
+      assert entry.kind == "fediverse_reaction"
+      assert entry.reaction_kind == "announce"
+      assert entry.post_id == post.id
+      assert entry.actor_handle == "@alice@social.example"
+    end
+
+    test "taking the reaction back takes its notification with it", %{user: user, note: note} do
+      :ok = Fediverse.record_reaction(user, note, "like", @actor)
+      :ok = Fediverse.remove_reaction(user, note, "like", @actor)
+
+      # The whole point of deriving the feed from the reaction rows: there is no
+      # second place that has to remember to forget.
+      assert Vutuv.Activity.unread_notification_count(user.id) == 0
+      assert %{entries: []} = Vutuv.Activity.notifications_page(user.id)
+    end
+  end
+
   describe "the count reaches the action bar" do
     test "engagement_counts/1 carries it beside the vutuv counters", %{
       user: user,
@@ -212,6 +312,30 @@ defmodule Vutuv.FediverseReactionsTest do
       :ok = Fediverse.record_reaction(user, note, "like", @actor)
 
       assert Posts.post_engagement(post.id, nil).fediverse_reactions == 1
+    end
+
+    test "and the accounts behind it, newest first and capped", %{
+      user: user,
+      post: post,
+      note: note
+    } do
+      for n <- 1..6 do
+        :ok =
+          Fediverse.record_reaction(user, note, "announce", %{
+            uri: "https://social.example/users/fan#{n}",
+            handle: "fan#{n}"
+          })
+      end
+
+      counts = Posts.engagement_counts(post.id)
+
+      # The count stays the true total; only the named rows are capped, so the
+      # card can render "and N more" without a second query.
+      assert counts.fediverse_reactions == 6
+      assert length(counts.fediverse_reaction_actors) == 4
+
+      assert [%{"handle" => "fan6", "kind" => "announce"} | _] =
+               counts.fediverse_reaction_actors
     end
   end
 end

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -526,13 +526,15 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     :ok = Vutuv.Posts.repost_post(fan, post)
     :ok = Vutuv.Posts.bookmark_post(fan, post)
 
-    # A favourite from another network (issue #1068): its own figure, so the
-    # `.json` sibling must carry the same number the HTML line shows. Written
-    # straight to the table — the inbox rules that put it there are the
-    # Fediverse tests' business, this one is about what the formats render.
+    # A favourite from another network (issue #1068): its own figure AND the
+    # account behind it, both of which the HTML line shows, so both must reach
+    # the siblings. Written straight to the table — the inbox rules that put it
+    # there are the Fediverse tests' business, this one is about what the
+    # formats render.
     Vutuv.Repo.insert!(%Vutuv.Fediverse.Reaction{
       post_id: post.id,
       actor_uri: "https://social.example/users/alice",
+      handle: "alice",
       kind: "like",
       received_at: DateTime.utc_now(:second)
     })
@@ -555,10 +557,21 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert doc["bookmark_count"] == 1
     assert doc["fediverse_reaction_count"] == 1
 
+    # The HTML names the account and the verb on its chip, so the siblings do
+    # too — a reader of the `.md` learns exactly what a reader of the page does.
+    assert [%{"handle" => "@alice@social.example", "kind" => "like"} = reaction] =
+             doc["fediverse_reactions"]
+
+    assert reaction["url"] == "https://social.example/users/alice"
+    assert reaction["network"] == "social.example"
+
     assert rendered.md =~ "Likes: 1"
     assert rendered.txt =~ "Likes: 1"
-    assert rendered.md =~ "Reactions from other networks: 1"
-    assert rendered.txt =~ "Reactions from other networks: 1"
+
+    for format <- [rendered.md, rendered.txt] do
+      assert format =~ "Reactions from other networks: 1"
+      assert format =~ "@alice@social.example liked this"
+    end
   end
 
   # Issue #1104. The rule these three assert together: an agent format shows

--- a/test/vutuv_web/controllers/post_controller_test.exs
+++ b/test/vutuv_web/controllers/post_controller_test.exs
@@ -25,6 +25,21 @@ defmodule VutuvWeb.PostControllerTest do
 
   defp pad(int), do: String.pad_leading(Integer.to_string(int), 2, "0")
 
+  # One reaction from another network, written straight to the table: these
+  # tests are about what the page *shows*, not about the inbox gates that put
+  # the row there (`Vutuv.FediverseReactionsTest` owns those). `handle: nil`
+  # stands for a server that sent no preferredUsername, and for every row
+  # stored before the column existed.
+  defp remote_reaction!(post, name, kind, opts \\ []) do
+    Repo.insert!(%Vutuv.Fediverse.Reaction{
+      post_id: post.id,
+      actor_uri: "https://social.example/users/#{name}",
+      handle: Keyword.get(opts, :handle, name),
+      kind: kind,
+      received_at: DateTime.utc_now(:second)
+    })
+  end
+
   # Where `text` first shows up in the rendered page — how the thread tests
   # assert reading order without parsing the whole card tree.
   defp position(html, text) do
@@ -1009,26 +1024,49 @@ defmodule VutuvWeb.PostControllerTest do
       refute html =~ "data-fediverse-reactions"
     end
 
-    test "reactions from other networks show as their own labelled line (#1068)", %{conn: conn} do
+    test "reactions from other networks name who reacted and what they did (#1068)", %{
+      conn: conn
+    } do
       user = insert_activated_user()
       post = create_post!(user, %{body: "travelled"})
 
-      for actor <- ["alice", "bob"] do
-        Repo.insert!(%Vutuv.Fediverse.Reaction{
-          post_id: post.id,
-          actor_uri: "https://social.example/users/#{actor}",
-          kind: "like",
-          received_at: DateTime.utc_now(:second)
-        })
-      end
+      remote_reaction!(post, "alice", "announce")
+      remote_reaction!(post, "bob", "like", handle: nil)
 
       html = html_response(get(conn, Posts.path(post)), 200)
 
       assert html =~ ~s(data-fediverse-reactions="2")
-      assert html =~ "reactions from other networks"
+      assert html =~ "From other networks"
+
+      # Each account is named and links out to itself — there is no vutuv
+      # profile behind it — and the verb rides along, so a boost and a
+      # favourite do not read as the same event.
+      assert html =~ ~s(href="https://social.example/users/alice")
+      assert html =~ ~s(data-fediverse-reaction="announce")
+      assert html =~ "@alice@social.example shared this"
+      # A server that sent no preferredUsername still gets a usable name out of
+      # its account URI (rows stored before the handle was kept, too).
+      assert html =~ ~s(data-fediverse-reaction="like")
+      assert html =~ "@bob@social.example liked this"
+
       # Its own line, never folded into the vutuv counters: nobody here liked
       # or reposted, so those counters must show no 2 of their own.
       refute html =~ ~r/data-count="(like|repost)">\s*2\s*</
+    end
+
+    test "a much-shared post names a few and counts the rest (#1068)", %{conn: conn} do
+      user = insert_activated_user()
+      post = create_post!(user, %{body: "went far"})
+
+      for n <- 1..9, do: remote_reaction!(post, "fan#{n}", "announce")
+
+      html = html_response(get(conn, Posts.path(post)), 200)
+
+      assert html =~ ~s(data-fediverse-reactions="9")
+      # Three named chips plus a tail, so the card cannot grow without bound and
+      # the named ones and the tail still add up to the real total.
+      assert length(Regex.scan(~r/data-fediverse-reaction="/, html)) == 3
+      assert html =~ ~s(data-fediverse-reactions-more="6")
     end
 
     test "the archive lists the author's reposts with the reposted-by line", %{conn: conn} do

--- a/test/vutuv_web/controllers/settings_controller_test.exs
+++ b/test/vutuv_web/controllers/settings_controller_test.exs
@@ -281,7 +281,10 @@ defmodule VutuvWeb.SettingsControllerTest do
       html = conn |> get(~p"/settings/fediverse") |> html_response(200)
 
       assert html =~ ~s(name="user[fediverse_reactions?]")
-      assert html =~ "Count reactions from other networks"
+      assert html =~ "Show reactions from other networks"
+      # The copy has to stay true to the line under the post, which names the
+      # accounts rather than merely counting them.
+      assert html =~ "who out there liked or shared it"
     end
 
     test "the switch is hidden until the member federates", %{conn: conn, user: user} do

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -861,6 +861,76 @@ defmodule VutuvWeb.NotificationLiveTest do
     end
   end
 
+  describe "reactions from other networks (#1068)" do
+    # Written straight to the table: the inbox gates are the Fediverse tests'
+    # business, this is about the row the reader gets.
+    defp remote_reaction!(post, name, kind) do
+      Vutuv.Repo.insert!(%Vutuv.Fediverse.Reaction{
+        post_id: post.id,
+        actor_uri: "https://social.example/users/#{name}",
+        handle: name,
+        kind: kind,
+        received_at: DateTime.utc_now(:second)
+      })
+    end
+
+    test "a boost names the account and says what they did", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "went out into the world"})
+      remote_reaction!(post, "alice", "announce")
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+      html = render(live)
+
+      assert length(row_ids(html, "fediverse_reaction")) == 1
+      assert html =~ "@alice@social.example"
+      assert html =~ "shared your post on another network."
+      # It opens the reader's own post, where the line naming them sits — not
+      # the remote copy, which they can still reach from the chip there.
+      assert has_element?(live, ~s(a[href="/#{user.username}/posts/#{post.id}"]))
+    end
+
+    test "a favourite and a boost of one post stay two rows", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "two kinds of answer"})
+      remote_reaction!(post, "alice", "announce")
+      remote_reaction!(post, "bob", "like")
+
+      html = render_the_page(conn)
+
+      # Same post, same day, but a re-share and a favourite are different news,
+      # so they must not merge into one sentence.
+      assert length(row_ids(html, "fediverse_reaction")) == 2
+      assert html =~ "shared your post on another network."
+      assert html =~ "liked your post on another network."
+    end
+
+    test "same-day boosts of one post merge into a single row", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = create_post!(user, %{body: "much shared"})
+      for name <- ~w(alice bob carol), do: remote_reaction!(post, name, "announce")
+
+      html = render_the_page(conn)
+
+      assert length(row_ids(html, "fediverse_reaction")) == 1
+      assert html =~ "and 1 more"
+    end
+
+    test "the posts filter tab keeps them", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      remote_reaction!(create_post!(user, %{body: "filtered"}), "alice", "like")
+
+      {:ok, live, _html} = live(conn, ~p"/notifications?filter=posts")
+
+      assert length(row_ids(render(live), "fediverse_reaction")) == 1
+    end
+
+    defp render_the_page(conn) do
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+      render(live)
+    end
+  end
+
   describe "pagination" do
     # The page size is 50 raw events; a day's followers group into ONE row, so
     # the rows are counted through the grouped row's overflow label ("and N

--- a/test/vutuv_web/live/post_actions_live_test.exs
+++ b/test/vutuv_web/live/post_actions_live_test.exs
@@ -15,7 +15,9 @@ defmodule VutuvWeb.PostActionsLiveTest do
   import Phoenix.LiveViewTest
   import Vutuv.PostsHelpers
 
+  alias Vutuv.Fediverse
   alias Vutuv.Posts
+  alias VutuvWeb.Fediverse.Docs
 
   defp other_user(attrs \\ []), do: insert(:user, Keyword.merge([email_confirmed?: true], attrs))
 
@@ -388,6 +390,43 @@ defmodule VutuvWeb.PostActionsLiveTest do
       {:ok, _} = Posts.delete_post(post)
       _ = :sys.get_state(bar.pid)
       refute render(bar) =~ ~s(phx-click="toggle")
+    end
+  end
+
+  describe "reactions from other networks (#1068)" do
+    # A favourite or a boost arrives with nobody here clicking anything, so the
+    # counter broadcast is the *only* path that can update an open bar — and
+    # since the line names the accounts, the chips have to ride it too, not just
+    # the number.
+    test "a reaction landing while the page is open names its account live" do
+      user = insert(:activated_user, fediverse_followers?: true)
+      post = create_post!(user, %{body: "waiting for the world"})
+
+      {:ok, bar, html} =
+        live_isolated(build_conn(), VutuvWeb.PostLive.Actions,
+          session: %{
+            "post_id" => post.id,
+            "id" => "post-actions-#{post.id}",
+            "locale" => "en"
+          }
+        )
+
+      refute html =~ "data-fediverse-reactions"
+
+      :ok =
+        Fediverse.record_reaction(
+          user,
+          Docs.note_url(user, post.id),
+          "announce",
+          %{uri: "https://social.example/users/alice", handle: "alice"}
+        )
+
+      _ = :sys.get_state(bar.pid)
+      html = render(bar)
+
+      assert html =~ ~s(data-fediverse-reactions="1")
+      assert html =~ "@alice@social.example"
+      assert html =~ ~s(data-fediverse-reaction="announce")
     end
   end
 


### PR DESCRIPTION
**TL;DR** "1 Reaktion aus anderen Netzwerken" told you nothing. The line now names each account that liked or boosted your post, and a reaction notifies you like every other kind of engagement does.

### Now vs Want

**Now:** a post that federated out shows a bare figure. Not what happened to it, not who did it, not where they were. The `fediverse_reactions` row already held the answer (`actor_uri` + `kind`); it was simply never rendered, and nothing notified the author either, so the count crept up unseen.

**Want:** the line under the action bar names them.

```
🌐 Aus anderen Netzwerken  [🔁 @veroandi@mastodon.social]  [❤ @foo@chaos.social]  +3 weitere
```

Each chip carries the glyph the vutuv action bar uses for the same act, the `@handle@host`, and links **out** to the account (there is no vutuv profile behind it). Three chips at most plus a tail, so a much-shared post cannot grow a feed card without bound; the count stays the true total.

### Decisions worth knowing

- **Public**, like the counts always were. A favourite and a re-share are both acts those networks publish under the actor's own name, and the remote reply cards right below already name their authors the same way.
- **No new category of data about a stranger.** `@handle@host` is the account address `actor_uri` already holds, in the notation those networks write it in, and the inbox has it in hand anyway from the actor fetch that verifies the signature. Still no display name, no avatar, no text. Rows written before the migration derive a usable name from their URI.
- **`Vutuv.Fediverse.Handle`** is now the one answer to "what do we call this account", shared by the follower list, the reply cards and the chips, so one person cannot read two ways on one page.
- **New notification kind `fediverse_reaction`**, shaped exactly like `fediverse_reply`: derived straight from the reaction rows, so an `Undo`, a deleted post or the member switching reactions off deletes the notification with the row. Rows merge per post *and* per kind, since a favourite and a re-share are different news.
- The chips ride the engagement select (a capped `json_agg`), so they are batched with the counters, arrive over the existing `{:post_counters, …}` broadcast with no reload, and reach the `.md`/`.txt`/`.json`/`.xml` siblings.

### Migration

One nullable column (`fediverse_reactions.handle`). Plain addition, N-1 safe.

### Follow-up that cannot ship in code

The privacy page still promises *"Öffentlich sichtbar ist allein die Gesamtzahl unter Ihrem Beitrag, niemals die einzelne Person"* and *"Namen … speichern wir nicht"*. That page is DB content, so it needs a hand edit at `/admin/legal`; the replacement paragraph is in the session notes.

### Checks

`mix precommit` green (5542 tests). Smoke-tested in a browser against a copy of production, in German, including the two reactions already stored there.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01YWjKs3JchYvQz1XUB9nAn9