### PR TITLE
SEO: unblock everything robots.txt fenced except /admin/, noindex instead

### DIFF
--- a/docs/architecture/agents-and-seo.md
+++ b/docs/architecture/agents-and-seo.md
@@ -53,8 +53,28 @@ never be crawled to learn it should drop out — which is exactly how these URLs
 piled up under Google's "indexed, though blocked by robots.txt" report. For the
 same reason the legacy `/users/…` URLs (which 301 to the canonical `/:slug`)
 stay crawlable: blocking a redirect strands the old URL instead of letting the
-301 consolidate it. So `robots.txt` blocks only genuinely private, crawl-trap
-paths (`/admin/`, `/login`, `/sessions`, `/api/`, `/search`).
+301 consolidate it. So `robots.txt` blocks only `/admin/`.
+
+Everything else resolves itself and is deliberately crawlable too, because any
+`Disallow` beyond `/admin/` kept re-filling that Search Console bucket (and a
+failed "validate fix" pass there emails the operator):
+
+- `/login` and `/search` serve `X-Robots-Tag: noindex` via the `:noindex_pipe`
+  in the router. `/login` matters doubly: it is the redirect target of every
+  login-only URL a crawler stumbles into (`/posts/:id/reply`, `/messages`, …),
+  so it must be fetchable for those chains to resolve. The reply links on
+  post cards additionally carry `rel="nofollow"`, so the per-post reply URLs
+  rarely enter the crawl frontier at all.
+- The RSS feeds (`/posts/feed.xml`, `/:slug/posts/feed.xml`) are always
+  `noindex` — Google filed a permissive member's feed as a "duplicate without
+  a user-selected canonical" of their profile.
+- `/sessions/new` is a 301 to `/login`; the pre-2026 API vCard URLs
+  (`/api/1.0/users/:slug/vcard`) 301 to `/:slug.vcf`
+  (`VutuvWeb.LegacyRedirectController`). Redirects must be crawlable.
+- The rest of `/api/` answers crawlers itself: 404 for retired 1.0 paths,
+  401 for the token-only 2.0 endpoints; nothing links it, nothing indexes it.
+- `GET /logout` does not exist (signing out is a `DELETE`), so a `Disallow`
+  for it fenced off nothing.
 
 Existing members were migrated as AI-opted-out (they were never asked) and can
 opt in on the edit form.

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -4014,7 +4014,10 @@ defmodule VutuvWeb.PostComponents do
 
   # The reply control is a navigation, not a toggle: it leads to the reply page
   # (which requires login itself). Restricted posts cannot be answered,
-  # mirroring the disabled repost button.
+  # mirroring the disabled repost button. rel="nofollow" because for a crawler
+  # every reply URL is just a 302 to /login — without it, every public post
+  # card feeds one useless URL into the crawl frontier, which piled up as
+  # "blocked by robots.txt" noise in Search Console.
   attr(:id, :string, required: true)
   attr(:post_id, :any, required: true)
   attr(:count, :integer, required: true)
@@ -4026,6 +4029,7 @@ defmodule VutuvWeb.PostComponents do
       :if={!@disabled}
       id={@id}
       href={~p"/posts/#{@post_id}/reply"}
