### PR TITLE
Following a vutuv member from another network no longer 404s

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -505,6 +505,40 @@ own redirect following would skip that second check), short timeouts, no
 retries, and a body ceiling that halts the stream rather than buffering. Every
 failure lands back on the profile with a plain-language flash naming the server,
 and the handle is right there to copy, so there is always a way through.
+
+### The same door from the other side: `/authorize_interaction`
+
+The template above is what *other* servers read out of *our* WebFinger document,
+and until v7.186.0 vutuv published none — so a member who pressed Follow on
+Mastodon and typed `@them@vutuv.de` was sent to Mastodon's fallback guess,
+`https://vutuv.de/authorize_interaction?uri=…`, and met a 404. Two halves fix
+that, and both are needed: `VutuvWeb.FediverseController`'s WebFinger document
+now names the template (implementations without Mastodon's fallback otherwise
+report that vutuv offers no follow dialog at all), and
+`VutuvWeb.AuthorizeInteractionController` answers that path.
+
+The word is a **root** route with a `Vutuv.Accounts.ReservedSlugs` entry rather
+than a `/system/` page, which is the exception the CLAUDE.md rule allows for:
+Mastodon hardcodes the path as its fallback, so it is spent whether we
+advertise it or not.
+
+What arrives in `uri` is whatever the visitor was looking at, in whatever
+spelling that server prefers — a profile URL, an `acct:` URI, a bare handle, or
+a link to a **single post** (Mastodon sends those here for a reply or a boost).
+All of them are read by `RemoteFollow.parse_address/1`, so an address means the
+same thing here as in the follow box; a post URL is reduced to its author's URL
+and parsed by the same function rather than by a second copy of its rules.
+
+It **follows nothing**. The arrival is a `GET` from another site, so acting on
+it would let any page on the web make a signed-in member send a signed `Follow`
+to a server of its choosing simply by linking here. The resolved address is
+handed to the follow box on `/settings/fediverse/following` instead — the same
+`?address=` prefill the search page uses, for the same reason it prefills rather
+than acts. A signed-out visitor is bounced through `/login` with the
+`:login_return_to` marker the OAuth consent screen uses, so the PIN round trip
+lands them back on this URL. The installation switch is checked first: an
+endpoint this vutuv does not run 404s instead of first asking anyone to sign in.
+
 ## Revocation: a takedown has to leave the building
 
 Until issue #1102 only one path federated a `Delete`: the owner pressing delete

--- a/lib/vutuv/accounts/reserved_slugs.ex
+++ b/lib/vutuv/accounts/reserved_slugs.ex
@@ -24,8 +24,12 @@ defmodule Vutuv.Accounts.ReservedSlugs do
   # directories, tools) go under the already-reserved /system/ prefix instead
   # of claiming another root word — see CLAUDE.md; the member directory
   # (/system/members) set the pattern, freeing "members" as a handle again.
