### PR TITLE
An internal page for an account on another network (#1162)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -770,3 +770,65 @@ inbox that no longer answers.
 The profile feed of a member's *own* linked Mastodon/Bluesky accounts
 (`Vutuv.SocialFeed`) remains a separate, unrelated thing: it shows the member's
 own posts, on their own profile, at their own request.
+
+### Their posts in the feed (issue #1161)
+
+`fediverse_posts` is one row per remote post — **not** one per follower, since
+several members can follow the same account and it is the same post — hanging
+off the account. A `Create(Note)` from an actor with at least one **accepted**
+local follow is reduced to plain text and stored by `perform_once/2` in the
+inbox controller, which runs once per delivery rather than once per addressed
+member.
+
+What is refused is as much of the design as what is stored. A reply into
+somebody else's conversation is dropped at the door (`own_thread?/2`): a
+followed account's own thread is what a follower subscribed to, while their
+reply under a stranger's post drags a third party's conversation into our
+storage for the sake of one half of it. An audience narrower than public /
+unlisted / followers is dropped too — a reply had to be kept in order to reach
+the member it was addressed to, a post nobody here was published to has no such
+claim. A `published` stamp in the future is clamped, so a server cannot pin
+itself to the top of a feed forever.
+
+Retention is the same "bounded copy" argument the replies make, minus the
+freshness re-fetch: a followed account's stream is pushed to us continuously, so
+an edit or a withdrawal arrives on its own, and re-asking about every cached post
+of every account our members read would be far heavier than the per-reply check.
+So: `FEDIVERSE_POST_RETENTION_DAYS` (183) as the ceiling, an upstream
+`Update`/`Delete` honoured at once, purged when the last follow of the author
+ends, gone with the accounts on an instance block.
+
+The feed reads it as a **fourth source** in `Vutuv.Posts.feed_page/2`, merged on
+publication time. `decorate_feed_entries/2` splits the remote entries off before
+the local pipeline (they are not `%Post{}`, have no thread, no reposters and no
+engagement) and merges them back on `at`. A muted follow leaves the feed and
+keeps the subscription; a followers-only post reaches only a member whose own
+follow is accepted.
+
+One thing worth remembering about the report path: there is **one** cached row
+per post, shared by everybody following its author, so one member's report
+deletes it out of all of their feeds. That is why the card leads with Mute — the
+private, reversible lever — and why the confirmation says so.
+
+### The account page (issue #1162)
+
+`/system/fediverse/account/:id` (`VutuvWeb.FediverseAccountLive`) is where every
+remote handle now points: reaction chips, remote reply cards and remote feed
+cards link inward when we know the account and straight out when we do not.
+Signed-in only and `noindex` (the `:noindex_pipe` pipeline), keyed by the **row
+id** so the page is no open-ended fetch surface, and it fetches nothing on view.
+
+Which means account rows have to exist for more than just followed accounts:
+`remember_remote_account/1` keeps the actor document the inbox already fetched
+and verified whenever a reply or a reaction from that actor is stored. That
+would otherwise grow into a directory of everybody who ever touched the
+installation, so `purge_unreferenced_remote_accounts/0` (hourly, in the sweeper)
+drops every account with no follow, no cached post, no stored reply and no
+stored reaction.
+
+The page is a **follow surface plus a preview**, not a mirror profile: identity,
+self-description (clamped), follow / requested / mute state, the cached posts
+capped at 30, and "View their full profile on <host>" in every state. It is also
+the only place a **muted** account can still be reached, which is why unmute
+lives here — muting from the feed removes that account's posts, and with them
+the menu that muted it.

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -640,15 +640,8 @@ defmodule Vutuv.Fediverse do
   """
   def follow_remote(%User{} = user, address) do
     with :ok <- check_can_follow(user),
-         {:ok, {_name, host}} <- RemoteFollow.parse_address(address),
-         :ok <- check_follow_host(host),
-         :ok <- claim_remote_follow_budget(user),
          :ok <- check_follow_limit(user),
-         {:ok, actor_uri} <- RemoteFollow.resolve_actor(address),
-         :ok <- check_follow_host(actor_uri),
-         {:ok, remote} <- fetch_follow_target(actor_uri, user),
-         :ok <- check_follow_host(remote.id),
-         {:ok, account} <- upsert_remote_account(remote),
+         {:ok, account} <- resolve_remote_account(user, address),
          {:ok, follow} <- insert_remote_follow(user, account) do
       enqueue(
         user,
@@ -659,6 +652,63 @@ defmodule Vutuv.Fediverse do
       {:ok, %{follow | remote_account: account}}
     end
   end
+
+  @doc """
+  Looks an address up and remembers the account behind it, **without** following
+  it (issue #1162): the half of `follow_remote/2` that answers "who is this",
+  which is the question somebody has before they decide.
+
+  Deliberately does **not** require the member to federate. Following needs their
+  own actor key to sign the request; looking somebody up does not, and requiring
+  it would be a chicken-and-egg — the account page is where a member who has not
+  switched participation on finds out what they would be switching it on for.
+  The fetch is then signed anonymously, which a few authorized-fetch servers
+  refuse; that is a worse answer for those accounts, not a wrong one.
+
+  Every other gate still holds, in the same order and for the same reasons: the
+  installation switch, the operator blocklist on each of the three hosts a
+  lookup passes through, an address on this installation, and the hourly budget
+  — this is a member-triggered outbound request either way.
+
+  Returns `{:ok, account}` or the same `{:error, reason}` vocabulary
+  `follow_remote/2` speaks.
+  """
+  def resolve_remote_account(%User{} = user, address) do
+    with :ok <- check_can_resolve(),
+         {:ok, {_name, host}} <- RemoteFollow.parse_address(address),
+         :ok <- check_follow_host(host),
+         :ok <- claim_remote_follow_budget(user),
+         {:ok, actor_uri} <- RemoteFollow.resolve_actor(address),
+         :ok <- check_follow_host(actor_uri),
+         {:ok, remote} <- fetch_follow_target(actor_uri, user),
+         :ok <- check_follow_host(remote.id) do
+      upsert_remote_account(remote)
+    end
+  end
+
+  @doc """
+  Remembers an account we have just stored something from — a reply under a
+  member's post, or a reaction to one (issue #1162).
+
+  It costs no request: the inbox has already fetched and verified that actor
+  document in order to check the signature, so this is only a matter of keeping
+  what it read. What it buys is that every remote handle vutuv shows has an
+  internal destination, instead of a bare link out of the site to somebody the
+  reader cannot decide about.
+
+  Called only after something from that actor was really stored, so a stranger's
+  activity cannot plant account rows; and the rows go again by themselves once
+  nothing references them (`purge_unreferenced_remote_accounts/0`).
+  """
+  def remember_remote_account(%{id: actor_uri} = remote) when is_binary(actor_uri) do
+    if enabled?(), do: upsert_remote_account(remote)
+    :ok
+  end
+
+  def remember_remote_account(_remote), do: :ok
+
+  @doc "One stored remote account by row id, or nil."
+  def get_remote_account(id), do: UUIDv7.with_cast(id, &Repo.get(RemoteAccount, &1))
 
   @doc """
   The member takes the follow back: a best-effort `Undo(Follow)` to the other
@@ -707,6 +757,42 @@ defmodule Vutuv.Fediverse do
     end)
 
     :ok
+  end
+
+  @doc """
+  *Why* this member cannot follow anybody out there, when they cannot: `nil`
+  when they can, else `:opted_out`, `:restricted` or `:disabled`.
+
+  `federated?/1` is one boolean over four very different situations, and the
+  difference decides which sentence is true and which link helps. Telling a
+  member the moderation freezer is holding to go and flip a switch they already
+  flipped, and pointing them at a page that shows it on, is exactly the wrong
+  answer in the one place clarity matters most.
+
+  Shared by every page that offers a follow (`/settings/fediverse/following`
+  and the account page), so the four situations cannot be told apart on one and
+  collapsed on the other.
+  """
+  def follow_refusal(%User{} = user) do
+    cond do
+      not enabled?() -> :disabled
+      Vutuv.Moderation.account_hidden?(user) -> :restricted
+      not user.fediverse_followers? or not user.email_confirmed? -> :opted_out
+      # A member who redirected their Fediverse followers elsewhere: this
+      # account no longer acts out there at all, so a live Follow button would
+      # be a promise `check_can_follow/1` then refuses. Listed last because it
+      # is the only one of the four that a *federating* member can be in.
+      moved?(user) -> :moved
+      true -> nil
+    end
+  end
+
+  @doc """
+  The member's follow of one remote account, or nil — what the account page's
+  button branches on.
+  """
+  def remote_follow_for(%User{id: user_id}, %RemoteAccount{id: account_id}) do
+    Repo.get_by(Follow, user_id: user_id, remote_account_id: account_id)
   end
 
   @doc """
@@ -899,13 +985,21 @@ defmodule Vutuv.Fediverse do
 
   # ── The gates, cheapest first ──────────────────────────────────────────────
 
+  # Following is looking somebody up plus an identity of one's own, so it is
+  # written that way: the installation switch is asserted once, where a lookup
+  # asserts it, instead of restated here where the two could drift apart.
   defp check_can_follow(%User{} = user) do
-    cond do
-      not enabled?() -> {:error, :fediverse_disabled}
-      not federated?(user) -> {:error, :not_federating}
-      moved?(user) -> {:error, :moved}
-      true -> :ok
+    with :ok <- check_can_resolve() do
+      cond do
+        not federated?(user) -> {:error, :not_federating}
+        moved?(user) -> {:error, :moved}
+        true -> :ok
+      end
     end
+  end
+
+  defp check_can_resolve do
+    if enabled?(), do: :ok, else: {:error, :fediverse_disabled}
   end
 
   # A block is both ears and mouth shut, and this is the mouth. Checked three
@@ -1394,6 +1488,84 @@ defmodule Vutuv.Fediverse do
 
   @doc "How many cached posts are stored across the installation."
   def remote_post_total, do: Repo.aggregate(RemotePost, :count)
+
+  # How many of an account's cached posts the account page shows. It is a
+  # preview — "what do they actually post", the thing that decides a follow —
+  # not an archive of somebody else's writing, and the page says so when there
+  # is more.
+  @account_page_posts 30
+
+  @doc """
+  The cached posts of one account for `viewer`, newest first, as
+  `{posts, more?}` (issue #1162).
+
+  Audience-scoped exactly like the feed: public and unlisted for anybody signed
+  in, followers-only solely for a viewer whose own follow is **accepted**. So the
+  page can be opened by any member without becoming a way to read what an author
+  addressed to their followers.
+
+  The cap and the "there is more" flag are both answered here — one row past the
+  cap is fetched and dropped — so no caller has to know the number or repeat the
+  +1 trick to rediscover a fact this query already had.
+  """
+  def account_posts(%RemoteAccount{id: account_id}, %User{id: viewer_id}) do
+    accepted =
+      from(f in Follow,
+        where:
+          f.remote_account_id == ^account_id and f.user_id == ^viewer_id and
+            f.state == "accepted"
+      )
+
+    from(p in RemotePost,
+      where: p.remote_account_id == ^account_id,
+      # The feed's vocabulary, not a negated literal: `open_audiences/0` is the
+      # one list the query and the card (`RemotePost.open?/1`) both read, so a
+      # fourth audience value cannot open here and close there.
+      where: p.audience in ^RemotePost.open_audiences() or exists(accepted),
+      order_by: [desc: p.published_at, desc: p.id],
+      limit: ^(@account_page_posts + 1)
+    )
+    |> Repo.all()
+    |> Enum.split(@account_page_posts)
+    |> then(fn {posts, rest} -> {posts, rest != []} end)
+  end
+
+  @doc """
+  Drops every stored remote account nothing refers to any more (issue #1162).
+
+  An account row is minted for three reasons — somebody followed it, it replied
+  under a member's post, or it reacted to one — and it is kept only while one of
+  those still holds. The follows and the cached posts are foreign keys; the
+  replies and reactions name the actor by URI, so those are matched on the URI.
+
+  This is what keeps "we remember who reacted to your post" from quietly
+  becoming "we keep a directory of everybody who ever touched this
+  installation".
+  """
+  def purge_unreferenced_remote_accounts do
+    {count, _} =
+      Repo.delete_all(
+        from(a in RemoteAccount,
+          as: :account,
+          # All four written the same way, as `NOT EXISTS`: an `a.id not in
+          # subquery(...)` form makes the planner hash every row of the other
+          # table first (a whole scan of the installation-wide post cache on
+          # every sweep), while a correlated anti-join can use that table's own
+          # index per candidate row.
+          where:
+            not exists(from(f in Follow, where: f.remote_account_id == parent_as(:account).id)),
+          where:
+            not exists(
+              from(p in RemotePost, where: p.remote_account_id == parent_as(:account).id)
+            ),
+          where: not exists(from(n in Note, where: n.actor_uri == parent_as(:account).actor_uri)),
+          where:
+            not exists(from(r in Reaction, where: r.actor_uri == parent_as(:account).actor_uri))
+        )
+      )
+
+    count
+  end
 
   @doc """
   What each remote server has stored here as cached posts, biggest first — the
@@ -2358,7 +2530,7 @@ defmodule Vutuv.Fediverse do
   read the pages use, so the visibility rule cannot be forgotten at a call site.
   """
   def list_notes(post_ids, viewer) do
-    from(n in Note,
+    from(n in notes_with_account(),
       join: p in Post,
       on: p.id == n.post_id,
       where: n.post_id in ^post_ids,
@@ -2367,6 +2539,24 @@ defmodule Vutuv.Fediverse do
     )
     |> Repo.all()
     |> Enum.group_by(& &1.post_id)
+  end
+
+  # Notes carrying `account_id`: whether we hold a row for the actor who wrote
+  # one, which is what decides whether the card's handle links to their page
+  # here or out to their own server (issue #1162). A LEFT join by URI rather
+  # than a foreign key, because a note may well be older than the account row
+  # and the row goes again by itself once nothing refers to it.
+  #
+  # **Every** loader of a note reads through this. The same card is rendered
+  # from a list on the permalink and from a single row on the reply page, and a
+  # handle that led two different places depending on which loader fetched it
+  # would be nobody's decision and nothing's test.
+  defp notes_with_account do
+    from(n in Note,
+      left_join: a in RemoteAccount,
+      on: a.actor_uri == n.actor_uri,
+      select: %{n | account_id: a.id}
+    )
   end
 
   @doc """
@@ -2384,7 +2574,11 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc "One stored reply, or nil."
-  def get_note(id), do: UUIDv7.with_cast(id, &Repo.get(Note, &1))
+  def get_note(id) do
+    UUIDv7.with_cast(id, fn uuid ->
+      Repo.one(from(n in notes_with_account(), where: n.id == ^uuid))
+    end)
+  end
 
   @doc """
   The member takes a reply off their own post. Deletes it at once and records

--- a/lib/vutuv/fediverse/note.ex
+++ b/lib/vutuv/fediverse/note.ex
@@ -79,6 +79,14 @@ defmodule Vutuv.Fediverse.Note do
     field(:checked_at, :utc_datetime)
     field(:expires_at, :utc_datetime)
 
+    # The stored account behind `actor_uri`, when we have one (issue #1162).
+    # Virtual because a note is keyed to its author by URI, not by a foreign
+    # key; every loader fills it through the one join that knows why (see the
+    # private `notes_with_account/0` in `Vutuv.Fediverse`). Nil means "we do not
+    # know them", and then the card's handle links straight out instead of
+    # inward.
+    field(:account_id, :binary_id, virtual: true)
+
     belongs_to(:post, Vutuv.Posts.Post)
   end
 

--- a/lib/vutuv/fediverse/note_sweeper.ex
+++ b/lib/vutuv/fediverse/note_sweeper.ex
@@ -55,7 +55,7 @@ defmodule Vutuv.Fediverse.NoteSweeper do
     {:noreply, state}
   end
 
-  # Three deletions, all of them "the reason for this copy is gone":
+  # Four deletions, all of them "the reason for this copy is gone":
   #
   #   * replies past their ceiling (issue #1069),
   #   * cached posts from followed accounts past theirs (issue #1161),
@@ -63,10 +63,13 @@ defmodule Vutuv.Fediverse.NoteSweeper do
   #     paths purge those immediately; this is what catches the follows that
   #     vanished through a cascade — a deleted member account, a purged
   #     instance — without anybody calling the purge.
+  #   * stored accounts nothing refers to any more (issue #1162). Last, so it
+  #     sees the rows the three above just freed.
   defp sweep do
     log("expired remote reply", Fediverse.expire_due_notes())
     log("expired cached post", Fediverse.expire_due_remote_posts())
     log("cached post of an unfollowed account", Fediverse.purge_unfollowed_remote_posts())
+    log("remote account nothing refers to", Fediverse.purge_unreferenced_remote_accounts())
   end
 
   defp log(_what, 0), do: :ok

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1067,7 +1067,9 @@ defmodule Vutuv.Posts do
           fragment(
             """
             (SELECT coalesce(json_agg(a ORDER BY a.received_at DESC, a.id DESC), '[]'::json)
-               FROM (SELECT fr.id, fr.kind, fr.actor_uri, fr.handle, fr.received_at
+               FROM (SELECT fr.id, fr.kind, fr.actor_uri, fr.handle, fr.received_at,
+                            (SELECT ra.id FROM fediverse_remote_accounts ra
+                              WHERE ra.actor_uri = fr.actor_uri) AS account_id
                        FROM fediverse_reactions fr
                       WHERE fr.post_id = ?
                       ORDER BY fr.received_at DESC, fr.id DESC

--- a/lib/vutuv_web/components/fediverse_components.ex
+++ b/lib/vutuv_web/components/fediverse_components.ex
@@ -1,0 +1,304 @@
+defmodule VutuvWeb.FediverseComponents do
+  @moduledoc """
+  What the two pages that offer a follow out there have in common: the
+  address box, the panel that explains a refusal, the wording of every
+  `{:error, reason}` the context can answer with, and the follow-state pill.
+
+  `VutuvWeb.FediverseFollowingLive` (`/settings/fediverse/following`) and
+  `VutuvWeb.FediverseAccountLive` (`/system/fediverse/account/:id`, issue #1162)
+  arrive at the same act from opposite ends — one starts from an address, the
+  other from an account already in front of the reader — but from the moment
+  the member presses Follow they are the same flow against the same context
+  function, so they must not describe it differently.
+
+  `Vutuv.Fediverse.follow_refusal/1` is the data half of that (which of the four
+  situations the member is in); this is the half that says it in words. Keeping
+  them apart would have been the same mistake one layer up: the atom shared,
+  the sentence copied.
+
+  Sibling of `VutuvWeb.BrowseTable`, which does the same job for the two
+  relationship tables.
+  """
+
+  use Phoenix.Component
+  use Gettext, backend: VutuvWeb.Gettext
+
+  use Phoenix.VerifiedRoutes,
+    endpoint: VutuvWeb.Endpoint,
+    router: VutuvWeb.Router,
+    statics: ~w(assets fonts images favicon.ico)
+
+  import VutuvWeb.UI
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+
+  attr(:id, :string,
+    required: true,
+    doc: "names the form, the input, the button and the error line (`<id>-form`, …)"
+  )
+
+  attr(:address, :string, required: true)
+  attr(:error, :any, default: nil, doc: "the reason the last submit came back with, or nil")
+  attr(:event, :string, required: true, doc: "the phx-submit event the host handles")
+  attr(:submit, :string, required: true, doc: "what the button says")
+  attr(:variant, :string, default: "primary")
+
+  attr(:label_hidden, :boolean,
+    default: false,
+    doc: "the field label reads to assistive tech only, where the card heading already names it"
+  )
+
+  attr(:class, :string, default: nil)
+
+  slot(:error_detail, doc: "where to go instead, appended to the message")
+
+  @doc """
+  The address box: an `@name@server` in, an act on that account out.
+
+  One markup for both pages, because the parts that matter here are the parts
+  that get fixed on one copy only — the phone-keyboard attributes, and the
+  `aria-invalid` / `aria-describedby` pair that ties the refusal to the field.
+  `phx-change="typing"` is shared too: typing again clears the last refusal, so
+  the box is not still shouting about an address the member has since corrected.
+  """
+  def address_form(assigns) do
+    ~H"""
+    <form
+      id={"#{@id}-form"}
+      phx-submit={@event}
+      phx-change="typing"
+      class={["flex flex-wrap items-end gap-3", @class]}
+    >
+      <div class="min-w-56 grow">
+        <label
+          for={"#{@id}-address"}
+          class={
+            if @label_hidden,
+              do: "sr-only",
+              else: "block text-sm font-semibold text-slate-700 dark:text-slate-200"
+          }
+        >
+          {gettext("Address of the account")}
+        </label>
+        <%!-- `inputmode="email"` for the @ and the dot on a phone keyboard's
+              first layer, without the validation an `type="email"` would apply
+              to a two-@ address. iOS honours autocorrect separately from
+              spellcheck. --%>
+        <input
+          type="text"
+          name="address"
+          id={"#{@id}-address"}
+          value={@address}
+          inputmode="email"
+          autocomplete="off"
+          autocapitalize="none"
+          autocorrect="off"
+          spellcheck="false"
+          placeholder="@name@server"
+          aria-invalid={@error && "true"}
+          aria-describedby={@error && "#{@id}-error"}
+          class={input_class(@error != nil)}
+        />
+      </div>
+      <.button type="submit" id={"#{@id}-submit"} variant={@variant} class="w-full sm:w-auto">
+        {@submit}
+      </.button>
+    </form>
+
+    <p
+      :if={@error}
+      id={"#{@id}-error"}
+      role="alert"
+      class="mt-2 text-sm font-medium text-red-700 dark:text-red-300"
+    >
+      {refusal_message(@error)}
+      {render_slot(@error_detail)}
+    </p>
+    """
+  end
+
+  attr(:id, :string, required: true)
+  attr(:reason, :atom, required: true, doc: "from `Vutuv.Fediverse.follow_refusal/1`")
+
+  attr(:address, :string,
+    default: nil,
+    doc: "an address the member brought along, kept in view while they go and switch on"
+  )
+
+  attr(:class, :string, default: nil)
+
+  @doc """
+  Why this member cannot follow anybody out there, and the one thing that helps.
+
+  No actor, no follow: the request is signed with the member's own key. Say
+  that, and put the switch one click away, rather than bouncing them to a page
+  that does not mention following. Which sentence, though, depends on why — a
+  member the moderation freezer is holding has already flipped that switch, and
+  telling them to flip it again, on a page that shows it on, is the worst place
+  to be vague.
+  """
+  def follow_refusal_panel(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      data-reason={@reason}
+      class={[
+        "rounded-lg bg-slate-50 p-4 text-sm leading-relaxed text-slate-700 ring-1 ring-slate-200",
+        "dark:bg-slate-800/50 dark:text-slate-300 dark:ring-slate-700",
+        @class
+      ]}
+    >
+      <%= case @reason do %>
+        <% :restricted -> %>
+          <p>
+            {gettext(
+              "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
+            )}
+          </p>
+          <p class="mt-3">
+            <.link navigate={~p"/moderation/cases"} id="moderation-cases-link" class={refusal_link()}>
+              {gettext("Why is my account on hold?")} ›
+            </.link>
+          </p>
+        <% :disabled -> %>
+          <p>
+            {gettext(
+              "This vutuv does not exchange anything with other networks, so there is nothing to follow from here. That is an operator setting, not yours."
+            )}
+          </p>
+        <% :moved -> %>
+          <%!-- The one refusal a *federating* member can be in: they redirected
+                their Fediverse followers to another account, so this one no
+                longer acts out there. Without its own arm they would get a live
+                Follow button and a "that did not work, try again" for a state
+                that is permanent until they cancel the redirect. --%>
+          <p>
+            {gettext(
+              "You redirected your Fediverse followers to another account, so this one no longer follows anybody out there."
+            )}
+          </p>
+          <p class="mt-3">
+            <.link navigate={~p"/settings/fediverse/move"} id="fediverse-move-link" class={refusal_link()}>
+              {gettext("Your account move")} ›
+            </.link>
+          </p>
+        <% _opted_out -> %>
+          <p>
+            {gettext(
+              "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
+            )}
+          </p>
+          <p :if={@address not in [nil, ""]} class="mt-3">
+            {gettext("The address you brought along is kept here:")}
+            <span class="font-semibold break-all">{@address}</span>
+          </p>
+          <p class="mt-3">
+            <.link navigate={~p"/settings/fediverse"} id="enable-fediverse-link" class={refusal_link()}>
+              {gettext("Take part in the Fediverse")} ›
+            </.link>
+          </p>
+      <% end %>
+    </div>
+    """
+  end
+
+  defp refusal_link,
+    do:
+      "font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-300 dark:hover:text-brand-100"
+
+  @doc """
+  A follow that has not been answered reads **"Requested"**, not "Following".
+  An account that approves its followers by hand may take days or never answer,
+  and showing it as settled would be a lie the member acts on.
+  """
+  def follow_state_label(follow) do
+    if Follow.accepted?(follow), do: gettext("Following"), else: gettext("Requested")
+  end
+
+  @doc "The pill's colours for that state: emerald once settled, calm slate while it waits."
+  def follow_state_class(follow) do
+    if Follow.accepted?(follow),
+      do:
+        "bg-emerald-50 text-emerald-800 ring-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-200 dark:ring-emerald-800",
+      else:
+        "bg-slate-100 text-slate-700 ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700"
+  end
+
+  @doc """
+  A request nobody has answered is not something you unfollow — you take the
+  request back. Two labels, because a member who reads "Unfollow" on a
+  Requested row learns that the state badge does not mean anything.
+  """
+  def end_follow_label(follow) do
+    if Follow.accepted?(follow), do: gettext("Unfollow"), else: gettext("Cancel request")
+  end
+
+  @doc """
+  The sentence for one `{:error, reason}` from `Vutuv.Fediverse`.
+
+  One table for both pages, because both speak to the same context function:
+  a reason that got a precise sentence on one page and a shrugging "that did
+  not work" on the other would be the same refusal explained twice, once badly.
+  """
+  def refusal_message(:invalid_address),
+    do:
+      gettext(
+        "That does not look like an address on another network. They look like @name@server."
+      )
+
+  def refusal_message(:unreachable),
+    do: gettext("That server did not answer. Check the address, and that the server is online.")
+
+  def refusal_message(:no_actor),
+    do: gettext("That server answered, but it has no account at that address to follow.")
+
+  def refusal_message(:unreachable_actor),
+    do: gettext("That account could not be loaded from its server. Try again in a little while.")
+
+  def refusal_message(:instance_blocked),
+    do: gettext("This vutuv does not exchange anything with that server.")
+
+  # The address turned out to name somebody on this very vutuv. The caller adds
+  # where to go instead, since only it knows whether the handle resolved.
+  def refusal_message(:local_account),
+    do: gettext("That is an address on this vutuv, not another network.")
+
+  # Deliberately without "it is in the list below": the error keeps the active
+  # filter and the table is paged, so the row it points at is often genuinely
+  # not below.
+  def refusal_message(:already_following),
+    do: gettext("You already follow that account.")
+
+  # The one refusal the member can act on, so it never falls through to the
+  # generic "check the address" line — the address was fine. Reachable although
+  # both pages render the switch panel for a non-federating member, because
+  # participation can end between mount and submit (a second tab, a freeze).
+  def refusal_message(:not_federating),
+    do:
+      gettext(
+        "You are not taking part in the Fediverse at the moment, so there is no identity to sign the request with. Open the Fediverse settings to switch it on."
+      )
+
+  def refusal_message(:follow_capped),
+    do:
+      gettext("You have sent a lot of follow requests in the last hour. Please try again later.")
+
+  def refusal_message(:follow_limit),
+    do:
+      gettext("You are following the most accounts we allow (%{max}).",
+        max: delimited_count(Fediverse.max_remote_follows())
+      )
+
+  def refusal_message(:moved),
+    do:
+      gettext(
+        "You redirected your Fediverse followers to another account, so this account no longer acts out there."
+      )
+
+  def refusal_message(:fediverse_disabled),
+    do: gettext("The Fediverse is switched off on this vutuv.")
+
+  def refusal_message(_other),
+    do: gettext("That did not work. Check the address and try again.")
+end

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -833,7 +833,13 @@ defmodule VutuvWeb.PostComponents do
         <.remote_avatar initials={@initials} />
 
         <div class="min-w-0 flex-1">
-          <.remote_header author={@author} handle={@handle} actor_uri={@note.actor_uri} at={@note.received_at}>
+          <.remote_header
+            author={@author}
+            handle={@handle}
+            actor_uri={@note.actor_uri}
+            at={@note.received_at}
+            account_id={@note.account_id}
+          >
             <:menu>
               <%!-- The takedown controls. Report is open to anyone who can see the
               reply (which for a private one is its addressee alone) and deletes it
@@ -908,13 +914,30 @@ defmodule VutuvWeb.PostComponents do
 
   attr(:initials, :string, required: true)
 
-  defp remote_avatar(assigns) do
+  attr(:size, :string,
+    default: "sm",
+    values: ~w(sm lg),
+    doc: "`lg` for the account page's header, where the tile is the page's subject"
+  )
+
+  @doc """
+  The slate initials tile with its globe badge — "this did not come from
+  vutuv", in one definition. Public so the account page
+  (`VutuvWeb.FediverseAccountLive`) wears the same skin as the cards: that page
+  is where a reader decides about a stranger, so it is the last place the badge
+  should be missing.
+  """
+  def remote_avatar(assigns) do
     ~H"""
     <span class="relative shrink-0">
       <span
         data-remote-avatar
         aria-hidden="true"
-        class="inline-flex h-9 w-9 select-none items-center justify-center rounded-full bg-slate-200 text-xs font-semibold text-slate-600 dark:bg-slate-700 dark:text-slate-300"
+        class={[
+          "inline-flex select-none items-center justify-center rounded-full bg-slate-200 font-semibold text-slate-600 dark:bg-slate-700 dark:text-slate-300",
+          @size == "lg" && "h-14 w-14 text-base",
+          @size == "sm" && "h-9 w-9 text-xs"
+        ]}
       >
         {@initials}
       </span>
@@ -939,6 +962,11 @@ defmodule VutuvWeb.PostComponents do
     doc: "the server, shown as a chip when the card's position does not say where it came from"
   )
 
+  attr(:account_id, :any,
+    default: nil,
+    doc: "the stored account row, when we know it: the handle then links to its page here"
+  )
+
   slot(:menu)
 
   # `break-words` on the author and the handle is not cosmetic: both come
@@ -953,12 +981,11 @@ defmodule VutuvWeb.PostComponents do
       <div class="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2">
         <span class="break-words font-semibold text-slate-900 dark:text-white">{@author}</span>
         <span class="min-w-0 text-xs text-slate-600 dark:text-slate-400">
-          <a
-            href={@actor_uri}
-            target="_blank"
-            rel="nofollow noopener noreferrer"
+          <.link
+            {remote_actor_destination(@account_id, @actor_uri)}
+            data-remote-account={@account_id}
             class="break-all hover:text-brand-700 dark:hover:text-brand-300 sm:break-normal"
-          >{@handle}</a>
+          >{@handle}</.link>
           · <.post_time at={@at} />
         </span>
         <%!-- Where this came from, up here where the eye lands, not only in the
@@ -979,6 +1006,24 @@ defmodule VutuvWeb.PostComponents do
     </div>
     """
   end
+
+  # Where a remote handle leads, as the attributes to splat onto a `<.link>`.
+  #
+  # Inward when we know the account (issue #1162): the handle is the thing a
+  # reader taps to ask "who is this", and the answer to that is a page here
+  # where they can see what the account posts and follow it — not a trip off
+  # the site to somebody else's server. The link out is still one click away,
+  # in the footer. Straight out when we do not know them, since there would be
+  # nothing to show.
+  #
+  # One definition, because the header of every remote card and the reaction
+  # chips ask the same question, and a chip that answered it differently from
+  # the card above it would be the same handle leading two places.
+  defp remote_actor_destination(nil, actor_uri),
+    do: [href: actor_uri, target: "_blank", rel: "nofollow noopener noreferrer"]
+
+  defp remote_actor_destination(account_id, _actor_uri),
+    do: [navigate: ~p"/system/fediverse/account/#{account_id}"]
 
   # The lock line. The same glyph a restricted vutuv post wears, so "not
   # everybody sees this" reads the same way across the app; the sentence is the
@@ -1110,6 +1155,7 @@ defmodule VutuvWeb.PostComponents do
             actor_uri={@account.actor_uri}
             at={@remote_post.published_at}
             network={@account.host}
+            account_id={@account.id}
           >
             <:menu>
               <.card_menu :if={@viewer} id={"remote-post-menu-#{@remote_post.id}"}>
@@ -3350,14 +3396,18 @@ defmodule VutuvWeb.PostComponents do
         </p>
 
         <p :if={@shown != []} class="flex flex-wrap items-center gap-x-2 gap-y-1">
-          <a
+          <%!-- A chip is somebody the reader may well want to know more about —
+                that is the whole point of naming them — so it goes wherever the
+                handle on a remote card goes (`remote_actor_destination/2`): to
+                their page here when we know them, out to their own server when
+                we do not. Only the destination differs; the chip is one. --%>
+          <.link
             :for={actor <- @shown}
-            href={actor.uri}
-            target="_blank"
-            rel="nofollow noopener noreferrer"
+            {remote_actor_destination(actor.account_id, actor.uri)}
             data-fediverse-reaction={actor.kind}
+            data-remote-account={actor.account_id}
             title={reaction_title(actor)}
-            class="inline-flex min-h-8 max-w-full items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-200 hover:text-brand-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-brand-300"
+            class="inline-flex min-h-10 max-w-full items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-200 hover:text-brand-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-brand-300"
           >
             <%!-- The same two glyphs the vutuv action bar above uses for the
                   same two acts, so "shared" and "favourited" read identically
@@ -3370,7 +3420,7 @@ defmodule VutuvWeb.PostComponents do
             />
             <span class="sr-only">{reaction_title(actor)}</span>
             <span aria-hidden="true" class="break-all">{actor.handle}</span>
-          </a>
+          </.link>
 
           <span :if={@more > 0} data-fediverse-reactions-more={@more}>
             {gettext("+%{count} more", count: compact_count(@more))}
@@ -3402,7 +3452,10 @@ defmodule VutuvWeb.PostComponents do
     %{
       uri: uri,
       kind: row["kind"],
-      handle: Handle.display(row["handle"], uri)
+      handle: Handle.display(row["handle"], uri),
+      # Whether we already know this account (issue #1162), read alongside the
+      # reaction in the engagement query rather than looked up per chip.
+      account_id: row["account_id"]
     }
   end
 

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -266,8 +266,9 @@ defmodule VutuvWeb.FediverseController do
   # conditions it failed.
   defp perform(user, %{"type" => type, "object" => object}, remote)
        when type in ["Like", "Announce"] do
-    Fediverse.record_reaction(user, object, reaction_kind(type), reacting_actor(remote))
-    :ok
+    user
+    |> Fediverse.record_reaction(object, reaction_kind(type), reacting_actor(remote))
+    |> remember_actor_if_stored(remote)
   end
 
   # The remote side took its reaction back. Honoured at once: an upstream
@@ -284,8 +285,9 @@ defmodule VutuvWeb.FediverseController do
   # whatever it decides, so a misdirected activity never learns which gate it
   # failed.
   defp perform(user, %{"type" => "Create"} = activity, remote) do
-    Fediverse.record_reply(user, activity, remote_author(remote))
-    :ok
+    user
+    |> Fediverse.record_reply(activity, remote_author(remote))
+    |> remember_actor_if_stored(remote)
   end
 
   # A remote actor that renamed or moved its inbox broadcasts an `Update` of
@@ -372,6 +374,17 @@ defmodule VutuvWeb.FediverseController do
   end
 
   defp perform_once(_activity, _remote), do: :ok
+
+  # Takes the outcome of `record_reaction/4` / `record_reply/3` and remembers
+  # the actor only when something was really stored (`Fediverse.remember_remote_account/1`):
+  # a stranger's activity that every gate refused must not be able to plant an
+  # account row.
+  defp remember_actor_if_stored(:ok, remote) do
+    Fediverse.remember_remote_account(remote)
+    :ok
+  end
+
+  defp remember_actor_if_stored(_skipped, _remote), do: :ok
 
   defp reaction_kind("Like"), do: "like"
   defp reaction_kind("Announce"), do: "announce"

--- a/lib/vutuv_web/live/fediverse_account_live.ex
+++ b/lib/vutuv_web/live/fediverse_account_live.ex
@@ -1,0 +1,385 @@
+defmodule VutuvWeb.FediverseAccountLive do
+  @moduledoc """
+  The page for an account on another network
+  (`/system/fediverse/account/:id`, issue #1162).
+
+  Every remote handle vutuv shows — a reaction chip, a remote reply card, a
+  remote post in the feed — used to link straight out of the site. So deciding
+  to follow somebody you saw react to your own post meant leaving, finding them,
+  coming back and pasting their address into a settings page. This is that
+  detour removed: the handle now lands here, where the account is what it is and
+  the follow button is right there.
+
+  **It is not a mirror profile.** It is a follow surface plus a preview: the
+  name, the address, the self-description, the follow state, and the posts we
+  already hold — capped, newest first — with "View the original" one click away.
+  Somebody's full history stays their own server's job. Nothing is fetched on
+  view: opening this page makes no request to anybody, so a link to it can never
+  be used to make vutuv poke a third-party server.
+
+  Two things it can show that the origin profile cannot, which is why it is
+  worth having at all: a post its author addressed to their followers is
+  readable here by a member whose own follow is accepted (logged out on that
+  server they would see nothing of it), and the cached posts are the "what do
+  they actually post" preview that decides the follow.
+
+  **Signed-in only and `noindex`.** The page is assembled from things other
+  people wrote on other servers, so it is neither ours to publish nor useful to
+  a crawler; the route carries the header, `on_mount` carries the login.
+
+  Keyed by the **row id**, never by a URI: a page that took an address would be
+  an open-ended "go and fetch this" surface. Reaching an account we do not know
+  yet goes the other way round — the lookup box below resolves the address
+  first, deliberately as an event and not as a GET.
+
+  The follow box, the refusal panel and the wording of every refusal are the
+  ones `/settings/fediverse/following` uses (`VutuvWeb.FediverseComponents`):
+  two ways into one act, described once.
+  """
+
+  use VutuvWeb, :live_view
+
+  import VutuvWeb.FediverseComponents
+  import VutuvWeb.PostComponents
+
+  on_mount({VutuvWeb.Live.InitAssigns, :require_login})
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.RemoteAccount
+
+  @impl true
+  def mount(%{"id" => id}, _session, socket) do
+    case Fediverse.get_remote_account(id) do
+      %RemoteAccount{} = account ->
+        viewer = socket.assigns.current_user
+
+        {:ok,
+         socket
+         |> assign(:address, "")
+         |> assign(:error, nil)
+         |> assign(:account, account)
+         # Named as what it is: the tab, the bookmark and the history entry all
+         # outlive the page, and a bare name there is indistinguishable from a
+         # vutuv profile.
+         |> assign(
+           :page_title,
+           gettext("%{name} (another network)", name: RemoteAccount.label(account))
+         )
+         |> assign(:blocked_reason, Fediverse.follow_refusal(viewer))
+         |> assign(:follow, Fediverse.remote_follow_for(viewer, account))
+         |> load_posts()}
+
+      _ ->
+        {:ok,
+         socket
+         |> put_flash(:error, gettext("Sorry, that page could not be found."))
+         |> redirect(to: ~p"/feed")}
+    end
+  end
+
+  # The cached posts, and whether the cap left any out. Only an unfollow can
+  # move this: the copies exist because somebody here follows the author, and
+  # `unfollow_remote/2` deletes them the moment nobody does.
+  defp load_posts(socket) do
+    {posts, more?} = Fediverse.account_posts(socket.assigns.account, socket.assigns.current_user)
+
+    socket |> assign(:posts, posts) |> assign(:more?, more?)
+  end
+
+  # ── Events ────────────────────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("follow", _params, socket) do
+    account = socket.assigns.account
+
+    case Fediverse.follow_remote(socket.assigns.current_user, account.actor_uri) do
+      {:ok, follow} ->
+        # Only the button changes. A fresh follow is "requested", so no
+        # followers-only post opens until the other server answers, and there is
+        # nothing to reload.
+        {:noreply,
+         socket
+         |> put_flash(
+           :info,
+           gettext("Follow request sent to %{account}.", account: RemoteAccount.label(account))
+         )
+         |> assign(:follow, follow)}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, refusal_message(reason))}
+    end
+  end
+
+  def handle_event("unfollow", _params, socket) do
+    follow = socket.assigns.follow
+
+    if follow, do: Fediverse.unfollow_remote(socket.assigns.current_user, follow.id)
+
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Unfollowed."))
+     |> assign(:follow, nil)
+     |> load_posts()}
+  end
+
+  # Mute and **unmute**. The feed's card menu can mute an account, and muting it
+  # takes its posts out of the feed — which takes the menu with them, so until
+  # this control existed the flash promising "you still follow them" described a
+  # door that only opened one way. This page is where a muted account can still
+  # be reached, so this is where the way back belongs.
+  def handle_event("toggle-mute", _params, socket) do
+    account = socket.assigns.account
+    viewer = socket.assigns.current_user
+    muted? = not socket.assigns.follow.muted
+
+    :ok = Fediverse.set_remote_follow_mute(viewer, account.id, muted?)
+
+    {:noreply,
+     socket
+     |> put_flash(:info, mute_message(muted?))
+     |> assign(:follow, Fediverse.remote_follow_for(viewer, account))}
+  end
+
+  # The two controls a cached post carries, handled here as well as on the feed:
+  # this page shows public posts of accounts the viewer does **not** follow (they
+  # are cached because somebody else does), so it is the only place those will
+  # ever be seen — and a card nobody can report is not a card, it is a display.
+  def handle_event("report-remote-post", %{"id" => id}, socket) do
+    case Fediverse.report_remote_post(id, socket.assigns.current_user) do
+      :ok ->
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("Thank you. Our copy was deleted right away."))
+         |> load_posts()}
+
+      {:error, :rate_limited} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("You have reported a lot today. Please try again tomorrow.")
+         )}
+
+      {:error, :not_found} ->
+        {:noreply, load_posts(socket)}
+    end
+  end
+
+  def handle_event("mute-remote-account", %{"id" => account_id}, socket) do
+    viewer = socket.assigns.current_user
+    :ok = Fediverse.set_remote_follow_mute(viewer, account_id, true)
+
+    {:noreply,
+     socket
+     |> put_flash(:info, mute_message(true))
+     |> assign(:follow, Fediverse.remote_follow_for(viewer, socket.assigns.account))}
+  end
+
+  # The lookup box: an address in, that account's page out. Resolving is an
+  # outbound request, so it is an event a member triggers on purpose, never
+  # something a URL does on arrival.
+  def handle_event("look-up", %{"address" => address}, socket) do
+    case Fediverse.resolve_remote_account(socket.assigns.current_user, address) do
+      {:ok, account} ->
+        {:noreply, push_navigate(socket, to: ~p"/system/fediverse/account/#{account.id}")}
+
+      {:error, reason} ->
+        {:noreply, socket |> assign(:address, address) |> assign(:error, reason)}
+    end
+  end
+
+  def handle_event("typing", %{"address" => address}, socket) do
+    {:noreply, socket |> assign(:address, address) |> assign(:error, nil)}
+  end
+
+  defp mute_message(true),
+    do: gettext("Muted. You still follow them; their posts leave your feed.")
+
+  defp mute_message(false), do: gettext("Unmuted. Their posts are back in your feed.")
+
+  # Why the Posts card is empty, which is a different sentence in each case. The
+  # flat "nobody here follows this account" was simply false for a member with a
+  # requested follow and only followers-only posts cached: we hold them and were
+  # telling them we hold nothing.
+  defp no_posts_message(nil),
+    do:
+      gettext(
+        "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
+      )
+
+  defp no_posts_message(%{state: "accepted"}),
+    do: gettext("Nothing cached yet. Their posts appear here as they publish them.")
+
+  defp no_posts_message(%{}),
+    do:
+      gettext(
+        "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
+      )
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="fediverse-account" class="mx-auto max-w-2xl space-y-6 py-6">
+      <.card>
+        <div class="flex items-start gap-4">
+          <.remote_avatar initials={name_initials(@account.name || @account.handle)} size="lg" />
+
+          <div class="min-w-0 flex-1">
+            <%!-- Before the name, not after the handle: the round tile, the
+            bold name and the muted line under it are exactly a member profile
+            header, and a reader must know which world they are looking at
+            before they read who it is. --%>
+            <.section_title>{gettext("Account on another network")}</.section_title>
+            <h1 class="mt-0.5 break-words text-xl font-bold text-slate-900 dark:text-white">
+              {RemoteAccount.label(@account)}
+            </h1>
+            <p class="mb-0 mt-0.5 text-sm text-slate-600 dark:text-slate-400">
+              <%!-- The address links out: this page is the follow surface, that
+              one is where they actually live, and the reader must always be one
+              click from the real thing. --%>
+              <a
+                href={@account.actor_uri}
+                target="_blank"
+                rel="nofollow noopener noreferrer"
+                data-remote-origin
+                class="break-all font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+              >
+                {RemoteAccount.display_handle(@account)}
+              </a>
+              · {gettext("From another network")}
+            </p>
+          </div>
+        </div>
+
+        <%!-- A self-description is remote text and may be 10,000 characters. Run
+        whole it would be some 400 lines on a phone, with Follow, the posts and
+        the lookup box all several screens below it. So it is clamped with a lid,
+        the same shape every other long remote text on the site wears. --%>
+        <details :if={@account.summary} data-remote-summary class="group mt-4">
+          <summary class="cursor-pointer list-none">
+            <p class="post-clamp mb-0 whitespace-pre-line break-words text-sm leading-relaxed text-slate-700 group-open:hidden dark:text-slate-300">
+              {@account.summary}
+            </p>
+            <span class="mt-1 inline-flex min-h-10 items-center text-xs font-medium text-brand-600 group-open:hidden dark:text-brand-400">
+              {gettext("Show the whole description")}
+            </span>
+            <span class="mt-1 hidden min-h-10 items-center text-xs font-medium text-brand-600 group-open:inline-flex dark:text-brand-400">
+              {gettext("Show less")}
+            </span>
+          </summary>
+          <p class="mb-0 whitespace-pre-line break-words text-sm leading-relaxed text-slate-700 dark:text-slate-300">
+            {@account.summary}
+          </p>
+        </details>
+
+        <div class="mt-5">
+          <%= if @blocked_reason do %>
+            <.follow_refusal_panel id="cannot-follow" reason={@blocked_reason} />
+          <% else %>
+            <%!-- One block for both follow states: what differs is the badge's
+                  word and colour and the button's label, and those come from
+                  the sibling page, so "Requested" cannot mean two things. --%>
+            <div :if={@follow} class="flex flex-wrap items-center gap-3">
+              <span
+                data-follow-state={@follow.state}
+                class={[
+                  "inline-flex rounded-full px-2 py-0.5 text-xs font-semibold ring-1",
+                  follow_state_class(@follow)
+                ]}
+              >
+                {follow_state_label(@follow)}
+              </span>
+              <span
+                :if={@follow.muted}
+                data-follow-muted
+                class="inline-flex rounded-full bg-slate-100 px-2 py-0.5 text-xs font-semibold text-slate-700 ring-1 ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700"
+              >
+                {gettext("Muted")}
+              </span>
+              <.button id="unfollow" variant="secondary" phx-click="unfollow">
+                {end_follow_label(@follow)}
+              </.button>
+              <%!-- The way back out of a mute. Muting from the feed removes the
+              account's posts, and with them the menu that muted it, so without
+              this the flash's "you still follow them" led nowhere. --%>
+              <.button id="toggle-mute" variant="ghost" phx-click="toggle-mute">
+                <%= if @follow.muted do %>
+                  {gettext("Unmute")}
+                <% else %>
+                  {gettext("Mute")}
+                <% end %>
+              </.button>
+            </div>
+
+            <.button :if={is_nil(@follow)} id="follow" phx-click="follow">
+              {gettext("Follow")}
+            </.button>
+          <% end %>
+        </div>
+      </.card>
+
+      <.card>
+        <.section_title>{gettext("Posts")}</.section_title>
+
+        <%= if @posts == [] do %>
+          <%!-- Why it is empty, which is a different sentence per follow state:
+          "nobody here follows this account" is simply untrue for a member whose
+          own follow is only requested. --%>
+          <p class="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400" id="no-posts">
+            {no_posts_message(@follow)}
+          </p>
+        <% else %>
+          <div class="mt-3 divide-y divide-slate-100 dark:divide-slate-800">
+            <%!-- The real viewer, so the card keeps its ⋯ menu. This page shows
+                  public posts of accounts the reader does NOT follow (cached
+                  because somebody else does), so it is the only place they will
+                  ever see them — a card nobody can report is a display, not a
+                  card. The account is stitched in rather than preloaded per row:
+                  it is the one account, already in hand. --%>
+            <div :for={post <- @posts} class="py-4 first:pt-0 last:pb-0">
+              <.remote_post_card
+                remote_post={%{post | remote_account: @account}}
+                viewer={@current_user}
+              />
+            </div>
+          </div>
+
+          <p :if={@more?} class="mt-3 text-xs text-slate-600 dark:text-slate-400">
+            {gettext("The most recent %{count} are shown. The rest are on their own server.",
+              count: delimited_count(length(@posts))
+            )}
+          </p>
+        <% end %>
+
+        <%!-- In EVERY state, not only when the cap cut something: for an account
+        nobody follows this card is otherwise a dead end, and this link is the
+        page's own thesis — a preview here, the whole person over there. --%>
+        <.card_footer_link href={@account.actor_uri}>
+          {gettext("View their full profile on %{host}", host: @account.host)}
+        </.card_footer_link>
+      </.card>
+
+      <.card>
+        <.section_title>{gettext("Look up another account")}</.section_title>
+        <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+          {gettext("Paste an address from Mastodon and friends to open its page here.")}
+        </p>
+
+        <.address_form
+          id="lookup"
+          address={@address}
+          error={@error}
+          event="look-up"
+          submit={gettext("Look up")}
+          variant="secondary"
+          class="mt-3"
+        />
+
+        <.card_footer_link href={~p"/settings/fediverse/following"}>
+          {gettext("Accounts you follow elsewhere")}
+        </.card_footer_link>
+      </.card>
+    </div>
+    """
+  end
+end

--- a/lib/vutuv_web/live/fediverse_following_live.ex
+++ b/lib/vutuv_web/live/fediverse_following_live.ex
@@ -34,17 +34,16 @@ defmodule VutuvWeb.FediverseFollowingLive do
   use VutuvWeb, :live_view
 
   import VutuvWeb.BrowseTable
+  import VutuvWeb.FediverseComponents
 
   on_mount({VutuvWeb.Live.InitAssigns, :require_login})
 
   alias Vutuv.Accounts
-  alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemoteFollow
   alias Vutuv.Handles
-  alias Vutuv.Moderation
   alias Vutuv.Pages
 
   @impl true
@@ -56,33 +55,11 @@ defmodule VutuvWeb.FediverseFollowingLive do
      |> assign(:page_title, gettext("Accounts you follow elsewhere"))
      |> assign(:user, user)
      |> assign(:federating?, Fediverse.federated?(user))
-     |> assign(:blocked_reason, blocked_reason(user))
+     |> assign(:blocked_reason, Fediverse.follow_refusal(user))
      |> assign(:address, "")
      |> assign(:error, nil)
      |> assign(:local_member, nil)
      |> assign_totals()}
-  end
-
-  # *Why* this member cannot follow, when they cannot. `federated?/1` is one
-  # boolean over four very different situations, and the difference decides
-  # which sentence is true and which link helps:
-  #
-  #   nil          — they can, nothing to explain.
-  #   :opted_out   — they have not switched Fediverse participation on. The
-  #                  switch is the answer.
-  #   :restricted  — the account is frozen, suspended, deactivated or
-  #                  unreachable. Telling them to flip a switch they already
-  #                  flipped, and linking to a page showing it on, is exactly
-  #                  the wrong answer in the one place clarity matters most.
-  #   :disabled    — the operator switched federation off installation-wide.
-  #                  Nothing the member can do, so nothing is offered.
-  defp blocked_reason(%User{} = user) do
-    cond do
-      Fediverse.federated?(user) -> nil
-      not Fediverse.enabled?() -> :disabled
-      Moderation.account_hidden?(user) -> :restricted
-      true -> :opted_out
-    end
   end
 
   @impl true
@@ -230,88 +207,14 @@ defmodule VutuvWeb.FediverseFollowingLive do
     gettext("Follow request sent to %{account}.", account: RemoteAccount.label(account))
   end
 
-  defp error_message(:invalid_address),
-    do:
-      gettext(
-        "That does not look like an address on another network. They look like @name@server."
-      )
-
-  defp error_message(:unreachable),
-    do: gettext("That server did not answer. Check the address, and that the server is online.")
-
-  defp error_message(:no_actor),
-    do: gettext("That server answered, but it has no account at that address to follow.")
-
-  defp error_message(:unreachable_actor),
-    do: gettext("That account could not be loaded from its server. Try again in a little while.")
-
-  defp error_message(:instance_blocked),
-    do: gettext("This vutuv does not exchange anything with that server.")
-
-  # Deliberately without "it is in the list below": the error keeps the active
-  # filter and the table is paged, so the row it points at is often genuinely
-  # not below.
-  defp error_message(:already_following),
-    do: gettext("You already follow that account.")
-
-  # The one refusal the member can act on, so it never falls through to the
-  # generic "check the address" line — the address was fine. Reachable although
-  # the page renders the switch panel for a non-federating member, because
-  # participation can end between mount and submit (a second tab, a freeze).
-  defp error_message(:not_federating),
-    do:
-      gettext(
-        "You are not taking part in the Fediverse at the moment, so there is no identity to sign the request with. Open the Fediverse settings to switch it on."
-      )
-
-  defp error_message(:follow_capped),
-    do:
-      gettext("You have sent a lot of follow requests in the last hour. Please try again later.")
-
-  defp error_message(:follow_limit),
-    do:
-      gettext("You are following the most accounts we allow (%{max}).",
-        max: delimited_count(Fediverse.max_remote_follows())
-      )
-
-  defp error_message(:moved),
-    do:
-      gettext(
-        "You redirected your Fediverse followers to another account, so this account no longer acts out there."
-      )
-
-  defp error_message(:fediverse_disabled),
-    do: gettext("The Fediverse is switched off on this vutuv.")
-
-  defp error_message(_other),
-    do: gettext("That did not work. Check the address and try again.")
-
-  defp state_label(follow) do
-    if Follow.accepted?(follow), do: gettext("Following"), else: gettext("Requested")
-  end
-
-  # A request nobody has answered is not something you unfollow — you take the
-  # request back. Two labels and two confirmations, because a member who reads
-  # "Unfollow" on a Requested row learns that the state badge does not mean
-  # anything.
-  defp end_follow_label(follow) do
-    if Follow.accepted?(follow), do: gettext("Unfollow"), else: gettext("Cancel request")
-  end
-
+  # The confirmation that goes with `end_follow_label/1`. This page knows the
+  # account behind the row (the table preloads it), so it names it.
   defp end_follow_confirm(follow) do
     account = RemoteAccount.label(follow.remote_account)
 
     if Follow.accepted?(follow),
       do: gettext("Stop following %{account}?", account: account),
       else: gettext("Withdraw your follow request to %{account}?", account: account)
-  end
-
-  defp state_class(follow) do
-    if Follow.accepted?(follow),
-      do:
-        "bg-emerald-50 text-emerald-800 ring-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-200 dark:ring-emerald-800",
-      else:
-        "bg-slate-100 text-slate-700 ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700"
   end
 
   # Both middle columns fold away on a phone (`phone_hidden_class/0`), so the
@@ -366,58 +269,21 @@ defmodule VutuvWeb.FediverseFollowingLive do
           <%= if @federating? do %>
             <%!-- The add box is the reason this page exists, so it sits above
                   everything else and is a full-size input at every width. --%>
-            <form
-              id="follow-form"
-              phx-submit="follow"
-              phx-change="typing"
-              class="mt-4 flex flex-wrap items-end gap-3"
+            <.address_form
+              id="follow"
+              address={@address}
+              error={@error}
+              event="follow"
+              submit={gettext("Follow")}
+              class="mt-4"
             >
-              <div class="min-w-56 grow">
-                <label
-                  for="follow-address"
-                  class="block text-sm font-semibold text-slate-700 dark:text-slate-200"
-                >
-                  {gettext("Address of the account")}
-                </label>
-                <%!-- `inputmode="email"` for the @ and the dot on a phone
-                      keyboard's first layer, without the validation an
-                      `type="email"` would apply to a two-@ address. iOS honours
-                      autocorrect separately from spellcheck. --%>
-                <input
-                  type="text"
-                  name="address"
-                  id="follow-address"
-                  value={@address}
-                  inputmode="email"
-                  autocomplete="off"
-                  autocapitalize="none"
-                  autocorrect="off"
-                  spellcheck="false"
-                  placeholder="@name@server"
-                  aria-invalid={@error && "true"}
-                  aria-describedby={@error && "follow-error"}
-                  class={input_class(@error != nil)}
-                />
-              </div>
-              <.button type="submit" id="follow-submit" class="w-full sm:w-auto">
-                {gettext("Follow")}
-              </.button>
-            </form>
-
-            <p
-              :if={@error}
-              id="follow-error"
-              role="alert"
-              class="mt-2 text-sm font-medium text-red-700 dark:text-red-300"
-            >
-              <%= if @error == :local_account do %>
-                {gettext("That is an address on this vutuv, not another network.")}
+              <:error_detail>
                 <%!-- The profile when the handle really resolves to a member,
                       the search when it does not (a pasted profile URL that is
                       local but names nothing) — either way a next step, never a
                       sentence that just stops. --%>
                 <.link
-                  :if={@local_member}
+                  :if={@error == :local_account and @local_member}
                   navigate={~p"/#{@local_member}"}
                   id="local-member-link"
                   class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-300"
@@ -425,70 +291,22 @@ defmodule VutuvWeb.FediverseFollowingLive do
                   {gettext("Open their profile")} ›
                 </.link>
                 <.link
-                  :if={is_nil(@local_member)}
+                  :if={@error == :local_account and is_nil(@local_member)}
                   navigate={~p"/search?#{[q: @address]}"}
                   id="local-member-search"
                   class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-300"
                 >
                   {gettext("Search for them here")} ›
                 </.link>
-              <% else %>
-                {error_message(@error)}
-              <% end %>
-            </p>
+              </:error_detail>
+            </.address_form>
           <% else %>
-            <%!-- No actor, no follow: the request is signed with the member's
-                  own key. Say that, and put the switch one click away, rather
-                  than bouncing them to a page that does not mention following.
-                  Which sentence, though, depends on why — see blocked_reason/1. --%>
-            <div
+            <.follow_refusal_panel
               id="not-federating"
-              data-reason={@blocked_reason}
-              class="mt-4 rounded-lg bg-slate-50 p-4 text-sm leading-relaxed text-slate-700 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:text-slate-300 dark:ring-slate-700"
-            >
-              <%= case @blocked_reason do %>
-                <% :restricted -> %>
-                  <p>
-                    {gettext(
-                      "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
-                    )}
-                  </p>
-                  <p class="mt-3">
-                    <.link
-                      navigate={~p"/moderation/cases"}
-                      id="moderation-cases-link"
-                      class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-300 dark:hover:text-brand-100"
-                    >
-                      {gettext("Why is my account on hold?")} ›
-                    </.link>
-                  </p>
-                <% :disabled -> %>
-                  <p>
-                    {gettext(
-                      "This vutuv does not exchange anything with other networks, so there is nothing to follow from here. That is an operator setting, not yours."
-                    )}
-                  </p>
-                <% _opted_out -> %>
-                  <p>
-                    {gettext(
-                      "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
-                    )}
-                  </p>
-                  <p :if={@address != ""} class="mt-3">
-                    {gettext("The address you brought along is kept here:")}
-                    <span class="font-semibold break-all">{@address}</span>
-                  </p>
-                  <p class="mt-3">
-                    <.link
-                      navigate={~p"/settings/fediverse"}
-                      id="enable-fediverse-link"
-                      class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-300 dark:hover:text-brand-100"
-                    >
-                      {gettext("Take part in the Fediverse")} ›
-                    </.link>
-                  </p>
-              <% end %>
-            </div>
+              reason={@blocked_reason}
+              address={@address}
+              class="mt-4"
+            />
           <% end %>
 
           <%= if @federating? and @total_follows == 0 do %>
@@ -556,10 +374,10 @@ defmodule VutuvWeb.FediverseFollowingLive do
                           data-follow-state={follow.state}
                           class={[
                             "inline-flex rounded-full px-2 py-0.5 text-xs font-semibold ring-1",
-                            state_class(follow)
+                            follow_state_class(follow)
                           ]}
                         >
-                          {state_label(follow)}
+                          {follow_state_label(follow)}
                         </span>
                         <button
                           type="button"

--- a/lib/vutuv_web/plugs/no_index.ex
+++ b/lib/vutuv_web/plugs/no_index.ex
@@ -11,6 +11,10 @@ defmodule VutuvWeb.Plug.NoIndex do
   `ListDocs`). The public profile page itself is not routed through this
   plug and carries only the member's own opt-outs.
 
+  Also by `:settings_pipe`, and by `:noindex_pipe` — the bare form, for the
+  signed-in `/system/fediverse/*` pages, which are assembled from what other
+  people wrote on other servers and are not ours to publish.
+
   robots.txt only *asks* crawlers not to fetch a URL; a disallowed URL can
   still be indexed (as a bare link) if referenced elsewhere. This header
   closes that gap by telling compliant crawlers not to index the page even

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -35,6 +35,14 @@ defmodule VutuvWeb.Router do
     plug(Plugs.AdBanner)
   end
 
+  # Pages that are routable but must not be indexed, without the rest of a
+  # scope's machinery. The header is what does the work; robots.txt only asks a
+  # crawler not to fetch, which does not stop a referenced URL being indexed as
+  # a bare link.
+  pipeline :noindex_pipe do
+    plug(Plugs.NoIndex)
+  end
+
   pipeline :user_pipe do
     # Keep the per-user detail pages (phone numbers, emails, addresses, …) out
     # of search indexes. Runs first so the header is present even when a later
@@ -446,10 +454,18 @@ defmodule VutuvWeb.Router do
       live("/posts/:id/edit", PostLive.Edit, :edit)
       live("/posts/:id/reply", PostLive.Reply, :new)
 
-      # Answering a reply that came from another network (issue #1070). Under
-      # /system/ rather than a new root word, which profiles own; "system" is
-      # already reserved, so this burns no handle.
-      live("/system/fediverse/reply/:id", PostLive.RemoteReply, :new)
+      # The two signed-in Fediverse pages that are not settings: answering a
+      # reply from another network (issue #1070) and the page for one remote
+      # account (issue #1162). Under /system/ rather than a new root word, which
+      # profiles own; "system" is already reserved, so this burns no handle.
+      # `:noindex_pipe` because both are assembled from things other people
+      # wrote on other servers.
+      scope "/system/fediverse" do
+        pipe_through(:noindex_pipe)
+
+        live("/reply/:id", PostLive.RemoteReply, :new)
+        live("/account/:id", FediverseAccountLive, :show)
+      end
 
       # The private likes / bookmarks lists (reserved slugs too).
       live("/likes", PostLive.Saved, :likes)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.177.0",
+      version: "7.178.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -154,7 +154,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:1642
+#: lib/vutuv_web/components/post_components.ex:1688
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -203,7 +203,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:1607
+#: lib/vutuv_web/components/post_components.ex:1653
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -329,6 +329,7 @@ msgstr "Follower"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:507
 #: lib/vutuv_web/agent_docs/text.ex:477
+#: lib/vutuv_web/components/fediverse_components.ex:216
 #: lib/vutuv_web/components/ui.ex:1551
 #: lib/vutuv_web/components/ui.ex:1576
 #: lib/vutuv_web/components/ui.ex:1579
@@ -336,7 +337,6 @@ msgstr "Follower"
 #: lib/vutuv_web/components/ui.ex:1589
 #: lib/vutuv_web/components/ui.ex:1647
 #: lib/vutuv_web/controllers/followee_controller.ex:23
-#: lib/vutuv_web/live/fediverse_following_live.ex:290
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
 #: lib/vutuv_web/templates/user/show.html.heex:819
@@ -660,7 +660,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1022
+#: lib/vutuv_web/components/post_components.ex:1067
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1696,7 +1696,7 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/post_components.ex:2084
+#: lib/vutuv_web/components/post_components.ex:2130
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
@@ -1767,7 +1767,8 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/components/ui.ex:1605
 #: lib/vutuv_web/components/ui.ex:1608
 #: lib/vutuv_web/components/ui.ex:1681
-#: lib/vutuv_web/live/fediverse_following_live.ex:403
+#: lib/vutuv_web/live/fediverse_account_live.ex:315
+#: lib/vutuv_web/live/fediverse_following_live.ex:277
 #: lib/vutuv_web/templates/user/show.html.heex:930
 #: lib/vutuv_web/templates/user/show.html.heex:1165
 #, elixir-autogen, elixir-format
@@ -1941,7 +1942,7 @@ msgstr ""
 "Wir haben eine PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie sie "
 "unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:960
+#: lib/vutuv_web/live/post_live/feed.ex:967
 #: lib/vutuv_web/templates/user/show.html.heex:1429
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2180,7 +2181,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:1639
+#: lib/vutuv_web/components/post_components.ex:1685
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2193,7 +2194,7 @@ msgid "Edit post"
 msgstr "Beitrag bearbeiten"
 
 #: lib/vutuv_web/live/post_live/feed.ex:87
-#: lib/vutuv_web/live/post_live/feed.ex:774
+#: lib/vutuv_web/live/post_live/feed.ex:781
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:116
@@ -2221,8 +2222,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:1593
-#: lib/vutuv_web/components/post_components.ex:1595
+#: lib/vutuv_web/components/post_components.ex:1639
+#: lib/vutuv_web/components/post_components.ex:1641
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2238,7 +2239,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:901
+#: lib/vutuv_web/live/post_live/feed.ex:908
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2278,6 +2279,7 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/controllers/user_controller.ex:76
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
+#: lib/vutuv_web/live/fediverse_account_live.ex:322
 #: lib/vutuv_web/live/notification_live/index.ex:777
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:200
@@ -2288,19 +2290,20 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2022
-#: lib/vutuv_web/components/post_components.ex:2026
+#: lib/vutuv_web/components/post_components.ex:2068
+#: lib/vutuv_web/components/post_components.ex:2072
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:2023
+#: lib/vutuv_web/components/post_components.ex:2069
+#: lib/vutuv_web/live/fediverse_account_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:849
+#: lib/vutuv_web/components/post_components.ex:855
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
@@ -2326,13 +2329,14 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:848
+#: lib/vutuv_web/live/post_live/feed.ex:855
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
 msgstr[0] "%{formatted} neuen Beitrag anzeigen"
 msgstr[1] "%{formatted} neue Beiträge anzeigen"
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:75
 #: lib/vutuv_web/live/post_live/edit.ex:36
 #: lib/vutuv_web/live/post_live/remote_reply.ex:79
 #: lib/vutuv_web/live/post_live/reply.ex:41
@@ -2384,27 +2388,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:1590
+#: lib/vutuv_web/components/post_components.ex:1636
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:3151
+#: lib/vutuv_web/components/post_components.ex:3197
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:3153
+#: lib/vutuv_web/components/post_components.ex:3199
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:3154
+#: lib/vutuv_web/components/post_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2445,7 +2449,7 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3235
+#: lib/vutuv_web/components/post_components.ex:3281
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2464,7 +2468,7 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:3451
+#: lib/vutuv_web/components/post_components.ex:3504
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
@@ -2475,7 +2479,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:909
-#: lib/vutuv_web/components/post_components.ex:3460
+#: lib/vutuv_web/components/post_components.ex:3513
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2495,12 +2499,12 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:3224
+#: lib/vutuv_web/components/post_components.ex:3270
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:3235
+#: lib/vutuv_web/components/post_components.ex:3281
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2509,23 +2513,23 @@ msgstr "Nur öffentliche Beiträge können repostet werden."
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:3221
+#: lib/vutuv_web/components/post_components.ex:3267
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:2636
+#: lib/vutuv_web/components/post_components.ex:2682
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3221
+#: lib/vutuv_web/components/post_components.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:3451
+#: lib/vutuv_web/components/post_components.ex:3504
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2534,11 +2538,11 @@ msgstr "Repost zurücknehmen"
 msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
+#: lib/vutuv_web/components/fediverse_components.ex:234
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1648
-#: lib/vutuv_web/live/fediverse_following_live.ex:298
-#: lib/vutuv_web/live/post_live/feed.ex:949
+#: lib/vutuv_web/live/post_live/feed.ex:956
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2549,7 +2553,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:3500
+#: lib/vutuv_web/components/post_components.ex:3553
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2560,16 +2564,16 @@ msgstr "Nur öffentliche Beiträge können beantwortet werden."
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:889
-#: lib/vutuv_web/components/post_components.ex:3483
-#: lib/vutuv_web/components/post_components.ex:3484
+#: lib/vutuv_web/components/post_components.ex:895
+#: lib/vutuv_web/components/post_components.ex:3536
+#: lib/vutuv_web/components/post_components.ex:3537
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1561
+#: lib/vutuv_web/components/post_components.ex:1607
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2597,12 +2601,12 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1556
+#: lib/vutuv_web/components/post_components.ex:1602
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:1550
+#: lib/vutuv_web/components/post_components.ex:1596
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2835,7 +2839,7 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:799
+#: lib/vutuv_web/live/post_live/feed.ex:806
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2916,7 +2920,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:3152
+#: lib/vutuv_web/components/post_components.ex:3198
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3195,7 +3199,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:1526
+#: lib/vutuv_web/components/post_components.ex:1572
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3274,9 +3278,9 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:859
-#: lib/vutuv_web/components/post_components.ex:1136
-#: lib/vutuv_web/components/post_components.ex:1663
+#: lib/vutuv_web/components/post_components.ex:865
+#: lib/vutuv_web/components/post_components.ex:1182
+#: lib/vutuv_web/components/post_components.ex:1709
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4731,7 +4735,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:906
+#: lib/vutuv_web/live/post_live/feed.ex:913
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -5588,7 +5592,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/controllers/settings_controller.ex:53
 #: lib/vutuv_web/live/account_activity_live.ex:155
 #: lib/vutuv_web/live/fediverse_followers_live.ex:126
-#: lib/vutuv_web/live/fediverse_following_live.ex:340
+#: lib/vutuv_web/live/fediverse_following_live.ex:243
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
@@ -5658,11 +5662,11 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:1726
-#: lib/vutuv_web/components/post_components.ex:1778
-#: lib/vutuv_web/components/post_components.ex:2159
+#: lib/vutuv_web/components/post_components.ex:1772
+#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:2205
 #: lib/vutuv_web/live/notification_live/index.ex:601
-#: lib/vutuv_web/live/post_live/feed.ex:1021
+#: lib/vutuv_web/live/post_live/feed.ex:1028
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr "Beitrag ansehen"
@@ -5716,7 +5720,7 @@ msgstr "Über Sie"
 #: lib/vutuv_web/components/ui.ex:3328
 #: lib/vutuv_web/live/admin/user_live.ex:279
 #: lib/vutuv_web/live/fediverse_followers_live.ex:112
-#: lib/vutuv_web/live/fediverse_following_live.ex:326
+#: lib/vutuv_web/live/fediverse_following_live.ex:229
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:192
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
@@ -6212,7 +6216,7 @@ msgid "Add a passkey"
 msgstr "Passkey hinzufügen"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/live/fediverse_following_live.ex:328
+#: lib/vutuv_web/live/fediverse_following_live.ex:231
 #: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Added"
@@ -6907,6 +6911,7 @@ msgstr ""
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
 #: lib/vutuv_web/components/ui.ex:1836
+#: lib/vutuv_web/live/fediverse_account_live.ex:309
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6930,6 +6935,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
 #: lib/vutuv_web/components/ui.ex:1835
+#: lib/vutuv_web/live/fediverse_account_live.ex:307
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6953,7 +6959,7 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:1660
+#: lib/vutuv_web/components/post_components.ex:1706
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6963,7 +6969,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:1659
+#: lib/vutuv_web/components/post_components.ex:1705
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7670,7 +7676,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
-#: lib/vutuv_web/components/post_components.ex:3376
+#: lib/vutuv_web/components/post_components.ex:3426
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8894,13 +8900,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:988
-#: lib/vutuv_web/live/post_live/feed.ex:989
+#: lib/vutuv_web/live/post_live/feed.ex:995
+#: lib/vutuv_web/live/post_live/feed.ex:996
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:983
+#: lib/vutuv_web/live/post_live/feed.ex:990
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -9124,7 +9130,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/controllers/settings_controller.ex:200
 #: lib/vutuv_web/controllers/settings_controller.ex:267
 #: lib/vutuv_web/live/fediverse_followers_live.ex:127
-#: lib/vutuv_web/live/fediverse_following_live.ex:341
+#: lib/vutuv_web/live/fediverse_following_live.ex:244
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:300
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -9287,7 +9293,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:2639
+#: lib/vutuv_web/components/post_components.ex:2685
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -14419,14 +14425,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3301
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:935
+#: lib/vutuv_web/live/post_live/feed.ex:942
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:950
+#: lib/vutuv_web/live/post_live/feed.ex:957
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -14584,7 +14590,7 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:3014
+#: lib/vutuv_web/components/post_components.ex:3060
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
@@ -14600,18 +14606,18 @@ msgid "Book"
 msgstr "Buch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:956
-#: lib/vutuv_web/components/post_components.ex:2971
+#: lib/vutuv_web/components/post_components.ex:3017
 #: lib/vutuv_web/live/post_live/composer.ex:1504
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:3015
+#: lib/vutuv_web/components/post_components.ex:3061
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:3017
+#: lib/vutuv_web/components/post_components.ex:3063
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
@@ -14621,7 +14627,7 @@ msgstr "DVD/Blu-ray"
 msgid "Director"
 msgstr "Regie"
 
-#: lib/vutuv_web/components/post_components.ex:3013
+#: lib/vutuv_web/components/post_components.ex:3059
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
@@ -14632,7 +14638,7 @@ msgid "Film"
 msgstr "Film"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:956
-#: lib/vutuv_web/components/post_components.ex:2970
+#: lib/vutuv_web/components/post_components.ex:3016
 #: lib/vutuv_web/live/post_live/composer.ex:1503
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -14648,6 +14654,7 @@ msgstr "IMDb-Link oder -ID"
 msgid "ISBN"
 msgstr "ISBN"
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:373
 #: lib/vutuv_web/live/post_live/composer.ex:1538
 #, elixir-autogen, elixir-format
 msgid "Look up"
@@ -14663,7 +14670,7 @@ msgstr "Wird nachgeschlagen …"
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr "Zu dieser ISBN wurde nichts gefunden. Bitte füllen Sie die Felder selbst aus."
 
-#: lib/vutuv_web/components/post_components.ex:3012
+#: lib/vutuv_web/components/post_components.ex:3058
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
@@ -14690,7 +14697,7 @@ msgstr "Ein Buch besprechen"
 msgid "Review a film"
 msgstr "Einen Film besprechen"
 
-#: lib/vutuv_web/components/post_components.ex:3016
+#: lib/vutuv_web/components/post_components.ex:3062
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14721,34 +14728,34 @@ msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:3053
+#: lib/vutuv_web/components/post_components.ex:3099
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:3083
+#: lib/vutuv_web/components/post_components.ex:3129
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:3084
+#: lib/vutuv_web/components/post_components.ex:3130
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:3082
+#: lib/vutuv_web/components/post_components.ex:3128
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:3042
+#: lib/vutuv_web/components/post_components.ex:3088
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:3089
+#: lib/vutuv_web/components/post_components.ex:3135
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14778,7 +14785,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:2856
+#: lib/vutuv_web/components/post_components.ex:2902
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14826,7 +14833,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:2847
+#: lib/vutuv_web/components/post_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -15224,14 +15231,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1306
+#: lib/vutuv_web/components/post_components.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1328
+#: lib/vutuv_web/components/post_components.ex:1374
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -15258,7 +15265,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:3459
+#: lib/vutuv_web/components/post_components.ex:3512
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15608,7 +15615,7 @@ msgstr "Kein Server ist blockiert."
 
 #: lib/vutuv_web/components/browse_table.ex:185
 #: lib/vutuv_web/live/fediverse_followers_live.ex:113
-#: lib/vutuv_web/live/fediverse_following_live.ex:327
+#: lib/vutuv_web/live/fediverse_following_live.ex:230
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:96
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:147
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:191
@@ -15700,7 +15707,7 @@ msgstr "Ihre öffentlichen vutuv-Beiträge erscheinen in deren Timelines."
 msgid "Nothing changes on vutuv itself, and you can switch it off again."
 msgstr "Auf vutuv selbst ändert sich nichts, und Sie können es jederzeit wieder ausschalten."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:487
+#: lib/vutuv_web/components/fediverse_components.ex:198
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "Take part in the Fediverse"
@@ -15790,7 +15797,7 @@ msgid "Send your Fediverse followers to another account. They are asked to follo
 msgstr "Schicken Sie Ihre Fediverse-Follower zu einem anderen Konto. Sie werden gebeten, stattdessen diesem zu folgen, und vutuv föderiert Ihre neuen Beiträge nicht mehr. Ihr vutuv-Profil bleibt genau wie es ist, und nichts wird gelöscht."
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:224
-#: lib/vutuv_web/live/fediverse_following_live.ex:618
+#: lib/vutuv_web/live/fediverse_following_live.ex:436
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Back to Fediverse settings"
@@ -16441,21 +16448,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:3418
+#: lib/vutuv_web/components/post_components.ex:3471
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3422
+#: lib/vutuv_web/components/post_components.ex:3475
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:3426
+#: lib/vutuv_web/components/post_components.ex:3479
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16463,7 +16470,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:928
-#: lib/vutuv_web/components/post_components.ex:3380
+#: lib/vutuv_web/components/post_components.ex:3430
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16479,13 +16486,14 @@ msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem 
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:923
-#: lib/vutuv_web/components/post_components.ex:1052
+#: lib/vutuv_web/components/post_components.ex:946
+#: lib/vutuv_web/components/post_components.ex:1097
+#: lib/vutuv_web/live/fediverse_account_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:847
+#: lib/vutuv_web/components/post_components.ex:853
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16512,7 +16520,7 @@ msgstr "Antwort aus einem anderen Netzwerk"
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:856
+#: lib/vutuv_web/components/post_components.ex:862
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16522,7 +16530,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:870
+#: lib/vutuv_web/components/post_components.ex:876
 #: lib/vutuv_web/live/notification_live/index.ex:497
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16554,8 +16562,8 @@ msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1089
-#: lib/vutuv_web/components/post_components.ex:875
-#: lib/vutuv_web/components/post_components.ex:1173
+#: lib/vutuv_web/components/post_components.ex:881
+#: lib/vutuv_web/components/post_components.ex:1219
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16566,6 +16574,7 @@ msgstr "Original ansehen"
 msgid "What"
 msgstr "Was"
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:160
 #: lib/vutuv_web/live/post_live/feed.ex:339
 #: lib/vutuv_web/live/post_live/thread.ex:209
 #, elixir-autogen, elixir-format
@@ -17012,7 +17021,7 @@ msgstr "Hier ist noch nichts. Wenn Sie sich das nächste Mal anmelden oder eine 
 
 #: lib/vutuv_web/live/account_activity_live.ex:243
 #: lib/vutuv_web/live/admin/activity_live.ex:275
-#: lib/vutuv_web/live/fediverse_following_live.ex:514
+#: lib/vutuv_web/live/fediverse_following_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr "Dazu passt nichts. Versuchen Sie eine kürzere Suche oder setzen Sie die Filter zurück."
@@ -17232,22 +17241,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:1538
+#: lib/vutuv_web/components/post_components.ex:1584
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:1626
+#: lib/vutuv_web/components/post_components.ex:1672
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:1634
+#: lib/vutuv_web/components/post_components.ex:1680
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:1620
+#: lib/vutuv_web/components/post_components.ex:1666
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17339,7 +17348,7 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1017
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:2087
+#: lib/vutuv_web/components/post_components.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
@@ -17379,7 +17388,7 @@ msgstr "Foto nach vorne schieben"
 msgid "Move photo later"
 msgstr "Foto nach hinten schieben"
 
-#: lib/vutuv_web/components/post_components.ex:2086
+#: lib/vutuv_web/components/post_components.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
@@ -17389,7 +17398,7 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:2503
+#: lib/vutuv_web/components/post_components.ex:2549
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr "Bisher sehen nur Sie diesen Beitrag."
@@ -17399,19 +17408,19 @@ msgstr "Bisher sehen nur Sie diesen Beitrag."
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2552
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] "Unsere KI prüft das Foto. Sobald es durch ist, geht der Beitrag von selbst online."
 msgstr[1] "Unsere KI prüft die Fotos, %{done} von %{total} sind durch. Sobald das letzte durch ist, geht der Beitrag von selbst online."
 
-#: lib/vutuv_web/components/post_components.ex:2331
+#: lib/vutuv_web/components/post_components.ex:2377
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:1833
+#: lib/vutuv_web/components/post_components.ex:1879
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17424,12 +17433,12 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1050
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:2540
+#: lib/vutuv_web/components/post_components.ex:2586
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/post_components.ex:2085
+#: lib/vutuv_web/components/post_components.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
@@ -17533,8 +17542,8 @@ msgstr "Fotos hinzufügen"
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:808
-#: lib/vutuv_web/live/post_live/feed.ex:809
+#: lib/vutuv_web/live/post_live/feed.ex:815
+#: lib/vutuv_web/live/post_live/feed.ex:816
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
@@ -17598,13 +17607,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:946
-#: lib/vutuv_web/components/post_components.ex:3415
+#: lib/vutuv_web/components/post_components.ex:3468
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:944
-#: lib/vutuv_web/components/post_components.ex:3412
+#: lib/vutuv_web/components/post_components.ex:3465
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17614,7 +17623,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:3311
+#: lib/vutuv_web/components/post_components.ex:3357
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17714,15 +17723,16 @@ msgstr "Rücknahme"
 msgid "Photo details"
 msgstr "Fotodetails"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:56
-#: lib/vutuv_web/live/fediverse_following_live.ex:338
-#: lib/vutuv_web/live/fediverse_following_live.ex:351
+#: lib/vutuv_web/live/fediverse_account_live.ex:379
+#: lib/vutuv_web/live/fediverse_following_live.ex:55
+#: lib/vutuv_web/live/fediverse_following_live.ex:241
+#: lib/vutuv_web/live/fediverse_following_live.ex:254
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
 msgstr "Konten, denen Sie anderswo folgen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:380
+#: lib/vutuv_web/components/fediverse_components.ex:82
 #, elixir-autogen, elixir-format
 msgid "Address of the account"
 msgstr "Adresse des Kontos"
@@ -17732,7 +17742,7 @@ msgstr "Adresse des Kontos"
 msgid "An account on another network"
 msgstr "Ein Konto in einem anderen Netzwerk"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:298
+#: lib/vutuv_web/components/fediverse_components.ex:234
 #, elixir-autogen, elixir-format
 msgid "Cancel request"
 msgstr "Anfrage zurückziehen"
@@ -17742,7 +17752,8 @@ msgstr "Anfrage zurückziehen"
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:230
+#: lib/vutuv_web/live/fediverse_account_live.ex:104
+#: lib/vutuv_web/live/fediverse_following_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Follow request sent to %{account}."
 msgstr "Follower-Anfrage an %{account} gesendet."
@@ -17767,17 +17778,17 @@ msgstr "Es geht auch andersherum: Fügen Sie die Adresse von jemandem bei Mastod
 msgid "Manage who you follow"
 msgstr "Verwalten, wem Sie folgen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:361
+#: lib/vutuv_web/live/fediverse_following_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Mastodon and the other networks work like email: an address is enough. Paste one here and vutuv asks that server to let you follow the account."
 msgstr "Mastodon und die anderen Netzwerke funktionieren wie E-Mail: Eine Adresse genügt. Fügen Sie hier eine ein, und vutuv fragt den betreffenden Server, ob Sie dem Konto folgen dürfen."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:425
+#: lib/vutuv_web/live/fediverse_following_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Open their profile"
 msgstr "Profil öffnen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:290
+#: lib/vutuv_web/components/fediverse_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr "Angefragt"
@@ -17787,12 +17798,12 @@ msgstr "Angefragt"
 msgid "Reset sorting"
 msgstr "Sortierung zurücksetzen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:433
+#: lib/vutuv_web/live/fediverse_following_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Search for them here"
 msgstr "Hier nach dieser Person suchen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:543
+#: lib/vutuv_web/live/fediverse_following_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Show only accounts on this server"
 msgstr "Nur Konten auf diesem Server anzeigen"
@@ -17802,27 +17813,27 @@ msgstr "Nur Konten auf diesem Server anzeigen"
 msgid "Sign in to follow this account"
 msgstr "Anmelden, um diesem Konto zu folgen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:528
+#: lib/vutuv_web/live/fediverse_following_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "State"
 msgstr "Status"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:305
+#: lib/vutuv_web/live/fediverse_following_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "Stop following %{account}?"
 msgstr "%{account} nicht mehr folgen?"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:246
+#: lib/vutuv_web/components/fediverse_components.ex:257
 #, elixir-autogen, elixir-format
 msgid "That account could not be loaded from its server. Try again in a little while."
 msgstr "Dieses Konto konnte von seinem Server nicht geladen werden. Versuchen Sie es in Kürze noch einmal."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:287
+#: lib/vutuv_web/components/fediverse_components.ex:303
 #, elixir-autogen, elixir-format
 msgid "That did not work. Check the address and try again."
 msgstr "Das hat nicht geklappt. Prüfen Sie die Adresse und versuchen Sie es erneut."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:235
+#: lib/vutuv_web/components/fediverse_components.ex:246
 #, elixir-autogen, elixir-format
 msgid "That does not look like an address on another network. They look like @name@server."
 msgstr "Das sieht nicht nach einer Adresse in einem anderen Netzwerk aus. Solche Adressen sehen aus wie @name@server."
@@ -17832,87 +17843,88 @@ msgstr "Das sieht nicht nach einer Adresse in einem anderen Netzwerk aus. Solche
 msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr "Das ist eine Adresse bei Mastodon oder einem der anderen Netzwerke, deshalb trägt sie hier niemand. Sie können ihr von vutuv aus folgen."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:414
+#: lib/vutuv_web/components/fediverse_components.ex:265
 #, elixir-autogen, elixir-format
 msgid "That is an address on this vutuv, not another network."
 msgstr "Das ist eine Adresse auf diesem vutuv, nicht in einem anderen Netzwerk."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:243
+#: lib/vutuv_web/components/fediverse_components.ex:254
 #, elixir-autogen, elixir-format
 msgid "That server answered, but it has no account at that address to follow."
 msgstr "Der Server hat geantwortet, führt unter dieser Adresse aber kein Konto, dem man folgen könnte."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:240
+#: lib/vutuv_web/components/fediverse_components.ex:251
 #, elixir-autogen, elixir-format
 msgid "That server did not answer. Check the address, and that the server is online."
 msgstr "Der Server hat nicht geantwortet. Prüfen Sie die Adresse und ob der Server erreichbar ist."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:284
+#: lib/vutuv_web/components/fediverse_components.ex:300
 #, elixir-autogen, elixir-format
 msgid "The Fediverse is switched off on this vutuv."
 msgstr "Das Fediverse ist auf diesem vutuv abgeschaltet."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:478
+#: lib/vutuv_web/components/fediverse_components.ex:193
 #, elixir-autogen, elixir-format
 msgid "The address you brought along is kept here:"
 msgstr "Die mitgebrachte Adresse bleibt hier stehen:"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:596
+#: lib/vutuv_web/live/fediverse_following_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "The other server decides. Most accounts accept straight away; one that checks its followers by hand stays on \"Requested\" until somebody there says yes."
 msgstr "Der andere Server entscheidet. Die meisten Konten nehmen sofort an; eines, das seine Follower von Hand prüft, bleibt auf „Angefragt“ stehen, bis dort jemand zustimmt."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:467
+#: lib/vutuv_web/components/fediverse_components.ex:166
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with other networks, so there is nothing to follow from here. That is an operator setting, not yours."
 msgstr "Dieses vutuv tauscht nichts mit anderen Netzwerken aus, deshalb lässt sich von hier aus niemandem folgen. Das ist eine Einstellung des Betreibers, nicht Ihre."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:249
+#: lib/vutuv_web/components/fediverse_components.ex:260
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with that server."
 msgstr "Dieses vutuv tauscht nichts mit diesem Server aus."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:473
+#: lib/vutuv_web/components/fediverse_components.ex:188
 #, elixir-autogen, elixir-format
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr "Um einem Konto dort draußen zu folgen, brauchen Sie eine eigene Fediverse-Identität: Die Anfrage wird in Ihrem Namen signiert, damit der andere Server weiß, wer fragt."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:170
+#: lib/vutuv_web/live/fediverse_account_live.ex:120
+#: lib/vutuv_web/live/fediverse_following_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Unfollowed."
 msgstr "Nicht mehr gefolgt."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:593
+#: lib/vutuv_web/live/fediverse_following_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "What following out there means"
 msgstr "Was Folgen dort draußen bedeutet"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:601
+#: lib/vutuv_web/live/fediverse_following_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Who you follow is yours alone. Your profile publishes how many accounts you follow out there, never which ones."
 msgstr "Wem Sie folgen, geht nur Sie etwas an. Ihr Profil veröffentlicht, wie vielen Konten Sie dort draußen folgen, nie welchen."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:462
+#: lib/vutuv_web/components/fediverse_components.ex:161
 #, elixir-autogen, elixir-format
 msgid "Why is my account on hold?"
 msgstr "Warum ist mein Konto gesperrt?"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:306
+#: lib/vutuv_web/live/fediverse_following_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Withdraw your follow request to %{account}?"
 msgstr "Ihre Follower-Anfrage an %{account} zurückziehen?"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:255
+#: lib/vutuv_web/components/fediverse_components.ex:271
 #, elixir-autogen, elixir-format
 msgid "You already follow that account."
 msgstr "Sie folgen diesem Konto bereits."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:273
+#: lib/vutuv_web/components/fediverse_components.ex:289
 #, elixir-autogen, elixir-format
 msgid "You are following the most accounts we allow (%{max})."
 msgstr "Sie folgen bereits so vielen Konten, wie hier erlaubt sind (%{max})."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:263
+#: lib/vutuv_web/components/fediverse_components.ex:279
 #, elixir-autogen, elixir-format
 msgid "You are not taking part in the Fediverse at the moment, so there is no identity to sign the request with. Open the Fediverse settings to switch it on."
 msgstr "Sie nehmen derzeit nicht am Fediverse teil, deshalb gibt es keine Identität, mit der die Anfrage signiert werden könnte. Schalten Sie die Teilnahme in den Fediverse-Einstellungen ein."
@@ -17929,17 +17941,17 @@ msgid_plural "You follow %{formatted} accounts on other networks"
 msgstr[0] "Sie folgen %{formatted} Konto in einem anderen Netzwerk"
 msgstr[1] "Sie folgen %{formatted} Konten in anderen Netzwerken"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:269
+#: lib/vutuv_web/components/fediverse_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of follow requests in the last hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Follower-Anfragen gesendet. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:279
+#: lib/vutuv_web/components/fediverse_components.ex:295
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so this account no longer acts out there."
 msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, deshalb tritt dieses Konto dort draußen nicht mehr auf."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:452
+#: lib/vutuv_web/components/fediverse_components.ex:155
 #, elixir-autogen, elixir-format
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere Netzwerke und Sie können dort niemandem folgen. Das endet von selbst, sobald die Sperre abläuft."
@@ -17949,7 +17961,7 @@ msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere 
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr "mastodon activitypub foederation federation follower folgen folge umzug migration entferntes konto"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:345
+#: lib/vutuv_web/live/fediverse_following_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Accounts followed"
 msgstr "Gefolgte Konten"
@@ -17964,17 +17976,18 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1145
+#: lib/vutuv_web/components/post_components.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:152
 #: lib/vutuv_web/live/post_live/feed.ex:331
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:1172
+#: lib/vutuv_web/components/post_components.ex:1218
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17994,21 +18007,22 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1025
+#: lib/vutuv_web/components/post_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:1151
+#: lib/vutuv_web/components/post_components.ex:1197
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
 
-#: lib/vutuv_web/components/post_components.ex:1124
+#: lib/vutuv_web/components/post_components.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr "%{handle} stummschalten"
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:196
 #: lib/vutuv_web/live/post_live/feed.ex:360
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -18019,17 +18033,87 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:1131
+#: lib/vutuv_web/components/post_components.ex:1177
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:612
+#: lib/vutuv_web/live/fediverse_following_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "To show their posts we keep a copy here for up to six months. If the author deletes or edits something, ours follows; and when you stop following an account, its posts are deleted here at once."
 msgstr "Um die Beiträge zeigen zu können, behalten wir hier bis zu sechs Monate lang eine Kopie. Löscht oder ändert die verfassende Person etwas, zieht unsere Kopie nach; und sobald Sie einem Konto nicht mehr folgen, werden dessen Beiträge hier sofort gelöscht."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:500
+#: lib/vutuv_web/live/fediverse_following_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "You do not follow anybody out there yet. Once you do, what they post appears in your feed among everything else."
 msgstr "Sie folgen dort draußen noch niemandem. Sobald Sie das tun, erscheinen deren Beiträge in Ihrem Feed zwischen allem anderen."
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:66
+#, elixir-autogen, elixir-format
+msgid "%{name} (another network)"
+msgstr "%{name} (anderes Netzwerk)"
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:232
+#, elixir-autogen, elixir-format
+msgid "Account on another network"
+msgstr "Konto in einem anderen Netzwerk"
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:363
+#, elixir-autogen, elixir-format
+msgid "Look up another account"
+msgstr "Ein anderes Konto nachschlagen"
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:297
+#, elixir-autogen, elixir-format
+msgid "Muted"
+msgstr "Stummgeschaltet"
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:211
+#, elixir-autogen, elixir-format
+msgid "Nothing cached yet. Their posts appear here as they publish them."
+msgstr "Noch nichts zwischengespeichert. Die Beiträge erscheinen hier, sobald sie veröffentlicht werden."
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:206
+#, elixir-autogen, elixir-format
+msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
+msgstr "Hier ist nichts. vutuv behält die Beiträge eines Kontos nur, solange jemand hier ihm folgt, und diese Seite ruft von sich aus keine ab."
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:365
+#, elixir-autogen, elixir-format
+msgid "Paste an address from Mastodon and friends to open its page here."
+msgstr "Fügen Sie eine Adresse von Mastodon und Co. ein, um die zugehörige Seite hier zu öffnen."
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:264
+#, elixir-autogen, elixir-format
+msgid "Show the whole description"
+msgstr "Ganze Beschreibung anzeigen"
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:348
+#, elixir-autogen, elixir-format
+msgid "The most recent %{count} are shown. The rest are on their own server."
+msgstr "Die neuesten %{count} werden angezeigt. Der Rest liegt auf dem eigenen Server."
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:198
+#, elixir-autogen, elixir-format
+msgid "Unmuted. Their posts are back in your feed."
+msgstr "Stummschaltung aufgehoben. Die Beiträge sind wieder in Ihrem Feed."
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:358
+#, elixir-autogen, elixir-format
+msgid "View their full profile on %{host}"
+msgstr "Vollständiges Profil auf %{host} ansehen"
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
+msgstr "Warten darauf, dass der Server Ihre Follower-Anfrage annimmt. Beiträge, die nur an die Follower gerichtet sind, erscheinen danach."
+
+#: lib/vutuv_web/components/fediverse_components.ex:177
+#, elixir-autogen, elixir-format
+msgid "You redirected your Fediverse followers to another account, so this one no longer follows anybody out there."
+msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, deshalb folgt dieses Konto dort draußen niemandem mehr."
+
+#: lib/vutuv_web/components/fediverse_components.ex:183
+#, elixir-autogen, elixir-format
+msgid "Your account move"
+msgstr "Ihr Kontoumzug"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1642
+#: lib/vutuv_web/components/post_components.ex:1688
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1607
+#: lib/vutuv_web/components/post_components.ex:1653
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -329,6 +329,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:507
 #: lib/vutuv_web/agent_docs/text.ex:477
+#: lib/vutuv_web/components/fediverse_components.ex:216
 #: lib/vutuv_web/components/ui.ex:1551
 #: lib/vutuv_web/components/ui.ex:1576
 #: lib/vutuv_web/components/ui.ex:1579
@@ -336,7 +337,6 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1589
 #: lib/vutuv_web/components/ui.ex:1647
 #: lib/vutuv_web/controllers/followee_controller.ex:23
-#: lib/vutuv_web/live/fediverse_following_live.ex:290
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
 #: lib/vutuv_web/templates/user/show.html.heex:819
@@ -660,7 +660,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1022
+#: lib/vutuv_web/components/post_components.ex:1067
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1662,7 +1662,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2084
+#: lib/vutuv_web/components/post_components.ex:2130
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
@@ -1733,7 +1733,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1605
 #: lib/vutuv_web/components/ui.ex:1608
 #: lib/vutuv_web/components/ui.ex:1681
-#: lib/vutuv_web/live/fediverse_following_live.ex:403
+#: lib/vutuv_web/live/fediverse_account_live.ex:315
+#: lib/vutuv_web/live/fediverse_following_live.ex:277
 #: lib/vutuv_web/templates/user/show.html.heex:930
 #: lib/vutuv_web/templates/user/show.html.heex:1165
 #, elixir-autogen, elixir-format
@@ -1898,7 +1899,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:960
+#: lib/vutuv_web/live/post_live/feed.ex:967
 #: lib/vutuv_web/templates/user/show.html.heex:1429
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2135,7 +2136,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1639
+#: lib/vutuv_web/components/post_components.ex:1685
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2148,7 +2149,7 @@ msgid "Edit post"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:87
-#: lib/vutuv_web/live/post_live/feed.ex:774
+#: lib/vutuv_web/live/post_live/feed.ex:781
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:116
@@ -2176,8 +2177,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1593
-#: lib/vutuv_web/components/post_components.ex:1595
+#: lib/vutuv_web/components/post_components.ex:1639
+#: lib/vutuv_web/components/post_components.ex:1641
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2193,7 +2194,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:901
+#: lib/vutuv_web/live/post_live/feed.ex:908
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2231,6 +2232,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:76
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
+#: lib/vutuv_web/live/fediverse_account_live.ex:322
 #: lib/vutuv_web/live/notification_live/index.ex:777
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:200
@@ -2241,19 +2243,20 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2022
-#: lib/vutuv_web/components/post_components.ex:2026
+#: lib/vutuv_web/components/post_components.ex:2068
+#: lib/vutuv_web/components/post_components.ex:2072
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2023
+#: lib/vutuv_web/components/post_components.ex:2069
+#: lib/vutuv_web/live/fediverse_account_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:849
+#: lib/vutuv_web/components/post_components.ex:855
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
@@ -2277,13 +2280,14 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:848
+#: lib/vutuv_web/live/post_live/feed.ex:855
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:75
 #: lib/vutuv_web/live/post_live/edit.ex:36
 #: lib/vutuv_web/live/post_live/remote_reply.ex:79
 #: lib/vutuv_web/live/post_live/reply.ex:41
@@ -2335,27 +2339,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1590
+#: lib/vutuv_web/components/post_components.ex:1636
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3151
+#: lib/vutuv_web/components/post_components.ex:3197
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3153
+#: lib/vutuv_web/components/post_components.ex:3199
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3154
+#: lib/vutuv_web/components/post_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2396,7 +2400,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3235
+#: lib/vutuv_web/components/post_components.ex:3281
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2415,7 +2419,7 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3451
+#: lib/vutuv_web/components/post_components.ex:3504
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
@@ -2426,7 +2430,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:909
-#: lib/vutuv_web/components/post_components.ex:3460
+#: lib/vutuv_web/components/post_components.ex:3513
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2446,12 +2450,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3224
+#: lib/vutuv_web/components/post_components.ex:3270
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3235
+#: lib/vutuv_web/components/post_components.ex:3281
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2460,23 +2464,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3221
+#: lib/vutuv_web/components/post_components.ex:3267
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2636
+#: lib/vutuv_web/components/post_components.ex:2682
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3221
+#: lib/vutuv_web/components/post_components.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3451
+#: lib/vutuv_web/components/post_components.ex:3504
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2485,11 +2489,11 @@ msgstr ""
 msgid "Unlike"
 msgstr ""
 
+#: lib/vutuv_web/components/fediverse_components.ex:234
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1648
-#: lib/vutuv_web/live/fediverse_following_live.ex:298
-#: lib/vutuv_web/live/post_live/feed.ex:949
+#: lib/vutuv_web/live/post_live/feed.ex:956
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2500,7 +2504,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3500
+#: lib/vutuv_web/components/post_components.ex:3553
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2511,16 +2515,16 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:889
-#: lib/vutuv_web/components/post_components.ex:3483
-#: lib/vutuv_web/components/post_components.ex:3484
+#: lib/vutuv_web/components/post_components.ex:895
+#: lib/vutuv_web/components/post_components.ex:3536
+#: lib/vutuv_web/components/post_components.ex:3537
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1561
+#: lib/vutuv_web/components/post_components.ex:1607
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2548,12 +2552,12 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1556
+#: lib/vutuv_web/components/post_components.ex:1602
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1550
+#: lib/vutuv_web/components/post_components.ex:1596
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2782,7 +2786,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:799
+#: lib/vutuv_web/live/post_live/feed.ex:806
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2861,7 +2865,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3152
+#: lib/vutuv_web/components/post_components.ex:3198
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3122,7 +3126,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1526
+#: lib/vutuv_web/components/post_components.ex:1572
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3197,9 +3201,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:859
-#: lib/vutuv_web/components/post_components.ex:1136
-#: lib/vutuv_web/components/post_components.ex:1663
+#: lib/vutuv_web/components/post_components.ex:865
+#: lib/vutuv_web/components/post_components.ex:1182
+#: lib/vutuv_web/components/post_components.ex:1709
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4556,7 +4560,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:906
+#: lib/vutuv_web/live/post_live/feed.ex:913
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5359,7 +5363,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:53
 #: lib/vutuv_web/live/account_activity_live.ex:155
 #: lib/vutuv_web/live/fediverse_followers_live.ex:126
-#: lib/vutuv_web/live/fediverse_following_live.ex:340
+#: lib/vutuv_web/live/fediverse_following_live.ex:243
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
@@ -5427,11 +5431,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1726
-#: lib/vutuv_web/components/post_components.ex:1778
-#: lib/vutuv_web/components/post_components.ex:2159
+#: lib/vutuv_web/components/post_components.ex:1772
+#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:2205
 #: lib/vutuv_web/live/notification_live/index.ex:601
-#: lib/vutuv_web/live/post_live/feed.ex:1021
+#: lib/vutuv_web/live/post_live/feed.ex:1028
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr ""
@@ -5485,7 +5489,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3328
 #: lib/vutuv_web/live/admin/user_live.ex:279
 #: lib/vutuv_web/live/fediverse_followers_live.ex:112
-#: lib/vutuv_web/live/fediverse_following_live.ex:326
+#: lib/vutuv_web/live/fediverse_following_live.ex:229
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:192
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
@@ -5968,7 +5972,7 @@ msgid "Add a passkey"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/live/fediverse_following_live.ex:328
+#: lib/vutuv_web/live/fediverse_following_live.ex:231
 #: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Added"
@@ -6619,6 +6623,7 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1836
+#: lib/vutuv_web/live/fediverse_account_live.ex:309
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6642,6 +6647,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1835
+#: lib/vutuv_web/live/fediverse_account_live.ex:307
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6664,7 +6670,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1660
+#: lib/vutuv_web/components/post_components.ex:1706
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6674,7 +6680,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1659
+#: lib/vutuv_web/components/post_components.ex:1705
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7357,7 +7363,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3376
+#: lib/vutuv_web/components/post_components.ex:3426
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8473,13 +8479,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:988
-#: lib/vutuv_web/live/post_live/feed.ex:989
+#: lib/vutuv_web/live/post_live/feed.ex:995
+#: lib/vutuv_web/live/post_live/feed.ex:996
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:983
+#: lib/vutuv_web/live/post_live/feed.ex:990
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8679,7 +8685,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:200
 #: lib/vutuv_web/controllers/settings_controller.ex:267
 #: lib/vutuv_web/live/fediverse_followers_live.ex:127
-#: lib/vutuv_web/live/fediverse_following_live.ex:341
+#: lib/vutuv_web/live/fediverse_following_live.ex:244
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:300
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -8830,7 +8836,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2639
+#: lib/vutuv_web/components/post_components.ex:2685
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -13702,14 +13708,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3301
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:935
+#: lib/vutuv_web/live/post_live/feed.ex:942
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:950
+#: lib/vutuv_web/live/post_live/feed.ex:957
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13865,7 +13871,7 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3014
+#: lib/vutuv_web/components/post_components.ex:3060
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
@@ -13881,18 +13887,18 @@ msgid "Book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:956
-#: lib/vutuv_web/components/post_components.ex:2971
+#: lib/vutuv_web/components/post_components.ex:3017
 #: lib/vutuv_web/live/post_live/composer.ex:1504
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3015
+#: lib/vutuv_web/components/post_components.ex:3061
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3017
+#: lib/vutuv_web/components/post_components.ex:3063
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
@@ -13902,7 +13908,7 @@ msgstr ""
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3013
+#: lib/vutuv_web/components/post_components.ex:3059
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
@@ -13913,7 +13919,7 @@ msgid "Film"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:956
-#: lib/vutuv_web/components/post_components.ex:2970
+#: lib/vutuv_web/components/post_components.ex:3016
 #: lib/vutuv_web/live/post_live/composer.ex:1503
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13929,6 +13935,7 @@ msgstr ""
 msgid "ISBN"
 msgstr ""
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:373
 #: lib/vutuv_web/live/post_live/composer.ex:1538
 #, elixir-autogen, elixir-format
 msgid "Look up"
@@ -13944,7 +13951,7 @@ msgstr ""
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3012
+#: lib/vutuv_web/components/post_components.ex:3058
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
@@ -13971,7 +13978,7 @@ msgstr ""
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3016
+#: lib/vutuv_web/components/post_components.ex:3062
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -14002,34 +14009,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3053
+#: lib/vutuv_web/components/post_components.ex:3099
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3083
+#: lib/vutuv_web/components/post_components.ex:3129
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3084
+#: lib/vutuv_web/components/post_components.ex:3130
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3082
+#: lib/vutuv_web/components/post_components.ex:3128
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3042
+#: lib/vutuv_web/components/post_components.ex:3088
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3089
+#: lib/vutuv_web/components/post_components.ex:3135
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14059,7 +14066,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2856
+#: lib/vutuv_web/components/post_components.ex:2902
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14107,7 +14114,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2847
+#: lib/vutuv_web/components/post_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14481,14 +14488,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1306
+#: lib/vutuv_web/components/post_components.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1328
+#: lib/vutuv_web/components/post_components.ex:1374
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14515,7 +14522,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3459
+#: lib/vutuv_web/components/post_components.ex:3512
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14863,7 +14870,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/browse_table.ex:185
 #: lib/vutuv_web/live/fediverse_followers_live.ex:113
-#: lib/vutuv_web/live/fediverse_following_live.ex:327
+#: lib/vutuv_web/live/fediverse_following_live.ex:230
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:96
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:147
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:191
@@ -14955,7 +14962,7 @@ msgstr ""
 msgid "Nothing changes on vutuv itself, and you can switch it off again."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:487
+#: lib/vutuv_web/components/fediverse_components.ex:198
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "Take part in the Fediverse"
@@ -15045,7 +15052,7 @@ msgid "Send your Fediverse followers to another account. They are asked to follo
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:224
-#: lib/vutuv_web/live/fediverse_following_live.ex:618
+#: lib/vutuv_web/live/fediverse_following_live.ex:436
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Back to Fediverse settings"
@@ -15682,21 +15689,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3418
+#: lib/vutuv_web/components/post_components.ex:3471
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3422
+#: lib/vutuv_web/components/post_components.ex:3475
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3426
+#: lib/vutuv_web/components/post_components.ex:3479
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15704,7 +15711,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:928
-#: lib/vutuv_web/components/post_components.ex:3380
+#: lib/vutuv_web/components/post_components.ex:3430
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15720,13 +15727,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:923
-#: lib/vutuv_web/components/post_components.ex:1052
+#: lib/vutuv_web/components/post_components.ex:946
+#: lib/vutuv_web/components/post_components.ex:1097
+#: lib/vutuv_web/live/fediverse_account_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:847
+#: lib/vutuv_web/components/post_components.ex:853
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15753,7 +15761,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:856
+#: lib/vutuv_web/components/post_components.ex:862
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15763,7 +15771,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:870
+#: lib/vutuv_web/components/post_components.ex:876
 #: lib/vutuv_web/live/notification_live/index.ex:497
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15795,8 +15803,8 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1089
-#: lib/vutuv_web/components/post_components.ex:875
-#: lib/vutuv_web/components/post_components.ex:1173
+#: lib/vutuv_web/components/post_components.ex:881
+#: lib/vutuv_web/components/post_components.ex:1219
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15807,6 +15815,7 @@ msgstr ""
 msgid "What"
 msgstr ""
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:160
 #: lib/vutuv_web/live/post_live/feed.ex:339
 #: lib/vutuv_web/live/post_live/thread.ex:209
 #, elixir-autogen, elixir-format
@@ -16249,7 +16258,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/account_activity_live.ex:243
 #: lib/vutuv_web/live/admin/activity_live.ex:275
-#: lib/vutuv_web/live/fediverse_following_live.ex:514
+#: lib/vutuv_web/live/fediverse_following_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16469,22 +16478,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1538
+#: lib/vutuv_web/components/post_components.ex:1584
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1626
+#: lib/vutuv_web/components/post_components.ex:1672
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1634
+#: lib/vutuv_web/components/post_components.ex:1680
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1620
+#: lib/vutuv_web/components/post_components.ex:1666
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16570,7 +16579,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1017
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:2087
+#: lib/vutuv_web/components/post_components.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16610,7 +16619,7 @@ msgstr ""
 msgid "Move photo later"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2086
+#: lib/vutuv_web/components/post_components.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16620,7 +16629,7 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2503
+#: lib/vutuv_web/components/post_components.ex:2549
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr ""
@@ -16630,19 +16639,19 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2552
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2331
+#: lib/vutuv_web/components/post_components.ex:2377
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1833
+#: lib/vutuv_web/components/post_components.ex:1879
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16655,12 +16664,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1050
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:2540
+#: lib/vutuv_web/components/post_components.ex:2586
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2085
+#: lib/vutuv_web/components/post_components.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
@@ -16764,8 +16773,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:808
-#: lib/vutuv_web/live/post_live/feed.ex:809
+#: lib/vutuv_web/live/post_live/feed.ex:815
+#: lib/vutuv_web/live/post_live/feed.ex:816
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
@@ -16829,13 +16838,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:946
-#: lib/vutuv_web/components/post_components.ex:3415
+#: lib/vutuv_web/components/post_components.ex:3468
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:944
-#: lib/vutuv_web/components/post_components.ex:3412
+#: lib/vutuv_web/components/post_components.ex:3465
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16845,7 +16854,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3311
+#: lib/vutuv_web/components/post_components.ex:3357
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16936,15 +16945,16 @@ msgstr ""
 msgid "Photo details"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:56
-#: lib/vutuv_web/live/fediverse_following_live.ex:338
-#: lib/vutuv_web/live/fediverse_following_live.ex:351
+#: lib/vutuv_web/live/fediverse_account_live.ex:379
+#: lib/vutuv_web/live/fediverse_following_live.ex:55
+#: lib/vutuv_web/live/fediverse_following_live.ex:241
+#: lib/vutuv_web/live/fediverse_following_live.ex:254
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:380
+#: lib/vutuv_web/components/fediverse_components.ex:82
 #, elixir-autogen, elixir-format
 msgid "Address of the account"
 msgstr ""
@@ -16954,7 +16964,7 @@ msgstr ""
 msgid "An account on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:298
+#: lib/vutuv_web/components/fediverse_components.ex:234
 #, elixir-autogen, elixir-format
 msgid "Cancel request"
 msgstr ""
@@ -16964,7 +16974,8 @@ msgstr ""
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:230
+#: lib/vutuv_web/live/fediverse_account_live.ex:104
+#: lib/vutuv_web/live/fediverse_following_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Follow request sent to %{account}."
 msgstr ""
@@ -16989,17 +17000,17 @@ msgstr ""
 msgid "Manage who you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:361
+#: lib/vutuv_web/live/fediverse_following_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Mastodon and the other networks work like email: an address is enough. Paste one here and vutuv asks that server to let you follow the account."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:425
+#: lib/vutuv_web/live/fediverse_following_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Open their profile"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:290
+#: lib/vutuv_web/components/fediverse_components.ex:216
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
@@ -17009,12 +17020,12 @@ msgstr ""
 msgid "Reset sorting"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:433
+#: lib/vutuv_web/live/fediverse_following_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Search for them here"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:543
+#: lib/vutuv_web/live/fediverse_following_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Show only accounts on this server"
 msgstr ""
@@ -17024,27 +17035,27 @@ msgstr ""
 msgid "Sign in to follow this account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:528
+#: lib/vutuv_web/live/fediverse_following_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "State"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:305
+#: lib/vutuv_web/live/fediverse_following_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "Stop following %{account}?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:246
+#: lib/vutuv_web/components/fediverse_components.ex:257
 #, elixir-autogen, elixir-format
 msgid "That account could not be loaded from its server. Try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:287
+#: lib/vutuv_web/components/fediverse_components.ex:303
 #, elixir-autogen, elixir-format
 msgid "That did not work. Check the address and try again."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:235
+#: lib/vutuv_web/components/fediverse_components.ex:246
 #, elixir-autogen, elixir-format
 msgid "That does not look like an address on another network. They look like @name@server."
 msgstr ""
@@ -17054,87 +17065,88 @@ msgstr ""
 msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:414
+#: lib/vutuv_web/components/fediverse_components.ex:265
 #, elixir-autogen, elixir-format
 msgid "That is an address on this vutuv, not another network."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:243
+#: lib/vutuv_web/components/fediverse_components.ex:254
 #, elixir-autogen, elixir-format
 msgid "That server answered, but it has no account at that address to follow."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:240
+#: lib/vutuv_web/components/fediverse_components.ex:251
 #, elixir-autogen, elixir-format
 msgid "That server did not answer. Check the address, and that the server is online."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:284
+#: lib/vutuv_web/components/fediverse_components.ex:300
 #, elixir-autogen, elixir-format
 msgid "The Fediverse is switched off on this vutuv."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:478
+#: lib/vutuv_web/components/fediverse_components.ex:193
 #, elixir-autogen, elixir-format
 msgid "The address you brought along is kept here:"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:596
+#: lib/vutuv_web/live/fediverse_following_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "The other server decides. Most accounts accept straight away; one that checks its followers by hand stays on \"Requested\" until somebody there says yes."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:467
+#: lib/vutuv_web/components/fediverse_components.ex:166
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with other networks, so there is nothing to follow from here. That is an operator setting, not yours."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:249
+#: lib/vutuv_web/components/fediverse_components.ex:260
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with that server."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:473
+#: lib/vutuv_web/components/fediverse_components.ex:188
 #, elixir-autogen, elixir-format
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:170
+#: lib/vutuv_web/live/fediverse_account_live.ex:120
+#: lib/vutuv_web/live/fediverse_following_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Unfollowed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:593
+#: lib/vutuv_web/live/fediverse_following_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "What following out there means"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:601
+#: lib/vutuv_web/live/fediverse_following_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Who you follow is yours alone. Your profile publishes how many accounts you follow out there, never which ones."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:462
+#: lib/vutuv_web/components/fediverse_components.ex:161
 #, elixir-autogen, elixir-format
 msgid "Why is my account on hold?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:306
+#: lib/vutuv_web/live/fediverse_following_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Withdraw your follow request to %{account}?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:255
+#: lib/vutuv_web/components/fediverse_components.ex:271
 #, elixir-autogen, elixir-format
 msgid "You already follow that account."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:273
+#: lib/vutuv_web/components/fediverse_components.ex:289
 #, elixir-autogen, elixir-format
 msgid "You are following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:263
+#: lib/vutuv_web/components/fediverse_components.ex:279
 #, elixir-autogen, elixir-format
 msgid "You are not taking part in the Fediverse at the moment, so there is no identity to sign the request with. Open the Fediverse settings to switch it on."
 msgstr ""
@@ -17151,17 +17163,17 @@ msgid_plural "You follow %{formatted} accounts on other networks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:269
+#: lib/vutuv_web/components/fediverse_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of follow requests in the last hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:279
+#: lib/vutuv_web/components/fediverse_components.ex:295
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so this account no longer acts out there."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:452
+#: lib/vutuv_web/components/fediverse_components.ex:155
 #, elixir-autogen, elixir-format
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
@@ -17171,7 +17183,7 @@ msgstr ""
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:345
+#: lib/vutuv_web/live/fediverse_following_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Accounts followed"
 msgstr ""
@@ -17186,17 +17198,18 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1145
+#: lib/vutuv_web/components/post_components.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:152
 #: lib/vutuv_web/live/post_live/feed.ex:331
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1172
+#: lib/vutuv_web/components/post_components.ex:1218
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -17216,21 +17229,22 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1025
+#: lib/vutuv_web/components/post_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1151
+#: lib/vutuv_web/components/post_components.ex:1197
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1124
+#: lib/vutuv_web/components/post_components.ex:1170
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr ""
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:196
 #: lib/vutuv_web/live/post_live/feed.ex:360
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -17241,17 +17255,87 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1131
+#: lib/vutuv_web/components/post_components.ex:1177
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:612
+#: lib/vutuv_web/live/fediverse_following_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "To show their posts we keep a copy here for up to six months. If the author deletes or edits something, ours follows; and when you stop following an account, its posts are deleted here at once."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:500
+#: lib/vutuv_web/live/fediverse_following_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "You do not follow anybody out there yet. Once you do, what they post appears in your feed among everything else."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:66
+#, elixir-autogen, elixir-format
+msgid "%{name} (another network)"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:232
+#, elixir-autogen, elixir-format
+msgid "Account on another network"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:363
+#, elixir-autogen, elixir-format
+msgid "Look up another account"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:297
+#, elixir-autogen, elixir-format
+msgid "Muted"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:211
+#, elixir-autogen, elixir-format
+msgid "Nothing cached yet. Their posts appear here as they publish them."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:206
+#, elixir-autogen, elixir-format
+msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:365
+#, elixir-autogen, elixir-format
+msgid "Paste an address from Mastodon and friends to open its page here."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:264
+#, elixir-autogen, elixir-format
+msgid "Show the whole description"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:348
+#, elixir-autogen, elixir-format
+msgid "The most recent %{count} are shown. The rest are on their own server."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:198
+#, elixir-autogen, elixir-format
+msgid "Unmuted. Their posts are back in your feed."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:358
+#, elixir-autogen, elixir-format
+msgid "View their full profile on %{host}"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
+msgstr ""
+
+#: lib/vutuv_web/components/fediverse_components.ex:177
+#, elixir-autogen, elixir-format
+msgid "You redirected your Fediverse followers to another account, so this one no longer follows anybody out there."
+msgstr ""
+
+#: lib/vutuv_web/components/fediverse_components.ex:183
+#, elixir-autogen, elixir-format
+msgid "Your account move"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -152,7 +152,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1642
+#: lib/vutuv_web/components/post_components.ex:1688
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -201,7 +201,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1607
+#: lib/vutuv_web/components/post_components.ex:1653
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -327,6 +327,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:507
 #: lib/vutuv_web/agent_docs/text.ex:477
+#: lib/vutuv_web/components/fediverse_components.ex:216
 #: lib/vutuv_web/components/ui.ex:1551
 #: lib/vutuv_web/components/ui.ex:1576
 #: lib/vutuv_web/components/ui.ex:1579
@@ -334,7 +335,6 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1589
 #: lib/vutuv_web/components/ui.ex:1647
 #: lib/vutuv_web/controllers/followee_controller.ex:23
-#: lib/vutuv_web/live/fediverse_following_live.ex:290
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
 #: lib/vutuv_web/templates/user/show.html.heex:819
@@ -658,7 +658,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1022
+#: lib/vutuv_web/components/post_components.ex:1067
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1660,7 +1660,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2084
+#: lib/vutuv_web/components/post_components.ex:2130
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
@@ -1731,7 +1731,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1605
 #: lib/vutuv_web/components/ui.ex:1608
 #: lib/vutuv_web/components/ui.ex:1681
-#: lib/vutuv_web/live/fediverse_following_live.ex:403
+#: lib/vutuv_web/live/fediverse_account_live.ex:315
+#: lib/vutuv_web/live/fediverse_following_live.ex:277
 #: lib/vutuv_web/templates/user/show.html.heex:930
 #: lib/vutuv_web/templates/user/show.html.heex:1165
 #, elixir-autogen, elixir-format
@@ -1896,7 +1897,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:960
+#: lib/vutuv_web/live/post_live/feed.ex:967
 #: lib/vutuv_web/templates/user/show.html.heex:1429
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2133,7 +2134,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1639
+#: lib/vutuv_web/components/post_components.ex:1685
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2146,7 +2147,7 @@ msgid "Edit post"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:87
-#: lib/vutuv_web/live/post_live/feed.ex:774
+#: lib/vutuv_web/live/post_live/feed.ex:781
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:116
@@ -2174,8 +2175,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1593
-#: lib/vutuv_web/components/post_components.ex:1595
+#: lib/vutuv_web/components/post_components.ex:1639
+#: lib/vutuv_web/components/post_components.ex:1641
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2191,7 +2192,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:901
+#: lib/vutuv_web/live/post_live/feed.ex:908
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2229,6 +2230,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:76
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
+#: lib/vutuv_web/live/fediverse_account_live.ex:322
 #: lib/vutuv_web/live/notification_live/index.ex:777
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:200
@@ -2239,19 +2241,20 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2022
-#: lib/vutuv_web/components/post_components.ex:2026
+#: lib/vutuv_web/components/post_components.ex:2068
+#: lib/vutuv_web/components/post_components.ex:2072
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2023
+#: lib/vutuv_web/components/post_components.ex:2069
+#: lib/vutuv_web/live/fediverse_account_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:849
+#: lib/vutuv_web/components/post_components.ex:855
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
@@ -2275,13 +2278,14 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:848
+#: lib/vutuv_web/live/post_live/feed.ex:855
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:75
 #: lib/vutuv_web/live/post_live/edit.ex:36
 #: lib/vutuv_web/live/post_live/remote_reply.ex:79
 #: lib/vutuv_web/live/post_live/reply.ex:41
@@ -2333,27 +2337,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1590
+#: lib/vutuv_web/components/post_components.ex:1636
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3151
+#: lib/vutuv_web/components/post_components.ex:3197
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3153
+#: lib/vutuv_web/components/post_components.ex:3199
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3154
+#: lib/vutuv_web/components/post_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2394,7 +2398,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3235
+#: lib/vutuv_web/components/post_components.ex:3281
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2413,7 +2417,7 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3451
+#: lib/vutuv_web/components/post_components.ex:3504
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
@@ -2424,7 +2428,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:909
-#: lib/vutuv_web/components/post_components.ex:3460
+#: lib/vutuv_web/components/post_components.ex:3513
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2444,12 +2448,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3224
+#: lib/vutuv_web/components/post_components.ex:3270
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3235
+#: lib/vutuv_web/components/post_components.ex:3281
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2458,23 +2462,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3221
+#: lib/vutuv_web/components/post_components.ex:3267
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2636
+#: lib/vutuv_web/components/post_components.ex:2682
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3221
+#: lib/vutuv_web/components/post_components.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3451
+#: lib/vutuv_web/components/post_components.ex:3504
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2483,11 +2487,11 @@ msgstr ""
 msgid "Unlike"
 msgstr ""
 
+#: lib/vutuv_web/components/fediverse_components.ex:234
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1511
 #: lib/vutuv_web/components/ui.ex:1648
-#: lib/vutuv_web/live/fediverse_following_live.ex:298
-#: lib/vutuv_web/live/post_live/feed.ex:949
+#: lib/vutuv_web/live/post_live/feed.ex:956
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3500
+#: lib/vutuv_web/components/post_components.ex:3553
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2509,16 +2513,16 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:889
-#: lib/vutuv_web/components/post_components.ex:3483
-#: lib/vutuv_web/components/post_components.ex:3484
+#: lib/vutuv_web/components/post_components.ex:895
+#: lib/vutuv_web/components/post_components.ex:3536
+#: lib/vutuv_web/components/post_components.ex:3537
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1561
+#: lib/vutuv_web/components/post_components.ex:1607
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2546,12 +2550,12 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1556
+#: lib/vutuv_web/components/post_components.ex:1602
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1550
+#: lib/vutuv_web/components/post_components.ex:1596
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2780,7 +2784,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:799
+#: lib/vutuv_web/live/post_live/feed.ex:806
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2859,7 +2863,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3152
+#: lib/vutuv_web/components/post_components.ex:3198
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3120,7 +3124,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1526
+#: lib/vutuv_web/components/post_components.ex:1572
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3195,9 +3199,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:859
-#: lib/vutuv_web/components/post_components.ex:1136
-#: lib/vutuv_web/components/post_components.ex:1663
+#: lib/vutuv_web/components/post_components.ex:865
+#: lib/vutuv_web/components/post_components.ex:1182
+#: lib/vutuv_web/components/post_components.ex:1709
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4554,7 +4558,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:906
+#: lib/vutuv_web/live/post_live/feed.ex:913
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5357,7 +5361,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:53
 #: lib/vutuv_web/live/account_activity_live.ex:155
 #: lib/vutuv_web/live/fediverse_followers_live.ex:126
-#: lib/vutuv_web/live/fediverse_following_live.ex:340
+#: lib/vutuv_web/live/fediverse_following_live.ex:243
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
@@ -5425,11 +5429,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1726
-#: lib/vutuv_web/components/post_components.ex:1778
-#: lib/vutuv_web/components/post_components.ex:2159
+#: lib/vutuv_web/components/post_components.ex:1772
+#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:2205
 #: lib/vutuv_web/live/notification_live/index.ex:601
-#: lib/vutuv_web/live/post_live/feed.ex:1021
+#: lib/vutuv_web/live/post_live/feed.ex:1028
 #, elixir-autogen, elixir-format
 msgid "View post"
 msgstr ""
@@ -5483,7 +5487,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3328
 #: lib/vutuv_web/live/admin/user_live.ex:279
 #: lib/vutuv_web/live/fediverse_followers_live.ex:112
-#: lib/vutuv_web/live/fediverse_following_live.ex:326
+#: lib/vutuv_web/live/fediverse_following_live.ex:229
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:192
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
@@ -5966,7 +5970,7 @@ msgid "Add a passkey"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/live/fediverse_following_live.ex:328
+#: lib/vutuv_web/live/fediverse_following_live.ex:231
 #: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Added"
@@ -6617,6 +6621,7 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1836
+#: lib/vutuv_web/live/fediverse_account_live.ex:309
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6640,6 +6645,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1835
+#: lib/vutuv_web/live/fediverse_account_live.ex:307
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6662,7 +6668,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1660
+#: lib/vutuv_web/components/post_components.ex:1706
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6672,7 +6678,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1659
+#: lib/vutuv_web/components/post_components.ex:1705
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7355,7 +7361,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3376
+#: lib/vutuv_web/components/post_components.ex:3426
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8471,13 +8477,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:988
-#: lib/vutuv_web/live/post_live/feed.ex:989
+#: lib/vutuv_web/live/post_live/feed.ex:995
+#: lib/vutuv_web/live/post_live/feed.ex:996
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:983
+#: lib/vutuv_web/live/post_live/feed.ex:990
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8677,7 +8683,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:200
 #: lib/vutuv_web/controllers/settings_controller.ex:267
 #: lib/vutuv_web/live/fediverse_followers_live.ex:127
-#: lib/vutuv_web/live/fediverse_following_live.ex:341
+#: lib/vutuv_web/live/fediverse_following_live.ex:244
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:300
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
@@ -8828,7 +8834,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2639
+#: lib/vutuv_web/components/post_components.ex:2685
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -13700,14 +13706,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3301
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:935
+#: lib/vutuv_web/live/post_live/feed.ex:942
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:950
+#: lib/vutuv_web/live/post_live/feed.ex:957
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13863,7 +13869,7 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3014
+#: lib/vutuv_web/components/post_components.ex:3060
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
@@ -13879,18 +13885,18 @@ msgid "Book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:956
-#: lib/vutuv_web/components/post_components.ex:2971
+#: lib/vutuv_web/components/post_components.ex:3017
 #: lib/vutuv_web/live/post_live/composer.ex:1504
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3015
+#: lib/vutuv_web/components/post_components.ex:3061
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3017
+#: lib/vutuv_web/components/post_components.ex:3063
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
@@ -13900,7 +13906,7 @@ msgstr ""
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3013
+#: lib/vutuv_web/components/post_components.ex:3059
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
@@ -13911,7 +13917,7 @@ msgid "Film"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:956
-#: lib/vutuv_web/components/post_components.ex:2970
+#: lib/vutuv_web/components/post_components.ex:3016
 #: lib/vutuv_web/live/post_live/composer.ex:1503
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13927,6 +13933,7 @@ msgstr ""
 msgid "ISBN"
 msgstr ""
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:373
 #: lib/vutuv_web/live/post_live/composer.ex:1538
 #, elixir-autogen, elixir-format
 msgid "Look up"
@@ -13942,7 +13949,7 @@ msgstr ""
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3012
+#: lib/vutuv_web/components/post_components.ex:3058
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
@@ -13969,7 +13976,7 @@ msgstr ""
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3016
+#: lib/vutuv_web/components/post_components.ex:3062
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -14000,34 +14007,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3053
+#: lib/vutuv_web/components/post_components.ex:3099
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3083
+#: lib/vutuv_web/components/post_components.ex:3129
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3084
+#: lib/vutuv_web/components/post_components.ex:3130
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3082
+#: lib/vutuv_web/components/post_components.ex:3128
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3042
+#: lib/vutuv_web/components/post_components.ex:3088
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3089
+#: lib/vutuv_web/components/post_components.ex:3135
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14057,7 +14064,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2856
+#: lib/vutuv_web/components/post_components.ex:2902
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14105,7 +14112,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2847
+#: lib/vutuv_web/components/post_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14479,14 +14486,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1306
+#: lib/vutuv_web/components/post_components.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1328
+#: lib/vutuv_web/components/post_components.ex:1374
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14513,7 +14520,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3459
+#: lib/vutuv_web/components/post_components.ex:3512
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14861,7 +14868,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/browse_table.ex:185
 #: lib/vutuv_web/live/fediverse_followers_live.ex:113
-#: lib/vutuv_web/live/fediverse_following_live.ex:327
+#: lib/vutuv_web/live/fediverse_following_live.ex:230
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:96
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:147
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:191
@@ -14953,7 +14960,7 @@ msgstr ""
 msgid "Nothing changes on vutuv itself, and you can switch it off again."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:487
+#: lib/vutuv_web/components/fediverse_components.ex:198
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "Take part in the Fediverse"
@@ -15043,7 +15050,7 @@ msgid "Send your Fediverse followers to another account. They are asked to follo
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:224
-#: lib/vutuv_web/live/fediverse_following_live.ex:618
+#: lib/vutuv_web/live/fediverse_following_live.ex:436
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Back to Fediverse settings"
@@ -15680,21 +15687,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3418
+#: lib/vutuv_web/components/post_components.ex:3471
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3422
+#: lib/vutuv_web/components/post_components.ex:3475
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3426
+#: lib/vutuv_web/components/post_components.ex:3479
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15702,7 +15709,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:928
-#: lib/vutuv_web/components/post_components.ex:3380
+#: lib/vutuv_web/components/post_components.ex:3430
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15718,13 +15725,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:923
-#: lib/vutuv_web/components/post_components.ex:1052
+#: lib/vutuv_web/components/post_components.ex:946
+#: lib/vutuv_web/components/post_components.ex:1097
+#: lib/vutuv_web/live/fediverse_account_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:847
+#: lib/vutuv_web/components/post_components.ex:853
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15751,7 +15759,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:856
+#: lib/vutuv_web/components/post_components.ex:862
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15761,7 +15769,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:870
+#: lib/vutuv_web/components/post_components.ex:876
 #: lib/vutuv_web/live/notification_live/index.ex:497
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15793,8 +15801,8 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1089
-#: lib/vutuv_web/components/post_components.ex:875
-#: lib/vutuv_web/components/post_components.ex:1173
+#: lib/vutuv_web/components/post_components.ex:881
+#: lib/vutuv_web/components/post_components.ex:1219
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15805,6 +15813,7 @@ msgstr ""
 msgid "What"
 msgstr ""
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:160
 #: lib/vutuv_web/live/post_live/feed.ex:339
 #: lib/vutuv_web/live/post_live/thread.ex:209
 #, elixir-autogen, elixir-format, fuzzy
@@ -16247,7 +16256,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/account_activity_live.ex:243
 #: lib/vutuv_web/live/admin/activity_live.ex:275
-#: lib/vutuv_web/live/fediverse_following_live.ex:514
+#: lib/vutuv_web/live/fediverse_following_live.ex:332
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16467,22 +16476,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1538
+#: lib/vutuv_web/components/post_components.ex:1584
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1626
+#: lib/vutuv_web/components/post_components.ex:1672
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1634
+#: lib/vutuv_web/components/post_components.ex:1680
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1620
+#: lib/vutuv_web/components/post_components.ex:1666
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16568,7 +16577,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1017
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:2087
+#: lib/vutuv_web/components/post_components.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16608,7 +16617,7 @@ msgstr ""
 msgid "Move photo later"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2086
+#: lib/vutuv_web/components/post_components.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16618,7 +16627,7 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2503
+#: lib/vutuv_web/components/post_components.ex:2549
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this post so far."
 msgstr ""
@@ -16628,19 +16637,19 @@ msgstr ""
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2506
+#: lib/vutuv_web/components/post_components.ex:2552
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2331
+#: lib/vutuv_web/components/post_components.ex:2377
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1833
+#: lib/vutuv_web/components/post_components.ex:1879
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16653,12 +16662,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1050
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:2540
+#: lib/vutuv_web/components/post_components.ex:2586
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2085
+#: lib/vutuv_web/components/post_components.ex:2131
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
@@ -16762,8 +16771,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:808
-#: lib/vutuv_web/live/post_live/feed.ex:809
+#: lib/vutuv_web/live/post_live/feed.ex:815
+#: lib/vutuv_web/live/post_live/feed.ex:816
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
@@ -16827,13 +16836,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:946
-#: lib/vutuv_web/components/post_components.ex:3415
+#: lib/vutuv_web/components/post_components.ex:3468
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:944
-#: lib/vutuv_web/components/post_components.ex:3412
+#: lib/vutuv_web/components/post_components.ex:3465
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16843,7 +16852,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3311
+#: lib/vutuv_web/components/post_components.ex:3357
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16934,15 +16943,16 @@ msgstr ""
 msgid "Photo details"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:56
-#: lib/vutuv_web/live/fediverse_following_live.ex:338
-#: lib/vutuv_web/live/fediverse_following_live.ex:351
+#: lib/vutuv_web/live/fediverse_account_live.ex:379
+#: lib/vutuv_web/live/fediverse_following_live.ex:55
+#: lib/vutuv_web/live/fediverse_following_live.ex:241
+#: lib/vutuv_web/live/fediverse_following_live.ex:254
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:380
+#: lib/vutuv_web/components/fediverse_components.ex:82
 #, elixir-autogen, elixir-format
 msgid "Address of the account"
 msgstr ""
@@ -16952,7 +16962,7 @@ msgstr ""
 msgid "An account on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:298
+#: lib/vutuv_web/components/fediverse_components.ex:234
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancel request"
 msgstr ""
@@ -16962,7 +16972,8 @@ msgstr ""
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:230
+#: lib/vutuv_web/live/fediverse_account_live.ex:104
+#: lib/vutuv_web/live/fediverse_following_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Follow request sent to %{account}."
 msgstr ""
@@ -16987,17 +16998,17 @@ msgstr ""
 msgid "Manage who you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:361
+#: lib/vutuv_web/live/fediverse_following_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Mastodon and the other networks work like email: an address is enough. Paste one here and vutuv asks that server to let you follow the account."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:425
+#: lib/vutuv_web/live/fediverse_following_live.ex:291
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Open their profile"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:290
+#: lib/vutuv_web/components/fediverse_components.ex:216
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Requested"
 msgstr ""
@@ -17007,12 +17018,12 @@ msgstr ""
 msgid "Reset sorting"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:433
+#: lib/vutuv_web/live/fediverse_following_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Search for them here"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:543
+#: lib/vutuv_web/live/fediverse_following_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Show only accounts on this server"
 msgstr ""
@@ -17022,27 +17033,27 @@ msgstr ""
 msgid "Sign in to follow this account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:528
+#: lib/vutuv_web/live/fediverse_following_live.ex:346
 #, elixir-autogen, elixir-format, fuzzy
 msgid "State"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:305
+#: lib/vutuv_web/live/fediverse_following_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "Stop following %{account}?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:246
+#: lib/vutuv_web/components/fediverse_components.ex:257
 #, elixir-autogen, elixir-format
 msgid "That account could not be loaded from its server. Try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:287
+#: lib/vutuv_web/components/fediverse_components.ex:303
 #, elixir-autogen, elixir-format
 msgid "That did not work. Check the address and try again."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:235
+#: lib/vutuv_web/components/fediverse_components.ex:246
 #, elixir-autogen, elixir-format
 msgid "That does not look like an address on another network. They look like @name@server."
 msgstr ""
@@ -17052,87 +17063,88 @@ msgstr ""
 msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:414
+#: lib/vutuv_web/components/fediverse_components.ex:265
 #, elixir-autogen, elixir-format
 msgid "That is an address on this vutuv, not another network."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:243
+#: lib/vutuv_web/components/fediverse_components.ex:254
 #, elixir-autogen, elixir-format
 msgid "That server answered, but it has no account at that address to follow."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:240
+#: lib/vutuv_web/components/fediverse_components.ex:251
 #, elixir-autogen, elixir-format
 msgid "That server did not answer. Check the address, and that the server is online."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:284
+#: lib/vutuv_web/components/fediverse_components.ex:300
 #, elixir-autogen, elixir-format
 msgid "The Fediverse is switched off on this vutuv."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:478
+#: lib/vutuv_web/components/fediverse_components.ex:193
 #, elixir-autogen, elixir-format
 msgid "The address you brought along is kept here:"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:596
+#: lib/vutuv_web/live/fediverse_following_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "The other server decides. Most accounts accept straight away; one that checks its followers by hand stays on \"Requested\" until somebody there says yes."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:467
+#: lib/vutuv_web/components/fediverse_components.ex:166
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with other networks, so there is nothing to follow from here. That is an operator setting, not yours."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:249
+#: lib/vutuv_web/components/fediverse_components.ex:260
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with that server."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:473
+#: lib/vutuv_web/components/fediverse_components.ex:188
 #, elixir-autogen, elixir-format
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:170
+#: lib/vutuv_web/live/fediverse_account_live.ex:120
+#: lib/vutuv_web/live/fediverse_following_live.ex:147
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unfollowed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:593
+#: lib/vutuv_web/live/fediverse_following_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "What following out there means"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:601
+#: lib/vutuv_web/live/fediverse_following_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Who you follow is yours alone. Your profile publishes how many accounts you follow out there, never which ones."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:462
+#: lib/vutuv_web/components/fediverse_components.ex:161
 #, elixir-autogen, elixir-format
 msgid "Why is my account on hold?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:306
+#: lib/vutuv_web/live/fediverse_following_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Withdraw your follow request to %{account}?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:255
+#: lib/vutuv_web/components/fediverse_components.ex:271
 #, elixir-autogen, elixir-format
 msgid "You already follow that account."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:273
+#: lib/vutuv_web/components/fediverse_components.ex:289
 #, elixir-autogen, elixir-format
 msgid "You are following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:263
+#: lib/vutuv_web/components/fediverse_components.ex:279
 #, elixir-autogen, elixir-format
 msgid "You are not taking part in the Fediverse at the moment, so there is no identity to sign the request with. Open the Fediverse settings to switch it on."
 msgstr ""
@@ -17149,17 +17161,17 @@ msgid_plural "You follow %{formatted} accounts on other networks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:269
+#: lib/vutuv_web/components/fediverse_components.ex:285
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You have sent a lot of follow requests in the last hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:279
+#: lib/vutuv_web/components/fediverse_components.ex:295
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so this account no longer acts out there."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:452
+#: lib/vutuv_web/components/fediverse_components.ex:155
 #, elixir-autogen, elixir-format
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
@@ -17169,7 +17181,7 @@ msgstr ""
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:345
+#: lib/vutuv_web/live/fediverse_following_live.ex:248
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Accounts followed"
 msgstr ""
@@ -17184,17 +17196,18 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1145
+#: lib/vutuv_web/components/post_components.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:152
 #: lib/vutuv_web/live/post_live/feed.ex:331
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1172
+#: lib/vutuv_web/components/post_components.ex:1218
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -17214,21 +17227,22 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1025
+#: lib/vutuv_web/components/post_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1151
+#: lib/vutuv_web/components/post_components.ex:1197
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1124
+#: lib/vutuv_web/components/post_components.ex:1170
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mute %{handle}"
 msgstr ""
 
+#: lib/vutuv_web/live/fediverse_account_live.ex:196
 #: lib/vutuv_web/live/post_live/feed.ex:360
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -17239,17 +17253,87 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1131
+#: lib/vutuv_web/components/post_components.ex:1177
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:612
+#: lib/vutuv_web/live/fediverse_following_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "To show their posts we keep a copy here for up to six months. If the author deletes or edits something, ours follows; and when you stop following an account, its posts are deleted here at once."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:500
+#: lib/vutuv_web/live/fediverse_following_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "You do not follow anybody out there yet. Once you do, what they post appears in your feed among everything else."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:66
+#, elixir-autogen, elixir-format
+msgid "%{name} (another network)"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:232
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account on another network"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:363
+#, elixir-autogen, elixir-format
+msgid "Look up another account"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:297
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Muted"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:211
+#, elixir-autogen, elixir-format
+msgid "Nothing cached yet. Their posts appear here as they publish them."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:206
+#, elixir-autogen, elixir-format
+msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:365
+#, elixir-autogen, elixir-format
+msgid "Paste an address from Mastodon and friends to open its page here."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:264
+#, elixir-autogen, elixir-format
+msgid "Show the whole description"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:348
+#, elixir-autogen, elixir-format
+msgid "The most recent %{count} are shown. The rest are on their own server."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:198
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unmuted. Their posts are back in your feed."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:358
+#, elixir-autogen, elixir-format
+msgid "View their full profile on %{host}"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_account_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
+msgstr ""
+
+#: lib/vutuv_web/components/fediverse_components.ex:177
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You redirected your Fediverse followers to another account, so this one no longer follows anybody out there."
+msgstr ""
+
+#: lib/vutuv_web/components/fediverse_components.ex:183
+#, elixir-autogen, elixir-format
+msgid "Your account move"
 msgstr ""

--- a/priv/repo/migrations/20260727105230_index_fediverse_reactions_by_actor.exs
+++ b/priv/repo/migrations/20260727105230_index_fediverse_reactions_by_actor.exs
@@ -1,0 +1,15 @@
+defmodule Vutuv.Repo.Migrations.IndexFediverseReactionsByActor do
+  use Ecto.Migration
+
+  # `Vutuv.Fediverse.purge_unreferenced_remote_accounts/0` (issue #1162) asks,
+  # per stored account, whether any reaction still names its address. The only
+  # index on this table is `unique_index([:post_id, :actor_uri, :kind])`, whose
+  # leading column is `post_id`, so that anti-join had to scan the whole
+  # reactions table on every hourly sweep — the notes arm gets a real index scan
+  # only because `fediverse_notes` carries its own `actor_uri` index.
+  #
+  # A plain addition, so the currently deployed release keeps working.
+  def change do
+    create(index(:fediverse_reactions, [:actor_uri]))
+  end
+end

--- a/test/vutuv/fediverse_remote_posts_test.exs
+++ b/test/vutuv/fediverse_remote_posts_test.exs
@@ -471,6 +471,62 @@ defmodule Vutuv.FediverseRemotePostsTest do
     end
   end
 
+  describe "remembering an account (issue #1162)" do
+    # The fetched actor document the inbox has in hand once a delivery is
+    # verified — the same shape `fetch_remote_actor/2` returns.
+    defp actor_doc(uri \\ @actor) do
+      %{
+        id: uri,
+        inbox: uri <> "/inbox",
+        shared_inbox: nil,
+        preferred_username: "them",
+        name: "Them",
+        summary: "<p>Schreibt über <b>Züge</b>.</p>",
+        public_key_id: nil,
+        public_key_pem: "PEM",
+        also_known_as: []
+      }
+    end
+
+    test "keeps what the inbox already read, as plain text" do
+      assert :ok = Fediverse.remember_remote_account(actor_doc())
+
+      account = Repo.get_by!(RemoteAccount, actor_uri: @actor)
+      assert account.host == "social.example"
+      assert account.handle == "them"
+      assert account.summary == "Schreibt über Züge."
+      refute account.summary =~ "<b>"
+    end
+
+    test "a second delivery re-syncs the one row" do
+      assert :ok = Fediverse.remember_remote_account(actor_doc())
+      assert :ok = Fediverse.remember_remote_account(%{actor_doc() | name: "Renamed"})
+
+      assert Repo.aggregate(RemoteAccount, :count) == 1
+      assert Repo.get_by!(RemoteAccount, actor_uri: @actor).name == "Renamed"
+    end
+
+    test "an account nothing refers to any more is forgotten" do
+      :ok = Fediverse.remember_remote_account(actor_doc())
+      assert Repo.aggregate(RemoteAccount, :count) == 1
+
+      # Nothing follows it, it wrote nothing here, nobody's post carries a reply
+      # or a reaction from it: "we remember who reacted to your post" must not
+      # become a directory of everybody who ever touched this installation.
+      assert Fediverse.purge_unreferenced_remote_accounts() == 1
+      assert Repo.aggregate(RemoteAccount, :count) == 0
+    end
+
+    test "an account somebody follows, or whose words we hold, is kept" do
+      :ok = Fediverse.remember_remote_account(actor_doc())
+      acc = Repo.get_by!(RemoteAccount, actor_uri: @actor)
+      follow(member(), acc)
+
+      assert Fediverse.purge_unreferenced_remote_accounts() == 0
+      assert Repo.aggregate(RemoteAccount, :count) == 1
+    end
+  end
+
   describe "who an activity concerns" do
     test "a Create from a followed account names the members who follow it" do
       user = member()

--- a/test/vutuv_web/live/fediverse_account_live_test.exs
+++ b/test/vutuv_web/live/fediverse_account_live_test.exs
@@ -1,0 +1,245 @@
+defmodule VutuvWeb.FediverseAccountLiveTest do
+  @moduledoc """
+  The page for one account on another network (`/system/fediverse/account/:id`,
+  issue #1162): who may open it, what it shows, the follow round trip, and the
+  entry points that now lead here instead of off the site.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+
+  @actor "https://social.example/users/them"
+
+  defp account do
+    Repo.insert!(%RemoteAccount{
+      actor_uri: @actor,
+      host: "social.example",
+      handle: "them",
+      name: "Them Themself",
+      summary: "Schreibt über Züge.",
+      inbox_uri: @actor <> "/inbox"
+    })
+  end
+
+  defp follow(user, account, state \\ "accepted") do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: account.id,
+      state: state,
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/#{account.id}"
+    })
+  end
+
+  defp cached_post(account, attrs \\ %{}) do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(
+      struct(
+        %RemotePost{
+          remote_account_id: account.id,
+          object_uri: "https://social.example/posts/#{System.unique_integer([:positive])}",
+          content_text: "Ein Beitrag von drüben.",
+          audience: "public",
+          kind: "note",
+          published_at: now,
+          received_at: now,
+          expires_at: DateTime.add(now, 86_400)
+        },
+        attrs
+      )
+    )
+  end
+
+  test "an anonymous visitor is sent away", %{conn: conn} do
+    acc = account()
+
+    conn = get(conn, ~p"/system/fediverse/account/#{acc.id}")
+    assert redirected_to(conn) == ~p"/login"
+  end
+
+  test "robots are told not to index it", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+    acc = account()
+
+    conn = get(conn, ~p"/system/fediverse/account/#{acc.id}")
+
+    # Assembled from what other people wrote on other servers: not ours to
+    # publish, and never a crawlable directory of who reacted to a post here.
+    assert [robots] = Plug.Conn.get_resp_header(conn, "x-robots-tag")
+    assert robots =~ "noindex"
+  end
+
+  test "an unknown id lands somewhere sensible instead of crashing", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+
+    assert {:error, {:redirect, %{to: "/feed"}}} =
+             live(conn, ~p"/system/fediverse/account/019fa2ba-b301-771a-8bbf-efd42278fd8a")
+  end
+
+  test "it shows who the account is and offers the follow", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    {:ok, user} = Vutuv.Accounts.update_user(user, %{"fediverse_followers?" => "true"})
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    acc = account()
+
+    {:ok, view, html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+
+    assert html =~ "Them Themself"
+    assert html =~ "@them@social.example"
+    assert has_element?(view, "[data-remote-summary]")
+    # The real thing stays one click away.
+    assert has_element?(view, "[data-remote-origin][href='#{@actor}']")
+    assert has_element?(view, "#follow")
+  end
+
+  test "an account nobody follows says why it has no posts", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+    acc = account()
+
+    {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+
+    # Not "this account never posts": we hold posts only while somebody here
+    # follows, and this page fetches nothing.
+    assert has_element?(view, "#no-posts")
+  end
+
+  test "the follow state reads honestly and round-trips with no reload", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    {:ok, user} = Vutuv.Accounts.update_user(user, %{"fediverse_followers?" => "true"})
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    acc = account()
+    follow(user, acc, "requested")
+
+    {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+
+    assert has_element?(view, "[data-follow-state=requested]")
+
+    view |> element("#unfollow") |> render_click()
+
+    assert has_element?(view, "#follow")
+    assert Repo.aggregate(Follow, :count) == 0
+  end
+
+  test "muting is reversible, and this page is where it reverses", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    {:ok, user} = Vutuv.Accounts.update_user(user, %{"fediverse_followers?" => "true"})
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    acc = account()
+    follow(user, acc)
+
+    {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+
+    view |> element("#toggle-mute") |> render_click()
+
+    assert has_element?(view, "[data-follow-muted]")
+    assert Repo.get_by!(Follow, user_id: user.id).muted
+
+    # The whole point: muting from the feed takes the account's posts away, and
+    # with them the menu that muted it. Without a way back the flash promising
+    # "you still follow them" describes a door that only opens one way.
+    view |> element("#toggle-mute") |> render_click()
+
+    refute has_element?(view, "[data-follow-muted]")
+    refute Repo.get_by!(Follow, user_id: user.id).muted
+  end
+
+  test "the empty Posts card says something true for each follow state", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    acc = account()
+
+    # Nobody follows: the copies only exist while somebody does.
+    {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+    assert render(view) =~ "posts while somebody here follows it"
+
+    # A requested follow with a followers-only post cached: we DO hold posts, so
+    # "nobody here follows this account" would be false.
+    cached_post(acc, %{audience: "followers"})
+    follow(user, acc, "requested")
+
+    {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+    assert has_element?(view, "#no-posts")
+    assert render(view) =~ "Waiting for that server"
+  end
+
+  test "there is a way to the real profile even when nothing is cached", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+    acc = account()
+
+    {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+
+    # Otherwise the empty page is a dead end, and "a preview here, the whole
+    # person over there" is only in the moduledoc.
+    assert has_element?(view, "a[href='#{@actor}']")
+    assert render(view) =~ "social.example"
+  end
+
+  test "a member who does not federate is told why, not shown a dead button", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+    acc = account()
+
+    {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+
+    assert has_element?(view, "#cannot-follow[data-reason=opted_out]")
+    assert has_element?(view, "#enable-fediverse-link")
+    refute has_element?(view, "#follow")
+  end
+
+  describe "the cached posts" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      %{conn: conn, user: user, account: account()}
+    end
+
+    test "public posts show to any signed-in member", %{conn: conn, account: acc} do
+      p = cached_post(acc)
+
+      {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+
+      assert has_element?(view, "[data-remote-post='#{p.id}']")
+      refute has_element?(view, "#no-posts")
+    end
+
+    test "a followers-only post needs the viewer's own accepted follow", %{
+      conn: conn,
+      user: user,
+      account: acc
+    } do
+      p = cached_post(acc, %{audience: "followers"})
+
+      {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+      refute has_element?(view, "[data-remote-post='#{p.id}']")
+
+      follow(user, acc)
+
+      {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+      assert has_element?(view, "[data-remote-post='#{p.id}']")
+    end
+
+    test "a requested follow does not open them", %{conn: conn, user: user, account: acc} do
+      p = cached_post(acc, %{audience: "followers"})
+      follow(user, acc, "requested")
+
+      {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+
+      refute has_element?(view, "[data-remote-post='#{p.id}']")
+    end
+  end
+
+  describe "the entry points" do
+    test "a remote post in the feed links to the account page", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      acc = account()
+      follow(user, acc)
+      cached_post(acc)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      assert has_element?(view, "[data-remote-account='#{acc.id}']")
+    end
+  end
+end


### PR DESCRIPTION
Closes #1162.

Every remote handle vutuv shows linked straight out of the site. Deciding to follow somebody you saw react to your own post meant leaving, finding them, coming back, and pasting their address into a settings page. `/system/fediverse/account/:id` removes that detour.

## What it is (and is not)

A **follow surface plus a preview**: who the account is, its self-description (clamped, with a lid), the follow / requested / muted state, and the posts we already hold — capped at 30, newest first — with "View their full profile on `<host>`" in **every** state, empty included. Somebody's full history stays their own server's job.

Signed-in only and `noindex` (a new `:noindex_pipe`). Keyed by the **row id**, never a URI, so the page is no open-ended fetch surface — and it fetches nothing on view, so a link to it can never make vutuv poke a third-party server. Reaching an account we do not know goes the other way round: the lookup box resolves the address first, deliberately as an event and not as a GET.

Two things it can show that the origin profile cannot, which is the argument for having it at all: a followers-only post is readable here by a member whose own follow is accepted, and the cached posts are the preview that decides the follow.

## Making the handles point somewhere

Account rows had to exist for more than followed accounts, so `remember_remote_account/1` keeps the actor document the inbox **already fetched and verified** whenever a reply or a reaction is stored — no extra request, and only on a successful store, so a stranger's activity cannot plant rows. Left alone that grows into a directory of everybody who ever touched the installation, so the hourly sweep now also drops every account with no follow, no cached post, no stored reply and no stored reaction.

Reaction chips and remote reply cards link inward when we know the account and out when we do not; the chip's `account_id` rides the existing engagement query and the note's rides `list_notes/2`'s join, so neither costs a lookup per card.

## Three problems the critique found, worth more than the page

**Muting was a one-way door.** #1161 gave the feed card a Mute item, and muting removes that account's posts from the feed — taking the menu that muted it with them. There was no unmute anywhere, so the flash promising "you still follow them" described something that could not be undone. Fixed here, because this page is where a muted account can still be reached.

**The empty Posts card lied.** It said "vutuv only keeps an account's posts while somebody here follows it" even for a member with a *requested* follow and cached followers-only posts — where we hold posts and were saying we hold none. Now a different, true sentence per follow state.

**`viewer={nil}` dropped the post cards' menu.** This page shows public posts of accounts the reader does *not* follow (cached because somebody else does), so it is the only place those will ever be seen. A card nobody can report is a display, not a card.

## Two bundled behaviour changes, both deliberate

- `/system/fediverse/reply/:id` now sends `X-Robots-Tag: noindex`. It did not before, and it should have.
- The total-follow ceiling is checked before the address is parsed, so a member at the ceiling submitting a garbage address is told about the ceiling rather than about the address.

## Verified

`mix precommit` green (5684 tests), 14 new LiveView tests and 4 new context tests. Smoke-tested in Chrome against the dev DB in German: the page renders with the "Konto in einem anderen Netzwerk" eyebrow and the globe badge, the follow pill and the mute round trip both work over the socket, and the footer link and lookup box read correctly.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01JK1wSgiwNTSQxepf9wprLg
