### PR TITLE
Render a quoted message, never its Markdown source

### DIFF
--- a/docs/architecture/messages.md
+++ b/docs/architecture/messages.md
@@ -23,6 +23,25 @@ Markdown (`VutuvWeb.Markdown.render/1`), unchanged by the editor. The `typing`
 handler keeps the draft body in the form so the editor clears after a send; see
 `.claude/rules/design.md` for the component.
 
+Because the stored body is Markdown **source**, every place that shows a message
+outside the thread must flatten it or it prints the markers themselves. The
+one-line glance form is `VutuvWeb.Markdown.to_preview_line/1` (plain text, block
+breaks folded into spaces, capped at 200 chars): the sidebar's last-message line
+and the `preview` field of the API's conversation list both go through it. In
+the LiveView that happens once per entry where the lists are built
+(`put_preview/1` in `MessageLive.Index`, on the `Chat` query result and on the
+in-memory bump), never in the template — the sidebar rows re-render on every
+presence tick and typing event, which would re-parse every preview each time.
+
+The **unread-message email** quotes the DM in full rather than at a glance, so it
+uses the email renderer (`VutuvWeb.EmailMarkdown`, the one invitations use: full
+Markdown, bare URLs kept whole and clickable, images dropped) — the HTML body
+through `<.email_markdown>`, the `text/plain` body through
+`EmailMarkdown.to_text/1`, which flattens that same HTML and expands each link to
+`label (url)`, because in a text body nothing is clickable and the URL *is* the
+link. Quoting the raw source instead put "Hello \*\*[Stefan](https://…" in the
+member's inbox.
+
 Messages carry **no images**: `Vutuv.MarkdownContent.validate_no_images/2` in
 `Message.changeset` rejects a body with image Markdown (`![](…)`) on every write
 path (the web composer and `POST …/messages` alike — a 422 for the API), and

--- a/lib/vutuv/notifications/emailer.ex
+++ b/lib/vutuv/notifications/emailer.ex
@@ -271,6 +271,7 @@ defmodule Vutuv.Notifications.Emailer do
   def unread_messages_email(email, user, other, conversation_id, message_body) do
     locale = get_locale(user.locale)
     unsubscribe_url = VutuvWeb.UnsubscribeToken.url(user)
+    excerpt = message_excerpt(message_body)
 
     base_email()
     |> to({VutuvWeb.UserHelpers.name_for_email_to_field(user), email})
@@ -286,7 +287,13 @@ defmodule Vutuv.Notifications.Emailer do
       user: user,
       other_slug: other.username,
       conversation_id: conversation_id,
-      message_body: message_excerpt(message_body),
+      # A DM is Markdown source (the composer is Milkdown), so the quote is
+      # rendered, not printed: the HTML body runs the source through
+      # `<.email_markdown>`, the text body gets it flattened. Quoting the source
+      # showed the markers themselves ("Hello **[Stefan](https://…") in a mail
+      # meant to let the member read the message without opening the app.
+      message_body: excerpt,
+      message_text: excerpt && VutuvWeb.EmailMarkdown.to_text(excerpt),
       # The recipient's own settings drive the copy: whether they are told this
       # is the only email for the burst or that every message is mailed, and the
       # deep link where they can change that (and the delay).

--- a/lib/vutuv_web/controllers/api_v2/message_controller.ex
+++ b/lib/vutuv_web/controllers/api_v2/message_controller.ex
@@ -28,6 +28,7 @@ defmodule VutuvWeb.ApiV2.MessageController do
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.ApiV2
   alias VutuvWeb.ApiV2.Problem
+  alias VutuvWeb.Markdown
 
   # ── Reads ──
 
@@ -194,7 +195,10 @@ defmodule VutuvWeb.ApiV2.MessageController do
       status: Chat.display_status(conversation),
       with: AgentDocs.person_ref(other),
       last_message_at: entry.last_at,
-      preview: entry.last_body && AgentDocs.excerpt(entry.last_body),
+      # A glance line, so it is flattened like the website's sidebar row: the
+      # Markdown source itself is served by the messages endpoint's
+      # `body_markdown`, and a preview full of `**`/`[…](…)` reads as noise.
+      preview: entry.last_body && Markdown.to_preview_line(entry.last_body),
       unread: entry.unread
     }
   end

