### PR TITLE
One like count, one reply count, one repost count

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -157,24 +157,40 @@ every endpoint 404s and nothing is delivered.
   deletion path, so it must not depend on a switch still being on. Rows live
   exactly as long as the post (FK cascade, so a post delete and an account
   delete both take them), like a vutuv like; there is no separate expiry.
-  - The count **and the newest few accounts** ride the existing engagement
-    select (`Vutuv.Posts.engagement_count_select/1` → `:fediverse_reactions`
-    plus a `json_agg` of `:fediverse_reaction_actors`, capped at 4 rows), so
-    both are batched with the other counters, tick live through
-    `{:post_counters, …}` (`broadcast_post_counters/1`) and reach
-    `VutuvWeb.AgentDocs.PostDoc` as `fediverse_reaction_count` and
-    `fediverse_reactions`. The cap lives in SQL so a post with a thousand boosts
-    cannot drag a thousand rows into a feed card; the count stays the true total
-    behind the "+N more" tail.
-  - It renders as its **own** line under the vutuv counters, never folded into
-    them: a hostile server can then inflate only its own line, and the reader
-    sees which world answered. Each account is a chip — the heart or re-share
-    glyph the vutuv action bar uses for the same act, the `@handle@host`
-    (`Vutuv.Fediverse.Handle`, shared with the follower list and the reply
-    cards), linking **out** to the account, since there is no vutuv profile
-    behind it. Public, like the counts always were: both acts are published
-    under the actor's own name on their own server, and the reply cards below
-    already name their authors the same way. Hidden at zero.
+  - The counts **and the newest few accounts** ride the existing engagement
+    select (`Vutuv.Posts.engagement_count_select/1` → `:fediverse_likes` and
+    `:fediverse_reposts`, counted per verb, plus a `json_agg` of
+    `:fediverse_reaction_actors`, capped at 4 rows), so all of it is batched
+    with the other counters, ticks live through `{:post_counters, …}`
+    (`broadcast_post_counters/1`) and reaches `VutuvWeb.AgentDocs.PostDoc`. The
+    cap lives in SQL so a post with a thousand boosts cannot drag a thousand
+    rows into a feed card; the counts stay the true totals behind the "+N more"
+    tail.
+  - **The card shows one number per act.** A favourite is a like and an
+    `Announce` is a repost, so `Vutuv.Posts.shown_counts/1` adds the remote
+    figures into the like / repost / reply counters the buttons print, and
+    `PostDoc` carries the same folded `like_count` / `repost_count` /
+    `reply_count`. The card used to print two sets of figures, the vutuv ones in
+    the buttons and a permanent "from other networks" line under them: correct,
+    and it read as bookkeeping — a reader had to add two columns in their head
+    to learn how a post did.
+  - **The split is one tap away, in an expandable panel** (`<details>`,
+    collapsed, no JS): how many of the likes / reposts / replies arrived from
+    out there, the accounts behind them, and the sentence that they are already
+    counted above. So the transparency the separate line was for survives the
+    folding — the reader can still see which world answered, and a hostile
+    server can only inflate figures this panel labels as its own. Each account
+    is a chip — the heart or re-share glyph the vutuv action bar uses for the
+    same act, the `@handle@host` (`Vutuv.Fediverse.Handle`, shared with the
+    follower list and the reply cards), linking **out** to the account, since
+    there is no vutuv profile behind it. Public, like the counts always were:
+    both acts are published under the actor's own name on their own server, and
+    the reply cards below already name their authors the same way. The whole
+    panel is hidden while every remote figure is zero, so a post nobody out
+    there touched stays clean. The agent formats mirror it: the folded totals,
+    then `fediverse_like_count` / `fediverse_repost_count` /
+    `fediverse_reaction_count` / `fediverse_reply_count` and `fediverse_reactions`
+    as the breakdown.
   - A new reaction also **notifies the author** (`fediverse_reaction`, the
     notification kind shaped exactly like `fediverse_reply`): derived straight
     from the reaction rows, so an `Undo`, a deleted post or the member switching

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1036,13 +1036,18 @@ defmodule Vutuv.Posts do
             unquote(post).id
           ),
         # What OTHER networks did with this post (issue #1068): favourites and
-        # re-shares that arrived over ActivityPub. Deliberately a separate
-        # figure, never folded into the vutuv counters above — a hostile remote
-        # server can then only inflate its own line, and the member can see
-        # which world answered.
-        fediverse_reactions:
+        # re-shares that arrived over ActivityPub. Counted **per verb**, because
+        # a favourite is a like and an `Announce` is a repost — the same two
+        # acts the buttons above count, so the card can show one figure each
+        # (`shown_counts/1`) and still break it down for whoever asks.
+        fediverse_likes:
           fragment(
-            "(SELECT count(*) FROM fediverse_reactions fr WHERE fr.post_id = ?)",
+            "(SELECT count(*) FROM fediverse_reactions fr WHERE fr.post_id = ? AND fr.kind = 'like')",
+            unquote(post).id
+          ),
+        fediverse_reposts:
+          fragment(
+            "(SELECT count(*) FROM fediverse_reactions fr WHERE fr.post_id = ? AND fr.kind = 'announce')",
             unquote(post).id
           ),
         # ...and WHO they were. A bare number told the author nothing: their
