### PR TITLE
The licence and download questions belong to a photo post, not a text post

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -549,9 +549,9 @@ bottom scrim is gone — with a single photo it was two dead arrows plus a ⚙
 the picture-tap covers. What remains on the tile: a remove dot top-right,
 and the ◀ ▶ reorder dots only when more than one photo gives them meaning
 (they stay the touch reorder path, native drag cannot fire there). The book/film review triggers and the bottom-row picker are
-text-mode-only; the licence row sits with the photos in both modes. The
-cover badge appears only from the second photo on, and the amber ALT nudge
-only while a photo has **neither** caption nor alt.
+text-mode-only; the licence and download pair is photo-mode-only (see
+below). The cover badge appears only from the second photo on, and the amber
+ALT nudge only while a photo has **neither** caption nor alt.
 
 The mode is a **radio pair inside the form** (`post[mode]`, the segmented
 control at the top), so switching is an ordinary `validate` and LiveView form
@@ -636,8 +636,9 @@ with JS off those links are plain hrefs to the full-size image.
 `PostLive.Composer.photo_panel/1`): a `caption` (shown to everyone; distinct
 from `alt`, which describes the picture for people who cannot see it), a
 **camera-settings** switch (renders from the DB columns — the served files stay
-metadata-stripped) and, for a set of several photos, the **download override**
-with its one follow-up, which file (see [images.md](images.md)). The panel
+metadata-stripped) and, in photo mode with a set of several photos, the
+**download override** with its one follow-up, which file (see
+[images.md](images.md)). The panel
 expands below the strip rather than floating — a popover on a phone covers what
 it is about and has nowhere to put a follow-up. In photo mode the caption and
 the camera switch move out of the panel to under the tile itself (the panel
@@ -646,7 +647,14 @@ input renders in the panel in both modes. An "apply to all photos" shortcut
 copies the two switches (never the texts: a caption describes one picture).
 
 **Per post**, the two questions about the pictures themselves, asked as a
-labeled pair below the photos in both modes and only once a photo is attached.
+labeled pair below the photos — **in photo mode only**, and only once a photo
+is attached. Someone stapling a screenshot to a text is not publishing
+pictures: making them rule on reuse rights and original files is two answers
+they do not have as the price of an ordinary post. A text post therefore takes
+the author's default licence and the web-versions-only download silently, and
+an edited photo post finds the pair again one tab away under *Fotos* (the
+stored answers are untouched by an edit that never rendered the controls,
+since `save` falls back to the assign).
 
 The first is **what a visitor can save**: the served AVIF versions only (the
 default), the full-resolution original with its metadata removed, or the

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -30,13 +30,17 @@ defmodule VutuvWeb.PostLive.Composer do
 
   **Two modes, one post.** The same composer serves two crowds whose needs
   point in opposite directions: the writer who staples a screenshot or two to
-  a text (camera facts are noise to them), and the photographer whose post IS
-  the photos (the prose is noise to them). `@mode` arranges the same fields
-  for one or the other; nothing about the stored post differs. `"text"` is
-  today's layout — editor first, compact photo strip below. `"photos"` leads
-  with a dropzone and a large photo grid whose caption/description inputs sit
-  under every photo (no panel hunting), the licence beside them, and the text
-  editor folded behind one button until asked for. The mode is a **radio pair
+  a text (camera facts, licences and download rules are noise to them), and
+  the photographer whose post IS the photos (the prose is noise to them).
+  `@mode` arranges the same fields for one or the other; nothing about the
+  stored post differs. `"text"` is today's layout — editor first, compact
+  photo strip below, and **no licence or download question at all**: a
+  screenshot stapled to a text keeps the author's default licence and the
+  web-versions-only download rather than charging a normal post two rulings
+  its author has no answer to. `"photos"` leads with a dropzone and a large
+  photo grid whose caption/description inputs sit under every photo (no panel
+  hunting), the licence and download pair beside them, and the text editor
+  folded behind one button until asked for. The mode is a **radio pair
   inside the form** (`post[mode]`), so switching is an ordinary `validate`
   (no event/race split) and form recovery restores the mode with the rest of
   the form after a reconnect. Entry points: the feed's camera trigger opens
@@ -1481,6 +1485,7 @@ defmodule VutuvWeb.PostLive.Composer do
             many?={length(@images) > 1}
             caption?={@mode == "text"}
             camera?={@mode == "text"}
+            download?={@mode == "photos"}
             insert?={@mode == "text"}
             id={"#{@id}-photo-panel"}
             myself={@myself}
@@ -1490,8 +1495,16 @@ defmodule VutuvWeb.PostLive.Composer do
           them, and what a visitor can actually save — as one quiet labeled
           pair, at home with the photos they are about instead of loose in the
           button row (where they read as controls about nothing, issue #1104
-          feedback). --%>
-          <div :if={@images != []} class="mt-3 space-y-2">
+          feedback).
+
+          They belong to PHOTO MODE only. Someone stapling a screenshot to a
+          text is not publishing a picture, and asking them to rule on reuse
+          rights and original files turns two questions they have no answer to
+          into the price of a normal post. A text post keeps the author's
+          default licence and the web-versions-only download; the moment the
+          pictures ARE the post, the Fotos tab asks — which is also where an
+          edited photo post finds the pair again. --%>
+          <div :if={@mode == "photos" and @images != []} class="mt-3 space-y-2">
             <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
               <label
                 for={"#{@id}-license"}
