### PR TITLE
The sign-up form asks about the Fediverse, with the box ticked

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -117,9 +117,9 @@ Everything else has a default (the vutuv.de production value):
 | `POST_EDIT_WINDOW_MINUTES` | `30` | How long a post stays editable after publishing. Editing also closes with the first like, repost or reply, whatever this value says (an edit would silently rewrite what somebody else endorsed); deleting is never blocked. Raise it for a closed community where posts get little immediate engagement |
 | `POST_DRAFT_RETENTION_DAYS` | `30` | How long the composer keeps a post somebody started and never sent, counted from the last change. Drafts are stored so a page reload cannot eat them, which means unpublished text of your members sits in your database — this is the retention promise your privacy page should quote. A draft is dropped the moment its post is sent, and any photo attached to it goes with it |
 | `LANDING_HEADLINE_EXPERIMENT` | `true` | `false` stops the split test on the start page's founder quote: every visitor sees the same headline and nothing is counted. Leave it on and read the result at `/admin/experiments`, or turn it off if your start page copy is your own and you do not want it to vary. Only aggregate counters are stored, never a visitor, and the test sets no cookie of its own |
-| `FEDIVERSE_ENABLED` | `true` | `false` turns follow-only ActivityPub federation off entirely (endpoints 404, nothing is delivered) — set it on intranet installations |
+| `FEDIVERSE_ENABLED` | `true` | `false` turns follow-only ActivityPub federation off entirely (endpoints 404, nothing is delivered, and the sign-up form drops the Fediverse question) — set it on intranet installations |
 | `FEDIVERSE_INBOUND_CAPS` | `600,60` | `host,actor`: how many rows one remote server, and one remote account, may store here per hour. Anything past the budget is dropped for that hour. The floor under the operator blocklist at `/admin/fediverse`, since it also bounds servers nobody has blocked yet |
-| `FEDIVERSE_NOTE_RETENTION_DAYS` | `183` | How long a reply written on another network may be held here at the very most, in days. It is deleted when the clock runs out whatever else happens, so this is the promise your privacy page can make. Only applies once a member switches replies on (off by default) |
+| `FEDIVERSE_NOTE_RETENTION_DAYS` | `183` | How long a reply written on another network may be held here at the very most, in days. It is deleted when the clock runs out whatever else happens, so this is the promise your privacy page can make. Applies once a member has replies on — which the ticked Fediverse box at sign-up does, and the settings switch on its own does not |
 | `FEDIVERSE_NOTE_REFRESH_DAYS` | `7` | How stale a stored reply may get before vutuv asks its origin server whether it is still published there. Still there means the text is refreshed and the retention clock starts again; gone (or locked away) means it is deleted at once; unreachable changes nothing. Replies sent to a member privately are never re-checked |
 | `FEDIVERSE_OUTBOUND_REPLY_LIMIT` | `30` | How many answers to other networks one member may send per hour. This is the one place a member's own action makes your installation POST to a server that never followed them, so it is metered: the budget is the backstop against a compromised account relaying. Sized for somebody holding a conversation, so it only ever bites automation. Answering is only possible where a reply from that server already sits on a vutuv post, so the targets are always people who wrote here first |
 | `FEDIVERSE_OUTBOUND_LIKE_LIMIT` | `200` | How many likes of posts on other networks one member may send per hour. A separate, far larger budget than the reply limit above, because the two are nothing alike in frequency: a like is one tap while reading, so a limit sized for writing prose would refuse ordinary reading. It is still a limit, because this too makes your installation POST to a server that never followed the member. Taking a like back is never metered: a withdrawal must not be refusable |
@@ -510,6 +510,25 @@ is not a vetted party. Your levers live at **`/admin` → Fediverse**
 (`/admin/fediverse`); the whole screen is gone on an installation with
 `FEDIVERSE_ENABLED=false`.
 
