### PR TITLE
WebFinger reads the resource the way other servers write it

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -52,7 +52,12 @@ every endpoint 404s and nothing is delivered.
   still holds.
 - **Discovery**: `GET /.well-known/webfinger?resource=acct:handle@host`
   answers with the actor URL — how Mastodon's search resolves
-  `@handle@vutuv.de`. The profile URL itself answers an
+  `@handle@vutuv.de`. The `resource` is read **tolerantly**, because the asking
+  server writes it and they do not all write it alike: a leading `@` on the
+  handle, any case in the handle or the (DNS, therefore case-free) host, the
+  profile URL `https://vutuv.de/@handle` and a trailing slash all resolve. A
+  404 there dead-ends the whole remote-follow flow before it starts, and none
+  of those spellings is ambiguous about who is meant. The profile URL itself answers an
   `Accept: application/activity+json` with the actor document (the `:browser`
   pipeline accepts `activity+json` for exactly this), and the profile HTML
   head advertises `<link rel="alternate" type="application/activity+json">`.

--- a/lib/vutuv_web/controllers/fediverse_controller.ex
+++ b/lib/vutuv_web/controllers/fediverse_controller.ex
@@ -34,6 +34,7 @@ defmodule VutuvWeb.FediverseController do
   alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.HttpSignature
+  alias Vutuv.Handles
   alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.RawBodyReader
 
@@ -533,10 +534,16 @@ defmodule VutuvWeb.FediverseController do
 
   # acct:handle@host (the WebFinger form Mastodon uses), or the profile /
   # actor URL pasted directly.
+  #
+  # Read tolerantly, because the asking server writes this string and not all of
+  # them write it the way Mastodon does: a leading `@` on the handle is common,
+  # and a host is a DNS name, so its case carries no meaning. A 404 here
+  # dead-ends the whole remote-follow flow before it starts, and none of the
+  # accepted spellings is ambiguous about who is meant.
   defp resolve_resource("acct:" <> acct) do
-    with [handle, host] <- String.split(acct, "@", parts: 2),
-         true <- host == VutuvWeb.Endpoint.host() do
-      Accounts.get_user_by_username(String.downcase(handle))
+    with [handle, host] <- acct |> String.trim_leading("@") |> String.split("@", parts: 2),
+         true <- String.downcase(String.trim(host)) == VutuvWeb.Endpoint.host() do
+      Accounts.get_user_by_username(Handles.normalize(handle))
     else
       _ -> nil
     end
@@ -546,8 +553,17 @@ defmodule VutuvWeb.FediverseController do
     base = String.trim_trailing(VutuvWeb.Endpoint.url(), "/") <> "/"
 
     case String.replace_prefix(url, base, "") do
-      ^url -> nil
-      rest -> rest |> String.trim_trailing("/actor") |> Accounts.get_user_by_username()
+      ^url ->
+        nil
+
+      rest ->
+        # `https://host/@handle` is the profile URL Mastodon itself shows, so it
+        # is what somebody pastes; the trailing slash is what a browser adds.
+        rest
+        |> String.trim_trailing("/")
+        |> String.trim_trailing("/actor")
+        |> Handles.normalize()
+        |> Accounts.get_user_by_username()
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.186.0",
+      version: "7.186.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/fediverse_controller_test.exs
+++ b/test/vutuv_web/controllers/fediverse_controller_test.exs
@@ -193,6 +193,30 @@ defmodule VutuvWeb.FediverseControllerTest do
                  "/authorize_interaction?uri={uri}"
     end
 
+    # The asking server writes the resource, and not every one writes it the way
+    # Mastodon does (which strips a leading @ and lowercases the host before it
+    # asks). A 404 here means the whole remote-follow flow dead-ends before it
+    # starts, so the tolerant reading is the right one: none of these spellings
+    # is ambiguous about who is meant.
+    test "reads the spellings other servers send", %{conn: conn} do
+      user = federated_user()
+
+      for resource <- [
+            "acct:@#{user.username}@#{host()}",
+            "acct:#{user.username}@#{String.upcase(host())}",
+            "#{String.trim_trailing(VutuvWeb.Endpoint.url(), "/")}/@#{user.username}",
+            "#{String.trim_trailing(VutuvWeb.Endpoint.url(), "/")}/#{user.username}/"
+          ] do
+        conn =
+          get(
+            recycle(conn),
+            "/.well-known/webfinger?resource=#{URI.encode_www_form(resource)}"
+          )
+
+        assert json_response(conn, 200)["subject"] == "acct:#{user.username}@#{host()}"
+      end
+    end
+
     test "404s for members without the opt-in, unknown handles and foreign hosts",
          %{conn: conn} do
       plain = insert(:activated_user)


### PR DESCRIPTION
**TL;DR** Three spellings of the same account 404ed at `/.well-known/webfinger`. They resolve now; nothing that used to 404 legitimately does anything different.

**Where:** `VutuvWeb.FediverseController.resolve_resource/1`

Measured against production right after v7.186.0 shipped:

| `resource` | before | after |
|---|---|---|
| `acct:wintermeyer@vutuv.de` | 200 | 200 |
| `acct:@wintermeyer@vutuv.de` | **404** | 200 |
| `acct:Wintermeyer@vutuv.de` | 200 | 200 |
| `acct:wintermeyer@VUTUV.DE` | **404** | 200 |
| `https://vutuv.de/wintermeyer` | 200 | 200 |
| `https://vutuv.de/@wintermeyer` | **404** | 200 |

**Why it matters:** the *asking* server writes that string, and they do not all write it alike. Mastodon strips the leading `@` and lowercases the host before it asks, which is why the flow in #1190 worked at all, but that is Mastodon's politeness rather than a guarantee. `https://vutuv.de/@handle` is the profile URL Mastodon itself displays, so it is what somebody pastes. A 404 there dead-ends the whole remote-follow flow before it starts, which is the same failure #1190 fixed one layer up.

**What changed:** the handle goes through `Vutuv.Handles.normalize/1` (the trim / strip-`@` / downcase the follow box already uses), the host comparison downcases (a DNS name's case carries no meaning), and the URL branch tolerates the `@` form plus a browser's trailing slash. Foreign hosts, unknown handles and members without the opt-in keep 404ing — the existing test for that is untouched and green.

`mix precommit` green (5881 tests), new case in `fediverse_controller_test.exs`.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*

https://claude.ai/code/session_011fNZuT5PWRqC4nYkfszMCf