### PR TITLE
Answer a post from an account you follow out there (#1165)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -951,3 +951,57 @@ likes that happened to pass through this installation would read as the real one
 while being a fraction of it. The marker cascades with the cached post, expiry
 included; the like on the author's server stands, and a re-like after expiry
 sends a duplicate every implementation treats as a no-op.
+
+### Answering one of their posts (issue #1165)
+
+The `Vutuv.Posts.PostRemoteReply` sidecar generalized rather than a second table
+appearing beside it. It now records either of two things a vutuv post can
+answer: a **reply** that arrived under one of the member's own posts (#1070,
+`note_id`) or a **post by an account they follow** (#1165, `remote_post_id`).
+Exactly one id is set, and **neither is what delivery reads** — every field the
+outgoing activity needs (`in_reply_to_uri`, `actor_uri`, `inbox_uri`, `handle`)
+was already copied onto the row at creation time, so both cases produce the same
+`Create(Note)` and nothing downstream has to know which it was. Both ids nilify
+rather than cascade: the member's own answer outlives our six-month copy of what
+it answered, and editing or deleting it has to keep reaching the person it went
+to.
+
+The difference is what sits underneath. A #1070 answer is a real reply to the
+vutuv post the remote reply arrived under, so local threading, the reply count
+and the edit window all apply. A #1165 answer has no vutuv post underneath at
+all — the thing answered lives entirely on somebody else's server — so
+`create_remote_post_reply/3` creates a **top-level** post that happens to carry
+the sidecar, and the card wears a "Replying to `@user@host`" line pointing at
+that account's page *here*, not out to their server.
+
+One gate is stricter than the reply path's: a **followers-only** post cannot be
+answered at all (`:post_not_public`). The answer is a public vutuv post, and
+republishing the audience its author deliberately narrowed is not ours to do —
+so the card offers no Reply there rather than a control that refuses, and the
+page refuses if the URL is typed by hand. That audience question is the whole of
+`check_remote_post_reply/2`; behind it sits the very gate the **like** path asks
+(`check_remote_like/2` — installation switch, the member's own standing, the
+blocklist, "is this post theirs to read"), because both are the same shape of
+act on the same cached post. Everything else is shared with #1070, including the
+hourly outbound budget: both are a member's own words leaving for a server that
+never followed them, and metering them separately would let one member's hour of
+answering hide inside the other's.
+
+The answer composer is deliberately **not** a draft context, and the reason is
+worth writing down because it looks like a two-line change. A draft is keyed by
+which composer it was typed in, so a fourth context needs its own partial unique
+index *and* has to be excluded from the new-post composer's — which means
+dropping and recreating that index. Deploys here are blue/green, so during the
+switch the previous release is still writing `ON CONFLICT (user_id) WHERE
+parent_id IS NULL AND remote_note_id IS NULL`, and Postgres infers an arbiter
+index only when the supplied predicate **implies** the index's: two conjuncts do
+not imply three, so every keystroke in the old release's feed composer would
+raise 42P10. (Verified against Postgres, not reasoned about.) Giving answers
+drafts is therefore an expand/contract pair of deploys, worth doing on its own.
+
+One thing that did have to change: `post_remote_replies`' three URI columns were
+`varchar(255)` while everything they copy from is `text` capped at 2048 bytes.
+A remote server publishing a post with a 300-character id — legal, accepted at
+our inbox, refused by no changeset — would have raised 22001 the moment a member
+answered it. Widened to `text`; the `handle` stays 255 and the writer truncates,
+since it is cosmetic and composed from two independently capped remote strings.

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -3477,6 +3477,35 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc """
+  Whether `user` may answer the cached post `post` (issue #1165), and when not,
+  which gate refused. The same vocabulary `check_remote_reply/2` answers in, so
+  one wording table covers both, plus one gate of its own:
+
+    * `:post_not_public` — the author published it to their followers only. The
+      answer would be a **public vutuv post** quoting a restricted context, and
+      republishing the audience somebody chose is not ours to do, so v1 offers no
+      Reply there at all rather than a control that refuses.
+
+  Everything after that is the like path's gate unchanged (`check_remote_like/2`
+  and its `:not_visible`), which is why the two share it: the same member-side
+  switches, the same blocklist and the same "is this theirs to see" question.
+
+  Free of side effects. The budget (`claim_reply_budget/1`) is the reply path's,
+  shared deliberately: both are the same act — a member's own words leaving for
+  a server that never followed them — and metering them separately would let one
+  member's hour of answering hide inside the other's budget.
+  """
+  def check_remote_post_reply(%User{} = user, %RemotePost{} = post) do
+    # The audience question first, and then nothing of its own: every other gate
+    # is the like path's, asked in the same order (`check_remote_post_act/2`).
+    # A followers-only post is refused whatever the member's own settings say,
+    # since no setting of theirs could ever make it answerable.
+    if RemotePost.open?(post),
+      do: check_remote_post_act(user, post),
+      else: {:error, :post_not_public}
+  end
+
+  @doc """
   Claims one slot from the member's hourly budget for answers that leave for
   another network. `:ok`, or `{:error, :reply_capped}`.
 
@@ -3531,7 +3560,16 @@ defmodule Vutuv.Fediverse do
 
   Free of side effects, so a render may ask it. The budget is claimed separately.
   """
-  def check_remote_like(%User{} = user, %RemotePost{} = post) do
+  def check_remote_like(%User{} = user, %RemotePost{} = post),
+    do: check_remote_post_act(user, post)
+
+  # What both outbound acts on a cached post ask, in one place: the installation
+  # switch, the member's own Fediverse standing (they sign with their own key,
+  # so there is no actorless like or answer), the operator blocklist — a block
+  # shuts both directions — and whether this is a post they may read at all,
+  # since the id in a click is attacker-controlled. Answering adds its own
+  # audience gate on top; liking has none.
+  defp check_remote_post_act(%User{} = user, %RemotePost{} = post) do
     cond do
       not enabled?() -> {:error, :fediverse_disabled}
       not federated?(user) -> {:error, :not_federating}
@@ -3638,7 +3676,18 @@ defmodule Vutuv.Fediverse do
     end
   end
 
-  defp reload_remote_post(%RemotePost{id: id, remote_account: account}) do
+  @doc """
+  This cached post as it is **now**, keeping the account already in hand, or nil
+  once the row is gone.
+
+  Every write path that acts on a post a member is looking at goes through here
+  first. A card is rendered at one moment and acted on at another, and in
+  between the row can be deleted (expiry, an upstream `Delete`, another
+  member's report, an instance block) or changed (its author narrowing the
+  audience with an `Update`). Acting on the struct in hand means a foreign-key
+  crash in the first case and a bypassed audience rule in the second.
+  """
+  def reload_remote_post(%RemotePost{id: id, remote_account: account}) do
     case Repo.get(RemotePost, id) do
       %RemotePost{} = post -> %{post | remote_account: account}
       nil -> nil

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -53,6 +53,8 @@ defmodule Vutuv.Posts do
 
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Mentions
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Pages
@@ -134,33 +136,8 @@ defmodule Vutuv.Posts do
   author_id:}}` to the author's and every follower's activity topic.
   """
   def create_post(%User{} = author, attrs) do
-    image_ids = parse_ids(fetch(attrs, :image_ids) || [])
-
-    with {:ok, denials} <- normalize_denials(author.id, fetch(attrs, :denials) || []),
-         :ok <- check_image_count(image_ids),
-         {:ok, changeset} <- build_changeset(%Post{user_id: author.id}, attrs, denials, image_ids) do
-      case insert_post(changeset, image_ids) do
-        {:ok, post} ->
-          post = preload_post(post)
-          broadcast_new_post(post)
-          # A photo post's license becomes the author's pre-selection next time.
-          remember_license(author, post)
-          # Everyone the body names by @handle is told they were named.
-          sync_mentions(post)
-          # Follow-only federation: a federating author's public post goes
-          # out to their remote followers (no-op for everyone else).
-          Vutuv.Fediverse.federate_new_post(post)
-          # A single-URL, image-less post gets a link screenshot, captured off
-          # the request path via the durable queue.
-          reconcile_screenshot(post)
-          # A book review with an ISBN gets its cover fetched off the request
-          # path (no-op for every other post).
-          ReviewCovers.reconcile(post)
-          {:ok, post}
-
-        {:error, _} = error ->
-          error
-      end
+    with {:ok, denials} <- normalize_denials(author.id, fetch(attrs, :denials) || []) do
+      do_create_post(author, attrs, denials, nil)
     end
   end
 
@@ -206,6 +183,79 @@ defmodule Vutuv.Posts do
     else
       nil -> {:error, :not_visible}
       {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Creates a member's answer to a post by an account they follow on another
+  network (issue #1165).
+
+  Unlike `create_remote_reply/3` this is **not** a reply to anything here: the
+  post being answered lives entirely on somebody else's server, so what is
+  created is a top-level vutuv post carrying the `Vutuv.Posts.PostRemoteReply`
+  sidecar. That sidecar is what makes the outgoing `Create(Note)` thread under
+  their post over there — `inReplyTo`, the author in `cc`, and a `Mention` built
+  from the stored actor URI rather than from anything the member typed.
+
+  Every gate is `Vutuv.Fediverse.check_remote_post_reply/2`'s, including the one
+  that makes this narrower than answering a reply: a followers-only post cannot
+  be answered at all, because the answer is public here and republishing the
+  audience its author chose is not ours to do.
+
+  Denials are dropped (an answer that federates is public by definition), the
+  same call `do_create_reply/4` makes.
+  """
+  def create_remote_post_reply(%User{} = author, %RemotePost{} = remote_post, attrs) do
+    # Re-read first, and gate on what comes back. The struct in hand was
+    # captured when the composer opened, and a member types for minutes: in that
+    # time the row can be **gone** (expiry, an upstream `Delete`, another
+    # member's report, an instance block), which would hit the sidecar's foreign
+    # key and take the LiveView down; or its **audience can have narrowed**, in
+    # which case the stale struct still says public and this feature's one rule
+    # — no public answer to a followers-only post — would be bypassed by simply
+    # having the form open when the author changed their mind.
+    with %RemotePost{} = remote_post <- Vutuv.Fediverse.reload_remote_post(remote_post),
+         :ok <- Vutuv.Fediverse.check_remote_post_reply(author, remote_post),
+         :ok <- Vutuv.Fediverse.claim_reply_budget(author) do
+      do_create_post(author, attrs, [], remote_post)
+    else
+      nil -> {:error, :not_found}
+      {:error, _} = error -> error
+    end
+  end
+
+  # Creating a post that answers nothing on this site: the feed's own composer
+  # (`create_post/2`, with the audience its author picked) and the answer to a
+  # post on another network (issue #1165 — public by definition, so no denials,
+  # and carrying the sidecar `remote_target` writes instead). Everything after
+  # the insert is the same act either way, so it is written once here.
+  defp do_create_post(%User{} = author, attrs, denials, remote_target) do
+    image_ids = parse_ids(fetch(attrs, :image_ids) || [])
+
+    with :ok <- check_image_count(image_ids),
+         {:ok, changeset} <- build_changeset(%Post{user_id: author.id}, attrs, denials, image_ids) do
+      case insert_post(changeset, image_ids, nil, remote_target) do
+        {:ok, post} ->
+          post = preload_post(post)
+          broadcast_new_post(post)
+          # A photo post's license becomes the author's pre-selection next time.
+          remember_license(author, post)
+          # Everyone the body names by @handle is told they were named.
+          sync_mentions(post)
+          # Follow-only federation: a federating author's public post goes
+          # out to their remote followers (no-op for everyone else).
+          Vutuv.Fediverse.federate_new_post(post)
+          # A single-URL, image-less post gets a link screenshot, captured off
+          # the request path via the durable queue.
+          reconcile_screenshot(post)
+          # A book review with an ISBN gets its cover fetched off the request
+          # path (no-op for every other post).
+          ReviewCovers.reconcile(post)
+          {:ok, post}
+
+        {:error, _} = error ->
+          error
+      end
     end
   end
 
@@ -441,7 +491,7 @@ defmodule Vutuv.Posts do
   # claims and — for a reply — the PostReply row (plus, when it answers another
   # network, the PostRemoteReply sidecar) in one transaction, so post and
   # references land (or roll back) together.
-  defp insert_post(changeset, image_ids, parent \\ nil, note \\ nil) do
+  defp insert_post(changeset, image_ids, parent, remote_target) do
     Repo.transaction(fn ->
       changeset
       |> Ecto.Changeset.change(published_on: Vutuv.BerlinTime.today())
@@ -450,7 +500,7 @@ defmodule Vutuv.Posts do
         {:ok, post} ->
           attach_images!(post, image_ids)
           insert_reply_ref!(post, parent)
-          insert_remote_reply_ref!(post, note)
+          insert_remote_reply_ref!(post, remote_target)
           hold_for_image_check!(post)
 
         {:error, changeset} ->
@@ -467,14 +517,40 @@ defmodule Vutuv.Posts do
   # after that. Hence the copies, and hence `note_id` nilifying rather than
   # cascading the answer away with its target.
   defp insert_remote_reply_ref!(%Post{} = post, %Note{} = note) do
-    %PostRemoteReply{post_id: post.id}
-    |> PostRemoteReply.changeset(%{
+    write_remote_reply_ref!(post, %{
       note_id: note.id,
       in_reply_to_uri: note.object_uri,
       actor_uri: note.actor_uri,
       inbox_uri: note.inbox_uri,
-      handle: Note.display_handle(note)
+      handle: truncate_handle(Note.display_handle(note))
     })
+  end
+
+  # The same row for a post by a followed account (issue #1165). Its author is
+  # an account row we resolved from a verified actor document, so its inbox has
+  # the property the note path relies on: an inbox on the actor's own host.
+  defp insert_remote_reply_ref!(%Post{} = post, %RemotePost{} = remote_post) do
+    account = remote_post.remote_account
+
+    write_remote_reply_ref!(post, %{
+      remote_post_id: remote_post.id,
+      in_reply_to_uri: remote_post.object_uri,
+      actor_uri: account.actor_uri,
+      inbox_uri: account.inbox_uri,
+      handle: truncate_handle(RemoteAccount.display_handle(account))
+    })
+  end
+
+  # The handle is cosmetic and composed from two independently 255-capped remote
+  # values ("@" <> handle <> "@" <> host), so it can overrun its own column.
+  # Cut it rather than lose the whole answer to an over-long display string: the
+  # addresses delivery actually uses are stored separately and untouched.
+  defp truncate_handle(handle) when is_binary(handle), do: String.slice(handle, 0, 255)
+  defp truncate_handle(handle), do: handle
+
+  defp write_remote_reply_ref!(%Post{} = post, attrs) do
+    %PostRemoteReply{post_id: post.id}
+    |> PostRemoteReply.changeset(attrs)
     |> Repo.insert!()
   end
 
@@ -2951,10 +3027,14 @@ defmodule Vutuv.Posts do
       # The book/film review sidecar (nil for ordinary posts) — the card
       # renders it wherever the post renders, so it always travels along.
       :review,
-      # Present only on an answer to a reply from another network (issue #1070).
-      # The conversation renderer reads it to hang such an answer under the
-      # remote card it answers rather than beside it.
-      :remote_reply_ref,
+      # Present only on an answer to something from another network. The
+      # conversation renderer reads it to hang an answer to a *reply* (issue
+      # #1070) under the remote card it answers rather than beside it; an answer
+      # to a followed account's *post* (issue #1165) has no card above it and
+      # instead wears a "Replying to @user@host" line, whose link needs the
+      # account behind the post. Two extra batched queries per page, and only
+      # for the handful of posts that carry the sidecar at all.
+      remote_reply_ref: [remote_post: :remote_account],
       denials: [:denied_user],
       tags: from(t in Tag, order_by: t.name),
       reply_ref: [
@@ -3268,8 +3348,9 @@ defmodule Vutuv.Posts do
   The member's draft for one composer context, or `nil`.
 
   `context` is what the composer is: `nil` for the feed's new post, a `%Post{}`
-  it is answering, or a `%Note{}` (a reply from another network) it is
-  answering. A draft holding nothing is treated as no draft, so an autosave
+  it is answering, a `%Note{}` (a reply from another network) it is answering,
+  or a `%RemotePost{}` (a post by an account the member follows there, issue
+  #1165). A draft holding nothing is treated as no draft, so an autosave
   that raced the member emptying the composer cannot make an empty composer
   announce itself as restored.
   """
@@ -3292,14 +3373,9 @@ defmodule Vutuv.Posts do
   """
   def save_draft(%User{} = author, context, attrs) do
     changeset =
-      PostDraft.changeset(
-        %PostDraft{
-          user_id: author.id,
-          parent_id: draft_parent_id(context),
-          remote_note_id: draft_remote_note_id(context)
-        },
-        attrs
-      )
+      %PostDraft{user_id: author.id}
+      |> struct(draft_context_fields(context))
+      |> PostDraft.changeset(attrs)
 
     cond do
       not changeset.valid? ->
@@ -3341,31 +3417,71 @@ defmodule Vutuv.Posts do
     count
   end
 
-  # The three composer contexts, as a scope and as the matching conflict target
-  # of the partial unique index that owns them.
-  defp draft_scope(%User{id: author_id}, nil),
-    do: dynamic([d], d.user_id == ^author_id and is_nil(d.parent_id) and is_nil(d.remote_note_id))
+  # Each composer context as the one draft column that names it — the single
+  # place a new context is added. A draft is keyed by which composer it was
+  # typed in, so a context missing from here would silently share the new-post
+  # composer's key and overwrite its draft.
+  defp draft_key(%Post{id: id}), do: {:parent_id, id}
+  defp draft_key(%Note{id: id}), do: {:remote_note_id, id}
+  defp draft_key(nil), do: nil
 
-  defp draft_scope(%User{id: author_id}, %Post{id: parent_id}),
-    do: dynamic([d], d.user_id == ^author_id and d.parent_id == ^parent_id)
+  # Answering a followed account's post (issue #1165) is deliberately NOT a
+  # draft context, and adding one is not the small change it looks like. Every
+  # context needs its own partial unique index, and a new one also has to be
+  # excluded from the new-post composer's index — which means dropping and
+  # recreating that index. Deploys here are blue/green, so during the switch
+  # the previous release is still writing `ON CONFLICT (user_id) WHERE
+  # parent_id IS NULL AND remote_note_id IS NULL`, and Postgres infers an
+  # arbiter only when the supplied predicate implies the index's: two conjuncts
+  # do not imply three, so every keystroke in the old release's feed composer
+  # would raise 42P10. Verified against Postgres, not reasoned about. Making it
+  # a draft context is therefore an expand/contract pair of deploys, worth doing
+  # on its own and not worth smuggling into this feature.
+  defp draft_key(_context), do: nil
 