@@ -1094,11 +1099,47 @@ defmodule Vutuv.Posts do
         bookmarks: 0,
         reposts: 0,
         replies: 0,
-        fediverse_reactions: 0,
+        fediverse_likes: 0,
+        fediverse_reposts: 0,
         fediverse_reaction_actors: [],
         fediverse_replies: 0
       }
   end
+
+  @doc """
+  The three figures a reader sees on the action bar: vutuv's own tally plus
+  what other networks did with the same post.
+
+  A favourite from another server is a like, an `Announce` is a repost and a
+  public remote reply is a reply, so one post has **one** like count, one reply
+  count and one repost count — a member should not have to add two columns in
+  their head to learn how their post did (the card used to print the vutuv
+  figures in the buttons and the remote ones on a line of their own).
+
+  Nothing is hidden by the folding: `fediverse_likes` / `fediverse_reposts` /
+  `fediverse_replies` stay on the engagement map, and the card's expandable
+  "from other networks" panel breaks the totals back down, names the accounts
+  and says the numbers above already include them. So a reader can still see
+  which world answered — and a server that inflates its own figures inflates a
+  line that is labelled as theirs.
+  """
+  def shown_counts(engagement) do
+    %{
+      likes: engagement.likes + remote_count(engagement, :fediverse_likes),
+      reposts: engagement.reposts + remote_count(engagement, :fediverse_reposts),
+      replies: engagement.replies + remote_count(engagement, :fediverse_replies)
+    }
+  end
+
+  @doc "Favourites and re-shares from other networks together (issue #1068)."
+  def fediverse_reaction_count(engagement) do
+    remote_count(engagement, :fediverse_likes) + remote_count(engagement, :fediverse_reposts)
+  end
+
+  # An engagement map assembled by hand (a test, a host that built one before
+  # these keys existed) may not carry the remote figures; a missing one means
+  # "nothing arrived", never a crash on a post card.
+  defp remote_count(engagement, key), do: Map.get(engagement, key) || 0
 
   @doc """
   How many publicly-visible replies a post has: the reply post must still

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -897,30 +897,37 @@ defmodule VutuvWeb.AgentDocs.Markdown do
   defp tags_line([]), do: nil
   defp tags_line(tags), do: "Tags: " <> Enum.map_join(tags, ", ", &"##{&1}")
 
-  # The public engagement counters, mirroring the HTML action bar — including
-  # the separate "from other networks" figure it shows on its own line
-  # (issue #1068), which is omitted here at zero exactly as the HTML omits it.
+  # The public engagement counters, mirroring the HTML action bar: one figure
+  # per act, vutuv's own and the other networks' together (issues #1068, #1069).
+  # What arrived from out there follows as a breakdown of those totals — the
+  # same split the card's expandable panel shows, down to the closing sentence
+  # that it is not additional — and is omitted at zero exactly as the HTML
+  # omits the whole panel.
   @doc false
   def engagement_line(doc) do
-    vutuv_counts =
+    counts =
       "#{gettext("Likes")}: #{doc.like_count} · #{gettext("Reposts")}: #{doc.repost_count} · " <>
         "#{gettext("Bookmarks")}: #{doc.bookmark_count}"
 
-    case doc.fediverse_reaction_count do
-      0 ->
-        vutuv_counts
-
-      count ->
-        vutuv_counts <>
-          " · " <>
-          gettext("Reactions from other networks") <> ": #{count}#{reaction_names(doc)}"
+    case fediverse_share(doc) do
+      [] -> counts
+      parts -> Enum.join([counts | parts], " · ")
     end
-    |> then(fn line ->
-      case doc[:fediverse_reply_count] || 0 do
-        0 -> line
-        count -> line <> " · " <> gettext("Replies from other networks") <> ": #{count}"
-      end
-    end)
+  end
+
+  # The "from other networks" clauses: how much of the counts above came from
+  # there, who reacted, and that it is already included.
+  defp fediverse_share(doc) do
+    reactions = doc[:fediverse_reaction_count] || 0
+    replies = doc[:fediverse_reply_count] || 0
+
+    [
+      reactions > 0 &&
+        gettext("Reactions from other networks") <> ": #{reactions}#{reaction_names(doc)}",
+      replies > 0 && gettext("Replies from other networks") <> ": #{replies}",
+      (reactions > 0 or replies > 0) && gettext("Already counted in the numbers above.")
+    ]
+    |> Enum.filter(& &1)
   end
 
   # The accounts behind those reactions, the same ones the HTML line names as

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -43,6 +43,15 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
     %{posts: thread, truncated?: thread_truncated?} = Posts.list_thread(post, viewer)
     {noindex?, noai?} = robots_axes(author, Posts.restricted?(post))
     engagement = Posts.engagement_counts(post.id)
+    counts = Posts.shown_counts(engagement)
+
+    # The replies written on other networks that the HTML thread weaves in
+    # (issue #1069). **Public ones only, on every path** — note the hardcoded
+    # `nil` viewer: `build/3` also serves the authenticated `/api/2.0` reads,
+    # and a reply addressed to the member alone (issue #1071) must not leave
+    # the page it was sent to, not through an API and not through a `.json`
+    # sibling. The member reads their private replies on the post itself.
+    remote_replies = [post.id] |> Fediverse.list_notes(nil) |> remote_entries(post.id)
 
     AgentDocs.doc_meta("post", Posts.path(post), noindex: noindex?, noai: noai?)
     |> Map.merge(%{
@@ -64,11 +73,13 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # reuse a picture should not have to parse a translated sentence.
       license: license_entry(post),
       in_reply_to: in_reply_to(post),
-      # The anonymous doc lists only anonymous-visible replies; count the loaded
-      # rows so it matches exactly. (Posts.reply_count/1 now also excludes
-      # frozen / denied replies (issue #774), but counting `replies` here avoids
-      # a second query and can never drift from the list.)
-      reply_count: length(replies),
+      # Every reply the page counts, from both worlds — the figure the HTML
+      # reply button now shows (a remote reply is a reply). Counted off the two
+      # loaded lists rather than re-queried, so the number and the entries below
+      # it can never drift: `replies` holds the anonymous-visible vutuv ones
+      # (Posts.reply_count/1 excludes frozen / denied replies since issue #774)
+      # and `fediverse_replies` the public remote ones.
+      reply_count: length(replies) + length(remote_replies),
       replies: Enum.map(replies, &reply_entry/1),
       # The whole conversation the HTML permalink renders (issue #1006), in
       # the same reading order (the reply tree depth-first, issue #1027);
@@ -77,25 +88,25 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
       # one-level list for API consumers that relied on it.
       thread: thread_entries(thread),
       thread_truncated: thread_truncated?,
-      # The public engagement counters the HTML action bar shows to everyone.
-      like_count: engagement.likes,
-      repost_count: engagement.reposts,
+      # The public engagement counters the HTML action bar shows to everyone —
+      # vutuv's own tally **and** what other networks did, in one figure each,
+      # exactly as the buttons print them (`Posts.shown_counts/1`).
+      like_count: counts.likes,
+      repost_count: counts.reposts,
       bookmark_count: engagement.bookmarks,
-      # Favourites and re-shares from OTHER networks (issue #1068), the same
-      # separate figure the HTML shows on its own line under the vutuv counters.
-      fediverse_reaction_count: engagement.fediverse_reactions,
+      # ...and the breakdown the card's "from other networks" panel shows when
+      # you open it, so a machine can tell the two worlds apart again: how many
+      # of the likes and reposts above arrived over ActivityPub (issue #1068).
+      # Nothing here is additional to the counts, it is part of them.
+      fediverse_like_count: engagement.fediverse_likes,
+      fediverse_repost_count: engagement.fediverse_reposts,
+      fediverse_reaction_count: Posts.fediverse_reaction_count(engagement),
       # ...and the accounts behind the newest few of them, exactly the chips the
-      # HTML line names — same rows, same cap, so the two cannot drift. The
-      # count above stays the true total.
+      # HTML panel names — same rows, same cap, so the two cannot drift. The
+      # counts above stay the true totals.
       fediverse_reactions: reaction_entries(engagement),
       fediverse_reply_count: engagement.fediverse_replies,
-      # The replies written on other networks that the HTML thread weaves in
-      # (issue #1069). **Public ones only, on every path** — note the hardcoded
-      # `nil` viewer: `build/3` also serves the authenticated `/api/2.0` reads,
-      # and a reply addressed to the member alone (issue #1071) must not leave
-      # the page it was sent to, not through an API and not through a `.json`
-      # sibling. The member reads their private replies on the post itself.
-      fediverse_replies: [post.id] |> Fediverse.list_notes(nil) |> remote_entries(post.id)
+      fediverse_replies: remote_replies
     })
   end
 

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -2954,12 +2954,15 @@ defmodule VutuvWeb.PostComponents do
 
   def post_actions(assigns) do
     assigns =
-      assign(
-        assigns,
+      assigns
+      |> assign(
         :own?,
         assigns.engagement != nil and assigns.viewer_id != nil and
           assigns.engagement.author_id == assigns.viewer_id
       )
+      # One number per act, vutuv's own and the other networks' together
+      # (`Posts.shown_counts/1`); the panel below breaks it back down.
+      |> assign(:counts, assigns.engagement && Posts.shown_counts(assigns.engagement))
 
     ~H"""
     <%!-- justify-between spreads the four controls across the column's full