+**Who federates, and what your privacy page has to say.** Each member decides
+for themselves, and they are asked twice: the sign-up form carries the question
+as a labelled checkbox that is **ticked by default** (with the explanation
+beside it, and one click to untick), and `/settings/fediverse` turns it off
+again at any time. That single box is the coarse "yes to all of it" and sets
+**all three** switches of the settings page — taking part, showing the
+reactions that come back, **and showing and storing the replies** people write
+on other networks — which is why its text spells the reply storage and its
+six-month limit out. So on an installation with `FEDIVERSE_ENABLED=true` expect
+most new accounts to federate from their first day, and to hold third-party
+replies; nothing leaves the building before the sign-up PIN confirms the
+address, and the three switches can be separated again at any time on the
+settings page. If holding a stranger's text is not acceptable on your
+installation, the only lever today is `FEDIVERSE_ENABLED=false`, which turns
+federation off entirely. **Your privacy page has to describe the choice the way
+it is actually offered** — presented at registration, pre-selected, covering
+reactions and replies, and revocable in the settings. It is per-installation
+content, edited at `/admin` → Legal pages, not shipped in the code.
+
 - **Blocklist.** Enter a server name (`mastodon.example` — a full address or an
   `@user@server` handle works too, only the server part is kept). From then on
   everything that server sends is dropped **before** its signature is checked
@@ -537,8 +556,10 @@ is not a vetted party. Your levers live at **`/admin` → Fediverse**
   address), and when — keeping a stranger's words after deleting their reply
   would make the deletion untrue.
 
-**Replies from other networks.** Off by default and switched on per member on
-their own Fediverse settings page. Once on, an answer written on another server
+**Replies from other networks.** Switched on per member, either by the ticked
+Fediverse box at sign-up (which covers all three switches, see above) or on
+their own Fediverse settings page, where the switch alone starts off. Once on,
+an answer written on another server
 under one of their public posts is stored here as **plain text** (never HTML,
 and no copy of the author's picture) and shown in the conversation, clearly
 marked as coming from elsewhere and linking to the original. A reply addressed
@@ -564,8 +585,9 @@ at all — they never signed up here and cannot practically be asked:
   tell that server we are holding it.
 
 If you run an installation where holding third-party text is not acceptable at
-all, leave it as it is: members have to switch it on themselves, and
-`FEDIVERSE_ENABLED=false` turns the whole of federation off.
+all, `FEDIVERSE_ENABLED=false` (which turns the whole of federation off) is the
+lever — the sign-up box switches replies on along with everything else, so
+expect most new accounts to hold them.
 
 **Answering those replies.** A member who takes part in the Fediverse can answer
 a **public** reply that came from another network, from the reply's own card in the

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -23,10 +23,34 @@ frozen/suspended/deactivated). On top sits the installation-wide switch
 `:fediverse_enabled` (`FEDIVERSE_ENABLED=false` for intranets): off means
 every endpoint 404s and nothing is delivered.
 
+**The question is asked twice, and once is at sign-up.** The `/settings`
+switch alone reaches only the people who go looking for it, so the sign-up
+form carries the same question as a labelled checkbox — **pre-ticked**, because
+most people who join want the connection, with three lines of explanation
+beside it and one click to take it back (`VutuvWeb.PageController.index/2`
+primes it on the changeset; the box is left out entirely where
+`:fediverse_enabled` is off). **That one box sets all three switches**
+(`expand_fediverse_choice/1`): participation, `fediverse_reactions?` *and*
+`fediverse_replies?` — which is why it is the only box on that form carrying an
+explanation, and why the explanation names the reply storage and its six-month
+limit. Ticking it consents to holding text written by people who never signed
+up here, so the sentence has to say so; the `/settings/fediverse` switch, whose
+wording promises none of that, still leaves replies off. Unticking sets
+participation to false and leaves the other two at their schema defaults, so a
+later yes on the settings page lands on that page's own defaults.
+That path cannot mint the keypair the way the settings page does — at sign-up
+the address is unconfirmed, so nothing may federate yet and a key per
+unconfirmed registration is work for the sweeper — so **confirmation mints it**
+(`Vutuv.Accounts.activate_user/1`, guarded by `federated?/1`). That is the
+moment `federated?/1` turns true, and it has to be: the delivery worker deletes
+every activity of a member it finds no key for, silently.
+
 ## The moving parts
 
 - **Actor** (`Vutuv.Fediverse.Actor`): the member's RSA-2048 keypair