+      rel="nofollow"
       aria-label={gettext("Reply")}
       title={gettext("Reply")}
       class={[

--- a/lib/vutuv_web/controllers/feed_controller.ex
+++ b/lib/vutuv_web/controllers/feed_controller.ex
@@ -44,7 +44,12 @@ defmodule VutuvWeb.FeedController do
     |> put_resp_content_type("application/rss+xml")
     |> put_resp_header("cache-control", "public, max-age=300")
     |> put_resp_header("content-signal", ContentPolicy.signal_header(noindex?, noai?))
-    |> ContentPolicy.put_robots_header(noindex?, noai?)
+    # The XML document itself is never a search result, so every feed is
+    # noindex — a permissive member's feed used to carry no robots header at
+    # all and got filed by Google as a "duplicate without a canonical" of the
+    # profile. The member's search choice still reaches crawlers through the
+    # Content-Signal above; their AI choice keeps its robots directives.
+    |> ContentPolicy.put_robots_header(true, noai?)
     |> send_resp(200, body)
   end
 end

--- a/lib/vutuv_web/controllers/legacy_redirect_controller.ex
+++ b/lib/vutuv_web/controllers/legacy_redirect_controller.ex
@@ -28,6 +28,11 @@ defmodule VutuvWeb.LegacyRedirectController do
 
   def login(conn, _params), do: permanent(conn, "/login")
 
+  # The pre-2026 API served a public vCard at /api/1.0/users/:slug/vcard;
+  # search engines still hold such URLs. The profile's vCard sibling is the
+  # canonical successor.
+  def api_vcard(conn, %{"slug" => slug}), do: permanent(conn, "/" <> encode(slug) <> ".vcf")
+
   def search(conn, _params), do: permanent(conn, "/search")
 
   def search_query(conn, %{"id" => id}), do: permanent(conn, search_path(id))

--- a/lib/vutuv_web/robots_txt.ex
+++ b/lib/vutuv_web/robots_txt.ex
@@ -28,33 +28,30 @@ defmodule VutuvWeb.RobotsTxt do
   # Help yourself to the public stuff: profiles, tags, listings.
   Allow: /
 
-  # ...but these are backstage. No autographs, no peeking.
+  # ...but the admin area is backstage. No autographs, no peeking.
   Disallow: /admin/
-  Disallow: /login
-  Disallow: /logout
-  Disallow: /sessions
-  Disallow: /api/
 
-  # Search results are an endless hall of mirrors; don't get lost in there.
-  Disallow: /search
-
-  # Two things are DELIBERATELY not disallowed here, though both look like
-  # candidates. Blocking either would backfire:
+  # Everything else that must stay out of search is DELIBERATELY not
+  # disallowed, though several paths look like candidates. A Disallow only
+  # stops the fetch: a URL linked from elsewhere still gets indexed as a
+  # bare link, can never be crawled to learn it should drop out, and a
+  # redirect on it can never consolidate. So instead:
   #
-  # 1. The old /users/... URLs. They 301 to the canonical /<slug> profile. A
-  #    crawler that cannot fetch them never sees the redirect, so the stale URL
-  #    is stranded in the index ("indexed, though blocked by robots.txt")
-  #    instead of being consolidated. Leaving them crawlable lets the 301 do
-  #    its job.
+  # 1. Redirects stay crawlable so their 301 can do its job: the old
+  #    /users/... URLs (-> /<slug>), /sessions/new (-> /login) and the
+  #    legacy /api/1.0/users/<slug>/vcard URLs (-> /<slug>.vcf).
   #
-  # 2. The personal profile detail sub-pages (/<slug>/emails, /tags,
-  #    /work_experiences, /followers, ...). They must stay OUT of search, but
-  #    robots.txt is the wrong lever: a Disallow only stops the fetch, so a
-  #    detail URL linked from elsewhere still gets indexed as a bare link and
-  #    can never be crawled to learn it should drop out. They carry a
-  #    page-level `X-Robots-Tag: noindex` instead (VutuvWeb.Plug.NoIndex on the
-  #    :user_pipe pipeline), which reliably de-indexes them once crawled. So we
-  #    keep them crawlable on purpose, precisely so that header is seen.
+  # 2. Pages that must never surface in results carry a page-level
+  #    `X-Robots-Tag: noindex` and stay crawlable precisely so that header
+  #    is seen: the personal profile detail sub-pages (/<slug>/emails,
+  #    /tags, /work_experiences, /followers, ...; VutuvWeb.Plug.NoIndex),
+  #    the RSS feeds, /login and /search. Keeping /login fetchable also
+  #    lets the sign-in redirect behind every login-only URL a crawler
+  #    stumbles into (/posts/<id>/reply, /messages, ...) resolve cleanly
+  #    instead of stranding those URLs as "blocked by robots.txt".
+  #
+  # 3. /api/ is linked nowhere and answers every crawler itself: 404/301
+  #    for the legacy 1.0 paths, 401 for the token-only 2.0 endpoints.
   """
 
   # The AI crawlers named explicitly (the spec's list): training collects

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -285,7 +285,16 @@ defmodule VutuvWeb.Router do
     # "session": POST /login handles both PIN steps, DELETE /logout signs out.
     # /login/resend mails a fresh PIN; /login/cancel abandons a pending login so
     # the visitor is no longer pinned to the PIN-entry form.
-    get("/login", SessionController, :new)
+    #
+    # The sign-in page is crawlable but noindex'd (see VutuvWeb.RobotsTxt): it
+    # is the redirect target of every login-only URL a crawler stumbles into,
+    # so it must be fetchable for those chains to resolve — a robots block here
+    # stranded them all as "blocked by robots.txt" in Search Console.
+    scope "/" do
+      pipe_through(:noindex_pipe)
+      get("/login", SessionController, :new)
+    end
+
     post("/login", SessionController, :create)
     post("/login/resend", SessionController, :resend)
     post("/login/cancel", SessionController, :cancel)
@@ -438,6 +447,9 @@ defmodule VutuvWeb.Router do
     get("/search_queries/:id", LegacyRedirectController, :search_query)
     get("/users/:slug", LegacyRedirectController, :user)
     get("/users/:slug/*rest", LegacyRedirectController, :user_subpage)
+    # The pre-2026 API's public vCard URL, which search engines still
+    # remember; consolidates onto the profile's vCard sibling.
+    get("/api/1.0/users/:slug/vcard", LegacyRedirectController, :api_vcard)
   end
 
   # Incremental LiveView surface. `InitAssigns` assigns `:current_user` from the
@@ -449,8 +461,16 @@ defmodule VutuvWeb.Router do
       pipe_through(:browser)
 
       live("/notifications", NotificationLive.Index, :index)
+
       # Search-as-you-type ("search" is a reserved slug; open to visitors).
-      live("/search", SearchLive, :index)
+      # Crawlable but noindex'd (see VutuvWeb.RobotsTxt): search results are
+      # an endless hall of mirrors no index should mirror again, but a robots
+      # block would strand externally linked /search URLs in the index.
+      scope "/" do
+        pipe_through(:noindex_pipe)
+        live("/search", SearchLive, :index)
+      end
+
       live("/messages", MessageLive.Index, :index)
       # The profile "Message" button: open my conversation with that member
       # (find-or-create), then land in the thread.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.185.0",
+      version: "7.185.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/detail_pages_noindex_test.exs
+++ b/test/vutuv_web/controllers/detail_pages_noindex_test.exs
@@ -61,4 +61,25 @@ defmodule VutuvWeb.DetailPagesNoIndexTest do
       assert get_resp_header(conn, "x-robots-tag") == []
     end
   end
+
+  # /login and /search are deliberately NOT robots-blocked (see RobotsTxt):
+  # /login is the redirect target of every login-only URL a crawler stumbles
+  # into, and a robots block on it stranded all those chains as "blocked by
+  # robots.txt" in Search Console. Both pages must therefore be fetchable and
+  # carry the page-level opt-out header so they never surface in results.
+  describe "X-Robots-Tag on the crawlable auth and search pages" do
+    test "GET /login serves with the page-level opt-out", %{conn: conn} do
+      conn = get(conn, "/login")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "x-robots-tag") == @page_level_robots
+    end
+
+    test "GET /search serves with the page-level opt-out", %{conn: conn} do
+      conn = get(conn, "/search")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "x-robots-tag") == @page_level_robots
+    end
+  end
 end

--- a/test/vutuv_web/controllers/feed_controller_test.exs
+++ b/test/vutuv_web/controllers/feed_controller_test.exs
@@ -117,6 +117,21 @@ defmodule VutuvWeb.FeedControllerTest do
       assert get(build_conn(), "/sleepy_member/posts/feed.xml").status == 404
     end
 
+    # The XML document itself is never a search result: every feed is served
+    # noindex so Google does not file it as a "duplicate without a canonical"
+    # of the profile (which is exactly what Search Console reported for
+    # member feeds). The member's choices still flow into the Content-Signal
+    # header and, for the AI axis, into the robots directives.
+    test "a permissive member's feed is still marked noindex" do
+      create_post!(insert_activated_user(username: "open_author"), %{"body" => "Open words"})
+
+      conn = get(build_conn(), "/open_author/posts/feed.xml")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "x-robots-tag") == ["noindex"]
+      assert get_resp_header(conn, "content-signal") == ["ai-train=yes, search=yes, ai-input=yes"]
+    end
+
     test "a noindexed member's feed serves, marked noindex, AI choice intact" do
       quiet = insert_activated_user(username: "quiet_author", noindex?: true, noai?: false)
       create_post!(quiet, %{"body" => "Quiet words"})
@@ -128,14 +143,14 @@ defmodule VutuvWeb.FeedControllerTest do
       assert get_resp_header(conn, "content-signal") == ["ai-train=yes, search=no, ai-input=yes"]
     end
 
-    test "an AI-opted-out member's feed serves with the noai directives" do
+    test "an AI-opted-out member's feed combines noindex with the noai directives" do
       human = insert_activated_user(username: "human_author", noindex?: false, noai?: true)
       create_post!(human, %{"body" => "For people"})
 
       conn = get(build_conn(), "/human_author/posts/feed.xml")
 
       assert conn.status == 200
-      assert get_resp_header(conn, "x-robots-tag") == ["noai, noimageai"]
+      assert get_resp_header(conn, "x-robots-tag") == ["noindex, noai, noimageai"]
       assert get_resp_header(conn, "content-signal") == ["ai-train=no, search=yes, ai-input=no"]
     end
   end
@@ -152,6 +167,8 @@ defmodule VutuvWeb.FeedControllerTest do
       assert conn.resp_body =~ mine.id
       assert conn.resp_body =~ theirs.id
       assert get_resp_header(conn, "content-signal") == ["ai-train=yes, search=yes, ai-input=yes"]
+      # The XML document itself never belongs in a search index.
+      assert get_resp_header(conn, "x-robots-tag") == ["noindex"]
     end
 
     # The aggregate feed carries one all-yes Content-Signal and cannot

--- a/test/vutuv_web/controllers/page_controller_test.exs
+++ b/test/vutuv_web/controllers/page_controller_test.exs
@@ -42,11 +42,12 @@ defmodule VutuvWeb.PageControllerTest do
       assert body =~ "User-agent: *"
       assert body =~ "Allow: /"
 
-      # Sensitive or backstage paths must never be indexed.
+      # The one true backstage path; everything else resolves itself (redirects
+      # consolidate, login-only pages 302 to the crawlable, noindex'd /login).
       assert body =~ "Disallow: /admin/"
-      assert body =~ "Disallow: /login"
-      assert body =~ "Disallow: /sessions"
-      assert body =~ "Disallow: /api/"
+      refute body =~ "Disallow: /login"
+      refute body =~ "Disallow: /sessions"
+      refute body =~ "Disallow: /api/"
 
       # Personal profile detail pages (phone numbers, emails, addresses, …) are
       # kept out of search by the page-level X-Robots-Tag: noindex header

--- a/test/vutuv_web/controllers/post_controller_test.exs
+++ b/test/vutuv_web/controllers/post_controller_test.exs
@@ -563,6 +563,19 @@ defmodule VutuvWeb.PostControllerTest do
       assert get_resp_header(conn, "x-robots-tag") == []
     end
 
+    test "the reply control is a nofollow link", %{conn: conn} do
+      # /posts/:id/reply requires login, so for a crawler every reply link is
+      # a 302 to /login. rel="nofollow" keeps thousands of per-post reply
+      # URLs (one per public post card) out of the crawl frontier instead of
+      # letting them pile up in Search Console.
+      user = insert_activated_user()
+      post = create_post!(user, %{body: "please answer"})
+
+      html = html_response(get(conn, Posts.path(post)), 200)
+
+      assert html =~ ~r{href="/posts/#{post.id}/reply"[^>]*rel="nofollow"}
+    end
+
     test "an inline-referenced attachment renders in place; the rest stays in the gallery", %{
       conn: conn
     } do

--- a/test/vutuv_web/controllers/url_structure_test.exs
+++ b/test/vutuv_web/controllers/url_structure_test.exs
@@ -66,6 +66,14 @@ defmodule VutuvWeb.UrlStructureTest do
       assert redirected_to(get(conn, "/sessions/new"), 301) == "/login"
     end
 
+    test "the legacy /api/1.0 vcard URLs 301 to the canonical /:slug.vcf", %{conn: conn} do
+      # Google still remembers pre-2026 URLs like /api/1.0/users/x.y/vcard.
+      # Now that /api/ is no longer robots-blocked, the 301 consolidates them
+      # onto the vCard sibling of the profile instead of a dead 404.
+      assert redirected_to(get(conn, "/api/1.0/users/gustav.gans/vcard"), 301) ==
+               "/gustav.gans.vcf"
+    end
+
     test "DELETE /logout signs the user out", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       conn = delete(conn, "/logout")
@@ -106,9 +114,13 @@ defmodule VutuvWeb.UrlStructureTest do
     } do
       body = conn |> get("/robots.txt") |> response(200)
 
-      # Backstage paths stay blocked.
-      assert body =~ "Disallow: /login"
-      assert body =~ "Disallow: /search"
+      # Only the admin area stays robots-blocked. /login and /search are
+      # crawlable and carry X-Robots-Tag: noindex instead, so the login
+      # redirects behind signed-in-only pages resolve for crawlers rather
+      # than stranding as "blocked by robots.txt".
+      assert body =~ "Disallow: /admin/"
+      refute body =~ "Disallow: /login"
+      refute body =~ "Disallow: /search"
       assert body =~ "Allow: /"
 
       # The per-user detail sub-pages are NOT robots-blocked: they carry a

--- a/test/vutuv_web/robots_txt_test.exs
+++ b/test/vutuv_web/robots_txt_test.exs
@@ -52,6 +52,28 @@ defmodule VutuvWeb.RobotsTxtTest do
       refute RobotsTxt.render(:permissive) =~ "Disallow: /users/"
     end
 
+    test "fences off only the admin area; everything else resolves itself" do
+      body = RobotsTxt.render(:permissive)
+
+      assert body =~ "Disallow: /admin/"
+
+      # /login and /search stay crawlable and carry X-Robots-Tag: noindex
+      # instead: /login is the redirect target of every login-only URL a
+      # crawler stumbles into (/posts/:id/reply, /messages, ...), so blocking
+      # it stranded all those chains as "blocked by robots.txt" and kept the
+      # Search Console validation failing.
+      refute body =~ "Disallow: /login"
+      refute body =~ "Disallow: /search"
+
+      # GET /logout does not exist (signing out is a DELETE), /sessions/new is
+      # a 301 that must be crawlable to consolidate, and /api/ answers 401/404
+      # for a crawler by itself — the legacy /api/1.0 vcard URLs 301 to the
+      # canonical /:slug.vcf and must be fetchable for that to happen.
+      refute body =~ "Disallow: /logout"
+      refute body =~ "Disallow: /sessions"
+      refute body =~ "Disallow: /api/"
+    end
+
     test "does not robots-block the per-user detail sub-pages (they carry X-Robots-Tag: noindex)" do
       # /:slug/emails, /:slug/tags, /:slug/work_experiences, ... are kept out of
       # search by the page-level noindex header (VutuvWeb.Plug.NoIndex on the


### PR DESCRIPTION
**TL;DR** The failed Search Console validation ("Durch robots.txt blockiert", 4,980 pages) kept re-failing on URLs that stayed deliberately blocked; robots.txt now fences only `/admin/` and everything else resolves itself, so the bucket can actually drain.

**Where:** `VutuvWeb.RobotsTxt`, router (`:noindex_pipe` on `GET /login` + `/search`), `FeedController`, `LegacyRedirectController`, `PostComponents.reply_link`
**Now:** `/login` (linked on every page) and every login-only URL a crawler follows (`/posts/:id/reply` on every public post card) 302 into a robots-blocked `/login`; legacy `/api/1.0/.../vcard` URLs sit unreachable behind `Disallow: /api/`; a permissive member's RSS feed carries no robots header and gets filed as "duplicate without a user-selected canonical".
**Want (this PR):**
- robots.txt disallows only `/admin/`; the strategy comment explains every deliberately crawlable path.
- `/login` and `/search` serve `X-Robots-Tag: noindex` and stay fetchable, so redirect chains resolve.
- Reply links carry `rel="nofollow"`.
- `/api/1.0/users/:slug/vcard` 301s to `/:slug.vcf`.
- Every RSS feed is `noindex`; the member's Content-Signals stay untouched.

No code needed for the other GSC buckets: the 372 404s are the agent-export opt-out working as designed, the 10 403s are moderation withholding (#812), the single 5xx is a stale April sample that 301s today.

After the deploy I will restart the failed validation in Search Console.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01S4jLCyKQcLDycSKyZSeSvj