### PR TITLE
Open a deep permalink on its own reply chain (#1156)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2360,11 +2360,24 @@ defmodule Vutuv.Posts do
   embedded action-bar LiveView each), most of them far from the post the
   visitor came for.
 
-  A conversation of at most `:all_limit` visible posts (#{@thread_all_limit})
-  still loads whole — `%{mode: :all, posts:, total:}` in `list_thread/3`
-  reading order, exactly the old page. A bigger one returns `%{mode: :window}`
+  A conversation loads whole — `%{mode: :all, posts:, total:}` in
+  `list_thread/3` reading order, exactly the old page — while it stays both
+  **small** (at most `:all_limit` visible posts, #{@thread_all_limit}) and
+  **shallow** (the post has at most `:ancestors` ancestors,
+  #{@thread_context_ancestors}). Fail either and it returns `%{mode: :window}`
   with the post's surroundings, each part budget-capped and grown on demand by
-  the LiveView's expanders:
+  the LiveView's expanders.
+
+  The depth half is issue #1156: size alone let a permalink four levels down
+  render its whole tree, so the card on top was the conversation's root — by
+  then often a topic the exchange had long since drifted away from — and the
+  sibling branches nobody had asked for came before the post the visitor had
+  followed the link for. Past the ancestor budget the chain *is* the context,
+  so it becomes the page and the branches move behind the "read it from the
+  start" link. Below the budget the window would show every ancestor anyway,
+  and the whole tree is the friendlier read.
+
+  The window's parts:
 
     * `root` — the conversation's first post, always pinned on top (`nil` when
       the permalinked post is the root itself);
@@ -2399,18 +2412,33 @@ defmodule Vutuv.Posts do
     {skeletons, truncated?} = thread_skeletons(post, viewer, skeleton_limit)
     order = skeleton_order(skeletons)
     total = length(order)
+    ancestors = skeleton_ancestors(post.id, Map.new(order))
 
-    if total <= all_limit and not truncated? do
+    if total <= all_limit and not truncated? and length(ancestors) <= ancestor_budget do
       posts = load_thread_posts(Enum.map(order, &elem(&1, 0)))
       %{mode: :all, posts: posts, total: total, truncated?: false}
     else
-      thread_window_slices(post, order, total, truncated?, ancestor_budget, reply_budget)
+      thread_window_slices(
+        post,
+        order,
+        ancestors,
+        total,
+        truncated?,
+        ancestor_budget,
+        reply_budget
+      )
     end
   end
 
-  defp thread_window_slices(post, order, total, truncated?, ancestor_budget, reply_budget) do
-    parent_of = Map.new(order)
-    ancestors = skeleton_ancestors(post.id, parent_of)
+  defp thread_window_slices(
+         post,
+         order,
+         ancestors,
+         total,
+         truncated?,
+         ancestor_budget,
+         reply_budget
+       ) do
     subtree_ids = focus_subtree(post.id, order)
     {shown_subtree, more} = chunk_prefix(subtree_ids, 1 + reply_budget)
     {root_id, chain_ids, gap} = split_ancestors(ancestors, ancestor_budget)

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -748,7 +748,7 @@ defmodule VutuvWeb.PostComponents do
             surface={@surface}
             conn_or_socket={@conn_or_socket}
             mode={Map.get(node, :mode, :preview)}
-            show_reply_banner={reply_banner?(node, @connected?, @indent?, first?)}
+            show_reply_banner={reply_banner?(node, @connected?, @indent?)}
           />
         <% end %>
       </div>
@@ -950,13 +950,17 @@ defmodule VutuvWeb.PostComponents do
 
   # A card names the post it answers only when its position alone does not say
   # it. While the thread still indents, the nesting says it. Past
-  # @thread_indent_cap every card shares its parent's column, so only the
-  # *first* answer — the one rendered directly below its parent — reads
-  # unambiguously and every later sibling (which follows the previous branch's
-  # whole subtree) gets its banner back. A forest root keeps it either way: its
+  # @thread_indent_cap it says nothing at all: every card shares its parent's
+  # column, so a whole run of generations reads as one flat list of siblings —
+  # which is how issue #1156 came in, its reporter unable to find the post his
+  # permalink answered though it sat two cards above. So every card past the
+  # cap names its parent, first answer included: the exemption used to argue
+  # that the first one is rendered directly below the post it answers, but with
+  # several capped generations stacked the card above is just as likely to be
+  # its own grandparent or a cousin. A forest root keeps it either way: its
   # parent is off the page.
-  defp reply_banner?(node, connected?, indent?, first?) do
-    Map.get(node, :show_reply_banner, false) or (connected? and not indent? and not first?)
+  defp reply_banner?(node, connected?, indent?) do
+    Map.get(node, :show_reply_banner, false) or (connected? and not indent?)
   end
 
   # Each node paired with whether it is the first and the last of its siblings —

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.171.2",
+      version: "7.171.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/posts_test.exs
+++ b/test/vutuv/posts_test.exs
@@ -2171,6 +2171,45 @@ defmodule Vutuv.PostsTest do
       assert id == post.id
     end
 
+    test "a focus at the ancestor budget still loads the conversation whole" do
+      root = create_post!(user(), %{body: "root"})
+      {:ok, a} = Posts.create_reply(user(), root, %{body: "a"})
+      {:ok, b} = Posts.create_reply(user(), a, %{body: "b"})
+      {:ok, focus} = Posts.create_reply(user(), b, %{body: "focus"})
+      {:ok, aside} = Posts.create_reply(user(), root, %{body: "aside"})
+
+      # Three ancestors, the default budget: the window would show all of them
+      # anyway, so the whole conversation (sibling branch included) still wins.
+      assert %{mode: :all, posts: posts, total: 5} = Posts.thread_window(focus, nil)
+      assert Enum.map(posts, & &1.id) == [root.id, a.id, b.id, focus.id, aside.id]
+    end
+
+    test "a focus below the ancestor budget windows even in a small conversation" do
+      # Issue #1156: a permalink four levels down rendered the whole tree, so
+      # the card on top was the conversation's root and the sibling branches
+      # came before the post the visitor had actually asked for.
+      root = create_post!(user(), %{body: "root"})
+      {:ok, a} = Posts.create_reply(user(), root, %{body: "a"})
+      {:ok, b} = Posts.create_reply(user(), a, %{body: "b"})
+      {:ok, parent} = Posts.create_reply(user(), b, %{body: "parent"})
+      {:ok, focus} = Posts.create_reply(user(), parent, %{body: "focus"})
+      for i <- 1..3, do: {:ok, _} = Posts.create_reply(user(), root, %{body: "elsewhere #{i}"})
+
+      assert %{
+               mode: :window,
+               root: %Post{id: root_id},
+               gap: 0,
+               chain: chain,
+               subtree: [%Post{id: focus_id}],
+               rest: 3,
+               total: 8
+             } = Posts.thread_window(focus, nil)
+
+      assert root_id == root.id
+      assert focus_id == focus.id
+      assert Enum.map(chain, & &1.id) == [a.id, b.id, parent.id]
+    end
+
     test "a deep chain windows to the root, a gap and the nearest ancestors" do
       [root | chain] = chain_thread(8)
       focus = List.last(chain)

--- a/test/vutuv_web/live/post_thread_live_test.exs
+++ b/test/vutuv_web/live/post_thread_live_test.exs
@@ -139,6 +139,58 @@ defmodule VutuvWeb.PostThreadLiveTest do
     end
   end
 
+  describe "a deep permalink opens on its own chain (issue #1156)" do
+    # The reporter's shape: a five-post chain hanging off a conversation that
+    # had branched elsewhere. The permalinked post sat four levels down, so
+    # the whole tree rendered — the card on top was the conversation's root,
+    # the branches nobody had asked for came first, and past the indent cap
+    # every card shared its parent's column with nothing naming the post it
+    # answered.
+    defp buried_thread do
+      root = create_post!(author(), %{body: "the far-off root"})
+      {:ok, a} = Posts.create_reply(author(), root, %{body: "level one"})
+      {:ok, b} = Posts.create_reply(author(), a, %{body: "level two"})
+
+      asker = author(username: Vutuv.Factory.unique_username("asker"))
+      {:ok, parent} = Posts.create_reply(asker, b, %{body: "the question asked"})
+      {:ok, focus} = Posts.create_reply(author(), parent, %{body: "the buried answer"})
+
+      for i <- 1..3, do: {:ok, _} = Posts.create_reply(author(), root, %{body: "aside #{i}"})
+
+      %{root: root, chain: [a, b, parent], asker: asker, parent: parent, focus: focus}
+    end
+
+    test "the ancestor chain is the page, not the whole tree" do
+      %{root: root, focus: focus} = buried_thread()
+
+      {:ok, _view, html} = thread_view(focus)
+
+      # Root pinned, then every ancestor down to the post itself.
+      assert html =~ "the far-off root"
+      assert html =~ "level one"
+      assert html =~ "level two"
+      assert html =~ "the question asked"
+      assert html =~ "the buried answer"
+
+      # The branches that have nothing to do with this exchange stay off it.
+      refute html =~ "aside 1"
+      assert html =~ "part of a conversation with"
+      assert html =~ ~s(id="thread-from-start")
+      assert html =~ Posts.path(root)
+    end
+
+    test "a card past the indent cap names the post it answers" do
+      %{asker: asker, parent: parent, focus: focus} = buried_thread()
+
+      {:ok, _view, html} = thread_view(focus)
+
+      # The focus is an only child, so it used to lose its banner the moment
+      # the indent gave up — leaving the reader no way to tell what it answers.
+      assert html =~ "Replying to @#{asker.username}"
+      assert html =~ Posts.path(parent)
+    end
+  end
+
   describe "live counters inside the thread host" do
     test "another viewer's like ticks the shown card's counter" do
       {root, replies} = wide_thread(2)


### PR DESCRIPTION
Closes #1156.

**TL;DR** A permalink four levels down a conversation rendered the whole tree, so the top card was the thread's root and unrelated branches came before the post you clicked. Deep permalinks now open on their own ancestor chain, and every card past the indent cap names the post it answers.

### What the reporter saw

He opened `/wintermeyer/posts/019f9f08…` and concluded that the post it answers (`/dirk/posts/019f9ef6…`) was not in the thread. It was — the direct parent, twelve cards down the page and two above his own. Two things made it unfindable.

**1. The window was gated on size alone.** A conversation over 25 posts already opened as a window around the permalinked post (root pinned + nearest ancestors + the post's own subtree). His thread had 14 posts, so it rendered whole: the root on top (a Fediverse question the exchange had long since drifted away from), then eight posts of sibling branches, then the post he came for.

Now `Posts.thread_window/3` is gated on size **and** depth — `:all` only while the post has at most `:ancestors` (3) ancestors. Past that the chain is the context, so it becomes the page and the branches move behind the existing "read it from the start" link. Shallow permalinks are untouched.

**2. The reply banner was suppressed on first answers.** Past `@thread_indent_cap` every card sits in its parent's column. The "Replying to @handle" banner was skipped for a first answer, arguing it renders directly below the post it answers — which stops holding once several capped generations stack, where the card above is as likely to be a grandparent or a cousin. Every card past the cap now names its parent.

### Before / after, on the reported thread

| | before | after |
|---|---|---|
| cards on the page | 14 (whole tree) | 6 (root + chain + subtree) |
| card above the focus | Stefan's *other* reply to Dirk | Dirk's post, the actual parent |
| cards past the cap naming their parent | 1 of 4 | 4 of 4 |

Permalinks at depth 0–3 in that same thread still render all 14 cards.

### Tests

- `posts_test.exs` — a focus **at** the ancestor budget still loads whole; one **below** it windows even in a small conversation (the reporter's shape).
- `post_thread_live_test.exs` — the ancestor chain is the page, not the whole tree; a card past the indent cap names the post it answers.

### Verified in a browser

Dev server against a copy of production, on the real thread from the issue: the page is now root → Dirk → Stefan → Dirk → the post → its reply, each capped card carrying its banner, and "Von Anfang an lesen" lands back on the root's permalink with all 14 posts. The `.md`/`.txt`/`.json`/`.xml` siblings still serve the whole capped thread, as they already did for long conversations.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*