--- a/lib/vutuv_web/email_markdown.ex
+++ b/lib/vutuv_web/email_markdown.ex
@@ -44,4 +44,41 @@ defmodule VutuvWeb.EmailMarkdown do
   end
 
   def render(_), do: Phoenix.HTML.raw("")
+
+  @doc """
+  The same message as **plain text**, for the `text/plain` half of the mail.
+
+  Both bodies must say the same thing, so the text part is this renderer's
+  output flattened (`VutuvWeb.Markdown.html_to_plain_text/1`) rather than the
+  Markdown source: nobody typed those `**` markers, the composer is a WYSIWYG
+  editor, and a reader in a plain-text client should not be the only one who
+  sees them.
+
+  Flattening a link would otherwise throw its target away — and in a text body
+  nothing is clickable, so the URL *is* the link. Each one is therefore expanded
+  to `label (url)` first, or left as the bare URL when the label already is it.
+  """
+  def to_text(text) when is_binary(text) do
+    text
+    |> render()
+    |> Phoenix.HTML.safe_to_string()
+    |> expand_links()
+    |> Markdown.html_to_plain_text()
+  end
+
+  def to_text(_), do: ""
+
+  # `<a … href="url" …>label</a>` -> `label (url)`. The href is matched
+  # independently of the other attributes because `open_links_in_new_tab/1` puts
+  # `target`/`rel` in front of it, and the label may still hold inline tags
+  # (`<strong>`), which the flattening drops a step later.
+  defp expand_links(html) do
+    Regex.replace(~r{<a\s[^>]*href="([^"]*)"[^>]*>(.*?)</a>}s, html, fn _match, url, label ->
+      if String.trim(strip_tags(label)) == String.trim(url),
+        do: label,
+        else: "#{label} (#{url})"
+    end)
+  end
+
+  defp strip_tags(html), do: String.replace(html, ~r/<[^>]*>/, "")
 end

--- a/lib/vutuv_web/live/message_live/index.ex
+++ b/lib/vutuv_web/live/message_live/index.ex
@@ -19,7 +19,7 @@ defmodule VutuvWeb.MessageLive.Index do
 
   alias Vutuv.Chat
   alias Vutuv.Chat.{Conversation, Message}
-  alias VutuvWeb.Presence
+  alias VutuvWeb.{Markdown, Presence}
 
   @typing_clear_ms 2500
   @page_size 30
@@ -364,9 +364,18 @@ defmodule VutuvWeb.MessageLive.Index do
     user = socket.assigns.current_user
 
     socket
-    |> assign(:conversations, Chat.list_conversations(user))
-    |> assign(:requests, Chat.list_requests(user))
+    |> assign(:conversations, put_previews(Chat.list_conversations(user)))
+    |> assign(:requests, put_previews(Chat.list_requests(user)))
   end
+
+  # A message body is Markdown *source* (the composer is Milkdown), so a sidebar
+  # row printing it raw showed the markers themselves — "Hello **[Stefan](https://…"
+  # where the thread reads "Hello Stefan". Flatten it once per entry, here and in
+  # bump_conversation/2, and never in the template: the row re-renders on every
+  # presence tick and typing event, which would re-parse every preview each time.
+  defp put_previews(entries), do: Enum.map(entries, &put_preview/1)
+
+  defp put_preview(entry), do: Map.put(entry, :preview, Markdown.to_preview_line(entry.last_body))
 
   # Reflect the just-marked-read state in the sidebar: drop the opened
   # conversation's unread badge to zero.
@@ -404,7 +413,14 @@ defmodule VutuvWeb.MessageLive.Index do
            &(&1.conversation.id == message.conversation_id)
          ) do
       {[entry], rest} ->
-        bumped = %{entry | last_body: message.body, last_at: message.inserted_at, unread: 0}
+        bumped =
+          put_preview(%{
+            entry
+            | last_body: message.body,
+              last_at: message.inserted_at,
+              unread: 0
+          })
+
         assign(socket, :conversations, [bumped | rest])
 
       _ ->
@@ -513,7 +529,7 @@ defmodule VutuvWeb.MessageLive.Index do
                   <span class="block truncate text-sm font-medium text-slate-800 dark:text-slate-100">
                     {display_name(entry.other)}
                   </span>