+  # `authorize_interaction` is the one root word here that another project
+  # chose for us: it is the remote-interaction path Mastodon guesses at when a
+  # server's WebFinger document names no subscribe template, so it has to
+  # answer at the root (see VutuvWeb.AuthorizeInteractionController).
   @route_slugs ~w(
-    about access_tokens account_deletion admin ads api assets avatars benutzername blocks blog bookmarks
+    about access_tokens account_deletion admin ads api assets authorize_interaction avatars benutzername blocks blog bookmarks
     organizations organization_images community connected_apps connections contact covers css datenschutzerklaerung dev developers
     edit emails favicon.ico feed follow_back
     follows fonts groups health help images impressum jobs js legal likes listings live

--- a/lib/vutuv_web/controllers/authorize_interaction_controller.ex
+++ b/lib/vutuv_web/controllers/authorize_interaction_controller.ex
@@ -1,0 +1,125 @@
+defmodule VutuvWeb.AuthorizeInteractionController do
+  @moduledoc """
+  `GET /authorize_interaction?uri=…` — the door the rest of the Fediverse sends
+  a member of *this* installation through when they want to act on an account
+  somewhere else.
+
+  It is the mirror image of `VutuvWeb.RemoteFollowController`: there a visitor
+  from another network follows a member here from their own server; here a
+  member here follows an account out there from that account's server. The
+  other server starts it. Press Follow on Mastodon while signed out, type
+  `@member@vutuv.de`, and that server reads our WebFinger document, takes the
+  `http://ostatus.org/schema/1.0/subscribe` template out of it (see
+  `VutuvWeb.FediverseController`) and sends the visitor here with the account
+  they were looking at in `uri`.
+
+  **The path is not ours to choose.** Mastodon falls back to
+  `https://<host>/authorize_interaction?uri={uri}` whenever a WebFinger
+  document names no template, so this word is spent whether we advertise it or
+  not — which is why it is a root route with a `Vutuv.Accounts.ReservedSlugs`
+  entry rather than living under `/system/` like a page of our own design.
+
+  **It follows nothing.** The arrival is a `GET` from another site, so acting on
+  it would let any page on the web make a signed-in member send a signed Follow
+  to a server of its choosing simply by linking here. Instead the address is
+  resolved (pure string work, no network) and handed to the follow box on
+  `/settings/fediverse/following`, where the member sees what they are about to
+  do and presses the button themselves — the same reason that page prefills
+  rather than acts on its own `?address=`.
+  """
+
+  use VutuvWeb, :controller
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.RemoteFollow
+  alias VutuvWeb.ControllerHelpers
+
+  def show(conn, params) do
+    cond do
+      not Fediverse.enabled?() ->
+        ControllerHelpers.render_error(conn, 404)
+
+      is_nil(conn.assigns[:current_user]) ->
+        # The same marker the OAuth consent screen sets, so the login survives
+        # the PIN round trip and lands back on this URL with the address still
+        # in it.
+        conn
+        |> put_session(:login_return_to, current_path(conn))
+        |> put_flash(
+          :info,
+          gettext(
+            "Please sign in first, then you can follow that account from your vutuv account."
+          )
+        )
+        |> redirect(to: ~p"/login")
+
+      true ->
+        hand_over(conn, params["uri"] || params["acct"])
+    end
+  end
+
+  defp hand_over(conn, uri) do
+    case interaction(uri) do
+      {:ok, :account, address} ->
+        redirect(conn, to: ~p"/settings/fediverse/following?#{[address: address]}")
+
+      {:ok, :post, address} ->
+        conn
+        |> put_flash(:info, post_link_message(address))
+        |> redirect(to: ~p"/settings/fediverse/following?#{[address: address]}")
+
+      :error ->
+        conn
+        |> put_flash(:error, gettext("That link did not name a Fediverse account we can read."))
+        |> redirect(to: ~p"/settings/fediverse/following")
+    end
+  end
+
+  # Every spelling of `{uri}` in the wild: the profile URL Mastodon fills in,
+  # the `acct:` URI older implementations send, and the plain handle. Parsed by
+  # `Vutuv.Fediverse.RemoteFollow`, so what counts as an address here is what
+  # counts as one in the follow box the member lands in.
+  defp interaction(uri) when is_binary(uri) do
+    uri = uri |> String.trim() |> String.replace_prefix("acct:", "")
+
+    case RemoteFollow.parse_address(uri) do
+      {:ok, {user, host}} -> {:ok, :account, "@#{user}@#{host}"}
+      {:error, _reason} -> author_of_post(uri)
+    end
+  end
+
+  defp interaction(_uri), do: :error
+
+  # A link to a single post rather than to an account: the other network sends
+  # those here too, for a reply or a boost. Neither is something vutuv can
+  # start from outside, so we read the author out of the URL and offer the one
+  # thing that does work — following them — saying so rather than answering a
+  # link we understood with an error.
+  #
+  # The author's own URL is rebuilt and handed back to `parse_address/1`, so
+  # the handle and host are validated by the one parser instead of a second
+  # copy of its rules living here.
+  defp author_of_post(url) do
+    with %URI{host: host, path: path} when is_binary(host) and is_binary(path) <- URI.parse(url),
+         {:ok, author_url} <- author_url(host, String.split(path, "/", trim: true)),
+         {:ok, {user, author_host}} <- RemoteFollow.parse_address(author_url) do
+      {:ok, :post, "@#{user}@#{author_host}"}
+    else
+      _not_a_post -> :error
+    end
+  end
+
+  defp author_url(host, ["@" <> user, _id]), do: {:ok, "https://#{host}/@#{user}"}
+
+  defp author_url(host, ["users", user, "statuses", _id]),
+    do: {:ok, "https://#{host}/users/#{user}"}
+
+  defp author_url(_host, _segments), do: :error
+
+  defp post_link_message(address) do
+    gettext(
+      "That link points at a single post. You can follow its author, %{account}, from here.",
+      account: address
+    )
+  end
+end

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -554,7 +554,8 @@ defmodule VutuvWeb.FediverseController do
   defp resolve_resource(_), do: nil
 
   defp jrd(user) do
-    profile_url = "#{String.trim_trailing(VutuvWeb.Endpoint.url(), "/")}/#{user.username}"
+    base = String.trim_trailing(VutuvWeb.Endpoint.url(), "/")
+    profile_url = "#{base}/#{user.username}"
 
     %{
       "subject" => "acct:#{user.username}@#{VutuvWeb.Endpoint.host()}",
@@ -565,6 +566,16 @@ defmodule VutuvWeb.FediverseController do
           "rel" => "http://webfinger.net/rel/profile-page",
           "type" => "text/html",
           "href" => profile_url
+        },
+        # Where this member confirms a follow they started on somebody else's
+        # server (`VutuvWeb.AuthorizeInteractionController`). Without this link
+        # a remote server has to guess: Mastodon guesses exactly this path, but
+        # others simply tell the visitor that vutuv offers no follow dialog. The
+        # `{uri}` placeholder is the object they were looking at and must stay
+        # unencoded — the other server fills it in.
+        %{
+          "rel" => "http://ostatus.org/schema/1.0/subscribe",
+          "template" => "#{base}/authorize_interaction?uri={uri}"
         }
       ]
     }

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -293,6 +293,16 @@ defmodule VutuvWeb.Router do
     scope "/" do
       pipe_through(:noindex_pipe)
       get("/login", SessionController, :new)