-  defp draft_scope(%User{id: author_id}, %Note{id: note_id}),
-    do: dynamic([d], d.user_id == ^author_id and d.remote_note_id == ^note_id)
+  # The feed's new-post composer is the row where every context column is NULL,
+  # which is why they are also listed: its scope and its conflict target are
+  # "none of these".
+  @draft_context_columns [:parent_id, :remote_note_id]
 
-  defp draft_parent_id(%Post{id: id}), do: id
-  defp draft_parent_id(_context), do: nil
+  # Read scope and write key of one context, derived from the same `draft_key/1`
+  # so a draft can never be looked up under one and stored under another. Each
+  # conflict target names the partial unique index that owns its context
+  # (`priv/repo/migrations/*_post_drafts*`): `(user_id, <column>) WHERE <column>
+  # IS NOT NULL`, and `(user_id) WHERE <every column> IS NULL` for the new post.
+  defp draft_scope(%User{id: author_id}, context) do
+    case draft_key(context) do
+      {column, id} ->
+        dynamic([d], d.user_id == ^author_id and field(d, ^column) == ^id)
 
-  defp draft_remote_note_id(%Note{id: id}), do: id
-  defp draft_remote_note_id(_context), do: nil
+      nil ->
+        mine = dynamic([d], d.user_id == ^author_id)
 
-  defp draft_conflict_target(nil),
-    do: {:unsafe_fragment, "(user_id) WHERE parent_id IS NULL AND remote_note_id IS NULL"}
+        Enum.reduce(@draft_context_columns, mine, fn column, scope ->
+          dynamic([d], ^scope and is_nil(field(d, ^column)))
+        end)
+    end
+  end
 
-  defp draft_conflict_target(%Post{}),
-    do: {:unsafe_fragment, "(user_id, parent_id) WHERE parent_id IS NOT NULL"}
+  defp draft_conflict_target(context) do
+    case draft_key(context) do
+      {column, _id} ->
+        {:unsafe_fragment, "(user_id, #{column}) WHERE #{column} IS NOT NULL"}
 
-  defp draft_conflict_target(%Note{}),
-    do: {:unsafe_fragment, "(user_id, remote_note_id) WHERE remote_note_id IS NOT NULL"}
+      nil ->
+        nulls = Enum.map_join(@draft_context_columns, " AND ", &"#{&1} IS NULL")
+        {:unsafe_fragment, "(user_id) WHERE #{nulls}"}
+    end
+  end
+
+  # What a new draft row carries of its context: the one column, or nothing at
+  # all for the feed's composer.
+  defp draft_context_fields(context) do
+    case draft_key(context) do
+      {column, id} -> [{column, id}]
+      nil -> []
+    end
+  end
 
   @doc """
   Person typeahead for the composer's "Hide from…" sheet: activated members

--- a/lib/vutuv/posts/post_draft.ex
+++ b/lib/vutuv/posts/post_draft.ex
@@ -15,8 +15,13 @@ defmodule Vutuv.Posts.PostDraft do
   leads the mosaic, so the order is the layout and an array keeps it.
 
   **A draft belongs to a composer context**, carried by the two nullable
-  references: both nil is the feed's new-post composer, `parent_id` is a reply
-  to that post, `remote_note_id` an answer to a reply from another network.
+  references: all nil is the feed's new-post composer, `parent_id` is a reply to
+  that post, `remote_note_id` an answer to a reply from another network. A draft
+  is keyed by which composer it was typed in, so the contexts must stay
+  distinct: a new one that forgot its own column would share the new-post
+  composer's key and overwrite the draft on `/feed`. Adding one is an
+  expand/contract pair of deploys, not one — see `Vutuv.Posts.draft_key/1`.
+
   The edit page deliberately has no draft: its composer opens full of a
   *published* post, and quietly restoring a weeks-old unsaved edit over text
   other people have already read is a different and much less welcome promise.

--- a/lib/vutuv/posts/post_remote_reply.ex
+++ b/lib/vutuv/posts/post_remote_reply.ex
@@ -1,20 +1,35 @@
 defmodule Vutuv.Posts.PostRemoteReply do
   @moduledoc """
-  One vutuv post that answers a reply written on another network (issue #1070).
+  One vutuv post that answers something written on another network.
 
-  The sidecar to `Vutuv.Posts.PostReply`, not a replacement for it: such an
-  answer is still an ordinary reply to the vutuv post underneath, so local
-  threading, the reply notification, the public reply count and the edit window
-  all keep working untouched. This row records the *other* thing it answers, and
-  it is what makes the outgoing `Create(Note)` carry an `inReplyTo` pointing into
-  the other network plus a `Mention` of the person being answered.
+  Two shapes of that, and one row for both:
 
-  **Why it holds its own copy of the target.** A stored remote reply is a cache:
-  it is collected six months out (`Vutuv.Fediverse.NoteSweeper`), and a takedown
-  or an upstream delete can remove it long before that. The member's own answer
-  lives on, and editing or deleting it has to keep reaching the person who was
-  answered. So `note_id` nilifies rather than cascading, and everything delivery
-  needs is copied here at creation time:
+    * a **reply** that arrived under one of the member's own posts (issue
+      #1070, `note_id`). It is still an ordinary reply to the vutuv post
+      underneath — the sidecar to `Vutuv.Posts.PostReply`, not a replacement
+      for it — so local threading, the reply notification, the public reply
+      count and the edit window all keep working untouched; this row records
+      the *other* thing it answers.
+    * a **post by an account the member follows** (issue #1165,
+      `remote_post_id`). There is no vutuv post underneath: the thing answered
+      lives entirely on another server, so the answer is a top-level vutuv post
+      that happens to carry this row.
+
+  Exactly one of the two ids is set, and neither is what delivery reads: every
+  field it needs is copied onto this row (below), so both cases produce the same
+  outgoing activity and nothing downstream has to know which it was. That is why
+  the sidecar generalized instead of a second table appearing beside it.
+
+  Either way it is what makes the outgoing `Create(Note)` carry an `inReplyTo`
+  pointing into the other network plus a `Mention` of the person answered.
+
+  **Why it holds its own copy of the target.** Both targets are caches: a stored
+  reply is collected six months out (`Vutuv.Fediverse.NoteSweeper`) and a cached
+  post likewise (`expire_due_remote_posts/1`), and a takedown or an upstream
+  delete can remove either long before that. The member's own answer lives on,
+  and editing or deleting it has to keep reaching the person who was answered.
+  So both target ids nilify rather than cascading, and everything delivery needs
+  is copied here at creation time:
 
     * `in_reply_to_uri` — the remote note's own id, what `inReplyTo` names.
     * `actor_uri` — who was answered. The `Mention` tag is built from **this**,
@@ -39,6 +54,7 @@ defmodule Vutuv.Posts.PostRemoteReply do
   schema "post_remote_replies" do
     belongs_to(:post, Vutuv.Posts.Post)
     belongs_to(:note, Vutuv.Fediverse.Note)
+    belongs_to(:remote_post, Vutuv.Fediverse.RemotePost)
 
     field(:in_reply_to_uri, :string)
     field(:actor_uri, :string)
@@ -50,7 +66,14 @@ defmodule Vutuv.Posts.PostRemoteReply do
 
   def changeset(%__MODULE__{} = remote_reply, attrs) do
     remote_reply
-    |> cast(attrs, [:note_id, :in_reply_to_uri, :actor_uri, :inbox_uri, :handle])
+    |> cast(attrs, [
+      :note_id,
+      :remote_post_id,
+      :in_reply_to_uri,
+      :actor_uri,
+      :inbox_uri,
+      :handle
+    ])
     |> validate_required([:in_reply_to_uri, :actor_uri])
     |> validate_length(:in_reply_to_uri, max: @max_uri_bytes, count: :bytes)
     |> validate_length(:actor_uri, max: @max_uri_bytes, count: :bytes)

--- a/lib/vutuv_web/agent_docs/post_doc.ex
+++ b/lib/vutuv_web/agent_docs/post_doc.ex
@@ -21,6 +21,7 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
   alias Vutuv.Posts.PhotoLicense
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostImage
+  alias Vutuv.Posts.PostRemoteReply
   alias Vutuv.Posts.PostReview
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.UserHelpers
@@ -359,7 +360,18 @@ defmodule VutuvWeb.AgentDocs.PostDoc do
         %{url: nil, author: nil}
 
       nil ->
-        nil
+        # Not a reply here, but it may answer a post on another network (issue
+        # #1165): the HTML card says so, so the agent formats must too, or a
+        # `.md`/`.json` sibling reads as a post with no context while the page
+        # names who it answers. The origin URI is the authoritative thing to
+        # point at — that answer threads under it over there.
+        remote_in_reply_to(post)
     end
   end
+
+  defp remote_in_reply_to(%{remote_reply_ref: %PostRemoteReply{} = ref})
+       when is_binary(ref.handle),
+       do: %{url: ref.in_reply_to_uri, author: ref.handle, network: "fediverse"}
+
+  defp remote_in_reply_to(_post), do: nil
 end

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -249,7 +249,7 @@ defmodule VutuvWeb.PostComponents do
       |> assign(:editable?, Posts.edit_window_open?(post))
       |> assign(:reporter?, user? and not Posts.author?(post, viewer))
       |> assign(:frozen?, post.frozen_at != nil)
-      |> assign(:reply_banner, reply_banner(post, assigns.show_reply_banner))
+      |> assign(:reply_banner, reply_banner(post, assigns.show_reply_banner, assigns[:viewer]))
       |> assign(:reposters, repost_roster(assigns))
       |> assign(
         :edited?,
@@ -1384,7 +1384,27 @@ defmodule VutuvWeb.PostComponents do
             origin={RemotePost.origin(@remote_post)}
             label={origin_label(@remote_post)}
             data-remote-origin
-          />
+          >
+            <%!-- Answering (issue #1165) sits beside where the post came from,
+            like the remote reply card's does. Only on an open post: an answer
+            is a public vutuv post, and republishing the audience a
+            followers-only post's author chose is not ours to do, so there is no
+            control rather than one that refuses. Shown to every signed-in
+            member including one who does not federate — the page behind it is
+            what explains why they cannot send yet. --%>
+            <span :if={@viewer && RemotePost.open?(@remote_post)}>
+              ·
+              <%!-- Padded to a finger-sized target rather than left as a
+              `text-xs` word: this is the card's second real action, and it sits
+              right beside a link that leaves the site — a mis-tap there is not
+              a small mistake. --%>
+              <.link
+                navigate={~p"/system/fediverse/reply/post/#{@remote_post.id}"}
+                data-remote-post-reply-link={@remote_post.id}
+                class="inline-flex min-h-10 items-center px-1 font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+              >{gettext("Reply")}</.link>
+            </span>
+          </.remote_footer>
         </div>
       </div>
     </article>
@@ -1427,6 +1447,121 @@ defmodule VutuvWeb.PostComponents do
       do: FediverseComponents.refusal_message(reason)
 
   def like_refusal_message(_reason), do: gettext("That did not work.")
+
+  @doc """
+  The chrome both "answer something on another network" pages wear: the reply
+  that arrived under one of the member's own posts
+  (`VutuvWeb.PostLive.RemoteReply`, issue #1070) and the post by an account they
+  follow (`VutuvWeb.PostLive.RemotePostReply`, issue #1165).
+
+  One definition, because what the two pages share is exactly what must never
+  drift between them: the sentence saying **before anybody types** that these
+  words leave the site, and the explanation a member who has not switched
+  Fediverse participation on gets instead of a hidden action. Each page still
+  brings what is genuinely its own — the card for the thing being answered, the
+  composer with its own context (and so its own save path), the way back, and
+  the one sentence that names what kind of thing is being answered.
+  """
+  attr(:id, :string, required: true, doc: "the page wrapper's id")
+  attr(:handle, :string, required: true, doc: "`@user@host` of the person being answered")
+
+  attr(:refusal, :atom,
+    default: nil,
+    doc:
+      "`:not_federating` puts the explanation where the composer would be; every other refusal redirects before this renders"
+  )
+
+  attr(:explanation, :string,
+    required: true,
+    doc: "why the words would leave the site, in the terms of this page's target"
+  )
+
+  attr(:back_href, :any, default: nil, doc: "the way back, or nil for no link")
+  attr(:back_label, :string, default: nil)
+
+  slot(:target, required: true, doc: "the remote card showing what is being answered")
+  slot(:composer, required: true)
+
+  def remote_answer_page(assigns) do
+    ~H"""
+    <div id={@id} class="py-6">
+      <div class="mx-auto max-w-2xl space-y-4">
+        <h1 class="text-2xl font-bold text-slate-800 dark:text-slate-100">
+          {gettext("Reply to %{handle}", handle: @handle)}
+        </h1>
+
+        <.card>{render_slot(@target)}</.card>
+
+        <%= if @refusal == :not_federating do %>
+          <.card>
+            <h2 class="mb-2 text-base font-semibold text-slate-900 dark:text-white">
+              {gettext("Turn on Fediverse participation to answer")}
+            </h2>
+            <p class="mb-3 text-sm text-slate-600 dark:text-slate-400">{@explanation}</p>
+            <.button navigate={~p"/settings/fediverse"}>
+              {gettext("Open Fediverse settings")}
+            </.button>
+          </.card>
+        <% else %>
+          <%!-- Said before they type, not after they send: the whole point of
+          the page is that nobody publishes to another network by accident. --%>
+          <p
+            data-remote-reply-notice
+            class="rounded-lg bg-brand-50 px-4 py-3 text-sm text-brand-800 dark:bg-brand-900/30 dark:text-brand-100"
+          >
+            {gettext(
+              "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well.",
+              handle: @handle
+            )}
+          </p>
+
+          {render_slot(@composer)}
+        <% end %>
+
+        <.link
+          :if={@back_href}
+          href={@back_href}
+          class="text-sm font-semibold text-brand-600 hover:text-brand-700"
+        >
+          {@back_label}
+        </.link>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  The sentence for one `{:error, reason}` that keeps a member off those pages
+  entirely (`Vutuv.Fediverse.check_remote_reply/2` and
+  `check_remote_post_reply/2` answer in one vocabulary, so one table covers
+  both). `:not_federating` is deliberately absent: it is the one refusal the
+  member can act on, so it gets the page and its explanation rather than a
+  sentence on the way out.
+
+  Its own table and not `like_refusal_message/1` beside it: a member who opened
+  a page in order to write something has asked why they cannot, where somebody
+  who pressed a heart while reading has not.
+  """
+  def answer_refusal_message(:note_not_public),
+    do: gettext("This reply was sent to you alone, so it cannot be answered publicly.")
+
+  def answer_refusal_message(:post_not_public),
+    do:
+      gettext(
+        "This post was published to that account's followers only, so it cannot be answered with a public post here."
+      )
+
+  def answer_refusal_message(:instance_blocked),
+    do: gettext("That server is blocked on this site, so no answer can be sent to it.")
+
+  def answer_refusal_message(:moved),
+    do:
+      gettext(
+        "You moved your Fediverse account to another server, so answers are no longer sent from here."
+      )
+
+  def answer_refusal_message(_disabled),
+    do: gettext("This site does not take part in the Fediverse.")
 
   # A card names the post it answers only when its position alone does not say
   # it. While the thread still indents, the nesting says it. Past
@@ -1810,6 +1945,25 @@ defmodule VutuvWeb.PostComponents do
             <.link href={~p"/#{parent_author}"} class="hover:text-brand-700">
               {gettext("Reply to a now-deleted post by %{handle}", handle: handle(parent_author))}
             </.link>
+          </.reply_banner_line>
+        <% {:remote, remote_handle, remote_account_id} -> %>
+          <%!-- Answering a post on another network (issue #1165). The link goes
+          to that account's page *here* rather than out to their server: the
+          reader is one click from the same context the answer's author had,
+          without leaving the site and without an outbound request. It degrades
+          to plain text once our copy of the post has expired, since the account
+          is reached through the post. --%>
+          <.reply_banner_line variant="remote">
+            <.link
+              :if={remote_account_id}
+              navigate={~p"/system/fediverse/account/#{remote_account_id}"}
+              class="hover:text-brand-700"
+            >
+              {gettext("Replying to %{handle}", handle: remote_handle)}
+            </.link>
+            <span :if={!remote_account_id}>
+              {gettext("Replying to %{handle}", handle: remote_handle)}
+            </span>
           </.reply_banner_line>
         <% :gone -> %>
           <.reply_banner_line variant="gone">
@@ -2909,15 +3063,42 @@ defmodule VutuvWeb.PostComponents do
   # Pattern-match the structs: an un-preloaded has_one is a truthy
   # %Ecto.Association.NotLoaded{}. `show?` is false where the caller already
   # shows the parent post inline (the profile thread), so the banner is dropped.
-  defp reply_banner(_post, false), do: nil
-  defp reply_banner(post, true), do: reply_banner(post)
+  defp reply_banner(_post, false, _viewer), do: nil
+  defp reply_banner(post, true, viewer), do: reply_banner(post, viewer)
 
-  defp reply_banner(post) do
+  defp reply_banner(post, viewer) do
     case Posts.reply_ref_state(post) do
       {:parent, parent} -> {:parent, parent.user, Posts.path(parent)}
+      # A top-level post that answers a post on another network (issue #1165)
+      # has no local parent at all, so its "Replying to" line comes from the
+      # sidecar instead. Only ever reached when there is no local reply ref: an
+      # answer to a *reply* (issue #1070) is a real reply here and shows the
+      # local parent, which is the more useful of the two.
+      nil -> remote_reply_banner(post, viewer)
       state -> state
     end
   end
+
+  # The account behind the post, not the post: the line is about *who* is being
+  # answered, and its link is the reader's way to that person's page here. It
+  # degrades to plain text once our six-month copy of the post has expired,
+  # which is also when the account row may have been swept — the handle stays,
+  # because the sidecar keeps its own copy of it.
+  defp remote_reply_banner(%{remote_reply_ref: %PostRemoteReply{handle: handle} = ref}, viewer)
+       when is_binary(handle),
+       # The account page behind the link is signed-in only, so a logged-out
+       # reader of this answer's public permalink gets the fact without a link
+       # into a login wall. The handle is the fact; the link is a convenience.
+       do: {:remote, handle, viewer && remote_account_id(ref)}
+
+  defp remote_reply_banner(_post, _viewer), do: nil
+
+  defp remote_account_id(%PostRemoteReply{
+         remote_post: %RemotePost{remote_account: %RemoteAccount{id: id}}
+       }),
+       do: id
+
+  defp remote_account_id(%PostRemoteReply{}), do: nil
 
   # Reply system messages name the account handle, never the clear name.
   defp handle(%User{username: username}), do: "@" <> username

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -56,6 +56,7 @@ defmodule VutuvWeb.PostLive.Composer do
 
   alias Vutuv.BookMetadata
   alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Posts
   alias Vutuv.Posts.PhotoLicense
   alias Vutuv.Posts.Post
@@ -96,6 +97,7 @@ defmodule VutuvWeb.PostLive.Composer do
           :post,
           :parent,
           :remote_note,
+          :remote_post,
           :initial_body
         ])
       )
@@ -121,6 +123,10 @@ defmodule VutuvWeb.PostLive.Composer do
     # Set when this composer answers a reply from another network (issue #1070);
     # it then saves through Posts.create_remote_reply/3 instead.
     |> assign_new(:remote_note, fn -> nil end)
+    # …and this one when it answers a post by an account the member follows
+    # (issue #1165): Posts.create_remote_post_reply/3, a top-level post rather
+    # than a reply.
+    |> assign_new(:remote_post, fn -> nil end)
     # Reposted or answered posts carry other people's shares and replies:
     # the audience is pinned to public (Posts.update_post/2 enforces it; the
     # select disappears).
@@ -193,9 +199,14 @@ defmodule VutuvWeb.PostLive.Composer do
   # The edit page is deliberately draft-free: its composer opens full of a
   # *published* post, and silently restoring a weeks-old unsaved edit over text
   # other people have already read is a different promise from keeping a draft.
-  defp draftable?(assigns), do: assigns[:post] == nil
+  defp draftable?(assigns), do: assigns[:post] == nil and assigns[:remote_post] == nil
 
   # Which composer this is, in the terms `Vutuv.Posts` keys drafts by.
+  # Which composer this is, in the terms `Vutuv.Posts` keys drafts by. The
+  # answer-to-a-followed-post composer (issue #1165) is deliberately absent: it
+  # is not a draft context, for the blue/green reason `Posts.draft_key/1`
+  # spells out. `draftable?/1` keeps it from autosaving into the feed
+  # composer's row.
   defp draft_context(assigns), do: assigns[:parent] || assigns[:remote_note]
 
   defp restore_draft(socket) do
@@ -879,14 +890,31 @@ defmodule VutuvWeb.PostLive.Composer do
     socket
   end
 
-  defp feed_composer?(assigns),
-    do: is_nil(assigns.post) and is_nil(assigns.parent) and is_nil(assigns.remote_note)
+  # The standalone composer on /feed: not editing a post, and answering nothing —
+  # which is exactly "no draft context", so a new context is added in one place
+  # (`draft_context/1`) rather than in every list of nils.
+  # Deliberately spelled out rather than derived from `draft_context/1`, though
+  # the two look interchangeable: "is this the feed's own composer" and "does
+  # this composer keep drafts" are different questions that merely coincided
+  # until issue #1165 added a composer that is neither. Defining one in terms of
+  # the other put the feed's ✕ back on the answer page, where nothing handles
+  # `close-composer` and a click therefore kills the LiveView.
+  defp feed_composer?(assigns) do
+    is_nil(assigns.post) and is_nil(assigns.parent) and is_nil(assigns.remote_note) and
+      is_nil(assigns.remote_post)
+  end
 
   # Answering a reply from another network goes through its own context function:
   # it writes the sidecar that carries the answer out to that network, and it
   # holds the federation gates (issue #1070).
   defp save_post(%{post: nil, remote_note: %Note{} = note, current_user: author}, attrs),
     do: Posts.create_remote_reply(author, note, attrs)
+
+  # Answering a post by a followed account (issue #1165). Not a reply to
+  # anything here — the thing answered lives on another server — so what this
+  # creates is a top-level post carrying the same sidecar.
+  defp save_post(%{post: nil, remote_post: %RemotePost{} = post, current_user: author}, attrs),
+    do: Posts.create_remote_post_reply(author, post, attrs)
 
   defp save_post(%{post: nil, parent: %Post{} = parent, current_user: author}, attrs),
     do: Posts.create_reply(author, parent, attrs)
@@ -905,7 +933,7 @@ defmodule VutuvWeb.PostLive.Composer do
       socket.assigns.post ->
         {:noreply, push_navigate(socket, to: Posts.path(post))}
 
-      socket.assigns[:remote_note] ->
+      socket.assigns[:remote_note] || socket.assigns[:remote_post] ->
         # An answer to a remote reply has no `parent` assign of its own, so its
         # own permalink is the way back into that conversation.
         {:noreply, push_navigate(socket, to: Posts.path(post))}
@@ -980,11 +1008,14 @@ defmodule VutuvWeb.PostLive.Composer do
         "You have sent a lot of answers to other networks in the past hour. Please try again later."
       )
 