-                  <span class="block truncate text-xs text-slate-600 dark:text-slate-400">{entry.last_body}</span>
+                  <span class="block truncate text-xs text-slate-600 dark:text-slate-400">{entry.preview}</span>
                 </span>
               </.link>
               <.request_actions id={entry.conversation.id} class="mt-2" />
@@ -539,7 +555,7 @@ defmodule VutuvWeb.MessageLive.Index do
                 <span class="block truncate text-sm font-medium text-slate-800 dark:text-slate-100">
                   {display_name(entry.other)}
                 </span>
-                <span class="block truncate text-xs text-slate-600 dark:text-slate-400">{entry.last_body}</span>
+                <span class="block truncate text-xs text-slate-600 dark:text-slate-400">{entry.preview}</span>
               </span>
               <.count_badge count={entry.unread} />
             </.link>

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -53,6 +53,9 @@ defmodule VutuvWeb.Markdown do
   # one-line intro above a long block doesn't leave a one-line preview) — but
   # only if at least this many characters of budget remain, else just stop.
   @preview_min_block 200
+  # A one-line preview is truncated by the row it sits in long before this, so
+  # the cap is only there to keep a whole essay out of a list payload.
+  @preview_line_length 200
   @inline_image ~r/!\[([^\]]*)\]\(([^)\s]+)\)/
   # The alignment fragments an inline image src may carry (`#left` floats the
   # picture beside the text, `#right` mirrored, `#center` centers it; no
@@ -187,8 +190,23 @@ defmodule VutuvWeb.Markdown do
   Entities are **not** linkified, so this costs no DB query.
   """
   def to_plain_text(text) when is_binary(text) do
-    text
-    |> render_pipeline()
+    text |> render_pipeline() |> html_to_plain_text()
+  end
+
+  def to_plain_text(_), do: ""
+
+  @doc """
+  The flattening half of `to_plain_text/1`, on HTML **one of our own renderers
+  produced**: block ends become line breaks, tags are dropped and the escapes
+  decoded.
+
+  Split out for `VutuvWeb.EmailMarkdown.to_text/1`, which runs the email
+  renderer (full URLs, real links) rather than the post pipeline and expands
+  each link's target before flattening. Only feed it already-sanitized HTML —
+  on arbitrary input the tag-stripping regex is not a sanitizer.
+  """
+  def html_to_plain_text(html) when is_binary(html) do
+    html
     |> String.replace(~r{<br\s*/?>}i, "\n")
     |> String.replace(~r{</(?:p|li|h[1-6]|blockquote|tr|div)>}i, "\n")
     # Every `<…>` left is a tag: the pipeline escaped typed HTML to `&lt;` a
@@ -198,7 +216,27 @@ defmodule VutuvWeb.Markdown do
     |> normalize_lines()
   end
 
-  def to_plain_text(_), do: ""
+  @doc """
+  Flatten Markdown to the **single line** a list row previews it with: the
+  messages sidebar's last-message line and the `preview` field of the API's
+  conversation list.
+
+  `to_plain_text/1` plus the block breaks folded into spaces, so a message
+  whose first line is short still fills the row, and capped at
+  #{@preview_line_length} characters (the row truncates far earlier; the cap
+  keeps a long body out of the payload).
+
+  Returns `""` for a body that isn't a string, so a `nil` preview can be
+  passed straight in.
+  """
+  def to_preview_line(text) when is_binary(text) do
+    text
+    |> to_plain_text()
+    |> String.replace("\n", " ")
+    |> String.slice(0, @preview_line_length)
+  end
+
+  def to_preview_line(_), do: ""
 
   # Earmark lays its HTML out with whitespace of its own (a newline after every
   # opening `<p>`, indented list items, blank lines between tags), which turns

--- a/lib/vutuv_web/templates/email/unread_messages_de.text.eex
+++ b/lib/vutuv_web/templates/email/unread_messages_de.text.eex
@@ -2,7 +2,7 @@
 
 Sie haben eine neue Nachricht von @<%= @other_slug %> auf vutuv:
 <%= if @message_body do %>
-<%= @message_body %>
+<%= @message_text %>
 <% end %>
 Hier können Sie sie lesen und beantworten:
 

--- a/lib/vutuv_web/templates/email/unread_messages_en.text.eex
+++ b/lib/vutuv_web/templates/email/unread_messages_en.text.eex
@@ -2,7 +2,7 @@
 
 you have a new message from @<%= @other_slug %> on vutuv:
 <%= if @message_body do %>
-<%= @message_body %>
+<%= @message_text %>
 <% end %>
 Read and reply here:
 

--- a/lib/vutuv_web/templates/email_body/unread_messages_de.html.heex
+++ b/lib/vutuv_web/templates/email_body/unread_messages_de.html.heex
@@ -1,7 +1,7 @@
 <.email_layout preheader="Sie haben eine neue Nachricht auf vutuv" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>Sie haben eine neue Nachricht von @{@other_slug} auf vutuv:</.email_p>
-  <.email_quote :if={@message_body} body={@message_body} />
+  <.email_markdown :if={@message_body} body={@message_body} />
   <.email_button href={"#{@url}messages/#{@conversation_id}"}>Lesen und antworten</.email_button>
   <.email_p>
     {(@each_message? &&

--- a/lib/vutuv_web/templates/email_body/unread_messages_en.html.heex
+++ b/lib/vutuv_web/templates/email_body/unread_messages_en.html.heex
@@ -1,7 +1,7 @@
 <.email_layout preheader="You have a new message on vutuv" locale={@locale}>
   <.email_p>{email_greeting(@user)},</.email_p>
   <.email_p>you have a new message from @{@other_slug} on vutuv:</.email_p>
-  <.email_quote :if={@message_body} body={@message_body} />
+  <.email_markdown :if={@message_body} body={@message_body} />
   <.email_button href={"#{@url}messages/#{@conversation_id}"}>Read and reply</.email_button>
   <.email_p>
     {(@each_message? &&

--- a/lib/vutuv_web/views/email_components.ex
+++ b/lib/vutuv_web/views/email_components.ex
@@ -2,7 +2,7 @@ defmodule VutuvWeb.EmailComponents do
   @moduledoc """
   The shared HTML-email framework: one `email_layout/1` chrome plus a small set
   of inline-styled building blocks (`email_p`, `email_pin`, `email_button`,
-  `email_panel`/`email_row`, `email_quote`, `email_list`, `email_divider`,
+  `email_panel`/`email_row`, `email_markdown`, `email_list`, `email_divider`,
   `email_muted`, `email_signature`). Every HTML email body
   (`lib/vutuv_web/templates/email_body/`) composes these, so the look and feel
   is defined in exactly one place.