+
+      # The Fediverse's remote-interaction endpoint (see
+      # VutuvWeb.AuthorizeInteractionController): another server sends a member
+      # of this installation here when they pressed Follow on an account out
+      # there. Our WebFinger document names this path as its subscribe
+      # template, and Mastodon guesses it anyway for a server that names none,
+      # so it is a root word (reserved in Vutuv.Accounts.ReservedSlugs) rather
+      # than a /system/ page. noindex: it is a redirect for one visitor, never
+      # a page.
+      get("/authorize_interaction", AuthorizeInteractionController, :show)
     end
 
     post("/login", SessionController, :create)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.185.4",
+      version: "7.186.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2559,7 +2559,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:4046
+#: lib/vutuv_web/components/post_components.ex:4050
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2572,8 +2572,8 @@ msgstr "Antworten"
 
 #: lib/vutuv_web/components/post_components.ex:898
 #: lib/vutuv_web/components/post_components.ex:1508
-#: lib/vutuv_web/components/post_components.ex:4029
-#: lib/vutuv_web/components/post_components.ex:4030
+#: lib/vutuv_web/components/post_components.ex:4033
+#: lib/vutuv_web/components/post_components.ex:4034
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
@@ -18322,3 +18322,22 @@ msgid "%{account} moved to another server. Your subscription already went with t
 msgstr ""
 "%{account} ist auf einen anderen Server umgezogen. Ihr Abonnement ist bereits "
 "mitgegangen — diesen alten Eintrag entfernen?"
+
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:50
+#, elixir-autogen, elixir-format
+msgid "Please sign in first, then you can follow that account from your vutuv account."
+msgstr ""
+"Bitte melden Sie sich zuerst an, danach können Sie diesem Konto mit Ihrem "
+"vutuv-Konto folgen."
+
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:71
+#, elixir-autogen, elixir-format
+msgid "That link did not name a Fediverse account we can read."
+msgstr "In diesem Link steckt keine Fediverse-Adresse, die wir lesen können."
+
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:115
+#, elixir-autogen, elixir-format
+msgid "That link points at a single post. You can follow its author, %{account}, from here."
+msgstr ""
+"Dieser Link zeigt auf einen einzelnen Beitrag. Von hier aus können Sie dem "
+"Konto dahinter folgen: %{account}."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4046
+#: lib/vutuv_web/components/post_components.ex:4050
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2523,8 +2523,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:898
 #: lib/vutuv_web/components/post_components.ex:1508
