### PR TITLE
The username notification points at the page that renames you (v7.187.1)

### DIFF
--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -743,7 +743,7 @@ defmodule VutuvWeb.NotificationLive.Index do
         before_handle: before_handle,
         between: between,
         tail: tail,
-        settings_url: url(~p"/settings/security")
+        settings_url: url(~p"/settings/username")
       )
 
     ~H"""

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.187.0",
+      version: "7.187.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/notification_live_test.exs
+++ b/test/vutuv_web/live/notification_live_test.exs
@@ -55,7 +55,9 @@ defmodule VutuvWeb.NotificationLiveTest do
                "@#{user.username}"
              )
 
-      settings_url = VutuvWeb.Endpoint.url() <> "/settings/security"
+      # The rename form lives on its own page (/settings/username); the
+      # security page holds sign-in credentials and cannot change a handle.
+      settings_url = VutuvWeb.Endpoint.url() <> "/settings/username"
 
       assert has_element?(
                live,


### PR DESCRIPTION
The welcome row on `/notifications` tells a new member the handle vutuv generated for them and where to change it. The spelled-out URL in that sentence was `http://…/settings/security`.

Renaming moved to its own page (`/settings/username`) when the settings information architecture was reworked; the security page holds sign-in credentials and has no rename form. So the one sentence whose whole job is to hand out that link sent people to a dead end.

The link now names `/settings/username`. The test that covers this row asserted the old URL, so it is updated first and fails without the fix.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*