@@ -2162,7 +2175,9 @@ defmodule VutuvWeb.PostLive.Composer do
   The download switch is the **override** of the post-wide answer the select
   beside the licence gives, so it renders only for a set of several photos
   (`many?`) — with one photo the two controls would be the same state asked
-  twice on the same screen.
+  twice on the same screen — and only where that answer is asked at all
+  (`download?`, photo mode). Overriding a question a text post never asks is
+  a control about nothing.
 
   Photo mode moves two things out of here to where they are seen (issue
   #1104 follow-up): `caption?` drops the caption input (it sits under every
@@ -2177,6 +2192,7 @@ defmodule VutuvWeb.PostLive.Composer do
   attr(:many?, :boolean, required: true)
   attr(:caption?, :boolean, default: true)
   attr(:camera?, :boolean, default: true)
+  attr(:download?, :boolean, default: true)
   attr(:insert?, :boolean, default: true)
   attr(:id, :string, required: true)
   attr(:myself, :any, required: true)
@@ -2269,8 +2285,10 @@ defmodule VutuvWeb.PostLive.Composer do
         <%!-- The per-photo override of the post-wide download answer, and the
         one follow-up it reveals. With a single photo there is nothing to
         override — the select beside the licence IS that photo's answer — so
-        the block stays away rather than offering the same state twice. --%>
-        <div :if={@many?}>
+        the block stays away rather than offering the same state twice. Text
+        mode is never asked the question in the first place, so there is
+        nothing to override there either. --%>
+        <div :if={@many? and @download?}>
           <label class="flex items-start gap-2 text-sm text-slate-700 dark:text-slate-200">
             <input
               type="checkbox"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.171.0",
+      version: "7.171.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/photo_composer_test.exs
+++ b/test/vutuv_web/live/photo_composer_test.exs
@@ -161,6 +161,40 @@ defmodule VutuvWeb.PhotoComposerTest do
       # control about nothing.
       refute has_element?(live, "#composer-license")
     end
+
+    test "is never asked about the licence or the download, photo or not", %{conn: conn} do
+      # Stapling a screenshot to a text does not make somebody a publisher of
+      # pictures: the two rights questions belong to the Fotos tab, and a text
+      # post takes the author's default licence and web versions only.
+      {conn, user} = create_and_login_user(conn)
+      live = open_composer(conn)
+      upload_photo!(live, user)
+
+      assert has_element?(live, "[data-photo-tile]")
+      refute has_element?(live, "#composer-license")
+      refute has_element?(live, "#composer-download")
+
+      live
+      |> form("#composer-form", %{"post" => %{"body" => "Ein Screenshot."}})
+      |> render_submit()
+
+      post = only_post(user)
+      assert post.license == "arr"
+      assert [%{download_original: false, download_exact: false}] = post.images
+    end
+
+    test "the panel offers no download override either", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      live = open_composer(conn)
+      image = upload_photo!(live, user)
+      upload_photo!(live, user)
+
+      open_panel(live, image)
+
+      # Two photos would earn the per-photo override — but only where the
+      # post-wide question is asked, which text mode never does.
+      refute has_element?(live, "input[data-photo-download-switch]")
+    end
   end
 
   describe "the panel" do
@@ -219,12 +253,14 @@ defmodule VutuvWeb.PhotoComposerTest do
     end
 
     test "one photo gets no download switch: the post-wide select is its answer", %{
-      live: live,
+      conn: conn,
       user: user
     } do
       # Two controls for one state on one screen is the duplicate the photo
       # grid keeps being cleaned of; the panel's switch is the OVERRIDE, so it
-      # only means something once there is a set to differ from.
+      # only means something once there is a set to differ from. Photo mode,
+      # because that is where the post-wide answer is given at all.
+      live = open_photo_composer(conn)
       image = upload_photo!(live, user)
       open_panel(live, image)
 
@@ -236,9 +272,10 @@ defmodule VutuvWeb.PhotoComposerTest do
     end
 
     test "the exact-file choice appears only once a download is offered", %{
-      live: live,
+      conn: conn,
       user: user
     } do
+      live = open_photo_composer(conn)
       image = upload_photo!(live, user)
       upload_photo!(live, user)
       open_panel(live, image)
@@ -253,9 +290,10 @@ defmodule VutuvWeb.PhotoComposerTest do
     end
 
     test "a photo carrying a location warns only when the exact file is picked", %{
-      live: live,
+      conn: conn,
       user: user
     } do
+      live = open_photo_composer(conn)
       image = upload_photo!(live, user, exif: [{"exif-ifd3-GPSLatitude", "50/1 56/1 0/1"}])
       assert image.has_gps
       upload_photo!(live, user)
@@ -275,7 +313,8 @@ defmodule VutuvWeb.PhotoComposerTest do
       assert has_element?(live, "[data-photo-gps-warning]")
     end
 
-    test "a photo with no location never warns, whatever is picked", %{live: live, user: user} do
+    test "a photo with no location never warns, whatever is picked", %{conn: conn, user: user} do
+      live = open_photo_composer(conn)
       image = upload_photo!(live, user)
       refute image.has_gps
       upload_photo!(live, user)
@@ -292,7 +331,9 @@ defmodule VutuvWeb.PhotoComposerTest do
       refute has_element?(live, "[data-photo-gps-warning]")
     end
 
-    test "apply-to-all copies the switches but never the caption", %{live: live, user: user} do
+    test "apply-to-all copies the switches but never the caption", %{conn: conn, user: user} do
+      # Photo mode: the download switch it copies is only asked there.
+      live = open_photo_composer(conn)
       first = upload_photo!(live, user)
       second = upload_photo!(live, user)
 
@@ -304,7 +345,7 @@ defmodule VutuvWeb.PhotoComposerTest do
 
       toggle(live, first, "download_original")
       live |> element("[data-photo-apply-all]") |> render_click()
-      live |> form("#composer-form", %{"post" => %{"body" => "Two photos."}}) |> render_submit()
+      live |> form("#composer-form") |> render_submit()
 
       assert %{download_original: true, caption: "Only mine"} = reload(first)
       # The switch travelled; the caption, which describes one particular
@@ -780,18 +821,41 @@ defmodule VutuvWeb.PhotoComposerTest do
   describe "the licence" do
     test "appears once a photo is attached and is remembered for next time", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
-      live = open_composer(conn)
+      live = open_photo_composer(conn)
       upload_photo!(live, user)
 
       assert has_element?(live, "#composer-license")
 
       live
-      |> form("#composer-form", %{"post" => %{"body" => "A photo.", "license" => "cc-by-4.0"}})
+      |> form("#composer-form", %{"post" => %{"license" => "cc-by-4.0"}})
       |> render_submit()
 
       post = only_post(user)
       assert post.license == "cc-by-4.0"
       assert Vutuv.Accounts.User |> Repo.get(user.id) |> Posts.default_license() == "cc-by-4.0"
+    end
+
+    test "a photo post edited from the text tab keeps the licence it was given", %{conn: conn} do
+      # The pair is one tab away rather than gone: the stored answer must not
+      # be reset by an edit that never showed the select.
+      {conn, user} = create_and_login_user(conn)
+      image = pending_image!(user)
+
+      {:ok, post} =
+        Posts.create_post(user, %{
+          body: "Worte dazu.",
+          image_ids: [image.id],
+          license: "cc-by-sa-4.0"
+        })
+
+      {:ok, live, _html} = live(conn, ~p"/posts/#{post.id}/edit")
+
+      assert has_element?(live, ~s(#composer[data-composer-mode="text"]))
+      refute has_element?(live, "#composer-license")
+
+      live |> form("#composer-form", %{"post" => %{"body" => "Andere Worte."}}) |> render_submit()
+
+      assert %{body: "Andere Worte.", license: "cc-by-sa-4.0"} = Repo.get!(Post, post.id)
     end
   end
 
@@ -801,13 +865,14 @@ defmodule VutuvWeb.PhotoComposerTest do
       %{conn: conn, user: user}
     end
 
-    test "it sits beside the licence in both modes, not behind a photo", %{
+    test "it sits beside the licence in photo mode, not behind a photo", %{
       conn: conn,
       user: user
     } do
       # Tapping a photo to find out whether the original can be downloaded is
       # exactly the hunt the photo grid was meant to end, so the question is
-      # asked where the licence is asked.
+      # asked where the licence is asked — and it leaves with the licence when
+      # the post goes back to being a text post.
       live = open_photo_composer(conn)
       upload_photo!(live, user)
 
@@ -815,11 +880,12 @@ defmodule VutuvWeb.PhotoComposerTest do
 
       live |> form("#composer-form", %{"post" => %{"mode" => "text"}}) |> render_change()
 
-      assert has_element?(live, "#composer-download")
+      refute has_element?(live, "#composer-download")
+      refute has_element?(live, "#composer-license")
     end
 
     test "no photos, no question", %{conn: conn} do
-      live = open_composer(conn)
+      live = open_photo_composer(conn)
 
       refute has_element?(live, "#composer-download")
     end


### PR DESCRIPTION
Attaching a screenshot to a text post made the composer ask two questions its author has no answer to: under which licence the picture may be reused, and what a visitor may download. Those are a photographer's decisions, and on the **Text** tab they read as controls about nothing, sitting between the editor and the tag field.

**Now:** both selects render whenever a photo is attached, in either mode.
**Want / this PR:** they render in photo mode only, together with the per-photo download override in the tile panel (overriding an answer that was never asked is the same control about nothing).

A text post keeps the author's default licence and the web-versions-only download silently. A photo post edited from the Text tab finds the pair one tab away under **Fotos** — `save` falls back to the stored value, so an edit that never rendered the select cannot reset it (covered by a new test).

v7.171.1. `mix precommit` green: 5545 tests.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01BrFK4dbs5rQ6P5RFBtpuic