@@ -2974,13 +2977,13 @@ defmodule VutuvWeb.PostComponents do
         target={@target}
         own?={@own?}
         liked?={@engagement.liked?}
-        count={@engagement.likes}
+        count={@counts.likes}
       />
 
       <.reply_link
         id={"#{@id}-reply"}
         post_id={@post_id}
-        count={@engagement.replies}
+        count={@counts.replies}
         disabled={@engagement.restricted?}
       />
 
@@ -2989,7 +2992,7 @@ defmodule VutuvWeb.PostComponents do
         target={@target}
         kind="repost"
         active?={@engagement.reposted?}
-        count={@engagement.reposts}
+        count={@counts.reposts}
         label={if @engagement.reposted?, do: gettext("Undo repost"), else: gettext("Repost")}
         active_class="text-brand-600 dark:text-brand-300"
         disabled={@engagement.restricted?}
@@ -3011,89 +3014,151 @@ defmodule VutuvWeb.PostComponents do
       </.action_button>
     </div>
 
-    <.fediverse_line
+    <.fediverse_details
       :if={@engagement}
-      reactions={@engagement.fediverse_reactions}
+      likes={Map.get(@engagement, :fediverse_likes) || 0}
+      reposts={Map.get(@engagement, :fediverse_reposts) || 0}
+      replies={Map.get(@engagement, :fediverse_replies) || 0}
       actors={Map.get(@engagement, :fediverse_reaction_actors, [])}