-#: lib/vutuv_web/components/post_components.ex:4029
-#: lib/vutuv_web/components/post_components.ex:4030
+#: lib/vutuv_web/components/post_components.ex:4033
+#: lib/vutuv_web/components/post_components.ex:4034
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
@@ -17538,4 +17538,19 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_following_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "%{account} moved to another server. Your subscription already went with them — remove this old entry?"
+msgstr ""
+
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:50
+#, elixir-autogen, elixir-format
+msgid "Please sign in first, then you can follow that account from your vutuv account."
+msgstr ""
+
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:71
+#, elixir-autogen, elixir-format
+msgid "That link did not name a Fediverse account we can read."
+msgstr ""
+
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:115
+#, elixir-autogen, elixir-format
+msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2508,7 +2508,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4046
+#: lib/vutuv_web/components/post_components.ex:4050
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2521,8 +2521,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:898
 #: lib/vutuv_web/components/post_components.ex:1508
-#: lib/vutuv_web/components/post_components.ex:4029
-#: lib/vutuv_web/components/post_components.ex:4030
+#: lib/vutuv_web/components/post_components.ex:4033
+#: lib/vutuv_web/components/post_components.ex:4034
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
@@ -17536,4 +17536,19 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_following_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "%{account} moved to another server. Your subscription already went with them — remove this old entry?"
+msgstr ""
+
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:50
+#, elixir-autogen, elixir-format
+msgid "Please sign in first, then you can follow that account from your vutuv account."
+msgstr ""
+
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:71
+#, elixir-autogen, elixir-format
+msgid "That link did not name a Fediverse account we can read."
+msgstr ""
+
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:115
+#, elixir-autogen, elixir-format
+msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""