-  (`Vutuv.Fediverse.Keys`), created lazily on opt-in. The documents are built
+  (`Vutuv.Fediverse.Keys`), created lazily — on opt-in from `/settings`, on the
+  PIN confirmation of a sign-up that opted in, and on the first fetch of the
+  actor document, whichever comes first. The documents are built
   by `VutuvWeb.Fediverse.Docs`; URLs hang off the member so no root slug is
   burned: `/:username/actor` (id), `.../inbox`, `.../followers` and
   `.../outbox` (count-only collections) and `.../collections/featured` (the

--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -399,6 +399,18 @@ defmodule Vutuv.Accounts do
       )
 
     MemberCounter.increment()
+
+    # The sign-up form's Fediverse box is the second way a member can be opted
+    # in, and unlike /settings/fediverse it cannot mint the actor keypair
+    # itself: at sign-up the address is unconfirmed, so nothing may federate
+    # yet, and a keypair per unconfirmed registration would be work done for
+    # `delete_unconfirmed_registrations/1` to throw away. Confirmation is the
+    # moment `Fediverse.federated?/1` turns true, so it is the moment the
+    # signing key has to exist — the delivery worker deletes every activity of
+    # a member it finds no key for (the first remote Follow they send, say)
+    # without a word to anyone.
+    if Vutuv.Fediverse.federated?(activated), do: Vutuv.Fediverse.ensure_actor(activated)
+
     activated
   end
 

--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -4,6 +4,7 @@ defmodule VutuvWeb.PageController do
   plug(VutuvWeb.Plug.RequireUserLoggedOut when action in [:index])
   alias Vutuv.Accounts.Email
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
   alias VutuvWeb.AgentDocs
   alias VutuvWeb.AgentDocs.ListDocs
   alias VutuvWeb.LandingExperiment
@@ -24,12 +25,27 @@ defmodule VutuvWeb.PageController do
     # the form's controls only - the User/Email schemas keep their own defaults
     # for every other code path, so an address created without an explicit
     # choice still stays private.