-      replies={Map.get(@engagement, :fediverse_replies, 0)}
     />
     """
   end
 
-  # What other networks did with this post (issues #1068 and #1069): its OWN
-  # line under the vutuv counters, never folded into them. A member who
-  # publishes outward otherwise gets no feedback at all, and keeping the figures
-  # separate means a hostile remote server can inflate only its own line — the
-  # reader can see which world answered.
+  # What other networks did with this post (issues #1068 and #1069), now folded
+  # into the counters above and explained here.
   #
-  # It **names** the accounts that reacted, one chip each, rather than reporting
-  # a bare number: "1 reaction from other networks" told the author that their
-  # post had travelled somewhere, and nothing whatsoever about where or to whom,
-  # which is not transparency but a rumour. A chip carries the whole stored row
-  # — the account address and the verb — and links out to the account, since
-  # there is no vutuv profile behind it. Public, like the counts always were:
+  # The card used to print two sets of figures: the vutuv counters in the
+  # buttons and a permanent "from other networks" line under them. Correct, and
+  # it read as bookkeeping — a reader wanting to know how a post did had to add
+  # two columns in their head, and a post with one boost carried a whole line
+  # about it. So a like is a like and a repost is a repost whichever world it
+  # came from (`Vutuv.Posts.shown_counts/1`), and the split moves in here, one
+  # tap away.
+  #
+  # Nothing is lost by folding, which is what this panel is for: it breaks the
+  # totals back down per verb, **names** the accounts that reacted (one chip
+  # each, linking out to the account — there is no vutuv profile behind it) and
+  # says in so many words that the numbers above already include them. A bare
+  # "1 reaction from other networks" was a rumour; a chip is the whole stored
+  # row, the account address and the verb. Public, like the counts always were:
   # both a favourite and a re-share are acts those networks publish under the
   # actor's own name, and the reply cards below already name their authors the
-  # same way.
+  # same way. A remote server can still only inflate figures that this panel
+  # labels as its own.
   #
-  # The reply figure stays a count (the replies themselves render as cards on
-  # the permalink) and counts **public** ones only, so a note addressed to the
-  # member alone (issue #1071) never moves a number a stranger can read.
-  # Renders nothing while everything is zero, so a post nobody out there touched
-  # stays clean.
-  attr(:reactions, :integer, required: true)
-  attr(:actors, :list, required: true, doc: "the newest few reaction rows, JSON-decoded")
+  # Collapsed by default (`<details>`, no JS), so the common reader sees three
+  # calm numbers; renders nothing at all while every remote figure is zero, so
+  # a post nobody out there touched stays clean. The reply figure counts
+  # **public** replies only, so a note addressed to the member alone (issue
+  # #1071) never moves a number a stranger can read.
+  attr(:likes, :integer, required: true)
+  attr(:reposts, :integer, required: true)
   attr(:replies, :integer, required: true)
+  attr(:actors, :list, required: true, doc: "the newest few reaction rows, JSON-decoded")
 
-  defp fediverse_line(%{reactions: reactions, replies: replies} = assigns)
-       when reactions > 0 or replies > 0 do
+  defp fediverse_details(%{likes: likes, reposts: reposts, replies: replies} = assigns)
+       when likes > 0 or reposts > 0 or replies > 0 do
+    reactions = likes + reposts
     shown = shown_reaction_actors(assigns.actors, reactions)
 
     assigns =
       assigns
+      |> assign(:reactions, reactions)
+      |> assign(:total, reactions + replies)
       |> assign(:shown, shown)
       |> assign(:more, reactions - length(shown))
 
     ~H"""
-    <div
-      class="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-slate-100 pt-2 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-400"
+    <details
+      class="group mt-2 border-t border-slate-100 pt-1 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-400"
+      data-fediverse-details
       data-fediverse-reactions={@reactions}
       data-fediverse-replies={@replies}
     >
-      <span class="inline-flex items-center gap-1">
-        <span aria-hidden="true">🌐</span>{gettext("From other networks")}
-      </span>
+      <%!-- min-h-10: a finger-sized target, since this is the one control on
+            the card a phone reader is meant to open. --%>
+      <summary class={[
+        "-mx-2 flex min-h-10 cursor-pointer list-none items-center gap-2 rounded-lg px-2",
+        "hover:bg-slate-100 dark:hover:bg-slate-800",
+        "[&::-webkit-details-marker]:hidden"
+      ]}>
+        <span aria-hidden="true">🌐</span>
+        <span>{gettext("From other networks")}</span>
+        <%!-- slate-200/700, a step off the row's own hover tint, so the pill
+              stays a pill while the summary is hovered or open. --%>
+        <span class="rounded-full bg-slate-200 px-1.5 text-xs font-semibold tabular-nums dark:bg-slate-700">
+          {compact_count(@total)}
+        </span>
+        <svg
+          class="ml-auto h-4 w-4 shrink-0 transition-transform group-open:rotate-180"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="m19 9-7 7-7-7" />
+        </svg>
+      </summary>
 