@@ -222,30 +222,16 @@ defmodule VutuvWeb.EmailComponents do
   end
 
   @doc """
-  A quoted message body — the DM that triggered an unread-notification email.
-  A brand left-rule panel that preserves the message's own line breaks
-  (`white-space:pre-wrap`) so it reads like the original, without rendering any
-  markup the sender wrote.
-  """
-  attr(:body, :string, required: true)
+  A quoted **Markdown** message body in a brand left-rule panel: the personal
+  note a member writes in an invitation (`Vutuv.Invitations`) and the DM that
+  triggered an unread-notification email. Rendered to HTML by
+  `VutuvWeb.EmailMarkdown`, so links are clickable and the formatting the writer
+  applied shows.
 
-  def email_quote(assigns) do
-    ~H"""
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" class="email-panel" style="margin:0 0 20px;background:#f8fafc;border:1px solid #e2e8f0;border-left:4px solid #1d4ed8;border-radius:8px;">
-      <tr>
-        <td class="email-text" style={quote_style()}>{@body}</td>
-      </tr>
-    </table>
-    """
-  end
-
-  @doc """
-  A **Markdown** message body — the personal note a member writes in an
-  invitation (`Vutuv.Invitations`). Same branded left-rule panel as
-  `email_quote/1`, but its body is rendered from Markdown to HTML by
-  `VutuvWeb.EmailMarkdown`, so links are clickable and formatting shows. Use
-  `email_quote/1` (literal, pre-wrapped text) for a quoted DM; use this for text
-  the writer means as Markdown.
+  Every member-written body we quote is Markdown, so there is no literal
+  (pre-wrapped, unrendered) variant: quoting the source printed the markers
+  themselves in the DM notice. The `text/plain` half of the same mail gets
+  `VutuvWeb.EmailMarkdown.to_text/1`.
   """
   attr(:body, :string, required: true)
 
