### PR TITLE
Drop post_drafts.mode: the contract half of the composer-tab removal

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.175.0",
+      version: "7.175.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260726210130_drop_post_drafts_mode.exs
+++ b/priv/repo/migrations/20260726210130_drop_post_drafts_mode.exs
@@ -1,0 +1,22 @@
+defmodule Vutuv.Repo.Migrations.DropPostDraftsMode do
+  use Ecto.Migration
+
+  @moduledoc """
+  The contract half of the composer-tab removal (PR #1172, v7.175.0).
+
+  `mode` carried the retired Text/Fotos tab of the draft's composer. The
+  expand/contract rule (one release of backward compatibility) is satisfied:
+  v7.175.0 neither reads nor writes the column — the `PostDraft` schema lost
+  the field there — so it keeps serving unchanged while this migration runs
+  during the blue/green switch.
+
+  `remove/3` with the full column definition keeps the migration reversible;
+  a rollback restores the column exactly as `create_post_drafts` declared it.
+  """
+
+  def change do
+    alter table(:post_drafts) do
+      remove(:mode, :string, null: false, default: "text")
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** #1172 (v7.175.0) stopped every read and write of `post_drafts.mode` but kept the column for one release per the N-1 deploy rule; that release is now the one in production, so this drops the column.

**Where:** `priv/repo/migrations/20260726210130_drop_post_drafts_mode.exs`
**Now:** the column sits unused (DB default fills it on every insert).
**Want:** column gone; `remove/3` carries the full original definition (`:string, null: false, default: "text"`), so a rollback restores it exactly as `create_post_drafts` declared it.

The v7.175.0 release keeps serving unchanged while the migration runs during the blue/green switch, since its `PostDraft` schema no longer names the field. `mix precommit` green (the test alias runs the migration; the migrated test DB verifiably has no `mode` column any more).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01QULVE9Ey8KvifXZ4NYYHaF