-      <a
-        :for={actor <- @shown}
-        href={actor.uri}
-        target="_blank"
-        rel="nofollow noopener noreferrer"
-        data-fediverse-reaction={actor.kind}
-        title={reaction_title(actor)}
-        class="inline-flex min-h-8 max-w-full items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-200 hover:text-brand-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-brand-300"
-      >
-        <%!-- The same two glyphs the vutuv action bar above uses for the same
-              two acts, so "shared" and "favourited" read identically whichever
-              world they came from. --%>
-        <.icon_repost :if={actor.kind == "announce"} class="h-3.5 w-3.5 shrink-0" />
-        <.icon_heart :if={actor.kind != "announce"} filled?={false} class="h-3.5 w-3.5 shrink-0" />
-        <span class="sr-only">{reaction_title(actor)}</span>
-        <span aria-hidden="true" class="break-all">{actor.handle}</span>
-      </a>
+      <div class="space-y-2 px-2 pb-2 pt-1">
+        <%!-- The split, in the same order and with the same glyphs as the
+              buttons above, so each figure is obviously part of one of them. --%>
+        <p class="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <span :if={@likes > 0} class="inline-flex items-center gap-1" data-fediverse-likes={@likes}>
+            <.icon_heart filled?={false} class="h-4 w-4 shrink-0" />{like_phrase(@likes)}
+          </span>
+          <span
+            :if={@replies > 0}
+            class="inline-flex items-center gap-1"
+            data-fediverse-reply-count={@replies}
+          >
+            <.icon_reply class="h-4 w-4 shrink-0" />{reply_phrase(@replies)}
+          </span>
+          <span
+            :if={@reposts > 0}
+            class="inline-flex items-center gap-1"
+            data-fediverse-reposts={@reposts}
+          >
+            <.icon_repost class="h-4 w-4 shrink-0" />{repost_phrase(@reposts)}
+          </span>
+        </p>
 
-      <span :if={@more > 0} data-fediverse-reactions-more={@more}>
-        {gettext("+%{count} more", count: compact_count(@more))}
-      </span>
+        <p :if={@shown != []} class="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <a
+            :for={actor <- @shown}
+            href={actor.uri}
+            target="_blank"
+            rel="nofollow noopener noreferrer"
+            data-fediverse-reaction={actor.kind}
+            title={reaction_title(actor)}
+            class="inline-flex min-h-8 max-w-full items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-200 hover:text-brand-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-brand-300"
+          >
+            <%!-- The same two glyphs the vutuv action bar above uses for the
+                  same two acts, so "shared" and "favourited" read identically
+                  whichever world they came from. --%>
+            <.icon_repost :if={actor.kind == "announce"} class="h-3.5 w-3.5 shrink-0" />
+            <.icon_heart
+              :if={actor.kind != "announce"}
+              filled?={false}
+              class="h-3.5 w-3.5 shrink-0"
+            />
+            <span class="sr-only">{reaction_title(actor)}</span>
+            <span aria-hidden="true" class="break-all">{actor.handle}</span>
+          </a>
 
