### PR TITLE
Ask other servers to withdraw what is taken down here (#1102)

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -617,6 +617,26 @@ first, in plain words, because neither can be undone: what has already been
 delivered is out of reach, and a member who leaves and comes back may not be
 shown again by every server right away.
 
+**When something is taken down here.** Every takedown now asks the other servers
+to withdraw their copy, not only a member pressing delete on their own post. A
+report that freezes a post asks for its copies to be deleted (and lifting the
+freeze publishes the post again); a permanent removal of an account — an admin
+ruling, or the third strike on the ladder — tells the servers that follow that
+member their account is gone, the same message a real account deletion sends; and
+reporting a reply that came from another network passes the report on to that
+server's moderators as well as deleting the copy here. Everything **temporary**
+deliberately sends nothing at all: a week's suspension or a frozen profile must
+never read to the network as "this account was deleted".
+
+None of it is enforceable. Another server can ignore the request, and a request
+addressed to a server that is down for a day is retried for about four hours and
+then given up on. That is why **`/admin` → Fediverse** ends in a
+"Takedowns that did not get through" list: the server, what was asked, and the
+last error. A copy on that list is very likely still published somewhere, so it
+is worth reading before you tell a member their post is gone — and a server
+appearing there again and again is either broken or ignoring you, and can be
+blocked on the same page.
+
 **What is stored from other servers.** Exactly one thing: a bare counter row per
 remote person per post per kind (favourite / re-share), holding only that
 person's account address, the kind and the time. No name, no picture, no text.

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -348,7 +348,8 @@ every endpoint 404s and nothing is delivered.
   fetched, against *both* the signature's `keyId` and the activity's claimed
   `actor`, since neither is verified yet — and answers `202` rather than `403`,
   so the list is not enumerable from outside. Blocking is also a purge
-  (`purge_instance/1`: that host's follower rows and its queued deliveries) and
+  (`purge_instance/1`: that host's follower rows, its queued deliveries and the
+  records of what was delivered there) and
   a mouth-shut: `deliver_due/0` drops a queued delivery to a blocked host, and
   since the follower rows are the delivery targets, the member's posts stop
   going there. Unblocking resurrects nothing. The **caps**
@@ -364,9 +365,13 @@ every endpoint 404s and nothing is delivered.
   signed with the member's key, exponential backoff (2, 4, 8 … minutes),
   dropped after 8 attempts or on 404/410. Test seam: `:fediverse_req_options`
   (Req plug), deliverer off in tests.
+- **Revocation** (issue #1102) — the one chokepoint every takedown goes through,
+  because "taken down here" must not mean "still published there". See the
+  section of its own below.
 - **Post lifecycle** (hooks in `Vutuv.Posts` after commit): publishing a
   public post enqueues `Create(Note)`, editing `Update`, deleting
-  `Delete(Tombstone)`; an edit that closes the audience federates a `Delete`
+  `Delete(Tombstone)` through the one revocation chokepoint (`revoke_post/1`, see
+  the revocation section); an edit that closes the audience revokes
   too. Replies federate with `inReplyTo` only when the parent's author also
   federates (else the id would not resolve). A **repost** of a public post
   enqueues an `Announce` to the reposter's own followers, un-reposting the
@@ -459,12 +464,14 @@ every endpoint 404s and nothing is delivered.
 - **The operator** sees federation health on `/admin`: `Fediverse.stats/0`
   reports federating members (the SQL mirror of `federated?/1`), total remote
   followers, delivery-queue depth, how many rows are stuck (carry a
-  `last_error`) and how many servers are blocked; the "Fediverse" dashboard card
+  `last_error`), how many servers are blocked and how many takedowns gave up
+  without arriving (`failed_takedowns`, issue #1102); the "Fediverse" dashboard card
   flags `attention` when a delivery run is stuck, names the busiest inbound host
   and links to `/admin/fediverse`, and hides itself when `:fediverse_enabled` is
   off. That page is the blocklist plus `inbound_hosts/1` — what each remote
   server has stored here, biggest first, which is what a block decision is made
-  from. The nightly Tagesbericht (`Vutuv.Reports`) counts new remote followers
+  from, plus the member takedown log and the undelivered-takedown list. The
+  nightly Tagesbericht (`Vutuv.Reports`) counts new remote followers
   per Berlin day.
 
 ## Follow from your own server
@@ -498,6 +505,95 @@ own redirect following would skip that second check), short timeouts, no
 retries, and a body ceiling that halts the stream rather than buffering. Every
 failure lands back on the profile with a plain-language flash naming the server,
 and the handle is right there to copy, so there is always a way through.
+## Revocation: a takedown has to leave the building
+
+Until issue #1102 only one path federated a `Delete`: the owner pressing delete
+on their own post. Everything else hid the content here and told the network
+nothing — a report that froze a post, an admin's `remove_owner :deactivate`, the
+strike ladder's permanent deactivation, and a reported reply from another network
+whose origin never learned anybody had objected. Worse, the one path that did
+federate was gated on `federated?/1`, which is false for a frozen, suspended or
+deactivated account: the accounts moderation had already hidden were exactly the
+ones whose deletions never went out.
+
+**One chokepoint.** `Vutuv.Fediverse.revoke_post/1` sends the
+`Delete(Tombstone)`, and every takedown calls it: `Vutuv.Posts.delete_post/1`, an
+edit that closes the audience (`federate_post_update/1`), and the moderation
+freezer (`Vutuv.Moderation.freeze_content/1`). `revoke_actor/1` is its
+account-level twin for a **permanent** removal (`remove_owner :deactivate` and the
+third strike), and `prepare_actor_delete/1` + `send_actor_delete/1` stay the
+account-deletion path, which has to outlive the rows it reads.
+
+**Gated on `ever_federated?/1`, not `federated?/1`** — the switch is on and the
+member has an actor, i.e. copies of their posts may exist out there. Every
+takedown runs at the moment the post or the account is hidden here, which is
+precisely when `federated?/1` turns false; gating on it made the withdrawing
+activities the only ones that never left. For the same reason there is no
+`moved?/1` skip: a member who redirected their followers elsewhere stopped
+*publishing*, but the servers that followed them still hold what came before.
+
+**Addressed, not broadcast.** `Vutuv.Fediverse.PostDelivery`
+(`fediverse_post_deliveries`) records each `(post, inbox, published Note id)`
+when a `Create`/`Update` is enqueued, and the revocation reads it back. That
+fixes two holes at once: delivery targets used to come from the follower table,
+so a server that received the post and has since unfollowed kept its copy
+forever; and the Tombstone id was built from the *current* username, so after a
+rename (issue #1086) a delivered `Delete` matched nothing. An `Update` sent after
+a rename publishes a second id, so the records are grouped by id and one `Delete`
+goes out per id. A post with no records at all (published before the records
+existed) falls back to the current follower inboxes and the current id — a worse
+address than the real one, and a much better one than silence. The rows carry
+**no foreign key** into `posts` on purpose: `delete_post/1` federates after the
+commit, so a cascade would erase the addresses moments before they are needed.
+They are cleared by the revocation that spends them, by
+`drop_post_deliveries/1` in the account-deletion chokepoint, and by
+`purge_instance/1`.
+
+**A freeze is reversible, so it revokes and re-publishes.** Freezing a post hides
+it from everyone but its owner, so leaving the remote copies up would make the
+freeze a local fiction — `freeze_content/1` revokes. Lifting it (a rejected
+report, or the owner editing the post) calls `republish_post/1`, which sends a
+fresh `Create`: the other servers were told to delete the object, so there is
+nothing left there for an `Update` to change. It re-reads the post rather than
+trusting the caller's struct, whose `frozen_at` is still set (the unfreeze is an
+`update_all`).
+
+**A temporary hiding sends nothing at all.** No actor `Delete` for a week's
+suspension, a profile freeze or an unconfirmed account, and no `410` either —
+that stays reserved for the member's own opt-out (see the next section). A
+three-day hiding must never read to the network as "this account is gone". A
+profile freeze also deliberately does *not* fan a `Delete` out over every post
+the member ever published: one report would then trigger a network-wide storm,
+and a rejection a second one.
+
+**Reports travel too.** Reporting a reply from another network
+(`report_note/2`) deletes our cached copy *and* POSTs a `Flag` to the origin
+actor's inbox — how these networks file a report with each other (Mastodon shows
+an incoming `Flag` as a report). It is signed by the member whose post the reply
+sat under, never by the reporter: a `Flag` is a signed statement, so it needs an
+actor we serve a key for, vutuv has no installation-wide actor to file from, and
+the thread's owner is the party that server already knows in this conversation.
+Nothing in it names the reporter and no content rides along — the reported
+object's own id is the whole reference, and the `content` line is a fixed English
+sentence (read by a stranger's moderators, so not `gettext`). The reporter's daily
+report cap bounds it, since the `Flag` only rides a successful takedown, and a
+`"flagged"` row joins the `NoteEvent` ledger so an operator can tell a takedown
+that only happened here from one the other server was told about. `remove_note/2`
+— taking a reply off your own post — sends nothing: that is a decision about your
+own page, not an accusation.
+
+**An incomplete takedown is not silent.** A `Delete` or `Flag` that exhausts its
+eight attempts is written to `Vutuv.Fediverse.DeliveryFailure` and listed on
+`/admin/fediverse` ("Takedowns that did not get through", with the server, the
+object and the last error), plus counted in `stats/0` as `failed_takedowns`. Only
+the withdrawing types are recorded: a `Create` that never lands is one post that
+did not travel, while a `Delete` that never lands means a copy somebody asked us
+to withdraw is still published somewhere.
+
+None of this is a guarantee. Remote deletion is advisory by protocol and always
+will be, so the UI never claims a copy is gone — but every takedown now at least
+asks.
+
 ## Leaving: 410 Gone, and saying so first
 
 Switching the opt-in off used to make every actor endpoint answer `404`, which
@@ -574,7 +670,9 @@ found now (issue #1072) — the hourly re-check above prunes a row only on a
 `404`/`410` from the actor document itself, never on a failed delivery to a
 shared inbox. And we now offer a shared inbox of our own (issue #1073), so the
 asymmetry of asking other servers for an efficiency we did not give back is
-gone; it is pure scale work, with no change to what any activity does.
+gone; it is pure scale work, with no change to what any activity does. Every
+takedown, not just the owner's own delete button, now asks the other servers to
+withdraw the copy (issue #1102, the revocation section above).
 
 ## Non-goal: reading other networks inside vutuv
 

--- a/docs/architecture/moderation.md
+++ b/docs/architecture/moderation.md
@@ -79,6 +79,18 @@ token-guarded `/moderation/evidence/:token` page), stored under the private
 `moderation_evidence/` tree and shown to admins via the authorizing
 `/admin/moderation/:id/evidence` route.
 
+**A takedown also leaves the building** (issue #1102). Freezing a post revokes
+the copies on other Fediverse servers (`Vutuv.Fediverse.revoke_post/1`) and
+lifting the freeze publishes it again, so a freeze is not a local fiction while
+the post stays up on Mastodon; a **permanent** account removal — `remove_owner/4`
+with `:deactivate`, and the strike ladder's third strike — broadcasts the actor
+`Delete` the way a real account deletion does. Everything temporary deliberately
+sends nothing: a week's suspension or a profile freeze must never tell the
+network an account is gone, and one report must not fan a `Delete` out over every
+post a member ever published. The reasoning, the addressing and the limits are in
+`fediverse.md`; remote deletion is advisory by protocol, so this asks, it does not
+promise.
+
 Every case carries an **audit log** (`moderation_events`: reports, freezes,
 severances, owner self-service, escalations, rulings, strikes, `owner_removed`)
 rendered as the History timeline on the admin case page, and the urgent admin

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -689,6 +689,13 @@ defmodule Vutuv.Accounts do
     # a member who never federated — nothing to send).
     actor_delete = Vutuv.Fediverse.prepare_actor_delete(user)
 
+    # The per-post delivery records (issue #1102) carry no foreign key into
+    # `posts` on purpose — a revocation has to outlive the post row — so the
+    # cascade below cannot clear them and this deletion says so explicitly. The
+    # copies themselves are covered by the actor `Delete`, which asks remote
+    # servers to purge the actor *and* its posts.
+    Vutuv.Fediverse.drop_post_deliveries(user)
+
     # Kill every device's live sockets before the cascade removes the session
     # rows (after which their per-session topics are unknowable), so open tabs
     # drop the logged-in chrome at once instead of on their next reload.

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -18,6 +18,13 @@ defmodule Vutuv.Fediverse do
     * deliveries — a DB-backed outbound queue (`Vutuv.Fediverse.Delivery`)
       drained by `Vutuv.Fediverse.Deliverer` with signed POSTs
       (`Vutuv.Fediverse.HttpSignature`), mirroring the webhooks queue.
+    * revocations — every takedown asks the other servers to drop their copy:
+      `revoke_post/1` for a post (from the owner's own delete *and* the
+      moderation freezer), `revoke_actor/1` for a permanently removed account,
+      and a `Flag` to the origin when a reply from another network is reported.
+      `Vutuv.Fediverse.PostDelivery` records where each copy went and under which
+      id, so a `Delete` is addressed rather than broadcast; a takedown that never
+      arrives lands in `Vutuv.Fediverse.DeliveryFailure`.
 
   Everything sits behind the global `:fediverse_enabled` switch
   (FEDIVERSE_ENABLED, for installations that must not call out — intranets)
@@ -36,12 +43,14 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.BlockedInstance
   alias Vutuv.Fediverse.Deliverer
   alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Fediverse.DeliveryFailure
   alias Vutuv.Fediverse.Follower
   alias Vutuv.Fediverse.FollowerPrune
   alias Vutuv.Fediverse.HttpSignature
   alias Vutuv.Fediverse.Keys
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.NoteEvent
+  alias Vutuv.Fediverse.PostDelivery
   alias Vutuv.Fediverse.Reaction
   alias Vutuv.Pages
   alias Vutuv.Posts
@@ -97,6 +106,23 @@ defmodule Vutuv.Fediverse do
 
   defp suspended?(%User{suspended_until: until}),
     do: NaiveDateTime.compare(until, NaiveDateTime.utc_now()) == :gt
+
+  @doc """
+  Whether a **revocation** for this member may still leave the building: the
+  switch is on and they have an actor, i.e. they took part at some point, so
+  copies of their posts may be sitting on other servers.
+
+  Deliberately **not** `federated?/1` (issue #1102). Every takedown path runs at
+  the exact moment the post or the account is hidden here — frozen, suspended,
+  deactivated — which is precisely when `federated?/1` turns false. Gating a
+  revocation on it would mean the only activities that never go out are the ones
+  asking other servers to remove something.
+
+  For the same reason it ignores `moved?/1`: a member who redirected their
+  Fediverse followers elsewhere stopped *publishing*, but the servers that
+  followed them still hold everything published before the move.
+  """
+  def ever_federated?(%User{} = user), do: enabled?() and get_actor(user) != nil
 
   ## Actors
 
@@ -412,7 +438,8 @@ defmodule Vutuv.Fediverse do
   how many members federate, how many remote followers they have between them,
   the outbound delivery-queue depth and how many of those rows are stuck
   (carry a `last_error`), so a broken delivery run is visible at a glance, plus
-  how many remote servers the operator has shut out (issue #1067).
+  how many remote servers the operator has shut out (issue #1067) and how many
+  takedowns gave up without arriving (issue #1102).
   """
   def stats do
     %{
@@ -421,7 +448,8 @@ defmodule Vutuv.Fediverse do
       queue_depth: Repo.aggregate(Delivery, :count),
       stuck_deliveries:
         Repo.aggregate(from(d in Delivery, where: not is_nil(d.last_error)), :count),
-      blocked_instances: blocked_instance_count()
+      blocked_instances: blocked_instance_count(),
+      failed_takedowns: delivery_failure_count()
     }
   end
 
@@ -701,8 +729,9 @@ defmodule Vutuv.Fediverse do
 
   @doc """
   Deletes everything stored from `host`: its remote followers, the replies its
-  members wrote under vutuv posts, and the outbound deliveries still queued for
-  it. Returns `%{followers: n, notes: n, deliveries: n}`.
+  members wrote under vutuv posts, the outbound deliveries still queued for it and
+  the records of what was delivered there.
+  Returns `%{followers: n, notes: n, deliveries: n, post_deliveries: n}`.
   """
   def purge_instance(host) when is_binary(host) do
     {followers, _} =
@@ -716,7 +745,17 @@ defmodule Vutuv.Fediverse do
     {deliveries, _} =
       Repo.delete_all(from(d in Delivery, where: uri_host(d.inbox_uri) == ^host))
 
-    %{followers: followers, notes: notes, deliveries: deliveries}
+    # A blocked server is not talked to again, so the record of what it received
+    # (issue #1102) would only ever address a revocation nobody will deliver.
+    {post_deliveries, _} =
+      Repo.delete_all(from(d in PostDelivery, where: uri_host(d.inbox_uri) == ^host))
+
+    %{
+      followers: followers,
+      notes: notes,
+      deliveries: deliveries,
+      post_deliveries: post_deliveries
+    }
   end
 
   @doc """
@@ -1206,9 +1245,16 @@ defmodule Vutuv.Fediverse do
   @doc """
   The member takes a reply off their own post. Deletes it at once and records
   the takedown in `Vutuv.Fediverse.NoteEvent`.
+
+  Nothing leaves the building: removing a reply from your own post is a decision
+  about *your* page, not an accusation, so the origin server is not told. Saying
+  "this is not appropriate" is `report_note/2`, which does tell them.
   """
-  def remove_note(note_id, %User{} = actor),
-    do: take_down_note(note_id, actor, "removed_by_member", &note_owner?/3)
+  def remove_note(note_id, %User{} = actor) do
+    with {:ok, _note, _author_id} <-
+           take_down_note(note_id, actor, "removed_by_member", &note_owner?/3),
+         do: :ok
+  end
 
   @doc """
   Somebody marks a reply as not appropriate. **Deletes it immediately** — there
@@ -1216,9 +1262,16 @@ defmodule Vutuv.Fediverse do
   a cache of something that still exists at its origin, so removing it costs the
   author nothing they did not keep.
 
+  And because it still exists there, the report also goes **out**: a `Flag` to the
+  origin server's inbox (issue #1102), which is how these networks file a report
+  with each other. Deleting our cached copy alone left the original up with its
+  moderators never learning anybody had objected.
+
   Rate limited per reporter (`report_limit/0` a day), so quietly wiping every
-  answer under somebody's post is not free. A private reply can only be reported
-  by the member it was addressed to, since nobody else may even see it.
+  answer under somebody's post is not free — and since the `Flag` only rides a
+  successful takedown, that same cap bounds how many reports one member can push
+  onto other servers. A private reply can only be reported by the member it was
+  addressed to, since nobody else may even see it.
   """
   def report_note(note_id, %User{} = reporter) do
     case RateLimiter.hit(
@@ -1226,8 +1279,43 @@ defmodule Vutuv.Fediverse do
            @note_report_limit,
            :timer.hours(24)
          ) do
-      :ok -> take_down_note(note_id, reporter, "reported", &note_visible?/3)
-      _ -> {:error, :rate_limited}
+      :ok ->
+        with {:ok, note, author_id} <-
+               take_down_note(note_id, reporter, "reported", &note_visible?/3) do
+          flag_note(note, author_id, reporter)
+          :ok
+        end
+
+      _ ->
+        {:error, :rate_limited}
+    end
+  end
+
+  # Files the report with the server the reply came from (issue #1102).
+  #
+  # Signed by the member whose post the reply sat under, never by the reporter.
+  # A `Flag` is a signed statement, so it has to come from an actor we serve a
+  # key for, and vutuv has no installation-wide actor to file from (Mastodon uses
+  # its instance actor for exactly this). The thread's owner is the party that
+  # server already knows in this conversation, and using them keeps a bystander
+  # reporter out of a message that travels to strangers: nothing in the `Flag`
+  # names who reported it, and no content rides along — the reported object's own
+  # id is the whole reference.
+  #
+  # Skipped when the note carried no answerable inbox (`own_inbox/1` refuses an
+  # inbox on a host the actor does not control), when the post's author never
+  # federated (no key to sign with), or when the operator has blocked that server
+  # — a block is both ears and mouth shut.
+  defp flag_note(%Note{} = note, author_id, %User{} = reporter) do
+    with inbox when is_binary(inbox) <- note.inbox_uri,
+         %User{} = author <- Repo.get(User, author_id),
+         true <- ever_federated?(author),
+         false <- instance_blocked?(note.actor_uri) do
+      enqueue(author, [inbox], Docs.flag_activity(author, note.object_uri, note.actor_uri))
+      log_note_event(note, author_id, reporter, "flagged")
+      :ok
+    else
+      _ -> :skip
     end
   end
 
@@ -1490,7 +1578,10 @@ defmodule Vutuv.Fediverse do
           Repo.delete(note)
           log_note_event(note, author_id, actor, action)
           Posts.broadcast_post_counters(note.post_id)
-          :ok
+          # The deleted row is handed back so the caller can still address the
+          # origin server (`flag_note/3`) — after this it is the only copy of
+          # that address left.
+          {:ok, note, author_id}
         else
           {:error, :not_allowed}
         end
@@ -1777,22 +1868,9 @@ defmodule Vutuv.Fediverse do
   """
   def federate_post_update(%Post{} = post) do
     if Posts.restricted?(post) do
-      federate_post_delete(post)
+      revoke_post(post)
     else
       maybe_federate(post, &Docs.update_activity/2, "post_update")
-    end
-  end
-
-  @doc "A deleted post -> Delete(Tombstone) (best effort)."
-  def federate_post_delete(%Post{id: post_id, user_id: user_id} = post) do
-    with true <- enabled?(),
-         %User{} = user <- Repo.get(User, user_id),
-         true <- federated?(user),
-         false <- moved?(user),
-         [_ | _] = inboxes <- recipients(user, post) do
-      enqueue(user, inboxes, Docs.delete_activity(post_id, user))
-    else
-      _ -> :skip
     end
   end
 
@@ -1804,10 +1882,187 @@ defmodule Vutuv.Fediverse do
          false <- Posts.restricted?(post),
          post = Repo.preload(post, Docs.note_preloads()),
          [_ | _] = inboxes <- recipients(user, post) do
+      # Remember where this copy went and under which id, so the takedown can be
+      # addressed rather than broadcast at whoever follows today (issue #1102).
+      record_post_deliveries(user, post, inboxes)
       enqueue(user, inboxes, builder.(post, user), hold_opts(post, kind))
     else
       _ -> :skip
     end
+  end
+
+  ## Revocation: taking something back off the other servers (issue #1102)
+
+  @doc """
+  **The one revocation chokepoint.** Asks every server that received this post
+  to drop its copy (`Delete(Tombstone)`), best effort.
+
+  Called from every takedown path, so "taken down here" can never mean "still
+  published there" for want of a call site: the owner's own delete
+  (`Vutuv.Posts.delete_post/1`), an edit that closes the audience
+  (`federate_post_update/1`), and the moderation freezer
+  (`Vutuv.Moderation.freeze_content/1` — a trusted report, or the second one that
+  upgrades a merely flagged case).
+
+  **Addressed, not broadcast.** The recorded deliveries
+  (`Vutuv.Fediverse.PostDelivery`) name the inboxes that actually received the
+  post and the Note id it was published under, so the `Delete` reaches a server
+  that has since unfollowed and still matches after a username change. A post
+  with no records — published before those were kept — falls back to the old
+  behaviour: the current follower inboxes and the current Note id, which is
+  better than sending nothing.
+
+  Gated on `ever_federated?/1`, not `federated?/1`, and with no `moved?/1` skip:
+  see that function for why a takedown must not be blocked by the very state the
+  takedown creates. Returns `:ok` or `:skip`.
+  """
+  def revoke_post(%Post{} = post) do
+    with true <- enabled?(),
+         %User{} = user <- Repo.get(User, post.user_id),
+         true <- ever_federated?(user),
+         [_ | _] = targets <- revocation_targets(user, post) do
+      Enum.each(targets, fn {object_uri, inboxes} ->
+        enqueue(user, inboxes, Docs.tombstone_activity(object_uri, user))
+      end)
+
+      # The addresses have done their job; a copy that comes back re-records
+      # them (`republish_post/1`).
+      forget_post_deliveries(post.id)
+      :ok
+    else
+      _ -> :skip
+    end
+  end
+
+  @doc """
+  Publishes a post again after a **reversible** takedown was lifted — the other
+  half of revoking on a freeze (issue #1102).
+
+  A freeze hides the post from everyone but its owner, so the copies elsewhere
+  have to go too or the freeze is a local fiction; and a rejected report has to
+  put the post back where it was, here and there. It is a fresh `Create`, not an
+  `Update`: the remote servers were told to delete the object, so there is
+  nothing left there for an `Update` to change.
+
+  Reads the post again rather than trusting the struct handed in: the callers
+  clear `frozen_at` with an `update_all`, so their copy still looks frozen and
+  the publish would gate itself away.
+  """
+  def republish_post(%Post{id: post_id}) do
+    case Posts.get_post(post_id) do
+      %Post{} = post -> maybe_federate(post, &Docs.create_activity/2, "post_create")
+      _ -> :skip
+    end
+  end
+
+  @doc """
+  Tells the servers that follow this member their actor is gone
+  (`Delete { object: <actor-url> }`) — the account-level revocation, for a
+  **permanent** moderation removal: an admin's `remove_owner :deactivate` and the
+  strike ladder's third strike (`Vutuv.Moderation`).
+
+  Deliberately a broadcast and not a status code. `410 Gone` on the actor
+  endpoints stays reserved for the member's own opt-out (`departed?/1`), and every
+  *temporary* hiding — a freeze, a week's suspension — keeps answering `404` and
+  sends nothing at all: a three-day suspension must never tell the network to
+  delete the account. What makes these two paths different is that they do not
+  come back.
+
+  Unlike `prepare_actor_delete/1` this enqueues an ordinary delivery, because
+  moderation leaves the account, its actor key and its follower rows in place —
+  so the takedown gets the full retry ladder and, if it never arrives, the
+  give-up ledger (`recent_delivery_failures/1`).
+  """
+  def revoke_actor(%User{} = user) do
+    with true <- enabled?(),
+         true <- ever_federated?(user),
+         [_ | _] = inboxes <- delivery_inboxes(user) do
+      enqueue(user, inboxes, Docs.actor_delete_activity(user))
+    else
+      _ -> :skip
+    end
+  end
+
+  @doc """
+  Drops every recorded post delivery for a member — called by the account
+  deletion chokepoint (`Vutuv.Accounts.delete_user/1`).
+
+  The rows carry no foreign key into `posts` (a revocation has to outlive the post
+  row), so the cascade cannot clear them and the deletion says so explicitly. The
+  member's actor `Delete` covers the copies themselves: it asks remote servers to
+  purge the actor **and** its posts, which is why nothing is revoked per post here.
+  """
+  def drop_post_deliveries(%User{id: user_id}) do
+    {count, _} = Repo.delete_all(from(d in PostDelivery, where: d.user_id == ^user_id))
+    count
+  end
+
+  @doc """
+  The takedowns that never arrived, newest first — a `Delete` or `Flag` dropped
+  after the last attempt. The operator's list on `/admin/fediverse`, so an
+  incomplete takedown is not just a line in the log.
+  """
+  def recent_delivery_failures(limit \\ 25) do
+    Repo.all(from(f in DeliveryFailure, order_by: [desc: f.id], limit: ^limit))
+  end
+
+  @doc "How many takedowns gave up without arriving."
+  def delivery_failure_count, do: Repo.aggregate(DeliveryFailure, :count)
+
+  # Where a post's copies are, as `[{published_note_id, inboxes}]`. Grouped by
+  # the id rather than flattened, because an `Update` sent after a rename
+  # published a second id and both copies have to be named.
+  defp revocation_targets(%User{} = user, %Post{} = post) do
+    case recorded_post_deliveries(post.id) do
+      [] -> fallback_targets(user, post)
+      recorded -> recorded
+    end
+  end
+
+  defp recorded_post_deliveries(post_id) do
+    from(d in PostDelivery,
+      where: d.post_id == ^post_id,
+      select: {d.object_uri, d.inbox_uri}
+    )
+    |> Repo.all()
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+    |> Enum.map(fn {object_uri, inboxes} -> {object_uri, Enum.uniq(inboxes)} end)
+  end
+
+  # Nothing recorded: a post from before the records existed. The current
+  # followers and the current Note id are a worse address than the real one, and
+  # a much better one than silence.
+  defp fallback_targets(%User{} = user, %Post{} = post) do
+    case recipients(user, post) do
+      [] -> []
+      inboxes -> [{Docs.note_url(user, post.id), inboxes}]
+    end
+  end
+
+  defp record_post_deliveries(%User{} = user, %Post{} = post, inboxes) do
+    object_uri = Docs.note_url(user, post.id)
+    stamp = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+
+    rows =
+      Enum.map(inboxes, fn inbox ->
+        %{
+          id: UUIDv7.generate(),
+          post_id: post.id,
+          user_id: user.id,
+          inbox_uri: inbox,
+          object_uri: object_uri,
+          inserted_at: stamp
+        }
+      end)
+
+    Repo.insert_all(PostDelivery, rows,
+      on_conflict: :nothing,
+      conflict_target: [:post_id, :inbox_uri, :object_uri]
+    )
+  end
+
+  defp forget_post_deliveries(post_id) do
+    Repo.delete_all(from(d in PostDelivery, where: d.post_id == ^post_id))
   end
 
   ## Holding a post back until its pictures are vetted (issue #1070)
@@ -2017,10 +2272,15 @@ defmodule Vutuv.Fediverse do
   Capturing then sending is the whole trick: the delivery queue keys on
   `user_id`, so a queued row would cascade away with the member; holding the
   key and inboxes in memory lets the signed POST outlive them.
+
+  Gated on `ever_federated?/1` (issue #1102). It used to require `federated?/1`,
+  which is false for a frozen, suspended or deactivated account — so deleting
+  exactly the accounts moderation had already hidden broadcast nothing, and their
+  posts stayed up everywhere.
   """
   def prepare_actor_delete(%User{} = user) do
     with true <- enabled?(),
-         true <- federated?(user),
+         true <- ever_federated?(user),
          %Actor{} = actor <- get_actor(user),
          [_ | _] = inboxes <- delivery_inboxes(user) do
       %{
@@ -2205,6 +2465,7 @@ defmodule Vutuv.Fediverse do
 
   defp fail(%Delivery{attempts: attempts} = delivery, error) when attempts + 1 >= @max_attempts do
     Logger.info("fediverse delivery to #{delivery.inbox_uri} gave up: #{error}")
+    record_give_up(delivery, error)
     Repo.delete(delivery)
   end
 
@@ -2222,6 +2483,36 @@ defmodule Vutuv.Fediverse do
   defp backoff_at(attempts) do
     DateTime.add(DateTime.utc_now(:second), trunc(:math.pow(2, attempts)) * 60)
   end
+
+  # The activities whose give-up an operator has to be able to see (issue #1102).
+  # A `Create` that never lands means one post did not travel; a `Delete` that
+  # never lands means a copy we promised to have asked about is still published,
+  # and a `Flag` that never lands means a report nobody received. Recording every
+  # type instead would drown that signal in ordinary delivery noise.
+  @revocation_types ~w(Delete Flag)
+
+  defp record_give_up(%Delivery{} = delivery, error) do
+    with {:ok, %{"type" => type} = activity} when type in @revocation_types <-
+           Jason.decode(delivery.activity_json) do
+      Repo.insert(%DeliveryFailure{
+        activity_type: type,
+        host: BlockedInstance.normalize_host(delivery.inbox_uri) || "unknown",
+        object_uri: give_up_object(activity),
+        user_id: delivery.user_id,
+        attempts: @max_attempts,
+        last_error: String.slice(error, 0, 255)
+      })
+    end
+
+    :ok
+  end
+
+  # What the activity was about: a Tombstone/actor object, a bare id, or the
+  # first entry of a Flag's object list.
+  defp give_up_object(%{"object" => %{"id" => id}}) when is_binary(id), do: id
+  defp give_up_object(%{"object" => id}) when is_binary(id), do: id
+  defp give_up_object(%{"object" => [id | _]}) when is_binary(id), do: id
+  defp give_up_object(_activity), do: nil
 
   ## Remote actors
 

--- a/lib/vutuv/fediverse/delivery_failure.ex
+++ b/lib/vutuv/fediverse/delivery_failure.ex
@@ -1,0 +1,36 @@
+defmodule Vutuv.Fediverse.DeliveryFailure do
+  @moduledoc """
+  One takedown that never arrived (issue #1102): a `Delete` or a `Flag` that
+  exhausted its eight delivery attempts and was dropped from the queue.
+
+  Every outbound activity is best effort — remote deletion is advisory by
+  protocol — but there is a difference in kind between the two failures. A
+  `Create` that never lands means one post did not travel; a `Delete` that never
+  lands means a copy we told a member we had asked to remove is still published
+  on somebody else's server. That is a fact an operator has to be able to see, so
+  the give-up is written here and shown on `/admin/fediverse` instead of only
+  passing through the log.
+
+  Only the withdrawing activity types are recorded (`Vutuv.Fediverse` keeps the
+  list); everything else would drown the signal the same way `NoteEvent` refuses
+  to record automatic deletions.
+
+  `user_id` is a plain value, not an association, like the other audit ledgers:
+  the row must stay readable after the account it names is gone. `object_uri` is
+  our own public Note (or actor) URL, so the row carries no content and no
+  third-party identifier.
+  """
+
+  use VutuvWeb, :model
+
+  schema "fediverse_delivery_failures" do
+    field(:activity_type, :string)
+    field(:host, :string)
+    field(:object_uri, :string)
+    field(:user_id, :binary_id)
+    field(:attempts, :integer)
+    field(:last_error, :string)
+
+    timestamps(updated_at: false)
+  end
+end

--- a/lib/vutuv/fediverse/note_event.ex
+++ b/lib/vutuv/fediverse/note_event.ex
@@ -5,6 +5,10 @@ defmodule Vutuv.Fediverse.NoteEvent do
   with no case workflow, because the note is a cache of something that still
   exists at its origin.
 
+  A report also writes a second `"flagged"` row when the report actually reached
+  that origin as an ActivityPub `Flag` (issue #1102), so the operator can tell a
+  takedown that only happened here from one the other server was told about.
+
   The row exists so the operator can answer one question: **is this one troll,
   or is this server the problem?** That is the decision the blocklist at
   `/admin/fediverse` acts on, and it needs the host, a way to tell repeat actors
@@ -31,7 +35,7 @@ defmodule Vutuv.Fediverse.NoteEvent do
 
   use VutuvWeb, :model
 
-  @actions ~w(reported removed_by_member)
+  @actions ~w(reported removed_by_member flagged)
 
   @doc "The closed set of `action` values this ledger records."
   def actions, do: @actions

--- a/lib/vutuv/fediverse/post_delivery.ex
+++ b/lib/vutuv/fediverse/post_delivery.ex
@@ -1,0 +1,40 @@
+defmodule Vutuv.Fediverse.PostDelivery do
+  @moduledoc """
+  One record of "this post went to that inbox, under this Note id" (issue #1102)
+  — the address book a **revocation** needs.
+
+  Written when a `Create`/`Update` is enqueued, read when the post is taken
+  down. It answers the two questions a `Delete(Tombstone)` cannot answer on its
+  own:
+
+    * **Where.** Delivery targets are read from the follower table, i.e. whoever
+      follows the member *now*. A server that received the post and has since
+      unfollowed would never hear about the takedown, so the copy would stay up
+      forever. The recorded inboxes are the set that actually got it.
+    * **What.** A Note id is `/<username>/posts/<id>`, built from the username at
+      send time. After a rename (issue #1086) an id built from the *current*
+      username no longer matches what the remote server stored, so a delivered
+      `Delete` would match nothing. The id is therefore recorded verbatim
+      alongside the inbox.
+
+  Deliberately **no foreign key** into `posts`: the revocation runs after the
+  post row is gone (`Vutuv.Posts.delete_post/1` federates the `Delete` after the
+  commit), so a cascade would erase these rows moments before they are needed.
+  They are cleared explicitly instead — by the revocation that used them
+  (`Vutuv.Fediverse.revoke_post/1`), by account deletion
+  (`drop_post_deliveries/1`) and by an instance block (`purge_instance/1`).
+
+  Nothing here is content: an inbox URL, a public Note URL, and who published it.
+  """
+
+  use VutuvWeb, :model
+
+  schema "fediverse_post_deliveries" do
+    field(:post_id, :binary_id)
+    field(:user_id, :binary_id)
+    field(:inbox_uri, :string)
+    field(:object_uri, :string)
+
+    timestamps(updated_at: false)
+  end
+end

--- a/lib/vutuv/moderation.ex
+++ b/lib/vutuv/moderation.ex
@@ -24,6 +24,14 @@ defmodule Vutuv.Moderation do
   consequences on the user row (`suspended_until`, `deactivated_at`); the
   visibility chokepoints (`Vutuv.Posts.scope_visible/2`, `Vutuv.Chat`,
   `Vutuv.Search`, `VutuvWeb.Plug.EnsureActivated`) read them directly.
+
+  A takedown here also leaves the building (issue #1102): freezing a post revokes
+  the copies on other Fediverse servers (`Vutuv.Fediverse.revoke_post/1`) and
+  lifting the freeze publishes it again, while a **permanent** account removal —
+  `remove_owner/4` with `:deactivate`, and the strike ladder's third strike —
+  broadcasts the actor `Delete` (`Vutuv.Fediverse.revoke_actor/1`). Everything
+  temporary deliberately sends nothing: a week's suspension or a profile freeze
+  must never tell the network an account is gone.
   """
 
   import Ecto.Query
@@ -31,6 +39,7 @@ defmodule Vutuv.Moderation do
   alias Vutuv.Accounts
   alias Vutuv.Accounts.User
   alias Vutuv.Chat.{Message, Participant}
+  alias Vutuv.Fediverse
   alias Vutuv.Jobs.JobPosting
 
   alias Vutuv.Moderation.{
@@ -778,8 +787,14 @@ defmodule Vutuv.Moderation do
 
       {:ok, updated} ->
         now = NaiveDateTime.utc_now(:second)
-        set_user_moderation!(case_record.owner_id, deactivated_at: now, moderation_reason: reason)
+        owner = Repo.get!(User, case_record.owner_id)
+        set_user_moderation!(owner.id, deactivated_at: now, moderation_reason: reason)
         log(updated, admin, "owner_removed", %{"action" => "deactivate", "reason" => reason})
+        # A removal that does not come back gets the same actor `Delete` a real
+        # account deletion sends (issue #1102), or the member keeps federating
+        # from every server that follows them. `410 Gone` stays reserved for the
+        # member's own opt-out, so this is a broadcast, not a status code.
+        Fediverse.revoke_actor(owner)
         {:ok, updated}
     end
   end
@@ -842,6 +857,10 @@ defmodule Vutuv.Moderation do
   defp apply_ladder(user, _level, now) do
     set_user_moderation!(user.id, deactivated_at: now)
     Notifier.deactivation(user)
+    # The third strike is permanent, so it federates like the admin's own
+    # removal above (issue #1102). The week's suspension one rung down does not:
+    # a temporary hiding must never tell the network an account is gone.
+    Fediverse.revoke_actor(user)
   end
 
   ## Relationship severance
@@ -1383,10 +1402,24 @@ defmodule Vutuv.Moderation do
     # Open chat threads drop the message live; posts need no push (the read
     # paths filter on the next render).
     if match?(%Message{}, content), do: Vutuv.Chat.broadcast_message_frozen(content)
+    # A frozen post is invisible to everyone but its owner here, so the copies on
+    # other servers have to be asked to go too, or the freeze is a local fiction
+    # (issue #1102). Best effort and reversible: lifting the freeze publishes it
+    # again. A frozen *profile* deliberately sends nothing — see the freeze note
+    # in `Vutuv.Fediverse.revoke_actor/1`: a temporary hiding must never tell the
+    # network an account is gone, and one report must not fan a Delete out over
+    # every post the member ever published.
+    if match?(%Post{}, content), do: Fediverse.revoke_post(content)
     :ok
   end
 
-  defp unfreeze_content(content), do: set_frozen_at(content, nil)
+  defp unfreeze_content(content) do
+    set_frozen_at(content, nil)
+    # The other half of revoking on a freeze: a rejected report (or the owner's
+    # own edit) has to put the post back on the other servers, not only here.
+    if match?(%Post{}, content), do: Fediverse.republish_post(content)
+    :ok
+  end
 
   defp set_frozen_at(%Post{id: id}, value) do
     Repo.update_all(from(p in Post, where: p.id == ^id), set: [frozen_at: value])

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -362,8 +362,9 @@ defmodule Vutuv.Posts do
         if parent_id, do: broadcast_reply_count(parent_id)
         # Deleting reported content settles its moderation case.
         Vutuv.Moderation.content_deleted(deleted)
-        # Remote copies get a Delete(Tombstone) — best effort by protocol.
-        Vutuv.Fediverse.federate_post_delete(deleted)
+        # Remote copies get a Delete(Tombstone) — best effort by protocol. The
+        # one revocation chokepoint, shared with the moderation takedowns.
+        Vutuv.Fediverse.revoke_post(deleted)
         {:ok, deleted}
 
       {:error, _} = error ->

--- a/lib/vutuv_web/controllers/admin/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/admin/fediverse_controller.ex
@@ -29,6 +29,10 @@ defmodule VutuvWeb.Admin.FediverseController do
       # us the most" question, now that text arrives too.
       note_hosts: Map.new(Fediverse.note_hosts(), &{&1.host, &1.notes}),
       note_events: Fediverse.recent_note_events(),
+      # Takedowns that gave up without arriving (issue #1102). The one delivery
+      # failure that is not just noise: a copy we asked to have removed is still
+      # published somewhere, and nobody would know from the log alone.
+      failed_takedowns: Fediverse.recent_delivery_failures(),
       stats: Fediverse.stats(),
       caps: Fediverse.inbound_caps(),
       page_title: gettext("Fediverse")

--- a/lib/vutuv_web/fediverse/docs.ex
+++ b/lib/vutuv_web/fediverse/docs.ex
@@ -195,13 +195,49 @@ defmodule VutuvWeb.Fediverse.Docs do
   end
 
   @doc "Delete(Tombstone): a removed post (or one whose audience closed)."
-  def delete_activity(post_id, user) do
-    note_url = note_url(user, post_id)
+  def delete_activity(post_id, user), do: tombstone_activity(note_url(user, post_id), user)
 
+  @doc """
+  Delete(Tombstone) for an **explicit** Note id (issue #1102).
+
+  A revocation names the id the receiving server actually stored, which is not
+  always the one `note_url/2` builds today: that id carries the username, so
+  after a rename (issue #1086) a Tombstone built from the current username
+  matches nothing on the other end. `Vutuv.Fediverse` keeps the published id per
+  delivery and passes it here.
+  """
+  def tombstone_activity(note_url, user) when is_binary(note_url) do
     envelope(user, "Delete", note_url <> "#delete", %{
       "id" => note_url,
       "type" => "Tombstone"
     })
+  end
+
+  @doc """
+  Flag: a reply that came from another network was reported here, so the
+  moderators of its home server hear about it (issue #1102). Mastodon files an
+  incoming `Flag` as a report.
+
+  `object` is a **list** — the shape those servers send and expect — naming the
+  reported note and the account that wrote it. Nothing else travels: no content,
+  no category, and above all not who reported it.
+
+  The `content` line is a fixed English sentence rather than a `gettext/1` one on
+  purpose. It is read by a stranger's moderation team, not by a vutuv member, so
+  it must not depend on the reporter's browser language; and a fixed sentence
+  cannot leak anything a member typed.
+  """
+  def flag_activity(user, object_uri, actor_uri) do
+    %{
+      "@context" => "https://www.w3.org/ns/activitystreams",
+      "id" => actor_url(user) <> "#flags/" <> Vutuv.UUIDv7.generate(),
+      "type" => "Flag",
+      "actor" => actor_url(user),
+      "object" => [object_uri, actor_uri],
+      "content" =>
+        "Reported by a member of #{VutuvWeb.Endpoint.host()} as inappropriate. " <>
+          "The copy stored there has been removed."
+    }
   end
 
   @doc """

--- a/lib/vutuv_web/templates/admin/fediverse/index.html.heex
+++ b/lib/vutuv_web/templates/admin/fediverse/index.html.heex
@@ -191,3 +191,52 @@ block) are not listed; they would drown this and go to the log file instead. --%
     <% end %>
   </section>
 </div>
+
+<%!-- Takedowns that never arrived (issue #1102). Every outbound activity is best
+effort, but there is a difference in kind: a post that did not travel is one post,
+while a Delete that did not travel means a copy somebody asked us to withdraw is
+still published on another server. That has to be visible, not only logged. --%>
+<div class="card-list">
+  <section class="card" id="failed-takedowns">
+    <h2 class="card__label">{gettext("Takedowns that did not get through")}</h2>
+    <%= if @failed_takedowns == [] do %>
+      <p class="card__empty">
+        {gettext("Every withdrawal request so far has been delivered.")}
+      </p>
+    <% else %>
+      <p class="editform__hint">
+        {gettext(
+          "These withdrawal requests were retried eight times over about four hours and then dropped. We cannot make another server delete anything, but a server showing up here repeatedly is either broken or ignoring us, and can be blocked above."
+        )}
+      </p>
+      <div class="card__tablewrap">
+        <table>
+          <thead>
+            <tr>
+              <th>{gettext("When")}</th>
+              <th>{gettext("What")}</th>
+              <th>{gettext("Server")}</th>
+              <th>{gettext("Reason given")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              :for={failure <- @failed_takedowns}
+              data-failed-takedown={failure.activity_type}
+            >
+              <td><.local_time at={failure.inserted_at} /></td>
+              <td class="breakwrap">
+                {takedown_label(failure)}
+                <span :if={failure.object_uri} class="editform__hint breakwrap">
+                  {failure.object_uri}
+                </span>
+              </td>
+              <td class="breakwrap">{failure.host}</td>
+              <td class="breakwrap">{failure.last_error || gettext("No answer")}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/lib/vutuv_web/views/admin/fediverse_html.ex
+++ b/lib/vutuv_web/views/admin/fediverse_html.ex
@@ -13,5 +13,14 @@ defmodule VutuvWeb.Admin.FediverseHTML do
   """
   def note_event_label(%{action: "reported"}), do: gettext("Reported as not appropriate")
   def note_event_label(%{action: "removed_by_member"}), do: gettext("Removed by the member")
+  def note_event_label(%{action: "flagged"}), do: gettext("Reported to the origin server")
   def note_event_label(_event), do: gettext("Taken down")
+
+  @doc """
+  What an undelivered takedown was trying to do, in words (issue #1102). The
+  stored types are the closed allowlist `Vutuv.Fediverse` records give-ups for.
+  """
+  def takedown_label(%{activity_type: "Delete"}), do: gettext("Asked to delete a copy")
+  def takedown_label(%{activity_type: "Flag"}), do: gettext("Passed a report on")
+  def takedown_label(_failure), do: gettext("Withdrawal request")
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.173.0",
+      version: "7.174.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -154,7 +154,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:1413
+#: lib/vutuv_web/components/post_components.ex:1417
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -195,7 +195,7 @@ msgid "Disable"
 msgstr "Inaktivieren"
 
 #: lib/vutuv_web/live/cv_live.ex:439
-#: lib/vutuv_web/live/post_live/composer.ex:1530
+#: lib/vutuv_web/live/post_live/composer.ex:1543
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:303
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -203,7 +203,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:1378
+#: lib/vutuv_web/components/post_components.ex:1382
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -493,7 +493,7 @@ msgstr "Name"
 msgid "New"
 msgstr "Neu"
 
-#: lib/vutuv/notifications/emailer.ex:280
+#: lib/vutuv/notifications/emailer.ex:281
 #, elixir-autogen
 msgid "New message from @%{slug} on vutuv"
 msgstr "Neue Nachricht von @%{slug} auf vutuv"
@@ -614,7 +614,7 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1780
+#: lib/vutuv_web/live/post_live/composer.ex:1793
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -624,7 +624,7 @@ msgstr "Öffentlich"
 
 #: lib/vutuv_web/components/ui.ex:2863
 #: lib/vutuv_web/live/organization_live/edit.ex:339
-#: lib/vutuv_web/live/post_live/composer.ex:1789
+#: lib/vutuv_web/live/post_live/composer.ex:1802
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:98
@@ -1695,13 +1695,13 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/post_components.ex:1855
+#: lib/vutuv_web/components/post_components.ex:1859
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1292
-#: lib/vutuv_web/live/post_live/composer.ex:1293
-#: lib/vutuv_web/live/post_live/composer.ex:2225
+#: lib/vutuv_web/live/post_live/composer.ex:1296
+#: lib/vutuv_web/live/post_live/composer.ex:1297
+#: lib/vutuv_web/live/post_live/composer.ex:2241
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1797,7 +1797,7 @@ msgstr "Ausloggen"
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
 #: lib/vutuv_web/live/admin/user_live.ex:168
-#: lib/vutuv_web/live/message_live/index.ex:439
+#: lib/vutuv_web/live/message_live/index.ex:455
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:55
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
@@ -1812,7 +1812,7 @@ msgid "Message"
 msgstr "Nachricht"
 
 #: lib/vutuv_web/live/message_live/index.ex:45
-#: lib/vutuv_web/live/message_live/index.ex:496
+#: lib/vutuv_web/live/message_live/index.ex:512
 #: lib/vutuv_web/live/shell_live.ex:497
 #: lib/vutuv_web/live/shell_live.ex:639
 #: lib/vutuv_web/templates/layout/app.html.heex:117
@@ -1868,7 +1868,7 @@ msgid "Pardon us! Something went wrong."
 msgstr "Entschuldigung! Etwas ist schiefgelaufen."
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:726
+#: lib/vutuv_web/live/message_live/index.ex:742
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1945,8 +1945,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
 
-#: lib/vutuv_web/live/message_live/index.ex:715
-#: lib/vutuv_web/live/message_live/index.ex:716
+#: lib/vutuv_web/live/message_live/index.ex:731
+#: lib/vutuv_web/live/message_live/index.ex:732
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr "Nachricht schreiben…"
@@ -2153,12 +2153,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:1740
+#: lib/vutuv_web/live/post_live/composer.ex:1753
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1897
+#: lib/vutuv_web/live/post_live/composer.ex:1910
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
@@ -2169,7 +2169,7 @@ msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1468
+#: lib/vutuv_web/live/post_live/composer.ex:1472
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2179,7 +2179,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:1410
+#: lib/vutuv_web/components/post_components.ex:1414
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2210,29 +2210,29 @@ msgstr "Folgen Sie %{name}, um ihn zu lesen."
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1873
+#: lib/vutuv_web/live/post_live/composer.ex:1886
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1801
+#: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:1364
-#: lib/vutuv_web/components/post_components.ex:1366
+#: lib/vutuv_web/components/post_components.ex:1368
+#: lib/vutuv_web/components/post_components.ex:1370
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1843
+#: lib/vutuv_web/live/post_live/composer.ex:1856
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1050
-#: lib/vutuv_web/live/post_live/composer.ex:1098
+#: lib/vutuv_web/live/post_live/composer.ex:1054
+#: lib/vutuv_web/live/post_live/composer.ex:1102
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
@@ -2244,23 +2244,23 @@ msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1026
+#: lib/vutuv_web/live/post_live/composer.ex:1030
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1833
+#: lib/vutuv_web/live/post_live/composer.ex:1846
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1823
+#: lib/vutuv_web/live/post_live/composer.ex:1836
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1789
+#: lib/vutuv_web/live/post_live/composer.ex:1802
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2287,13 +2287,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1793
 #: lib/vutuv_web/components/post_components.ex:1797
+#: lib/vutuv_web/components/post_components.ex:1801
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:1794
+#: lib/vutuv_web/components/post_components.ex:1798
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
@@ -2304,7 +2304,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:1859
+#: lib/vutuv_web/live/post_live/composer.ex:1872
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2320,7 +2320,7 @@ msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1787
+#: lib/vutuv_web/live/post_live/composer.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
@@ -2339,12 +2339,12 @@ msgstr[1] "%{formatted} neue Beiträge anzeigen"
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1124
+#: lib/vutuv_web/live/post_live/composer.ex:1128
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1008
+#: lib/vutuv_web/live/post_live/composer.ex:1012
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
@@ -2354,12 +2354,12 @@ msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2397
+#: lib/vutuv_web/live/post_live/composer.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2398
+#: lib/vutuv_web/live/post_live/composer.ex:2416
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
@@ -2373,37 +2373,37 @@ msgstr "Upload fehlgeschlagen."
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1958
+#: lib/vutuv_web/live/post_live/composer.ex:1971
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1959
+#: lib/vutuv_web/live/post_live/composer.ex:1972
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:1361
+#: lib/vutuv_web/components/post_components.ex:1365
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:2922
+#: lib/vutuv_web/components/post_components.ex:2926
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:2926
+#: lib/vutuv_web/components/post_components.ex:2930
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:2924
+#: lib/vutuv_web/components/post_components.ex:2928
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:2925
+#: lib/vutuv_web/components/post_components.ex:2929
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2414,17 +2414,17 @@ msgstr "Personen, denen Sie nicht folgen"
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1610
+#: lib/vutuv_web/live/post_live/composer.ex:1623
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr "Tags, durch Komma oder Leerzeichen getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2388
+#: lib/vutuv_web/live/post_live/composer.ex:2406
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2392
+#: lib/vutuv_web/live/post_live/composer.ex:2410
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
@@ -2444,7 +2444,7 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3003
+#: lib/vutuv_web/components/post_components.ex:3007
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2463,7 +2463,7 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:3147
+#: lib/vutuv_web/components/post_components.ex:3151
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
@@ -2474,7 +2474,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:906
-#: lib/vutuv_web/components/post_components.ex:3156
+#: lib/vutuv_web/components/post_components.ex:3160
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2494,12 +2494,12 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:2992
+#: lib/vutuv_web/components/post_components.ex:2996
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:3003
+#: lib/vutuv_web/components/post_components.ex:3007
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2508,23 +2508,23 @@ msgstr "Nur öffentliche Beiträge können repostet werden."
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:2989
+#: lib/vutuv_web/components/post_components.ex:2993
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2411
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2989
+#: lib/vutuv_web/components/post_components.ex:2993
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:3147
+#: lib/vutuv_web/components/post_components.ex:3151
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2547,7 +2547,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:3196
+#: lib/vutuv_web/components/post_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2559,26 +2559,26 @@ msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:942
-#: lib/vutuv_web/components/post_components.ex:3179
-#: lib/vutuv_web/components/post_components.ex:3180
+#: lib/vutuv_web/components/post_components.ex:3183
+#: lib/vutuv_web/components/post_components.ex:3184
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1332
+#: lib/vutuv_web/components/post_components.ex:1336
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1011
-#: lib/vutuv_web/live/post_live/composer.ex:1777
+#: lib/vutuv_web/live/post_live/composer.ex:1015
+#: lib/vutuv_web/live/post_live/composer.ex:1790
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empfängerkreis nicht einschränken."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1904
+#: lib/vutuv_web/live/post_live/composer.ex:1917
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
@@ -2595,57 +2595,57 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1327
+#: lib/vutuv_web/components/post_components.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:1321
+#: lib/vutuv_web/components/post_components.ex:1325
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
 
-#: lib/vutuv_web/live/message_live/index.ex:477
+#: lib/vutuv_web/live/message_live/index.ex:493
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr "%{names} schreiben…"
 
-#: lib/vutuv_web/live/message_live/index.ex:476
+#: lib/vutuv_web/live/message_live/index.ex:492
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr "%{name} schreibt…"
 
-#: lib/vutuv_web/live/message_live/index.ex:738
+#: lib/vutuv_web/live/message_live/index.ex:754
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr "@%{slug} hat Ihre Nachrichtenanfrage noch nicht angenommen."
 
-#: lib/vutuv_web/live/message_live/index.ex:692
+#: lib/vutuv_web/live/message_live/index.ex:708
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr "@%{slug} möchte Ihnen Nachrichten schicken."
 
-#: lib/vutuv_web/live/message_live/index.ex:460
+#: lib/vutuv_web/live/message_live/index.ex:476
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr "Annehmen"
 
-#: lib/vutuv_web/live/message_live/index.ex:574
+#: lib/vutuv_web/live/message_live/index.ex:590
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr "Zurück zu den Unterhaltungen"
 
-#: lib/vutuv_web/live/message_live/index.ex:467
+#: lib/vutuv_web/live/message_live/index.ex:483
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr "Ablehnen"
 
-#: lib/vutuv_web/live/message_live/index.ex:435
+#: lib/vutuv_web/live/message_live/index.ex:451
 #, elixir-autogen, elixir-format
 msgid "Deleted account"
 msgstr "Gelöschtes Konto"
 
-#: lib/vutuv_web/live/message_live/index.ex:620
+#: lib/vutuv_web/live/message_live/index.ex:636
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr "Ältere Nachrichten laden"
@@ -2656,23 +2656,23 @@ msgstr "Ältere Nachrichten laden"
 msgid "Member not found."
 msgstr "Mitglied nicht gefunden."
 
-#: lib/vutuv_web/live/message_live/index.ex:553
+#: lib/vutuv_web/live/message_live/index.ex:569
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
 #: lib/vutuv_web/components/ui.ex:2048
-#: lib/vutuv_web/live/message_live/index.ex:596
+#: lib/vutuv_web/live/message_live/index.ex:612
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr "Online"
 
-#: lib/vutuv_web/live/message_live/index.ex:506
+#: lib/vutuv_web/live/message_live/index.ex:522
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr "Anfragen"
 
-#: lib/vutuv_web/live/message_live/index.ex:747
+#: lib/vutuv_web/live/message_live/index.ex:763
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr "Wählen Sie eine Unterhaltung aus."
@@ -2891,7 +2891,7 @@ msgstr "Noch keine Vernetzungen."
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1813
+#: lib/vutuv_web/live/post_live/composer.ex:1826
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
@@ -2914,12 +2914,12 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:2923
+#: lib/vutuv_web/components/post_components.ex:2927
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
 
-#: lib/vutuv_web/live/message_live/index.ex:554
+#: lib/vutuv_web/live/message_live/index.ex:570
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr "Verborgen. Sie können das selbst klären, siehe unten."
 
-#: lib/vutuv_web/live/message_live/index.ex:649
+#: lib/vutuv_web/live/message_live/index.ex:665
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr "Verborgen: gemeldet, wird geprüft"
@@ -3193,7 +3193,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:1297
+#: lib/vutuv_web/components/post_components.ex:1301
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3273,7 +3273,7 @@ msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
 #: lib/vutuv_web/components/post_components.ex:884
-#: lib/vutuv_web/components/post_components.ex:1434
+#: lib/vutuv_web/components/post_components.ex:1438
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3301,8 +3301,8 @@ msgstr "Meldung abgelehnt; der Inhalt ist wieder sichtbar."
 msgid "Report this content"
 msgstr "Diesen Inhalt melden"
 
-#: lib/vutuv_web/live/message_live/index.ex:668
-#: lib/vutuv_web/live/message_live/index.ex:669
+#: lib/vutuv_web/live/message_live/index.ex:684
+#: lib/vutuv_web/live/message_live/index.ex:685
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr "Diese Nachricht melden"
@@ -3614,42 +3614,42 @@ msgstr ""
 msgid "yes"
 msgstr "ja"
 
-#: lib/vutuv/notifications/emailer.ex:902
+#: lib/vutuv/notifications/emailer.ex:909
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr "Eine Verwarnung für Ihr vutuv-Konto"
 
-#: lib/vutuv/notifications/emailer.ex:986
+#: lib/vutuv/notifications/emailer.ex:993
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr "Moderation: %{count} Fälle warten"
 
-#: lib/vutuv/notifications/emailer.ex:964
+#: lib/vutuv/notifications/emailer.ex:971
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr "Moderation: Ein Profil wurde gemeldet"
 
-#: lib/vutuv/notifications/emailer.ex:876
+#: lib/vutuv/notifications/emailer.ex:883
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr "Der von Ihnen gemeldete Inhalt wurde überarbeitet"
 
-#: lib/vutuv/notifications/emailer.ex:869
+#: lib/vutuv/notifications/emailer.ex:876
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr "Ihr Inhalt auf vutuv wird geprüft"
 
-#: lib/vutuv/notifications/emailer.ex:862
+#: lib/vutuv/notifications/emailer.ex:869
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr "Ihr Inhalt auf vutuv wurde gemeldet und ist verborgen"
 
-#: lib/vutuv/notifications/emailer.ex:916
+#: lib/vutuv/notifications/emailer.ex:923
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr "Ihr vutuv-Konto wurde deaktiviert"
 
-#: lib/vutuv/notifications/emailer.ex:909
+#: lib/vutuv/notifications/emailer.ex:916
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr "Ihr vutuv-Konto ist gesperrt"
@@ -4733,7 +4733,7 @@ msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
 
-#: lib/vutuv_web/live/message_live/index.ex:557
+#: lib/vutuv_web/live/message_live/index.ex:573
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr "Mitglieder finden"
@@ -5536,7 +5536,7 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1029
+#: lib/vutuv_web/live/post_live/composer.ex:1033
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
@@ -5654,9 +5654,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:1497
-#: lib/vutuv_web/components/post_components.ex:1549
-#: lib/vutuv_web/components/post_components.ex:1930
+#: lib/vutuv_web/components/post_components.ex:1501
+#: lib/vutuv_web/components/post_components.ex:1553
+#: lib/vutuv_web/components/post_components.ex:1934
 #: lib/vutuv_web/live/notification_live/index.ex:601
 #: lib/vutuv_web/live/post_live/feed.ex:894
 #, elixir-autogen, elixir-format
@@ -5758,7 +5758,7 @@ msgstr "Personen, die nicht mit Ihnen interagieren können."
 msgid "Personal tokens for the vutuv API."
 msgstr "Persönliche Tokens für die vutuv-API."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1271
+#: lib/vutuv_web/live/post_live/composer.ex:1275
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -5864,12 +5864,12 @@ msgstr "z. B. Dr. oder Prof."
 msgid "e.g. Jr. or PhD"
 msgstr "z. B. jun. oder B.Sc."
 
-#: lib/vutuv/notifications/emailer.ex:340
+#: lib/vutuv/notifications/emailer.ex:347
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr "@%{slug} hat Sie auf vutuv empfohlen"
 
-#: lib/vutuv/notifications/emailer.ex:326
+#: lib/vutuv/notifications/emailer.ex:333
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
@@ -5966,7 +5966,7 @@ msgstr "Wenn jemand beginnt, Ihnen zu folgen."
 msgid "@handle"
 msgstr "@handle"
 
-#: lib/vutuv_web/live/message_live/index.ex:612
+#: lib/vutuv_web/live/message_live/index.ex:628
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr "@%{slug} blockieren"
@@ -6115,7 +6115,7 @@ msgstr[1] "vor %{count} Minuten"
 msgid "All other devices have been logged out."
 msgstr "Alle anderen Geräte wurden abgemeldet."
 
-#: lib/vutuv/notifications/emailer.ex:646
+#: lib/vutuv/notifications/emailer.ex:653
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr "Auf Ihrem Konto war bereits eine andere Sitzung aktiv."
@@ -6140,7 +6140,7 @@ msgstr "Von allen Geräten außer diesem abmelden?"
 msgid "Log this device out of your account?"
 msgstr "Dieses Gerät von Ihrem Konto abmelden?"
 
-#: lib/vutuv/notifications/emailer.ex:621
+#: lib/vutuv/notifications/emailer.ex:628
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr "Neue Anmeldung bei Ihrem vutuv-Konto"
@@ -6155,7 +6155,7 @@ msgstr "Angemeldete Geräte"
 msgid "That device has been logged out."
 msgstr "Dieses Gerät wurde abgemeldet."
 
-#: lib/vutuv/notifications/emailer.ex:649
+#: lib/vutuv/notifications/emailer.ex:656
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
@@ -6165,7 +6165,7 @@ msgstr "Der Ort weicht von dem ab, von dem Sie sich üblicherweise anmelden."
 msgid "This device"
 msgstr "Dieses Gerät"
 
-#: lib/vutuv/notifications/emailer.ex:643
+#: lib/vutuv/notifications/emailer.ex:650
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -6814,6 +6814,7 @@ msgstr "Das rohe Bounce-Protokoll, neueste zuerst."
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:175
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:216
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -6947,7 +6948,7 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:1431
+#: lib/vutuv_web/components/post_components.ex:1435
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6957,7 +6958,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:1430
+#: lib/vutuv_web/components/post_components.ex:1434
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7664,7 +7665,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
-#: lib/vutuv_web/components/post_components.ex:3082
+#: lib/vutuv_web/components/post_components.ex:3086
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8341,8 +8342,8 @@ msgstr "Identität verifiziert. Das Mitglied wurde per E-Mail benachrichtigt."
 msgid "Identity-verified"
 msgstr "Identität verifiziert"
 
-#: lib/vutuv/accounts.ex:1004
-#: lib/vutuv/accounts.ex:1053
+#: lib/vutuv/accounts.ex:1011
+#: lib/vutuv/accounts.ex:1060
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8383,7 +8384,7 @@ msgstr "Nicht bestätigt"
 msgid "Open the member browser"
 msgstr "Mitgliederübersicht öffnen"
 
-#: lib/vutuv/accounts.ex:1021
+#: lib/vutuv/accounts.ex:1028
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -9114,7 +9115,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/text.ex:467
 #: lib/vutuv_web/agent_docs/text.ex:471
 #: lib/vutuv_web/components/ui.ex:3320
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:34
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:200
 #: lib/vutuv_web/controllers/settings_controller.ex:267
 #: lib/vutuv_web/live/fediverse_followers_live.ex:186
@@ -9164,7 +9165,7 @@ msgstr "Social-Media-Konten verwalten"
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
 
-#: lib/vutuv/accounts.ex:1016
+#: lib/vutuv/accounts.ex:1023
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9280,7 +9281,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:2410
+#: lib/vutuv_web/components/post_components.ex:2414
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -10281,7 +10282,7 @@ msgstr ""
 "Ihr Geburtsdatum wird entfernt und Ihr Alter wird nicht mehr in Ihrem Profil"
 " angezeigt. Sie können es jederzeit wieder hinzufügen."
 
-#: lib/vutuv/notifications/emailer.ex:552
+#: lib/vutuv/notifications/emailer.ex:559
 #, elixir-autogen, elixir-format
 msgid "%{name} invited you to vutuv"
 msgstr "%{name} hat Sie zu vutuv eingeladen"
@@ -13233,7 +13234,7 @@ msgstr "Veröffentlichen"
 
 #: lib/vutuv/accounts/user.ex:905
 #: lib/vutuv/jobs/job_posting.ex:164
-#: lib/vutuv/notifications/emailer.ex:427
+#: lib/vutuv/notifications/emailer.ex:434
 #: lib/vutuv_web/agent_docs/markdown.ex:348
 #: lib/vutuv_web/agent_docs/markdown.ex:350
 #: lib/vutuv_web/agent_docs/text.ex:373
@@ -13368,12 +13369,12 @@ msgstr "Arbeitsort"
 msgid "You already have the maximum number of published postings."
 msgstr "Sie haben bereits die maximale Anzahl veröffentlichter Anzeigen."
 
-#: lib/vutuv/notifications/emailer.ex:932
+#: lib/vutuv/notifications/emailer.ex:939
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr "Ihre Stellenanzeige auf vutuv läuft bald ab"
 
-#: lib/vutuv/notifications/emailer.ex:835
+#: lib/vutuv/notifications/emailer.ex:842
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr "Eine Domain Ihrer Organisationsseite auf vutuv entfällt bald"
@@ -13393,12 +13394,12 @@ msgstr "Nachweis fehlt"
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr "Der Nachweis dieser Domain war bei der letzten Prüfung nicht abrufbar. Stellen Sie ihn wieder her und prüfen Sie erneut, sonst verliert die Domain ihre Verifizierung."
 
-#: lib/vutuv/notifications/emailer.ex:832
+#: lib/vutuv/notifications/emailer.ex:839
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr "Ihre Organisationsseite auf vutuv verliert bald ihre Verifizierung"
 
-#: lib/vutuv/notifications/emailer.ex:853
+#: lib/vutuv/notifications/emailer.ex:860
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr "Ihre Organisationsseite auf vutuv ist nicht mehr öffentlich"
@@ -13826,7 +13827,7 @@ msgid "Search title, poster or organization"
 msgstr "Titel, Ersteller oder Organisation suchen"
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1682
+#: lib/vutuv_web/live/post_live/composer.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
@@ -13852,7 +13853,7 @@ msgstr "verifizierte Organisationsseite"
 msgid "—"
 msgstr "—"
 
-#: lib/vutuv/notifications/emailer.ex:376
+#: lib/vutuv/notifications/emailer.ex:383
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -14348,7 +14349,7 @@ msgstr "Volle Breite"
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2367
+#: lib/vutuv_web/live/post_live/composer.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
@@ -14577,128 +14578,128 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:2785
+#: lib/vutuv_web/components/post_components.ex:2789
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1690
+#: lib/vutuv_web/live/post_live/composer.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Author(s)"
 msgstr "Autor(en)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1758
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #, elixir-autogen, elixir-format
 msgid "Book"
 msgstr "Buch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:949
-#: lib/vutuv_web/components/post_components.ex:2742
-#: lib/vutuv_web/live/post_live/composer.ex:1636
+#: lib/vutuv_web/components/post_components.ex:2746
+#: lib/vutuv_web/live/post_live/composer.ex:1649
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:2786
+#: lib/vutuv_web/components/post_components.ex:2790
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:2788
+#: lib/vutuv_web/components/post_components.ex:2792
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1690
+#: lib/vutuv_web/live/post_live/composer.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Director"
 msgstr "Regie"
 
-#: lib/vutuv_web/components/post_components.ex:2784
+#: lib/vutuv_web/components/post_components.ex:2788
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1770
+#: lib/vutuv_web/live/post_live/composer.ex:1783
 #, elixir-autogen, elixir-format
 msgid "Film"
 msgstr "Film"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:949
-#: lib/vutuv_web/components/post_components.ex:2741
-#: lib/vutuv_web/live/post_live/composer.ex:1635
+#: lib/vutuv_web/components/post_components.ex:2745
+#: lib/vutuv_web/live/post_live/composer.ex:1648
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1656
+#: lib/vutuv_web/live/post_live/composer.ex:1669
 #, elixir-autogen, elixir-format
 msgid "IMDb link or ID"
 msgstr "IMDb-Link oder -ID"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1657
+#: lib/vutuv_web/live/post_live/composer.ex:1670
 #, elixir-autogen, elixir-format
 msgid "ISBN"
 msgstr "ISBN"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1670
+#: lib/vutuv_web/live/post_live/composer.ex:1683
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1667
+#: lib/vutuv_web/live/post_live/composer.ex:1680
 #, elixir-autogen, elixir-format
 msgid "Looking up…"
 msgstr "Wird nachgeschlagen …"
 
-#: lib/vutuv_web/live/post_live/composer.ex:647
+#: lib/vutuv_web/live/post_live/composer.ex:651
 #, elixir-autogen, elixir-format
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr "Zu dieser ISBN wurde nichts gefunden. Bitte füllen Sie die Felder selbst aus."
 
-#: lib/vutuv_web/components/post_components.ex:2783
+#: lib/vutuv_web/components/post_components.ex:2787
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1709
+#: lib/vutuv_web/live/post_live/composer.ex:1722
 #, elixir-autogen, elixir-format
 msgid "Read as… (optional)"
 msgstr "Gelesen als … (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1645
+#: lib/vutuv_web/live/post_live/composer.ex:1658
 #, elixir-autogen, elixir-format
 msgid "Remove review"
 msgstr "Besprechung entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1754
-#: lib/vutuv_web/live/post_live/composer.ex:1755
+#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1768
 #, elixir-autogen, elixir-format
 msgid "Review a book"
 msgstr "Ein Buch besprechen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1766
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1779
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #, elixir-autogen, elixir-format
 msgid "Review a film"
 msgstr "Einen Film besprechen"
 
-#: lib/vutuv_web/components/post_components.ex:2787
+#: lib/vutuv_web/components/post_components.ex:2791
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1708
+#: lib/vutuv_web/live/post_live/composer.ex:1721
 #, elixir-autogen, elixir-format
 msgid "Watched as… (optional)"
 msgstr "Gesehen als … (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1722
+#: lib/vutuv_web/live/post_live/composer.ex:1735
 #, elixir-autogen, elixir-format
 msgid "With an ISBN, the post shows the book cover and a shop link automatically."
 msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1702
+#: lib/vutuv_web/live/post_live/composer.ex:1715
 #: lib/vutuv_web/templates/education/form_content.html.heex:47
 #: lib/vutuv_web/templates/education/form_content.html.heex:48
 #: lib/vutuv_web/templates/education/form_content.html.heex:67
@@ -14714,34 +14715,34 @@ msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:2824
+#: lib/vutuv_web/components/post_components.ex:2828
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:2854
+#: lib/vutuv_web/components/post_components.ex:2858
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:2855
+#: lib/vutuv_web/components/post_components.ex:2859
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:2853
+#: lib/vutuv_web/components/post_components.ex:2857
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:2813
+#: lib/vutuv_web/components/post_components.ex:2817
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:2860
+#: lib/vutuv_web/components/post_components.ex:2864
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14771,7 +14772,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2627
+#: lib/vutuv_web/components/post_components.ex:2631
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14819,7 +14820,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:2618
+#: lib/vutuv_web/components/post_components.ex:2622
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -15068,7 +15069,7 @@ msgstr ""
 "Ihr automatisch zugewiesener vutuv-Benutzername ist {handle}. Sie können ihn "
 "jederzeit unter {url} ändern."
 
-#: lib/vutuv/notifications/emailer.ex:894
+#: lib/vutuv/notifications/emailer.ex:901
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
@@ -15115,13 +15116,13 @@ msgstr "Erwähnung"
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1016
+#: lib/vutuv_web/live/post_live/composer.ex:1020
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten: jemand hat ihn geliked, geteilt oder beantwortet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1019
+#: lib/vutuv_web/live/post_live/composer.ex:1023
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -15217,14 +15218,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1077
+#: lib/vutuv_web/components/post_components.ex:1081
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1099
+#: lib/vutuv_web/components/post_components.ex:1103
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -15251,7 +15252,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:3159
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15524,17 +15525,17 @@ msgstr "Sie haben in diesem Thread geschrieben."
 msgid "e.g. crypto*, \"machine learning\", politics"
 msgstr "z. B. crypto*, \"machine learning\", Politik"
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:49
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:53
 #, elixir-autogen, elixir-format
 msgid "Enter the server name on its own, for example mastodon.example."
 msgstr "Geben Sie nur den Servernamen ein, zum Beispiel mastodon.example."
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:63
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:67
 #, elixir-autogen, elixir-format
 msgid "%{host} is no longer blocked. What was deleted stays deleted; the server has to follow again."
 msgstr "%{host} ist nicht mehr blockiert. Gelöschtes bleibt gelöscht; der Server muss erneut folgen."
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:76
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:80
 #, elixir-autogen, elixir-format
 msgid "%{host} is blocked. Removed: %{followers} remote followers and %{deliveries} queued deliveries."
 msgstr "%{host} ist blockiert. Entfernt: %{followers} entfernte Follower und %{deliveries} wartende Zustellungen."
@@ -15604,6 +15605,7 @@ msgstr "Kein Server ist blockiert."
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:84
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:135
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:177
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Server"
 msgstr "Server"
@@ -16440,7 +16442,7 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:3124
+#: lib/vutuv_web/components/post_components.ex:3128
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
@@ -16552,7 +16554,7 @@ msgstr "Antworten aus anderen Netzwerken anzeigen"
 msgid "Stored replies"
 msgstr "Gespeicherte Antworten"
 
-#: lib/vutuv_web/views/admin/fediverse_html.ex:16
+#: lib/vutuv_web/views/admin/fediverse_html.ex:17
 #, elixir-autogen, elixir-format
 msgid "Taken down"
 msgstr "Entfernt"
@@ -16574,6 +16576,7 @@ msgid "View the original"
 msgstr "Original ansehen"
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:176
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "What"
 msgstr "Was"
@@ -17242,22 +17245,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:1309
+#: lib/vutuv_web/components/post_components.ex:1313
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:1397
+#: lib/vutuv_web/components/post_components.ex:1401
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:1405
+#: lib/vutuv_web/components/post_components.ex:1409
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:1391
+#: lib/vutuv_web/components/post_components.ex:1395
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17307,7 +17310,7 @@ msgstr ""
 "in eckigen Klammern, wie eine Lautschrift geschrieben wird; die Klammern "
 "ergänzen wir für Sie. Bleibt das Feld leer, wird nichts angezeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2380
+#: lib/vutuv_web/live/post_live/composer.ex:2398
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Diese Einstellungen für alle Fotos übernehmen"
@@ -17337,74 +17340,74 @@ msgstr "CC BY-SA 4.0 (Namensnennung, gleiche Bedingungen)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2209
+#: lib/vutuv_web/live/post_live/composer.ex:2225
 #, elixir-autogen, elixir-format
 msgid "Caption, shown under the photo (optional)"
 msgstr "Bildunterschrift, erscheint unter dem Foto (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2040
+#: lib/vutuv_web/live/post_live/composer.ex:2053
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Titelbild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2217
+#: lib/vutuv_web/live/post_live/composer.ex:2233
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1010
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:1858
+#: lib/vutuv_web/components/post_components.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1456
+#: lib/vutuv_web/live/post_live/composer.ex:1460
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr "Zum Umsortieren ziehen. Das erste Foto führt die Galerie an."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2329
+#: lib/vutuv_web/live/post_live/composer.ex:2347
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr "Alle Metadaten bleiben erhalten, auch alles, was Ihre Kamera hineingeschrieben hat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2286
+#: lib/vutuv_web/live/post_live/composer.ex:2304
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Alle dürfen dieses Foto herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2288
+#: lib/vutuv_web/live/post_live/composer.ex:2306
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Volle Auflösung, direkt aus dem Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2307
+#: lib/vutuv_web/live/post_live/composer.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2077
+#: lib/vutuv_web/live/post_live/composer.ex:2090
 #, elixir-autogen, elixir-format
 msgid "Move photo earlier"
 msgstr "Foto nach vorne schieben"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2089
+#: lib/vutuv_web/live/post_live/composer.ex:2102
 #, elixir-autogen, elixir-format
 msgid "Move photo later"
 msgstr "Foto nach hinten schieben"
 
-#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:1861
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2047
+#: lib/vutuv_web/live/post_live/composer.ex:2060
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:2274
+#: lib/vutuv_web/components/post_components.ex:2278
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr "Bisher sehen nur Sie diesen Beitrag."
@@ -17414,85 +17417,85 @@ msgstr "Bisher sehen nur Sie diesen Beitrag."
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2277
+#: lib/vutuv_web/components/post_components.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] "Unsere KI prüft das Foto. Sobald es durch ist, geht der Beitrag von selbst online."
 msgstr[1] "Unsere KI prüft die Fotos, %{done} von %{total} sind durch. Sobald das letzte durch ist, geht der Beitrag von selbst online."
 
-#: lib/vutuv_web/components/post_components.ex:2102
+#: lib/vutuv_web/components/post_components.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:1604
+#: lib/vutuv_web/components/post_components.ex:1608
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2015
-#: lib/vutuv_web/live/post_live/composer.ex:2016
+#: lib/vutuv_web/live/post_live/composer.ex:2028
+#: lib/vutuv_web/live/post_live/composer.ex:2029
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1043
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:2311
+#: lib/vutuv_web/components/post_components.ex:2315
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/post_components.ex:1856
+#: lib/vutuv_web/components/post_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2060
-#: lib/vutuv_web/live/post_live/composer.ex:2061
+#: lib/vutuv_web/live/post_live/composer.ex:2073
+#: lib/vutuv_web/live/post_live/composer.ex:2074
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2309
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qualität unverändert."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1414
-#: lib/vutuv_web/live/post_live/composer.ex:2255
+#: lib/vutuv_web/live/post_live/composer.ex:1418
+#: lib/vutuv_web/live/post_live/composer.ex:2271
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1041
+#: lib/vutuv_web/live/post_live/composer.ex:1045
 #: lib/vutuv_web/live/post_live/remote_reply.ex:87
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2327
+#: lib/vutuv_web/live/post_live/composer.ex:2345
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Die Datei genau so, wie ich sie hochgeladen habe"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2263
+#: lib/vutuv_web/live/post_live/composer.ex:2279
 #, elixir-autogen, elixir-format
 msgid "This file carries no camera information."
 msgstr "Diese Datei enthält keine Kameradaten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2350
+#: lib/vutuv_web/live/post_live/composer.ex:2368
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen Sie das Foto, wenn Sie das nicht möchten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2342
+#: lib/vutuv_web/live/post_live/composer.ex:2360
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1044
+#: lib/vutuv_web/live/post_live/composer.ex:1048
 #: lib/vutuv_web/live/post_live/remote_reply.ex:84
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
@@ -17513,12 +17516,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1505
+#: lib/vutuv_web/live/post_live/composer.ex:1518
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Wer diese Fotos weiterverwenden darf"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1036
+#: lib/vutuv_web/live/post_live/composer.ex:1040
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
@@ -17528,7 +17531,7 @@ msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke gesc
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1047
+#: lib/vutuv_web/live/post_live/composer.ex:1051
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
@@ -17543,17 +17546,17 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr "© Alle Rechte vorbehalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1432
+#: lib/vutuv_web/live/post_live/composer.ex:1436
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Fotos hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1592
+#: lib/vutuv_web/live/post_live/composer.ex:1605
 #, elixir-autogen, elixir-format
 msgid "Add text (optional)"
 msgstr "Text hinzufügen (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1500
+#: lib/vutuv_web/live/post_live/composer.ex:1513
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Lizenz"
@@ -17564,89 +17567,89 @@ msgstr "Lizenz"
 msgid "Post photos"
 msgstr "Fotos posten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1264
+#: lib/vutuv_web/live/post_live/composer.ex:1268
 #, elixir-autogen, elixir-format
 msgid "Post type"
 msgstr "Beitragsart"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1443
+#: lib/vutuv_web/live/post_live/composer.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Select photos, or drag them here"
 msgstr "Fotos auswählen oder hierher ziehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1268
+#: lib/vutuv_web/live/post_live/composer.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Text"
 msgstr "Text"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1958
+#: lib/vutuv_web/live/post_live/composer.ex:1971
 #, elixir-autogen, elixir-format
 msgid "Text (optional)"
 msgstr "Text (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1446
+#: lib/vutuv_web/live/post_live/composer.ex:1450
 #, elixir-autogen, elixir-format
 msgid "Up to %{max} photos per post"
 msgstr "Bis zu %{max} Fotos pro Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1391
+#: lib/vutuv_web/live/post_live/composer.ex:1395
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Bildunterschrift (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1307
+#: lib/vutuv_web/live/post_live/composer.ex:1311
 #, elixir-autogen, elixir-format
 msgid "A photo post shows your pictures big and first; text is optional. For a post that is mainly text, switch to \"Text\"."
 msgstr "Ein Foto-Beitrag zeigt Ihre Bilder groß und zuerst; Text ist optional. Für einen Beitrag, der vor allem Text ist, wechseln Sie zu \"Text\"."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1238
-#: lib/vutuv_web/live/post_live/composer.ex:1292
-#: lib/vutuv_web/live/post_live/composer.ex:1293
+#: lib/vutuv_web/live/post_live/composer.ex:1242
+#: lib/vutuv_web/live/post_live/composer.ex:1296
+#: lib/vutuv_web/live/post_live/composer.ex:1297
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Entwurf verwerfen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1290
+#: lib/vutuv_web/live/post_live/composer.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr "Fotos und Text dieses Entwurfs verwerfen?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1231
+#: lib/vutuv_web/live/post_live/composer.ex:1235
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Weiter, wo Sie aufgehört haben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1574
+#: lib/vutuv_web/live/post_live/composer.ex:1587
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr "Eine Datei, deren Format sich nicht säubern lässt, wird exakt so weitergegeben, wie sie hochgeladen wurde."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1550
+#: lib/vutuv_web/live/post_live/composer.ex:1563
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Pro Foto verschieden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1547
+#: lib/vutuv_web/live/post_live/composer.ex:1560
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Original, exakt wie hochgeladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1544
+#: lib/vutuv_web/live/post_live/composer.ex:1557
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Original, ohne Metadaten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1541
+#: lib/vutuv_web/live/post_live/composer.ex:1554
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Nur Web-Versionen (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1537
+#: lib/vutuv_web/live/post_live/composer.ex:1550
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Was Besucher speichern können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1563
+#: lib/vutuv_web/live/post_live/composer.ex:1576
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17654,13 +17657,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:939
-#: lib/vutuv_web/components/post_components.ex:3121
+#: lib/vutuv_web/components/post_components.ex:3125
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:937
-#: lib/vutuv_web/components/post_components.ex:3118
+#: lib/vutuv_web/components/post_components.ex:3122
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17670,7 +17673,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:3060
+#: lib/vutuv_web/components/post_components.ex:3064
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17715,3 +17718,52 @@ msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
 msgstr[0] "hat Ihren Beitrag in einem anderen Netzwerk geteilt."
 msgstr[1] "haben Ihren Beitrag in einem anderen Netzwerk geteilt."
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:23
+#, elixir-autogen, elixir-format
+msgid "Asked to delete a copy"
+msgstr "Löschung einer Kopie angefragt"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:204
+#, elixir-autogen, elixir-format
+msgid "Every withdrawal request so far has been delivered."
+msgstr "Bisher wurde jede Rücknahme zugestellt."
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:235
+#, elixir-autogen, elixir-format
+msgid "No answer"
+msgstr "Keine Antwort"
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:24
+#, elixir-autogen, elixir-format
+msgid "Passed a report on"
+msgstr "Meldung weitergegeben"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:219
+#, elixir-autogen, elixir-format
+msgid "Reason given"
+msgstr "Genannter Grund"
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:16
+#, elixir-autogen, elixir-format
+msgid "Reported to the origin server"
+msgstr "An den Ursprungsserver gemeldet"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:201
+#, elixir-autogen, elixir-format
+msgid "Takedowns that did not get through"
+msgstr "Rücknahmen, die nicht angekommen sind"
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:208
+#, elixir-autogen, elixir-format
+msgid "These withdrawal requests were retried eight times over about four hours and then dropped. We cannot make another server delete anything, but a server showing up here repeatedly is either broken or ignoring us, and can be blocked above."
+msgstr ""
+"Diese Rücknahmen wurden über etwa vier Stunden achtmal wiederholt und dann "
+"verworfen. Wir können keinen anderen Server zum Löschen zwingen, aber ein "
+"Server, der hier wiederholt auftaucht, ist entweder defekt oder ignoriert "
+"uns, und kann oben gesperrt werden."
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:25
+#, elixir-autogen, elixir-format
+msgid "Withdrawal request"
+msgstr "Rücknahme"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1413
+#: lib/vutuv_web/components/post_components.ex:1417
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -195,7 +195,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:439
-#: lib/vutuv_web/live/post_live/composer.ex:1530
+#: lib/vutuv_web/live/post_live/composer.ex:1543
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:303
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1378
+#: lib/vutuv_web/components/post_components.ex:1382
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -493,7 +493,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:280
+#: lib/vutuv/notifications/emailer.ex:281
 #, elixir-autogen
 msgid "New message from @%{slug} on vutuv"
 msgstr ""
@@ -614,7 +614,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1780
+#: lib/vutuv_web/live/post_live/composer.ex:1793
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -624,7 +624,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2863
 #: lib/vutuv_web/live/organization_live/edit.ex:339
-#: lib/vutuv_web/live/post_live/composer.ex:1789
+#: lib/vutuv_web/live/post_live/composer.ex:1802
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:98
@@ -1661,13 +1661,13 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1855
+#: lib/vutuv_web/components/post_components.ex:1859
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1292
-#: lib/vutuv_web/live/post_live/composer.ex:1293
-#: lib/vutuv_web/live/post_live/composer.ex:2225
+#: lib/vutuv_web/live/post_live/composer.ex:1296
+#: lib/vutuv_web/live/post_live/composer.ex:1297
+#: lib/vutuv_web/live/post_live/composer.ex:2241
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1760,7 +1760,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
 #: lib/vutuv_web/live/admin/user_live.ex:168
-#: lib/vutuv_web/live/message_live/index.ex:439
+#: lib/vutuv_web/live/message_live/index.ex:455
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:55
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
@@ -1775,7 +1775,7 @@ msgid "Message"
 msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:45
-#: lib/vutuv_web/live/message_live/index.ex:496
+#: lib/vutuv_web/live/message_live/index.ex:512
 #: lib/vutuv_web/live/shell_live.ex:497
 #: lib/vutuv_web/live/shell_live.ex:639
 #: lib/vutuv_web/templates/layout/app.html.heex:117
@@ -1831,7 +1831,7 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:726
+#: lib/vutuv_web/live/message_live/index.ex:742
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1902,8 +1902,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:715
-#: lib/vutuv_web/live/message_live/index.ex:716
+#: lib/vutuv_web/live/message_live/index.ex:731
+#: lib/vutuv_web/live/message_live/index.ex:732
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -2108,12 +2108,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:1740
+#: lib/vutuv_web/live/post_live/composer.ex:1753
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1897
+#: lib/vutuv_web/live/post_live/composer.ex:1910
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2124,7 +2124,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1468
+#: lib/vutuv_web/live/post_live/composer.ex:1472
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2134,7 +2134,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1410
+#: lib/vutuv_web/components/post_components.ex:1414
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2165,29 +2165,29 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1873
+#: lib/vutuv_web/live/post_live/composer.ex:1886
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1801
+#: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1364
-#: lib/vutuv_web/components/post_components.ex:1366
+#: lib/vutuv_web/components/post_components.ex:1368
+#: lib/vutuv_web/components/post_components.ex:1370
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1843
+#: lib/vutuv_web/live/post_live/composer.ex:1856
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1050
-#: lib/vutuv_web/live/post_live/composer.ex:1098
+#: lib/vutuv_web/live/post_live/composer.ex:1054
+#: lib/vutuv_web/live/post_live/composer.ex:1102
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2197,23 +2197,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1026
+#: lib/vutuv_web/live/post_live/composer.ex:1030
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1833
+#: lib/vutuv_web/live/post_live/composer.ex:1846
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1823
+#: lib/vutuv_web/live/post_live/composer.ex:1836
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1789
+#: lib/vutuv_web/live/post_live/composer.ex:1802
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2240,13 +2240,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1793
 #: lib/vutuv_web/components/post_components.ex:1797
+#: lib/vutuv_web/components/post_components.ex:1801
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1794
+#: lib/vutuv_web/components/post_components.ex:1798
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2257,7 +2257,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:1859
+#: lib/vutuv_web/live/post_live/composer.ex:1872
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2271,7 +2271,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1787
+#: lib/vutuv_web/live/post_live/composer.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2290,12 +2290,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1124
+#: lib/vutuv_web/live/post_live/composer.ex:1128
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1008
+#: lib/vutuv_web/live/post_live/composer.ex:1012
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2305,12 +2305,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2397
+#: lib/vutuv_web/live/post_live/composer.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2398
+#: lib/vutuv_web/live/post_live/composer.ex:2416
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2324,37 +2324,37 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1958
+#: lib/vutuv_web/live/post_live/composer.ex:1971
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1959
+#: lib/vutuv_web/live/post_live/composer.ex:1972
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1361
+#: lib/vutuv_web/components/post_components.ex:1365
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2922
+#: lib/vutuv_web/components/post_components.ex:2926
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2926
+#: lib/vutuv_web/components/post_components.ex:2930
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2924
+#: lib/vutuv_web/components/post_components.ex:2928
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2925
+#: lib/vutuv_web/components/post_components.ex:2929
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2365,17 +2365,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1610
+#: lib/vutuv_web/live/post_live/composer.ex:1623
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2388
+#: lib/vutuv_web/live/post_live/composer.ex:2406
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2392
+#: lib/vutuv_web/live/post_live/composer.ex:2410
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2395,7 +2395,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3003
+#: lib/vutuv_web/components/post_components.ex:3007
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2414,7 +2414,7 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3147
+#: lib/vutuv_web/components/post_components.ex:3151
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
@@ -2425,7 +2425,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:906
-#: lib/vutuv_web/components/post_components.ex:3156
+#: lib/vutuv_web/components/post_components.ex:3160
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2445,12 +2445,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2992
+#: lib/vutuv_web/components/post_components.ex:2996
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3003
+#: lib/vutuv_web/components/post_components.ex:3007
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2459,23 +2459,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2989
+#: lib/vutuv_web/components/post_components.ex:2993
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2411
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2989
+#: lib/vutuv_web/components/post_components.ex:2993
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3147
+#: lib/vutuv_web/components/post_components.ex:3151
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2498,7 +2498,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3196
+#: lib/vutuv_web/components/post_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2510,26 +2510,26 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:942
-#: lib/vutuv_web/components/post_components.ex:3179
-#: lib/vutuv_web/components/post_components.ex:3180
+#: lib/vutuv_web/components/post_components.ex:3183
+#: lib/vutuv_web/components/post_components.ex:3184
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1332
+#: lib/vutuv_web/components/post_components.ex:1336
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1011
-#: lib/vutuv_web/live/post_live/composer.ex:1777
+#: lib/vutuv_web/live/post_live/composer.ex:1015
+#: lib/vutuv_web/live/post_live/composer.ex:1790
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1904
+#: lib/vutuv_web/live/post_live/composer.ex:1917
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2546,57 +2546,57 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1327
+#: lib/vutuv_web/components/post_components.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1321
+#: lib/vutuv_web/components/post_components.ex:1325
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:477
+#: lib/vutuv_web/live/message_live/index.ex:493
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:476
+#: lib/vutuv_web/live/message_live/index.ex:492
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:738
+#: lib/vutuv_web/live/message_live/index.ex:754
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:692
+#: lib/vutuv_web/live/message_live/index.ex:708
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:460
+#: lib/vutuv_web/live/message_live/index.ex:476
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:574
+#: lib/vutuv_web/live/message_live/index.ex:590
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:467
+#: lib/vutuv_web/live/message_live/index.ex:483
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:435
+#: lib/vutuv_web/live/message_live/index.ex:451
 #, elixir-autogen, elixir-format
 msgid "Deleted account"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:620
+#: lib/vutuv_web/live/message_live/index.ex:636
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr ""
@@ -2607,23 +2607,23 @@ msgstr ""
 msgid "Member not found."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:553
+#: lib/vutuv_web/live/message_live/index.ex:569
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2048
-#: lib/vutuv_web/live/message_live/index.ex:596
+#: lib/vutuv_web/live/message_live/index.ex:612
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:506
+#: lib/vutuv_web/live/message_live/index.ex:522
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:747
+#: lib/vutuv_web/live/message_live/index.ex:763
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
@@ -2836,7 +2836,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1813
+#: lib/vutuv_web/live/post_live/composer.ex:1826
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2859,12 +2859,12 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2923
+#: lib/vutuv_web/components/post_components.ex:2927
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:554
+#: lib/vutuv_web/live/message_live/index.ex:570
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr ""
@@ -3028,7 +3028,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:649
+#: lib/vutuv_web/live/message_live/index.ex:665
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr ""
@@ -3120,7 +3120,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1297
+#: lib/vutuv_web/components/post_components.ex:1301
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3196,7 +3196,7 @@ msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:884
-#: lib/vutuv_web/components/post_components.ex:1434
+#: lib/vutuv_web/components/post_components.ex:1438
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3224,8 +3224,8 @@ msgstr ""
 msgid "Report this content"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:668
-#: lib/vutuv_web/live/message_live/index.ex:669
+#: lib/vutuv_web/live/message_live/index.ex:684
+#: lib/vutuv_web/live/message_live/index.ex:685
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr ""
@@ -3507,42 +3507,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:902
+#: lib/vutuv/notifications/emailer.ex:909
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:986
+#: lib/vutuv/notifications/emailer.ex:993
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:964
+#: lib/vutuv/notifications/emailer.ex:971
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:876
+#: lib/vutuv/notifications/emailer.ex:883
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:869
+#: lib/vutuv/notifications/emailer.ex:876
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:862
+#: lib/vutuv/notifications/emailer.ex:869
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:916
+#: lib/vutuv/notifications/emailer.ex:923
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:909
+#: lib/vutuv/notifications/emailer.ex:916
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Discover people to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:557
+#: lib/vutuv_web/live/message_live/index.ex:573
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr ""
@@ -5307,7 +5307,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1029
+#: lib/vutuv_web/live/post_live/composer.ex:1033
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5423,9 +5423,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1497
-#: lib/vutuv_web/components/post_components.ex:1549
-#: lib/vutuv_web/components/post_components.ex:1930
+#: lib/vutuv_web/components/post_components.ex:1501
+#: lib/vutuv_web/components/post_components.ex:1553
+#: lib/vutuv_web/components/post_components.ex:1934
 #: lib/vutuv_web/live/notification_live/index.ex:601
 #: lib/vutuv_web/live/post_live/feed.ex:894
 #, elixir-autogen, elixir-format
@@ -5526,7 +5526,7 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1271
+#: lib/vutuv_web/live/post_live/composer.ex:1275
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -5630,12 +5630,12 @@ msgstr ""
 msgid "e.g. Jr. or PhD"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:340
+#: lib/vutuv/notifications/emailer.ex:347
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:326
+#: lib/vutuv/notifications/emailer.ex:333
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
@@ -5730,7 +5730,7 @@ msgstr ""
 msgid "@handle"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:612
+#: lib/vutuv_web/live/message_live/index.ex:628
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr ""
@@ -5877,7 +5877,7 @@ msgstr[1] ""
 msgid "All other devices have been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:646
+#: lib/vutuv/notifications/emailer.ex:653
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr ""
@@ -5902,7 +5902,7 @@ msgstr ""
 msgid "Log this device out of your account?"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:621
+#: lib/vutuv/notifications/emailer.ex:628
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr ""
@@ -5917,7 +5917,7 @@ msgstr ""
 msgid "That device has been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:649
+#: lib/vutuv/notifications/emailer.ex:656
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr ""
@@ -5927,7 +5927,7 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:643
+#: lib/vutuv/notifications/emailer.ex:650
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -6536,6 +6536,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:175
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:216
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -6658,7 +6659,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1431
+#: lib/vutuv_web/components/post_components.ex:1435
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6668,7 +6669,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1430
+#: lib/vutuv_web/components/post_components.ex:1434
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7351,7 +7352,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3082
+#: lib/vutuv_web/components/post_components.ex:3086
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7972,8 +7973,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1004
-#: lib/vutuv/accounts.ex:1053
+#: lib/vutuv/accounts.ex:1011
+#: lib/vutuv/accounts.ex:1060
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8012,7 +8013,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1021
+#: lib/vutuv/accounts.ex:1028
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8669,7 +8670,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:467
 #: lib/vutuv_web/agent_docs/text.ex:471
 #: lib/vutuv_web/components/ui.ex:3320
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:34
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:200
 #: lib/vutuv_web/controllers/settings_controller.ex:267
 #: lib/vutuv_web/live/fediverse_followers_live.ex:186
@@ -8714,7 +8715,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1016
+#: lib/vutuv/accounts.ex:1023
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8823,7 +8824,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2410
+#: lib/vutuv_web/components/post_components.ex:2414
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9779,7 +9780,7 @@ msgstr ""
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:552
+#: lib/vutuv/notifications/emailer.ex:559
 #, elixir-autogen, elixir-format
 msgid "%{name} invited you to vutuv"
 msgstr ""
@@ -12535,7 +12536,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:905
 #: lib/vutuv/jobs/job_posting.ex:164
-#: lib/vutuv/notifications/emailer.ex:427
+#: lib/vutuv/notifications/emailer.ex:434
 #: lib/vutuv_web/agent_docs/markdown.ex:348
 #: lib/vutuv_web/agent_docs/markdown.ex:350
 #: lib/vutuv_web/agent_docs/text.ex:373
@@ -12670,12 +12671,12 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:932
+#: lib/vutuv/notifications/emailer.ex:939
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:835
+#: lib/vutuv/notifications/emailer.ex:842
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
@@ -12695,12 +12696,12 @@ msgstr ""
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:832
+#: lib/vutuv/notifications/emailer.ex:839
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:853
+#: lib/vutuv/notifications/emailer.ex:860
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
@@ -13128,7 +13129,7 @@ msgid "Search title, poster or organization"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1682
+#: lib/vutuv_web/live/post_live/composer.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -13154,7 +13155,7 @@ msgstr ""
 msgid "—"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:376
+#: lib/vutuv/notifications/emailer.ex:383
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -13636,7 +13637,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2367
+#: lib/vutuv_web/live/post_live/composer.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13858,128 +13859,128 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2785
+#: lib/vutuv_web/components/post_components.ex:2789
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1690
+#: lib/vutuv_web/live/post_live/composer.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Author(s)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1758
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #, elixir-autogen, elixir-format
 msgid "Book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:949
-#: lib/vutuv_web/components/post_components.ex:2742
-#: lib/vutuv_web/live/post_live/composer.ex:1636
+#: lib/vutuv_web/components/post_components.ex:2746
+#: lib/vutuv_web/live/post_live/composer.ex:1649
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2786
+#: lib/vutuv_web/components/post_components.ex:2790
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2788
+#: lib/vutuv_web/components/post_components.ex:2792
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1690
+#: lib/vutuv_web/live/post_live/composer.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2784
+#: lib/vutuv_web/components/post_components.ex:2788
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1770
+#: lib/vutuv_web/live/post_live/composer.ex:1783
 #, elixir-autogen, elixir-format
 msgid "Film"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:949
-#: lib/vutuv_web/components/post_components.ex:2741
-#: lib/vutuv_web/live/post_live/composer.ex:1635
+#: lib/vutuv_web/components/post_components.ex:2745
+#: lib/vutuv_web/live/post_live/composer.ex:1648
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1656
+#: lib/vutuv_web/live/post_live/composer.ex:1669
 #, elixir-autogen, elixir-format
 msgid "IMDb link or ID"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1657
+#: lib/vutuv_web/live/post_live/composer.ex:1670
 #, elixir-autogen, elixir-format
 msgid "ISBN"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1670
+#: lib/vutuv_web/live/post_live/composer.ex:1683
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1667
+#: lib/vutuv_web/live/post_live/composer.ex:1680
 #, elixir-autogen, elixir-format
 msgid "Looking up…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:647
+#: lib/vutuv_web/live/post_live/composer.ex:651
 #, elixir-autogen, elixir-format
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2783
+#: lib/vutuv_web/components/post_components.ex:2787
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1709
+#: lib/vutuv_web/live/post_live/composer.ex:1722
 #, elixir-autogen, elixir-format
 msgid "Read as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1645
+#: lib/vutuv_web/live/post_live/composer.ex:1658
 #, elixir-autogen, elixir-format
 msgid "Remove review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1754
-#: lib/vutuv_web/live/post_live/composer.ex:1755
+#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1768
 #, elixir-autogen, elixir-format
 msgid "Review a book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1766
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1779
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #, elixir-autogen, elixir-format
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2787
+#: lib/vutuv_web/components/post_components.ex:2791
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1708
+#: lib/vutuv_web/live/post_live/composer.ex:1721
 #, elixir-autogen, elixir-format
 msgid "Watched as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1722
+#: lib/vutuv_web/live/post_live/composer.ex:1735
 #, elixir-autogen, elixir-format
 msgid "With an ISBN, the post shows the book cover and a shop link automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1702
+#: lib/vutuv_web/live/post_live/composer.ex:1715
 #: lib/vutuv_web/templates/education/form_content.html.heex:47
 #: lib/vutuv_web/templates/education/form_content.html.heex:48
 #: lib/vutuv_web/templates/education/form_content.html.heex:67
@@ -13995,34 +13996,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2824
+#: lib/vutuv_web/components/post_components.ex:2828
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2854
+#: lib/vutuv_web/components/post_components.ex:2858
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2855
+#: lib/vutuv_web/components/post_components.ex:2859
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2853
+#: lib/vutuv_web/components/post_components.ex:2857
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2813
+#: lib/vutuv_web/components/post_components.ex:2817
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2860
+#: lib/vutuv_web/components/post_components.ex:2864
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14052,7 +14053,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2627
+#: lib/vutuv_web/components/post_components.ex:2631
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14100,7 +14101,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2618
+#: lib/vutuv_web/components/post_components.ex:2622
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14335,7 +14336,7 @@ msgstr ""
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:894
+#: lib/vutuv/notifications/emailer.ex:901
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -14379,13 +14380,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1016
+#: lib/vutuv_web/live/post_live/composer.ex:1020
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1019
+#: lib/vutuv_web/live/post_live/composer.ex:1023
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14474,14 +14475,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1077
+#: lib/vutuv_web/components/post_components.ex:1081
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1099
+#: lib/vutuv_web/components/post_components.ex:1103
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14508,7 +14509,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:3159
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14779,17 +14780,17 @@ msgstr ""
 msgid "e.g. crypto*, \"machine learning\", politics"
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:49
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:53
 #, elixir-autogen, elixir-format
 msgid "Enter the server name on its own, for example mastodon.example."
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:63
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:67
 #, elixir-autogen, elixir-format
 msgid "%{host} is no longer blocked. What was deleted stays deleted; the server has to follow again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:76
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:80
 #, elixir-autogen, elixir-format
 msgid "%{host} is blocked. Removed: %{followers} remote followers and %{deliveries} queued deliveries."
 msgstr ""
@@ -14859,6 +14860,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:84
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:135
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:177
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Server"
 msgstr ""
@@ -15681,7 +15683,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3124
+#: lib/vutuv_web/components/post_components.ex:3128
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
@@ -15793,7 +15795,7 @@ msgstr ""
 msgid "Stored replies"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/fediverse_html.ex:16
+#: lib/vutuv_web/views/admin/fediverse_html.ex:17
 #, elixir-autogen, elixir-format
 msgid "Taken down"
 msgstr ""
@@ -15815,6 +15817,7 @@ msgid "View the original"
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:176
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "What"
 msgstr ""
@@ -16479,22 +16482,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1309
+#: lib/vutuv_web/components/post_components.ex:1313
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1397
+#: lib/vutuv_web/components/post_components.ex:1401
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1405
+#: lib/vutuv_web/components/post_components.ex:1409
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1391
+#: lib/vutuv_web/components/post_components.ex:1395
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16538,7 +16541,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2380
+#: lib/vutuv_web/live/post_live/composer.ex:2398
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16568,74 +16571,74 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2209
+#: lib/vutuv_web/live/post_live/composer.ex:2225
 #, elixir-autogen, elixir-format
 msgid "Caption, shown under the photo (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2040
+#: lib/vutuv_web/live/post_live/composer.ex:2053
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2217
+#: lib/vutuv_web/live/post_live/composer.ex:2233
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1010
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:1858
+#: lib/vutuv_web/components/post_components.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1456
+#: lib/vutuv_web/live/post_live/composer.ex:1460
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2329
+#: lib/vutuv_web/live/post_live/composer.ex:2347
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2286
+#: lib/vutuv_web/live/post_live/composer.ex:2304
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2288
+#: lib/vutuv_web/live/post_live/composer.ex:2306
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2307
+#: lib/vutuv_web/live/post_live/composer.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2077
+#: lib/vutuv_web/live/post_live/composer.ex:2090
 #, elixir-autogen, elixir-format
 msgid "Move photo earlier"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2089
+#: lib/vutuv_web/live/post_live/composer.ex:2102
 #, elixir-autogen, elixir-format
 msgid "Move photo later"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:1861
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2047
+#: lib/vutuv_web/live/post_live/composer.ex:2060
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2274
+#: lib/vutuv_web/components/post_components.ex:2278
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr ""
@@ -16645,85 +16648,85 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2277
+#: lib/vutuv_web/components/post_components.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2102
+#: lib/vutuv_web/components/post_components.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1604
+#: lib/vutuv_web/components/post_components.ex:1608
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2015
-#: lib/vutuv_web/live/post_live/composer.ex:2016
+#: lib/vutuv_web/live/post_live/composer.ex:2028
+#: lib/vutuv_web/live/post_live/composer.ex:2029
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1043
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:2311
+#: lib/vutuv_web/components/post_components.ex:2315
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1856
+#: lib/vutuv_web/components/post_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2060
-#: lib/vutuv_web/live/post_live/composer.ex:2061
+#: lib/vutuv_web/live/post_live/composer.ex:2073
+#: lib/vutuv_web/live/post_live/composer.ex:2074
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2309
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1414
-#: lib/vutuv_web/live/post_live/composer.ex:2255
+#: lib/vutuv_web/live/post_live/composer.ex:1418
+#: lib/vutuv_web/live/post_live/composer.ex:2271
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1041
+#: lib/vutuv_web/live/post_live/composer.ex:1045
 #: lib/vutuv_web/live/post_live/remote_reply.ex:87
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2327
+#: lib/vutuv_web/live/post_live/composer.ex:2345
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2263
+#: lib/vutuv_web/live/post_live/composer.ex:2279
 #, elixir-autogen, elixir-format
 msgid "This file carries no camera information."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2350
+#: lib/vutuv_web/live/post_live/composer.ex:2368
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2342
+#: lib/vutuv_web/live/post_live/composer.ex:2360
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1044
+#: lib/vutuv_web/live/post_live/composer.ex:1048
 #: lib/vutuv_web/live/post_live/remote_reply.ex:84
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
@@ -16744,12 +16747,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1505
+#: lib/vutuv_web/live/post_live/composer.ex:1518
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1036
+#: lib/vutuv_web/live/post_live/composer.ex:1040
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16759,7 +16762,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1047
+#: lib/vutuv_web/live/post_live/composer.ex:1051
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16774,17 +16777,17 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1432
+#: lib/vutuv_web/live/post_live/composer.ex:1436
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1592
+#: lib/vutuv_web/live/post_live/composer.ex:1605
 #, elixir-autogen, elixir-format
 msgid "Add text (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1500
+#: lib/vutuv_web/live/post_live/composer.ex:1513
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr ""
@@ -16795,89 +16798,89 @@ msgstr ""
 msgid "Post photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1264
+#: lib/vutuv_web/live/post_live/composer.ex:1268
 #, elixir-autogen, elixir-format
 msgid "Post type"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1443
+#: lib/vutuv_web/live/post_live/composer.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Select photos, or drag them here"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1268
+#: lib/vutuv_web/live/post_live/composer.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Text"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1958
+#: lib/vutuv_web/live/post_live/composer.ex:1971
 #, elixir-autogen, elixir-format
 msgid "Text (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1446
+#: lib/vutuv_web/live/post_live/composer.ex:1450
 #, elixir-autogen, elixir-format
 msgid "Up to %{max} photos per post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1391
+#: lib/vutuv_web/live/post_live/composer.ex:1395
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1307
+#: lib/vutuv_web/live/post_live/composer.ex:1311
 #, elixir-autogen, elixir-format
 msgid "A photo post shows your pictures big and first; text is optional. For a post that is mainly text, switch to \"Text\"."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1238
-#: lib/vutuv_web/live/post_live/composer.ex:1292
-#: lib/vutuv_web/live/post_live/composer.ex:1293
+#: lib/vutuv_web/live/post_live/composer.ex:1242
+#: lib/vutuv_web/live/post_live/composer.ex:1296
+#: lib/vutuv_web/live/post_live/composer.ex:1297
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1290
+#: lib/vutuv_web/live/post_live/composer.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1231
+#: lib/vutuv_web/live/post_live/composer.ex:1235
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1574
+#: lib/vutuv_web/live/post_live/composer.ex:1587
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1550
+#: lib/vutuv_web/live/post_live/composer.ex:1563
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1547
+#: lib/vutuv_web/live/post_live/composer.ex:1560
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1544
+#: lib/vutuv_web/live/post_live/composer.ex:1557
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1541
+#: lib/vutuv_web/live/post_live/composer.ex:1554
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1537
+#: lib/vutuv_web/live/post_live/composer.ex:1550
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1563
+#: lib/vutuv_web/live/post_live/composer.ex:1576
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16885,13 +16888,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:939
-#: lib/vutuv_web/components/post_components.ex:3121
+#: lib/vutuv_web/components/post_components.ex:3125
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:937
-#: lib/vutuv_web/components/post_components.ex:3118
+#: lib/vutuv_web/components/post_components.ex:3122
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16901,7 +16904,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3060
+#: lib/vutuv_web/components/post_components.ex:3064
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16941,3 +16944,48 @@ msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:23
+#, elixir-autogen, elixir-format
+msgid "Asked to delete a copy"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:204
+#, elixir-autogen, elixir-format
+msgid "Every withdrawal request so far has been delivered."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:235
+#, elixir-autogen, elixir-format
+msgid "No answer"
+msgstr ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:24
+#, elixir-autogen, elixir-format
+msgid "Passed a report on"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:219
+#, elixir-autogen, elixir-format
+msgid "Reason given"
+msgstr ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:16
+#, elixir-autogen, elixir-format
+msgid "Reported to the origin server"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:201
+#, elixir-autogen, elixir-format
+msgid "Takedowns that did not get through"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:208
+#, elixir-autogen, elixir-format
+msgid "These withdrawal requests were retried eight times over about four hours and then dropped. We cannot make another server delete anything, but a server showing up here repeatedly is either broken or ignoring us, and can be blocked above."
+msgstr ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:25
+#, elixir-autogen, elixir-format
+msgid "Withdrawal request"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -152,7 +152,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1413
+#: lib/vutuv_web/components/post_components.ex:1417
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -193,7 +193,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:439
-#: lib/vutuv_web/live/post_live/composer.ex:1530
+#: lib/vutuv_web/live/post_live/composer.ex:1543
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:303
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -201,7 +201,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1378
+#: lib/vutuv_web/components/post_components.ex:1382
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -491,7 +491,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:280
+#: lib/vutuv/notifications/emailer.ex:281
 #, elixir-autogen
 msgid "New message from @%{slug} on vutuv"
 msgstr ""
@@ -612,7 +612,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1780
+#: lib/vutuv_web/live/post_live/composer.ex:1793
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -622,7 +622,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2863
 #: lib/vutuv_web/live/organization_live/edit.ex:339
-#: lib/vutuv_web/live/post_live/composer.ex:1789
+#: lib/vutuv_web/live/post_live/composer.ex:1802
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:98
@@ -1659,13 +1659,13 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1855
+#: lib/vutuv_web/components/post_components.ex:1859
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1292
-#: lib/vutuv_web/live/post_live/composer.ex:1293
-#: lib/vutuv_web/live/post_live/composer.ex:2225
+#: lib/vutuv_web/live/post_live/composer.ex:1296
+#: lib/vutuv_web/live/post_live/composer.ex:1297
+#: lib/vutuv_web/live/post_live/composer.ex:2241
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1758,7 +1758,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
 #: lib/vutuv_web/live/admin/user_live.ex:168
-#: lib/vutuv_web/live/message_live/index.ex:439
+#: lib/vutuv_web/live/message_live/index.ex:455
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:55
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:28
@@ -1773,7 +1773,7 @@ msgid "Message"
 msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:45
-#: lib/vutuv_web/live/message_live/index.ex:496
+#: lib/vutuv_web/live/message_live/index.ex:512
 #: lib/vutuv_web/live/shell_live.ex:497
 #: lib/vutuv_web/live/shell_live.ex:639
 #: lib/vutuv_web/templates/layout/app.html.heex:117
@@ -1829,7 +1829,7 @@ msgid "Pardon us! Something went wrong."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:130
-#: lib/vutuv_web/live/message_live/index.ex:726
+#: lib/vutuv_web/live/message_live/index.ex:742
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Send"
@@ -1900,8 +1900,8 @@ msgstr ""
 msgid "Who to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:715
-#: lib/vutuv_web/live/message_live/index.ex:716
+#: lib/vutuv_web/live/message_live/index.ex:731
+#: lib/vutuv_web/live/message_live/index.ex:732
 #, elixir-autogen, elixir-format
 msgid "Write a message…"
 msgstr ""
@@ -2106,12 +2106,12 @@ msgid "Markdown is supported: bold, italics, links and lists."
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:503
-#: lib/vutuv_web/live/post_live/composer.ex:1740
+#: lib/vutuv_web/live/post_live/composer.ex:1753
 #, elixir-autogen, elixir-format
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1897
+#: lib/vutuv_web/live/post_live/composer.ex:1910
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2122,7 +2122,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1468
+#: lib/vutuv_web/live/post_live/composer.ex:1472
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2132,7 +2132,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1410
+#: lib/vutuv_web/components/post_components.ex:1414
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2163,29 +2163,29 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1873
+#: lib/vutuv_web/live/post_live/composer.ex:1886
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1801
+#: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1364
-#: lib/vutuv_web/components/post_components.ex:1366
+#: lib/vutuv_web/components/post_components.ex:1368
+#: lib/vutuv_web/components/post_components.ex:1370
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1843
+#: lib/vutuv_web/live/post_live/composer.ex:1856
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1050
-#: lib/vutuv_web/live/post_live/composer.ex:1098
+#: lib/vutuv_web/live/post_live/composer.ex:1054
+#: lib/vutuv_web/live/post_live/composer.ex:1102
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2195,23 +2195,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1026
+#: lib/vutuv_web/live/post_live/composer.ex:1030
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1833
+#: lib/vutuv_web/live/post_live/composer.ex:1846
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1823
+#: lib/vutuv_web/live/post_live/composer.ex:1836
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1789
+#: lib/vutuv_web/live/post_live/composer.ex:1802
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2238,13 +2238,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1793
 #: lib/vutuv_web/components/post_components.ex:1797
+#: lib/vutuv_web/components/post_components.ex:1801
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1794
+#: lib/vutuv_web/components/post_components.ex:1798
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2255,7 +2255,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:1859
+#: lib/vutuv_web/live/post_live/composer.ex:1872
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1787
+#: lib/vutuv_web/live/post_live/composer.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2288,12 +2288,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1124
+#: lib/vutuv_web/live/post_live/composer.ex:1128
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1008
+#: lib/vutuv_web/live/post_live/composer.ex:1012
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2303,12 +2303,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2397
+#: lib/vutuv_web/live/post_live/composer.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2398
+#: lib/vutuv_web/live/post_live/composer.ex:2416
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2322,37 +2322,37 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1958
+#: lib/vutuv_web/live/post_live/composer.ex:1971
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1959
+#: lib/vutuv_web/live/post_live/composer.ex:1972
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1361
+#: lib/vutuv_web/components/post_components.ex:1365
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2922
+#: lib/vutuv_web/components/post_components.ex:2926
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2926
+#: lib/vutuv_web/components/post_components.ex:2930
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2924
+#: lib/vutuv_web/components/post_components.ex:2928
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2925
+#: lib/vutuv_web/components/post_components.ex:2929
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2363,17 +2363,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1610
+#: lib/vutuv_web/live/post_live/composer.ex:1623
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2388
+#: lib/vutuv_web/live/post_live/composer.ex:2406
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2392
+#: lib/vutuv_web/live/post_live/composer.ex:2410
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2393,7 +2393,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3003
+#: lib/vutuv_web/components/post_components.ex:3007
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2412,7 +2412,7 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3147
+#: lib/vutuv_web/components/post_components.ex:3151
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
@@ -2423,7 +2423,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:906
-#: lib/vutuv_web/components/post_components.ex:3156
+#: lib/vutuv_web/components/post_components.ex:3160
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2443,12 +2443,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2992
+#: lib/vutuv_web/components/post_components.ex:2996
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3003
+#: lib/vutuv_web/components/post_components.ex:3007
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2457,23 +2457,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2989
+#: lib/vutuv_web/components/post_components.ex:2993
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2411
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2989
+#: lib/vutuv_web/components/post_components.ex:2993
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3147
+#: lib/vutuv_web/components/post_components.ex:3151
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2496,7 +2496,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3196
+#: lib/vutuv_web/components/post_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2508,26 +2508,26 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:942
-#: lib/vutuv_web/components/post_components.ex:3179
-#: lib/vutuv_web/components/post_components.ex:3180
+#: lib/vutuv_web/components/post_components.ex:3183
+#: lib/vutuv_web/components/post_components.ex:3184
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1332
+#: lib/vutuv_web/components/post_components.ex:1336
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1011
-#: lib/vutuv_web/live/post_live/composer.ex:1777
+#: lib/vutuv_web/live/post_live/composer.ex:1015
+#: lib/vutuv_web/live/post_live/composer.ex:1790
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1904
+#: lib/vutuv_web/live/post_live/composer.ex:1917
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2544,57 +2544,57 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1327
+#: lib/vutuv_web/components/post_components.ex:1331
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1321
+#: lib/vutuv_web/components/post_components.ex:1325
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:477
+#: lib/vutuv_web/live/message_live/index.ex:493
 #, elixir-autogen, elixir-format
 msgid "%{names} are typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:476
+#: lib/vutuv_web/live/message_live/index.ex:492
 #, elixir-autogen, elixir-format
 msgid "%{name} is typing…"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:738
+#: lib/vutuv_web/live/message_live/index.ex:754
 #, elixir-autogen, elixir-format
 msgid "@%{slug} has not accepted your message request yet."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:692
+#: lib/vutuv_web/live/message_live/index.ex:708
 #, elixir-autogen, elixir-format
 msgid "@%{slug} wants to message you."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:460
+#: lib/vutuv_web/live/message_live/index.ex:476
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:574
+#: lib/vutuv_web/live/message_live/index.ex:590
 #, elixir-autogen, elixir-format
 msgid "Back to conversations"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:467
+#: lib/vutuv_web/live/message_live/index.ex:483
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:435
+#: lib/vutuv_web/live/message_live/index.ex:451
 #, elixir-autogen, elixir-format
 msgid "Deleted account"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:620
+#: lib/vutuv_web/live/message_live/index.ex:636
 #, elixir-autogen, elixir-format
 msgid "Load older messages"
 msgstr ""
@@ -2605,23 +2605,23 @@ msgstr ""
 msgid "Member not found."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:553
+#: lib/vutuv_web/live/message_live/index.ex:569
 #, elixir-autogen, elixir-format
 msgid "No conversations yet."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2048
-#: lib/vutuv_web/live/message_live/index.ex:596
+#: lib/vutuv_web/live/message_live/index.ex:612
 #, elixir-autogen, elixir-format
 msgid "Online"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:506
+#: lib/vutuv_web/live/message_live/index.ex:522
 #, elixir-autogen, elixir-format
 msgid "Requests"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:747
+#: lib/vutuv_web/live/message_live/index.ex:763
 #, elixir-autogen, elixir-format
 msgid "Select a conversation."
 msgstr ""
@@ -2834,7 +2834,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1813
+#: lib/vutuv_web/live/post_live/composer.ex:1826
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2857,12 +2857,12 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2923
+#: lib/vutuv_web/components/post_components.ex:2927
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:554
+#: lib/vutuv_web/live/message_live/index.ex:570
 #, elixir-autogen, elixir-format
 msgid "Open someone's profile to message them."
 msgstr ""
@@ -3026,7 +3026,7 @@ msgstr ""
 msgid "Hidden. You can settle this yourself - see below."
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:649
+#: lib/vutuv_web/live/message_live/index.ex:665
 #, elixir-autogen, elixir-format
 msgid "Hidden: reported, under review"
 msgstr ""
@@ -3118,7 +3118,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1297
+#: lib/vutuv_web/components/post_components.ex:1301
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3194,7 +3194,7 @@ msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:884
-#: lib/vutuv_web/components/post_components.ex:1434
+#: lib/vutuv_web/components/post_components.ex:1438
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3222,8 +3222,8 @@ msgstr ""
 msgid "Report this content"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:668
-#: lib/vutuv_web/live/message_live/index.ex:669
+#: lib/vutuv_web/live/message_live/index.ex:684
+#: lib/vutuv_web/live/message_live/index.ex:685
 #, elixir-autogen, elixir-format
 msgid "Report this message"
 msgstr ""
@@ -3505,42 +3505,42 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:902
+#: lib/vutuv/notifications/emailer.ex:909
 #, elixir-autogen, elixir-format
 msgid "A warning for your vutuv account"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:986
+#: lib/vutuv/notifications/emailer.ex:993
 #, elixir-autogen, elixir-format
 msgid "Moderation: %{count} cases are waiting"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:964
+#: lib/vutuv/notifications/emailer.ex:971
 #, elixir-autogen, elixir-format
 msgid "Moderation: a profile was reported"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:876
+#: lib/vutuv/notifications/emailer.ex:883
 #, elixir-autogen, elixir-format
 msgid "The content you reported was revised"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:869
+#: lib/vutuv/notifications/emailer.ex:876
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv is under review"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:862
+#: lib/vutuv/notifications/emailer.ex:869
 #, elixir-autogen, elixir-format
 msgid "Your content on vutuv was reported and is hidden"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:916
+#: lib/vutuv/notifications/emailer.ex:923
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account has been deactivated"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:909
+#: lib/vutuv/notifications/emailer.ex:916
 #, elixir-autogen, elixir-format
 msgid "Your vutuv account is suspended"
 msgstr ""
@@ -4556,7 +4556,7 @@ msgstr ""
 msgid "Discover people to follow"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:557
+#: lib/vutuv_web/live/message_live/index.ex:573
 #, elixir-autogen, elixir-format
 msgid "Find members"
 msgstr ""
@@ -5305,7 +5305,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1029
+#: lib/vutuv_web/live/post_live/composer.ex:1033
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5421,9 +5421,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1497
-#: lib/vutuv_web/components/post_components.ex:1549
-#: lib/vutuv_web/components/post_components.ex:1930
+#: lib/vutuv_web/components/post_components.ex:1501
+#: lib/vutuv_web/components/post_components.ex:1553
+#: lib/vutuv_web/components/post_components.ex:1934
 #: lib/vutuv_web/live/notification_live/index.ex:601
 #: lib/vutuv_web/live/post_live/feed.ex:894
 #, elixir-autogen, elixir-format
@@ -5524,7 +5524,7 @@ msgstr ""
 msgid "Personal tokens for the vutuv API."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1271
+#: lib/vutuv_web/live/post_live/composer.ex:1275
 #: lib/vutuv_web/templates/user/edit.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Photos"
@@ -5628,12 +5628,12 @@ msgstr ""
 msgid "e.g. Jr. or PhD"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:340
+#: lib/vutuv/notifications/emailer.ex:347
 #, elixir-autogen, elixir-format
 msgid "@%{slug} endorsed you on vutuv"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:326
+#: lib/vutuv/notifications/emailer.ex:333
 #, elixir-autogen, elixir-format
 msgid "@%{slug} started following you on vutuv"
 msgstr ""
@@ -5728,7 +5728,7 @@ msgstr ""
 msgid "@handle"
 msgstr ""
 
-#: lib/vutuv_web/live/message_live/index.ex:612
+#: lib/vutuv_web/live/message_live/index.ex:628
 #, elixir-autogen, elixir-format
 msgid "Block @%{slug}"
 msgstr ""
@@ -5875,7 +5875,7 @@ msgstr[1] ""
 msgid "All other devices have been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:646
+#: lib/vutuv/notifications/emailer.ex:653
 #, elixir-autogen, elixir-format
 msgid "Another session was already active on your account."
 msgstr ""
@@ -5900,7 +5900,7 @@ msgstr ""
 msgid "Log this device out of your account?"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:621
+#: lib/vutuv/notifications/emailer.ex:628
 #, elixir-autogen, elixir-format
 msgid "New sign-in to your vutuv account"
 msgstr ""
@@ -5915,7 +5915,7 @@ msgstr ""
 msgid "That device has been logged out."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:649
+#: lib/vutuv/notifications/emailer.ex:656
 #, elixir-autogen, elixir-format
 msgid "The location looks different from where you usually sign in."
 msgstr ""
@@ -5925,7 +5925,7 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:643
+#: lib/vutuv/notifications/emailer.ex:650
 #, elixir-autogen, elixir-format
 msgid "This is the first sign-in we have seen from this device or browser."
 msgstr ""
@@ -6534,6 +6534,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:175
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:216
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #, elixir-autogen, elixir-format
@@ -6656,7 +6657,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1431
+#: lib/vutuv_web/components/post_components.ex:1435
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6666,7 +6667,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1430
+#: lib/vutuv_web/components/post_components.ex:1434
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7349,7 +7350,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3082
+#: lib/vutuv_web/components/post_components.ex:3086
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7970,8 +7971,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1004
-#: lib/vutuv/accounts.ex:1053
+#: lib/vutuv/accounts.ex:1011
+#: lib/vutuv/accounts.ex:1060
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8010,7 +8011,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1021
+#: lib/vutuv/accounts.ex:1028
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8667,7 +8668,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:467
 #: lib/vutuv_web/agent_docs/text.ex:471
 #: lib/vutuv_web/components/ui.ex:3320
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:34
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:200
 #: lib/vutuv_web/controllers/settings_controller.ex:267
 #: lib/vutuv_web/live/fediverse_followers_live.ex:186
@@ -8712,7 +8713,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1016
+#: lib/vutuv/accounts.ex:1023
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8821,7 +8822,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2410
+#: lib/vutuv_web/components/post_components.ex:2414
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9777,7 +9778,7 @@ msgstr ""
 msgid "Your date of birth will be removed and your age will no longer be shown on your profile. You can add it again at any time."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:552
+#: lib/vutuv/notifications/emailer.ex:559
 #, elixir-autogen, elixir-format
 msgid "%{name} invited you to vutuv"
 msgstr ""
@@ -12533,7 +12534,7 @@ msgstr ""
 
 #: lib/vutuv/accounts/user.ex:905
 #: lib/vutuv/jobs/job_posting.ex:164
-#: lib/vutuv/notifications/emailer.ex:427
+#: lib/vutuv/notifications/emailer.ex:434
 #: lib/vutuv_web/agent_docs/markdown.ex:348
 #: lib/vutuv_web/agent_docs/markdown.ex:350
 #: lib/vutuv_web/agent_docs/text.ex:373
@@ -12668,12 +12669,12 @@ msgstr ""
 msgid "You already have the maximum number of published postings."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:932
+#: lib/vutuv/notifications/emailer.ex:939
 #, elixir-autogen, elixir-format
 msgid "Your job posting on vutuv expires soon"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:835
+#: lib/vutuv/notifications/emailer.ex:842
 #, elixir-autogen, elixir-format
 msgid "A domain of your organization page on vutuv is about to be dropped"
 msgstr ""
@@ -12693,12 +12694,12 @@ msgstr ""
 msgid "We could not read this domain's proof on the last check. Restore it and check again, or the domain loses its verification."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:832
+#: lib/vutuv/notifications/emailer.ex:839
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is about to lose its verification"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:853
+#: lib/vutuv/notifications/emailer.ex:860
 #, elixir-autogen, elixir-format
 msgid "Your organization page on vutuv is no longer public"
 msgstr ""
@@ -13126,7 +13127,7 @@ msgid "Search title, poster or organization"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1682
+#: lib/vutuv_web/live/post_live/composer.ex:1695
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -13152,7 +13153,7 @@ msgstr ""
 msgid "—"
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:376
+#: lib/vutuv/notifications/emailer.ex:383
 #, elixir-autogen, elixir-format
 msgid "%{count} new match for your saved searches"
 msgid_plural "%{count} new matches for your saved searches"
@@ -13634,7 +13635,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2367
+#: lib/vutuv_web/live/post_live/composer.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13856,128 +13857,128 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2785
+#: lib/vutuv_web/components/post_components.ex:2789
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1690
+#: lib/vutuv_web/live/post_live/composer.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Author(s)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1758
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #, elixir-autogen, elixir-format
 msgid "Book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:949
-#: lib/vutuv_web/components/post_components.ex:2742
-#: lib/vutuv_web/live/post_live/composer.ex:1636
+#: lib/vutuv_web/components/post_components.ex:2746
+#: lib/vutuv_web/live/post_live/composer.ex:1649
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2786
+#: lib/vutuv_web/components/post_components.ex:2790
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2788
+#: lib/vutuv_web/components/post_components.ex:2792
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1690
+#: lib/vutuv_web/live/post_live/composer.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2784
+#: lib/vutuv_web/components/post_components.ex:2788
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1770
+#: lib/vutuv_web/live/post_live/composer.ex:1783
 #, elixir-autogen, elixir-format
 msgid "Film"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:949
-#: lib/vutuv_web/components/post_components.ex:2741
-#: lib/vutuv_web/live/post_live/composer.ex:1635
+#: lib/vutuv_web/components/post_components.ex:2745
+#: lib/vutuv_web/live/post_live/composer.ex:1648
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1656
+#: lib/vutuv_web/live/post_live/composer.ex:1669
 #, elixir-autogen, elixir-format
 msgid "IMDb link or ID"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1657
+#: lib/vutuv_web/live/post_live/composer.ex:1670
 #, elixir-autogen, elixir-format
 msgid "ISBN"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1670
+#: lib/vutuv_web/live/post_live/composer.ex:1683
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1667
+#: lib/vutuv_web/live/post_live/composer.ex:1680
 #, elixir-autogen, elixir-format
 msgid "Looking up…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:647
+#: lib/vutuv_web/live/post_live/composer.ex:651
 #, elixir-autogen, elixir-format
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2783
+#: lib/vutuv_web/components/post_components.ex:2787
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1709
+#: lib/vutuv_web/live/post_live/composer.ex:1722
 #, elixir-autogen, elixir-format
 msgid "Read as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1645
+#: lib/vutuv_web/live/post_live/composer.ex:1658
 #, elixir-autogen, elixir-format
 msgid "Remove review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1754
-#: lib/vutuv_web/live/post_live/composer.ex:1755
+#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1768
 #, elixir-autogen, elixir-format
 msgid "Review a book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1766
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1779
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #, elixir-autogen, elixir-format
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2787
+#: lib/vutuv_web/components/post_components.ex:2791
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1708
+#: lib/vutuv_web/live/post_live/composer.ex:1721
 #, elixir-autogen, elixir-format
 msgid "Watched as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1722
+#: lib/vutuv_web/live/post_live/composer.ex:1735
 #, elixir-autogen, elixir-format
 msgid "With an ISBN, the post shows the book cover and a shop link automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1702
+#: lib/vutuv_web/live/post_live/composer.ex:1715
 #: lib/vutuv_web/templates/education/form_content.html.heex:47
 #: lib/vutuv_web/templates/education/form_content.html.heex:48
 #: lib/vutuv_web/templates/education/form_content.html.heex:67
@@ -13993,34 +13994,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2824
+#: lib/vutuv_web/components/post_components.ex:2828
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2854
+#: lib/vutuv_web/components/post_components.ex:2858
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2855
+#: lib/vutuv_web/components/post_components.ex:2859
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2853
+#: lib/vutuv_web/components/post_components.ex:2857
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2813
+#: lib/vutuv_web/components/post_components.ex:2817
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2860
+#: lib/vutuv_web/components/post_components.ex:2864
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14050,7 +14051,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2627
+#: lib/vutuv_web/components/post_components.ex:2631
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14098,7 +14099,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2618
+#: lib/vutuv_web/components/post_components.ex:2622
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14333,7 +14334,7 @@ msgstr ""
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
 
-#: lib/vutuv/notifications/emailer.ex:894
+#: lib/vutuv/notifications/emailer.ex:901
 #, elixir-autogen, elixir-format
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
@@ -14377,13 +14378,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1016
+#: lib/vutuv_web/live/post_live/composer.ex:1020
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1019
+#: lib/vutuv_web/live/post_live/composer.ex:1023
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14472,14 +14473,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1077
+#: lib/vutuv_web/components/post_components.ex:1081
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1099
+#: lib/vutuv_web/components/post_components.ex:1103
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14506,7 +14507,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:3159
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14777,17 +14778,17 @@ msgstr ""
 msgid "e.g. crypto*, \"machine learning\", politics"
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:49
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:53
 #, elixir-autogen, elixir-format
 msgid "Enter the server name on its own, for example mastodon.example."
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:63
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:67
 #, elixir-autogen, elixir-format
 msgid "%{host} is no longer blocked. What was deleted stays deleted; the server has to follow again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:76
+#: lib/vutuv_web/controllers/admin/fediverse_controller.ex:80
 #, elixir-autogen, elixir-format
 msgid "%{host} is blocked. Removed: %{followers} remote followers and %{deliveries} queued deliveries."
 msgstr ""
@@ -14857,6 +14858,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:84
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:135
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:177
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:218
 #, elixir-autogen, elixir-format
 msgid "Server"
 msgstr ""
@@ -15679,7 +15681,7 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3124
+#: lib/vutuv_web/components/post_components.ex:3128
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
@@ -15791,7 +15793,7 @@ msgstr ""
 msgid "Stored replies"
 msgstr ""
 
-#: lib/vutuv_web/views/admin/fediverse_html.ex:16
+#: lib/vutuv_web/views/admin/fediverse_html.ex:17
 #, elixir-autogen, elixir-format
 msgid "Taken down"
 msgstr ""
@@ -15813,6 +15815,7 @@ msgid "View the original"
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:176
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:217
 #, elixir-autogen, elixir-format
 msgid "What"
 msgstr ""
@@ -16477,22 +16480,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1309
+#: lib/vutuv_web/components/post_components.ex:1313
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1397
+#: lib/vutuv_web/components/post_components.ex:1401
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1405
+#: lib/vutuv_web/components/post_components.ex:1409
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1391
+#: lib/vutuv_web/components/post_components.ex:1395
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16536,7 +16539,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2380
+#: lib/vutuv_web/live/post_live/composer.ex:2398
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16566,74 +16569,74 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2209
+#: lib/vutuv_web/live/post_live/composer.ex:2225
 #, elixir-autogen, elixir-format
 msgid "Caption, shown under the photo (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2040
+#: lib/vutuv_web/live/post_live/composer.ex:2053
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2217
+#: lib/vutuv_web/live/post_live/composer.ex:2233
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1010
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:1858
+#: lib/vutuv_web/components/post_components.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1456
+#: lib/vutuv_web/live/post_live/composer.ex:1460
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2329
+#: lib/vutuv_web/live/post_live/composer.ex:2347
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2286
+#: lib/vutuv_web/live/post_live/composer.ex:2304
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2288
+#: lib/vutuv_web/live/post_live/composer.ex:2306
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2307
+#: lib/vutuv_web/live/post_live/composer.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2077
+#: lib/vutuv_web/live/post_live/composer.ex:2090
 #, elixir-autogen, elixir-format
 msgid "Move photo earlier"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2089
+#: lib/vutuv_web/live/post_live/composer.ex:2102
 #, elixir-autogen, elixir-format
 msgid "Move photo later"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1857
+#: lib/vutuv_web/components/post_components.ex:1861
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2047
+#: lib/vutuv_web/live/post_live/composer.ex:2060
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2274
+#: lib/vutuv_web/components/post_components.ex:2278
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this post so far."
 msgstr ""
@@ -16643,85 +16646,85 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2277
+#: lib/vutuv_web/components/post_components.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2102
+#: lib/vutuv_web/components/post_components.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1604
+#: lib/vutuv_web/components/post_components.ex:1608
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2015
-#: lib/vutuv_web/live/post_live/composer.ex:2016
+#: lib/vutuv_web/live/post_live/composer.ex:2028
+#: lib/vutuv_web/live/post_live/composer.ex:2029
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1043
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:2311
+#: lib/vutuv_web/components/post_components.ex:2315
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1856
+#: lib/vutuv_web/components/post_components.ex:1860
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2060
-#: lib/vutuv_web/live/post_live/composer.ex:2061
+#: lib/vutuv_web/live/post_live/composer.ex:2073
+#: lib/vutuv_web/live/post_live/composer.ex:2074
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2309
+#: lib/vutuv_web/live/post_live/composer.ex:2327
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1414
-#: lib/vutuv_web/live/post_live/composer.ex:2255
+#: lib/vutuv_web/live/post_live/composer.ex:1418
+#: lib/vutuv_web/live/post_live/composer.ex:2271
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1041
+#: lib/vutuv_web/live/post_live/composer.ex:1045
 #: lib/vutuv_web/live/post_live/remote_reply.ex:87
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2327
+#: lib/vutuv_web/live/post_live/composer.ex:2345
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2263
+#: lib/vutuv_web/live/post_live/composer.ex:2279
 #, elixir-autogen, elixir-format
 msgid "This file carries no camera information."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2350
+#: lib/vutuv_web/live/post_live/composer.ex:2368
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2342
+#: lib/vutuv_web/live/post_live/composer.ex:2360
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1044
+#: lib/vutuv_web/live/post_live/composer.ex:1048
 #: lib/vutuv_web/live/post_live/remote_reply.ex:84
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
@@ -16742,12 +16745,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1505
+#: lib/vutuv_web/live/post_live/composer.ex:1518
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1036
+#: lib/vutuv_web/live/post_live/composer.ex:1040
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16757,7 +16760,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1047
+#: lib/vutuv_web/live/post_live/composer.ex:1051
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16772,17 +16775,17 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1432
+#: lib/vutuv_web/live/post_live/composer.ex:1436
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1592
+#: lib/vutuv_web/live/post_live/composer.ex:1605
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add text (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1500
+#: lib/vutuv_web/live/post_live/composer.ex:1513
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Licence"
 msgstr ""
@@ -16793,89 +16796,89 @@ msgstr ""
 msgid "Post photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1264
+#: lib/vutuv_web/live/post_live/composer.ex:1268
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post type"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1443
+#: lib/vutuv_web/live/post_live/composer.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Select photos, or drag them here"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1268
+#: lib/vutuv_web/live/post_live/composer.ex:1272
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Text"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1958
+#: lib/vutuv_web/live/post_live/composer.ex:1971
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Text (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1446
+#: lib/vutuv_web/live/post_live/composer.ex:1450
 #, elixir-autogen, elixir-format
 msgid "Up to %{max} photos per post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1391
+#: lib/vutuv_web/live/post_live/composer.ex:1395
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1307
+#: lib/vutuv_web/live/post_live/composer.ex:1311
 #, elixir-autogen, elixir-format
 msgid "A photo post shows your pictures big and first; text is optional. For a post that is mainly text, switch to \"Text\"."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1238
-#: lib/vutuv_web/live/post_live/composer.ex:1292
-#: lib/vutuv_web/live/post_live/composer.ex:1293
+#: lib/vutuv_web/live/post_live/composer.ex:1242
+#: lib/vutuv_web/live/post_live/composer.ex:1296
+#: lib/vutuv_web/live/post_live/composer.ex:1297
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1290
+#: lib/vutuv_web/live/post_live/composer.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1231
+#: lib/vutuv_web/live/post_live/composer.ex:1235
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1574
+#: lib/vutuv_web/live/post_live/composer.ex:1587
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1550
+#: lib/vutuv_web/live/post_live/composer.ex:1563
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1547
+#: lib/vutuv_web/live/post_live/composer.ex:1560
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1544
+#: lib/vutuv_web/live/post_live/composer.ex:1557
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1541
+#: lib/vutuv_web/live/post_live/composer.ex:1554
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1537
+#: lib/vutuv_web/live/post_live/composer.ex:1550
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1563
+#: lib/vutuv_web/live/post_live/composer.ex:1576
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16883,13 +16886,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:939
-#: lib/vutuv_web/components/post_components.ex:3121
+#: lib/vutuv_web/components/post_components.ex:3125
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:937
-#: lib/vutuv_web/components/post_components.ex:3118
+#: lib/vutuv_web/components/post_components.ex:3122
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16899,7 +16902,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3060
+#: lib/vutuv_web/components/post_components.ex:3064
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16939,3 +16942,48 @@ msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:23
+#, elixir-autogen, elixir-format
+msgid "Asked to delete a copy"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:204
+#, elixir-autogen, elixir-format
+msgid "Every withdrawal request so far has been delivered."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:235
+#, elixir-autogen, elixir-format
+msgid "No answer"
+msgstr ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:24
+#, elixir-autogen, elixir-format
+msgid "Passed a report on"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:219
+#, elixir-autogen, elixir-format
+msgid "Reason given"
+msgstr ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:16
+#, elixir-autogen, elixir-format
+msgid "Reported to the origin server"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:201
+#, elixir-autogen, elixir-format
+msgid "Takedowns that did not get through"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/fediverse/index.html.heex:208
+#, elixir-autogen, elixir-format
+msgid "These withdrawal requests were retried eight times over about four hours and then dropped. We cannot make another server delete anything, but a server showing up here repeatedly is either broken or ignoring us, and can be blocked above."
+msgstr ""
+
+#: lib/vutuv_web/views/admin/fediverse_html.ex:25
+#, elixir-autogen, elixir-format
+msgid "Withdrawal request"
+msgstr ""

--- a/priv/repo/migrations/20260726195751_create_fediverse_revocation_records.exs
+++ b/priv/repo/migrations/20260726195751_create_fediverse_revocation_records.exs
@@ -1,0 +1,67 @@
+defmodule Vutuv.Repo.Migrations.CreateFediverseRevocationRecords do
+  use Ecto.Migration
+
+  # Issue #1102: a takedown here has to leave the building. Two plain additions.
+  #
+  # `fediverse_post_deliveries` is the address book a revocation needs: which
+  # inbox received a post, and under which Note id. Without it a `Delete` can
+  # only go to whoever follows the member *now* (a server that has since
+  # unfollowed keeps its copy forever) and can only name the id built from the
+  # *current* username (which stops matching after a rename).
+  #
+  # `fediverse_delivery_failures` is the ledger that keeps an incomplete takedown
+  # from being silent: a `Delete` or `Flag` dropped after the last retry lands
+  # here for the operator to see on /admin/fediverse.
+  def change do
+    create table(:fediverse_post_deliveries) do
+      # No foreign key into `posts` on purpose: the revocation runs **after** the
+      # post row is gone (see `Vutuv.Posts.delete_post/1`), so a cascade would
+      # erase the addresses moments before they are needed. The rows are cleared
+      # explicitly instead, by the revocation itself and by account deletion.
+      add(:post_id, :binary_id, null: false)
+      add(:user_id, :binary_id, null: false)
+      # `:text`, like every other URI column here (`fediverse_followers.inbox_uri`,
+      # `fediverse_notes.object_uri`): a remote server's inbox address is not ours
+      # to bound, and a varchar(255) would raise 22001 on the publish path.
+      add(:inbox_uri, :text, null: false)
+      # The Note id this copy was published under, kept verbatim: it is what the
+      # remote server stored, and a rename must not change what a Tombstone names.
+      add(:object_uri, :text, null: false)
+
+      timestamps(updated_at: false)
+    end
+
+    # One row per (post, inbox, published id). An `Update` after a rename
+    # therefore adds a second id rather than overwriting the first, so both
+    # copies can be revoked.
+    #
+    # Two `:text` columns in one btree index stay inside Postgres' ~2704-byte
+    # index-entry limit because both sources cap a URI at 2048 bytes
+    # (`Vutuv.Fediverse.Follower` / `.Note`) and the published id is our own
+    # short URL. Raising either cap means revisiting this index.
+    create(
+      unique_index(:fediverse_post_deliveries, [:post_id, :inbox_uri, :object_uri],
+        name: :fediverse_post_deliveries_target_index
+      )
+    )
+
+    create(index(:fediverse_post_deliveries, [:user_id]))
+
+    create table(:fediverse_delivery_failures) do
+      add(:activity_type, :string, null: false)
+      add(:host, :string, null: false)
+      # A Flag names the *remote* note it reports, so this is not always one of
+      # our own bounded URLs either.
+      add(:object_uri, :text)
+      # A plain value, not an association, like the other audit ledgers: the row
+      # must stay readable after the account it names is gone.
+      add(:user_id, :binary_id)
+      add(:attempts, :integer, null: false)
+      add(:last_error, :string)
+
+      timestamps(updated_at: false)
+    end
+
+    create(index(:fediverse_delivery_failures, [:inserted_at]))
+  end
+end

--- a/test/vutuv/fediverse_blocklist_test.exs
+++ b/test/vutuv/fediverse_blocklist_test.exs
@@ -140,7 +140,9 @@ defmodule Vutuv.FediverseBlocklistTest do
 
       # `notes` joined the tally with issue #1069: a block is also a takedown of
       # the replies that server's members wrote under vutuv posts.
-      assert purged == %{followers: 1, deliveries: 1, notes: 0}
+      # `post_deliveries` joined with issue #1102: the record of what that server
+      # received would only ever address a revocation nobody will deliver.
+      assert purged == %{followers: 1, deliveries: 1, notes: 0, post_deliveries: 0}
       assert [%Follower{actor_uri: "https://social.example/users/alice"}] = Repo.all(Follower)
       assert [%Delivery{inbox_uri: "https://social.example/inbox"}] = Repo.all(Delivery)
     end

--- a/test/vutuv/fediverse_revocation_test.exs
+++ b/test/vutuv/fediverse_revocation_test.exs
@@ -1,0 +1,440 @@
+defmodule Vutuv.FediverseRevocationTest do
+  @moduledoc """
+  Taking something back off the other servers (issue #1102).
+
+  Before this, only the owner's own delete button federated a `Delete`: a report
+  that froze a post, an admin removal and the strike ladder all hid the content
+  here and told the network nothing, and a reported reply from another network
+  was deleted from our cache while its origin never learned anybody objected.
+
+  async: false — the HTTP stub and the report rate limit both live outside the
+  SQL sandbox (the app env and the shared `Vutuv.RateLimiter` ETS table).
+  """
+  use Vutuv.DataCase, async: false
+
+  import Ecto.Query
+  import Vutuv.PostsHelpers
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Fediverse.DeliveryFailure
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.NoteEvent
+  alias Vutuv.Fediverse.PostDelivery
+  alias Vutuv.Moderation
+  alias VutuvWeb.Fediverse.Docs
+
+  @public "https://www.w3.org/ns/activitystreams#Public"
+  @remote_actor "https://social.example/users/alice"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp federating(attrs \\ []) do
+    user = insert(:activated_user, Keyword.merge([fediverse_followers?: true], attrs))
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    user
+  end
+
+  defp follower_on(user, host) do
+    {:ok, follower} =
+      Fediverse.add_follower(user, %{
+        actor_uri: "https://#{host}/users/x",
+        inbox_uri: "https://#{host}/inbox"
+      })
+
+    follower
+  end
+
+  # A post that really went out: enqueued, recorded, and the queue cleared again
+  # so each test only sees what its own takedown produced.
+  defp published_post(user, body \\ "Federated far and wide.") do
+    post = create_post!(user, %{"body" => body})
+    Repo.delete_all(Delivery)
+    post
+  end
+
+  defp deliveries, do: Repo.all(from(d in Delivery, order_by: d.id))
+
+  defp hide!(user, fields) do
+    Repo.update_all(from(u in User, where: u.id == ^user.id), set: fields)
+  end
+
+  defp reporter! do
+    reporter = insert(:activated_user)
+    insert(:email, user: reporter)
+    reporter
+  end
+
+  # A suspended member can no longer publish, so walking the strike ladder needs
+  # one post (and therefore one case) per rung.
+  defp report_new_post!(user, reporter, body) do
+    post = insert(:post, user: user, body: body)
+    Moderation.report_content(reporter, post, %{"category" => "spam"})
+  end
+
+  # Drives the queued row to its last allowed attempt, which is where the
+  # deliverer gives up for good.
+  defp exhaust_attempts do
+    Repo.update_all(from(d in Delivery),
+      set: [attempts: 7, next_attempt_at: DateTime.add(DateTime.utc_now(:second), -1)]
+    )
+
+    assert Fediverse.deliver_due() == 1
+    assert Repo.aggregate(Delivery, :count) == 0
+  end
+
+  describe "revoke_post/1 addresses the servers that got the post" do
+    test "the Delete reaches a server that has since unfollowed" do
+      user = federating()
+      follower_on(user, "gone.example")
+      post = published_post(user)
+      assert Repo.aggregate(PostDelivery, :count) == 1
+
+      # The server drops the follow. Its copy of the post does not go with it,
+      # which is exactly what a "send it to whoever follows now" Delete misses.
+      :ok = Fediverse.remove_follower(user, "https://gone.example/users/x")
+      assert Fediverse.delivery_inboxes(user) == []
+
+      assert :ok = Fediverse.revoke_post(post)
+
+      assert [delivery] = deliveries()
+      assert delivery.inbox_uri == "https://gone.example/inbox"
+      assert delivery.activity_json =~ ~s("type":"Delete")
+      assert delivery.activity_json =~ ~s("type":"Tombstone")
+    end
+
+    test "the Tombstone names the id the post was published under, not the current one" do
+      user = federating()
+      follower_on(user, "social.example")
+      post = published_post(user)
+      published_id = Docs.note_url(user, post.id)
+
+      # A rename (issue #1086) moves every future Note URL. Written straight to
+      # the row: what is under test is the id inside the activity, not the flow
+      # that changes a username.
+      renamed =
+        user
+        |> Ecto.Changeset.change(username: "renamed#{System.unique_integer([:positive])}")
+        |> Repo.update!()
+
+      refute Docs.note_url(renamed, post.id) == published_id
+
+      assert :ok = Fediverse.revoke_post(post)
+
+      assert [delivery] = deliveries()
+      assert delivery.activity_json =~ published_id
+      refute delivery.activity_json =~ Docs.note_url(renamed, post.id)
+    end
+
+    test "the records are spent once the revocation is queued" do
+      user = federating()
+      follower_on(user, "social.example")
+      post = published_post(user)
+
+      assert :ok = Fediverse.revoke_post(post)
+      assert Repo.aggregate(PostDelivery, :count) == 0
+    end
+
+    test "a post with no records falls back to the current followers, not to silence" do
+      user = federating()
+      post = published_post(user, "Published before anybody followed.")
+      # Nothing was recorded, because there was no inbox to record.
+      assert Repo.aggregate(PostDelivery, :count) == 0
+
+      follower_on(user, "late.example")
+
+      assert :ok = Fediverse.revoke_post(post)
+
+      assert [delivery] = deliveries()
+      assert delivery.inbox_uri == "https://late.example/inbox"
+      assert delivery.activity_json =~ Docs.note_url(user, post.id)
+    end
+
+    test "a takedown is not blocked by the very state the takedown creates" do
+      for fields <- [
+            [frozen_at: NaiveDateTime.utc_now(:second)],
+            [deactivated_at: NaiveDateTime.utc_now(:second)],
+            [suspended_until: ~N[2099-01-01 00:00:00]]
+          ] do
+        user = federating()
+        follower_on(user, "social.example")
+        post = published_post(user)
+
+        hide!(user, fields)
+        refute Fediverse.federated?(Repo.reload!(user))
+
+        assert :ok = Fediverse.revoke_post(post),
+               "a #{inspect(fields)} account must still be able to withdraw a post"
+
+        assert [_delivery] = deliveries()
+        Repo.delete_all(Delivery)
+      end
+    end
+
+    test "a member who moved their followers away can still withdraw" do
+      user = federating()
+      follower_on(user, "social.example")
+      post = published_post(user)
+
+      moved =
+        user
+        |> Ecto.Changeset.change(moved_to: "https://elsewhere.example/users/me")
+        |> Repo.update!()
+
+      assert Fediverse.moved?(moved)
+      assert :ok = Fediverse.revoke_post(post)
+      assert [_delivery] = deliveries()
+    end
+
+    test "nothing is sent for a member who never federated" do
+      post = insert(:post, user: insert(:activated_user))
+
+      assert :skip == Fediverse.revoke_post(post)
+      assert deliveries() == []
+    end
+  end
+
+  describe "the moderation freezer (the takedown paths that used to send nothing)" do
+    test "a report that freezes a post withdraws the copies, and rejecting it publishes again" do
+      user = federating()
+      follower_on(user, "social.example")
+      post = published_post(user)
+
+      {:ok, case_record} =
+        Moderation.report_content(reporter!(), post, %{"category" => "bullying"})
+
+      assert Repo.reload!(post).frozen_at
+      assert [withdrawal] = deliveries()
+      assert withdrawal.activity_json =~ ~s("type":"Delete")
+
+      Repo.delete_all(Delivery)
+
+      # An unfounded report has to put the post back on the other servers too,
+      # and a Delete leaves nothing there for an Update to change: it is a Create.
+      {:ok, _} = Moderation.reject_case(case_record, insert(:activated_user, admin?: true))
+
+      refute Repo.reload!(post).frozen_at
+      assert [republish] = deliveries()
+      assert republish.activity_json =~ ~s("type":"Create")
+      assert Repo.aggregate(PostDelivery, :count) == 1
+    end
+
+    test "an upheld report leaves the withdrawal in place and sends nothing more" do
+      user = federating()
+      follower_on(user, "social.example")
+      post = published_post(user)
+
+      {:ok, case_record} = Moderation.report_content(reporter!(), post, %{"category" => "spam"})
+      assert [_withdrawal] = deliveries()
+      Repo.delete_all(Delivery)
+
+      {:ok, _} = Moderation.uphold_case(case_record, insert(:activated_user, admin?: true))
+
+      assert deliveries() == []
+    end
+
+    test "a permanent removal broadcasts the actor Delete" do
+      user = federating()
+      follower_on(user, "social.example")
+      post = published_post(user)
+
+      {:ok, case_record} = Moderation.report_content(reporter!(), post, %{"category" => "spam"})
+      Repo.delete_all(Delivery)
+
+      {:ok, _} =
+        Moderation.remove_owner(case_record, insert(:activated_user, admin?: true), :deactivate)
+
+      assert Repo.reload!(user).deactivated_at
+      assert [broadcast] = deliveries()
+      assert broadcast.activity_json =~ ~s("type":"Delete")
+      assert broadcast.activity_json =~ Docs.actor_url(user)
+    end
+
+    test "the strike ladder broadcasts on the permanent third strike, not on the suspension" do
+      user = federating()
+      follower_on(user, "social.example")
+      insert(:email, user: user)
+      admin = insert(:activated_user, admin?: true)
+      reporter = reporter!()
+
+      # A warning, then a week's suspension: both temporary, so the network hears
+      # nothing — a seven-day hiding must never read as "this account is gone".
+      for level <- 1..2 do
+        {:ok, case_record} = report_new_post!(user, reporter, "strike #{level}")
+        Repo.delete_all(Delivery)
+        {:ok, _} = Moderation.uphold_case(case_record, admin)
+
+        refute Enum.any?(deliveries(), &(&1.activity_json =~ Docs.actor_url(user)))
+      end
+
+      assert Repo.reload!(user).suspended_until
+
+      {:ok, case_record} = report_new_post!(user, reporter, "strike three")
+      Repo.delete_all(Delivery)
+      {:ok, _} = Moderation.uphold_case(case_record, admin)
+
+      assert Repo.reload!(user).deactivated_at
+      assert [broadcast] = deliveries()
+      assert broadcast.activity_json =~ ~s("type":"Delete")
+      assert broadcast.activity_json =~ Docs.actor_url(user)
+    end
+  end
+
+  describe "reporting a reply from another network (the Flag)" do
+    setup do
+      author = federating(fediverse_replies?: true)
+      post = create_post!(author, %{"body" => "Ask me anything."})
+      Repo.delete_all(Delivery)
+
+      :ok =
+        Fediverse.record_reply(
+          author,
+          %{
+            "type" => "Create",
+            "actor" => @remote_actor,
+            "to" => [@public],
+            "object" => %{
+              "id" => "#{@remote_actor}/statuses/1",
+              "type" => "Note",
+              "inReplyTo" => Docs.note_url(author, post.id),
+              "content" => "<p>Rubbish.</p>",
+              "to" => [@public]
+            }
+          },
+          %{
+            uri: @remote_actor,
+            handle: "alice",
+            name: "Alice Anders",
+            inbox: "#{@remote_actor}/inbox"
+          }
+        )
+
+      {:ok, author: author, note: Repo.one!(Note)}
+    end
+
+    test "the report is passed on to the origin server", %{author: author, note: note} do
+      reporter = insert(:activated_user)
+
+      assert :ok = Fediverse.report_note(note.id, reporter)
+
+      assert [flag] = deliveries()
+      assert flag.inbox_uri == "#{@remote_actor}/inbox"
+      assert flag.activity_json =~ ~s("type":"Flag")
+      # The reported object, and never who reported it: the Flag travels to a
+      # stranger's moderators, so it is signed by the thread's owner and names
+      # nobody here.
+      assert flag.activity_json =~ note.object_uri
+      assert flag.activity_json =~ Docs.actor_url(author)
+      refute flag.activity_json =~ reporter.id
+
+      assert %NoteEvent{} = Repo.get_by(NoteEvent, action: "flagged")
+      assert %NoteEvent{} = Repo.get_by(NoteEvent, action: "reported")
+    end
+
+    test "the report stops at the border for a blocked server", %{note: note} do
+      admin = insert(:activated_user, admin?: true)
+      {:ok, _} = Fediverse.block_instance(%{"host" => "social.example"}, admin)
+
+      # The block purged the note itself, so there is nothing left to report.
+      assert {:error, :not_found} = Fediverse.report_note(note.id, insert(:activated_user))
+      assert deliveries() == []
+    end
+
+    test "taking a reply off your own post tells nobody", %{author: author, note: note} do
+      assert :ok = Fediverse.remove_note(note.id, author)
+
+      assert deliveries() == []
+      assert Repo.get_by(NoteEvent, action: "flagged") == nil
+      assert %NoteEvent{} = Repo.get_by(NoteEvent, action: "removed_by_member")
+    end
+
+    test "a report the reporter may not file changes nothing", %{note: note} do
+      Repo.update_all(from(n in Note, where: n.id == ^note.id), set: [audience: "direct"])
+
+      assert {:error, :not_allowed} = Fediverse.report_note(note.id, insert(:activated_user))
+      assert deliveries() == []
+      assert Repo.aggregate(NoteEvent, :count) == 0
+    end
+  end
+
+  describe "a takedown that never arrives" do
+    setup do
+      Application.put_env(:vutuv, :fediverse_req_options,
+        plug: fn conn -> Plug.Conn.send_resp(conn, 500, "boom") end
+      )
+
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+      :ok
+    end
+
+    test "is written to the ledger the operator reads" do
+      user = federating()
+      follower_on(user, "social.example")
+      post = published_post(user)
+      published_id = Docs.note_url(user, post.id)
+
+      assert :ok = Fediverse.revoke_post(post)
+      exhaust_attempts()
+
+      assert [failure] = Repo.all(DeliveryFailure)
+      assert failure.activity_type == "Delete"
+      assert failure.host == "social.example"
+      assert failure.object_uri == published_id
+      assert failure.attempts == 8
+      assert failure.last_error =~ "500"
+      assert failure.user_id == user.id
+
+      assert Fediverse.stats().failed_takedowns == 1
+      assert [^failure] = Fediverse.recent_delivery_failures()
+    end
+
+    test "an ordinary post that did not travel is not in it" do
+      user = federating()
+      follower_on(user, "social.example")
+      create_post!(user, %{"body" => "Hello out there."})
+      assert [%Delivery{}] = deliveries()
+
+      exhaust_attempts()
+
+      assert Repo.all(DeliveryFailure) == []
+      assert Fediverse.stats().failed_takedowns == 0
+    end
+  end
+
+  describe "account deletion" do
+    test "captures the actor Delete even for an account moderation had already hidden" do
+      user = federating()
+      follower_on(user, "social.example")
+      hide!(user, deactivated_at: NaiveDateTime.utc_now(:second))
+      hidden = Repo.reload!(user)
+
+      refute Fediverse.federated?(hidden)
+      assert %{inboxes: ["https://social.example/inbox"]} = Fediverse.prepare_actor_delete(hidden)
+    end
+
+    test "clears the delivery records the cascade cannot reach" do
+      user = federating()
+      follower_on(user, "social.example")
+      published_post(user)
+      assert Repo.aggregate(PostDelivery, :count) == 1
+
+      assert 1 == Fediverse.drop_post_deliveries(user)
+      assert Repo.aggregate(PostDelivery, :count) == 0
+    end
+  end
+
+  describe "purge_instance/1" do
+    test "forgets what a blocked server received" do
+      user = federating()
+      follower_on(user, "social.example")
+      published_post(user)
+
+      assert %{post_deliveries: 1} = Fediverse.purge_instance("social.example")
+      assert Repo.aggregate(PostDelivery, :count) == 0
+    end
+  end
+end

--- a/test/vutuv/fediverse_test.exs
+++ b/test/vutuv/fediverse_test.exs
@@ -698,7 +698,9 @@ defmodule Vutuv.FediverseTest do
                remote_followers: 2,
                queue_depth: 2,
                stuck_deliveries: 1,
-               blocked_instances: 0
+               blocked_instances: 0,
+               # Takedowns that gave up without arriving (issue #1102).
+               failed_takedowns: 0
              }
     end
   end

--- a/test/vutuv_web/controllers/admin/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/admin/fediverse_controller_test.exs
@@ -77,6 +77,29 @@ defmodule VutuvWeb.Admin.FediverseControllerTest do
     assert Fediverse.blocked_instance_count() == 0
   end
 
+  test "names the takedowns that never arrived (issue #1102)", %{conn: conn} do
+    {conn, _admin} = login_admin(conn)
+    member = insert(:activated_user, fediverse_followers?: true)
+
+    Repo.insert!(%Vutuv.Fediverse.DeliveryFailure{
+      activity_type: "Delete",
+      host: "stubborn.example",
+      object_uri: "https://vutuv.test/#{member.username}/posts/abc",
+      user_id: member.id,
+      attempts: 8,
+      last_error: "HTTP 500"
+    })
+
+    html = conn |> get(~p"/admin/fediverse") |> html_response(200)
+
+    # A copy somebody asked us to withdraw is still published somewhere; the one
+    # delivery failure that must not be invisible.
+    assert html =~ ~s(data-failed-takedown="Delete")
+    assert html =~ "stubborn.example"
+    assert html =~ "HTTP 500"
+    assert html =~ "posts/abc"
+  end
+
   test "the page 404s on an installation with federation switched off", %{conn: conn} do
     {conn, _admin} = login_admin(conn)
     Application.put_env(:vutuv, :fediverse_enabled, false)


### PR DESCRIPTION
Closes #1102.

Only one takedown path federated a `Delete`: a member pressing delete on their own
post. Everything else hid the content on vutuv and told the network nothing, and
`lib/vutuv/moderation.ex` did not reference `Vutuv.Fediverse` at all. Worse, the one
path that *did* federate was gated on `federated?/1`, which is false for a frozen,
suspended or deactivated account — so the accounts moderation had already hidden were
exactly the ones whose deletions never went out.

| takedown path | before | now |
| --- | --- | --- |
| owner deletes their post | `Delete(Tombstone)` | same, via the chokepoint |
| report freezes a post | nothing | `Delete`, and a `Create` again if the report is rejected |
| `remove_owner :deactivate` | nothing | actor `Delete` broadcast |
| strike ladder, third strike | nothing | actor `Delete` broadcast |
| admin deletes a hidden account | nothing (the `federated?/1` gate) | actor `Delete` broadcast |
| reported remote reply | cache row gone | plus a `Flag` to the origin server |
| week's suspension, profile freeze | nothing | still nothing, deliberately |

**One chokepoint.** `Fediverse.revoke_post/1` sends the `Delete(Tombstone)` and every
takedown calls it; `revoke_actor/1` is its account-level twin for a permanent removal.
Both gate on the new `ever_federated?/1` (the switch is on and the member has an actor)
rather than `federated?/1`, so a takedown is not blocked by the state the takedown
creates, and neither skips a member who moved their followers away — they stopped
publishing, but the servers that followed them still hold what came before.

**Addressed, not broadcast.** `fediverse_post_deliveries` records each
`(post, inbox, published Note id)` when a `Create`/`Update` is enqueued, closing two
holes named in the issue: targets used to come from the follower table, so a server that
received the post and has since unfollowed kept its copy forever; and the Tombstone id
was built from the *current* username, so after a rename (#1086) a delivered `Delete`
matched nothing. Those rows carry no FK into `posts` on purpose — `delete_post/1`
federates *after* the commit, so a cascade would erase the addresses moments before they
are needed.

**Two judgement calls the issue asked for explicitly:**

- *Revoke on freeze, re-`Create` on rejection* (rather than revoking only on uphold).
  A frozen post is invisible to everyone but its owner here, so leaving the remote copies
  up makes the freeze a local fiction. Lifting it sends a fresh `Create`, since a `Delete`
  leaves nothing there for an `Update` to change.
- *A **profile** freeze sends nothing.* No actor `Delete` for anything temporary, and
  `410 Gone` stays reserved for the member's own opt-out (`FediverseController.refuse/2`'s
  rule is untouched). A profile freeze also does not fan a `Delete` out over every post
  the member ever published: one report would trigger a network-wide storm and a rejection
  a second one.

**The `Flag`** is signed by the member whose post the reply sat under, never by the
reporter: a `Flag` is a signed statement and vutuv has no installation-wide actor to file
from, so it comes from the party that server already knows in this conversation. Nothing
in it names the reporter, no content rides along, and the reporter's daily report cap
bounds it since the `Flag` only rides a successful takedown. A `"flagged"` row joins the
`NoteEvent` ledger.

**Nothing fails silently.** A `Delete` or `Flag` that exhausts its eight attempts lands in
`fediverse_delivery_failures` and is listed on `/admin/fediverse` with the server, the
object and the last error (`failed_takedowns` in `Fediverse.stats/0`). Only the withdrawing
types are recorded: a `Create` that never lands is one post that did not travel, a `Delete`
that never lands is a copy somebody asked us to withdraw that is still published somewhere.

Remote deletion is advisory by protocol and the UI does not pretend otherwise. The point is
that every takedown now at least asks.

**Tests** (`test/vutuv/fediverse_revocation_test.exs`, 20 cases): the `Delete` reaching a
server that unfollowed; the Tombstone naming the published id after a rename; every hidden
account state and a moved member still able to withdraw; freeze → revoke → reject →
re-publish; the ladder broadcasting on the third strike but not the suspension; the `Flag`
and its absence on `remove_note/2`; the give-up ledger recording a `Delete` and ignoring a
`Create`. Plus the admin-page rendering, and docs updated in `fediverse.md`,
`moderation.md` and `ADMINS.md`.

Two plain additive tables, so the migration is N-1 compatible.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_0112KcX5ZW97DZrQGnvd5tUq
