### PR TITLE
Offer one shared inbox, so a server delivers once (#1073)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -30,7 +30,10 @@ every endpoint 404s and nothing is delivered.
   by `VutuvWeb.Fediverse.Docs`; URLs hang off the member so no root slug is
   burned: `/:username/actor` (id), `.../inbox`, `.../followers` and
   `.../outbox` (count-only collections) and `.../collections/featured` (the
-  pinned post, see the post-lifecycle bullet below). The actor also carries
+  pinned post, see the post-lifecycle bullet below). The one URL that belongs to
+  nobody in particular is `endpoints.sharedInbox` (issue #1073), which for the
+  same reason lives under `/system/` rather than at a root word — see the
+  shared-inbox bullet below. The actor also carries
   **`alsoKnownAs`** (issue #986) — the account URIs a member is migrating
   *from* (`users.also_known_as`, set on `/settings/fediverse/move`, one per line).
   A remote server that moves a member's followers *to* vutuv checks this before
@@ -63,6 +66,41 @@ every endpoint 404s and nothing is delivered.
   (anti-spoofing). A valid `Follow` stores the follower
   (`Vutuv.Fediverse.Follower`: actor URI + inbox + sharedInbox) and answers
   with a delivered `Accept`; `Undo` removes it. Per-IP rate limited.
+- **Shared inbox** (`POST /system/inbox`, issue #1073): the same endpoint once
+  for the whole installation, advertised as `endpoints.sharedInbox` in every
+  actor document (`Docs.shared_inbox_url/0`), so a server with many followers
+  here delivers a broadcast **once** instead of once per member it touches —
+  the efficiency we already take advantage of on the way out, where the queue
+  dedupes one row per distinct remote inbox. It is the same code: the same
+  installation switch, the same blocklist checked first, the same per-IP limit,
+  the same signature and anti-spoofing verification, and then the very same
+  per-member handling. The per-member inbox keeps working forever; it is what
+  every server already knows.
+
+  The only thing that differs is where the addressees come from —
+  `Vutuv.Fediverse.inbox_recipients/2` reads them out of the activity instead of
+  the URL, from three places: the **addressing** (`to`/`cc`/`bto`/`bcc`/
+  `audience` on the activity and its object, plus the object itself and, for an
+  `Undo`, the object it wraps — a `Follow` names an actor URL, a `Like` a Note
+  URL, a reply its `inReplyTo`, each of which hangs off the member it belongs
+  to); the **remote actor's own `Update`/`Delete`**, which names no local member
+  at all and is therefore fanned out to exactly the members that actor follows
+  here (this is the case worth having the endpoint for — one account deletion
+  used to be one signed delivery per member); and an author's `Update`/`Delete`
+  **of a note they wrote**, fanned out to the members whose posts hold a copy.
+  Addressee URIs are attacker-chosen text, so the list is cut at 25; the two
+  lifecycle fan-outs are bounded by rows we wrote ourselves and are not.
+
+  Two deliberate asymmetries. It never answers `404`/`410`: those belong to a
+  URL that names one member, where a `410` is how a server learns *that account*
+  is gone, so here a member who does not federate is simply no recipient and the
+  delivery is acknowledged like any other — the endpoint cannot be used to ask
+  who takes part. And the actor fetch that verification needs is signed with the
+  key of the first addressee resolved from the still-unverified body (the
+  per-member inbox uses the addressed member's key); it only ever picks a member
+  the sender itself named, and the fetch goes back to the sender's own host.
+  Recipients are resolved before verification because a key is needed for it,
+  and acted on only afterwards, once the claimed `actor` is proven.
 - **Remote actor lifecycle**: an `Update` of the actor itself re-syncs the
   stored row from the freshly fetched document (a renamed remote must not stay
   listed under the old handle, a moved inbox must not keep receiving posts) and
@@ -518,7 +556,9 @@ stay. Deleting an account remains its own separate action. The followers
 collection is count-only (privacy). Followers who leave without saying so are
 found now (issue #1072) — the hourly re-check above prunes a row only on a
 `404`/`410` from the actor document itself, never on a failed delivery to a
-shared inbox.
+shared inbox. And we now offer a shared inbox of our own (issue #1073), so the
+asymmetry of asking other servers for an efficiency we did not give back is
+gone; it is pure scale work, with no change to what any activity does.
 
 ## Non-goal: reading other networks inside vutuv
 

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -769,6 +769,135 @@ defmodule Vutuv.Fediverse do
 
   defp check_inbound_cap(_), do: :ok
 
+  ## The shared inbox (issue #1073)
+
+  # How many addressee URIs one delivery may name. `to`/`cc` are attacker-chosen
+  # text and each entry costs a lookup, so the list is cut rather than walked:
+  # a real mention list is a handful of accounts, far under this. The fan-out
+  # that is NOT capped is the actor-lifecycle one below, because it is bounded
+  # by rows we ourselves wrote (who really follows whom), and it is exactly the
+  # work the per-member inbox would otherwise do across N separate requests.
+  @inbox_addressed_cap 25
+
+  @doc """
+  Every local member a delivery to the **shared inbox** is for (issue #1073).
+
+  The per-member inbox learns who the activity is for from the URL; the shared
+  one has to read it out of the activity. Three sources, because that is where
+  ActivityPub actually puts it:
+
+    * the **addressing** — `to` / `cc` / `bto` / `bcc` / `audience` on the
+      activity and on its object — plus the object itself and, for an `Undo`,
+      the object it wraps: a `Follow` names an actor URL, a `Like` or
+      `Announce` a Note URL, a reply its `inReplyTo`. Every URL of ours resolves
+      to the member it hangs off.
+    * the **remote actor's own lifecycle** (`Update`/`Delete` of itself), which
+      names no local member at all: it is broadcast to everyone following that
+      actor, so the addressees are exactly the members it follows here. This is
+      the case the endpoint is worth having for — one account deletion used to
+      mean one signed delivery per member.
+    * an author's **`Update`/`Delete` of a note they wrote**, which likewise
+      names nobody here: the addressees are the members whose posts hold a
+      stored copy of it.
+
+  Members who do not federate (or are suspended, frozen, gone) are filtered out,
+  so a delivery to them is silently dropped — never answered differently, or the
+  endpoint would become a way to ask who takes part.
+
+  `actor_uri` is the activity's *claimed* actor. The caller resolves recipients
+  before the signature is verified (it needs one of their keys to sign the
+  actor fetch that verification depends on) and only acts on the result
+  afterwards, once that claim is proven.
+  """
+  def inbox_recipients(activity, actor_uri) when is_map(activity) do
+    (addressed_users(activity) ++ lifecycle_users(activity, actor_uri))
+    |> Enum.uniq_by(& &1.id)
+    |> Enum.filter(&federated?/1)
+  end
+
+  def inbox_recipients(_activity, _actor_uri), do: []
+
+  defp addressed_users(activity) do
+    object = if is_map(activity["object"]), do: activity["object"], else: %{}
+    base = String.trim_trailing(VutuvWeb.Endpoint.url(), "/") <> "/"
+
+    (audience_uris(activity) ++
+       audience_uris(object) ++
+       [activity["object"], object["object"], object["inReplyTo"]])
+    |> Enum.filter(&is_binary/1)
+    |> Enum.uniq()
+    |> Enum.take(@inbox_addressed_cap)
+    |> Enum.flat_map(&local_username(&1, base))
+    |> users_by_username()
+  end
+
+  defp audience_uris(map) when is_map(map) do
+    Enum.flat_map(~w(to cc bto bcc audience), fn field ->
+      case map[field] do
+        list when is_list(list) -> list
+        uri when is_binary(uri) -> [uri]
+        _ -> []
+      end
+    end)
+  end
+
+  defp audience_uris(_other), do: []
+
+  # The member an actor or Note URL of ours hangs off, as a username. Anything
+  # else — a foreign host, the public collection, a malformed URI — is a miss.
+  defp local_username(uri, base) do
+    case String.replace_prefix(uri, base, "") do
+      ^uri -> []
+      rest -> rest |> String.split("/") |> username_from_segments()
+    end
+  end
+
+  defp username_from_segments([username, "actor" | _rest]), do: [String.downcase(username)]
+  defp username_from_segments([username, "posts", _id | _rest]), do: [String.downcase(username)]
+  defp username_from_segments(_segments), do: []
+
+  # One query for the whole addressee list, not one per URI.
+  defp users_by_username([]), do: []
+
+  defp users_by_username(usernames),
+    do: Repo.all(from(u in User, where: u.username in ^usernames))
+
+  defp lifecycle_users(%{"type" => type} = activity, actor_uri)
+       when type in ~w(Update Delete) and is_binary(actor_uri) do
+    case activity_object_id(activity["object"]) do
+      ^actor_uri -> followed_local_users(actor_uri)
+      uri when is_binary(uri) -> note_holding_users(actor_uri, uri)
+      _ -> []
+    end
+  end
+
+  defp lifecycle_users(_activity, _actor_uri), do: []
+
+  defp followed_local_users(actor_uri) do
+    Repo.all(
+      from(f in Follower,
+        join: u in User,
+        on: u.id == f.user_id,
+        where: f.actor_uri == ^actor_uri,
+        select: u
+      )
+    )
+  end
+
+  defp note_holding_users(actor_uri, object_uri) do
+    Repo.all(
+      from(n in Note,
+        join: p in Post,
+        on: p.id == n.post_id,
+        join: u in User,
+        on: u.id == p.user_id,
+        where: n.object_uri == ^object_uri and n.actor_uri == ^actor_uri,
+        distinct: true,
+        select: u
+      )
+    )
+  end
+
   ## Inbound reactions (issue #1068)
 
   @doc """

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -12,7 +12,10 @@ defmodule VutuvWeb.FediverseController do
       issue #1068; `Create(Note)`, issues #1069 and #1071, plus the author's own
       `Update`/`Delete` of such a note) and the remote actor's own lifecycle
       (`Update` re-syncs the stored follower, `Delete` of the actor removes it);
-      everything else is acknowledged and dropped.
+      everything else is acknowledged and dropped,
+    * `POST /system/inbox` — the same handling once for the whole installation
+      (issue #1073), so a server with many followers here delivers a broadcast
+      once and it is fanned out to every member the activity addresses.
 
   Deliberately outside the `:browser` pipeline: no session, no CSRF — remote
   servers authenticate with HTTP signatures instead, verified against the
@@ -97,25 +100,64 @@ defmodule VutuvWeb.FediverseController do
 
   def inbox(conn, %{"slug" => slug}) do
     with_federated_user(conn, slug, fn user ->
-      cond do
-        # The operator's kill switch (issue #1067), checked FIRST: before the
-        # signature is verified, before the remote actor document is fetched
-        # (an outbound request to a host we refuse to talk to) and before any
-        # write. Answered 202 like every other dropped activity, never 403, so
-        # the blocklist cannot be enumerated from outside.
-        blocked_sender?(conn) ->
-          send_resp(conn, 202, "")
-
-        VutuvWeb.RateLimit.check(conn, :fediverse_inbox, nil,
-          limit: 300,
-          window_ms: :timer.hours(1)
-        ) == :rate_limited ->
-          send_resp(conn, 429, "")
-
-        true ->
-          verify_and_perform(conn, user)
-      end
+      guarded(conn, fn -> verify_and_perform(conn, [user]) end)
     end)
+  end
+
+  @doc """
+  The installation-wide inbox (issue #1073, `VutuvWeb.Fediverse.Docs.shared_inbox_url/0`):
+  one endpoint a remote server can deliver a broadcast to **once** instead of
+  once per member it touches here — the efficiency we already take advantage of
+  when we deliver outward through a remote's own sharedInbox.
+
+  Everything about it is the per-member inbox: the same installation switch, the
+  same operator blocklist checked first, the same per-IP limit, the same
+  signature and anti-spoofing verification, and then the very same handling per
+  member. The only difference is where the addressees come from — the activity
+  instead of the URL (`Vutuv.Fediverse.inbox_recipients/2`).
+
+  Two deliberate asymmetries:
+
+    * it never answers `404`/`410`. Those belong to a URL that names one member,
+      where a `410` is how a server learns *that account* is gone; here every
+      accepted delivery is a `202`, so the endpoint cannot be used to ask
+      whether a given member takes part.
+    * the actor fetch that verification needs is signed with the key of the
+      first addressee we resolved from the still-unverified body (the per-member
+      inbox uses the addressed member's key). It only ever picks a member the
+      sender itself named, and the fetch goes back to the sender's own host.
+  """
+  def shared_inbox(conn, _params) do
+    if Fediverse.enabled?() do
+      activity = conn.body_params
+
+      guarded(conn, fn ->
+        verify_and_perform(conn, Fediverse.inbox_recipients(activity, activity["actor"]))
+      end)
+    else
+      send_resp(conn, 404, "")
+    end
+  end
+
+  # The operator's kill switch (issue #1067) is checked FIRST: before the
+  # signature is verified, before the remote actor document is fetched (an
+  # outbound request to a host we refuse to talk to) and before any write.
+  # Answered 202 like every other dropped activity, never 403, so the blocklist
+  # cannot be enumerated from outside.
+  defp guarded(conn, fun) do
+    cond do
+      blocked_sender?(conn) ->
+        send_resp(conn, 202, "")
+
+      VutuvWeb.RateLimit.check(conn, :fediverse_inbox, nil,
+        limit: 300,
+        window_ms: :timer.hours(1)
+      ) == :rate_limited ->
+        send_resp(conn, 429, "")
+
+      true ->
+        fun.()
+    end
   end
 
   # Both names the request offers for its sender: the signature's `keyId` (whose
@@ -137,15 +179,21 @@ defmodule VutuvWeb.FediverseController do
   # The signature names the sender (keyId -> actor document -> public key).
   # The activity's actor must be that same actor, or anyone could sign a
   # Follow as themselves while claiming to be someone else.
-  defp verify_and_perform(conn, user) do
+  #
+  # `users` is who the activity is for: exactly one member at the per-member
+  # inbox, whoever the activity addressed at the shared one — where it may also
+  # be nobody, which is still verified first and only then dropped, so an
+  # unsigned delivery is a 401 whatever it claims to be addressed to.
+  defp verify_and_perform(conn, users) do
     activity = conn.body_params
 
     with {:ok, key_id} <- signature_key_id(conn),
-         {:ok, remote} <- Fediverse.fetch_remote_actor(key_id, signer(user)),
+         {:ok, remote} <- Fediverse.fetch_remote_actor(key_id, signer(users)),
          true <- same_authority?(key_id, remote.id),
          :ok <- verify_signature(conn, remote),
          true <- activity["actor"] == remote.id do
-      perform(conn, user, activity, remote)
+      Enum.each(users, &perform(&1, activity, remote))
+      send_resp(conn, 202, "")
     else
       _ -> send_resp(conn, 401, "")
     end
@@ -161,7 +209,10 @@ defmodule VutuvWeb.FediverseController do
 
   defp same_authority?(_key_id, _actor_id), do: false
 
-  defp perform(conn, user, %{"type" => "Follow"} = activity, remote) do
+  # What one addressed member does with an activity. Deliberately returns
+  # nothing the caller uses: the answer is the same 202 whatever any of these
+  # decide, and at the shared inbox one delivery runs this once per addressee.
+  defp perform(user, %{"type" => "Follow"} = activity, remote) do
     if activity["object"] == Docs.actor_url(user) do
       # A remote actor doc with an over-long / malformed inbox or id yields an
       # invalid changeset; accept only a successful insert, never crash the inbox.
@@ -171,12 +222,12 @@ defmodule VutuvWeb.FediverseController do
       end
     end
 
-    send_resp(conn, 202, "")
+    :ok
   end
 
-  defp perform(conn, user, %{"type" => "Undo", "object" => %{"type" => "Follow"}}, remote) do
+  defp perform(user, %{"type" => "Undo", "object" => %{"type" => "Follow"}}, remote) do
     Fediverse.remove_follower(user, remote.id)
-    send_resp(conn, 202, "")
+    :ok
   end
 
   # Somebody on another network favourited (`Like`) or re-shared (`Announce`)
@@ -188,23 +239,18 @@ defmodule VutuvWeb.FediverseController do
   # `Fediverse.record_reaction/4`; whatever it decides, the answer is the same
   # 202, so a misdirected activity never tells the sender which of the
   # conditions it failed.
-  defp perform(conn, user, %{"type" => type, "object" => object}, remote)
+  defp perform(user, %{"type" => type, "object" => object}, remote)
        when type in ["Like", "Announce"] do
     Fediverse.record_reaction(user, object, reaction_kind(type), reacting_actor(remote))
-    send_resp(conn, 202, "")
+    :ok
   end
 
   # The remote side took its reaction back. Honoured at once: an upstream
   # withdrawal is the deletion path that makes storing the row defensible.
-  defp perform(
-         conn,
-         user,
-         %{"type" => "Undo", "object" => %{"type" => type} = undone},
-         remote
-       )
+  defp perform(user, %{"type" => "Undo", "object" => %{"type" => type} = undone}, remote)
        when type in ["Like", "Announce"] do
     Fediverse.remove_reaction(user, undone["object"], reaction_kind(type), remote.id)
-    send_resp(conn, 202, "")
+    :ok
   end
 
   # Somebody on another network answered one of the member's posts (issues
@@ -212,9 +258,9 @@ defmodule VutuvWeb.FediverseController do
   # member's separate opt-in among them — and the answer is the same 202
   # whatever it decides, so a misdirected activity never learns which gate it
   # failed.
-  defp perform(conn, user, %{"type" => "Create"} = activity, remote) do
+  defp perform(user, %{"type" => "Create"} = activity, remote) do
     Fediverse.record_reply(user, activity, remote_author(remote))
-    send_resp(conn, 202, "")
+    :ok
   end
 
   # A remote actor that renamed or moved its inbox broadcasts an `Update` of
@@ -226,14 +272,14 @@ defmodule VutuvWeb.FediverseController do
   # An `Update` of anything else is an author editing a note they sent us, which
   # is honoured too — including a narrowed audience, which is the same "stop
   # showing this" signal a 403 carries.
-  defp perform(conn, user, %{"type" => "Update"} = activity, remote) do
+  defp perform(user, %{"type" => "Update"} = activity, remote) do
     if object_id(activity["object"]) == remote.id do
       Fediverse.refresh_follower(user, follower_attrs(remote))
     else
       Fediverse.update_reply(user, activity, remote.id)
     end
 
-    send_resp(conn, 202, "")
+    :ok
   end
 
   # A remote account deleting itself tells every server that follows it, so
@@ -244,7 +290,7 @@ defmodule VutuvWeb.FediverseController do
   # so the signature can no longer be verified and `verify_and_perform/2`
   # rejects it; this catches the window where the account is suspended but
   # still served, which is when most servers send the Delete.
-  defp perform(conn, user, %{"type" => "Delete"} = activity, remote) do
+  defp perform(user, %{"type" => "Delete"} = activity, remote) do
     if object_id(activity["object"]) == remote.id do
       Fediverse.remove_follower(user, remote.id)
     else
@@ -255,12 +301,12 @@ defmodule VutuvWeb.FediverseController do
       Fediverse.delete_reply(remote.id, object_id(activity["object"]))
     end
 
-    send_resp(conn, 202, "")
+    :ok
   end
 
   # Outbound-only federation: likes, replies, announces etc. are acknowledged
   # (so well-behaved servers stop retrying) and dropped.
-  defp perform(conn, _user, _activity, _remote), do: send_resp(conn, 202, "")
+  defp perform(_user, _activity, _remote), do: :ok
 
   defp reaction_kind("Like"), do: "like"
   defp reaction_kind("Announce"), do: "announce"
@@ -325,13 +371,18 @@ defmodule VutuvWeb.FediverseController do
 
   # Remote-actor fetches are signed with the followed member's own key —
   # instances running in authorized-fetch ("secure") mode reject anonymous
-  # GETs.
-  defp signer(user) do
+  # GETs. At the shared inbox that is the first addressee we resolved; a
+  # delivery addressed to nobody here falls back to an anonymous fetch, which
+  # such an instance may refuse — and then the delivery is rejected, which is
+  # the right outcome for an activity that was for none of our members anyway.
+  defp signer([%User{} = user | _rest]) do
     case Fediverse.get_actor(user) do
       nil -> nil
       actor -> {Docs.key_id(user), actor.private_key_pem}
     end
   end
+
+  defp signer([]), do: nil
 
   defp with_federated_user(conn, slug, fun) do
     with true <- Fediverse.enabled?(),

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -15,6 +15,10 @@ defmodule VutuvWeb.Fediverse.Docs do
       /:username/actor/followers             count-only collection
       /:username/actor/outbox                count-only collection
       /:username/actor/collections/featured  the pinned post (issue #1110)
+
+  The one exception is the installation-wide `endpoints.sharedInbox` (issue
+  #1073), which belongs to nobody in particular and therefore lives under
+  `/system/` — see `shared_inbox_url/0`.
   """
 
   alias Vutuv.Fediverse.Actor
@@ -41,6 +45,20 @@ defmodule VutuvWeb.Fediverse.Docs do
   def actor_url(user), do: "#{base()}/#{user.username}/actor"
   def key_id(user), do: actor_url(user) <> "#main-key"
   def note_url(user, post_id), do: "#{base()}/#{user.username}/posts/#{post_id}"
+
+  @doc """
+  The one inbox the whole installation offers (issue #1073), advertised as
+  `endpoints.sharedInbox` in every actor document so a server with many
+  followers here delivers a broadcast **once** instead of once per member — the
+  efficiency we already take advantage of when we deliver outward.
+
+  It is the only Fediverse URL that does not hang off a member, so it lives
+  under `/system/` rather than at a root word: profiles own the URL root, and a
+  new root segment would permanently burn a word a member could otherwise claim
+  as a handle. Nothing is lost by the odd-looking path — remote servers only
+  ever read it out of the actor document.
+  """
+  def shared_inbox_url, do: "#{base()}/system/inbox"
 
   @doc """
   The `featured` collection: the member's pinned post (issue #1110), which is
@@ -78,6 +96,10 @@ defmodule VutuvWeb.Fediverse.Docs do
       "inbox" => actor_url <> "/inbox",
       "outbox" => actor_url <> "/outbox",
       "followers" => actor_url <> "/followers",
+      # The installation-wide inbox (issue #1073). The per-member one above is
+      # what every server already knows and keeps working forever; this is the
+      # offer to deliver a broadcast once for all of them.
+      "endpoints" => %{"sharedInbox" => shared_inbox_url()},
       # Where a remote server looks for the pinned post (issue #1110). Always
       # advertised, even with nothing pinned: the collection is then simply
       # empty, and an actor that only sometimes names the field would make the

--- a/lib/vutuv_web/raw_body_reader.ex
+++ b/lib/vutuv_web/raw_body_reader.ex
@@ -1,13 +1,14 @@
 defmodule VutuvWeb.RawBodyReader do
   @moduledoc """
   The endpoint's `Plug.Parsers` body reader: passes every body through
-  unchanged, but keeps a copy of the **raw bytes** for the ActivityPub inbox
-  (`POST /:slug/actor/inbox`) in `conn.private[:fediverse_raw_body]`.
+  unchanged, but keeps a copy of the **raw bytes** for the two ActivityPub
+  inboxes (`POST /:slug/actor/inbox` and the installation-wide
+  `POST /system/inbox`, issue #1073) in `conn.private[:fediverse_raw_body]`.
 
   HTTP-signature verification (`Vutuv.Fediverse.HttpSignature`) must hash the
   body exactly as sent — after `Plug.Parsers` has consumed it into
-  `body_params`, the original bytes are otherwise gone. Only the inbox path
-  pays the copy; every other request streams through untouched.
+  `body_params`, the original bytes are otherwise gone. Only those paths pay
+  the copy; every other request streams through untouched.
   """
 
   def read_body(conn, opts) do
@@ -24,10 +25,17 @@ defmodule VutuvWeb.RawBodyReader do
 
   def raw_body(_conn), do: nil
 
-  defp store(%Plug.Conn{path_info: [_slug, "actor", "inbox"]} = conn, chunk) do
+  defp store(%Plug.Conn{path_info: [_slug, "actor", "inbox"]} = conn, chunk),
+    do: keep(conn, chunk)
+
+  # The installation-wide inbox (issue #1073) verifies the very same signature,
+  # so it needs the very same copy of the bytes.
+  defp store(%Plug.Conn{path_info: ["system", "inbox"]} = conn, chunk), do: keep(conn, chunk)
+
+  defp store(conn, _chunk), do: conn
+
+  defp keep(conn, chunk) do
     collected = conn.private[:fediverse_raw_body] || []
     Plug.Conn.put_private(conn, :fediverse_raw_body, [collected, chunk])
   end
-
-  defp store(conn, _chunk), do: conn
 end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -134,6 +134,14 @@ defmodule VutuvWeb.Router do
     # The pinned post (issue #1110), at the path other servers already look for.
     get("/:slug/actor/collections/featured", FediverseController, :featured)
     post("/:slug/actor/inbox", FediverseController, :inbox)
+    # The installation-wide inbox (issue #1073), so a server with many
+    # followers here delivers a broadcast once instead of once per member.
+    # Under /system/ rather than at a root word, which profiles own; remote
+    # servers only ever read the path out of the actor document's
+    # endpoints.sharedInbox. Must stay above the /system scopes further down —
+    # those ride the :browser pipeline, which this machine-to-machine POST
+    # (no session, no CSRF) must not.
+    post("/system/inbox", FediverseController, :shared_inbox)
     # Deploy readiness probe (see VutuvWeb.HealthController). No pipeline:
     # it is hit by curl on localhost and must not depend on sessions or
     # content negotiation.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.171.3",
+      version: "7.172.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/fediverse_controller_test.exs
@@ -51,9 +51,13 @@ defmodule VutuvWeb.FediverseControllerTest do
     on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
   end
 
-  defp signed_post(conn, user, activity, private_pem) do
+  defp signed_post(conn, user, activity, private_pem),
+    do: signed_post_to(conn, "/#{user.username}/actor/inbox", activity, private_pem)
+
+  # The shared inbox (issue #1073) is the same delivery to a different path, so
+  # the signing helper takes the path rather than the addressed member.
+  defp signed_post_to(conn, path, activity, private_pem) do
     body = Jason.encode!(activity)
-    path = "/#{user.username}/actor/inbox"
 
     headers =
       HttpSignature.signed_headers(
@@ -769,6 +773,232 @@ defmodule VutuvWeb.FediverseControllerTest do
 
       assert conn.status == 202
       assert Fediverse.follower_count(user) == 1
+    end
+  end
+
+  # One inbox for the whole installation (issue #1073): a server with many
+  # followers here delivers a broadcast once instead of once per member. Same
+  # signature, anti-spoofing, blocklist and rate-limit rules as the per-member
+  # inbox — the only difference is that who the activity is for is read out of
+  # the activity instead of the URL.
+  describe "POST /system/inbox — the shared inbox (#1073)" do
+    defp shared_post(conn, activity, priv),
+      do: signed_post_to(conn, "/system/inbox", activity, priv)
+
+    test "every actor document advertises it", %{conn: conn} do
+      user = federated_user()
+
+      body = conn |> get("/#{user.username}/actor") |> Map.fetch!(:resp_body) |> Jason.decode!()
+
+      assert body["endpoints"]["sharedInbox"] == Docs.shared_inbox_url()
+      assert Docs.shared_inbox_url() == "#{VutuvWeb.Endpoint.url()}/system/inbox"
+      # The per-member inbox is what every server already knows; it stays.
+      assert body["inbox"] == Docs.actor_url(user) <> "/inbox"
+    end
+
+    test "one Update of the remote actor re-syncs the row of every member it follows",
+         %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub, %{"preferredUsername" => "alice_renamed", "name" => "Alice Renamed"})
+
+      users = for _ <- 1..3, do: federated_user()
+      for user <- users, do: :ok = existing_follower(user)
+
+      activity = lifecycle_activity("Update", %{"id" => @remote_actor, "type" => "Person"})
+      conn = shared_post(conn, activity, priv)
+
+      assert conn.status == 202
+
+      # One delivery, one row updated per member — the whole point of the
+      # endpoint.
+      for user <- users do
+        assert [follower] = Fediverse.list_followers(user)
+        assert follower.handle == "alice_renamed"
+        assert follower.name == "Alice Renamed"
+        assert follower.shared_inbox_uri == @remote_shared
+      end
+    end
+
+    test "one Delete of the remote actor drops it from every member it followed",
+         %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+
+      users = for _ <- 1..3, do: federated_user()
+      for user <- users, do: :ok = existing_follower(user)
+
+      conn = shared_post(conn, lifecycle_activity("Delete", @remote_actor), priv)
+
+      assert conn.status == 202
+      for user <- users, do: assert(Fediverse.follower_count(user) == 0)
+    end
+
+    test "a Follow stores the follower and queues the Accept", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = federated_user()
+
+      conn = shared_post(conn, follow_activity(user), priv)
+
+      assert conn.status == 202
+      assert Fediverse.follower_count(user) == 1
+
+      [delivery] = Repo.all(Delivery)
+      assert delivery.inbox_uri == @remote_inbox
+      assert delivery.activity_json =~ ~s("type":"Accept")
+    end
+
+    test "Undo(Follow) finds the member through the Follow it wraps", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = federated_user()
+      :ok = existing_follower(user)
+
+      undo = %{
+        "@context" => "https://www.w3.org/ns/activitystreams",
+        "id" => "https://social.example/activities/2",
+        "type" => "Undo",
+        "actor" => @remote_actor,
+        "object" => follow_activity(user)
+      }
+
+      conn = shared_post(conn, undo, priv)
+
+      assert conn.status == 202
+      assert Fediverse.follower_count(user) == 0
+    end
+
+    test "a Like is counted on the post it names, and on nobody else's", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = federated_user()
+      bystander = federated_user()
+      post = create_post!(user, %{body: "Reachable from anywhere."})
+      other = create_post!(bystander, %{body: "Not the one that was liked."})
+
+      conn = shared_post(conn, reaction_activity("Like", Docs.note_url(user, post.id)), priv)
+
+      assert conn.status == 202
+      assert Fediverse.reaction_count(post.id) == 1
+      assert Fediverse.reaction_count(other.id) == 0
+    end
+
+    test "a reply lands under the post it answers, and only there", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub, %{"preferredUsername" => "alice"})
+      user = replying_user()
+      bystander = replying_user()
+      post = create_post!(user, %{body: "Reachable from anywhere."})
+      other = create_post!(bystander, %{body: "Nobody answered this one."})
+
+      conn = shared_post(conn, create_note(Docs.note_url(user, post.id)), priv)
+
+      assert conn.status == 202
+      assert [note] = Fediverse.list_notes([post.id], user)[post.id]
+      assert note.content_text == "Sehe ich auch so."
+      assert Fediverse.note_count(other.id) == 0
+    end
+
+    test "the author's Delete of that reply finds it without naming the member",
+         %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = replying_user()
+      post = create_post!(user, %{body: "Reachable from anywhere."})
+
+      shared_post(conn, create_note(Docs.note_url(user, post.id)), priv)
+      assert Fediverse.note_count(post.id) == 1
+
+      delete = %{
+        "@context" => "https://www.w3.org/ns/activitystreams",
+        "id" => "https://social.example/activities/delete-1",
+        "type" => "Delete",
+        "actor" => @remote_actor,
+        "object" => %{"id" => "#{@remote_actor}/statuses/1", "type" => "Tombstone"}
+      }
+
+      conn = shared_post(recycle(conn), delete, priv)
+
+      assert conn.status == 202
+      assert Fediverse.note_count(post.id) == 0
+    end
+
+    test "an unsigned activity is rejected exactly as at the per-member inbox", %{conn: conn} do
+      user = federated_user()
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/activity+json")
+        |> post("/system/inbox", Jason.encode!(follow_activity(user)))
+
+      assert conn.status == 401
+      assert Fediverse.follower_count(user) == 0
+    end
+
+    test "a spoofed actor is rejected", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = federated_user()
+
+      spoofed = Map.put(follow_activity(user), "actor", "https://evil.example/users/mallory")
+      conn = shared_post(conn, spoofed, priv)
+
+      assert conn.status == 401
+      assert Fediverse.follower_count(user) == 0
+    end
+
+    test "an activity signed with the wrong key is rejected", %{conn: conn} do
+      {_remote_priv, remote_pub} = Keys.generate()
+      {other_priv, _} = Keys.generate()
+      stub_remote_actor(remote_pub)
+      user = federated_user()
+
+      conn = shared_post(conn, follow_activity(user), other_priv)
+
+      assert conn.status == 401
+      assert Fediverse.follower_count(user) == 0
+    end
+
+    test "a blocked server is refused here too, before the signature is checked", %{conn: conn} do
+      admin = insert(:activated_user, admin?: true)
+      {:ok, {_blocked, _purged}} = Fediverse.block_instance(%{"host" => "social.example"}, admin)
+      user = federated_user()
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/activity+json")
+        |> post("/system/inbox", Jason.encode!(follow_activity(user)))
+
+      assert conn.status == 202
+      assert Fediverse.follower_count(user) == 0
+      assert Repo.aggregate(Delivery, :count) == 0
+    end
+
+    test "a member without the opt-in is no recipient — acknowledged and dropped",
+         %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      plain = insert(:activated_user)
+
+      conn = shared_post(conn, follow_activity(plain), priv)
+
+      # 202, not the per-member inbox's 404: the shared endpoint must not become
+      # a way to ask whether a given member federates.
+      assert conn.status == 202
+      assert Fediverse.follower_count(plain) == 0
+    end
+
+    test "404s while federation is globally off", %{conn: conn} do
+      {priv, pub} = Keys.generate()
+      stub_remote_actor(pub)
+      user = federated_user()
+      Application.put_env(:vutuv, :fediverse_enabled, false)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_enabled) end)
+
+      conn = shared_post(conn, follow_activity(user), priv)
+
+      assert conn.status == 404
+      assert Fediverse.follower_count(user) == 0
     end
   end
 


### PR DESCRIPTION
Closes #1073.

**TL;DR** vutuv now offers a single shared inbox at `POST /system/inbox`, advertised as `endpoints.sharedInbox`, so a remote server with many followers here delivers a broadcast once instead of once per member. Pure scale work, no behaviour change.

### Why

We already use a remote server's shared inbox when we deliver outward (the queue dedupes one row per distinct inbox), while advertising only per-member inboxes ourselves. We were asking for an efficiency we did not give back. With one federating member that costs nothing; it grows linearly with members, and it starts to matter now that inbound content is accepted (#1067/#1068/#1069).

### What it is

The same code, not a second implementation: the same `:fediverse_enabled` gate, the same operator blocklist checked first, the same per-IP limit, the same HTTP-signature and anti-spoofing verification, and then the very same per-member handling. The per-member inbox keeps working forever, since it is what every server already knows.

The only genuinely new part is where the addressees come from. The per-member inbox learns that from the URL; the shared one reads it out of the activity (`Vutuv.Fediverse.inbox_recipients/2`), from three places:

- the **addressing** (`to`/`cc`/`bto`/`bcc`/`audience` on the activity and its object, plus the object itself and, for an `Undo`, the object it wraps) — a `Follow` names an actor URL, a `Like` a Note URL, a reply its `inReplyTo`;
- the remote **actor's own `Update`/`Delete`**, which names no local member at all, fanned out to exactly the members that actor follows here. This is the case the endpoint is worth having for: an account deletion over there used to be one signed delivery per member over here;
- an author's **`Update`/`Delete` of a note they wrote**, fanned out to the members whose posts hold a copy.

Addressee URIs are attacker-chosen text, so that list is cut at 25. The two lifecycle fan-outs are bounded by rows we wrote ourselves, so they are not capped.

### Two deliberate asymmetries

- **It never answers `404`/`410`.** Those belong to a URL that names one member, where a `410` is how a server learns *that account* is gone. Here a member who does not federate is simply no recipient and the delivery is acknowledged like any other, so the endpoint cannot be used to ask who takes part.
- **The actor fetch that verification needs is signed with the first addressee's key** (the per-member inbox uses the addressed member's key). It only ever picks a member the sender itself named, and the fetch goes back to the sender's own host. Recipients are resolved before verification because a key is needed for it, and acted on only afterwards, once the claimed `actor` is proven.

The path lives under `/system/` rather than at a root word, since profiles own the URL root. Nothing is lost: remote servers only ever read the path out of the actor document.

### Tests

14 new cases in `test/vutuv_web/controllers/fediverse_controller_test.exs`, covering the acceptance list: one `Update` of a remote actor re-syncs the row of all three members it follows from a single delivery (and one `Delete` drops it from all three); a `Follow`, an `Undo(Follow)`, a `Like` and a reply each land on the member the activity names and nobody else; an author's `Delete` of their reply finds it without naming a member; unsigned, wrongly signed and spoofed deliveries are rejected `401` exactly as at the per-member inbox; a blocked host is refused here too, before the signature is checked; the actor document advertises the endpoint and still carries the per-member inbox; a member without the opt-in is no recipient; and the whole thing 404s while `:fediverse_enabled` is off.

`mix precommit` green (5567 tests). Also smoke-tested against a live dev server: the actor document advertises the endpoint derived from `Endpoint.url()`, an unsigned POST to `/system/inbox` answers `401` like the per-member one, and the `/system/*` browser routes are unaffected.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01Qc1rhkHscmmboCqUSp9UbK