-      <span :if={@replies > 0} class="inline-flex items-center gap-1">
-        <.icon_reply class="h-3.5 w-3.5 shrink-0" />{reply_phrase(@replies)}
-      </span>
-    </div>
+          <span :if={@more > 0} data-fediverse-reactions-more={@more}>
+            {gettext("+%{count} more", count: compact_count(@more))}
+          </span>
+        </p>
+
+        <p class="text-xs">{gettext("Already counted in the numbers above.")}</p>
+      </div>
+    </details>
     """
   end
 
-  defp fediverse_line(assigns), do: ~H""
+  defp fediverse_details(assigns), do: ~H""
 
   # The rows the SQL cap handed us (`Vutuv.Posts.engagement_count_select/1`
   # fetches a few more than a card should show), normalised out of their
@@ -3126,6 +3191,16 @@ defmodule VutuvWeb.PostComponents do
 
   defp reply_phrase(count) do
     ngettext("%{formatted} reply", "%{formatted} replies", count, formatted: compact_count(count))
+  end
+
+  defp like_phrase(count) do
+    ngettext("%{formatted} like", "%{formatted} likes", count, formatted: compact_count(count))
+  end
+
+  defp repost_phrase(count) do
+    ngettext("%{formatted} repost", "%{formatted} reposts", count,
+      formatted: compact_count(count)
+    )
   end
 
   # The Like control: a real toggle for everyone but the author. On your OWN

--- a/lib/vutuv_web/live/post_live/action_bar.ex
+++ b/lib/vutuv_web/live/post_live/action_bar.ex
@@ -97,9 +97,12 @@ defmodule VutuvWeb.PostLive.ActionBar do
               replies: replies,
               # Issues #1068 and #1069: a reaction or a reply from another
               # network arrives without any viewer of ours acting, so this is the
-              # only path that updates the two remote figures — and, since the
-              # reactions line names the accounts behind them, the chips too.
-              fediverse_reactions: payload.fediverse_reactions,
+              # only path that updates the remote figures — which now also move
+              # the like / repost / reply counters themselves, since the card
+              # shows one number per act. The chips ride along, the panel behind
+              # them naming the accounts.
+              fediverse_likes: payload.fediverse_likes,
+              fediverse_reposts: payload.fediverse_reposts,
               fediverse_reaction_actors: payload.fediverse_reaction_actors,
               fediverse_replies: payload.fediverse_replies
           })

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.172.0",
+      version: "7.173.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -16447,6 +16447,26 @@ msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
+#: lib/vutuv_web/components/post_components.ex:3195
+#, elixir-autogen, elixir-format
+msgid "%{formatted} like"
+msgid_plural "%{formatted} likes"
+msgstr[0] "%{formatted} Like"
+msgstr[1] "%{formatted} Likes"
+
+#: lib/vutuv_web/components/post_components.ex:3199
+#, elixir-autogen, elixir-format
+msgid "%{formatted} repost"
+msgid_plural "%{formatted} reposts"
+msgstr[0] "%{formatted} Repost"
+msgstr[1] "%{formatted} Reposts"
+
+#: lib/vutuv_web/agent_docs/markdown.ex:928
+#: lib/vutuv_web/components/post_components.ex:3153
+#, elixir-autogen, elixir-format
+msgid "Already counted in the numbers above."
+msgstr "Bereits in den Zahlen oben enthalten."
+
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "A report deletes the reply right away, with no queue to work through. This is the trail, so a server that keeps showing up here can be blocked above. It holds no text and no links, only which server and which account (as a short digest)."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -15688,6 +15688,26 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
+#: lib/vutuv_web/components/post_components.ex:3195
+#, elixir-autogen, elixir-format
+msgid "%{formatted} like"
+msgid_plural "%{formatted} likes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/components/post_components.ex:3199
+#, elixir-autogen, elixir-format
+msgid "%{formatted} repost"
+msgid_plural "%{formatted} reposts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:928
+#: lib/vutuv_web/components/post_components.ex:3153
+#, elixir-autogen, elixir-format
+msgid "Already counted in the numbers above."
+msgstr ""
+
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "A report deletes the reply right away, with no queue to work through. This is the trail, so a server that keeps showing up here can be blocked above. It holds no text and no links, only which server and which account (as a short digest)."

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -15686,6 +15686,26 @@ msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
+#: lib/vutuv_web/components/post_components.ex:3195
+#, elixir-autogen, elixir-format
+msgid "%{formatted} like"
+msgid_plural "%{formatted} likes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/components/post_components.ex:3199
+#, elixir-autogen, elixir-format
+msgid "%{formatted} repost"
+msgid_plural "%{formatted} reposts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/agent_docs/markdown.ex:928
+#: lib/vutuv_web/components/post_components.ex:3153
+#, elixir-autogen, elixir-format
+msgid "Already counted in the numbers above."
+msgstr ""
+
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "A report deletes the reply right away, with no queue to work through. This is the trail, so a server that keeps showing up here can be blocked above. It holds no text and no links, only which server and which account (as a short digest)."

--- a/test/vutuv/fediverse_notes_test.exs
+++ b/test/vutuv/fediverse_notes_test.exs
@@ -787,10 +787,12 @@ defmodule Vutuv.FediverseNotesTest do
 
       counts = Posts.engagement_counts(post.id)
       assert counts.fediverse_replies == 1
-      # Never folded into the vutuv figures: a hostile remote server may only
-      # inflate its own line.
+      # Kept apart in the data — a remote reply never moves the vutuv figure —
+      # while the card adds the two up into the one reply count it shows
+      # (`shown_counts/1`) and names the split in its panel.
       assert counts.replies == 0
-      assert counts.fediverse_reactions == 0
+      assert Posts.fediverse_reaction_count(counts) == 0
+      assert %{replies: 1} = Posts.shown_counts(counts)
     end
 
     test "a private reply is invisible to the public figure", %{

--- a/test/vutuv/fediverse_reactions_test.exs
+++ b/test/vutuv/fediverse_reactions_test.exs
@@ -296,22 +296,40 @@ defmodule Vutuv.FediverseReactionsTest do
       post: post,
       note: note
     } do
-      assert Posts.engagement_counts(post.id).fediverse_reactions == 0
+      assert Posts.engagement_counts(post.id).fediverse_likes == 0
 
       :ok = Fediverse.record_reaction(user, note, "like", @actor)
 
       counts = Posts.engagement_counts(post.id)
-      assert counts.fediverse_reactions == 1
-      # Never folded into the vutuv figures: a hostile remote server may only
-      # inflate its own line.
+      # Counted per verb, and kept apart from vutuv's own tally in the data —
+      # the card adds the two up for display (`shown_counts/1`), the panel
+      # behind it breaks them back down, and a hostile remote server can still
+      # only inflate the figures that panel labels as its own.
+      assert counts.fediverse_likes == 1
+      assert counts.fediverse_reposts == 0
       assert counts.likes == 0
       assert counts.reposts == 0
+
+      assert %{likes: 1, reposts: 0, replies: 0} = Posts.shown_counts(counts)
+    end
+
+    test "a re-share counts as a repost, a favourite as a like", %{
+      user: user,
+      post: post,
+      note: note
+    } do
+      :ok = Fediverse.record_reaction(user, note, "announce", @actor)
+
+      counts = Posts.engagement_counts(post.id)
+      assert counts.fediverse_reposts == 1
+      assert counts.fediverse_likes == 0
+      assert %{likes: 0, reposts: 1} = Posts.shown_counts(counts)
     end
 
     test "post_engagement/2 carries it too", %{user: user, post: post, note: note} do
       :ok = Fediverse.record_reaction(user, note, "like", @actor)
 
-      assert Posts.post_engagement(post.id, nil).fediverse_reactions == 1
+      assert Posts.post_engagement(post.id, nil).fediverse_likes == 1
     end
 
     test "and the accounts behind it, newest first and capped", %{
@@ -331,7 +349,7 @@ defmodule Vutuv.FediverseReactionsTest do
 
       # The count stays the true total; only the named rows are capped, so the
       # card can render "and N more" without a second query.
-      assert counts.fediverse_reactions == 6
+      assert Posts.fediverse_reaction_count(counts) == 6
       assert length(counts.fediverse_reaction_actors) == 4
 
       assert [%{"handle" => "fan6", "kind" => "announce"} | _] =

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -526,11 +526,12 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     :ok = Vutuv.Posts.repost_post(fan, post)
     :ok = Vutuv.Posts.bookmark_post(fan, post)
 
-    # A favourite from another network (issue #1068): its own figure AND the
-    # account behind it, both of which the HTML line shows, so both must reach
-    # the siblings. Written straight to the table — the inbox rules that put it
-    # there are the Fediverse tests' business, this one is about what the
-    # formats render.
+    # A favourite from another network (issue #1068): the HTML counts it as a
+    # like like any other and breaks it back out — with the account behind it —
+    # in the card's "from other networks" panel, so the siblings must carry the
+    # folded figure AND the split. Written straight to the table — the inbox
+    # rules that put it there are the Fediverse tests' business, this one is
+    # about what the formats render.
     Vutuv.Repo.insert!(%Vutuv.Fediverse.Reaction{
       post_id: post.id,
       actor_uri: "https://social.example/users/alice",
@@ -552,9 +553,14 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     doc = Jason.decode!(rendered.json)
     assert doc["type"] == "post"
     assert doc["reply_count"] == 1
-    assert doc["like_count"] == 1
+    # The vutuv like plus the remote favourite: one like count, the way the
+    # button shows it.
+    assert doc["like_count"] == 2
     assert doc["repost_count"] == 1
     assert doc["bookmark_count"] == 1
+    # ...and the panel's breakdown of how much of that came from out there.
+    assert doc["fediverse_like_count"] == 1
+    assert doc["fediverse_repost_count"] == 0
     assert doc["fediverse_reaction_count"] == 1
 
     # The HTML names the account and the verb on its chip, so the siblings do
@@ -565,12 +571,15 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert reaction["url"] == "https://social.example/users/alice"
     assert reaction["network"] == "social.example"
 
-    assert rendered.md =~ "Likes: 1"
-    assert rendered.txt =~ "Likes: 1"
+    assert rendered.md =~ "Likes: 2"
+    assert rendered.txt =~ "Likes: 2"
 
     for format <- [rendered.md, rendered.txt] do
       assert format =~ "Reactions from other networks: 1"
       assert format =~ "@alice@social.example liked this"
+      # The same sentence the panel closes with: the split is part of the
+      # counts above, not something to add to them.
+      assert format =~ "Already counted in the numbers above."
     end
   end
 
@@ -684,9 +693,12 @@ defmodule VutuvWeb.AgentDocsDriftTest do
     assert [entry] = doc["fediverse_replies"]
     assert entry["handle"] == "@alice@social.example"
     assert entry["url"] == "https://social.example/@alice/9"
-    # Never folded into the vutuv reply figure: this post has no vutuv reply,
-    # and one from another network must not make it look as though it had.
-    assert doc["reply_count"] == 0
+    # A reply is a reply, whichever world wrote it: the HTML reply button counts
+    # this one, so `reply_count` does too. The split stays readable one field
+    # down — `fediverse_reply_count` says how much of it came from out there,
+    # and `replies` (the vutuv ones) is empty.
+    assert doc["reply_count"] == 1
+    assert doc["replies"] == []
 
     assert rendered.md =~ "Replies from other networks: 1"
     assert rendered.txt =~ "Replies from other networks: 1"

--- a/test/vutuv_web/controllers/post_controller_test.exs
+++ b/test/vutuv_web/controllers/post_controller_test.exs
@@ -40,6 +40,26 @@ defmodule VutuvWeb.PostControllerTest do
     })
   end
 
+  # A public reply written on another network (issue #1069), straight to the
+  # table — the inbox rules that put it there are the Fediverse tests' business.
+  defp remote_note!(post, name) do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(%Vutuv.Fediverse.Note{
+      post_id: post.id,
+      object_uri: "https://social.example/users/#{name}/statuses/1",
+      actor_uri: "https://social.example/users/#{name}",
+      origin_url: "https://social.example/@#{name}/1",
+      handle: name,
+      display_name: name,
+      content_text: "Nice one.",
+      audience: "public",
+      received_at: now,
+      checked_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+  end
+
   # Where `text` first shows up in the rendered page — how the thread tests
   # assert reading order without parsing the whole card tree.
   defp position(html, text) do
@@ -1048,10 +1068,45 @@ defmodule VutuvWeb.PostControllerTest do
       # its account URI (rows stored before the handle was kept, too).
       assert html =~ ~s(data-fediverse-reaction="like")
       assert html =~ "@bob@social.example liked this"
+    end
 
-      # Its own line, never folded into the vutuv counters: nobody here liked
-      # or reposted, so those counters must show no 2 of their own.
-      refute html =~ ~r/data-count="(like|repost)">\s*2\s*</
+    test "a remote like, boost and reply are counted in the post's own counters", %{conn: conn} do
+      user = insert_activated_user()
+      post = create_post!(user, %{body: "travelled far"})
+      :ok = Posts.like_post(insert(:user), post)
+
+      remote_reaction!(post, "alice", "announce")
+      remote_reaction!(post, "bob", "like")
+      remote_note!(post, "carol")
+
+      html = html_response(get(conn, Posts.path(post)), 200)
+
+      # One number per act: the vutuv like plus the remote favourite are two
+      # likes, the boost is the post's one repost, the remote note its one
+      # reply. A reader should not have to add two columns in their head.
+      assert html =~ ~r/data-count="like">\s*2\s*</
+      assert html =~ ~r/data-count="repost">\s*1\s*</
+      assert html =~ ~r/data-count="reply">\s*1\s*</
+
+      # ...and the panel behind them still breaks it back down, names the
+      # accounts and says the numbers above already include them.
+      assert html =~ "data-fediverse-details"
+      assert html =~ ~s(data-fediverse-likes="1")
+      assert html =~ ~s(data-fediverse-reposts="1")
+      assert html =~ ~s(data-fediverse-reply-count="1")
+      assert html =~ "@alice@social.example shared this"
+      assert html =~ "Already counted in the numbers above."
+    end
+
+    test "a post nobody out there touched carries no panel at all", %{conn: conn} do
+      user = insert_activated_user()
+      post = create_post!(user, %{body: "stayed home"})
+      :ok = Posts.like_post(insert(:user), post)
+
+      html = html_response(get(conn, Posts.path(post)), 200)
+
+      refute html =~ "data-fediverse-details"
+      refute html =~ "From other networks"
     end
 
     test "a much-shared post names a few and counts the rest (#1068)", %{conn: conn} do

--- a/test/vutuv_web/live/post_actions_live_test.exs
+++ b/test/vutuv_web/live/post_actions_live_test.exs
@@ -424,6 +424,9 @@ defmodule VutuvWeb.PostActionsLiveTest do
       _ = :sys.get_state(bar.pid)
       html = render(bar)
 
+      # The boost is the post's repost count now, not a figure beside it...
+      assert html =~ ~r/data-count="repost">\s*1\s*</
+      # ...and the panel behind that number still names who it was.
       assert html =~ ~s(data-fediverse-reactions="1")
       assert html =~ "@alice@social.example"
       assert html =~ ~s(data-fediverse-reaction="announce")
@@ -566,7 +569,8 @@ defmodule VutuvWeb.PostActionsLiveTest do
         bookmarks: 0,
         reposts: 0,
         replies: 0,
-        fediverse_reactions: 0,
+        fediverse_likes: 0,
+        fediverse_reposts: 0,
         liked?: true,
         bookmarked?: false,
         reposted?: false,


### PR DESCRIPTION
**TL;DR** The vutuv counters and the "from other networks" line are one set of numbers now: a remote favourite counts as a like, an `Announce` as a repost, a public remote reply as a reply. The split moves into a collapsed "Aus anderen Netzwerken" panel under the bar.

**Where:** `VutuvWeb.PostComponents.post_actions/1` + the new `fediverse_details/1`, `Vutuv.Posts.shown_counts/1`, `VutuvWeb.AgentDocs.PostDoc`.

**Now (before):** a post that travelled printed two sets of figures — the buttons showed vutuv's tally, a permanent line under them showed what other networks did. A reader had to add two columns in their head, and one boost cost a whole line.

**Want (after):**
- One figure per act in the buttons (`Posts.shown_counts/1`; the engagement select counts remote reactions per verb now — `fediverse_likes` / `fediverse_reposts` — instead of one lump sum).
- Under it a `<details>`, collapsed, no JS: "🌐 Aus anderen Netzwerken (4)". Opening it shows the split per verb ("2 Likes · 1 Antwort · 1 Repost"), the accounts that reacted as the same chips linking out, and "Bereits in den Zahlen oben enthalten."
- Hidden entirely while every remote figure is zero, so a post nobody out there touched stays clean. The summary row is a finger-sized target on a phone.
- The transparency the separate line existed for survives: the reader still sees which world answered, and a hostile server can only inflate figures the panel labels as its own.

Agent formats move with the page (`agent_docs_drift_test`): `like_count` / `repost_count` / `reply_count` are the folded totals, `fediverse_like_count` / `fediverse_repost_count` join the existing `fediverse_reaction_count` / `fediverse_reply_count` as the breakdown, and the `.md`/`.txt` engagement line closes with the same "already counted" sentence. German strings added to the catalog; `docs/architecture/fediverse.md` updated.

Smoke-tested in a browser at phone width with `Accept-Language: de` (collapsed and expanded), fixture removed from the dev DB afterwards. `mix precommit` green: 5570 tests.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_01MnLpDRLU88qSH1xx7szVty