+    #
+    # The Fediverse box is pre-checked the same way: most people who join want
+    # the connection to Mastodon and friends, and sign-up is the one moment
+    # every member passes through, while the switch on /settings/fediverse is
+    # one hardly anybody goes looking for. It stays a visible question with a
+    # line of explanation next to it, and unticking it is one click. Primed to
+    # `false` where the installation federates nothing at all
+    # (FEDIVERSE_ENABLED=false, intranets), which is also where the template
+    # leaves the whole question out.
+    #
+    # One question, all three switches: a ticked box is expanded by
+    # `expand_fediverse_choice/1` below into taking part *plus* the reactions
+    # and replies that come back, because that is what "take part" means to
+    # somebody reading it, and the box's own text says so.
     changeset =
       %User{
         gender: prefill_gender(prefill["gender"]),
         first_name: presence(prefill["first_name"]),
         last_name: presence(prefill["last_name"]),
-        tag_list: presence(prefill["tags"])
+        tag_list: presence(prefill["tags"]),
+        fediverse_followers?: Fediverse.enabled?()
       }
       |> User.changeset()
       |> Ecto.Changeset.put_assoc(:emails, [
@@ -130,6 +146,8 @@ defmodule VutuvWeb.PageController do
   end
 
   def new_registration(conn, %{"user" => user_params}) do
+    user_params = expand_fediverse_choice(user_params)
+
     # Extract defensively: a malformed "emails" param (not the nested
     # %{"0" => %{"value" => …}} the form produces) must reach register_user/2
     # as a plain error changeset, not crash on chained Access indexing.
@@ -168,6 +186,26 @@ defmodule VutuvWeb.PageController do
         end
     end
   end
+
+  # The sign-up form asks about the Fediverse once; `/settings/fediverse` has
+  # three switches. Ticking the box means the whole thing, so it sets all three:
+  # taking part, the reactions that come back, and the replies people write out
+  # there. That is why the box's own text has to name the reply storage and its
+  # six-month limit — a consent may only cover what it says out loud, and one of
+  # these three keeps a stranger's words on our server.
+  #
+  # Unticking sets participation to false and leaves the other two alone, at
+  # their schema defaults (reactions on, replies off). They mean nothing while
+  # nobody federates, and if the member later switches participation on from
+  # `/settings/fediverse` — where the switch promises no reply storage — they
+  # land on exactly the defaults that page argues for, rather than on a silent
+  # echo of a box they unticked at sign-up.
+  defp expand_fediverse_choice(%{"fediverse_followers?" => value} = params)
+       when value in [true, "true", "1", "on"] do
+    Map.merge(params, %{"fediverse_reactions?" => "true", "fediverse_replies?" => "true"})
+  end
+
+  defp expand_fediverse_choice(params), do: params
 
   defp handle_post_registration_login(conn, email) do
     # The account was just created, so login_by_email/2 always mails the PIN

--- a/lib/vutuv_web/templates/page/index.html.heex
+++ b/lib/vutuv_web/templates/page/index.html.heex
@@ -130,13 +130,14 @@
       </.inputs_for>
     </div>
 
-    <%!-- Group 3: privacy. Positive, opt-in phrasing to match the email
-          checkbox above, and checked by default. Both fields are inverted:
-          the box reads positively ("Allow ...") while the underlying
-          `noindex?` / `noai?` flags are negative, so a checked box submits
-          "false" (allow). The SEO question (search engines) and the GEO
-          question (AI agents / LLMs) are asked separately, since a member may
-          say yes to one and no to the other. --%>
+    <%!-- Group 3: reach. Positive, opt-in phrasing to match the email
+          checkbox above, and every box checked by default. The first two
+          fields are inverted: the box reads positively ("Allow ...") while the
+          underlying `noindex?` / `noai?` flags are negative, so a checked box
+          submits "false" (allow). The SEO question (search engines), the GEO
+          question (AI agents / LLMs) and the Fediverse question (other social
+          networks) are asked separately, since a member may say yes to one and
+          no to the next. --%>
     <div class="space-y-3 border-t border-slate-200 pt-6 dark:border-slate-800">
       <label class={check_label_class}>
         <%= checkbox f, :noindex?, checked_value: "false", unchecked_value: "true", class: checkbox_class() %>
@@ -149,6 +150,39 @@
         <%= checkbox f, :noai?, checked_value: "false", unchecked_value: "true", class: checkbox_class() %>
         <span>{gettext("Allow AI agents and LLMs to use your profile")} (GEO)</span>
         <%= error_tag f, :noai? %>
+      </label>
+      <%!-- The third "who may reach this profile" question (Vutuv.Fediverse),
+            and the one that is NOT inverted: checked means taking part.
+            Pre-checked by the controller, because most people who join want it
+            and this is the only moment they are asked; /settings/fediverse
+            takes it back at any time. The label is deliberately the same
+            sentence as the switch on that page, so the member recognizes the
+            thing they are looking for later.
+
+            One box, all three of that page's switches (see
+            PageController.expand_fediverse_choice/1) — which is exactly why
+            this box carries three lines of explanation where the other two
+            carry none. It is the only choice on this form that is not just
+            about the member's own data: ticking it means answers written by
+            people who never signed up here are stored on our server, so the
+            text has to say that, and say for how long, before the tick counts
+            as consent to it. Left out entirely where the installation
+            federates nothing (FEDIVERSE_ENABLED=false, intranets). --%>
+      <label :if={Vutuv.Fediverse.enabled?()} class={check_label_class}>
+        <%= checkbox f, :fediverse_followers?, class: checkbox_class() %>
+        <span>
+          {gettext("Take part in the Fediverse")}
+          <%!-- `font-normal` is not decoration: components.css sets every
+                <label> bold, which the three box labels want and this helper
+                line does not - without it the explanation shouts as loudly as
+                the choice it explains. --%>
+          <span class="mt-0.5 block text-xs font-normal text-slate-600 dark:text-slate-400">
+            {gettext(
+              "People on Mastodon and other independent networks can then follow this profile, and your public posts appear there. What they answer or share comes back and is shown under your posts, by their account address. A reply from there is stored here for up to six months. You can switch all of it off again at any time."
+            )}
+          </span>
+        </span>
+        <%= error_tag f, :fediverse_followers? %>
       </label>
     </div>
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.186.2",
+      version: "7.187.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -18341,3 +18341,14 @@ msgid "That link points at a single post. You can follow its author, %{account},
 msgstr ""
 "Dieser Link zeigt auf einen einzelnen Beitrag. Von hier aus können Sie dem "
 "Konto dahinter folgen: %{account}."
+
+#: lib/vutuv_web/templates/page/index.html.heex:176
+#, elixir-autogen, elixir-format
+msgid "People on Mastodon and other independent networks can then follow this profile, and your public posts appear there. What they answer or share comes back and is shown under your posts, by their account address. A reply from there is stored here for up to six months. You can switch all of it off again at any time."
+msgstr ""
+"Menschen auf Mastodon und in anderen unabhängigen Netzwerken können diesem "
+"Profil dann folgen, und Ihre öffentlichen Beiträge erscheinen dort. Was von "
+"dort geantwortet oder geteilt wird, kommt zurück und erscheint unter Ihren "
+"Beiträgen, mit der Adresse des jeweiligen Kontos. Eine Antwort von dort "
+"speichern wir dafür bis zu sechs Monate. Alles davon lässt sich jederzeit "
+"wieder abschalten."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -17554,3 +17554,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
+
+#: lib/vutuv_web/templates/page/index.html.heex:176
+#, elixir-autogen, elixir-format
+msgid "People on Mastodon and other independent networks can then follow this profile, and your public posts appear there. What they answer or share comes back and is shown under your posts, by their account address. A reply from there is stored here for up to six months. You can switch all of it off again at any time."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -17552,3 +17552,8 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
+
+#: lib/vutuv_web/templates/page/index.html.heex:176
+#, elixir-autogen, elixir-format
+msgid "People on Mastodon and other independent networks can then follow this profile, and your public posts appear there. What they answer or share comes back and is shown under your posts, by their account address. A reply from there is stored here for up to six months. You can switch all of it off again at any time."
+msgstr ""

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -120,6 +120,19 @@ defmodule VutuvWeb.ConnCase do
         token
       end
 
+      # True when the <input type="checkbox" name=name> in `html` is rendered
+      # checked, regardless of attribute order. The assertion a form's default
+      # state needs: a box that submits "true" only because it is pre-ticked is
+      # a different product decision from one the member has to find and click.
+      defp checkbox_checked?(html, name) do
+        regex = ~r/<input(?=[^>]*\btype="checkbox")(?=[^>]*\bname="#{Regex.escape(name)}")[^>]*>/
+
+        case Regex.run(regex, html) do
+          [tag] -> tag =~ "checked"
+          _ -> false
+        end
+      end
+
       # ── /api/2.0 helpers (shared by every API test file) ──
 
       defp authed(conn, token) do

--- a/test/vutuv_web/controllers/page_controller_test.exs
+++ b/test/vutuv_web/controllers/page_controller_test.exs
@@ -675,16 +675,8 @@ defmodule VutuvWeb.PageControllerTest do
     end
   end
 
-  # True when the <input type="checkbox" name=name> in `html` is checked,
-  # regardless of attribute order.
-  defp checkbox_checked?(html, name) do
-    regex = ~r/<input(?=[^>]*\btype="checkbox")(?=[^>]*\bname="#{Regex.escape(name)}")[^>]*>/
-
-    case Regex.run(regex, html) do
-      [tag] -> tag =~ "checked"
-      _ -> false
-    end
-  end
+  # `checkbox_checked?/2` is shared with the other form tests and lives in
+  # VutuvWeb.ConnCase.
 
   # True when the <input type="radio" name=name value=value> in `html` is
   # checked, regardless of attribute order.

--- a/test/vutuv_web/controllers/registration_fediverse_test.exs
+++ b/test/vutuv_web/controllers/registration_fediverse_test.exs
@@ -1,0 +1,170 @@
+defmodule VutuvWeb.RegistrationFediverseTest do
+  @moduledoc """
+  The Fediverse question on the sign-up form (`/`, `POST /new_registration`).
+
+  Most people who join want the connection to Mastodon and friends, so the box
+  is ticked by default. Sign-up is the one moment every member passes through,
+  while the switch on `/settings/fediverse` is one hardly anybody goes looking
+  for — a member who would have said yes never gets asked there.
+
+  One box, all three switches of that page (`Vutuv.Fediverse` participation,
+  the reactions that come back, the replies people write out there), so the
+  wording carries the weight: the last of those stores text written by people
+  who never signed up here, and a consent only covers what it says out loud.
+
+  What the box may not do is federate anything on its own. At sign-up the
+  address is still unconfirmed, so `Vutuv.Fediverse.federated?/1` says no and no
+  keypair exists; confirmation is the moment both turn true, and it has to mint
+  the actor, because the delivery worker silently drops every activity of a
+  member who has no key.
+
+  `async: false`: two tests flip `:fediverse_enabled`, application env the SQL
+  sandbox does not roll back, and every other test here asserts on the box that
+  same switch governs.
+  """
+  use VutuvWeb.ConnCase, async: false
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
+
+  describe "GET /" do
+    test "offers the Fediverse box, ticked by default", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+
+      # The same sentence the switch on /settings/fediverse wears, so the
+      # member recognizes what they are looking for when they want it back.
+      assert body =~ "Take part in the Fediverse"
+      assert body =~ "Mastodon"
+      assert checkbox_checked?(body, "user[fediverse_followers?]")
+    end
+
+    # One tick switches all three of the settings page's switches on, and one of
+    # those stores what people who never signed up here wrote. A consent covers
+    # what it says out loud, so the box has to say it: that replies come back,
+    # and that a copy is kept for up to six months.
+    test "the box says that replies are stored, and for how long", %{conn: conn} do
+      body = conn |> get(~p"/") |> html_response(200)
+
+      assert body =~ "A reply from there is stored here for up to six months"
+      assert body =~ "shown under your posts"
+    end
+
+    # vutuv is a German site, and a new English string on the one page every
+    # visitor starts on is an English island nothing else would catch: the test
+    # suite and a bare curl both ask for English (see the locale rule).
+    test "asks in German when the browser asks in German", %{conn: conn} do
+      body =
+        conn
+        |> put_req_header("accept-language", "de-DE,de;q=0.9")
+        |> get(~p"/")
+        |> html_response(200)
+
+      assert body =~ "Am Fediverse teilnehmen"
+      assert body =~ "Eine Antwort von dort speichern wir dafür bis zu sechs Monate."
+    end
+
+    # An intranet installation (FEDIVERSE_ENABLED=false) federates nothing, so
+    # the question would promise something it cannot deliver.
+    test "asks nothing on an installation that does not federate", %{conn: conn} do
+      Application.put_env(:vutuv, :fediverse_enabled, false)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_enabled) end)
+
+      body = conn |> get(~p"/") |> html_response(200)
+
+      refute body =~ "user[fediverse_followers?]"
+      refute body =~ "Take part in the Fediverse"
+    end
+  end
+
+  describe "POST /new_registration" do
+    # One question on the form, all three switches of /settings/fediverse: the
+    # box means taking part, and the box's text says what that includes.
+    test "the ticked box switches all three settings on", %{conn: conn} do
+      attrs = fediverse_attrs("fedi-on", "true")
+
+      post(conn, ~p"/new_registration", user: attrs)
+
+      user = registered(attrs)
+      assert user.fediverse_followers?
+      assert user.fediverse_reactions?
+      assert user.fediverse_replies?
+    end
+
+    # Unticking submits the checkbox's hidden "false", which must land as an
+    # account outside the Fediverse — the state the schema default describes.
+    test "unticking it leaves the account out", %{conn: conn} do
+      attrs = fediverse_attrs("fedi-off", "false")
+
+      post(conn, ~p"/new_registration", user: attrs)
+
+      refute registered(attrs).fediverse_followers?
+    end
+
+    # Saying no switches participation off and nothing else: the other two mean
+    # nothing while nobody federates, and a member who later says yes on
+    # /settings/fediverse — where the switch promises no reply storage — has to
+    # land on that page's own defaults, not on an echo of a box they unticked
+    # here.
+    test "unticking leaves the follow-up switches at their schema defaults", %{conn: conn} do
+      attrs = fediverse_attrs("fedi-defaults", "false")
+
+      post(conn, ~p"/new_registration", user: attrs)
+
+      user = registered(attrs)
+      assert user.fediverse_reactions?
+      refute user.fediverse_replies?
+    end
+
+    test "nothing federates while the address is unconfirmed", %{conn: conn} do
+      attrs = fediverse_attrs("fedi-pending", "true")
+
+      post(conn, ~p"/new_registration", user: attrs)
+
+      user = registered(attrs)
+      assert user.fediverse_followers?
+      refute user.email_confirmed?
+      refute Fediverse.federated?(user)
+      refute Fediverse.get_actor(user)
+    end
+
+    # Confirming is the moment `federated?/1` turns true, so it is the moment
+    # the signing key has to exist: without it the delivery worker throws away
+    # every activity this member queues (their first remote Follow, say) as
+    # unsignable, and nothing anywhere says so.
+    test "the PIN confirmation mints the actor keypair", %{conn: conn} do
+      attrs = fediverse_attrs("fedi-confirm", "true")
+
+      conn = post(conn, ~p"/new_registration", user: attrs)
+      post(conn, ~p"/login", session: %{"pin" => sent_pin()})
+
+      user = registered(attrs)
+      assert user.email_confirmed?
+      assert Fediverse.federated?(user)
+      assert Fediverse.get_actor(user)
+    end
+
+    test "a member who said no gets no keypair on confirmation", %{conn: conn} do
+      attrs = fediverse_attrs("fedi-no-key", "false")
+
+      conn = post(conn, ~p"/new_registration", user: attrs)
+      post(conn, ~p"/login", session: %{"pin" => sent_pin()})
+
+      user = registered(attrs)
+      assert user.email_confirmed?
+      refute Fediverse.get_actor(user)
+    end
+  end
+
+  defp fediverse_attrs(prefix, value) do
+    prefix |> registration_attrs() |> Map.put("fediverse_followers?", value)
+  end
+
+  defp registered(%{"emails" => %{"0" => %{"value" => email}}}) do
+    Repo.one!(
+      from(u in User,
+        join: e in assoc(u, :emails),
+        where: e.value == ^email
+      )
+    )
+  end
+end