@@ -431,12 +417,8 @@ defmodule VutuvWeb.EmailComponents do
   defp row_value_style,
     do: "padding:6px 0;font-family:#{@font};font-size:14px;color:#334155;word-break:break-word;"
 
-  defp quote_style,
-    do:
-      "padding:14px 18px;font-family:#{@font};font-size:15px;line-height:1.6;color:#334155;white-space:pre-wrap;word-break:break-word;"
-
-  # Like quote_style/0 but without white-space:pre-wrap — the rendered Markdown
-  # is block HTML that manages its own line breaks and spacing.
+  # No `white-space: pre-wrap` — the rendered Markdown is block HTML that
+  # manages its own line breaks and spacing.
   defp markdown_quote_style,
     do:
       "padding:14px 18px;font-family:#{@font};font-size:15px;line-height:1.6;color:#334155;word-break:break-word;"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.171.1",
+      version: "7.171.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/dev_docs/reference.md
+++ b/priv/dev_docs/reference.md
@@ -328,7 +328,8 @@ declines. Declining is silent. New requests are rate-limited.
 Scope: `messages:read`. Your accepted conversations and own outgoing
 requests under `conversations`, incoming requests under `requests` — each
 with the other member, a preview, `last_message_at` and your `unread`
-count.
+count. The preview is the last message flattened to one line of plain
+text; its Markdown source is in `body_markdown` on the thread endpoint.
 
 ### GET /conversations/:id/messages
 

--- a/test/vutuv/notifications/emailer_test.exs
+++ b/test/vutuv/notifications/emailer_test.exs
@@ -290,6 +290,32 @@ defmodule Vutuv.Notifications.EmailerTest do
       refute email.text_body =~ "only email"
     end
 
+    test "the unread email renders the quoted message instead of its Markdown source" do
+      user = insert(:user, locale: "en")
+      other = insert(:user, username: "the-sender")
+
+      email =
+        Emailer.unread_messages_email(
+          "unread@example.com",
+          user,
+          other,
+          Vutuv.UUIDv7.generate(),
+          "Hello **[Stefan](https://vutuv.de/wintermeyer)** glad to be in touch."
+        )
+
+      # The HTML part shows the formatting the sender applied — real bold, a
+      # real link — never the markers they never typed (the composer is WYSIWYG).
+      assert email.html_body =~ "<strong>"
+      assert email.html_body =~ ~s|href="https://vutuv.de/wintermeyer"|
+      refute email.html_body =~ "**"
+      refute email.html_body =~ "[Stefan]"
+
+      # The text part reads as prose but keeps the link target, which is the one
+      # thing flattening must not drop: nothing is clickable there.
+      assert email.text_body =~ "Hello Stefan (https://vutuv.de/wintermeyer) glad"
+      refute email.text_body =~ "**"
+    end
+
     test "the unread email quotes only an opening excerpt of a long message" do
       user = insert(:user, locale: "en")
       other = insert(:user, username: "the-sender")

--- a/test/vutuv_web/controllers/api_v2/messages_api_test.exs
+++ b/test/vutuv_web/controllers/api_v2/messages_api_test.exs
@@ -170,6 +170,28 @@ defmodule VutuvWeb.ApiV2.MessagesApiTest do
       assert [%{"unread" => 0}] = json_response(conn4, 200)["conversations"]
     end
 
+    test "the conversation preview is flattened text, the message keeps its Markdown", %{
+      conn: conn,
+      me: me,
+      other: other,
+      token: token
+    } do
+      follow!(other, me)
+      conversation = insert_conversation_between(me, other)
+      body = "Hello **[Stefan](https://vutuv.de/stefan)** welcome"
+      {:ok, _} = Chat.send_message(other, conversation.id, body)
+
+      conn1 = get(authed(conn, token), "/api/2.0/conversations")
+
+      assert [%{"preview" => preview}] = json_response(conn1, 200)["conversations"]
+      assert preview == "Hello Stefan welcome"
+
+      conn2 =
+        get(authed(build_conn(), token), "/api/2.0/conversations/#{conversation.id}/messages")
+
+      assert [%{"body_markdown" => ^body}] = json_response(conn2, 200)["messages"]
+    end
+
     test "messages:read cannot send", %{conn: conn, me: me, other: other} do
       {:ok, read_token, _} =
         ApiAuth.create_pat(me, %{"name" => "r", "scopes" => ["messages:read"]})

