### PR TITLE
CV pages are noindex: the profile is the page a name search should find

### DIFF
--- a/lib/vutuv_web/controllers/cv_controller.ex
+++ b/lib/vutuv_web/controllers/cv_controller.ex
@@ -28,6 +28,8 @@ defmodule VutuvWeb.CVController do
   alias VutuvWeb.ControllerHelpers
   alias VutuvWeb.CV
 
+  plug(:noindex)
+
   @content_types %{
     "html" => "text/html",
     "tex" => "application/x-tex",
@@ -40,7 +42,6 @@ defmodule VutuvWeb.CVController do
     user = conn.assigns[:user]
 
     conn
-    |> ContentPolicy.put_robots_header(user.noindex?, user.noai?)
     |> put_layout(html: false)
     |> live_render(VutuvWeb.CVLive,
       session: Map.put(ControllerHelpers.live_render_session(conn), "profile_user_id", user.id)
@@ -75,6 +76,16 @@ defmodule VutuvWeb.CVController do
 
   # A comma-separated list of hide-keys (identity fields / section keys /
   # entry ids); only ever removes data, so no validation beyond splitting.
+  # The profile is the page a name search should find. Every CV surface —
+  # builder, print view, downloads — shows the same data as a tool, so all
+  # three actions are served `X-Robots-Tag: noindex` (forced; the member's
+  # own AI axis rides along) and stay crawlable precisely so the header is
+  # seen — the same noindex-not-Disallow doctrine as the profile detail
+  # sub-pages and the RSS feeds (see VutuvWeb.RobotsTxt).
+  defp noindex(conn, _opts) do
+    ContentPolicy.put_robots_header(conn, true, conn.assigns[:user].noai?)
+  end
+
   defp parse_hide(params) do
     (params["hide"] || "")
     |> String.split(",", trim: true)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.185.3",
+      version: "7.185.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/cv_controller_test.exs
+++ b/test/vutuv_web/controllers/cv_controller_test.exs
@@ -398,5 +398,31 @@ defmodule VutuvWeb.CVControllerTest do
       assert conn |> recycle() |> get(~p"/#{owner}/cv/download/docx") |> response(200)
       assert conn |> recycle() |> get(~p"/#{owner}/cv/print") |> response(200)
     end
+
+    # The profile is the page a name search should find; the CV builder, the
+    # print view and the downloads show the same data as a tool, so they must
+    # never compete with the profile in the index. They stay crawlable (no
+    # robots.txt block, see VutuvWeb.RobotsTxt) precisely so this header is
+    # seen and Google can drop already-known CV URLs.
+    test "every CV surface is noindex for a permissive member", %{conn: conn} do
+      owner = seed_profile(insert(:activated_user))
+
+      for path <- [~p"/#{owner}/cv", ~p"/#{owner}/cv/print", ~p"/#{owner}/cv/download/html"] do
+        result = get(conn, path)
+
+        assert result.status == 200
+
+        assert get_resp_header(result, "x-robots-tag") == ["noindex"],
+               "expected X-Robots-Tag: noindex on #{path}"
+      end
+    end
+
+    test "a member's AI opt-out still rides on the CV's noindex", %{conn: conn} do
+      owner = :activated_user |> insert(noai?: true) |> seed_profile()
+
+      result = get(conn, ~p"/#{owner}/cv")
+
+      assert get_resp_header(result, "x-robots-tag") == ["noindex, noai, noimageai"]
+    end
   end
 end


### PR DESCRIPTION
**TL;DR** `/:slug/cv`, `/cv/print` and `/cv/download/*` now serve `X-Robots-Tag: noindex` — they show the profile's data as a tool and were competing with the profile in Google's index.

**Where:** `VutuvWeb.CVController` (one `noindex` plug across all three actions) + tests
**Now:** only the member's own opt-outs reach the CV's robots header, so a permissive member's CV builder is fully indexable — one near-duplicate page per member, linked from every profile (the same duplicate mechanic Search Console flagged for the RSS feeds).
**Want:** forced `noindex` on every CV surface, member's AI opt-out riding along; pages stay crawlable (no robots.txt entry) so the header is actually seen. Decided with Stefan: the profile suffices as the searchable page.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01S4jLCyKQcLDycSKyZSeSvj