### PR DESCRIPTION
**TL;DR** New members are asked about the Fediverse at sign-up, with the box ticked. That one box sets all three switches of `/settings/fediverse`, so its wording names the reply storage and its six-month limit. Confirming the address now mints the actor keypair.

**Version:** 7.187.0 · **Hot deploy** (no migrations, no config, no deps, no supervision changes).

### Why

Federation only ever reached people who went looking for it: the switch lives on `/settings/fediverse`, a page nobody visits without already knowing the word. Sign-up is the one moment everybody passes through, and most people who join want the connection to Mastodon and friends.

### What the box does

- Ticking it sets `fediverse_followers?`, `fediverse_reactions?` **and** `fediverse_replies?` (`PageController.expand_fediverse_choice/1`). That is what "take part" means to somebody reading it — and because the third one stores text written by people who never signed up here, the box carries three lines of explanation naming the reply storage and the six-month ceiling. A consent covers what it says out loud.
- The `/settings/fediverse` switch is unchanged: on its own it still leaves replies off, because its wording promises none of that.
- Unticking sets only participation to `false` and leaves the other two at their schema defaults, so a later yes on the settings page lands on that page's defaults, not on an echo of a box unticked months earlier.
- `FEDIVERSE_ENABLED=false` (intranets) drops the question entirely.

### The keypair gap this closed

"Opted in" and "has a key" could not come apart before, because the settings page was the only way in and it calls `ensure_actor/1`. Sign-up cannot mint it (address unconfirmed, nothing may federate yet, and a key per unconfirmed registration is work for the sweeper). So `Accounts.activate_user/1` mints it on first confirmation — without that the delivery worker deletes every activity of a keyless member ("No key … undeliverable for good"), and their first remote Follow would have vanished with no error anywhere.

### Tests & docs

Ten tests in `test/vutuv_web/controllers/registration_fediverse_test.exs` (`async: false` — two flip `:fediverse_enabled`), covering the ticked default, all three switches, the unticked path, the German render, the intranet case and the keypair-on-confirmation. `checkbox_checked?/2` moved to `VutuvWeb.ConnCase` since two files need it. `docs/architecture/fediverse.md` and `docs/ADMINS.md` updated — the latter now says plainly what the ticked box means for a third-party installation (expect most new accounts to hold third-party replies; `FEDIVERSE_ENABLED=false` is the only lever).

The vutuv.de privacy page was updated by hand at `/admin/legal` before this shipped.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01PTwE9gLKFFqrkEkVpnpYiN