-  defp save_error_message(:instance_blocked),
-    do: gettext("That server is blocked on this site, so no answer can be sent to it.")
-
-  defp save_error_message(:note_not_public),
-    do: gettext("This reply was sent to you alone, so it cannot be answered publicly.")
+  # The three the answer page itself refuses with, in the page's own words
+  # (`PostComponents.answer_refusal_message/1`): the audience of the thing being
+  # answered can narrow while the form sits open (an `Update` arrives), and the
+  # operator can block the server in that same window. A refusal must not be
+  # worded one way on the page and another way on save.
+  defp save_error_message(reason)
+       when reason in [:instance_blocked, :note_not_public, :post_not_public],
+       do: PostComponents.answer_refusal_message(reason)
 
   defp save_error_message(reason) when reason in [:not_federating, :moved, :fediverse_disabled],
     do: gettext("Your Fediverse settings do not allow sending an answer right now.")
@@ -1201,7 +1232,7 @@ defmodule VutuvWeb.PostLive.Composer do
           remote-reply page has no close handler and a click there crashed
           the page). --%>
           <div
-            :if={@post == nil and @parent == nil and @remote_note == nil}
+            :if={feed_composer?(assigns)}
             class="-mt-1 mb-2 flex items-center justify-end gap-1"
           >
             <button

--- a/lib/vutuv_web/live/post_live/remote_post_reply.ex
+++ b/lib/vutuv_web/live/post_live/remote_post_reply.ex
@@ -1,0 +1,116 @@
+defmodule VutuvWeb.PostLive.RemotePostReply do
+  @moduledoc """
+  Answering a post by an account the member follows on another network (issue
+  #1165) — the sibling of `VutuvWeb.PostLive.RemoteReply`, which answers a reply
+  that arrived under one of the member's own posts.
+
+  The two pages look and behave the same on purpose, and share one definition of
+  it (`VutuvWeb.PostComponents.remote_answer_page/1`): the thing being answered
+  above in its own remote card, the plain sentence about where the words are
+  going stated **before** anybody types, the same composer below, and the same
+  treatment of a member who has not switched Fediverse participation on (the
+  page explains and links to the setting rather than hiding the action).
+
+  What differs is underneath. There is no vutuv post beneath this one: the post
+  being answered lives entirely on somebody else's server, so what gets created
+  is a **top-level vutuv post** carrying the remote-target sidecar. Hence "Back
+  to the feed" rather than "Back to the conversation" — there is no conversation
+  here to go back to, and the answer's own permalink is where the member lands
+  after sending.
+
+  One gate is stricter than the reply page's: a **followers-only** post cannot be
+  answered at all. The answer is a public vutuv post, and republishing the
+  audience its author deliberately narrowed is not ours to do — so the card
+  offers no Reply there in the first place, and this page refuses if somebody
+  reaches it anyway.
+  """
+
+  use VutuvWeb, :live_view
+
+  import VutuvWeb.PostComponents
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+
+  on_mount({VutuvWeb.Live.InitAssigns, :require_login})
+
+  @impl true
+  def mount(%{"id" => id}, _session, socket) do
+    viewer = socket.assigns.current_user
+    post = Fediverse.get_remote_post(id)
+
+    # Readable, not merely present: this page shows the post it is about, so the
+    # same rule that decides whether a member may see it at all decides whether
+    # this page exists for them. Anything else is a 404, so nothing leaks.
+    if post && Fediverse.remote_post_readable?(post, viewer) do
+      {:ok, assign_gate(socket, post, viewer)}
+    else
+      {:ok, not_found(socket)}
+    end
+  end
+
+  defp assign_gate(socket, %RemotePost{} = post, viewer) do
+    handle = RemoteAccount.display_handle(post.remote_account)
+
+    socket =
+      socket
+      |> assign(:page_title, gettext("Reply to %{handle}", handle: handle))
+      |> assign(:remote_post, post)
+      |> assign(:handle, handle)
+
+    case Fediverse.check_remote_post_reply(viewer, post) do
+      :ok ->
+        assign(socket, :refusal, nil)
+
+      # The one refusal the member can act on, so it gets the page rather than
+      # a redirect: hiding it would leave them with no way to find out that
+      # answering exists and is one setting away.
+      {:error, :not_federating} ->
+        assign(socket, :refusal, :not_federating)
+
+      {:error, reason} ->
+        socket
+        |> put_flash(:error, answer_refusal_message(reason))
+        |> redirect(to: ~p"/feed")
+    end
+  end
+
+  defp not_found(socket) do
+    socket
+    |> put_flash(:error, gettext("Sorry, that page could not be found."))
+    |> redirect(to: ~p"/")
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.remote_answer_page
+      id="remote-post-reply"
+      handle={@handle}
+      refusal={@refusal}
+      explanation={
+        gettext(
+          "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
+        )
+      }
+      back_href={~p"/feed"}
+      back_label={gettext("Back to the feed")}
+    >
+      <:target>
+        <.remote_post_card remote_post={@remote_post} viewer={@current_user} />
+      </:target>
+      <:composer>
+        <.live_component
+          module={VutuvWeb.PostLive.Composer}
+          id="composer"
+          current_user={@current_user}
+          post={nil}
+          parent={nil}
+          remote_post={@remote_post}
+        />
+      </:composer>
+    </.remote_answer_page>
+    """
+  end
+end

--- a/lib/vutuv_web/live/post_live/remote_reply.ex
+++ b/lib/vutuv_web/live/post_live/remote_reply.ex
@@ -69,7 +69,7 @@ defmodule VutuvWeb.PostLive.RemoteReply do
 
       {:error, reason} ->
         socket
-        |> put_flash(:error, refusal_message(reason))
+        |> put_flash(:error, answer_refusal_message(reason))
         |> redirect(to: Posts.path(socket.assigns.post))
     end
   end
@@ -80,80 +80,35 @@ defmodule VutuvWeb.PostLive.RemoteReply do
     |> redirect(to: ~p"/")
   end
 
-  defp refusal_message(:note_not_public),
-    do: gettext("This reply was sent to you alone, so it cannot be answered publicly.")
-
-  defp refusal_message(:instance_blocked),
-    do: gettext("That server is blocked on this site, so no answer can be sent to it.")
-
-  defp refusal_message(:moved),
-    do:
-      gettext(
-        "You moved your Fediverse account to another server, so answers are no longer sent from here."
-      )
-
-  defp refusal_message(_disabled),
-    do: gettext("This site does not take part in the Fediverse.")
-
   @impl true
   def render(assigns) do
     ~H"""