--- a/test/vutuv_web/live/message_live_test.exs
+++ b/test/vutuv_web/live/message_live_test.exs
@@ -50,6 +50,30 @@ defmodule VutuvWeb.MessageLiveTest do
       assert html =~ "Hello there"
     end
 
+    test "the sidebar preview shows the rendered text, not the Markdown source", %{conn: conn} do
+      {conn, me} = create_and_login_user(conn)
+      other = insert_activated_user(first_name: "Berta", last_name: "Beispiel")
+      conversation = insert_conversation_between(me, other)
+
+      {:ok, _} =
+        Chat.send_message(
+          other,
+          conversation.id,
+          "Hello **[Stefan](https://vutuv.de/stefan)** I'm glad to be in touch."
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/messages")
+
+      preview =
+        view
+        |> element(~s|a[href="/messages/#{conversation.id}"] span.truncate.text-xs|)
+        |> render()
+
+      assert preview =~ "Hello Stefan I"
+      refute preview =~ "**"
+      refute preview =~ "https://vutuv.de/stefan"
+    end
+
     test "shows an empty state without any conversations", %{conn: conn} do
       {conn, _me} = create_and_login_user(conn)
 
@@ -241,6 +265,25 @@ defmodule VutuvWeb.MessageLiveTest do
     defp at_index(html, needle) do
       {index, _length} = :binary.match(html, needle)
       index
+    end
+
+    test "a message arriving in the open thread flattens the sidebar preview too", %{conn: conn} do
+      {conn, me} = create_and_login_user(conn)
+      {_other_conn, other} = login_other_user("Alpha")
+      conversation = insert_conversation_between(me, other)
+      {:ok, _} = Chat.send_message(other, conversation.id, "first")
+
+      {:ok, view, _} = live(conn, ~p"/messages/#{conversation.id}")
+      {:ok, _} = Chat.send_message(other, conversation.id, "a **bold** claim")
+      _ = :sys.get_state(view.pid)
+
+      preview =
+        view
+        |> element(~s|a[href="/messages/#{conversation.id}"] span.truncate.text-xs|)
+        |> render()
+
+      assert preview =~ "a bold claim"
+      refute preview =~ "**"
     end
 
     test "messages render markdown safely with a timestamp", %{conn: conn} do


### PR DESCRIPTION
**TL;DR** The message sidebar, the API conversation preview and the unread-message email all printed a DM's Markdown *source* (`Hello **[Stefan](https://vutuv…`) where the thread renders it. All three now show the rendered message.

**Where:** `MessageLive.Index` sidebar rows, `ApiV2.MessageController` `preview`, the `unread_messages` email (both bodies)

**What changed**

- **One-line glance** (sidebar row, API `preview`): new `VutuvWeb.Markdown.to_preview_line/1` flattens to plain text, folds block breaks into spaces, caps at 200 chars. In the LiveView it runs once per entry where the lists are built (`put_preview/1`, also on the in-memory bump), never in the template: those rows re-render on every presence tick and typing event, which would re-parse every preview each time.
- **The email** quotes the message in full, so it uses the email renderer instead: `VutuvWeb.EmailMarkdown` (the one invitations use, with full Markdown, bare URLs kept whole and clickable, images dropped). HTML body via `<.email_markdown>`, `text/plain` via the new `EmailMarkdown.to_text/1`, which flattens that same HTML and expands each link to `label (url)` — in a text body nothing is clickable, so the URL *is* the link. The post-renderer flattening would have been wrong here: it drops link targets and shortens bare URLs for display.
- `<.email_quote>` had no call sites left and its doc pointed the next reader at exactly this bug, so it is removed; the shared flattening step is now `Markdown.html_to_plain_text/1`.
- Docs: `docs/architecture/messages.md` + the API reference's `preview` description.

**Tests** LiveView sidebar (initial list and live bump), API (`preview` flat while `body_markdown` keeps the source), email (HTML shows `<strong>` and a real link, text keeps the URL). A sample email was also rendered and read by hand.

**Deploy** Hot. No migrations, no config, deps or supervision-tree changes. Version 7.171.1.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_015F3DpYd9ksp5prjED4R5h4