### PR TITLE
Order the remote-follows delivery assertions by id (CI flake on main)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.185.1",
+      version: "7.185.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_remote_follows_test.exs
+++ b/test/vutuv/fediverse_remote_follows_test.exs
@@ -89,8 +89,12 @@ defmodule Vutuv.FediverseRemoteFollowsTest do
     user
   end
 
+  # Ordered by id (UUID v7, so id order is creation order): without an
+  # order_by, Postgres returns the rows in arbitrary order, and the
+  # "[follow, undo]" assertion below flaked on CI when the two came back
+  # reversed.
   defp deliveries(user) do
-    Repo.all(from(d in Delivery, where: d.user_id == ^user.id))
+    Repo.all(from(d in Delivery, where: d.user_id == ^user.id, order_by: d.id))
     |> Enum.map(&Jason.decode!(&1.activity_json))
   end
 


### PR DESCRIPTION
**TL;DR** The post-merge CI run for v7.185.1 flaked in `fediverse_remote_follows_test.exs:310` because the test helper read Delivery rows without an `order_by`; ordering by id (UUID v7 = creation order) makes it deterministic.

**Where:** `test/vutuv/fediverse_remote_follows_test.exs` (`deliveries/1` helper)
**Now:** `Repo.all` without `order_by` lets Postgres return the queued Follow and its Undo in either order; on run 30335969808 they came back reversed and the `[follow, undo]` match failed, leaving `main` red (the Deploy itself succeeded).
**Want:** `order_by: d.id` — ids are `Vutuv.UUIDv7` with sub-millisecond ordering bits, so id order is creation order (the same invariant keyset pagination relies on). Test-only change.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01S4jLCyKQcLDycSKyZSeSvj