--- a/test/vutuv_web/controllers/authorize_interaction_test.exs
+++ b/test/vutuv_web/controllers/authorize_interaction_test.exs
@@ -1,0 +1,108 @@
+defmodule VutuvWeb.AuthorizeInteractionTest do
+  @moduledoc """
+  `GET /authorize_interaction?uri=…` — the door Mastodon (Pleroma, Misskey, …)
+  sends somebody through who pressed Follow on an account out there and named
+  their vutuv account as the place they are signed in.
+
+  `async: false`: two of these flip `:fediverse_enabled`, the installation-wide
+  switch, which lives in the application env and is not rolled back by the SQL
+  sandbox.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  # The exact shape of the URL from the bug report: Mastodon fills `{uri}` with
+  # the profile page of the account you were looking at.
+  @account "https://infosec.exchange/@isotopp"
+  @address "@isotopp@infosec.exchange"
+  @follow_page "/settings/fediverse/following"
+
+  describe "GET /authorize_interaction" do
+    test "hands the account over to the follow box", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      conn = get(conn, ~p"/authorize_interaction?#{[uri: @account]}")
+
+      assert redirected_to(conn) == ~p"/settings/fediverse/following?#{[address: @address]}"
+    end
+
+    test "reads the other spellings of the same address", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      for uri <- [
+            "acct:isotopp@infosec.exchange",
+            "@isotopp@infosec.exchange",
+            "isotopp@infosec.exchange",
+            "https://infosec.exchange/users/isotopp"
+          ] do
+        conn = get(recycle(conn), ~p"/authorize_interaction?#{[uri: uri]}")
+
+        assert redirected_to(conn) == ~p"/settings/fediverse/following?#{[address: @address]}"
+      end
+    end
+
+    # Mastodon sends a *post* URL to the same endpoint when the visitor pressed
+    # reply or boost rather than follow. vutuv has nothing to offer there, but
+    # the author of that post is somebody they can follow.
+    test "offers the author when the link points at a single post", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      for uri <- [
+            "https://infosec.exchange/@isotopp/115123456789",
+            "https://infosec.exchange/users/isotopp/statuses/115123456789"
+          ] do
+        conn = get(recycle(conn), ~p"/authorize_interaction?#{[uri: uri]}")
+
+        assert redirected_to(conn) == ~p"/settings/fediverse/following?#{[address: @address]}"
+        assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "@isotopp@infosec.exchange"
+      end
+    end
+
+    test "sends a signed-out visitor to log in and back again", %{conn: conn} do
+      path = ~p"/authorize_interaction?#{[uri: @account]}"
+
+      conn = get(conn, path)
+
+      assert redirected_to(conn) == ~p"/login"
+      assert get_session(conn, :login_return_to) == path
+    end
+
+    test "says what is wrong with a link it cannot read", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      conn = get(conn, ~p"/authorize_interaction?#{[uri: "not-an-address"]}")
+
+      assert redirected_to(conn) == @follow_page
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "Fediverse"
+    end
+
+    test "handles an arrival with no uri at all", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+
+      conn = get(conn, ~p"/authorize_interaction")
+
+      assert redirected_to(conn) == @follow_page
+    end
+
+    test "404s while federation is off", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      Application.put_env(:vutuv, :fediverse_enabled, false)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_enabled) end)
+
+      conn = get(conn, ~p"/authorize_interaction?#{[uri: @account]}")
+
+      assert conn.status == 404
+    end
+
+    # The switch is the installation's, so it is checked before the login
+    # bounce: an endpoint this vutuv does not run must not first ask a visitor
+    # to sign in.
+    test "404s for a signed-out visitor while federation is off", %{conn: conn} do
+      Application.put_env(:vutuv, :fediverse_enabled, false)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_enabled) end)
+
+      conn = get(conn, ~p"/authorize_interaction?#{[uri: @account]}")
+
+      assert conn.status == 404
+    end
+  end
+end

--- a/test/vutuv_web/controllers/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/fediverse_controller_test.exs
@@ -173,6 +173,26 @@ defmodule VutuvWeb.FediverseControllerTest do
       assert href == Docs.actor_url(user)
     end
 
+    # Without this link a remote server guesses where our members confirm a
+    # follow. Mastodon's guess happens to be the path we serve, but Pleroma and
+    # friends simply report "that server offers no follow dialog", so the
+    # template is what makes following from another network work at all.
+    test "publishes the remote-follow (subscribe) template", %{conn: conn} do
+      user = federated_user()
+
+      conn = get(conn, "/.well-known/webfinger?resource=acct:#{user.username}@#{host()}")
+
+      assert %{"template" => template} =
+               Enum.find(
+                 json_response(conn, 200)["links"],
+                 &(&1["rel"] == "http://ostatus.org/schema/1.0/subscribe")
+               )
+
+      assert template ==
+               String.trim_trailing(VutuvWeb.Endpoint.url(), "/") <>
+                 "/authorize_interaction?uri={uri}"
+    end
+
     test "404s for members without the opt-in, unknown handles and foreign hosts",
          %{conn: conn} do
       plain = insert(:activated_user)


### PR DESCRIPTION
**TL;DR** `GET /authorize_interaction?uri=…` 404ed, so pressing Follow on a Mastodon profile and naming your vutuv account led nowhere. The endpoint now exists, and our WebFinger document names the subscribe template it belongs to.

**Where:** `VutuvWeb.AuthorizeInteractionController` (new), `VutuvWeb.FediverseController.jrd/1`, `VutuvWeb.Router`, `Vutuv.Accounts.ReservedSlugs`

**Now:** vutuv publishes no remote-follow (OStatus subscribe) template, so Mastodon falls back to its hardcoded guess `https://vutuv.de/authorize_interaction?uri={uri}` and vutuv answers 404. Implementations without that fallback do not guess at all and report that vutuv offers no follow dialog.

**Want:** the visitor lands on their own follow box with the account filled in.

**Repro:** 1. open `https://infosec.exchange/@isotopp` signed out 2. press "Folgen", type `@you@vutuv.de`, press "Los" 3. 404.

### What it does

The WebFinger document now carries the `http://ostatus.org/schema/1.0/subscribe` template, and the path answers. `?uri=` is read in every spelling in the wild (profile URL, `acct:` URI, bare handle) through the one parser the follow box uses; a link to a single **post** (what Mastodon sends for a reply or a boost) is reduced to its author and offered as a follow, with a flash saying so.

It **follows nothing**. The arrival is a `GET` from another site, so acting on it would let any page on the web make a signed-in member send a signed `Follow` to a server of its choosing simply by linking here. The resolved address is handed to `/settings/fediverse/following`, which already prefills from `?address=` for that reason. A signed-out visitor rides the OAuth screen's `:login_return_to` marker through the PIN round trip and comes back; the installation switch is checked first, so an endpoint this vutuv does not run 404s instead of first asking anyone to sign in.

### The root word

`authorize_interaction` is a root route with a `ReservedSlugs` entry rather than a `/system/` page. That is the exception the root-word rule allows for: the path is hardcoded in other projects as the fallback, so it is spent whether we advertise it or not. No member holds it as a handle.

### Checks

- `mix precommit` green (5878 tests).
- New `authorize_interaction_test.exs` plus a WebFinger template assertion.
- Smoke-tested in Chrome against a dev server: the URL from the bug report lands on "Konten, denen Sie anderswo folgen" with `@isotopp@infosec.exchange` in the box, the post-URL variant shows its flash, and the signed-out request redirects to `/login`.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_011fNZuT5PWRqC4nYkfszMCf