-    <div id="remote-reply" class="py-6">
-      <div class="mx-auto max-w-2xl space-y-4">
-        <h1 class="text-2xl font-bold text-slate-800 dark:text-slate-100">
-          {gettext("Reply to %{handle}", handle: Note.display_handle(@note))}
-        </h1>
-
-        <.card>
-          <.remote_reply_card note={@note} viewer={@current_user} />
-        </.card>
-
-        <%= if @refusal == :not_federating do %>
-          <.card>
-            <h2 class="mb-2 text-base font-semibold text-slate-900 dark:text-white">
-              {gettext("Turn on Fediverse participation to answer")}
-            </h2>
-            <p class="mb-3 text-sm text-slate-600 dark:text-slate-400">
-              {gettext(
-                "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
-              )}
-            </p>
-            <.button navigate={~p"/settings/fediverse"}>
-              {gettext("Open Fediverse settings")}
-            </.button>
-          </.card>
-        <% else %>
-          <%!-- Said before they type, not after they send: the whole point of the
-          page is that nobody publishes to another network by accident. --%>
-          <p
-            data-remote-reply-notice
-            class="rounded-lg bg-brand-50 px-4 py-3 text-sm text-brand-800 dark:bg-brand-900/30 dark:text-brand-100"
-          >
-            {gettext(
-              "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well.",
-              handle: Note.display_handle(@note)
-            )}
-          </p>
-
-          <.live_component
-            module={VutuvWeb.PostLive.Composer}
-            id="composer"
-            current_user={@current_user}
-            post={nil}
-            parent={nil}
-            remote_note={@note}
-          />
-        <% end %>
-
-        <.link
-          :if={@post}
-          href={Posts.path(@post)}
-          class="text-sm font-semibold text-brand-600 hover:text-brand-700"
-        >
-          {gettext("Back to the conversation")}
-        </.link>
-      </div>
-    </div>
+    <.remote_answer_page
+      id="remote-reply"
+      handle={Note.display_handle(@note)}
+      refusal={@refusal}
+      explanation={
+        gettext(
+          "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
+        )
+      }
+      back_href={@post && Posts.path(@post)}
+      back_label={gettext("Back to the conversation")}
+    >
+      <:target>
+        <.remote_reply_card note={@note} viewer={@current_user} />
+      </:target>
+      <:composer>
+        <.live_component
+          module={VutuvWeb.PostLive.Composer}
+          id="composer"
+          current_user={@current_user}
+          post={nil}
+          parent={nil}
+          remote_note={@note}
+        />
+      </:composer>
+    </.remote_answer_page>
     """
   end
 end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -464,16 +464,21 @@ defmodule VutuvWeb.Router do
       live("/posts/:id/edit", PostLive.Edit, :edit)
       live("/posts/:id/reply", PostLive.Reply, :new)
 
-      # The two signed-in Fediverse pages that are not settings: answering a
-      # reply from another network (issue #1070) and the page for one remote
-      # account (issue #1162). Under /system/ rather than a new root word, which
+      # The signed-in Fediverse pages that are not settings: answering a reply
+      # that arrived under one's own post (issue #1070), answering a post by a
+      # followed account (issue #1165) and the page for one remote account
+      # (issue #1162). Under /system/ rather than a new root word, which
       # profiles own; "system" is already reserved, so this burns no handle.
-      # `:noindex_pipe` because both are assembled from things other people
-      # wrote on other servers.
+      # `:noindex_pipe` because all of them are assembled from things other
+      # people wrote on other servers.
+      #
+      # The two reply routes differ in segment count, so neither shadows the
+      # other, and each keeps the id space of its own table.
       scope "/system/fediverse" do
         pipe_through(:noindex_pipe)
 
         live("/reply/:id", PostLive.RemoteReply, :new)
+        live("/reply/post/:id", PostLive.RemotePostReply, :new)
         live("/account/:id", FediverseAccountLive, :show)
       end
 

--- a/lib/vutuv_web/views/post_json.ex
+++ b/lib/vutuv_web/views/post_json.ex
@@ -39,9 +39,11 @@ defmodule VutuvWeb.PostJSON do
     }
   end
 
-  # The reply reference mirrors the card banner's three states: a live
-  # parent, a deleted post whose author still exists, or nothing nameable
-  # once the account is gone too. `nil` when the post is not a reply.
+  # The reply reference mirrors the card banner's states: a live parent, a
+  # deleted post whose author still exists, nothing nameable once the account is
+  # gone too, or — for an answer to a post on another network (issue #1165) —
+  # the origin URI and the handle it threads under over there. `nil` when the
+  # post answers nothing.
   defp in_reply_to(post) do
     case Posts.reply_ref_state(post) do
       {:parent, parent} ->
@@ -58,9 +60,15 @@ defmodule VutuvWeb.PostJSON do
         %{post_id: nil, url: nil, author: nil}
 
       nil ->
-        nil
+        remote_in_reply_to(post)
     end
   end
+
+  defp remote_in_reply_to(%{remote_reply_ref: %Vutuv.Posts.PostRemoteReply{} = ref})
+       when is_binary(ref.handle),
+       do: %{post_id: nil, url: ref.in_reply_to_uri, author: ref.handle, network: "fediverse"}
+
+  defp remote_in_reply_to(_post), do: nil
 
   # AI-moderation limbo filter: released for everyone, everything for the
   # author and admins (the proxy enforces the same rule on the bytes).

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.181.0",
+      version: "7.182.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -154,7 +154,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:1897
+#: lib/vutuv_web/components/post_components.ex:2051
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -195,7 +195,7 @@ msgid "Disable"
 msgstr "Inaktivieren"
 
 #: lib/vutuv_web/live/cv_live.ex:439
-#: lib/vutuv_web/live/post_live/composer.ex:1421
+#: lib/vutuv_web/live/post_live/composer.ex:1452
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:303
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -203,7 +203,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:1862
+#: lib/vutuv_web/components/post_components.ex:2016
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -615,7 +615,7 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1650
+#: lib/vutuv_web/live/post_live/composer.ex:1681
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -625,7 +625,7 @@ msgstr "Öffentlich"
 
 #: lib/vutuv_web/components/ui.ex:2863
 #: lib/vutuv_web/live/organization_live/edit.ex:339
-#: lib/vutuv_web/live/post_live/composer.ex:1659
+#: lib/vutuv_web/live/post_live/composer.ex:1690
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:105
@@ -1697,13 +1697,13 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/post_components.ex:2339
+#: lib/vutuv_web/components/post_components.ex:2493
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1221
-#: lib/vutuv_web/live/post_live/composer.ex:1222
-#: lib/vutuv_web/live/post_live/composer.ex:2043
+#: lib/vutuv_web/live/post_live/composer.ex:1252
+#: lib/vutuv_web/live/post_live/composer.ex:1253
+#: lib/vutuv_web/live/post_live/composer.ex:2074
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -2161,7 +2161,7 @@ msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1798
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
@@ -2172,7 +2172,7 @@ msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1341
+#: lib/vutuv_web/live/post_live/composer.ex:1372
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2182,7 +2182,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:1894
+#: lib/vutuv_web/components/post_components.ex:2048
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2213,29 +2213,29 @@ msgstr "Folgen Sie %{name}, um ihn zu lesen."
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1743
+#: lib/vutuv_web/live/post_live/composer.ex:1774
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1671
+#: lib/vutuv_web/live/post_live/composer.ex:1702
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:1848
-#: lib/vutuv_web/components/post_components.ex:1850
+#: lib/vutuv_web/components/post_components.ex:2002
+#: lib/vutuv_web/components/post_components.ex:2004
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1713
+#: lib/vutuv_web/live/post_live/composer.ex:1744
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:993
-#: lib/vutuv_web/live/post_live/composer.ex:1041
+#: lib/vutuv_web/live/post_live/composer.ex:1024
+#: lib/vutuv_web/live/post_live/composer.ex:1072
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
@@ -2247,23 +2247,23 @@ msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:969
+#: lib/vutuv_web/live/post_live/composer.ex:997
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1703
+#: lib/vutuv_web/live/post_live/composer.ex:1734
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1693
+#: lib/vutuv_web/live/post_live/composer.ex:1724
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1659
+#: lib/vutuv_web/live/post_live/composer.ex:1690
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2274,7 +2274,7 @@ msgstr "Posten"
 msgid "Post deleted successfully."
 msgstr "Beitrag erfolgreich gelöscht."
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:126
+#: lib/vutuv_web/agent_docs/post_doc.ex:127
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/user_controller.ex:76
@@ -2291,13 +2291,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2277
-#: lib/vutuv_web/components/post_components.ex:2281
+#: lib/vutuv_web/components/post_components.ex:2431
+#: lib/vutuv_web/components/post_components.ex:2435
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:2278
+#: lib/vutuv_web/components/post_components.ex:2432
 #: lib/vutuv_web/live/fediverse_account_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2309,7 +2309,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:1729
+#: lib/vutuv_web/live/post_live/composer.ex:1760
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2325,7 +2325,7 @@ msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1657
+#: lib/vutuv_web/live/post_live/composer.ex:1688
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
@@ -2339,18 +2339,19 @@ msgstr[1] "%{formatted} neue Beiträge anzeigen"
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:75
 #: lib/vutuv_web/live/post_live/edit.ex:36
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:81
 #: lib/vutuv_web/live/post_live/remote_reply.ex:79
 #: lib/vutuv_web/live/post_live/reply.ex:41
 #, elixir-autogen, elixir-format
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1067
+#: lib/vutuv_web/live/post_live/composer.ex:1098
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:951
+#: lib/vutuv_web/live/post_live/composer.ex:979
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
@@ -2360,12 +2361,12 @@ msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2178
+#: lib/vutuv_web/live/post_live/composer.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2210
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
@@ -2379,37 +2380,37 @@ msgstr "Upload fehlgeschlagen."
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1810
+#: lib/vutuv_web/live/post_live/composer.ex:1841
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1811
+#: lib/vutuv_web/live/post_live/composer.ex:1842
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:1845
+#: lib/vutuv_web/components/post_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:3406
+#: lib/vutuv_web/components/post_components.ex:3587
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:3410
+#: lib/vutuv_web/components/post_components.ex:3591
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:3408
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:3409
+#: lib/vutuv_web/components/post_components.ex:3590
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2420,17 +2421,17 @@ msgstr "Personen, denen Sie nicht folgen"
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1478
+#: lib/vutuv_web/live/post_live/composer.ex:1509
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr "Tags, durch Komma oder Leerzeichen getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2169
+#: lib/vutuv_web/live/post_live/composer.ex:2200
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2173
+#: lib/vutuv_web/live/post_live/composer.ex:2204
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
@@ -2450,7 +2451,7 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3490
+#: lib/vutuv_web/components/post_components.ex:3671
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2470,7 +2471,7 @@ msgid "Bookmarks"
 msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:1377
-#: lib/vutuv_web/components/post_components.ex:3713
+#: lib/vutuv_web/components/post_components.ex:3894
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
@@ -2481,7 +2482,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:926
-#: lib/vutuv_web/components/post_components.ex:3722
+#: lib/vutuv_web/components/post_components.ex:3903
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2501,12 +2502,12 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:3479
+#: lib/vutuv_web/components/post_components.ex:3660
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:3490
+#: lib/vutuv_web/components/post_components.ex:3671
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2515,23 +2516,23 @@ msgstr "Nur öffentliche Beiträge können repostet werden."
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:3476
+#: lib/vutuv_web/components/post_components.ex:3657
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:2891
+#: lib/vutuv_web/components/post_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3476
+#: lib/vutuv_web/components/post_components.ex:3657
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:3713
+#: lib/vutuv_web/components/post_components.ex:3894
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2555,7 +2556,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:3762
+#: lib/vutuv_web/components/post_components.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2567,26 +2568,27 @@ msgid "Replies"
 msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:898
-#: lib/vutuv_web/components/post_components.ex:3745
-#: lib/vutuv_web/components/post_components.ex:3746
+#: lib/vutuv_web/components/post_components.ex:1405
+#: lib/vutuv_web/components/post_components.ex:3926
+#: lib/vutuv_web/components/post_components.ex:3927
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1816
+#: lib/vutuv_web/components/post_components.ex:1970
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:954
-#: lib/vutuv_web/live/post_live/composer.ex:1647
+#: lib/vutuv_web/live/post_live/composer.ex:982
+#: lib/vutuv_web/live/post_live/composer.ex:1678
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empfängerkreis nicht einschränken."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1774
+#: lib/vutuv_web/live/post_live/composer.ex:1805
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
@@ -2596,19 +2598,22 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
+#: lib/vutuv_web/components/post_components.ex:1490
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:58
 #: lib/vutuv_web/live/post_live/remote_reply.ex:57
-#: lib/vutuv_web/live/post_live/remote_reply.ex:104
 #: lib/vutuv_web/live/post_live/reply.ex:52
 #, elixir-autogen, elixir-format
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1811
+#: lib/vutuv_web/components/post_components.ex:1946
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:1805
+#: lib/vutuv_web/components/post_components.ex:1940
+#: lib/vutuv_web/components/post_components.ex:1962
+#: lib/vutuv_web/components/post_components.ex:1965
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2891,7 +2896,7 @@ msgstr "Noch keine Vernetzungen."
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1683
+#: lib/vutuv_web/live/post_live/composer.ex:1714
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
@@ -2914,7 +2919,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:3407
+#: lib/vutuv_web/components/post_components.ex:3588
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3193,7 +3198,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:1781
+#: lib/vutuv_web/components/post_components.ex:1916
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3274,7 +3279,7 @@ msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
 #: lib/vutuv_web/components/post_components.ex:868
 #: lib/vutuv_web/components/post_components.ex:1324
-#: lib/vutuv_web/components/post_components.ex:1918
+#: lib/vutuv_web/components/post_components.ex:2072
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4060,7 +4065,7 @@ msgstr "Mitglieder mit den meisten Followern"
 msgid "People %{name} follows"
 msgstr "Wem %{name} folgt"
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:127
+#: lib/vutuv_web/agent_docs/post_doc.ex:128
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr "Beitragsarchiv von %{name}"
@@ -5538,7 +5543,7 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:972
+#: lib/vutuv_web/live/post_live/composer.ex:1000
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
@@ -5657,9 +5662,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:1981
-#: lib/vutuv_web/components/post_components.ex:2033
-#: lib/vutuv_web/components/post_components.ex:2414
+#: lib/vutuv_web/components/post_components.ex:2135
+#: lib/vutuv_web/components/post_components.ex:2187
+#: lib/vutuv_web/components/post_components.ex:2568
 #: lib/vutuv_web/live/notification_live/index.ex:601
 #: lib/vutuv_web/live/post_live/feed.ex:1067
 #, elixir-autogen, elixir-format
@@ -6954,7 +6959,7 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:1915
+#: lib/vutuv_web/components/post_components.ex:2069
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6964,7 +6969,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:1914
+#: lib/vutuv_web/components/post_components.ex:2068
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7671,7 +7676,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
-#: lib/vutuv_web/components/post_components.ex:3635
+#: lib/vutuv_web/components/post_components.ex:3816
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -9288,7 +9293,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:2894
+#: lib/vutuv_web/components/post_components.ex:3048
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -13836,7 +13841,7 @@ msgid "Search title, poster or organization"
 msgstr "Titel, Ersteller oder Organisation suchen"
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1550
+#: lib/vutuv_web/live/post_live/composer.ex:1581
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
@@ -13972,7 +13977,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:1429
+#: lib/vutuv_web/components/post_components.ex:1449
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -14359,7 +14364,7 @@ msgstr "Volle Breite"
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2148
+#: lib/vutuv_web/live/post_live/composer.ex:2179
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
@@ -14588,129 +14593,129 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:3269
+#: lib/vutuv_web/components/post_components.ex:3450
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1558
+#: lib/vutuv_web/live/post_live/composer.ex:1589
 #, elixir-autogen, elixir-format
 msgid "Author(s)"
 msgstr "Autor(en)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1628
+#: lib/vutuv_web/live/post_live/composer.ex:1659
 #, elixir-autogen, elixir-format
 msgid "Book"
 msgstr "Buch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:973
-#: lib/vutuv_web/components/post_components.ex:3226
-#: lib/vutuv_web/live/post_live/composer.ex:1504
+#: lib/vutuv_web/components/post_components.ex:3407
+#: lib/vutuv_web/live/post_live/composer.ex:1535
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:3270
+#: lib/vutuv_web/components/post_components.ex:3451
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:3272
+#: lib/vutuv_web/components/post_components.ex:3453
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1558
+#: lib/vutuv_web/live/post_live/composer.ex:1589
 #, elixir-autogen, elixir-format
 msgid "Director"
 msgstr "Regie"
 
-#: lib/vutuv_web/components/post_components.ex:3268
+#: lib/vutuv_web/components/post_components.ex:3449
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1640
+#: lib/vutuv_web/live/post_live/composer.ex:1671
 #, elixir-autogen, elixir-format
 msgid "Film"
 msgstr "Film"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:973
-#: lib/vutuv_web/components/post_components.ex:3225
-#: lib/vutuv_web/live/post_live/composer.ex:1503
+#: lib/vutuv_web/components/post_components.ex:3406
+#: lib/vutuv_web/live/post_live/composer.ex:1534
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1524
+#: lib/vutuv_web/live/post_live/composer.ex:1555
 #, elixir-autogen, elixir-format
 msgid "IMDb link or ID"
 msgstr "IMDb-Link oder -ID"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1525
+#: lib/vutuv_web/live/post_live/composer.ex:1556
 #, elixir-autogen, elixir-format
 msgid "ISBN"
 msgstr "ISBN"
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:418
-#: lib/vutuv_web/live/post_live/composer.ex:1538
+#: lib/vutuv_web/live/post_live/composer.ex:1569
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1535
+#: lib/vutuv_web/live/post_live/composer.ex:1566
 #, elixir-autogen, elixir-format
 msgid "Looking up…"
 msgstr "Wird nachgeschlagen …"
 
-#: lib/vutuv_web/live/post_live/composer.ex:617
+#: lib/vutuv_web/live/post_live/composer.ex:628
 #, elixir-autogen, elixir-format
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr "Zu dieser ISBN wurde nichts gefunden. Bitte füllen Sie die Felder selbst aus."
 
-#: lib/vutuv_web/components/post_components.ex:3267
+#: lib/vutuv_web/components/post_components.ex:3448
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:1608
 #, elixir-autogen, elixir-format
 msgid "Read as… (optional)"
 msgstr "Gelesen als … (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1513
+#: lib/vutuv_web/live/post_live/composer.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Remove review"
 msgstr "Besprechung entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1624
-#: lib/vutuv_web/live/post_live/composer.ex:1625
+#: lib/vutuv_web/live/post_live/composer.ex:1655
+#: lib/vutuv_web/live/post_live/composer.ex:1656
 #, elixir-autogen, elixir-format
 msgid "Review a book"
 msgstr "Ein Buch besprechen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1636
-#: lib/vutuv_web/live/post_live/composer.ex:1637
+#: lib/vutuv_web/live/post_live/composer.ex:1667
+#: lib/vutuv_web/live/post_live/composer.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Review a film"
 msgstr "Einen Film besprechen"
 
-#: lib/vutuv_web/components/post_components.ex:3271
+#: lib/vutuv_web/components/post_components.ex:3452
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1576
+#: lib/vutuv_web/live/post_live/composer.ex:1607
 #, elixir-autogen, elixir-format
 msgid "Watched as… (optional)"
 msgstr "Gesehen als … (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1590
+#: lib/vutuv_web/live/post_live/composer.ex:1621
 #, elixir-autogen, elixir-format
 msgid "With an ISBN, the post shows the book cover and a shop link automatically."
 msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1570
+#: lib/vutuv_web/live/post_live/composer.ex:1601
 #: lib/vutuv_web/templates/education/form_content.html.heex:47
 #: lib/vutuv_web/templates/education/form_content.html.heex:48
 #: lib/vutuv_web/templates/education/form_content.html.heex:67
@@ -14726,34 +14731,34 @@ msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:3308
+#: lib/vutuv_web/components/post_components.ex:3489
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:3338
+#: lib/vutuv_web/components/post_components.ex:3519
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:3339
+#: lib/vutuv_web/components/post_components.ex:3520
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:3337
+#: lib/vutuv_web/components/post_components.ex:3518
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:3297
+#: lib/vutuv_web/components/post_components.ex:3478
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:3344
+#: lib/vutuv_web/components/post_components.ex:3525
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14783,7 +14788,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3111
+#: lib/vutuv_web/components/post_components.ex:3292
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14831,7 +14836,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:3102
+#: lib/vutuv_web/components/post_components.ex:3283
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -15127,13 +15132,13 @@ msgstr "Erwähnung"
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:959
+#: lib/vutuv_web/live/post_live/composer.ex:987
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten: jemand hat ihn geliked, geteilt oder beantwortet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:962
+#: lib/vutuv_web/live/post_live/composer.ex:990
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -15229,14 +15234,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1561
+#: lib/vutuv_web/components/post_components.ex:1696
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1583
+#: lib/vutuv_web/components/post_components.ex:1718
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -15263,7 +15268,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:3721
+#: lib/vutuv_web/components/post_components.ex:3902
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -16446,21 +16451,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:3680
+#: lib/vutuv_web/components/post_components.ex:3861
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3684
+#: lib/vutuv_web/components/post_components.ex:3865
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:3688
+#: lib/vutuv_web/components/post_components.ex:3869
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16468,7 +16473,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:945
-#: lib/vutuv_web/components/post_components.ex:3639
+#: lib/vutuv_web/components/post_components.ex:3820
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16561,7 +16566,7 @@ msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1106
 #: lib/vutuv_web/components/post_components.ex:884
-#: lib/vutuv_web/components/post_components.ex:1397
+#: lib/vutuv_web/components/post_components.ex:1417
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -17241,22 +17246,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:1793
+#: lib/vutuv_web/components/post_components.ex:1928
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:1881
+#: lib/vutuv_web/components/post_components.ex:2035
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:1889
+#: lib/vutuv_web/components/post_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:1875
+#: lib/vutuv_web/components/post_components.ex:2029
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17306,12 +17311,12 @@ msgstr ""
 "in eckigen Klammern, wie eine Lautschrift geschrieben wird; die Klammern "
 "ergänzen wir für Sie. Bleibt das Feld leer, wird nichts angezeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2161
+#: lib/vutuv_web/live/post_live/composer.ex:2192
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Diese Einstellungen für alle Fotos übernehmen"
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:153
+#: lib/vutuv_web/live/post_live/remote_reply.ex:96
 #, elixir-autogen, elixir-format
 msgid "Back to the conversation"
 msgstr "Zurück zum Beitrag"
@@ -17336,192 +17341,190 @@ msgstr "CC BY-SA 4.0 (Namensnennung, gleiche Bedingungen)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1880
+#: lib/vutuv_web/live/post_live/composer.ex:1911
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Titelbild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2035
+#: lib/vutuv_web/live/post_live/composer.ex:2066
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1034
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:2342
+#: lib/vutuv_web/components/post_components.ex:2496
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1329
+#: lib/vutuv_web/live/post_live/composer.ex:1360
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr "Zum Umsortieren ziehen. Das erste Foto führt die Galerie an."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2111
+#: lib/vutuv_web/live/post_live/composer.ex:2142
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr "Alle Metadaten bleiben erhalten, auch alles, was Ihre Kamera hineingeschrieben hat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2068
+#: lib/vutuv_web/live/post_live/composer.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Alle dürfen dieses Foto herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2070
+#: lib/vutuv_web/live/post_live/composer.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Volle Auflösung, direkt aus dem Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2089
+#: lib/vutuv_web/live/post_live/composer.ex:2120
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:1948
 #, elixir-autogen, elixir-format
 msgid "Move photo earlier"
 msgstr "Foto nach vorne schieben"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1929
+#: lib/vutuv_web/live/post_live/composer.ex:1960
 #, elixir-autogen, elixir-format
 msgid "Move photo later"
 msgstr "Foto nach hinten schieben"
 
-#: lib/vutuv_web/components/post_components.ex:2341
+#: lib/vutuv_web/components/post_components.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1887
+#: lib/vutuv_web/live/post_live/composer.ex:1918
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:2758
+#: lib/vutuv_web/components/post_components.ex:2912
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr "Bisher sehen nur Sie diesen Beitrag."
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:122
+#: lib/vutuv_web/components/post_components.ex:1502
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:2761
+#: lib/vutuv_web/components/post_components.ex:2915
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] "Unsere KI prüft das Foto. Sobald es durch ist, geht der Beitrag von selbst online."
 msgstr[1] "Unsere KI prüft die Fotos, %{done} von %{total} sind durch. Sobald das letzte durch ist, geht der Beitrag von selbst online."
 
-#: lib/vutuv_web/components/post_components.ex:2586
+#: lib/vutuv_web/components/post_components.ex:2740
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:2088
+#: lib/vutuv_web/components/post_components.ex:2242
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1860
-#: lib/vutuv_web/live/post_live/composer.ex:1861
+#: lib/vutuv_web/live/post_live/composer.ex:1891
+#: lib/vutuv_web/live/post_live/composer.ex:1892
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1067
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:2795
+#: lib/vutuv_web/components/post_components.ex:2949
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/post_components.ex:2340
+#: lib/vutuv_web/components/post_components.ex:2494
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1900
-#: lib/vutuv_web/live/post_live/composer.ex:1901
+#: lib/vutuv_web/live/post_live/composer.ex:1931
+#: lib/vutuv_web/live/post_live/composer.ex:1932
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2091
+#: lib/vutuv_web/live/post_live/composer.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qualität unverändert."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1301
+#: lib/vutuv_web/live/post_live/composer.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:984
-#: lib/vutuv_web/live/post_live/remote_reply.ex:87
+#: lib/vutuv_web/components/post_components.ex:1555
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2109
+#: lib/vutuv_web/live/post_live/composer.ex:2140
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Die Datei genau so, wie ich sie hochgeladen habe"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2132
+#: lib/vutuv_web/live/post_live/composer.ex:2163
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen Sie das Foto, wenn Sie das nicht möchten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2124
+#: lib/vutuv_web/live/post_live/composer.ex:2155
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:987
-#: lib/vutuv_web/live/post_live/remote_reply.ex:84
+#: lib/vutuv_web/components/post_components.ex:1546
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:117
+#: lib/vutuv_web/live/post_live/remote_reply.ex:91
 #, elixir-autogen, elixir-format
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:96
+#: lib/vutuv_web/components/post_components.ex:1564
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:114
+#: lib/vutuv_web/components/post_components.ex:1498
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1399
+#: lib/vutuv_web/live/post_live/composer.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Wer diese Fotos weiterverwenden darf"
 
-#: lib/vutuv_web/live/post_live/composer.ex:979
+#: lib/vutuv_web/live/post_live/composer.ex:1007
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:91
+#: lib/vutuv_web/components/post_components.ex:1559
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:990
+#: lib/vutuv_web/live/post_live/composer.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:132
+#: lib/vutuv_web/components/post_components.ex:1512
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17531,13 +17534,13 @@ msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fedive
 msgid "© All rights reserved"
 msgstr "© Alle Rechte vorbehalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1320
-#: lib/vutuv_web/live/post_live/composer.ex:1612
+#: lib/vutuv_web/live/post_live/composer.ex:1351
+#: lib/vutuv_web/live/post_live/composer.ex:1643
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Fotos hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1394
+#: lib/vutuv_web/live/post_live/composer.ex:1425
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Lizenz"
@@ -17548,58 +17551,58 @@ msgstr "Lizenz"
 msgid "Post photos"
 msgstr "Fotos posten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1278
+#: lib/vutuv_web/live/post_live/composer.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Bildunterschrift (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1181
-#: lib/vutuv_web/live/post_live/composer.ex:1216
+#: lib/vutuv_web/live/post_live/composer.ex:1212
+#: lib/vutuv_web/live/post_live/composer.ex:1247
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Entwurf verwerfen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1213
+#: lib/vutuv_web/live/post_live/composer.ex:1244
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr "Fotos und Text dieses Entwurfs verwerfen?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1174
+#: lib/vutuv_web/live/post_live/composer.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Weiter, wo Sie aufgehört haben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1465
+#: lib/vutuv_web/live/post_live/composer.ex:1496
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr "Eine Datei, deren Format sich nicht säubern lässt, wird exakt so weitergegeben, wie sie hochgeladen wurde."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1793
+#: lib/vutuv_web/live/post_live/composer.ex:1824
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Pro Foto verschieden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1792
+#: lib/vutuv_web/live/post_live/composer.ex:1823
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Original, exakt wie hochgeladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1791
+#: lib/vutuv_web/live/post_live/composer.ex:1822
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Original, ohne Metadaten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1796
+#: lib/vutuv_web/live/post_live/composer.ex:1827
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Nur Web-Versionen (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1428
+#: lib/vutuv_web/live/post_live/composer.ex:1459
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Was Besucher speichern können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1454
+#: lib/vutuv_web/live/post_live/composer.ex:1485
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17607,13 +17610,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:963
-#: lib/vutuv_web/components/post_components.ex:3677
+#: lib/vutuv_web/components/post_components.ex:3858
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:961
-#: lib/vutuv_web/components/post_components.ex:3674
+#: lib/vutuv_web/components/post_components.ex:3855
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17623,7 +17626,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:3566
+#: lib/vutuv_web/components/post_components.ex:3747
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17718,7 +17721,7 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Rücknahme"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1382
+#: lib/vutuv_web/live/post_live/composer.ex:1413
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Fotodetails"
@@ -17987,7 +17990,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:1396
+#: lib/vutuv_web/components/post_components.ex:1416
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -18269,12 +18272,32 @@ msgstr "Wieder verdecken"
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:1414
+#: lib/vutuv_web/components/post_components.ex:1434
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:1417
+#: lib/vutuv_web/components/post_components.ex:1437
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
+
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:98
+#, elixir-autogen, elixir-format
+msgid "Back to the feed"
+msgstr "Zurück zum Feed"
+
+#: lib/vutuv_web/components/post_components.ex:1550
+#, elixir-autogen, elixir-format
+msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
+msgstr ""
+"Dieser Beitrag wurde nur an die Follower dieses Kontos veröffentlicht und "
+"lässt sich hier deshalb nicht mit einem öffentlichen Beitrag beantworten."
+
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:93
+#, elixir-autogen, elixir-format
+msgid "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
+msgstr ""
+"Dieser Beitrag wurde in einem anderen Netzwerk geschrieben. Ihn zu "
+"beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv "
+"nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1897
+#: lib/vutuv_web/components/post_components.ex:2051
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -195,7 +195,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:439
-#: lib/vutuv_web/live/post_live/composer.ex:1421
+#: lib/vutuv_web/live/post_live/composer.ex:1452
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:303
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1862
+#: lib/vutuv_web/components/post_components.ex:2016
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -615,7 +615,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1650
+#: lib/vutuv_web/live/post_live/composer.ex:1681
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -625,7 +625,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2863
 #: lib/vutuv_web/live/organization_live/edit.ex:339
-#: lib/vutuv_web/live/post_live/composer.ex:1659
+#: lib/vutuv_web/live/post_live/composer.ex:1690
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:105
@@ -1663,13 +1663,13 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2339
+#: lib/vutuv_web/components/post_components.ex:2493
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1221
-#: lib/vutuv_web/live/post_live/composer.ex:1222
-#: lib/vutuv_web/live/post_live/composer.ex:2043
+#: lib/vutuv_web/live/post_live/composer.ex:1252
+#: lib/vutuv_web/live/post_live/composer.ex:1253
+#: lib/vutuv_web/live/post_live/composer.ex:2074
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1798
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2127,7 +2127,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1341
+#: lib/vutuv_web/live/post_live/composer.ex:1372
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2137,7 +2137,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1894
+#: lib/vutuv_web/components/post_components.ex:2048
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2168,29 +2168,29 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1743
+#: lib/vutuv_web/live/post_live/composer.ex:1774
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1671
+#: lib/vutuv_web/live/post_live/composer.ex:1702
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1848
-#: lib/vutuv_web/components/post_components.ex:1850
+#: lib/vutuv_web/components/post_components.ex:2002
+#: lib/vutuv_web/components/post_components.ex:2004
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1713
+#: lib/vutuv_web/live/post_live/composer.ex:1744
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:993
-#: lib/vutuv_web/live/post_live/composer.ex:1041
+#: lib/vutuv_web/live/post_live/composer.ex:1024
+#: lib/vutuv_web/live/post_live/composer.ex:1072
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2200,23 +2200,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:969
+#: lib/vutuv_web/live/post_live/composer.ex:997
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1703
+#: lib/vutuv_web/live/post_live/composer.ex:1734
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1693
+#: lib/vutuv_web/live/post_live/composer.ex:1724
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1659
+#: lib/vutuv_web/live/post_live/composer.ex:1690
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2227,7 +2227,7 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:126
+#: lib/vutuv_web/agent_docs/post_doc.ex:127
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/user_controller.ex:76
@@ -2244,13 +2244,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2277
-#: lib/vutuv_web/components/post_components.ex:2281
+#: lib/vutuv_web/components/post_components.ex:2431
+#: lib/vutuv_web/components/post_components.ex:2435
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2278
+#: lib/vutuv_web/components/post_components.ex:2432
 #: lib/vutuv_web/live/fediverse_account_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2262,7 +2262,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:1729
+#: lib/vutuv_web/live/post_live/composer.ex:1760
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2276,7 +2276,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1657
+#: lib/vutuv_web/live/post_live/composer.ex:1688
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2290,18 +2290,19 @@ msgstr[1] ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:75
 #: lib/vutuv_web/live/post_live/edit.ex:36
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:81
 #: lib/vutuv_web/live/post_live/remote_reply.ex:79
 #: lib/vutuv_web/live/post_live/reply.ex:41
 #, elixir-autogen, elixir-format
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1067
+#: lib/vutuv_web/live/post_live/composer.ex:1098
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:951
+#: lib/vutuv_web/live/post_live/composer.ex:979
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2311,12 +2312,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2178
+#: lib/vutuv_web/live/post_live/composer.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2210
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2330,37 +2331,37 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1810
+#: lib/vutuv_web/live/post_live/composer.ex:1841
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1811
+#: lib/vutuv_web/live/post_live/composer.ex:1842
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1845
+#: lib/vutuv_web/components/post_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3406
+#: lib/vutuv_web/components/post_components.ex:3587
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3410
+#: lib/vutuv_web/components/post_components.ex:3591
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3408
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3409
+#: lib/vutuv_web/components/post_components.ex:3590
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2371,17 +2372,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1478
+#: lib/vutuv_web/live/post_live/composer.ex:1509
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2169
+#: lib/vutuv_web/live/post_live/composer.ex:2200
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2173
+#: lib/vutuv_web/live/post_live/composer.ex:2204
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2401,7 +2402,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3490
+#: lib/vutuv_web/components/post_components.ex:3671
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2421,7 +2422,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1377
-#: lib/vutuv_web/components/post_components.ex:3713
+#: lib/vutuv_web/components/post_components.ex:3894
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
@@ -2432,7 +2433,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:926
-#: lib/vutuv_web/components/post_components.ex:3722
+#: lib/vutuv_web/components/post_components.ex:3903
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2452,12 +2453,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3479
+#: lib/vutuv_web/components/post_components.ex:3660
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3490
+#: lib/vutuv_web/components/post_components.ex:3671
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2466,23 +2467,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3476
+#: lib/vutuv_web/components/post_components.ex:3657
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2891
+#: lib/vutuv_web/components/post_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3476
+#: lib/vutuv_web/components/post_components.ex:3657
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3713
+#: lib/vutuv_web/components/post_components.ex:3894
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2506,7 +2507,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3762
+#: lib/vutuv_web/components/post_components.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2518,26 +2519,27 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:898
-#: lib/vutuv_web/components/post_components.ex:3745
-#: lib/vutuv_web/components/post_components.ex:3746
+#: lib/vutuv_web/components/post_components.ex:1405
+#: lib/vutuv_web/components/post_components.ex:3926
+#: lib/vutuv_web/components/post_components.ex:3927
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1816
+#: lib/vutuv_web/components/post_components.ex:1970
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:954
-#: lib/vutuv_web/live/post_live/composer.ex:1647
+#: lib/vutuv_web/live/post_live/composer.ex:982
+#: lib/vutuv_web/live/post_live/composer.ex:1678
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1774
+#: lib/vutuv_web/live/post_live/composer.ex:1805
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2547,19 +2549,22 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
+#: lib/vutuv_web/components/post_components.ex:1490
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:58
 #: lib/vutuv_web/live/post_live/remote_reply.ex:57
-#: lib/vutuv_web/live/post_live/remote_reply.ex:104
 #: lib/vutuv_web/live/post_live/reply.ex:52
 #, elixir-autogen, elixir-format
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1811
+#: lib/vutuv_web/components/post_components.ex:1946
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1805
+#: lib/vutuv_web/components/post_components.ex:1940
+#: lib/vutuv_web/components/post_components.ex:1962
+#: lib/vutuv_web/components/post_components.ex:1965
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1683
+#: lib/vutuv_web/live/post_live/composer.ex:1714
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2861,7 +2866,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3407
+#: lib/vutuv_web/components/post_components.ex:3588
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3122,7 +3127,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1781
+#: lib/vutuv_web/components/post_components.ex:1916
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3199,7 +3204,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:868
 #: lib/vutuv_web/components/post_components.ex:1324
-#: lib/vutuv_web/components/post_components.ex:1918
+#: lib/vutuv_web/components/post_components.ex:2072
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:127
+#: lib/vutuv_web/agent_docs/post_doc.ex:128
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -5311,7 +5316,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:972
+#: lib/vutuv_web/live/post_live/composer.ex:1000
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5428,9 +5433,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1981
-#: lib/vutuv_web/components/post_components.ex:2033
-#: lib/vutuv_web/components/post_components.ex:2414
+#: lib/vutuv_web/components/post_components.ex:2135
+#: lib/vutuv_web/components/post_components.ex:2187
+#: lib/vutuv_web/components/post_components.ex:2568
 #: lib/vutuv_web/live/notification_live/index.ex:601
 #: lib/vutuv_web/live/post_live/feed.ex:1067
 #, elixir-autogen, elixir-format
@@ -6667,7 +6672,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1915
+#: lib/vutuv_web/components/post_components.ex:2069
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6677,7 +6682,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1914
+#: lib/vutuv_web/components/post_components.ex:2068
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7360,7 +7365,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3635
+#: lib/vutuv_web/components/post_components.ex:3816
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8833,7 +8838,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2894
+#: lib/vutuv_web/components/post_components.ex:3048
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -13140,7 +13145,7 @@ msgid "Search title, poster or organization"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1550
+#: lib/vutuv_web/live/post_live/composer.ex:1581
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -13270,7 +13275,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1429
+#: lib/vutuv_web/components/post_components.ex:1449
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -13649,7 +13654,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2148
+#: lib/vutuv_web/live/post_live/composer.ex:2179
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13871,129 +13876,129 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3269
+#: lib/vutuv_web/components/post_components.ex:3450
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1558
+#: lib/vutuv_web/live/post_live/composer.ex:1589
 #, elixir-autogen, elixir-format
 msgid "Author(s)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1628
+#: lib/vutuv_web/live/post_live/composer.ex:1659
 #, elixir-autogen, elixir-format
 msgid "Book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:973
-#: lib/vutuv_web/components/post_components.ex:3226
-#: lib/vutuv_web/live/post_live/composer.ex:1504
+#: lib/vutuv_web/components/post_components.ex:3407
+#: lib/vutuv_web/live/post_live/composer.ex:1535
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3270
+#: lib/vutuv_web/components/post_components.ex:3451
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3272
+#: lib/vutuv_web/components/post_components.ex:3453
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1558
+#: lib/vutuv_web/live/post_live/composer.ex:1589
 #, elixir-autogen, elixir-format
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3268
+#: lib/vutuv_web/components/post_components.ex:3449
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1640
+#: lib/vutuv_web/live/post_live/composer.ex:1671
 #, elixir-autogen, elixir-format
 msgid "Film"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:973
-#: lib/vutuv_web/components/post_components.ex:3225
-#: lib/vutuv_web/live/post_live/composer.ex:1503
+#: lib/vutuv_web/components/post_components.ex:3406
+#: lib/vutuv_web/live/post_live/composer.ex:1534
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1524
+#: lib/vutuv_web/live/post_live/composer.ex:1555
 #, elixir-autogen, elixir-format
 msgid "IMDb link or ID"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1525
+#: lib/vutuv_web/live/post_live/composer.ex:1556
 #, elixir-autogen, elixir-format
 msgid "ISBN"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:418
-#: lib/vutuv_web/live/post_live/composer.ex:1538
+#: lib/vutuv_web/live/post_live/composer.ex:1569
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1535
+#: lib/vutuv_web/live/post_live/composer.ex:1566
 #, elixir-autogen, elixir-format
 msgid "Looking up…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:617
+#: lib/vutuv_web/live/post_live/composer.ex:628
 #, elixir-autogen, elixir-format
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3267
+#: lib/vutuv_web/components/post_components.ex:3448
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:1608
 #, elixir-autogen, elixir-format
 msgid "Read as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1513
+#: lib/vutuv_web/live/post_live/composer.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Remove review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1624
-#: lib/vutuv_web/live/post_live/composer.ex:1625
+#: lib/vutuv_web/live/post_live/composer.ex:1655
+#: lib/vutuv_web/live/post_live/composer.ex:1656
 #, elixir-autogen, elixir-format
 msgid "Review a book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1636
-#: lib/vutuv_web/live/post_live/composer.ex:1637
+#: lib/vutuv_web/live/post_live/composer.ex:1667
+#: lib/vutuv_web/live/post_live/composer.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3271
+#: lib/vutuv_web/components/post_components.ex:3452
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1576
+#: lib/vutuv_web/live/post_live/composer.ex:1607
 #, elixir-autogen, elixir-format
 msgid "Watched as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1590
+#: lib/vutuv_web/live/post_live/composer.ex:1621
 #, elixir-autogen, elixir-format
 msgid "With an ISBN, the post shows the book cover and a shop link automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1570
+#: lib/vutuv_web/live/post_live/composer.ex:1601
 #: lib/vutuv_web/templates/education/form_content.html.heex:47
 #: lib/vutuv_web/templates/education/form_content.html.heex:48
 #: lib/vutuv_web/templates/education/form_content.html.heex:67
@@ -14009,34 +14014,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3308
+#: lib/vutuv_web/components/post_components.ex:3489
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3338
+#: lib/vutuv_web/components/post_components.ex:3519
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3339
+#: lib/vutuv_web/components/post_components.ex:3520
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3337
+#: lib/vutuv_web/components/post_components.ex:3518
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3297
+#: lib/vutuv_web/components/post_components.ex:3478
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3344
+#: lib/vutuv_web/components/post_components.ex:3525
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14066,7 +14071,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3111
+#: lib/vutuv_web/components/post_components.ex:3292
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14114,7 +14119,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3102
+#: lib/vutuv_web/components/post_components.ex:3283
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14393,13 +14398,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:959
+#: lib/vutuv_web/live/post_live/composer.ex:987
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:962
+#: lib/vutuv_web/live/post_live/composer.ex:990
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14488,14 +14493,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1561
+#: lib/vutuv_web/components/post_components.ex:1696
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1583
+#: lib/vutuv_web/components/post_components.ex:1718
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14522,7 +14527,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3721
+#: lib/vutuv_web/components/post_components.ex:3902
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15689,21 +15694,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3680
+#: lib/vutuv_web/components/post_components.ex:3861
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3684
+#: lib/vutuv_web/components/post_components.ex:3865
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3688
+#: lib/vutuv_web/components/post_components.ex:3869
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15711,7 +15716,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:945
-#: lib/vutuv_web/components/post_components.ex:3639
+#: lib/vutuv_web/components/post_components.ex:3820
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15804,7 +15809,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1106
 #: lib/vutuv_web/components/post_components.ex:884
-#: lib/vutuv_web/components/post_components.ex:1397
+#: lib/vutuv_web/components/post_components.ex:1417
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16480,22 +16485,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1793
+#: lib/vutuv_web/components/post_components.ex:1928
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1881
+#: lib/vutuv_web/components/post_components.ex:2035
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1889
+#: lib/vutuv_web/components/post_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1875
+#: lib/vutuv_web/components/post_components.ex:2029
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16539,12 +16544,12 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2161
+#: lib/vutuv_web/live/post_live/composer.ex:2192
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:153
+#: lib/vutuv_web/live/post_live/remote_reply.ex:96
 #, elixir-autogen, elixir-format
 msgid "Back to the conversation"
 msgstr ""
@@ -16569,192 +16574,190 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1880
+#: lib/vutuv_web/live/post_live/composer.ex:1911
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2035
+#: lib/vutuv_web/live/post_live/composer.ex:2066
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1034
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:2342
+#: lib/vutuv_web/components/post_components.ex:2496
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1329
+#: lib/vutuv_web/live/post_live/composer.ex:1360
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2111
+#: lib/vutuv_web/live/post_live/composer.ex:2142
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2068
+#: lib/vutuv_web/live/post_live/composer.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2070
+#: lib/vutuv_web/live/post_live/composer.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2089
+#: lib/vutuv_web/live/post_live/composer.ex:2120
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:1948
 #, elixir-autogen, elixir-format
 msgid "Move photo earlier"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1929
+#: lib/vutuv_web/live/post_live/composer.ex:1960
 #, elixir-autogen, elixir-format
 msgid "Move photo later"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2341
+#: lib/vutuv_web/components/post_components.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1887
+#: lib/vutuv_web/live/post_live/composer.ex:1918
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2758
+#: lib/vutuv_web/components/post_components.ex:2912
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:122
+#: lib/vutuv_web/components/post_components.ex:1502
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2761
+#: lib/vutuv_web/components/post_components.ex:2915
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2586
+#: lib/vutuv_web/components/post_components.ex:2740
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2088
+#: lib/vutuv_web/components/post_components.ex:2242
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1860
-#: lib/vutuv_web/live/post_live/composer.ex:1861
+#: lib/vutuv_web/live/post_live/composer.ex:1891
+#: lib/vutuv_web/live/post_live/composer.ex:1892
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1067
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:2795
+#: lib/vutuv_web/components/post_components.ex:2949
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2340
+#: lib/vutuv_web/components/post_components.ex:2494
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1900
-#: lib/vutuv_web/live/post_live/composer.ex:1901
+#: lib/vutuv_web/live/post_live/composer.ex:1931
+#: lib/vutuv_web/live/post_live/composer.ex:1932
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2091
+#: lib/vutuv_web/live/post_live/composer.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1301
+#: lib/vutuv_web/live/post_live/composer.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:984
-#: lib/vutuv_web/live/post_live/remote_reply.ex:87
+#: lib/vutuv_web/components/post_components.ex:1555
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2109
+#: lib/vutuv_web/live/post_live/composer.ex:2140
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2132
+#: lib/vutuv_web/live/post_live/composer.ex:2163
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2124
+#: lib/vutuv_web/live/post_live/composer.ex:2155
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:987
-#: lib/vutuv_web/live/post_live/remote_reply.ex:84
+#: lib/vutuv_web/components/post_components.ex:1546
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:117
+#: lib/vutuv_web/live/post_live/remote_reply.ex:91
 #, elixir-autogen, elixir-format
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:96
+#: lib/vutuv_web/components/post_components.ex:1564
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:114
+#: lib/vutuv_web/components/post_components.ex:1498
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1399
+#: lib/vutuv_web/live/post_live/composer.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:979
+#: lib/vutuv_web/live/post_live/composer.ex:1007
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:91
+#: lib/vutuv_web/components/post_components.ex:1559
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:990
+#: lib/vutuv_web/live/post_live/composer.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:132
+#: lib/vutuv_web/components/post_components.ex:1512
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16764,13 +16767,13 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1320
-#: lib/vutuv_web/live/post_live/composer.ex:1612
+#: lib/vutuv_web/live/post_live/composer.ex:1351
+#: lib/vutuv_web/live/post_live/composer.ex:1643
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1394
+#: lib/vutuv_web/live/post_live/composer.ex:1425
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr ""
@@ -16781,58 +16784,58 @@ msgstr ""
 msgid "Post photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1278
+#: lib/vutuv_web/live/post_live/composer.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1181
-#: lib/vutuv_web/live/post_live/composer.ex:1216
+#: lib/vutuv_web/live/post_live/composer.ex:1212
+#: lib/vutuv_web/live/post_live/composer.ex:1247
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1213
+#: lib/vutuv_web/live/post_live/composer.ex:1244
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1174
+#: lib/vutuv_web/live/post_live/composer.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1465
+#: lib/vutuv_web/live/post_live/composer.ex:1496
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1793
+#: lib/vutuv_web/live/post_live/composer.ex:1824
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1792
+#: lib/vutuv_web/live/post_live/composer.ex:1823
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1791
+#: lib/vutuv_web/live/post_live/composer.ex:1822
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1796
+#: lib/vutuv_web/live/post_live/composer.ex:1827
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1428
+#: lib/vutuv_web/live/post_live/composer.ex:1459
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1454
+#: lib/vutuv_web/live/post_live/composer.ex:1485
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16840,13 +16843,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:963
-#: lib/vutuv_web/components/post_components.ex:3677
+#: lib/vutuv_web/components/post_components.ex:3858
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:961
-#: lib/vutuv_web/components/post_components.ex:3674
+#: lib/vutuv_web/components/post_components.ex:3855
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16856,7 +16859,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3566
+#: lib/vutuv_web/components/post_components.ex:3747
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16942,7 +16945,7 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1382
+#: lib/vutuv_web/live/post_live/composer.ex:1413
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -17211,7 +17214,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1396
+#: lib/vutuv_web/components/post_components.ex:1416
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -17493,12 +17496,27 @@ msgstr ""
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1414
+#: lib/vutuv_web/components/post_components.ex:1434
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1417
+#: lib/vutuv_web/components/post_components.ex:1437
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:98
+#, elixir-autogen, elixir-format
+msgid "Back to the feed"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1550
+#, elixir-autogen, elixir-format
+msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:93
+#, elixir-autogen, elixir-format
+msgid "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -152,7 +152,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1897
+#: lib/vutuv_web/components/post_components.ex:2051
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -193,7 +193,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:439
-#: lib/vutuv_web/live/post_live/composer.ex:1421
+#: lib/vutuv_web/live/post_live/composer.ex:1452
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:303
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -201,7 +201,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1862
+#: lib/vutuv_web/components/post_components.ex:2016
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1650
+#: lib/vutuv_web/live/post_live/composer.ex:1681
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -623,7 +623,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2863
 #: lib/vutuv_web/live/organization_live/edit.ex:339
-#: lib/vutuv_web/live/post_live/composer.ex:1659
+#: lib/vutuv_web/live/post_live/composer.ex:1690
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:105
@@ -1661,13 +1661,13 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2339
+#: lib/vutuv_web/components/post_components.ex:2493
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1221
-#: lib/vutuv_web/live/post_live/composer.ex:1222
-#: lib/vutuv_web/live/post_live/composer.ex:2043
+#: lib/vutuv_web/live/post_live/composer.ex:1252
+#: lib/vutuv_web/live/post_live/composer.ex:1253
+#: lib/vutuv_web/live/post_live/composer.ex:2074
 #: lib/vutuv_web/templates/layout/app.html.heex:152
 #: lib/vutuv_web/templates/layout/app.html.heex:158
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -2114,7 +2114,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1767
+#: lib/vutuv_web/live/post_live/composer.ex:1798
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2125,7 +2125,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1341
+#: lib/vutuv_web/live/post_live/composer.ex:1372
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2135,7 +2135,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1894
+#: lib/vutuv_web/components/post_components.ex:2048
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2166,29 +2166,29 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1743
+#: lib/vutuv_web/live/post_live/composer.ex:1774
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1671
+#: lib/vutuv_web/live/post_live/composer.ex:1702
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1848
-#: lib/vutuv_web/components/post_components.ex:1850
+#: lib/vutuv_web/components/post_components.ex:2002
+#: lib/vutuv_web/components/post_components.ex:2004
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1713
+#: lib/vutuv_web/live/post_live/composer.ex:1744
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:993
-#: lib/vutuv_web/live/post_live/composer.ex:1041
+#: lib/vutuv_web/live/post_live/composer.ex:1024
+#: lib/vutuv_web/live/post_live/composer.ex:1072
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
@@ -2198,23 +2198,23 @@ msgstr ""
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:969
+#: lib/vutuv_web/live/post_live/composer.ex:997
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1703
+#: lib/vutuv_web/live/post_live/composer.ex:1734
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1693
+#: lib/vutuv_web/live/post_live/composer.ex:1724
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1659
+#: lib/vutuv_web/live/post_live/composer.ex:1690
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2225,7 +2225,7 @@ msgstr ""
 msgid "Post deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:126
+#: lib/vutuv_web/agent_docs/post_doc.ex:127
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
 #: lib/vutuv_web/controllers/user_controller.ex:76
@@ -2242,13 +2242,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2277
-#: lib/vutuv_web/components/post_components.ex:2281
+#: lib/vutuv_web/components/post_components.ex:2431
+#: lib/vutuv_web/components/post_components.ex:2435
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2278
+#: lib/vutuv_web/components/post_components.ex:2432
 #: lib/vutuv_web/live/fediverse_account_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2260,7 +2260,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:1729
+#: lib/vutuv_web/live/post_live/composer.ex:1760
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2274,7 +2274,7 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1657
+#: lib/vutuv_web/live/post_live/composer.ex:1688
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
@@ -2288,18 +2288,19 @@ msgstr[1] ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:75
 #: lib/vutuv_web/live/post_live/edit.ex:36
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:81
 #: lib/vutuv_web/live/post_live/remote_reply.ex:79
 #: lib/vutuv_web/live/post_live/reply.ex:41
 #, elixir-autogen, elixir-format
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1067
+#: lib/vutuv_web/live/post_live/composer.ex:1098
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:951
+#: lib/vutuv_web/live/post_live/composer.ex:979
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2309,12 +2310,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2178
+#: lib/vutuv_web/live/post_live/composer.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2179
+#: lib/vutuv_web/live/post_live/composer.ex:2210
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2328,37 +2329,37 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1810
+#: lib/vutuv_web/live/post_live/composer.ex:1841
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1811
+#: lib/vutuv_web/live/post_live/composer.ex:1842
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1845
+#: lib/vutuv_web/components/post_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3406
+#: lib/vutuv_web/components/post_components.ex:3587
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3410
+#: lib/vutuv_web/components/post_components.ex:3591
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3408
+#: lib/vutuv_web/components/post_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3409
+#: lib/vutuv_web/components/post_components.ex:3590
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2369,17 +2370,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1478
+#: lib/vutuv_web/live/post_live/composer.ex:1509
 #, elixir-autogen, elixir-format
 msgid "Tags, comma- or space-separated (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2169
+#: lib/vutuv_web/live/post_live/composer.ex:2200
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2173
+#: lib/vutuv_web/live/post_live/composer.ex:2204
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2399,7 +2400,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3490
+#: lib/vutuv_web/components/post_components.ex:3671
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2419,7 +2420,7 @@ msgid "Bookmarks"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1377
-#: lib/vutuv_web/components/post_components.ex:3713
+#: lib/vutuv_web/components/post_components.ex:3894
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
@@ -2430,7 +2431,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:926
-#: lib/vutuv_web/components/post_components.ex:3722
+#: lib/vutuv_web/components/post_components.ex:3903
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2450,12 +2451,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3479
+#: lib/vutuv_web/components/post_components.ex:3660
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3490
+#: lib/vutuv_web/components/post_components.ex:3671
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2464,23 +2465,23 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3476
+#: lib/vutuv_web/components/post_components.ex:3657
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2891
+#: lib/vutuv_web/components/post_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3476
+#: lib/vutuv_web/components/post_components.ex:3657
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3713
+#: lib/vutuv_web/components/post_components.ex:3894
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2504,7 +2505,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3762
+#: lib/vutuv_web/components/post_components.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2516,26 +2517,27 @@ msgid "Replies"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:898
-#: lib/vutuv_web/components/post_components.ex:3745
-#: lib/vutuv_web/components/post_components.ex:3746
+#: lib/vutuv_web/components/post_components.ex:1405
+#: lib/vutuv_web/components/post_components.ex:3926
+#: lib/vutuv_web/components/post_components.ex:3927
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1816
+#: lib/vutuv_web/components/post_components.ex:1970
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:954
-#: lib/vutuv_web/live/post_live/composer.ex:1647
+#: lib/vutuv_web/live/post_live/composer.ex:982
+#: lib/vutuv_web/live/post_live/composer.ex:1678
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1774
+#: lib/vutuv_web/live/post_live/composer.ex:1805
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2545,19 +2547,22 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
+#: lib/vutuv_web/components/post_components.ex:1490
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:58
 #: lib/vutuv_web/live/post_live/remote_reply.ex:57
-#: lib/vutuv_web/live/post_live/remote_reply.ex:104
 #: lib/vutuv_web/live/post_live/reply.ex:52
 #, elixir-autogen, elixir-format
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1811
+#: lib/vutuv_web/components/post_components.ex:1946
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1805
+#: lib/vutuv_web/components/post_components.ex:1940
+#: lib/vutuv_web/components/post_components.ex:1962
+#: lib/vutuv_web/components/post_components.ex:1965
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2836,7 +2841,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1683
+#: lib/vutuv_web/live/post_live/composer.ex:1714
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2859,7 +2864,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3407
+#: lib/vutuv_web/components/post_components.ex:3588
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3120,7 +3125,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1781
+#: lib/vutuv_web/components/post_components.ex:1916
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3197,7 +3202,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:868
 #: lib/vutuv_web/components/post_components.ex:1324
-#: lib/vutuv_web/components/post_components.ex:1918
+#: lib/vutuv_web/components/post_components.ex:2072
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -3928,7 +3933,7 @@ msgstr ""
 msgid "People %{name} follows"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/post_doc.ex:127
+#: lib/vutuv_web/agent_docs/post_doc.ex:128
 #, elixir-autogen, elixir-format
 msgid "Post archive of %{name}"
 msgstr ""
@@ -5309,7 +5314,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:972
+#: lib/vutuv_web/live/post_live/composer.ex:1000
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5426,9 +5431,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1981
-#: lib/vutuv_web/components/post_components.ex:2033
-#: lib/vutuv_web/components/post_components.ex:2414
+#: lib/vutuv_web/components/post_components.ex:2135
+#: lib/vutuv_web/components/post_components.ex:2187
+#: lib/vutuv_web/components/post_components.ex:2568
 #: lib/vutuv_web/live/notification_live/index.ex:601
 #: lib/vutuv_web/live/post_live/feed.ex:1067
 #, elixir-autogen, elixir-format
@@ -6665,7 +6670,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1915
+#: lib/vutuv_web/components/post_components.ex:2069
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6675,7 +6680,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1914
+#: lib/vutuv_web/components/post_components.ex:2068
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7358,7 +7363,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3635
+#: lib/vutuv_web/components/post_components.ex:3816
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8831,7 +8836,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2894
+#: lib/vutuv_web/components/post_components.ex:3048
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -13138,7 +13143,7 @@ msgid "Search title, poster or organization"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1550
+#: lib/vutuv_web/live/post_live/composer.ex:1581
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -13268,7 +13273,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1429
+#: lib/vutuv_web/components/post_components.ex:1449
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -13647,7 +13652,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2148
+#: lib/vutuv_web/live/post_live/composer.ex:2179
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13869,129 +13874,129 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3269
+#: lib/vutuv_web/components/post_components.ex:3450
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1558
+#: lib/vutuv_web/live/post_live/composer.ex:1589
 #, elixir-autogen, elixir-format
 msgid "Author(s)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1628
+#: lib/vutuv_web/live/post_live/composer.ex:1659
 #, elixir-autogen, elixir-format
 msgid "Book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:973
-#: lib/vutuv_web/components/post_components.ex:3226
-#: lib/vutuv_web/live/post_live/composer.ex:1504
+#: lib/vutuv_web/components/post_components.ex:3407
+#: lib/vutuv_web/live/post_live/composer.ex:1535
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3270
+#: lib/vutuv_web/components/post_components.ex:3451
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3272
+#: lib/vutuv_web/components/post_components.ex:3453
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1558
+#: lib/vutuv_web/live/post_live/composer.ex:1589
 #, elixir-autogen, elixir-format
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3268
+#: lib/vutuv_web/components/post_components.ex:3449
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1640
+#: lib/vutuv_web/live/post_live/composer.ex:1671
 #, elixir-autogen, elixir-format
 msgid "Film"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:973
-#: lib/vutuv_web/components/post_components.ex:3225
-#: lib/vutuv_web/live/post_live/composer.ex:1503
+#: lib/vutuv_web/components/post_components.ex:3406
+#: lib/vutuv_web/live/post_live/composer.ex:1534
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1524
+#: lib/vutuv_web/live/post_live/composer.ex:1555
 #, elixir-autogen, elixir-format
 msgid "IMDb link or ID"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1525
+#: lib/vutuv_web/live/post_live/composer.ex:1556
 #, elixir-autogen, elixir-format
 msgid "ISBN"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:418
-#: lib/vutuv_web/live/post_live/composer.ex:1538
+#: lib/vutuv_web/live/post_live/composer.ex:1569
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1535
+#: lib/vutuv_web/live/post_live/composer.ex:1566
 #, elixir-autogen, elixir-format
 msgid "Looking up…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:617
+#: lib/vutuv_web/live/post_live/composer.ex:628
 #, elixir-autogen, elixir-format
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3267
+#: lib/vutuv_web/components/post_components.ex:3448
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1577
+#: lib/vutuv_web/live/post_live/composer.ex:1608
 #, elixir-autogen, elixir-format
 msgid "Read as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1513
+#: lib/vutuv_web/live/post_live/composer.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Remove review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1624
-#: lib/vutuv_web/live/post_live/composer.ex:1625
+#: lib/vutuv_web/live/post_live/composer.ex:1655
+#: lib/vutuv_web/live/post_live/composer.ex:1656
 #, elixir-autogen, elixir-format
 msgid "Review a book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1636
-#: lib/vutuv_web/live/post_live/composer.ex:1637
+#: lib/vutuv_web/live/post_live/composer.ex:1667
+#: lib/vutuv_web/live/post_live/composer.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3271
+#: lib/vutuv_web/components/post_components.ex:3452
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1576
+#: lib/vutuv_web/live/post_live/composer.ex:1607
 #, elixir-autogen, elixir-format
 msgid "Watched as… (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1590
+#: lib/vutuv_web/live/post_live/composer.ex:1621
 #, elixir-autogen, elixir-format
 msgid "With an ISBN, the post shows the book cover and a shop link automatically."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1570
+#: lib/vutuv_web/live/post_live/composer.ex:1601
 #: lib/vutuv_web/templates/education/form_content.html.heex:47
 #: lib/vutuv_web/templates/education/form_content.html.heex:48
 #: lib/vutuv_web/templates/education/form_content.html.heex:67
@@ -14007,34 +14012,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3308
+#: lib/vutuv_web/components/post_components.ex:3489
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3338
+#: lib/vutuv_web/components/post_components.ex:3519
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3339
+#: lib/vutuv_web/components/post_components.ex:3520
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3337
+#: lib/vutuv_web/components/post_components.ex:3518
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3297
+#: lib/vutuv_web/components/post_components.ex:3478
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3344
+#: lib/vutuv_web/components/post_components.ex:3525
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14064,7 +14069,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3111
+#: lib/vutuv_web/components/post_components.ex:3292
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14112,7 +14117,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3102
+#: lib/vutuv_web/components/post_components.ex:3283
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14391,13 +14396,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:959
+#: lib/vutuv_web/live/post_live/composer.ex:987
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:962
+#: lib/vutuv_web/live/post_live/composer.ex:990
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14486,14 +14491,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1561
+#: lib/vutuv_web/components/post_components.ex:1696
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1583
+#: lib/vutuv_web/components/post_components.ex:1718
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14520,7 +14525,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3721
+#: lib/vutuv_web/components/post_components.ex:3902
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15687,21 +15692,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3680
+#: lib/vutuv_web/components/post_components.ex:3861
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3684
+#: lib/vutuv_web/components/post_components.ex:3865
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3688
+#: lib/vutuv_web/components/post_components.ex:3869
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15709,7 +15714,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:945
-#: lib/vutuv_web/components/post_components.ex:3639
+#: lib/vutuv_web/components/post_components.ex:3820
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15802,7 +15807,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1106
 #: lib/vutuv_web/components/post_components.ex:884
-#: lib/vutuv_web/components/post_components.ex:1397
+#: lib/vutuv_web/components/post_components.ex:1417
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16478,22 +16483,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1793
+#: lib/vutuv_web/components/post_components.ex:1928
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1881
+#: lib/vutuv_web/components/post_components.ex:2035
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1889
+#: lib/vutuv_web/components/post_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1875
+#: lib/vutuv_web/components/post_components.ex:2029
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16537,12 +16542,12 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2161
+#: lib/vutuv_web/live/post_live/composer.ex:2192
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:153
+#: lib/vutuv_web/live/post_live/remote_reply.ex:96
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to the conversation"
 msgstr ""
@@ -16567,192 +16572,190 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1880
+#: lib/vutuv_web/live/post_live/composer.ex:1911
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2035
+#: lib/vutuv_web/live/post_live/composer.ex:2066
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1034
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:2342
+#: lib/vutuv_web/components/post_components.ex:2496
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1329
+#: lib/vutuv_web/live/post_live/composer.ex:1360
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2111
+#: lib/vutuv_web/live/post_live/composer.ex:2142
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2068
+#: lib/vutuv_web/live/post_live/composer.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2070
+#: lib/vutuv_web/live/post_live/composer.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2089
+#: lib/vutuv_web/live/post_live/composer.ex:2120
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1917
+#: lib/vutuv_web/live/post_live/composer.ex:1948
 #, elixir-autogen, elixir-format
 msgid "Move photo earlier"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1929
+#: lib/vutuv_web/live/post_live/composer.ex:1960
 #, elixir-autogen, elixir-format
 msgid "Move photo later"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2341
+#: lib/vutuv_web/components/post_components.ex:2495
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1887
+#: lib/vutuv_web/live/post_live/composer.ex:1918
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2758
+#: lib/vutuv_web/components/post_components.ex:2912
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:122
+#: lib/vutuv_web/components/post_components.ex:1502
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2761
+#: lib/vutuv_web/components/post_components.ex:2915
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2586
+#: lib/vutuv_web/components/post_components.ex:2740
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2088
+#: lib/vutuv_web/components/post_components.ex:2242
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1860
-#: lib/vutuv_web/live/post_live/composer.ex:1861
+#: lib/vutuv_web/live/post_live/composer.ex:1891
+#: lib/vutuv_web/live/post_live/composer.ex:1892
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1067
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:2795
+#: lib/vutuv_web/components/post_components.ex:2949
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2340
+#: lib/vutuv_web/components/post_components.ex:2494
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1900
-#: lib/vutuv_web/live/post_live/composer.ex:1901
+#: lib/vutuv_web/live/post_live/composer.ex:1931
+#: lib/vutuv_web/live/post_live/composer.ex:1932
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2091
+#: lib/vutuv_web/live/post_live/composer.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1301
+#: lib/vutuv_web/live/post_live/composer.ex:1332
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:984
-#: lib/vutuv_web/live/post_live/remote_reply.ex:87
+#: lib/vutuv_web/components/post_components.ex:1555
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2109
+#: lib/vutuv_web/live/post_live/composer.ex:2140
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2132
+#: lib/vutuv_web/live/post_live/composer.ex:2163
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2124
+#: lib/vutuv_web/live/post_live/composer.ex:2155
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:987
-#: lib/vutuv_web/live/post_live/remote_reply.ex:84
+#: lib/vutuv_web/components/post_components.ex:1546
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:117
+#: lib/vutuv_web/live/post_live/remote_reply.ex:91
 #, elixir-autogen, elixir-format
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:96
+#: lib/vutuv_web/components/post_components.ex:1564
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:114
+#: lib/vutuv_web/components/post_components.ex:1498
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1399
+#: lib/vutuv_web/live/post_live/composer.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:979
+#: lib/vutuv_web/live/post_live/composer.ex:1007
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:91
+#: lib/vutuv_web/components/post_components.ex:1559
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:990
+#: lib/vutuv_web/live/post_live/composer.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:132
+#: lib/vutuv_web/components/post_components.ex:1512
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16762,13 +16765,13 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1320
-#: lib/vutuv_web/live/post_live/composer.ex:1612
+#: lib/vutuv_web/live/post_live/composer.ex:1351
+#: lib/vutuv_web/live/post_live/composer.ex:1643
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1394
+#: lib/vutuv_web/live/post_live/composer.ex:1425
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Licence"
 msgstr ""
@@ -16779,58 +16782,58 @@ msgstr ""
 msgid "Post photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1278
+#: lib/vutuv_web/live/post_live/composer.ex:1309
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1181
-#: lib/vutuv_web/live/post_live/composer.ex:1216
+#: lib/vutuv_web/live/post_live/composer.ex:1212
+#: lib/vutuv_web/live/post_live/composer.ex:1247
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1213
+#: lib/vutuv_web/live/post_live/composer.ex:1244
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1174
+#: lib/vutuv_web/live/post_live/composer.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1465
+#: lib/vutuv_web/live/post_live/composer.ex:1496
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1793
+#: lib/vutuv_web/live/post_live/composer.ex:1824
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1792
+#: lib/vutuv_web/live/post_live/composer.ex:1823
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1791
+#: lib/vutuv_web/live/post_live/composer.ex:1822
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1796
+#: lib/vutuv_web/live/post_live/composer.ex:1827
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1428
+#: lib/vutuv_web/live/post_live/composer.ex:1459
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1454
+#: lib/vutuv_web/live/post_live/composer.ex:1485
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16838,13 +16841,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:963
-#: lib/vutuv_web/components/post_components.ex:3677
+#: lib/vutuv_web/components/post_components.ex:3858
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:961
-#: lib/vutuv_web/components/post_components.ex:3674
+#: lib/vutuv_web/components/post_components.ex:3855
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16854,7 +16857,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3566
+#: lib/vutuv_web/components/post_components.ex:3747
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16940,7 +16943,7 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1382
+#: lib/vutuv_web/live/post_live/composer.ex:1413
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -17209,7 +17212,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1396
+#: lib/vutuv_web/components/post_components.ex:1416
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -17491,12 +17494,27 @@ msgstr ""
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1414
+#: lib/vutuv_web/components/post_components.ex:1434
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1417
+#: lib/vutuv_web/components/post_components.ex:1437
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:98
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Back to the feed"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1550
+#, elixir-autogen, elixir-format
+msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:93
+#, elixir-autogen, elixir-format, fuzzy
+msgid "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""

--- a/priv/repo/migrations/20260727140053_add_remote_post_to_post_remote_replies.exs
+++ b/priv/repo/migrations/20260727140053_add_remote_post_to_post_remote_replies.exs
@@ -1,0 +1,29 @@
+defmodule Vutuv.Repo.Migrations.AddRemotePostToPostRemoteReplies do
+  use Ecto.Migration
+
+  @moduledoc """
+  The sidecar generalizes: a vutuv post can now answer either a reply that
+  arrived under one of the member's own posts (issue #1070, `note_id`) or a post
+  by an account they follow (issue #1165, `remote_post_id`).
+
+  Two nullable columns rather than one polymorphic pair, because the two targets
+  are different tables with different lifetimes and a `{type, id}` column would
+  buy nothing but a lost foreign key. Exactly one is set; everything delivery
+  needs was already copied onto the row itself at creation time, so a null here
+  costs nothing.
+
+  `nilify_all`, like `note_id`: both targets are six-month caches, and the
+  member's own answer must outlive the copy of what it answered — deleting the
+  cached post must never delete somebody's post.
+  """
+
+  def change do
+    alter table(:post_remote_replies) do
+      add(:remote_post_id, references(:fediverse_posts, on_delete: :nilify_all))
+    end
+
+    # The cascade's own index: without it every cached-post delete sequentially
+    # scans this table, and expiry deletes in bulk.
+    create(index(:post_remote_replies, [:remote_post_id]))
+  end
+end

--- a/priv/repo/migrations/20260727145414_widen_post_remote_reply_uris.exs
+++ b/priv/repo/migrations/20260727145414_widen_post_remote_reply_uris.exs
@@ -1,0 +1,42 @@
+defmodule Vutuv.Repo.Migrations.WidenPostRemoteReplyUris do
+  use Ecto.Migration
+
+  @moduledoc """
+  The sidecar's three URIs are `varchar(255)` while everything they are copied
+  from is `text` capped at 2048 bytes, and its own changeset permits 2048. So a
+  remote server publishing a post with a 300-character `id` — perfectly legal,
+  accepted at our inbox, refused by no changeset anywhere — makes Postgres raise
+  22001 the moment a member answers it. A crashed composer, triggered from
+  another server, on ordinary input.
+
+  This is the `fediverse_post_deliveries.inbox_uri` lesson again: a column that
+  stores a value copied from an existing one takes **that column's** type.
+  Nothing user-facing writes these, so no changeset validation would have caught
+  the drift; only reading the source column's type does.
+
+  A widen is safe for the previous release (every value that fit still fits),
+  but a column type change does invalidate its cached prepared statements, so
+  expect a single 0A000 blip per affected statement on the old slot during the
+  switch — the pool re-prepares itself (`disconnect_on_error_codes`).
+
+  `handle` stays `varchar(255)`: it is cosmetic and remote-supplied, so the
+  writer truncates it rather than the column growing to hold whatever a hostile
+  server sends.
+  """
+
+  def up do
+    alter table(:post_remote_replies) do
+      modify(:in_reply_to_uri, :text)
+      modify(:actor_uri, :text)
+      modify(:inbox_uri, :text)
+    end
+  end
+
+  def down do
+    alter table(:post_remote_replies) do
+      modify(:in_reply_to_uri, :string)
+      modify(:actor_uri, :string)
+      modify(:inbox_uri, :string)
+    end
+  end
+end

--- a/test/vutuv/fediverse_post_replies_test.exs
+++ b/test/vutuv/fediverse_post_replies_test.exs
@@ -1,0 +1,251 @@
+defmodule Vutuv.FediversePostRepliesTest do
+  @moduledoc """
+  Answering a post by an account somebody follows on another network (issue
+  #1165): what is created here, what the activity carries over there, and what
+  refuses.
+
+  `async: false` — the outbound reply budget lives in the shared
+  `Vutuv.RateLimiter` ETS table, which the SQL sandbox does not roll back.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PostRemoteReply
+
+  @actor "https://social.example/users/them"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp account(attrs \\ []) do
+    Repo.insert!(%RemoteAccount{
+      actor_uri: attrs[:actor_uri] || @actor,
+      host: attrs[:host] || "social.example",
+      handle: "them",
+      name: "Them Themself",
+      inbox_uri: (attrs[:actor_uri] || @actor) <> "/inbox"
+    })
+  end
+
+  defp cached_post(acc, audience \\ "public") do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(%RemotePost{
+      remote_account_id: acc.id,
+      object_uri: "https://social.example/p/#{System.unique_integer([:positive])}",
+      content_text: "Eine Frage in die Runde.",
+      audience: audience,
+      kind: "note",
+      published_at: now,
+      received_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+    |> Repo.preload(:remote_account)
+  end
+
+  defp federating_member do
+    user = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    Repo.reload!(user)
+  end
+
+  defp follow(user, acc, state \\ "accepted") do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: acc.id,
+      state: state,
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#f/#{acc.id}"
+    })
+  end
+
+  defp queued do
+    Repo.all(from(d in Delivery, order_by: [asc: d.id]))
+    |> Enum.map(&Jason.decode!(&1.activity_json))
+  end
+
+  describe "the answer itself" do
+    setup do
+      %{user: federating_member(), post: cached_post(account())}
+    end
+
+    test "is a top-level vutuv post, not a reply to anything here", ctx do
+      assert {:ok, post} =
+               Posts.create_remote_post_reply(ctx.user, ctx.post, %{body: "Ja, klar."})
+
+      # Nothing on this site sits above it: what it answers lives entirely on
+      # somebody else's server.
+      assert post.body == "Ja, klar."
+      assert is_nil(post.reply_ref)
+      assert Repo.aggregate(Vutuv.Posts.PostReply, :count) == 0
+    end
+
+    test "carries the sidecar with its own copy of everything delivery needs", ctx do
+      {:ok, post} = Posts.create_remote_post_reply(ctx.user, ctx.post, %{body: "Ja, klar."})
+
+      assert %PostRemoteReply{} = ref = Repo.get_by!(PostRemoteReply, post_id: post.id)
+      assert ref.remote_post_id == ctx.post.id
+      assert is_nil(ref.note_id)
+      assert ref.in_reply_to_uri == ctx.post.object_uri
+      assert ref.actor_uri == @actor
+      assert ref.inbox_uri == @actor <> "/inbox"
+      assert ref.handle == "@them@social.example"
+    end
+
+    test "threads over there: inReplyTo, the author in cc, a Mention from the stored URI", ctx do
+      {:ok, _post} = Posts.create_remote_post_reply(ctx.user, ctx.post, %{body: "Ja, klar."})
+
+      assert [%{"type" => "Create", "object" => note}] = queued()
+      assert note["inReplyTo"] == ctx.post.object_uri
+      assert @actor in note["cc"]
+
+      # Built from the stored actor URI, never from parsing typed text — that
+      # would let anybody mint a verified-looking Mention at any actor.
+      assert Enum.any?(note["tag"], &(&1["type"] == "Mention" and &1["href"] == @actor))
+    end
+
+    test "outlives our copy of the post it answers", ctx do
+      {:ok, post} = Posts.create_remote_post_reply(ctx.user, ctx.post, %{body: "Ja, klar."})
+
+      Repo.delete!(ctx.post)
+
+      # The answer stands and still knows where to go: the target id nilifies,
+      # the copied address does not.
+      assert %Vutuv.Posts.Post{} = Posts.get_post(post.id)
+      ref = Repo.get_by!(PostRemoteReply, post_id: post.id)
+      assert is_nil(ref.remote_post_id)
+      assert ref.inbox_uri == @actor <> "/inbox"
+    end
+  end
+
+  describe "the gates" do
+    test "a followers-only post cannot be answered at all" do
+      user = federating_member()
+      acc = account()
+      follow(user, acc)
+      post = cached_post(acc, "followers")
+
+      # The answer is a public vutuv post; republishing the audience its author
+      # chose is not ours to do.
+      assert {:error, :post_not_public} = Fediverse.check_remote_post_reply(user, post)
+
+      assert {:error, :post_not_public} =
+               Posts.create_remote_post_reply(user, post, %{body: "Doch nicht."})
+
+      assert queued() == []
+    end
+
+    test "a member who does not federate is told which refusal it is" do
+      user = insert(:activated_user)
+
+      assert {:error, :not_federating} =
+               Fediverse.check_remote_post_reply(user, cached_post(account()))
+    end
+
+    test "a blocked server refuses" do
+      user = federating_member()
+      post = cached_post(account(actor_uri: "https://blocked.example/users/them"))
+
+      {:ok, _} =
+        Fediverse.block_instance(%{"host" => "blocked.example"}, insert(:user, admin?: true))
+
+      assert {:error, :instance_blocked} = Fediverse.check_remote_post_reply(user, post)
+    end
+
+    test "the answer budget is the reply budget, shared on purpose" do
+      Application.put_env(:vutuv, :fediverse_outbound_reply_limit, 1)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_outbound_reply_limit) end)
+
+      user = federating_member()
+      acc = account()
+
+      assert {:ok, _} = Posts.create_remote_post_reply(user, cached_post(acc), %{body: "Eins."})
+
+      assert {:error, :reply_capped} =
+               Posts.create_remote_post_reply(user, cached_post(acc), %{body: "Zwei."})
+    end
+  end
+
+  describe "what can change while the form sits open" do
+    setup do
+      %{user: federating_member(), post: cached_post(account())}
+    end
+
+    test "a post deleted meanwhile is an answer, not a crash", ctx do
+      # Another member's report, expiry, an upstream Delete, an instance block:
+      # the row goes while somebody is still typing. Writing the sidecar against
+      # it would hit the foreign key and take the LiveView down.
+      Repo.delete!(ctx.post)
+
+      assert {:error, :not_found} =
+               Posts.create_remote_post_reply(ctx.user, ctx.post, %{body: "Zu spät."})
+
+      assert queued() == []
+    end
+
+    test "an author narrowing the audience meanwhile is honoured", ctx do
+      # The card said public when it rendered. Answering has to read what is
+      # true now, or this feature's one rule is bypassed by having the form
+      # open when the author changed their mind.
+      Repo.update_all(RemotePost, set: [audience: "followers"])
+
+      assert {:error, :post_not_public} =
+               Posts.create_remote_post_reply(ctx.user, ctx.post, %{body: "Doch nicht."})
+
+      assert queued() == []
+    end
+  end
+
+  describe "where the answer goes" do
+    test "to the author's own inbox and to the member's own remote followers" do
+      user = federating_member()
+      post = cached_post(account())
+
+      Repo.insert!(%Vutuv.Fediverse.Follower{
+        user_id: user.id,
+        actor_uri: "https://elsewhere.example/users/fan",
+        inbox_uri: "https://elsewhere.example/users/fan/inbox",
+        handle: "fan"
+      })
+
+      {:ok, _} = Posts.create_remote_post_reply(user, post, %{body: "Für alle."})
+
+      inboxes = Repo.all(from(d in Delivery, select: d.inbox_uri))
+
+      # Both halves: the person answered, and the member's own audience.
+      assert (@actor <> "/inbox") in inboxes
+      assert "https://elsewhere.example/users/fan/inbox" in inboxes
+    end
+
+    test "a member who follows nobody may still answer a cached public post" do
+      # Deliberate, and the same call the like path makes: the account page
+      # shows public posts of accounts the reader does not follow, so what they
+      # are shown they may answer.
+      user = federating_member()
+
+      assert {:ok, _} =
+               Posts.create_remote_post_reply(user, cached_post(account()), %{body: "Hallo."})
+    end
+  end
+
+  describe "the shared budget" do
+    test "one hour's worth is spent across both kinds of answer" do
+      Application.put_env(:vutuv, :fediverse_outbound_reply_limit, 1)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_outbound_reply_limit) end)
+
+      user = federating_member()
+      acc = account()
+
+      # Both are the same act — a member's own words leaving for a server that
+      # never followed them — so one must not hide inside the other's budget.
+      assert {:ok, _} = Posts.create_remote_post_reply(user, cached_post(acc), %{body: "Eins."})
+      assert {:error, :reply_capped} = Fediverse.claim_reply_budget(user)
+    end
+  end
+end

