### PR TITLE
A link in a post from another network is a link again

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -212,13 +212,25 @@ every endpoint 404s and nothing is delivered.
   sentence with their name on it does), the Note answers one of *their own*
   posts, the post is public, the sender is within its inbound cap, and there is
   text left once the markup is gone. Same 202 whatever it decides.
-  - **Plain text, never HTML.** `Vutuv.RemoteHtml.to_text/2` (shared with the
-    Mastodon profile feed, so remote HTML is reduced exactly one way) drops
-    `<script>`/`<style>` **with their contents**, turns `<br>`/`</p>` into line
-    breaks, strips every remaining tag, decodes the base entities once and
-    clamps. So nothing a stranger wrote is ever rendered `raw`, the agent-format
-    siblings carry the value unchanged, and the cap is well defined. **No avatar
-    is copied**: the card renders initials and links to the origin.
+  - **Stored as plain text, never HTML.** `Vutuv.RemoteHtml.to_text/2` (shared
+    with the Mastodon profile feed, so remote HTML is reduced exactly one way)
+    drops `<script>`/`<style>` **with their contents**, turns `<br>`/`</p>` into
+    line breaks, strips every remaining tag, decodes the base entities once and
+    clamps. So no markup a stranger wrote survives into the database, the
+    agent-format siblings carry the value unchanged, and the cap is well
+    defined. **No avatar is copied**: the card renders initials and links to the
+    origin.
+  - **Shown through `VutuvWeb.Markdown.render_remote/1`** — the same renderer
+    the Mastodon profile feed uses, so remote text reads one way across the app.
+    A post from those networks is largely links, and as raw strings they sat on
+    the card unclickable and wrapping mid-URL; now bare URLs autolink with a
+    truncated display, `#hashtags` reach our tag pages (only where the tag is
+    non-empty) and a `@user@host` handle reaches that remote account. It is the
+    foreign-namespace renderer on purpose: every `<img>` is dropped (a hotlink
+    would leak each reader's IP), and a bare `@mention` stays plain text —
+    over there it names an account in the fediverse, not the vutuv member who
+    happens to share the handle. What is rendered `raw` is our own pipeline's
+    sanitized output, exactly as for a member post.
   - **Audience** (issue #1071), read from `to`/`cc` on both the Create and the
     Note, handling all three spellings of the public collection. Only `"public"`
     is public; `"followers"`, `"direct"` and `"unknown"` render to the addressed

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -43,6 +43,7 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.RemoteMedia
   alias Vutuv.ReviewCover
   alias VutuvWeb.FediverseComponents
+  alias VutuvWeb.Markdown
 
   # How many reposter faces the "Reposted by" avatar stack shows before the
   # rest collapse into a `+N` chip. Five keeps the strip to one tidy line even
@@ -161,7 +162,7 @@ defmodule VutuvWeb.PostComponents do
     # simply stays absent for strangers while the author sees it; a preview
     # body carrying inline images switches to the height-based media clamp
     # (`inline_media?` below — a line clamp cannot hold pictures or floats).
-    body_html = VutuvWeb.Markdown.render_post(post.body, post.images)
+    body_html = Markdown.render_post(post.body, post.images)
 
     # Attachments the body references inline render in place; the rest form
     # the gallery (full mode) / the image tile row (preview).
@@ -791,11 +792,14 @@ defmodule VutuvWeb.PostComponents do
       rather than dead. What is there instead is where it came from, a link to
       the original, and the takedown controls.
 
-  The body is escaped **plain text** (`Vutuv.RemoteHtml` reduced it at the
-  inbox), rendered with `whitespace-pre-line` and deliberately *not* run through
-  `VutuvWeb.Markdown`: a stranger's text must not be able to mint links, least
-  of all `@mention` links into local profiles. The "view the original" link
-  carries the reader on when they want the real thing.
+  What is **stored** is plain text (`Vutuv.RemoteHtml` reduced the remote HTML
+  at the inbox, and that does not change). What is **shown** is that text run
+  through `VutuvWeb.Markdown.render_remote/1` — see `remote_body/1` — so the
+  links a post from those networks mostly consists of are clickable instead of
+  sitting there as raw strings. It is the foreign-namespace renderer on purpose:
+  a bare `@mention` stays plain text rather than minting a link into the local
+  profile of whoever shares that handle. The "view the original" link carries
+  the reader on when they want the real thing.
 
   A note its author put behind a content warning renders the warning as a closed
   lid and reveals the text on a click, which is the one thing that author asked
@@ -1070,15 +1074,34 @@ defmodule VutuvWeb.PostComponents do
   attr(:warning, :any, default: nil)
   attr(:text, :string, required: true)
 
-  # `break-words` for the same reason the header has it: this is a stranger's
-  # text, up to 10,000 characters, and nothing stops it being one unbroken
-  # token. A vutuv post body is saved by `.markdown`'s own rule; this one is
-  # outside it.
+  # The body is the stored **plain text** (`Vutuv.RemoteHtml` reduced the remote
+  # HTML at the inbox), formatted for reading by
+  # `VutuvWeb.Markdown.render_remote/1` — the same renderer the Mastodon feed on
+  # the profile uses, so remote text reads one way across the app. What that
+  # buys here is mostly the thing a bare `whitespace-pre-line` paragraph got
+  # wrong: a post on those networks is largely *links*, and they sat on the card
+  # as raw unclickable strings that wrapped mid-URL. Now they autolink with a
+  # truncated display, `#hashtags` reach our tag pages (only where the tag is
+  # non-empty) and a `@user@host` handle reaches that remote account.
+  #
+  # It stays inside a foreign namespace, which is what `render_remote/1` is for
+  # and why the plain renderer is still the wrong one: every `<img>` is dropped
+  # (a hotlink would leak each reader's IP), and a bare `@mention` deliberately
+  # stays plain text — over there it names an account in the fediverse, not the
+  # member here who happens to share the handle. The output is sanitized exactly
+  # like a member post's, so `raw/1` on it is the same `raw/1` every post body
+  # gets.
+  #
+  # `.markdown` carries the wrapper's `overflow-wrap: break-word` for the same
+  # reason the header has `break-words`: this is a stranger's text, up to 10,000
+  # characters, and nothing stops it being one unbroken token.
   #
   # The lid is a real touch target (`min-h-10`) and says both things: "Show"
   # while it is closed, "Hide" once it is open — a lid you cannot shut again is
   # not a lid.
   defp remote_body(assigns) do
+    assigns = assign(assigns, :html, Markdown.render_remote(assigns.text))
+
     ~H"""
     <div
       :if={@warning || presence?(@text)}
@@ -1096,14 +1119,14 @@ defmodule VutuvWeb.PostComponents do
               {gettext("Hide")}
             </span>
           </summary>
-          <p class="mb-0 mt-1.5 whitespace-pre-line break-words text-sm text-slate-700 dark:text-slate-300">
-            {@text}
-          </p>
+          <div class="markdown markdown--post mt-1.5 text-sm text-slate-700 dark:text-slate-300">
+            {Phoenix.HTML.raw(@html)}
+          </div>
         </details>
       <% else %>
-        <p class="mb-0 whitespace-pre-line break-words text-sm text-slate-700 dark:text-slate-300">
-          {@text}
-        </p>
+        <div class="markdown markdown--post text-sm text-slate-700 dark:text-slate-300">
+          {Phoenix.HTML.raw(@html)}
+        </div>
       <% end %>
     </div>
     """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.186.1",
+      version: "7.186.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/feed_remote_posts_test.exs
+++ b/test/vutuv_web/live/feed_remote_posts_test.exs
@@ -67,6 +67,24 @@ defmodule VutuvWeb.FeedRemotePostsTest do
     refute has_element?(view, "[data-remote-post='#{post.id}'] [data-post-actions]")
   end
 
+  test "the body is formatted: links are clickable, hashtags reach our tag pages", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    # The hashtag grammar is `[A-Za-z0-9_]+`, so the factory's hyphenated name
+    # would not parse; and a tag page only links once it lists somebody.
+    name = "klima#{System.unique_integer([:positive])}"
+    {:ok, user_tag} = Vutuv.Tags.add_user_tag(user, name)
+    tag = Repo.preload(user_tag, :tag).tag
+
+    cached_post(user, %{
+      content_text: "Read this: https://taz.de/Klimaschutzvorgaben/!6199402/ ##{name}"
+    })
+
+    {:ok, _view, html} = live(conn, ~p"/feed")
+
+    assert html =~ ~s(href="https://taz.de/Klimaschutzvorgaben/!6199402/")
+    assert html =~ ~s(href="/tags/#{tag.slug}")
+  end
+
   describe "the heart (issue #1164)" do
     setup %{conn: conn} do
       {conn, user} = create_and_login_user(conn)

--- a/test/vutuv_web/live/post_thread_remote_replies_test.exs
+++ b/test/vutuv_web/live/post_thread_remote_replies_test.exs
@@ -121,6 +121,33 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
       assert html =~ "<details"
     end
 
+    test "its links are clickable, not raw strings", %{post: post} do
+      # A post on those networks is largely links. Stored as plain text, they
+      # used to sit on the card unclickable and wrapping mid-URL.
+      note!(post, content_text: "Worth reading: https://taz.de/Klimaschutzvorgaben/!6199402/")
+
+      {:ok, _view, html} = thread_view(post)
+
+      assert html =~ ~s(href="https://taz.de/Klimaschutzvorgaben/!6199402/")
+      # New tab, and no ranking credit passed to a stranger's link.
+      assert html =~ "noopener"
+    end
+
+    test "a bare @mention stays plain text, it never links a local member", %{post: post} do
+      # Over there `@name` names an account in the fediverse, not the vutuv
+      # member who happens to share the handle — linking it would point the
+      # reader at the wrong person.
+      # A real, mentionable handle: the factory's `user-1` carries a hyphen,
+      # which the mention grammar stops at, so it would prove nothing.
+      member = insert(:activated_user, username: unique_username())
+      note!(post, content_text: "Ask @#{member.username} about it.")
+
+      {:ok, _view, html} = thread_view(post)
+
+      assert html =~ "Ask @#{member.username} about it."
+      refute html =~ ~s(href="/#{member.username}")
+    end
+
     test "a lone post with only a remote reply still renders the conversation", %{post: post} do
       # The single-card shortcut must not swallow the one answer the post got.
       note!(post)


### PR DESCRIPTION
**TL;DR** Fediverse post/reply cards rendered their body as raw plain text, so the URLs those posts mostly consist of sat there unclickable and wrapped mid-string. They now go through `VutuvWeb.Markdown.render_remote/1`, the renderer the profile's Mastodon feed already used.

**Where:** `VutuvWeb.PostComponents.remote_body/1` (feeds `remote_post_card/1` + `remote_reply_card/1`)

**Now:** the stored plain text in a `whitespace-pre-line` paragraph. Reading a linked article meant selecting the URL and pasting it into the address bar.

**Want / after this PR:**
- bare URLs autolink with a truncated display (`taz.de/Unbequeme-Klimaschutzvorgaben/…`), new tab, `rel="noopener noreferrer"`
- `#hashtags` link to our tag pages, but only where the tag exists and lists members
- `@user@host` links to that remote account
- paragraphs get normal post spacing, so a remote body reads like a vutuv post

**Deliberately unchanged:**
- a bare `@mention` stays plain text. Over there `@name` names a fediverse account, not the vutuv member sharing that handle, so a link would point at the wrong person. That risk is why the body originally skipped Markdown; `render_remote/1` is the answer to it rather than a reversal of it.
- every `<img>` is dropped (a hotlink would hand each reader's IP to a stranger's server)
- storage: `Vutuv.RemoteHtml` still reduces remote HTML to plain text at the inbox, so the `.md`/`.txt`/`.json`/`.xml` siblings carry the same value and no stranger's markup reaches the database. What is rendered `raw` is our own pipeline's sanitized output, the same path a member post takes.

**Tests:** links clickable + hashtag resolves to the tag page (`feed_remote_posts_test.exs`); links clickable + `@mention` links no member (`post_thread_remote_replies_test.exs`).

**Deploy:** hot. No migrations, no config, no supervision-tree or dependency changes. Version 7.186.2.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*