--- a/test/vutuv_web/live/remote_post_reply_test.exs
+++ b/test/vutuv_web/live/remote_post_reply_test.exs
@@ -1,0 +1,169 @@
+defmodule VutuvWeb.RemotePostReplyTest do
+  @moduledoc """
+  The page for answering a post by an account somebody follows on another
+  network (issue #1165), and the Reply affordance that leads to it.
+
+  What is under test here is mostly what the page refuses to do quietly: it says
+  where the words are going before anybody types, it offers no answer at all on
+  a followers-only post, and it explains rather than hides the one refusal a
+  member can act on.
+
+  `async: false` — the outbound reply budget lives in the shared
+  `Vutuv.RateLimiter` ETS table, which the SQL sandbox does not roll back.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+
+  @actor "https://social.example/users/them"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp account do
+    Repo.insert!(%RemoteAccount{
+      actor_uri: @actor,
+      host: "social.example",
+      handle: "them",
+      name: "Them Themself",
+      inbox_uri: @actor <> "/inbox"
+    })
+  end
+
+  defp cached_post(acc, audience \\ "public") do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(%RemotePost{
+      remote_account_id: acc.id,
+      object_uri: "https://social.example/p/#{System.unique_integer([:positive])}",
+      origin_url: "https://social.example/@them/1",
+      content_text: "Eine Frage in die Runde.",
+      audience: audience,
+      kind: "note",
+      published_at: now,
+      received_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+  end
+
+  defp follow(user, acc) do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: acc.id,
+      state: "accepted",
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#f/#{acc.id}"
+    })
+  end
+
+  defp federating(user) do
+    user |> Ecto.Changeset.change(fediverse_followers?: true) |> Repo.update!()
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    Repo.reload!(user)
+  end
+
+  describe "the Reply affordance" do
+    test "a public post from a followed account offers one", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      acc = account()
+      follow(user, acc)
+      post = cached_post(acc)
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      assert has_element?(view, "[data-remote-post-reply-link='#{post.id}']")
+    end
+
+    test "a followers-only post offers none", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      acc = account()
+      follow(user, acc)
+      post = cached_post(acc, "followers")
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      # No control rather than one that refuses: the answer would be a public
+      # vutuv post quoting a restricted context.
+      assert has_element?(view, "[data-remote-post='#{post.id}']")
+      refute has_element?(view, "[data-remote-post-reply-link='#{post.id}']")
+    end
+  end
+
+  describe "the page" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      acc = account()
+      follow(user, acc)
+      %{conn: conn, user: federating(user), account: acc, post: cached_post(acc)}
+    end
+
+    test "says where the words are going before anybody types", ctx do
+      {:ok, view, html} = live(ctx.conn, ~p"/system/fediverse/reply/post/#{ctx.post.id}")
+
+      assert has_element?(view, "[data-remote-reply-notice]")
+      assert html =~ "@them@social.example"
+      # And it shows the post being answered, so nobody replies blind.
+      assert has_element?(view, "[data-remote-post='#{ctx.post.id}']")
+      # No feed chrome: nothing here handles `close-composer`, so rendering the
+      # feed's ✕ would give the page a button that kills it.
+      refute has_element?(view, "#composer [phx-click='close-composer']")
+    end
+
+    test "sending creates a top-level post that wears the replying-to line", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/system/fediverse/reply/post/#{ctx.post.id}")
+
+      view
+      |> form("#composer form", post: %{body: "Meine Antwort."})
+      |> render_submit()
+
+      assert [post] = Repo.all(from(p in Vutuv.Posts.Post, where: p.user_id == ^ctx.user.id))
+      assert post.body == "Meine Antwort."
+
+      {:ok, view, html} = live(ctx.conn, ~p"/feed")
+      assert html =~ "data-reply-banner=\"remote\""
+      assert html =~ "@them@social.example"
+
+      # The line names who is being answered, so it links to that account's
+      # page here — not out to their server, and not to a compose form.
+      assert has_element?(
+               view,
+               "[data-reply-banner='remote'] a[href='/system/fediverse/account/#{ctx.account.id}']"
+             )
+    end
+
+    test "a followers-only post is refused even when the URL is typed by hand", ctx do
+      restricted = cached_post(ctx.account, "followers")
+
+      assert {:error, {:redirect, %{to: "/feed", flash: flash}}} =
+               live(ctx.conn, ~p"/system/fediverse/reply/post/#{restricted.id}")
+
+      assert flash["error"] =~ "followers"
+    end
+
+    test "an unknown id is a 404, so nothing leaks", ctx do
+      assert {:error, {:redirect, %{to: "/"}}} =
+               live(ctx.conn, ~p"/system/fediverse/reply/post/#{Vutuv.UUIDv7.generate()}")
+    end
+  end
+
+  test "a member who does not federate gets the explanation, not a dead end", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    acc = account()
+    follow(user, acc)
+    post = cached_post(acc)
+
+    {:ok, view, html} = live(conn, ~p"/system/fediverse/reply/post/#{post.id}")
+
+    # The page explains and links to the switch; hiding the action would leave
+    # them no way to find out that answering exists.
+    assert html =~ "Fediverse"
+    assert has_element?(view, "a[href='/settings/fediverse']")
+    refute has_element?(view, "#composer")
+  end
+end


### PR DESCRIPTION
Closes #1165.

A member can now reply to a post by an account they follow on another network. Until now answering only worked in the other direction (#1070: somebody out there replied under one of your posts). The far more common case — reading something in your feed and wanting to respond — had no control at all.

## The shape

`Vutuv.Posts.PostRemoteReply` **generalized** rather than a second table appearing beside it. It records either of two things a vutuv post can answer (`note_id` or `remote_post_id`), and **neither id is what delivery reads**: every field the outgoing activity needs (`in_reply_to_uri`, `actor_uri`, `inbox_uri`, `handle`) was already copied onto the row at creation time. Both cases produce the same `Create(Note)` and nothing downstream has to know which it was.

What differs is what sits underneath. A #1070 answer is a real reply here (local threading, reply count, edit window). A #1165 answer has no vutuv post beneath it — the thing answered lives entirely on somebody else's server — so `create_remote_post_reply/3` creates a **top-level** post carrying the sidecar, and it wears a "Replying to `@user@host`" line pointing at that account's page *here*.

## The gate that defines the feature

A **followers-only** post cannot be answered at all. The answer is a public post here, and republishing the audience its author deliberately narrowed is not ours to do — so the card offers no Reply rather than a control that refuses.

Crucially that gate reads the row **as it is at save time**, not as it was when the composer opened. An author can narrow a post while somebody types, and reading the stale struct would let the rule be bypassed by simply having the form open. The same re-read turns a post deleted meanwhile (expiry, an upstream `Delete`, another member's report, an instance block) into `{:error, :not_found}` instead of a foreign-key crash that killed the LiveView.

## Two things found on the way

- **`post_remote_replies`' URI columns were `varchar(255)`** while everything they copy from is `text` capped at 2048 bytes. A remote server publishing a post with a 300-character id — legal, accepted at our inbox, refused by no changeset — would raise 22001 in the composer of anyone answering it. Widened to `text` (the `fediverse_post_deliveries.inbox_uri` lesson again). `handle` stays 255 and the writer truncates.
- **The answer composer deliberately keeps no draft.** A fourth draft context needs its own partial unique index *and* has to be excluded from the new-post composer's, which means dropping and recreating that index. During a blue/green switch the previous release still writes `ON CONFLICT (user_id) WHERE parent_id IS NULL AND remote_note_id IS NULL`, and Postgres infers an arbiter only when the supplied predicate implies the index's — two conjuncts do not imply three, so **every keystroke in the old release's feed composer would raise 42P10**. Verified against Postgres, not reasoned about. That is an expand/contract pair of deploys, worth doing on its own.

## Checks

- `mix precommit` green (5797 tests), including both races (target deleted, target narrowed), the delivery fan-out to the author's inbox **and** the member's own followers, and the shared outbound budget.
- Smoke-tested in Chrome against the dev database: the public post offers Reply (40px target), the followers-only one does not, the page states where the words go before you type, and the sent answer produced `inReplyTo=https://smoke.example/ask/1`, the author in `cc`, and a `Mention` built from the stored actor URI — with the "Replying to" line on the feed linking to the account page.
- Agent-format siblings (`.md`/`.json` and the v2 API) now carry the remote target too, so they no longer say less than the card.
- Docs: `docs/architecture/fediverse.md`.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01JK1wSgiwNTSQxepf9wprLg