### PR TITLE
A new member's profile now leads with people to follow (v7.188.0)

### DIFF
--- a/docs/architecture/settings-and-account.md
+++ b/docs/architecture/settings-and-account.md
@@ -163,11 +163,16 @@ instead of its regular late-rail spot: every other card on a fresh profile
 points inward, and this is the one moment to show that there are people here
 to follow. The placement is sticky per page view — the fifth follow, made from
 the promoted card itself, must not teleport the card away mid-click; the next
-visit demotes it. The card only ever suggests accounts that posted within the
-last three weeks (`Posts.recently_posting_ids/2`,
-`UserProfileLive.@suggested_activity_days`): a suggestion promises that
-following fills your feed, and a silent account cannot keep that promise —
-deliberately strict, so a thin card beats a padded one.
+visit demotes it. The suggestions are the last four weeks' most-hearted
+posters (`Posts.top_recent_posters/2`,
+`UserProfileLive.@suggested_window_days`): members with a post in the window,
+ranked by the local hearts those posts collected (post count breaks ties),
+then thinned by the per-viewer exclusions (owner, viewer, already-followed,
+blocked). Follower totals deliberately play no part — they reward the past,
+while the card's promise is a feed with something in it, which only current,
+liked output can keep. Deliberately strict, so a thin card beats a padded
+one; an installation with no recent posts renders no card, and the checklist
+step then links to the most-followed listing instead.
 
 Work experience is deliberately not on the checklist; its section card keeps its
 own add tile.

--- a/docs/architecture/settings-and-account.md
+++ b/docs/architecture/settings-and-account.md
@@ -146,11 +146,24 @@ found; validated in `User.registration_changeset/2` with the same comma/space
 parsing and case-insensitive de-duplication the tag creation uses).
 
 After the confirmation PIN a fresh member lands on their own profile, where the
-**"Complete your profile" checklist** (owner-only, first 24h or 24h after a
-dormant return) opens with the tag step already checked — 1/4 done — and leads
-through photo → tagline (Kurzbeschreibung) → **first post**, the last step
-suggesting a topic from the member's own tags ("Zum Beispiel ein Gedanke
-zu #elixir").
+**"Complete your profile" checklist** (owner-only, first hour after sign-up —
+`UserProfileLive.@onboarding_window_seconds`) opens with the tag step already
+checked — 1/5 done — and leads through photo → tagline (Kurzbeschreibung) →
+**first post** (suggesting a topic from the member's own tags, "Zum Beispiel
+ein Gedanke zu #elixir") → **"Follow 5 members"**. The follow step shows the
+running count as its hint, ticks off live when the fifth follow happens on the
+page itself, and links to the "Who to follow" card — or, on an installation
+with nobody to suggest, to the most-followed listing.
+
+While the owner follows fewer than five members
+(`UserProfileLive.@discovery_follow_target`), the profile also renders the
+**"Who to follow" card promoted at the top of the rail** (`data-promoted`,
+plus an intro line saying that the feed is built from followed members)
+instead of its regular late-rail spot: every other card on a fresh profile
+points inward, and this is the one moment to show that there are people here
+to follow. The placement is sticky per page view — the fifth follow, made from
+the promoted card itself, must not teleport the card away mid-click; the next
+visit demotes it.
 
 Work experience is deliberately not on the checklist; its section card keeps its
 own add tile.

--- a/docs/architecture/settings-and-account.md
+++ b/docs/architecture/settings-and-account.md
@@ -163,7 +163,11 @@ instead of its regular late-rail spot: every other card on a fresh profile
 points inward, and this is the one moment to show that there are people here
 to follow. The placement is sticky per page view — the fifth follow, made from
 the promoted card itself, must not teleport the card away mid-click; the next
-visit demotes it.
+visit demotes it. The card only ever suggests accounts that posted within the
+last three weeks (`Posts.recently_posting_ids/2`,
+`UserProfileLive.@suggested_activity_days`): a suggestion promises that
+following fills your feed, and a silent account cannot keep that promise —
+deliberately strict, so a thin card beats a padded one.
 
 Work experience is deliberately not on the checklist; its section card keeps its
 own add tile.

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2059,6 +2059,26 @@ defmodule Vutuv.Posts do
   end
 
   @doc """
+  Of `users`, the ids of those who authored a post (replies included) within
+  the last `days` days, as a MapSet. The follow-suggestion surfaces gate on
+  this: a suggestion is a promise that following fills your feed, which a
+  silent account cannot keep. One query for the whole candidate list.
+  """
+  def recently_posting_ids(users, days) do
+    cutoff = NaiveDateTime.add(NaiveDateTime.utc_now(), -days, :day)
+    ids = Enum.map(users, & &1.id)
+
+    Repo.all(
+      from(p in Post,
+        where: p.user_id in ^ids and p.inserted_at > ^cutoff,
+        select: p.user_id,
+        distinct: true
+      )
+    )
+    |> MapSet.new()
+  end
+
+  @doc """
   Maps a raw filter string (a phx-value or `?type=` query param) to one of the
   timeline filters `author_posts_page/5` / `profile_posts/3` / `count_author_posts/3`
   understand, defaulting to `:all` for anything unrecognised (issue #945).

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2059,23 +2059,42 @@ defmodule Vutuv.Posts do
   end
 
   @doc """
-  Of `users`, the ids of those who authored a post (replies included) within
-  the last `days` days, as a MapSet. The follow-suggestion surfaces gate on
-  this: a suggestion is a promise that following fills your feed, which a
-  silent account cannot keep. One query for the whole candidate list.
+  The profile card's "Who to follow" candidate pool: the members who posted
+  (replies included) within the last `days` days, ranked by the hearts those
+  in-window posts collected, post count breaking ties - at most `limit` of
+  them, as listing-row `User` structs. A suggestion is a promise that
+  following fills your feed, so the pool is built from demonstrated recent
+  output and the ranking from what readers actually liked about it; a
+  most-followed veteran who went quiet does not qualify. Local hearts only,
+  like the discover rail's ranking (fediverse reactions stay out); no
+  self-like filter is needed since a member cannot like their own post.
   """
-  def recently_posting_ids(users, days) do
+  def top_recent_posters(days, limit) do
+    # Re-imported locally: a scoped `import Mod, only:` replaces the module
+    # import's visible names inside this function, so both macros must appear.
+    import Vutuv.Moderation.Query, only: [account_hidden_row: 1, account_confirmed_row: 1]
+
     cutoff = NaiveDateTime.add(NaiveDateTime.utc_now(), -days, :day)
-    ids = Enum.map(users, & &1.id)
+
+    stats =
+      from(p in Post,
+        where: p.inserted_at > ^cutoff,
+        left_join: l in PostLike,
+        on: l.post_id == p.id,
+        group_by: p.user_id,
+        select: %{user_id: p.user_id, hearts: count(l.id), posts: count(p.id, :distinct)}
+      )
 
     Repo.all(
-      from(p in Post,
-        where: p.user_id in ^ids and p.inserted_at > ^cutoff,
-        select: p.user_id,
-        distinct: true
+      from(u in User,
+        join: s in subquery(stats),
+        on: s.user_id == u.id,
+        where: account_confirmed_row(u) and not account_hidden_row(u),
+        order_by: [desc: s.hearts, desc: s.posts, asc: u.first_name, asc: u.id],
+        limit: ^limit,
+        select: struct(u, ^User.listing_fields())
       )
     )
-    |> MapSet.new()
   end
 
   @doc """

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -45,7 +45,6 @@ defmodule VutuvWeb.UserProfileLive do
   alias Vutuv.Social.Follow
   alias Vutuv.SocialFeed
   alias Vutuv.Tags
-  alias Vutuv.Tags.Tag
   alias Vutuv.Tags.UserTag
   alias Vutuv.Tags.UserTagEndorsement
   alias VutuvWeb.Fediverse.Docs
@@ -1123,52 +1122,39 @@ defmodule VutuvWeb.UserProfileLive do
       @onboarding_window_seconds
   end
 
-  # The rail's count, and the size of the popularity pool we top up from when the
-  # topical pool is thin.
+  # The rail's count, and how many ranked candidates we draw before the
+  # per-viewer exclusions (self, owner, already-followed, blocked) thin them.
   @recommended_count 6
   @recommended_pool 60
 
-  # A suggested account must have posted within this window: the card promises
-  # that following fills your feed, and a silent account cannot keep that
-  # promise. Strict on purpose - a thin (or empty) card is more honest than
-  # padding it with accounts whose posts nobody will ever see.
-  @suggested_activity_days 21
+  # The candidate window: only members who posted within it are suggested at
+  # all. The card promises that following fills your feed, and a silent
+  # account cannot keep that promise - strict on purpose, a thin (or empty)
+  # card is more honest than padding it with inactive accounts.
+  @suggested_window_days 28
 
-  # The "Who to follow" rail. We suggest members most endorsed for this profile's
-  # leading tag (so the suggestion is topically tied to whoever you're viewing),
-  # falling back to the most-followed members when the profile has no tag. Then we
-  # drop everyone the rail must never suggest: the profile owner, the `viewer`
-  # themselves and — the bug this fixes — anyone the viewer *already follows*
-  # (listing someone you already follow as a suggestion is pointless; the rail
-  # used to come back all "Following" rows). When the topical pool is mostly
-  # already-followed and runs thin, we top it up from the most-followed pool so
-  # the rail still fills with fresh faces. `viewer` is the current user (nil when
+  # The "Who to follow" rail: the window's most-hearted recent posters
+  # (`Posts.top_recent_posters/2` - members who posted in the last
+  # @suggested_window_days days, ranked by the hearts those posts collected),
+  # minus everyone the rail must never suggest: the profile owner, the
+  # `viewer` themselves, anyone the viewer *already follows* (suggesting them
+  # is pointless) and blocked members. `viewer` is the current user (nil when
   # logged out), so a logged-out visitor gets unfiltered suggestions and no
-  # follow state.
+  # follow state. This replaced a most-followed/topical-tag source: follower
+  # totals reward the past, but the card's promise is a feed with something
+  # in it, which only current, liked output can keep.
   defp recommended_users(user, viewer) do
-    topical =
-      case first_tag(user) do
-        nil -> []
-        tag -> Tag.recommended_users(tag)
-      end
-      |> suggestable(user, viewer)
+    candidates = Vutuv.Posts.top_recent_posters(@suggested_window_days, @recommended_pool)
 
-    users =
-      if length(topical) >= @recommended_count do
-        topical
-      else
-        popular = suggestable(Social.most_followed_users(@recommended_pool), user, viewer)
-        Enum.uniq_by(topical ++ popular, & &1.id)
-      end
-
-    Enum.take(users, @recommended_count)
+    candidates
+    |> suggestable(user, viewer)
+    |> Enum.take(@recommended_count)
   end
 
   # Keep only members the rail may suggest: not the profile owner, not the viewer,
   # not anyone the viewer already follows (one batched lookup via `following_map`),
-  # not a member the viewer blocked / who blocked them (the follow would be
-  # refused as :blocked and the suggestion would just reappear) - and only
-  # accounts that posted within the activity window (see @suggested_activity_days).
+  # and not a member the viewer blocked / who blocked them (the follow would be
+  # refused as :blocked and the suggestion would just reappear).
   defp suggestable(candidates, user, viewer) do
     following = following_map(viewer, candidates)
     # `viewer` is nil for a logged-out visitor; a nil id never equals a real UUID,
@@ -1177,25 +1163,9 @@ defmodule VutuvWeb.UserProfileLive do
     viewer_id = viewer && viewer.id
     blocked = if viewer, do: Social.blocked_user_ids(viewer.id), else: MapSet.new()
 
-    kept =
-      Enum.reject(candidates, fn u ->
-        u.id == user.id or u.id == viewer_id or Map.has_key?(following, u.id) or
-          MapSet.member?(blocked, u.id)
-      end)
-
-    # The activity gate last, so its one query only sees the survivors.
-    active = Vutuv.Posts.recently_posting_ids(kept, @suggested_activity_days)
-    Enum.filter(kept, &MapSet.member?(active, &1.id))
-  end
-
-  defp first_tag(user) do
-    Repo.one(
-      from(w in Ecto.assoc(user, :user_tags),
-        join: t in assoc(w, :tag),
-        order_by: w.inserted_at,
-        limit: 1,
-        select: t
-      )
-    )
+    Enum.reject(candidates, fn u ->
+      u.id == user.id or u.id == viewer_id or Map.has_key?(following, u.id) or
+        MapSet.member?(blocked, u.id)
+    end)
   end
 end

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -1128,6 +1128,12 @@ defmodule VutuvWeb.UserProfileLive do
   @recommended_count 6
   @recommended_pool 60
 
+  # A suggested account must have posted within this window: the card promises
+  # that following fills your feed, and a silent account cannot keep that
+  # promise. Strict on purpose - a thin (or empty) card is more honest than
+  # padding it with accounts whose posts nobody will ever see.
+  @suggested_activity_days 21
+
   # The "Who to follow" rail. We suggest members most endorsed for this profile's
   # leading tag (so the suggestion is topically tied to whoever you're viewing),
   # falling back to the most-followed members when the profile has no tag. Then we
@@ -1160,8 +1166,9 @@ defmodule VutuvWeb.UserProfileLive do
 
   # Keep only members the rail may suggest: not the profile owner, not the viewer,
   # not anyone the viewer already follows (one batched lookup via `following_map`),
-  # and not a member the viewer blocked / who blocked them (the follow would be
-  # refused as :blocked and the suggestion would just reappear).
+  # not a member the viewer blocked / who blocked them (the follow would be
+  # refused as :blocked and the suggestion would just reappear) - and only
+  # accounts that posted within the activity window (see @suggested_activity_days).
   defp suggestable(candidates, user, viewer) do
     following = following_map(viewer, candidates)
     # `viewer` is nil for a logged-out visitor; a nil id never equals a real UUID,
@@ -1170,10 +1177,15 @@ defmodule VutuvWeb.UserProfileLive do
     viewer_id = viewer && viewer.id
     blocked = if viewer, do: Social.blocked_user_ids(viewer.id), else: MapSet.new()
 
-    Enum.reject(candidates, fn u ->
-      u.id == user.id or u.id == viewer_id or Map.has_key?(following, u.id) or
-        MapSet.member?(blocked, u.id)
-    end)
+    kept =
+      Enum.reject(candidates, fn u ->
+        u.id == user.id or u.id == viewer_id or Map.has_key?(following, u.id) or
+          MapSet.member?(blocked, u.id)
+      end)
+
+    # The activity gate last, so its one query only sees the survivors.
+    active = Vutuv.Posts.recently_posting_ids(kept, @suggested_activity_days)
+    Enum.filter(kept, &MapSet.member?(active, &1.id))
   end
 
   defp first_tag(user) do

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -476,7 +476,14 @@ defmodule VutuvWeb.UserProfileLive do
         force: true
       )
 
-    put_social_assigns(socket, user)
+    socket
+    |> put_social_assigns(user)
+    # The follow step is the one checklist item completable on this very page
+    # (the promoted rail's follow buttons), so re-derive the steps and the tick
+    # lands live. The checklist's visibility and the rail's promoted spot stay
+    # as mounted; recomputing them here would yank the panel (or the card)
+    # away under the member's cursor on the fifth follow.
+    |> refresh_completion_steps()
   end
 
   # The follow-graph slice of the assigns, shared by the initial load and the
@@ -572,6 +579,13 @@ defmodule VutuvWeb.UserProfileLive do
 
   # ── Initial load (ports UserController.show_html) ──
 
+  # The discovery threshold: the owner's own profile leads the rail with the
+  # promoted "Who to follow" card (and the checklist carries a follow step)
+  # until they follow at least this many members. Below it their feed is too
+  # empty to be worth visiting (Home.path even keeps them on the profile), so
+  # discovery outranks their own detail cards.
+  @discovery_follow_target 5
+
   defp load_profile(socket) do
     current_user = socket.assigns.current_user
     base_user = Repo.get!(User, socket.assigns.profile_user_id)
@@ -597,16 +611,11 @@ defmodule VutuvWeb.UserProfileLive do
     recommended_users = recommended_users(user, current_user)
 
     posts_total = Vutuv.Posts.count_author_posts(user, current_user)
-    steps = completion_steps(user, posts_total)
 
     # The showcased post (issue #1110), scoped to this viewer: a pin that is
     # restricted, frozen or gone simply isn't there. It renders above the
     # timeline, which therefore leaves it out (see profile_posts/4).
     pinned_post = Vutuv.Posts.pinned_post(user, current_user)
-
-    show_completion? =
-      owner? and not user.onboarding_dismissed? and
-        Enum.any?(steps, &(not &1.done)) and onboarding_window?(user)
 
     socket
     |> assign(:as_owner?, owner?)
@@ -642,13 +651,25 @@ defmodule VutuvWeb.UserProfileLive do
     # memory (no extra query). header_job stays the resolved work role for the
     # JSON-LD Person markup below.
     |> assign(:work_info, profile_headline(user, header_job, 60))
-    |> assign(:completion_steps, steps)
-    |> assign(:show_completion?, show_completion?)
     |> assign(:recommended_users, recommended_users)
     |> assign(:totals, totals)
     # Builds the social slice (counts, header pill state, follow previews); reads
     # :current_user / :recommended_users set above, so it goes last.
     |> put_social_assigns(user)
+    # The rail promotion and the checklist's follow step both read the followee
+    # count put_social_assigns just computed. The promotion is deliberately set
+    # only here, never on the social-graph refresh: the fifth follow, made from
+    # the promoted rail itself, must not teleport the card to the bottom of the
+    # page under the member's cursor. The next visit demotes it.
+    |> then(
+      &assign(
+        &1,
+        :promote_discovery?,
+        owner? and &1.assigns.followee_count < @discovery_follow_target
+      )
+    )
+    |> refresh_completion_steps()
+    |> then(&assign(&1, :show_completion?, show_completion?(&1.assigns)))
     |> put_social_feed_assigns(user)
     |> put_code_stats_assigns(user)
     |> put_job_search_assigns(user)
@@ -1012,7 +1033,25 @@ defmodule VutuvWeb.UserProfileLive do
     )
   end
 
-  defp completion_steps(user, posts_total) do
+  # Re-derive the checklist from the current assigns; called from the initial
+  # load and from the social-graph refresh (the follow step's count changes
+  # live). Reads :followee_count, so it must run after put_social_assigns.
+  defp refresh_completion_steps(socket) do
+    %{user: user, posts_total: posts_total, followee_count: followee_count} = socket.assigns
+
+    assign(
+      socket,
+      :completion_steps,
+      completion_steps(user, posts_total, followee_count, socket.assigns.recommended_users != [])
+    )
+  end
+
+  defp show_completion?(%{as_owner?: owner?, user: user, completion_steps: steps}) do
+    owner? and not user.onboarding_dismissed? and
+      Enum.any?(steps, &(not &1.done)) and onboarding_window?(user)
+  end
+
+  defp completion_steps(user, posts_total, followee_count, suggestions?) do
     [
       # Sign-up requires three tags, so this step arrives already checked: the
       # checklist opens with visible progress instead of a wall of zeros
@@ -1035,9 +1074,29 @@ defmodule VutuvWeb.UserProfileLive do
         done: posts_total > 0,
         href: ~p"/feed#compose",
         hint: first_post_hint(user)
+      },
+      # vutuv runs on following: the feed stays empty until the member follows
+      # people, so the list closes with the social step. Its link jumps to the
+      # "Who to follow" card, which the under-threshold owner view promotes to
+      # the top of the rail; an installation with nobody to suggest falls back
+      # to the browsable most-followed listing instead of a dead anchor.
+      %{
+        label: gettext("Follow %{count} members", count: @discovery_follow_target),
+        done: followee_count >= @discovery_follow_target,
+        href:
+          if(suggestions?, do: "#profile-who-to-follow", else: ~p"/listings/most_followed_users"),
+        hint: follow_step_hint(followee_count)
       }
     ]
   end
+
+  # Progress under the follow step ("You already follow 2 members."): visible
+  # momentum once the count has started, nothing at zero (the label alone
+  # reads cleaner) and nothing once the step is done.
+  defp follow_step_hint(n) when n < 1 or n >= @discovery_follow_target, do: nil
+
+  defp follow_step_hint(n),
+    do: ngettext("You already follow one member.", "You already follow %{count} members.", n)
 
   # A concrete first-post prompt borrowed from the member's own sign-up tags
   # ("a thought on #elixir") — which doubles as a quiet demo that #hashtags

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -959,6 +959,21 @@ the resulting ~200px rail width. --%>
   cards join the single flex column and can interleave with the main column's;
   a real box again at md+. --%>
   <aside class="contents md:block md:space-y-6">
+    <%!-- Discovery leads the rail while the owner still follows fewer than
+    five members (@promote_discovery?): a fresh account otherwise never learns
+    that there are people here to follow. Above the threshold the card keeps
+    its regular spot further down. Sticky per page view: the fifth follow must
+    not teleport the card away mid-click (see UserProfileLive). --%>
+    <.who_to_follow_card
+      :if={@promote_discovery?}
+      promoted
+      recommended_users={@recommended_users}
+      current_user={@current_user}
+      current_user_id={@current_user_id}
+      work_info_by_id={@work_info_by_id}
+      following_by_id={@following_by_id}
+    />
+
     <%!-- General info leads the rail: who the person is (gender + birthday).
     The headline already lives in the header. The birthday obeys the member's
     chosen granularity (birthdate_mode/1): full date + age, age only, day and
@@ -1435,25 +1450,17 @@ the resulting ~200px rail width. --%>
 
     <%!-- "Who to follow" comes after the profile's own details (contact, info,
     links): the member's own card leads, discovery of other people follows.
-    `order-1` groups it with Followers / Following at the end on a phone. --%>
-    <.card
-      :if={@recommended_users != []}
-      id="profile-who-to-follow"
-      class="order-1 md:order-none"
-    >
-      <.section_title class="mb-4">{gettext("Who to follow")}</.section_title>
-      <ul class="space-y-4">
-        <.user_row
-          :for={user <- @recommended_users}
-          user={user}
-          current_user={@current_user}
-          current_user_id={@current_user_id}
-          work_info_by_id={@work_info_by_id}
-          following_by_id={@following_by_id}
-          live?
-        />
-      </ul>
-    </.card>
+    The under-five-follows owner instead gets it promoted at the top of the
+    rail (the copy above; the two :ifs are mutually exclusive). `order-1`
+    groups it with Followers / Following at the end on a phone. --%>
+    <.who_to_follow_card
+      :if={!@promote_discovery?}
+      recommended_users={@recommended_users}
+      current_user={@current_user}
+      current_user_id={@current_user_id}
+      work_info_by_id={@work_info_by_id}
+      following_by_id={@following_by_id}
+    />
 
     <%!-- The formatted CV / Lebenslauf downloads (issue #841), for every
     viewer: the documents carry only data the viewer can already see, so the

--- a/lib/vutuv_web/views/user_html.ex
+++ b/lib/vutuv_web/views/user_html.ex
@@ -68,6 +68,50 @@ defmodule VutuvWeb.UserHTML do
     """
   end
 
+  @doc """
+  The profile's "Who to follow" card. Its home is late in the rail (the
+  member's own detail cards lead); for the owner still following fewer than
+  five members (`@promote_discovery?` in `UserProfileLive`) the profile
+  renders it at the top of the rail instead, `promoted`: marker attribute,
+  an intro line saying why following matters, and no late-rail order classes.
+  A brand-new member otherwise never learns that there are people here to
+  follow — every other card on their fresh profile points inward. The two
+  call sites are mutually exclusive, so the DOM id stays unique.
+  """
+  attr(:promoted, :boolean, default: false)
+  attr(:recommended_users, :list, required: true)
+  attr(:current_user, :any, required: true)
+  attr(:current_user_id, :any, required: true)
+  attr(:work_info_by_id, :map, required: true)
+  attr(:following_by_id, :map, required: true)
+
+  def who_to_follow_card(assigns) do
+    ~H"""
+    <.card
+      :if={@recommended_users != []}
+      id="profile-who-to-follow"
+      class={if(@promoted, do: "scroll-mt-24", else: "scroll-mt-24 order-1 md:order-none")}
+      data-promoted={@promoted}
+    >
+      <.section_title class="mb-4">{gettext("Who to follow")}</.section_title>
+      <p :if={@promoted} id="discovery-intro" class="-mt-2 mb-4 text-sm text-slate-600 dark:text-slate-400">
+        {gettext("Your feed shows the posts of members you follow. Follow a few to fill it.")}
+      </p>
+      <ul class="space-y-4">
+        <.user_row
+          :for={user <- @recommended_users}
+          user={user}
+          current_user={@current_user}
+          current_user_id={@current_user_id}
+          work_info_by_id={@work_info_by_id}
+          following_by_id={@following_by_id}
+          live?
+        />
+      </ul>
+    </.card>
+    """
+  end
+
   # Work line for a user row; falls back to a non-breaking space so an empty
   # line still reserves its height and rows stay a uniform two-line height.
   defp work_line(work_info_by_id, user_id) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.187.1",
+      version: "7.188.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr "Language: de\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:77
+#: lib/vutuv_web/controllers/page_controller.ex:93
 #: lib/vutuv_web/templates/layout/app.html.heex:93
 #, elixir-autogen
 msgid "About us"
@@ -35,7 +35,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1356
+#: lib/vutuv_web/templates/user/show.html.heex:1371
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -72,7 +72,7 @@ msgstr "Eine Adresse wurde geändert."
 msgid "Addresses"
 msgstr "Adressen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:176
+#: lib/vutuv_web/templates/page/index.html.heex:210
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
@@ -98,7 +98,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/agent_docs/markdown.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/templates/user/show.html.heex:990
+#: lib/vutuv_web/templates/user/show.html.heex:1005
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
@@ -145,7 +145,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1028
+#: lib/vutuv_web/templates/user/show.html.heex:1043
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -154,7 +154,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:2154
+#: lib/vutuv_web/components/post_components.ex:2177
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -203,7 +203,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:2119
+#: lib/vutuv_web/components/post_components.ex:2142
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -217,7 +217,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1013
+#: lib/vutuv_web/templates/user/show.html.heex:1028
 #, elixir-autogen
 msgid "Edit"
 msgstr "Ändern"
@@ -354,7 +354,7 @@ msgstr "Folge ich"
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:67
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:985
+#: lib/vutuv_web/templates/user/show.html.heex:1000
 #: lib/vutuv_web/views/account_event_text.ex:153
 #, elixir-autogen
 msgid "Gender"
@@ -660,7 +660,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1093
+#: lib/vutuv_web/components/post_components.ex:1116
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -670,7 +670,7 @@ msgstr "Suche"
 msgid "Show"
 msgstr "Anzeigen"
 
-#: lib/vutuv_web/templates/page/index.html.heex:155
+#: lib/vutuv_web/templates/page/index.html.heex:189
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr "Gratis-Konto erstellen"
@@ -695,13 +695,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1141
+#: lib/vutuv_web/templates/user/show.html.heex:1156
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1143
+#: lib/vutuv_web/templates/user/show.html.heex:1158
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -733,12 +733,12 @@ msgstr "Profil wurde geändert."
 msgid "Profile deleted successfully."
 msgstr "Profil wurde gelöscht."
 
-#: lib/vutuv_web/views/user_html.ex:385
+#: lib/vutuv_web/views/user_html.ex:429
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr "Soziale Netzwerke"
 
-#: lib/vutuv_web/views/user_html.ex:391
+#: lib/vutuv_web/views/user_html.ex:435
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr "Code & Repositorys"
@@ -877,7 +877,7 @@ msgstr "Sichtbarkeit"
 msgid "We can't find em' cap'n!"
 msgstr "Nichts zu finden, Käpt'n!"
 
-#: lib/vutuv_web/templates/page/index.html.heex:179
+#: lib/vutuv_web/templates/page/index.html.heex:213
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -963,7 +963,7 @@ msgstr "Eine E-Mail mit einem Löschlink wurde gerade an Sie verschickt."
 msgid "Allow others to view your email address"
 msgstr "Diese E-Mail-Adresse soll auf meinem Profil öffentlich sichtbar sein."
 
-#: lib/vutuv_web/templates/page/index.html.heex:165
+#: lib/vutuv_web/templates/page/index.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1083,7 +1083,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:974
+#: lib/vutuv_web/templates/user/show.html.heex:989
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1123,7 +1123,7 @@ msgstr "vutuv Login-PIN"
 msgid "Listings"
 msgstr "Listen"
 
-#: lib/vutuv_web/controllers/page_controller.ex:198
+#: lib/vutuv_web/controllers/page_controller.ex:236
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1697,7 +1697,7 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/post_components.ex:2596
+#: lib/vutuv_web/components/post_components.ex:2619
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
@@ -1723,17 +1723,17 @@ msgstr "Bestätigen"
 msgid "Confirm account deletion"
 msgstr "Kontolöschung bestätigen"
 
-#: lib/vutuv_web/controllers/page_controller.ex:81
+#: lib/vutuv_web/controllers/page_controller.ex:97
 #: lib/vutuv_web/templates/layout/app.html.heex:89
-#: lib/vutuv_web/templates/page/index.html.heex:172
+#: lib/vutuv_web/templates/page/index.html.heex:206
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr "Datenschutzerklärung"
 
-#: lib/vutuv_web/controllers/page_controller.ex:87
+#: lib/vutuv_web/controllers/page_controller.ex:103
 #: lib/vutuv_web/templates/layout/app.html.heex:91
-#: lib/vutuv_web/templates/page/index.html.heex:172
+#: lib/vutuv_web/templates/page/index.html.heex:206
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1771,7 +1771,7 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/fediverse_account_live.ex:380
 #: lib/vutuv_web/live/fediverse_following_live.ex:287
 #: lib/vutuv_web/templates/user/show.html.heex:945
-#: lib/vutuv_web/templates/user/show.html.heex:1180
+#: lib/vutuv_web/templates/user/show.html.heex:1195
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1829,7 +1829,7 @@ msgstr "Nachrichten"
 msgid "Network"
 msgstr "Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:336
+#: lib/vutuv_web/components/post_components.ex:337
 #: lib/vutuv_web/components/ui.ex:3077
 #: lib/vutuv_web/live/admin/user_live.ex:311
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
@@ -1944,7 +1944,7 @@ msgstr ""
 "unten ein, um die Adresse zu bestätigen."
 
 #: lib/vutuv_web/live/post_live/feed.ex:1052
-#: lib/vutuv_web/templates/user/show.html.heex:1444
+#: lib/vutuv_web/views/user_html.ex:96
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr "Vorgeschlagene Profile"
@@ -2124,12 +2124,12 @@ msgstr "März"
 msgid "May"
 msgstr "Mai"
 
-#: lib/vutuv_web/views/user_html.ex:92
+#: lib/vutuv_web/views/user_html.ex:136
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr "Mitglied seit %{month} %{year}"
 
-#: lib/vutuv_web/views/user_html.ex:97
+#: lib/vutuv_web/views/user_html.ex:141
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
@@ -2182,7 +2182,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:2151
+#: lib/vutuv_web/components/post_components.ex:2174
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2223,8 +2223,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:2105
-#: lib/vutuv_web/components/post_components.ex:2107
+#: lib/vutuv_web/components/post_components.ex:2128
+#: lib/vutuv_web/components/post_components.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2291,13 +2291,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2534
-#: lib/vutuv_web/components/post_components.ex:2538
+#: lib/vutuv_web/components/post_components.ex:2557
+#: lib/vutuv_web/components/post_components.ex:2561
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:2535
+#: lib/vutuv_web/components/post_components.ex:2558
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2305,7 +2305,7 @@ msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:252
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:858
+#: lib/vutuv_web/components/post_components.ex:862
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
@@ -2391,27 +2391,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:2102
+#: lib/vutuv_web/components/post_components.ex:2125
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:3690
+#: lib/vutuv_web/components/post_components.ex:3713
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:3694
+#: lib/vutuv_web/components/post_components.ex:3717
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:3692
+#: lib/vutuv_web/components/post_components.ex:3715
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:3693
+#: lib/vutuv_web/components/post_components.ex:3716
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2452,7 +2452,7 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3774
+#: lib/vutuv_web/components/post_components.ex:3797
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2471,8 +2471,8 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1456
-#: lib/vutuv_web/components/post_components.ex:3997
+#: lib/vutuv_web/components/post_components.ex:1479
+#: lib/vutuv_web/components/post_components.ex:4020
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
@@ -2483,7 +2483,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:926
-#: lib/vutuv_web/components/post_components.ex:4006
+#: lib/vutuv_web/components/post_components.ex:4029
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2503,12 +2503,12 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:3763
+#: lib/vutuv_web/components/post_components.ex:3786
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:3774
+#: lib/vutuv_web/components/post_components.ex:3797
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2517,25 +2517,25 @@ msgstr "Nur öffentliche Beiträge können repostet werden."
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1480
-#: lib/vutuv_web/components/post_components.ex:3760
+#: lib/vutuv_web/components/post_components.ex:1503
+#: lib/vutuv_web/components/post_components.ex:3783
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1181
-#: lib/vutuv_web/components/post_components.ex:3148
+#: lib/vutuv_web/components/post_components.ex:1204
+#: lib/vutuv_web/components/post_components.ex:3171
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3760
+#: lib/vutuv_web/components/post_components.ex:3783
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:3997
+#: lib/vutuv_web/components/post_components.ex:4020
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2559,28 +2559,28 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:4050
+#: lib/vutuv_web/components/post_components.ex:4073
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
-#: lib/vutuv_web/components/post_components.ex:325
+#: lib/vutuv_web/components/post_components.ex:326
 #: lib/vutuv_web/live/notification_live/index.ex:858
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:898
-#: lib/vutuv_web/components/post_components.ex:1508
-#: lib/vutuv_web/components/post_components.ex:4033
-#: lib/vutuv_web/components/post_components.ex:4034
+#: lib/vutuv_web/components/post_components.ex:902
+#: lib/vutuv_web/components/post_components.ex:1531
+#: lib/vutuv_web/components/post_components.ex:4056
+#: lib/vutuv_web/components/post_components.ex:4057
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2073
+#: lib/vutuv_web/components/post_components.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2601,7 +2601,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:1593
+#: lib/vutuv_web/components/post_components.ex:1616
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:58
 #: lib/vutuv_web/live/post_live/remote_reply.ex:57
 #: lib/vutuv_web/live/post_live/reply.ex:52
@@ -2609,14 +2609,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2049
+#: lib/vutuv_web/components/post_components.ex:2072
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:2043
-#: lib/vutuv_web/components/post_components.ex:2065
-#: lib/vutuv_web/components/post_components.ex:2068
+#: lib/vutuv_web/components/post_components.ex:2066
+#: lib/vutuv_web/components/post_components.ex:2088
+#: lib/vutuv_web/components/post_components.ex:2091
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2745,7 +2745,7 @@ msgstr "Willkommen zurück!"
 msgid "Founder of vutuv"
 msgstr "Gründer von vutuv"
 
-#: lib/vutuv_web/templates/page/index.html.heex:145
+#: lib/vutuv_web/templates/page/index.html.heex:146
 #: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
@@ -2791,26 +2791,26 @@ msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1102
+#: lib/vutuv_web/templates/user/show.html.heex:1117
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1358
+#: lib/vutuv_web/templates/user/show.html.heex:1373
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1030
+#: lib/vutuv_web/templates/user/show.html.heex:1045
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:976
+#: lib/vutuv_web/templates/user/show.html.heex:991
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
@@ -2822,7 +2822,7 @@ msgstr "Persönliche Angaben hinzufügen"
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1034
+#: lib/vutuv_web/live/user_profile_live.ex:1073
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
@@ -2922,7 +2922,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:3691
+#: lib/vutuv_web/components/post_components.ex:3714
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3029,7 +3029,7 @@ msgstr "Mobbing oder Belästigung"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:296
 #: lib/vutuv_web/agent_docs/text.ex:280
-#: lib/vutuv_web/controllers/page_controller.ex:60
+#: lib/vutuv_web/controllers/page_controller.ex:76
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
@@ -3195,13 +3195,13 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1070
-#: lib/vutuv_web/templates/user/show.html.heex:1071
+#: lib/vutuv_web/templates/user/show.html.heex:1085
+#: lib/vutuv_web/templates/user/show.html.heex:1086
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:2019
+#: lib/vutuv_web/components/post_components.ex:2042
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3280,9 +3280,9 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:868
-#: lib/vutuv_web/components/post_components.ex:1403
-#: lib/vutuv_web/components/post_components.ex:2175
+#: lib/vutuv_web/components/post_components.ex:872
+#: lib/vutuv_web/components/post_components.ex:1426
+#: lib/vutuv_web/components/post_components.ex:2198
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4816,7 +4816,7 @@ msgstr ""
 msgid "Similar names"
 msgstr "Ähnliche Namen"
 
-#: lib/vutuv_web/components/post_components.ex:322
+#: lib/vutuv_web/components/post_components.ex:323
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/notification_live/index.ex:776
@@ -4868,7 +4868,7 @@ msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/live/user_profile_live.ex:1022
+#: lib/vutuv_web/live/user_profile_live.ex:1061
 #: lib/vutuv_web/templates/user/show.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -5489,7 +5489,7 @@ msgstr ""
 "Webhook-Dokumentation). Nur https://; http://localhost ist für die "
 "Entwicklung erlaubt."
 
-#: lib/vutuv_web/templates/page/index.html.heex:150
+#: lib/vutuv_web/templates/page/index.html.heex:151
 #: lib/vutuv_web/templates/settings/privacy.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
@@ -5639,7 +5639,7 @@ msgstr "Profil vervollständigen"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1024
+#: lib/vutuv_web/live/user_profile_live.ex:1063
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -5665,9 +5665,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:2238
-#: lib/vutuv_web/components/post_components.ex:2290
-#: lib/vutuv_web/components/post_components.ex:2671
+#: lib/vutuv_web/components/post_components.ex:2261
+#: lib/vutuv_web/components/post_components.ex:2313
+#: lib/vutuv_web/components/post_components.ex:2694
 #: lib/vutuv_web/live/notification_live/index.ex:601
 #: lib/vutuv_web/live/post_live/feed.ex:1113
 #, elixir-autogen, elixir-format
@@ -5700,7 +5700,7 @@ msgstr "Andere"
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:518
+#: lib/vutuv_web/views/user_html.ex:562
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr "Privat"
@@ -6322,7 +6322,7 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1028
+#: lib/vutuv_web/live/user_profile_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
@@ -6358,7 +6358,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1409
+#: lib/vutuv_web/templates/user/show.html.heex:1424
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6403,8 +6403,8 @@ msgstr "Foto verwenden"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:996
-#: lib/vutuv_web/templates/user/show.html.heex:1006
+#: lib/vutuv_web/templates/user/show.html.heex:1011
+#: lib/vutuv_web/templates/user/show.html.heex:1021
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6446,12 +6446,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1117
+#: lib/vutuv_web/templates/user/show.html.heex:1132
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1128
+#: lib/vutuv_web/templates/user/show.html.heex:1143
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6487,13 +6487,13 @@ msgid "Previous day"
 msgstr "Vorheriger Tag"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:926
-#: lib/vutuv_web/components/post_components.ex:324
+#: lib/vutuv_web/components/post_components.ex:325
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1126
+#: lib/vutuv_web/templates/user/show.html.heex:1141
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6549,9 +6549,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1395
-#: lib/vutuv_web/templates/user/show.html.heex:1403
-#: lib/vutuv_web/templates/user/show.html.heex:1415
+#: lib/vutuv_web/templates/user/show.html.heex:1410
+#: lib/vutuv_web/templates/user/show.html.heex:1418
+#: lib/vutuv_web/templates/user/show.html.heex:1430
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6962,17 +6962,17 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:2172
+#: lib/vutuv_web/components/post_components.ex:2195
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
 
-#: lib/vutuv_web/views/user_html.ex:517
+#: lib/vutuv_web/views/user_html.ex:561
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:2171
+#: lib/vutuv_web/components/post_components.ex:2194
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7679,7 +7679,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
-#: lib/vutuv_web/components/post_components.ex:3919
+#: lib/vutuv_web/components/post_components.ex:3942
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8356,8 +8356,8 @@ msgstr "Identität verifiziert. Das Mitglied wurde per E-Mail benachrichtigt."
 msgid "Identity-verified"
 msgstr "Identität verifiziert"
 
-#: lib/vutuv/accounts.ex:1011
-#: lib/vutuv/accounts.ex:1060
+#: lib/vutuv/accounts.ex:1023
+#: lib/vutuv/accounts.ex:1072
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8398,7 +8398,7 @@ msgstr "Nicht bestätigt"
 msgid "Open the member browser"
 msgstr "Mitgliederübersicht öffnen"
 
-#: lib/vutuv/accounts.ex:1028
+#: lib/vutuv/accounts.ex:1040
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8739,7 +8739,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1047
+#: lib/vutuv_web/live/user_profile_live.ex:1106
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr "Zum Beispiel ein Gedanke zu %{tag}."
@@ -8763,13 +8763,13 @@ msgstr[1] ""
 "%{count} Einträge übersprungen, die schon in Ihrem Profil stehen oder von "
 "einem anderen Mitglied belegt sind."
 
-#: lib/vutuv_web/views/user_html.ex:431
+#: lib/vutuv_web/views/user_html.ex:475
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:99
-#: lib/vutuv_web/templates/user/show.html.heex:1262
+#: lib/vutuv_web/templates/user/show.html.heex:1277
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -9140,7 +9140,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
 #: lib/vutuv_web/templates/user/show.html.heex:873
-#: lib/vutuv_web/templates/user/show.html.heex:1167
+#: lib/vutuv_web/templates/user/show.html.heex:1182
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverse"
@@ -9180,7 +9180,7 @@ msgstr "Social-Media-Konten verwalten"
 msgid "Your Fediverse handle"
 msgstr "Ihr Fediverse-Handle"
 
-#: lib/vutuv/accounts.ex:1023
+#: lib/vutuv/accounts.ex:1035
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -9296,7 +9296,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:3151
+#: lib/vutuv_web/components/post_components.ex:3174
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -10263,8 +10263,8 @@ msgstr "Bevorzugt"
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1092
-#: lib/vutuv_web/templates/user/show.html.heex:1093
+#: lib/vutuv_web/templates/user/show.html.heex:1107
+#: lib/vutuv_web/templates/user/show.html.heex:1108
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10961,14 +10961,14 @@ msgid_plural "%{count} stars"
 msgstr[0] "%{count} Stern"
 msgstr[1] "%{count} Sterne"
 
-#: lib/vutuv_web/views/user_html.ex:308
+#: lib/vutuv_web/views/user_html.ex:352
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] "%{formatted} Follower"
 msgstr[1] "%{formatted} Follower"
 
-#: lib/vutuv_web/views/user_html.ex:301
+#: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10977,7 +10977,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1236
+#: lib/vutuv_web/templates/user/show.html.heex:1251
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -10996,7 +10996,7 @@ msgstr ""
 "dessen öffentliche Statistiken zeigen: Sterne, Repositories, Follower, "
 "Sprachen und letzte Aktivität."
 
-#: lib/vutuv_web/views/user_html.ex:315
+#: lib/vutuv_web/views/user_html.ex:359
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr "Zuletzt aktiv %{date}"
@@ -11023,7 +11023,7 @@ msgstr "zuletzt aktiv %{date}"
 msgid "since %{date}"
 msgstr "seit %{date}"
 
-#: lib/vutuv_web/views/user_html.ex:231
+#: lib/vutuv_web/views/user_html.ex:275
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr "seit %{year}"
@@ -13980,7 +13980,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:1552
+#: lib/vutuv_web/components/post_components.ex:1575
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -14401,22 +14401,22 @@ msgstr "Mobil (privat)"
 msgid "Work mobile"
 msgstr "Mobil (Arbeit)"
 
-#: lib/vutuv_web/components/post_components.ex:333
+#: lib/vutuv_web/components/post_components.ex:334
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr "Noch keine Beiträge."
 
-#: lib/vutuv_web/components/post_components.ex:335
+#: lib/vutuv_web/components/post_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr "Noch keine Antworten."
 
-#: lib/vutuv_web/components/post_components.ex:334
+#: lib/vutuv_web/components/post_components.ex:335
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr "Noch keine Reposts."
 
-#: lib/vutuv_web/components/post_components.ex:323
+#: lib/vutuv_web/components/post_components.ex:324
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr "Eigene Beiträge"
@@ -14482,7 +14482,7 @@ msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzerna
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1202
+#: lib/vutuv_web/templates/user/show.html.heex:1217
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14519,7 +14519,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1200
+#: lib/vutuv_web/templates/user/show.html.heex:1215
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14596,7 +14596,7 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:3553
+#: lib/vutuv_web/components/post_components.ex:3576
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
@@ -14612,18 +14612,18 @@ msgid "Book"
 msgstr "Buch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:973
-#: lib/vutuv_web/components/post_components.ex:3510
+#: lib/vutuv_web/components/post_components.ex:3533
 #: lib/vutuv_web/live/post_live/composer.ex:1535
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:3554
+#: lib/vutuv_web/components/post_components.ex:3577
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:3556
+#: lib/vutuv_web/components/post_components.ex:3579
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
@@ -14633,7 +14633,7 @@ msgstr "DVD/Blu-ray"
 msgid "Director"
 msgstr "Regie"
 
-#: lib/vutuv_web/components/post_components.ex:3552
+#: lib/vutuv_web/components/post_components.ex:3575
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
@@ -14644,7 +14644,7 @@ msgid "Film"
 msgstr "Film"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:973
-#: lib/vutuv_web/components/post_components.ex:3509
+#: lib/vutuv_web/components/post_components.ex:3532
 #: lib/vutuv_web/live/post_live/composer.ex:1534
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -14676,7 +14676,7 @@ msgstr "Wird nachgeschlagen …"
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr "Zu dieser ISBN wurde nichts gefunden. Bitte füllen Sie die Felder selbst aus."
 
-#: lib/vutuv_web/components/post_components.ex:3551
+#: lib/vutuv_web/components/post_components.ex:3574
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
@@ -14703,7 +14703,7 @@ msgstr "Ein Buch besprechen"
 msgid "Review a film"
 msgstr "Einen Film besprechen"
 
-#: lib/vutuv_web/components/post_components.ex:3555
+#: lib/vutuv_web/components/post_components.ex:3578
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14734,34 +14734,34 @@ msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:3592
+#: lib/vutuv_web/components/post_components.ex:3615
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:3622
+#: lib/vutuv_web/components/post_components.ex:3645
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:3623
+#: lib/vutuv_web/components/post_components.ex:3646
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:3621
+#: lib/vutuv_web/components/post_components.ex:3644
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:3581
+#: lib/vutuv_web/components/post_components.ex:3604
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:3628
+#: lib/vutuv_web/components/post_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14791,7 +14791,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3395
+#: lib/vutuv_web/components/post_components.ex:3418
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14839,7 +14839,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:3386
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -15237,14 +15237,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1799
+#: lib/vutuv_web/components/post_components.ex:1822
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1821
+#: lib/vutuv_web/components/post_components.ex:1844
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -15271,7 +15271,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:4005
+#: lib/vutuv_web/components/post_components.ex:4028
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15714,6 +15714,7 @@ msgid "Nothing changes on vutuv itself, and you can switch it off again."
 msgstr "Auf vutuv selbst ändert sich nichts, und Sie können es jederzeit wieder ausschalten."
 
 #: lib/vutuv_web/components/fediverse_components.ex:198
+#: lib/vutuv_web/templates/page/index.html.heex:174
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "Take part in the Fediverse"
@@ -16454,21 +16455,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:3964
+#: lib/vutuv_web/components/post_components.ex:3987
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:3968
+#: lib/vutuv_web/components/post_components.ex:3991
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:3972
+#: lib/vutuv_web/components/post_components.ex:3995
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16476,7 +16477,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:945
-#: lib/vutuv_web/components/post_components.ex:3923
+#: lib/vutuv_web/components/post_components.ex:3946
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16492,14 +16493,14 @@ msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem 
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:969
-#: lib/vutuv_web/components/post_components.ex:1123
+#: lib/vutuv_web/components/post_components.ex:973
+#: lib/vutuv_web/components/post_components.ex:1146
 #: lib/vutuv_web/live/fediverse_account_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:856
+#: lib/vutuv_web/components/post_components.ex:860
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16526,7 +16527,7 @@ msgstr "Antwort aus einem anderen Netzwerk"
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:865
+#: lib/vutuv_web/components/post_components.ex:869
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16536,7 +16537,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:879
+#: lib/vutuv_web/components/post_components.ex:883
 #: lib/vutuv_web/live/notification_live/index.ex:497
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16568,8 +16569,8 @@ msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1106
-#: lib/vutuv_web/components/post_components.ex:884
-#: lib/vutuv_web/components/post_components.ex:1520
+#: lib/vutuv_web/components/post_components.ex:888
+#: lib/vutuv_web/components/post_components.ex:1543
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -17249,22 +17250,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:2031
+#: lib/vutuv_web/components/post_components.ex:2054
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2138
+#: lib/vutuv_web/components/post_components.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:2146
+#: lib/vutuv_web/components/post_components.ex:2169
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:2132
+#: lib/vutuv_web/components/post_components.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17356,7 +17357,7 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1034
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:2599
+#: lib/vutuv_web/components/post_components.ex:2622
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
@@ -17396,7 +17397,7 @@ msgstr "Foto nach vorne schieben"
 msgid "Move photo later"
 msgstr "Foto nach hinten schieben"
 
-#: lib/vutuv_web/components/post_components.ex:2598
+#: lib/vutuv_web/components/post_components.ex:2621
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
@@ -17406,29 +17407,29 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3015
+#: lib/vutuv_web/components/post_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr "Bisher sehen nur Sie diesen Beitrag."
 
-#: lib/vutuv_web/components/post_components.ex:1605
+#: lib/vutuv_web/components/post_components.ex:1628
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:3018
+#: lib/vutuv_web/components/post_components.ex:3041
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] "Unsere KI prüft das Foto. Sobald es durch ist, geht der Beitrag von selbst online."
 msgstr[1] "Unsere KI prüft die Fotos, %{done} von %{total} sind durch. Sobald das letzte durch ist, geht der Beitrag von selbst online."
 
-#: lib/vutuv_web/components/post_components.ex:2843
+#: lib/vutuv_web/components/post_components.ex:2866
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:2345
+#: lib/vutuv_web/components/post_components.ex:2368
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17441,12 +17442,12 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1067
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:3052
+#: lib/vutuv_web/components/post_components.ex:3075
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/post_components.ex:2597
+#: lib/vutuv_web/components/post_components.ex:2620
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
@@ -17467,7 +17468,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1658
+#: lib/vutuv_web/components/post_components.ex:1681
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -17487,7 +17488,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:1649
+#: lib/vutuv_web/components/post_components.ex:1672
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -17497,12 +17498,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:1667
+#: lib/vutuv_web/components/post_components.ex:1690
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:1601
+#: lib/vutuv_web/components/post_components.ex:1624
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -17517,7 +17518,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:1662
+#: lib/vutuv_web/components/post_components.ex:1685
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -17527,7 +17528,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:1615
+#: lib/vutuv_web/components/post_components.ex:1638
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17613,13 +17614,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:963
-#: lib/vutuv_web/components/post_components.ex:3961
+#: lib/vutuv_web/components/post_components.ex:3984
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:961
-#: lib/vutuv_web/components/post_components.ex:3958
+#: lib/vutuv_web/components/post_components.ex:3981
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17629,7 +17630,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:3850
+#: lib/vutuv_web/components/post_components.ex:3873
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17982,7 +17983,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1412
+#: lib/vutuv_web/components/post_components.ex:1435
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17993,7 +17994,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:1519
+#: lib/vutuv_web/components/post_components.ex:1542
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -18013,17 +18014,17 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1096
+#: lib/vutuv_web/components/post_components.ex:1119
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:1418
+#: lib/vutuv_web/components/post_components.ex:1441
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
 
-#: lib/vutuv_web/components/post_components.ex:1391
+#: lib/vutuv_web/components/post_components.ex:1414
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr "%{handle} stummschalten"
@@ -18039,7 +18040,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:1398
+#: lib/vutuv_web/components/post_components.ex:1421
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -18260,27 +18261,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:1226
+#: lib/vutuv_web/components/post_components.ex:1249
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr "Ein Bild ist unterwegs."
 
-#: lib/vutuv_web/components/post_components.ex:1255
+#: lib/vutuv_web/components/post_components.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:1250
+#: lib/vutuv_web/components/post_components.ex:1273
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:1537
+#: lib/vutuv_web/components/post_components.ex:1560
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:1540
+#: lib/vutuv_web/components/post_components.ex:1563
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -18290,7 +18291,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:1653
+#: lib/vutuv_web/components/post_components.ex:1676
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18330,19 +18331,19 @@ msgstr ""
 "Bitte melden Sie sich zuerst an, danach können Sie diesem Konto mit Ihrem "
 "vutuv-Konto folgen."
 
-#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:71
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:73
 #, elixir-autogen, elixir-format
 msgid "That link did not name a Fediverse account we can read."
 msgstr "In diesem Link steckt keine Fediverse-Adresse, die wir lesen können."
 
-#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:115
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:120
 #, elixir-autogen, elixir-format
 msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
 "Dieser Link zeigt auf einen einzelnen Beitrag. Von hier aus können Sie dem "
 "Konto dahinter folgen: %{account}."
 
-#: lib/vutuv_web/templates/page/index.html.heex:176
+#: lib/vutuv_web/templates/page/index.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "People on Mastodon and other independent networks can then follow this profile, and your public posts appear there. What they answer or share comes back and is shown under your posts, by their account address. A reply from there is stored here for up to six months. You can switch all of it off again at any time."
 msgstr ""
@@ -18352,3 +18353,22 @@ msgstr ""
 "Beiträgen, mit der Adresse des jeweiligen Kontos. Eine Antwort von dort "
 "speichern wir dafür bis zu sechs Monate. Alles davon lässt sich jederzeit "
 "wieder abschalten."
+
+#: lib/vutuv_web/live/user_profile_live.ex:1084
+#, elixir-autogen, elixir-format
+msgid "Follow %{count} members"
+msgstr "%{count} Mitgliedern folgen"
+
+#: lib/vutuv_web/live/user_profile_live.ex:1099
+#, elixir-autogen, elixir-format
+msgid "You already follow one member."
+msgid_plural "You already follow %{count} members."
+msgstr[0] "Sie folgen bereits einem Mitglied."
+msgstr[1] "Sie folgen bereits %{count} Mitgliedern."
+
+#: lib/vutuv_web/views/user_html.ex:98
+#, elixir-autogen, elixir-format
+msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
+msgstr ""
+"Ihr Feed zeigt die Beiträge der Mitglieder, denen Sie folgen. Folgen Sie ein "
+"paar Mitgliedern, um ihn zu füllen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Language: INSERT LANGUAGE HERE\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:77
+#: lib/vutuv_web/controllers/page_controller.ex:93
 #: lib/vutuv_web/templates/layout/app.html.heex:93
 #, elixir-autogen
 msgid "About us"
@@ -37,7 +37,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1356
+#: lib/vutuv_web/templates/user/show.html.heex:1371
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -74,7 +74,7 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:176
+#: lib/vutuv_web/templates/page/index.html.heex:210
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
@@ -100,7 +100,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/templates/user/show.html.heex:990
+#: lib/vutuv_web/templates/user/show.html.heex:1005
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -145,7 +145,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1028
+#: lib/vutuv_web/templates/user/show.html.heex:1043
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2154
+#: lib/vutuv_web/components/post_components.ex:2177
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2119
+#: lib/vutuv_web/components/post_components.ex:2142
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -217,7 +217,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1013
+#: lib/vutuv_web/templates/user/show.html.heex:1028
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -354,7 +354,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:67
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:985
+#: lib/vutuv_web/templates/user/show.html.heex:1000
 #: lib/vutuv_web/views/account_event_text.ex:153
 #, elixir-autogen
 msgid "Gender"
@@ -660,7 +660,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1093
+#: lib/vutuv_web/components/post_components.ex:1116
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -670,7 +670,7 @@ msgstr ""
 msgid "Show"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:155
+#: lib/vutuv_web/templates/page/index.html.heex:189
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr ""
@@ -695,13 +695,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1141
+#: lib/vutuv_web/templates/user/show.html.heex:1156
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1143
+#: lib/vutuv_web/templates/user/show.html.heex:1158
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -731,12 +731,12 @@ msgstr ""
 msgid "Profile deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:385
+#: lib/vutuv_web/views/user_html.ex:429
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:391
+#: lib/vutuv_web/views/user_html.ex:435
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr ""
@@ -873,7 +873,7 @@ msgstr ""
 msgid "We can't find em' cap'n!"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:179
+#: lib/vutuv_web/templates/page/index.html.heex:213
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -953,7 +953,7 @@ msgstr ""
 msgid "Allow others to view your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:165
+#: lib/vutuv_web/templates/page/index.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1060,7 +1060,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:974
+#: lib/vutuv_web/templates/user/show.html.heex:989
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1100,7 +1100,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:198
+#: lib/vutuv_web/controllers/page_controller.ex:236
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2596
+#: lib/vutuv_web/components/post_components.ex:2619
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
@@ -1689,17 +1689,17 @@ msgstr ""
 msgid "Confirm account deletion"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:81
+#: lib/vutuv_web/controllers/page_controller.ex:97
 #: lib/vutuv_web/templates/layout/app.html.heex:89
-#: lib/vutuv_web/templates/page/index.html.heex:172
+#: lib/vutuv_web/templates/page/index.html.heex:206
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:87
+#: lib/vutuv_web/controllers/page_controller.ex:103
 #: lib/vutuv_web/templates/layout/app.html.heex:91
-#: lib/vutuv_web/templates/page/index.html.heex:172
+#: lib/vutuv_web/templates/page/index.html.heex:206
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1737,7 +1737,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_account_live.ex:380
 #: lib/vutuv_web/live/fediverse_following_live.ex:287
 #: lib/vutuv_web/templates/user/show.html.heex:945
-#: lib/vutuv_web/templates/user/show.html.heex:1180
+#: lib/vutuv_web/templates/user/show.html.heex:1195
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:336
+#: lib/vutuv_web/components/post_components.ex:337
 #: lib/vutuv_web/components/ui.ex:3077
 #: lib/vutuv_web/live/admin/user_live.ex:311
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
@@ -1901,7 +1901,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:1052
-#: lib/vutuv_web/templates/user/show.html.heex:1444
+#: lib/vutuv_web/views/user_html.ex:96
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -2079,12 +2079,12 @@ msgstr ""
 msgid "May"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:92
+#: lib/vutuv_web/views/user_html.ex:136
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:97
+#: lib/vutuv_web/views/user_html.ex:141
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr ""
@@ -2137,7 +2137,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2151
+#: lib/vutuv_web/components/post_components.ex:2174
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2178,8 +2178,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2105
-#: lib/vutuv_web/components/post_components.ex:2107
+#: lib/vutuv_web/components/post_components.ex:2128
+#: lib/vutuv_web/components/post_components.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2244,13 +2244,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2534
-#: lib/vutuv_web/components/post_components.ex:2538
+#: lib/vutuv_web/components/post_components.ex:2557
+#: lib/vutuv_web/components/post_components.ex:2561
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2535
+#: lib/vutuv_web/components/post_components.ex:2558
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2258,7 +2258,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:252
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:858
+#: lib/vutuv_web/components/post_components.ex:862
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
@@ -2342,27 +2342,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2102
+#: lib/vutuv_web/components/post_components.ex:2125
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3690
+#: lib/vutuv_web/components/post_components.ex:3713
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3694
+#: lib/vutuv_web/components/post_components.ex:3717
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3692
+#: lib/vutuv_web/components/post_components.ex:3715
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3693
+#: lib/vutuv_web/components/post_components.ex:3716
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2403,7 +2403,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3774
+#: lib/vutuv_web/components/post_components.ex:3797
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2422,8 +2422,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1456
-#: lib/vutuv_web/components/post_components.ex:3997
+#: lib/vutuv_web/components/post_components.ex:1479
+#: lib/vutuv_web/components/post_components.ex:4020
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
@@ -2434,7 +2434,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:926
-#: lib/vutuv_web/components/post_components.ex:4006
+#: lib/vutuv_web/components/post_components.ex:4029
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2454,12 +2454,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3763
+#: lib/vutuv_web/components/post_components.ex:3786
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3774
+#: lib/vutuv_web/components/post_components.ex:3797
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2468,25 +2468,25 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1480
-#: lib/vutuv_web/components/post_components.ex:3760
+#: lib/vutuv_web/components/post_components.ex:1503
+#: lib/vutuv_web/components/post_components.ex:3783
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1181
-#: lib/vutuv_web/components/post_components.ex:3148
+#: lib/vutuv_web/components/post_components.ex:1204
+#: lib/vutuv_web/components/post_components.ex:3171
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3760
+#: lib/vutuv_web/components/post_components.ex:3783
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3997
+#: lib/vutuv_web/components/post_components.ex:4020
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2510,28 +2510,28 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4050
+#: lib/vutuv_web/components/post_components.ex:4073
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:325
+#: lib/vutuv_web/components/post_components.ex:326
 #: lib/vutuv_web/live/notification_live/index.ex:858
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:898
-#: lib/vutuv_web/components/post_components.ex:1508
-#: lib/vutuv_web/components/post_components.ex:4033
-#: lib/vutuv_web/components/post_components.ex:4034
+#: lib/vutuv_web/components/post_components.ex:902
+#: lib/vutuv_web/components/post_components.ex:1531
+#: lib/vutuv_web/components/post_components.ex:4056
+#: lib/vutuv_web/components/post_components.ex:4057
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2073
+#: lib/vutuv_web/components/post_components.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1593
+#: lib/vutuv_web/components/post_components.ex:1616
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:58
 #: lib/vutuv_web/live/post_live/remote_reply.ex:57
 #: lib/vutuv_web/live/post_live/reply.ex:52
@@ -2560,14 +2560,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2049
+#: lib/vutuv_web/components/post_components.ex:2072
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2043
-#: lib/vutuv_web/components/post_components.ex:2065
-#: lib/vutuv_web/components/post_components.ex:2068
+#: lib/vutuv_web/components/post_components.ex:2066
+#: lib/vutuv_web/components/post_components.ex:2088
+#: lib/vutuv_web/components/post_components.ex:2091
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2694,7 +2694,7 @@ msgstr ""
 msgid "Founder of vutuv"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:145
+#: lib/vutuv_web/templates/page/index.html.heex:146
 #: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
@@ -2740,26 +2740,26 @@ msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1102
+#: lib/vutuv_web/templates/user/show.html.heex:1117
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1358
+#: lib/vutuv_web/templates/user/show.html.heex:1373
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1030
+#: lib/vutuv_web/templates/user/show.html.heex:1045
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:976
+#: lib/vutuv_web/templates/user/show.html.heex:991
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
@@ -2771,7 +2771,7 @@ msgstr ""
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1034
+#: lib/vutuv_web/live/user_profile_live.ex:1073
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
@@ -2869,7 +2869,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3691
+#: lib/vutuv_web/components/post_components.ex:3714
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2976,7 +2976,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:296
 #: lib/vutuv_web/agent_docs/text.ex:280
-#: lib/vutuv_web/controllers/page_controller.ex:60
+#: lib/vutuv_web/controllers/page_controller.ex:76
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
@@ -3124,13 +3124,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1070
-#: lib/vutuv_web/templates/user/show.html.heex:1071
+#: lib/vutuv_web/templates/user/show.html.heex:1085
+#: lib/vutuv_web/templates/user/show.html.heex:1086
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2019
+#: lib/vutuv_web/components/post_components.ex:2042
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3205,9 +3205,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:868
-#: lib/vutuv_web/components/post_components.ex:1403
-#: lib/vutuv_web/components/post_components.ex:2175
+#: lib/vutuv_web/components/post_components.ex:872
+#: lib/vutuv_web/components/post_components.ex:1426
+#: lib/vutuv_web/components/post_components.ex:2198
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4639,7 +4639,7 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:322
+#: lib/vutuv_web/components/post_components.ex:323
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/notification_live/index.ex:776
@@ -4691,7 +4691,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/live/user_profile_live.ex:1022
+#: lib/vutuv_web/live/user_profile_live.ex:1061
 #: lib/vutuv_web/templates/user/show.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -5267,7 +5267,7 @@ msgstr ""
 msgid "vutuv POSTs signed JSON envelopes here (see the webhooks documentation). https:// only; http://localhost is allowed for development."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:150
+#: lib/vutuv_web/templates/page/index.html.heex:151
 #: lib/vutuv_web/templates/settings/privacy.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
@@ -5410,7 +5410,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1024
+#: lib/vutuv_web/live/user_profile_live.ex:1063
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5436,9 +5436,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2238
-#: lib/vutuv_web/components/post_components.ex:2290
-#: lib/vutuv_web/components/post_components.ex:2671
+#: lib/vutuv_web/components/post_components.ex:2261
+#: lib/vutuv_web/components/post_components.ex:2313
+#: lib/vutuv_web/components/post_components.ex:2694
 #: lib/vutuv_web/live/notification_live/index.ex:601
 #: lib/vutuv_web/live/post_live/feed.ex:1113
 #, elixir-autogen, elixir-format
@@ -5471,7 +5471,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:518
+#: lib/vutuv_web/views/user_html.ex:562
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -6074,7 +6074,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1028
+#: lib/vutuv_web/live/user_profile_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6110,7 +6110,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1409
+#: lib/vutuv_web/templates/user/show.html.heex:1424
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6153,8 +6153,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:996
-#: lib/vutuv_web/templates/user/show.html.heex:1006
+#: lib/vutuv_web/templates/user/show.html.heex:1011
+#: lib/vutuv_web/templates/user/show.html.heex:1021
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6194,12 +6194,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1117
+#: lib/vutuv_web/templates/user/show.html.heex:1132
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1128
+#: lib/vutuv_web/templates/user/show.html.heex:1143
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6235,13 +6235,13 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:926
-#: lib/vutuv_web/components/post_components.ex:324
+#: lib/vutuv_web/components/post_components.ex:325
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1126
+#: lib/vutuv_web/templates/user/show.html.heex:1141
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6295,9 +6295,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1395
-#: lib/vutuv_web/templates/user/show.html.heex:1403
-#: lib/vutuv_web/templates/user/show.html.heex:1415
+#: lib/vutuv_web/templates/user/show.html.heex:1410
+#: lib/vutuv_web/templates/user/show.html.heex:1418
+#: lib/vutuv_web/templates/user/show.html.heex:1430
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6675,17 +6675,17 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2172
+#: lib/vutuv_web/components/post_components.ex:2195
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:517
+#: lib/vutuv_web/views/user_html.ex:561
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2171
+#: lib/vutuv_web/components/post_components.ex:2194
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7368,7 +7368,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3919
+#: lib/vutuv_web/components/post_components.ex:3942
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7989,8 +7989,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1011
-#: lib/vutuv/accounts.ex:1060
+#: lib/vutuv/accounts.ex:1023
+#: lib/vutuv/accounts.ex:1072
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8029,7 +8029,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1028
+#: lib/vutuv/accounts.ex:1040
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8348,7 +8348,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1047
+#: lib/vutuv_web/live/user_profile_live.ex:1106
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
@@ -8368,13 +8368,13 @@ msgid_plural "Skipped %{count} entries that are already on your profile or taken
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:431
+#: lib/vutuv_web/views/user_html.ex:475
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:99
-#: lib/vutuv_web/templates/user/show.html.heex:1262
+#: lib/vutuv_web/templates/user/show.html.heex:1277
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8697,7 +8697,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
 #: lib/vutuv_web/templates/user/show.html.heex:873
-#: lib/vutuv_web/templates/user/show.html.heex:1167
+#: lib/vutuv_web/templates/user/show.html.heex:1182
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8732,7 +8732,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1023
+#: lib/vutuv/accounts.ex:1035
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8841,7 +8841,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3151
+#: lib/vutuv_web/components/post_components.ex:3174
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9765,8 +9765,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1092
-#: lib/vutuv_web/templates/user/show.html.heex:1093
+#: lib/vutuv_web/templates/user/show.html.heex:1107
+#: lib/vutuv_web/templates/user/show.html.heex:1108
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -10405,14 +10405,14 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:308
+#: lib/vutuv_web/views/user_html.ex:352
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:301
+#: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10421,7 +10421,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1236
+#: lib/vutuv_web/templates/user/show.html.heex:1251
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10437,7 +10437,7 @@ msgstr ""
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:315
+#: lib/vutuv_web/views/user_html.ex:359
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr ""
@@ -10462,7 +10462,7 @@ msgstr ""
 msgid "since %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:231
+#: lib/vutuv_web/views/user_html.ex:275
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr ""
@@ -13278,7 +13278,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1552
+#: lib/vutuv_web/components/post_components.ex:1575
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -13689,22 +13689,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:333
+#: lib/vutuv_web/components/post_components.ex:334
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:335
+#: lib/vutuv_web/components/post_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:334
+#: lib/vutuv_web/components/post_components.ex:335
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:323
+#: lib/vutuv_web/components/post_components.ex:324
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13765,7 +13765,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1202
+#: lib/vutuv_web/templates/user/show.html.heex:1217
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13802,7 +13802,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1200
+#: lib/vutuv_web/templates/user/show.html.heex:1215
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13879,7 +13879,7 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3553
+#: lib/vutuv_web/components/post_components.ex:3576
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
@@ -13895,18 +13895,18 @@ msgid "Book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:973
-#: lib/vutuv_web/components/post_components.ex:3510
+#: lib/vutuv_web/components/post_components.ex:3533
 #: lib/vutuv_web/live/post_live/composer.ex:1535
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3554
+#: lib/vutuv_web/components/post_components.ex:3577
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3556
+#: lib/vutuv_web/components/post_components.ex:3579
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
@@ -13916,7 +13916,7 @@ msgstr ""
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3552
+#: lib/vutuv_web/components/post_components.ex:3575
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
@@ -13927,7 +13927,7 @@ msgid "Film"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:973
-#: lib/vutuv_web/components/post_components.ex:3509
+#: lib/vutuv_web/components/post_components.ex:3532
 #: lib/vutuv_web/live/post_live/composer.ex:1534
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13959,7 +13959,7 @@ msgstr ""
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3551
+#: lib/vutuv_web/components/post_components.ex:3574
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
@@ -13986,7 +13986,7 @@ msgstr ""
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3555
+#: lib/vutuv_web/components/post_components.ex:3578
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -14017,34 +14017,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3592
+#: lib/vutuv_web/components/post_components.ex:3615
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3622
+#: lib/vutuv_web/components/post_components.ex:3645
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3623
+#: lib/vutuv_web/components/post_components.ex:3646
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3621
+#: lib/vutuv_web/components/post_components.ex:3644
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3581
+#: lib/vutuv_web/components/post_components.ex:3604
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3628
+#: lib/vutuv_web/components/post_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14074,7 +14074,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3395
+#: lib/vutuv_web/components/post_components.ex:3418
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14122,7 +14122,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3386
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14496,14 +14496,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1799
+#: lib/vutuv_web/components/post_components.ex:1822
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1821
+#: lib/vutuv_web/components/post_components.ex:1844
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14530,7 +14530,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4005
+#: lib/vutuv_web/components/post_components.ex:4028
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14971,6 +14971,7 @@ msgid "Nothing changes on vutuv itself, and you can switch it off again."
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:198
+#: lib/vutuv_web/templates/page/index.html.heex:174
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "Take part in the Fediverse"
@@ -15697,21 +15698,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3964
+#: lib/vutuv_web/components/post_components.ex:3987
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3968
+#: lib/vutuv_web/components/post_components.ex:3991
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3972
+#: lib/vutuv_web/components/post_components.ex:3995
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15719,7 +15720,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:945
-#: lib/vutuv_web/components/post_components.ex:3923
+#: lib/vutuv_web/components/post_components.ex:3946
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15735,14 +15736,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:969
-#: lib/vutuv_web/components/post_components.ex:1123
+#: lib/vutuv_web/components/post_components.ex:973
+#: lib/vutuv_web/components/post_components.ex:1146
 #: lib/vutuv_web/live/fediverse_account_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:856
+#: lib/vutuv_web/components/post_components.ex:860
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15769,7 +15770,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:865
+#: lib/vutuv_web/components/post_components.ex:869
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15779,7 +15780,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:879
+#: lib/vutuv_web/components/post_components.ex:883
 #: lib/vutuv_web/live/notification_live/index.ex:497
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15811,8 +15812,8 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1106
-#: lib/vutuv_web/components/post_components.ex:884
-#: lib/vutuv_web/components/post_components.ex:1520
+#: lib/vutuv_web/components/post_components.ex:888
+#: lib/vutuv_web/components/post_components.ex:1543
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16488,22 +16489,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2031
+#: lib/vutuv_web/components/post_components.ex:2054
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2138
+#: lib/vutuv_web/components/post_components.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2146
+#: lib/vutuv_web/components/post_components.ex:2169
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2132
+#: lib/vutuv_web/components/post_components.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16589,7 +16590,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1034
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:2599
+#: lib/vutuv_web/components/post_components.ex:2622
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16629,7 +16630,7 @@ msgstr ""
 msgid "Move photo later"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2598
+#: lib/vutuv_web/components/post_components.ex:2621
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16639,29 +16640,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3015
+#: lib/vutuv_web/components/post_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1605
+#: lib/vutuv_web/components/post_components.ex:1628
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3018
+#: lib/vutuv_web/components/post_components.ex:3041
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2843
+#: lib/vutuv_web/components/post_components.ex:2866
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2345
+#: lib/vutuv_web/components/post_components.ex:2368
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16674,12 +16675,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1067
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:3052
+#: lib/vutuv_web/components/post_components.ex:3075
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2597
+#: lib/vutuv_web/components/post_components.ex:2620
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
@@ -16700,7 +16701,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1658
+#: lib/vutuv_web/components/post_components.ex:1681
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16720,7 +16721,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1649
+#: lib/vutuv_web/components/post_components.ex:1672
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16730,12 +16731,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1667
+#: lib/vutuv_web/components/post_components.ex:1690
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1601
+#: lib/vutuv_web/components/post_components.ex:1624
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16750,7 +16751,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1662
+#: lib/vutuv_web/components/post_components.ex:1685
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16760,7 +16761,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1615
+#: lib/vutuv_web/components/post_components.ex:1638
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16846,13 +16847,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:963
-#: lib/vutuv_web/components/post_components.ex:3961
+#: lib/vutuv_web/components/post_components.ex:3984
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:961
-#: lib/vutuv_web/components/post_components.ex:3958
+#: lib/vutuv_web/components/post_components.ex:3981
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16862,7 +16863,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3850
+#: lib/vutuv_web/components/post_components.ex:3873
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -17206,7 +17207,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1412
+#: lib/vutuv_web/components/post_components.ex:1435
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -17217,7 +17218,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1519
+#: lib/vutuv_web/components/post_components.ex:1542
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -17237,17 +17238,17 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1096
+#: lib/vutuv_web/components/post_components.ex:1119
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1418
+#: lib/vutuv_web/components/post_components.ex:1441
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1391
+#: lib/vutuv_web/components/post_components.ex:1414
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr ""
@@ -17263,7 +17264,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1398
+#: lib/vutuv_web/components/post_components.ex:1421
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17484,27 +17485,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1226
+#: lib/vutuv_web/components/post_components.ex:1249
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1255
+#: lib/vutuv_web/components/post_components.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1250
+#: lib/vutuv_web/components/post_components.ex:1273
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1537
+#: lib/vutuv_web/components/post_components.ex:1560
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1540
+#: lib/vutuv_web/components/post_components.ex:1563
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17514,7 +17515,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1653
+#: lib/vutuv_web/components/post_components.ex:1676
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17545,17 +17546,34 @@ msgstr ""
 msgid "Please sign in first, then you can follow that account from your vutuv account."
 msgstr ""
 
-#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:71
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:73
 #, elixir-autogen, elixir-format
 msgid "That link did not name a Fediverse account we can read."
 msgstr ""
 
-#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:115
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:120
 #, elixir-autogen, elixir-format
 msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:176
+#: lib/vutuv_web/templates/page/index.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "People on Mastodon and other independent networks can then follow this profile, and your public posts appear there. What they answer or share comes back and is shown under your posts, by their account address. A reply from there is stored here for up to six months. You can switch all of it off again at any time."
+msgstr ""
+
+#: lib/vutuv_web/live/user_profile_live.ex:1084
+#, elixir-autogen, elixir-format
+msgid "Follow %{count} members"
+msgstr ""
+
+#: lib/vutuv_web/live/user_profile_live.ex:1099
+#, elixir-autogen, elixir-format
+msgid "You already follow one member."
+msgid_plural "You already follow %{count} members."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/views/user_html.ex:98
+#, elixir-autogen, elixir-format
+msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr "Language: en\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:77
+#: lib/vutuv_web/controllers/page_controller.ex:93
 #: lib/vutuv_web/templates/layout/app.html.heex:93
 #, elixir-autogen
 msgid "About us"
@@ -35,7 +35,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1356
+#: lib/vutuv_web/templates/user/show.html.heex:1371
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -72,7 +72,7 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:176
+#: lib/vutuv_web/templates/page/index.html.heex:210
 #, elixir-autogen
 msgid "Already a member? Sign in here."
 msgstr ""
@@ -98,7 +98,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/templates/user/show.html.heex:990
+#: lib/vutuv_web/templates/user/show.html.heex:1005
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -143,7 +143,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1028
+#: lib/vutuv_web/templates/user/show.html.heex:1043
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -152,7 +152,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2154
+#: lib/vutuv_web/components/post_components.ex:2177
 #: lib/vutuv_web/components/ui.ex:2967
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -201,7 +201,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2119
+#: lib/vutuv_web/components/post_components.ex:2142
 #: lib/vutuv_web/components/ui.ex:2958
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -215,7 +215,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1013
+#: lib/vutuv_web/templates/user/show.html.heex:1028
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -352,7 +352,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:67
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:985
+#: lib/vutuv_web/templates/user/show.html.heex:1000
 #: lib/vutuv_web/views/account_event_text.ex:153
 #, elixir-autogen
 msgid "Gender"
@@ -658,7 +658,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1093
+#: lib/vutuv_web/components/post_components.ex:1116
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -668,7 +668,7 @@ msgstr ""
 msgid "Show"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:155
+#: lib/vutuv_web/templates/page/index.html.heex:189
 #, elixir-autogen
 msgid "Sign up for a free account"
 msgstr ""
@@ -693,13 +693,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1141
+#: lib/vutuv_web/templates/user/show.html.heex:1156
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1143
+#: lib/vutuv_web/templates/user/show.html.heex:1158
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -729,12 +729,12 @@ msgstr ""
 msgid "Profile deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:385
+#: lib/vutuv_web/views/user_html.ex:429
 #, elixir-autogen, elixir-format
 msgid "Social networks"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:391
+#: lib/vutuv_web/views/user_html.ex:435
 #, elixir-autogen, elixir-format
 msgid "Code & repositories"
 msgstr ""
@@ -871,7 +871,7 @@ msgstr ""
 msgid "We can't find em' cap'n!"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:179
+#: lib/vutuv_web/templates/page/index.html.heex:213
 #, elixir-autogen
 msgid "We reserve the right to stop this service or delete your account anytime without warning."
 msgstr ""
@@ -951,7 +951,7 @@ msgstr ""
 msgid "Allow others to view your email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:165
+#: lib/vutuv_web/templates/page/index.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "By creating an account you accept our {nutzungsbedingungen} and confirm that you have read our {datenschutz}."
 msgstr ""
@@ -1058,7 +1058,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:974
+#: lib/vutuv_web/templates/user/show.html.heex:989
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1098,7 +1098,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:198
+#: lib/vutuv_web/controllers/page_controller.ex:236
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2596
+#: lib/vutuv_web/components/post_components.ex:2619
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
@@ -1687,17 +1687,17 @@ msgstr ""
 msgid "Confirm account deletion"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:81
+#: lib/vutuv_web/controllers/page_controller.ex:97
 #: lib/vutuv_web/templates/layout/app.html.heex:89
-#: lib/vutuv_web/templates/page/index.html.heex:172
+#: lib/vutuv_web/templates/page/index.html.heex:206
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:87
+#: lib/vutuv_web/controllers/page_controller.ex:103
 #: lib/vutuv_web/templates/layout/app.html.heex:91
-#: lib/vutuv_web/templates/page/index.html.heex:172
+#: lib/vutuv_web/templates/page/index.html.heex:206
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "Nutzungsbedingungen"
@@ -1735,7 +1735,7 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_account_live.ex:380
 #: lib/vutuv_web/live/fediverse_following_live.ex:287
 #: lib/vutuv_web/templates/user/show.html.heex:945
-#: lib/vutuv_web/templates/user/show.html.heex:1180
+#: lib/vutuv_web/templates/user/show.html.heex:1195
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1790,7 +1790,7 @@ msgstr ""
 msgid "Network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:336
+#: lib/vutuv_web/components/post_components.ex:337
 #: lib/vutuv_web/components/ui.ex:3077
 #: lib/vutuv_web/live/admin/user_live.ex:311
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
@@ -1899,7 +1899,7 @@ msgid "We sent a PIN to your new email address. Enter it below to confirm the ad
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:1052
-#: lib/vutuv_web/templates/user/show.html.heex:1444
+#: lib/vutuv_web/views/user_html.ex:96
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
 msgstr ""
@@ -2077,12 +2077,12 @@ msgstr ""
 msgid "May"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:92
+#: lib/vutuv_web/views/user_html.ex:136
 #, elixir-autogen, elixir-format
 msgid "Member since %{month} %{year}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:97
+#: lib/vutuv_web/views/user_html.ex:141
 #, elixir-autogen, elixir-format
 msgid "Member since %{year}"
 msgstr ""
@@ -2135,7 +2135,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2151
+#: lib/vutuv_web/components/post_components.ex:2174
 #: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2176,8 +2176,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2105
-#: lib/vutuv_web/components/post_components.ex:2107
+#: lib/vutuv_web/components/post_components.ex:2128
+#: lib/vutuv_web/components/post_components.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2242,13 +2242,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2534
-#: lib/vutuv_web/components/post_components.ex:2538
+#: lib/vutuv_web/components/post_components.ex:2557
+#: lib/vutuv_web/components/post_components.ex:2561
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2535
+#: lib/vutuv_web/components/post_components.ex:2558
 #: lib/vutuv_web/live/fediverse_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2256,7 +2256,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:252
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:858
+#: lib/vutuv_web/components/post_components.ex:862
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:371
@@ -2340,27 +2340,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2102
+#: lib/vutuv_web/components/post_components.ex:2125
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3690
+#: lib/vutuv_web/components/post_components.ex:3713
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3694
+#: lib/vutuv_web/components/post_components.ex:3717
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3692
+#: lib/vutuv_web/components/post_components.ex:3715
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3693
+#: lib/vutuv_web/components/post_components.ex:3716
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2401,7 +2401,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3774
+#: lib/vutuv_web/components/post_components.ex:3797
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:1876
 #: lib/vutuv_web/components/ui.ex:2492
@@ -2420,8 +2420,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1456
-#: lib/vutuv_web/components/post_components.ex:3997
+#: lib/vutuv_web/components/post_components.ex:1479
+#: lib/vutuv_web/components/post_components.ex:4020
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:1905
 #: lib/vutuv_web/components/ui.ex:2478
@@ -2432,7 +2432,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:926
-#: lib/vutuv_web/components/post_components.ex:4006
+#: lib/vutuv_web/components/post_components.ex:4029
 #: lib/vutuv_web/live/notification_live/index.ex:857
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2452,12 +2452,12 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3763
+#: lib/vutuv_web/components/post_components.ex:3786
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3774
+#: lib/vutuv_web/components/post_components.ex:3797
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/components/ui.ex:1866
 #: lib/vutuv_web/live/post_live/saved.ex:694
@@ -2466,25 +2466,25 @@ msgstr ""
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1480
-#: lib/vutuv_web/components/post_components.ex:3760
+#: lib/vutuv_web/components/post_components.ex:1503
+#: lib/vutuv_web/components/post_components.ex:3783
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1181
-#: lib/vutuv_web/components/post_components.ex:3148
+#: lib/vutuv_web/components/post_components.ex:1204
+#: lib/vutuv_web/components/post_components.ex:3171
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3760
+#: lib/vutuv_web/components/post_components.ex:3783
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3997
+#: lib/vutuv_web/components/post_components.ex:4020
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/components/ui.ex:1895
 #: lib/vutuv_web/live/post_live/saved.ex:693
@@ -2508,28 +2508,28 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4050
+#: lib/vutuv_web/components/post_components.ex:4073
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:325
+#: lib/vutuv_web/components/post_components.ex:326
 #: lib/vutuv_web/live/notification_live/index.ex:858
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:898
-#: lib/vutuv_web/components/post_components.ex:1508
-#: lib/vutuv_web/components/post_components.ex:4033
-#: lib/vutuv_web/components/post_components.ex:4034
+#: lib/vutuv_web/components/post_components.ex:902
+#: lib/vutuv_web/components/post_components.ex:1531
+#: lib/vutuv_web/components/post_components.ex:4056
+#: lib/vutuv_web/components/post_components.ex:4057
 #: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/live/post_live/reply.ex:35
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2073
+#: lib/vutuv_web/components/post_components.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2550,7 +2550,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1593
+#: lib/vutuv_web/components/post_components.ex:1616
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:58
 #: lib/vutuv_web/live/post_live/remote_reply.ex:57
 #: lib/vutuv_web/live/post_live/reply.ex:52
@@ -2558,14 +2558,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2049
+#: lib/vutuv_web/components/post_components.ex:2072
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2043
-#: lib/vutuv_web/components/post_components.ex:2065
-#: lib/vutuv_web/components/post_components.ex:2068
+#: lib/vutuv_web/components/post_components.ex:2066
+#: lib/vutuv_web/components/post_components.ex:2088
+#: lib/vutuv_web/components/post_components.ex:2091
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2692,7 +2692,7 @@ msgstr ""
 msgid "Founder of vutuv"
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:145
+#: lib/vutuv_web/templates/page/index.html.heex:146
 #: lib/vutuv_web/templates/settings/privacy.html.heex:58
 #, elixir-autogen, elixir-format
 msgid "Allow search engines to index your profile"
@@ -2738,26 +2738,26 @@ msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1102
+#: lib/vutuv_web/templates/user/show.html.heex:1117
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1358
+#: lib/vutuv_web/templates/user/show.html.heex:1373
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1030
+#: lib/vutuv_web/templates/user/show.html.heex:1045
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:976
+#: lib/vutuv_web/templates/user/show.html.heex:991
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
@@ -2769,7 +2769,7 @@ msgstr ""
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1034
+#: lib/vutuv_web/live/user_profile_live.ex:1073
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
@@ -2867,7 +2867,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3691
+#: lib/vutuv_web/components/post_components.ex:3714
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2974,7 +2974,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:296
 #: lib/vutuv_web/agent_docs/text.ex:280
-#: lib/vutuv_web/controllers/page_controller.ex:60
+#: lib/vutuv_web/controllers/page_controller.ex:76
 #: lib/vutuv_web/templates/layout/app.html.heex:87
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
@@ -3122,13 +3122,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1070
-#: lib/vutuv_web/templates/user/show.html.heex:1071
+#: lib/vutuv_web/templates/user/show.html.heex:1085
+#: lib/vutuv_web/templates/user/show.html.heex:1086
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2019
+#: lib/vutuv_web/components/post_components.ex:2042
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3203,9 +3203,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:868
-#: lib/vutuv_web/components/post_components.ex:1403
-#: lib/vutuv_web/components/post_components.ex:2175
+#: lib/vutuv_web/components/post_components.ex:872
+#: lib/vutuv_web/components/post_components.ex:1426
+#: lib/vutuv_web/components/post_components.ex:2198
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4637,7 +4637,7 @@ msgstr ""
 msgid "Similar names"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:322
+#: lib/vutuv_web/components/post_components.ex:323
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
 #: lib/vutuv_web/live/notification_live/index.ex:776
@@ -4689,7 +4689,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:47
-#: lib/vutuv_web/live/user_profile_live.ex:1022
+#: lib/vutuv_web/live/user_profile_live.ex:1061
 #: lib/vutuv_web/templates/user/show.html.heex:523
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -5265,7 +5265,7 @@ msgstr ""
 msgid "vutuv POSTs signed JSON envelopes here (see the webhooks documentation). https:// only; http://localhost is allowed for development."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:150
+#: lib/vutuv_web/templates/page/index.html.heex:151
 #: lib/vutuv_web/templates/settings/privacy.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Allow AI agents and LLMs to use your profile"
@@ -5408,7 +5408,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1024
+#: lib/vutuv_web/live/user_profile_live.ex:1063
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5434,9 +5434,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2238
-#: lib/vutuv_web/components/post_components.ex:2290
-#: lib/vutuv_web/components/post_components.ex:2671
+#: lib/vutuv_web/components/post_components.ex:2261
+#: lib/vutuv_web/components/post_components.ex:2313
+#: lib/vutuv_web/components/post_components.ex:2694
 #: lib/vutuv_web/live/notification_live/index.ex:601
 #: lib/vutuv_web/live/post_live/feed.ex:1113
 #, elixir-autogen, elixir-format
@@ -5469,7 +5469,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/email/form_content.html.heex:33
 #: lib/vutuv_web/views/email_html.ex:12
-#: lib/vutuv_web/views/user_html.ex:518
+#: lib/vutuv_web/views/user_html.ex:562
 #, elixir-autogen, elixir-format
 msgid "Personal"
 msgstr ""
@@ -6072,7 +6072,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1028
+#: lib/vutuv_web/live/user_profile_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6108,7 +6108,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1409
+#: lib/vutuv_web/templates/user/show.html.heex:1424
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6151,8 +6151,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:996
-#: lib/vutuv_web/templates/user/show.html.heex:1006
+#: lib/vutuv_web/templates/user/show.html.heex:1011
+#: lib/vutuv_web/templates/user/show.html.heex:1021
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6192,12 +6192,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1117
+#: lib/vutuv_web/templates/user/show.html.heex:1132
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1128
+#: lib/vutuv_web/templates/user/show.html.heex:1143
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6233,13 +6233,13 @@ msgid "Previous day"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:926
-#: lib/vutuv_web/components/post_components.ex:324
+#: lib/vutuv_web/components/post_components.ex:325
 #: lib/vutuv_web/views/admin/report_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1126
+#: lib/vutuv_web/templates/user/show.html.heex:1141
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6293,9 +6293,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1395
-#: lib/vutuv_web/templates/user/show.html.heex:1403
-#: lib/vutuv_web/templates/user/show.html.heex:1415
+#: lib/vutuv_web/templates/user/show.html.heex:1410
+#: lib/vutuv_web/templates/user/show.html.heex:1418
+#: lib/vutuv_web/templates/user/show.html.heex:1430
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6673,17 +6673,17 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2172
+#: lib/vutuv_web/components/post_components.ex:2195
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:517
+#: lib/vutuv_web/views/user_html.ex:561
 #, elixir-autogen, elixir-format
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2171
+#: lib/vutuv_web/components/post_components.ex:2194
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7366,7 +7366,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3919
+#: lib/vutuv_web/components/post_components.ex:3942
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7987,8 +7987,8 @@ msgstr ""
 msgid "Identity-verified"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1011
-#: lib/vutuv/accounts.ex:1060
+#: lib/vutuv/accounts.ex:1023
+#: lib/vutuv/accounts.ex:1072
 #: lib/vutuv_web/gettext_extraction_anchors.ex:43
 #, elixir-autogen, elixir-format
 msgid "Incorrect PIN"
@@ -8027,7 +8027,7 @@ msgstr ""
 msgid "Open the member browser"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1028
+#: lib/vutuv/accounts.ex:1040
 #: lib/vutuv_web/gettext_extraction_anchors.ex:44
 #, elixir-autogen, elixir-format
 msgid "PIN expired"
@@ -8346,7 +8346,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1047
+#: lib/vutuv_web/live/user_profile_live.ex:1106
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
@@ -8366,13 +8366,13 @@ msgid_plural "Skipped %{count} entries that are already on your profile or taken
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:431
+#: lib/vutuv_web/views/user_html.ex:475
 #, elixir-autogen, elixir-format
 msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:99
-#: lib/vutuv_web/templates/user/show.html.heex:1262
+#: lib/vutuv_web/templates/user/show.html.heex:1277
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8695,7 +8695,7 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
 #: lib/vutuv_web/templates/user/show.html.heex:873
-#: lib/vutuv_web/templates/user/show.html.heex:1167
+#: lib/vutuv_web/templates/user/show.html.heex:1182
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8730,7 +8730,7 @@ msgstr ""
 msgid "Your Fediverse handle"
 msgstr ""
 
-#: lib/vutuv/accounts.ex:1023
+#: lib/vutuv/accounts.ex:1035
 #: lib/vutuv_web/gettext_extraction_anchors.ex:45
 #, elixir-autogen, elixir-format
 msgid "This PIN has already been used."
@@ -8839,7 +8839,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3151
+#: lib/vutuv_web/components/post_components.ex:3174
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9763,8 +9763,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1092
-#: lib/vutuv_web/templates/user/show.html.heex:1093
+#: lib/vutuv_web/templates/user/show.html.heex:1107
+#: lib/vutuv_web/templates/user/show.html.heex:1108
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -10403,14 +10403,14 @@ msgid_plural "%{count} stars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:308
+#: lib/vutuv_web/views/user_html.ex:352
 #, elixir-autogen, elixir-format
 msgid "%{formatted} follower"
 msgid_plural "%{formatted} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_html.ex:301
+#: lib/vutuv_web/views/user_html.ex:345
 #, elixir-autogen, elixir-format
 msgid "%{formatted} star"
 msgid_plural "%{formatted} stars"
@@ -10419,7 +10419,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1236
+#: lib/vutuv_web/templates/user/show.html.heex:1251
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10435,7 +10435,7 @@ msgstr ""
 msgid "If you list a GitHub, GitLab or Codeberg account, your profile can show its public statistics: stars, repositories, followers, languages and recent activity."
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:315
+#: lib/vutuv_web/views/user_html.ex:359
 #, elixir-autogen, elixir-format
 msgid "Last active %{date}"
 msgstr ""
@@ -10460,7 +10460,7 @@ msgstr ""
 msgid "since %{date}"
 msgstr ""
 
-#: lib/vutuv_web/views/user_html.ex:231
+#: lib/vutuv_web/views/user_html.ex:275
 #, elixir-autogen, elixir-format
 msgid "since %{year}"
 msgstr ""
@@ -13276,7 +13276,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1552
+#: lib/vutuv_web/components/post_components.ex:1575
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -13687,22 +13687,22 @@ msgstr ""
 msgid "Work mobile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:333
+#: lib/vutuv_web/components/post_components.ex:334
 #, elixir-autogen, elixir-format
 msgid "No posts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:335
+#: lib/vutuv_web/components/post_components.ex:336
 #, elixir-autogen, elixir-format
 msgid "No replies yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:334
+#: lib/vutuv_web/components/post_components.ex:335
 #, elixir-autogen, elixir-format
 msgid "No reposts yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:323
+#: lib/vutuv_web/components/post_components.ex:324
 #, elixir-autogen, elixir-format
 msgid "Own posts"
 msgstr ""
@@ -13763,7 +13763,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1202
+#: lib/vutuv_web/templates/user/show.html.heex:1217
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13800,7 +13800,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1200
+#: lib/vutuv_web/templates/user/show.html.heex:1215
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13877,7 +13877,7 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3553
+#: lib/vutuv_web/components/post_components.ex:3576
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
@@ -13893,18 +13893,18 @@ msgid "Book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:973
-#: lib/vutuv_web/components/post_components.ex:3510
+#: lib/vutuv_web/components/post_components.ex:3533
 #: lib/vutuv_web/live/post_live/composer.ex:1535
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3554
+#: lib/vutuv_web/components/post_components.ex:3577
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3556
+#: lib/vutuv_web/components/post_components.ex:3579
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
@@ -13914,7 +13914,7 @@ msgstr ""
 msgid "Director"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3552
+#: lib/vutuv_web/components/post_components.ex:3575
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
@@ -13925,7 +13925,7 @@ msgid "Film"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:973
-#: lib/vutuv_web/components/post_components.ex:3509
+#: lib/vutuv_web/components/post_components.ex:3532
 #: lib/vutuv_web/live/post_live/composer.ex:1534
 #, elixir-autogen, elixir-format
 msgid "Film review"
@@ -13957,7 +13957,7 @@ msgstr ""
 msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3551
+#: lib/vutuv_web/components/post_components.ex:3574
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
@@ -13984,7 +13984,7 @@ msgstr ""
 msgid "Review a film"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3555
+#: lib/vutuv_web/components/post_components.ex:3578
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -14015,34 +14015,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3592
+#: lib/vutuv_web/components/post_components.ex:3615
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3622
+#: lib/vutuv_web/components/post_components.ex:3645
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3623
+#: lib/vutuv_web/components/post_components.ex:3646
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3621
+#: lib/vutuv_web/components/post_components.ex:3644
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3581
+#: lib/vutuv_web/components/post_components.ex:3604
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3628
+#: lib/vutuv_web/components/post_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14072,7 +14072,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3395
+#: lib/vutuv_web/components/post_components.ex:3418
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14120,7 +14120,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3386
+#: lib/vutuv_web/components/post_components.ex:3409
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14494,14 +14494,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1799
+#: lib/vutuv_web/components/post_components.ex:1822
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1821
+#: lib/vutuv_web/components/post_components.ex:1844
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14528,7 +14528,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4005
+#: lib/vutuv_web/components/post_components.ex:4028
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14969,6 +14969,7 @@ msgid "Nothing changes on vutuv itself, and you can switch it off again."
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:198
+#: lib/vutuv_web/templates/page/index.html.heex:174
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:64
 #, elixir-autogen, elixir-format
 msgid "Take part in the Fediverse"
@@ -15695,21 +15696,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3964
+#: lib/vutuv_web/components/post_components.ex:3987
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3968
+#: lib/vutuv_web/components/post_components.ex:3991
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3972
+#: lib/vutuv_web/components/post_components.ex:3995
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15717,7 +15718,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:945
-#: lib/vutuv_web/components/post_components.ex:3923
+#: lib/vutuv_web/components/post_components.ex:3946
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15733,14 +15734,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:969
-#: lib/vutuv_web/components/post_components.ex:1123
+#: lib/vutuv_web/components/post_components.ex:973
+#: lib/vutuv_web/components/post_components.ex:1146
 #: lib/vutuv_web/live/fediverse_account_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:856
+#: lib/vutuv_web/components/post_components.ex:860
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15767,7 +15768,7 @@ msgstr ""
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:865
+#: lib/vutuv_web/components/post_components.ex:869
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15777,7 +15778,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:879
+#: lib/vutuv_web/components/post_components.ex:883
 #: lib/vutuv_web/live/notification_live/index.ex:497
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15809,8 +15810,8 @@ msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1106
-#: lib/vutuv_web/components/post_components.ex:884
-#: lib/vutuv_web/components/post_components.ex:1520
+#: lib/vutuv_web/components/post_components.ex:888
+#: lib/vutuv_web/components/post_components.ex:1543
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16486,22 +16487,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2031
+#: lib/vutuv_web/components/post_components.ex:2054
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2138
+#: lib/vutuv_web/components/post_components.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2146
+#: lib/vutuv_web/components/post_components.ex:2169
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2132
+#: lib/vutuv_web/components/post_components.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16587,7 +16588,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1034
 #: lib/vutuv_web/agent_docs/text.ex:647
-#: lib/vutuv_web/components/post_components.ex:2599
+#: lib/vutuv_web/components/post_components.ex:2622
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16627,7 +16628,7 @@ msgstr ""
 msgid "Move photo later"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2598
+#: lib/vutuv_web/components/post_components.ex:2621
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16637,29 +16638,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3015
+#: lib/vutuv_web/components/post_components.ex:3038
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1605
+#: lib/vutuv_web/components/post_components.ex:1628
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3018
+#: lib/vutuv_web/components/post_components.ex:3041
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2843
+#: lib/vutuv_web/components/post_components.ex:2866
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2345
+#: lib/vutuv_web/components/post_components.ex:2368
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16672,12 +16673,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1067
 #: lib/vutuv_web/agent_docs/text.ex:634
-#: lib/vutuv_web/components/post_components.ex:3052
+#: lib/vutuv_web/components/post_components.ex:3075
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2597
+#: lib/vutuv_web/components/post_components.ex:2620
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
@@ -16698,7 +16699,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1658
+#: lib/vutuv_web/components/post_components.ex:1681
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16718,7 +16719,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1649
+#: lib/vutuv_web/components/post_components.ex:1672
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16728,12 +16729,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1667
+#: lib/vutuv_web/components/post_components.ex:1690
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1601
+#: lib/vutuv_web/components/post_components.ex:1624
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16748,7 +16749,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1662
+#: lib/vutuv_web/components/post_components.ex:1685
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16758,7 +16759,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1615
+#: lib/vutuv_web/components/post_components.ex:1638
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16844,13 +16845,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:963
-#: lib/vutuv_web/components/post_components.ex:3961
+#: lib/vutuv_web/components/post_components.ex:3984
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:961
-#: lib/vutuv_web/components/post_components.ex:3958
+#: lib/vutuv_web/components/post_components.ex:3981
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16860,7 +16861,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3850
+#: lib/vutuv_web/components/post_components.ex:3873
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -17204,7 +17205,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1412
+#: lib/vutuv_web/components/post_components.ex:1435
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -17215,7 +17216,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1519
+#: lib/vutuv_web/components/post_components.ex:1542
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -17235,17 +17236,17 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1096
+#: lib/vutuv_web/components/post_components.ex:1119
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1418
+#: lib/vutuv_web/components/post_components.ex:1441
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1391
+#: lib/vutuv_web/components/post_components.ex:1414
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mute %{handle}"
 msgstr ""
@@ -17261,7 +17262,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1398
+#: lib/vutuv_web/components/post_components.ex:1421
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17482,27 +17483,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1226
+#: lib/vutuv_web/components/post_components.ex:1249
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1255
+#: lib/vutuv_web/components/post_components.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1250
+#: lib/vutuv_web/components/post_components.ex:1273
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1537
+#: lib/vutuv_web/components/post_components.ex:1560
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1540
+#: lib/vutuv_web/components/post_components.ex:1563
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17512,7 +17513,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1653
+#: lib/vutuv_web/components/post_components.ex:1676
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17543,17 +17544,34 @@ msgstr ""
 msgid "Please sign in first, then you can follow that account from your vutuv account."
 msgstr ""
 
-#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:71
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:73
 #, elixir-autogen, elixir-format
 msgid "That link did not name a Fediverse account we can read."
 msgstr ""
 
-#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:115
+#: lib/vutuv_web/controllers/authorize_interaction_controller.ex:120
 #, elixir-autogen, elixir-format
 msgid "That link points at a single post. You can follow its author, %{account}, from here."
 msgstr ""
 
-#: lib/vutuv_web/templates/page/index.html.heex:176
+#: lib/vutuv_web/templates/page/index.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "People on Mastodon and other independent networks can then follow this profile, and your public posts appear there. What they answer or share comes back and is shown under your posts, by their account address. A reply from there is stored here for up to six months. You can switch all of it off again at any time."
+msgstr ""
+
+#: lib/vutuv_web/live/user_profile_live.ex:1084
+#, elixir-autogen, elixir-format
+msgid "Follow %{count} members"
+msgstr ""
+
+#: lib/vutuv_web/live/user_profile_live.ex:1099
+#, elixir-autogen, elixir-format
+msgid "You already follow one member."
+msgid_plural "You already follow %{count} members."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/vutuv_web/views/user_html.ex:98
+#, elixir-autogen, elixir-format
+msgid "Your feed shows the posts of members you follow. Follow a few to fill it."
 msgstr ""

--- a/test/vutuv/posts/top_recent_posters_test.exs
+++ b/test/vutuv/posts/top_recent_posters_test.exs
@@ -1,0 +1,67 @@
+defmodule Vutuv.Posts.TopRecentPostersTest do
+  @moduledoc """
+  The "Who to follow" candidate pool of the profile card
+  (`Posts.top_recent_posters/2`): the members who posted within the window,
+  ranked by the hearts their in-window posts collected, post count as the
+  tie-break. Async-safe: only factory sequences, no shared literals, and the
+  sandbox keeps each test's posts invisible to the others.
+  """
+  use Vutuv.DataCase, async: true
+
+  alias Vutuv.Posts
+
+  defp days_ago(days), do: NaiveDateTime.add(NaiveDateTime.utc_now(), -days, :day)
+
+  test "ranks the window's posters by hearts, then by post count" do
+    hearted = insert_activated_user()
+    liked_post = insert(:post, user: hearted)
+    :ok = Posts.like_post(insert_activated_user(), liked_post)
+
+    busy = insert_activated_user()
+    insert(:post, user: busy)
+    insert(:post, user: busy)
+
+    quiet = insert_activated_user()
+    insert(:post, user: quiet)
+
+    # The liker never posted, so they are not in the pool at all.
+    assert Enum.map(Posts.top_recent_posters(28, 10), & &1.id) ==
+             [hearted.id, busy.id, quiet.id]
+  end
+
+  test "only members who posted inside the window qualify" do
+    outsider = insert_activated_user()
+    old = insert(:post, user: outsider, inserted_at: days_ago(30))
+    :ok = Posts.like_post(insert_activated_user(), old)
+
+    assert Posts.top_recent_posters(28, 10) == []
+  end
+
+  test "hearts on posts from before the window do not count" do
+    # A veteran whose likes all sit on an old post ranks below a member whose
+    # fresh post collected one - only in-window hearts speak for the feed a
+    # new follower would actually get.
+    veteran = insert_activated_user()
+    old = insert(:post, user: veteran, inserted_at: days_ago(30))
+    :ok = Posts.like_post(insert_activated_user(), old)
+    insert(:post, user: veteran)
+
+    fresh = insert_activated_user()
+    :ok = Posts.like_post(insert_activated_user(), insert(:post, user: fresh))
+
+    assert Enum.map(Posts.top_recent_posters(28, 10), & &1.id) == [fresh.id, veteran.id]
+  end
+
+  test "unconfirmed accounts never surface, and the limit caps the list" do
+    unconfirmed = insert(:user)
+    insert(:post, user: unconfirmed)
+
+    first = insert_activated_user()
+    :ok = Posts.like_post(insert_activated_user(), insert(:post, user: first))
+    second = insert_activated_user()
+    insert(:post, user: second)
+
+    assert Enum.map(Posts.top_recent_posters(28, 1), & &1.id) == [first.id]
+    refute unconfirmed.id in Enum.map(Posts.top_recent_posters(28, 10), & &1.id)
+  end
+end

--- a/test/vutuv_web/controllers/listing_batching_test.exs
+++ b/test/vutuv_web/controllers/listing_batching_test.exs
@@ -262,9 +262,11 @@ defmodule VutuvWeb.ListingBatchingTest do
       insert(:follow, follower: insert_activated_user(), followee: owner)
       insert(:follow, follower: insert_activated_user(), followee: owner)
 
-      # A second member so the rail still has someone genuine to recommend.
+      # A second member so the rail still has someone genuine to recommend
+      # (with a recent post, since suggestions require one).
       other = insert_activated_user(first_name: "Somebody")
       insert(:follow, follower: insert_activated_user(), followee: other)
+      insert(:post, user: other)
 
       conn = get(conn, ~p"/#{owner}")
       assert html_response(conn, 200)

--- a/test/vutuv_web/controllers/profile_edit_affordances_test.exs
+++ b/test/vutuv_web/controllers/profile_edit_affordances_test.exs
@@ -115,7 +115,7 @@ defmodule VutuvWeb.ProfileEditAffordancesTest do
     # The owner's onboarding nudge: a few high-impact steps, shown only while
     # something is still undone, and gone once the profile is complete. It is
     # owner-only (a visitor never sees it). Since sign-up requires three tags,
-    # the tag step arrives already checked: the list opens at 1/4, visible
+    # the tag step arrives already checked: the list opens at 1/5, visible
     # progress instead of a wall of zeros.
 
     test "a new owner sees the checklist with the tag step already done", %{conn: conn} do
@@ -129,8 +129,9 @@ defmodule VutuvWeb.ProfileEditAffordancesTest do
       assert checklist =~ "Add a profile photo"
       assert checklist =~ "Add a tagline"
       assert checklist =~ "Write your first post"
+      assert checklist =~ "Follow 5 members"
       # The registration tags already check the first step off.
-      assert checklist =~ "1/4"
+      assert checklist =~ "1/5"
     end
 
     # The checklist leads to photo / tagline / first post; work experience is
@@ -165,6 +166,8 @@ defmodule VutuvWeb.ProfileEditAffordancesTest do
         Repo.update(Ecto.Changeset.change(user, avatar: "me.jpg", headline: "Builder of things"))
 
       insert(:post, user: user)
+      # The follow step completes at five followed members.
+      for _ <- 1..5, do: insert(:follow, follower: user, followee: insert_activated_user())
 
       html = conn |> get(~p"/#{user}") |> html_response(200)
 

--- a/test/vutuv_web/live/user_profile_live_test.exs
+++ b/test/vutuv_web/live/user_profile_live_test.exs
@@ -255,16 +255,9 @@ defmodule VutuvWeb.UserProfileLiveTest do
       {conn, viewer} = create_and_login_user(conn)
       owner = insert_activated_user()
 
-      # The owner's leading tag drives the topical suggestions: everyone endorsed
-      # for it is a candidate.
-      tag = insert(:tag)
-      insert(:user_tag, user: owner, tag: tag)
-
       already_followed = insert_activated_user()
       not_followed = insert_activated_user()
-      insert(:user_tag, user: already_followed, tag: tag)
-      insert(:user_tag, user: not_followed, tag: tag)
-      # Both pass the recent-activity gate, so the follow edge alone decides.
+      # Both are in the pool (recent posters), so the follow edge alone decides.
       insert(:post, user: already_followed)
       insert(:post, user: not_followed)
       # The viewer already follows one of the two candidates.
@@ -592,23 +585,10 @@ defmodule VutuvWeb.UserProfileLiveTest do
     end
   end
 
-  # Put `candidate` into `owner`'s topical suggestion pool: tag them with
-  # every one of the owner's tags, so whichever tag `first_tag/1` resolves as
-  # the leading one (the three registration tags share an inserted_at second),
-  # the pool contains the candidate. Suggestions additionally require a post
-  # from the last three weeks, so this alone does NOT make them appear.
-  defp tag_to_owner(owner, candidate) do
-    for ut <- Repo.all(from(ut in Tags.UserTag, where: ut.user_id == ^owner.id, preload: :tag)) do
-      insert(:user_tag, user: candidate, tag: ut.tag)
-    end
-
-    candidate
-  end
-
-  # Make `candidate` really appear in the rail: topical pool + the recent post
-  # the activity gate requires.
-  defp suggest_to(owner, candidate) do
-    tag_to_owner(owner, candidate)
+  # Make `candidate` appear in the "Who to follow" pool: the suggestions are
+  # the window's most-hearted recent posters (Posts.top_recent_posters/2), so
+  # one fresh post is the ticket in.
+  defp suggest_to(_owner, candidate) do
     insert(:post, user: candidate)
     candidate
   end
@@ -658,10 +638,7 @@ defmodule VutuvWeb.UserProfileLiveTest do
       # promotion is the owner's onboarding, not a viewer state.
       {conn, _viewer} = create_and_login_user(conn)
       owner = insert_activated_user()
-      tag = insert(:tag)
-      insert(:user_tag, user: owner, tag: tag)
       candidate = insert_activated_user()
-      insert(:user_tag, user: candidate, tag: tag)
       insert(:post, user: candidate)
 
       {:ok, view, _html} = live(conn, ~p"/#{owner}")
@@ -671,20 +648,20 @@ defmodule VutuvWeb.UserProfileLiveTest do
       refute has_element?(view, "#discovery-intro")
     end
 
-    test "only accounts that posted in the last three weeks are suggested", %{conn: conn} do
+    test "only accounts that posted in the last four weeks are suggested", %{conn: conn} do
       {conn, owner} = create_and_login_user(conn)
 
-      # Three candidates in the topical pool: one with a fresh post, one whose
-      # last post is older than the window, one who never posted.
+      # Three members: one with a fresh post, one whose last post is older
+      # than the window, one who never posted.
       active = suggest_to(owner, insert_activated_user())
-      stale = tag_to_owner(owner, insert_activated_user())
+      stale = insert_activated_user()
 
       insert(:post,
         user: stale,
-        inserted_at: NaiveDateTime.add(NaiveDateTime.utc_now(), -22, :day)
+        inserted_at: NaiveDateTime.add(NaiveDateTime.utc_now(), -30, :day)
       )
 
-      silent = tag_to_owner(owner, insert_activated_user())
+      silent = insert_activated_user()
 
       {:ok, view, _html} = live(conn, ~p"/#{owner}")
 

--- a/test/vutuv_web/live/user_profile_live_test.exs
+++ b/test/vutuv_web/live/user_profile_live_test.exs
@@ -264,6 +264,9 @@ defmodule VutuvWeb.UserProfileLiveTest do
       not_followed = insert_activated_user()
       insert(:user_tag, user: already_followed, tag: tag)
       insert(:user_tag, user: not_followed, tag: tag)
+      # Both pass the recent-activity gate, so the follow edge alone decides.
+      insert(:post, user: already_followed)
+      insert(:post, user: not_followed)
       # The viewer already follows one of the two candidates.
       insert(:follow, follower: viewer, followee: already_followed)
 
@@ -589,15 +592,24 @@ defmodule VutuvWeb.UserProfileLiveTest do
     end
   end
 
-  # Make `candidate` appear in `owner`'s "Who to follow" rail: tag them with
+  # Put `candidate` into `owner`'s topical suggestion pool: tag them with
   # every one of the owner's tags, so whichever tag `first_tag/1` resolves as
   # the leading one (the three registration tags share an inserted_at second),
-  # the topical suggestion pool contains the candidate.
-  defp suggest_to(owner, candidate) do
+  # the pool contains the candidate. Suggestions additionally require a post
+  # from the last three weeks, so this alone does NOT make them appear.
+  defp tag_to_owner(owner, candidate) do
     for ut <- Repo.all(from(ut in Tags.UserTag, where: ut.user_id == ^owner.id, preload: :tag)) do
       insert(:user_tag, user: candidate, tag: ut.tag)
     end
 
+    candidate
+  end
+
+  # Make `candidate` really appear in the rail: topical pool + the recent post
+  # the activity gate requires.
+  defp suggest_to(owner, candidate) do
+    tag_to_owner(owner, candidate)
+    insert(:post, user: candidate)
     candidate
   end
 
@@ -650,12 +662,38 @@ defmodule VutuvWeb.UserProfileLiveTest do
       insert(:user_tag, user: owner, tag: tag)
       candidate = insert_activated_user()
       insert(:user_tag, user: candidate, tag: tag)
+      insert(:post, user: candidate)
 
       {:ok, view, _html} = live(conn, ~p"/#{owner}")
 
       assert has_element?(view, "#profile-who-to-follow")
       refute has_element?(view, ~s(#profile-who-to-follow[data-promoted]))
       refute has_element?(view, "#discovery-intro")
+    end
+
+    test "only accounts that posted in the last three weeks are suggested", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+
+      # Three candidates in the topical pool: one with a fresh post, one whose
+      # last post is older than the window, one who never posted.
+      active = suggest_to(owner, insert_activated_user())
+      stale = tag_to_owner(owner, insert_activated_user())
+
+      insert(:post,
+        user: stale,
+        inserted_at: NaiveDateTime.add(NaiveDateTime.utc_now(), -22, :day)
+      )
+
+      silent = tag_to_owner(owner, insert_activated_user())
+
+      {:ok, view, _html} = live(conn, ~p"/#{owner}")
+
+      # A suggestion is a promise that following fills your feed; only the
+      # recently posting account can keep it.
+      rail = "#profile-who-to-follow"
+      assert has_element?(view, ~s(#{rail} a[href="/#{active.username}"]))
+      refute has_element?(view, ~s(#{rail} a[href="/#{stale.username}"]))
+      refute has_element?(view, ~s(#{rail} a[href="/#{silent.username}"]))
     end
 
     test "the fifth follow ticks the checklist live but leaves the card in place",

--- a/test/vutuv_web/live/user_profile_live_test.exs
+++ b/test/vutuv_web/live/user_profile_live_test.exs
@@ -589,6 +589,131 @@ defmodule VutuvWeb.UserProfileLiveTest do
     end
   end
 
+  # Make `candidate` appear in `owner`'s "Who to follow" rail: tag them with
+  # every one of the owner's tags, so whichever tag `first_tag/1` resolves as
+  # the leading one (the three registration tags share an inserted_at second),
+  # the topical suggestion pool contains the candidate.
+  defp suggest_to(owner, candidate) do
+    for ut <- Repo.all(from(ut in Tags.UserTag, where: ut.user_id == ^owner.id, preload: :tag)) do
+      insert(:user_tag, user: candidate, tag: ut.tag)
+    end
+
+    candidate
+  end
+
+  describe "'Who to follow' promotion while the owner follows fewer than five members" do
+    test "the owner's rail leads with the promoted card", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      suggest_to(owner, insert_activated_user())
+
+      {:ok, view, _html} = live(conn, ~p"/#{owner}")
+
+      # Promoted: the marker attribute and the intro line explaining why
+      # following matters are both on.
+      assert has_element?(view, ~s(#profile-who-to-follow[data-promoted]))
+      assert has_element?(view, "#discovery-intro")
+
+      # And the card really renders at the top of the rail, before the
+      # "General Info" card that normally leads it. Position is document
+      # order, so this one assertion reads the raw HTML.
+      html = render(view)
+      {rail_idx, _} = :binary.match(html, ~s(id="profile-who-to-follow"))
+      {about_idx, _} = :binary.match(html, ~s(id="profile-about"))
+      assert rail_idx < about_idx
+    end
+
+    test "five follows put the card back in its regular late-rail spot", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      suggest_to(owner, insert_activated_user())
+      for _ <- 1..5, do: insert(:follow, follower: owner, followee: insert_activated_user())
+
+      {:ok, view, _html} = live(conn, ~p"/#{owner}")
+
+      # The card still renders (there is a suggestion), but demoted: no
+      # marker, no intro line, and it sits after the General Info card again.
+      refute has_element?(view, ~s(#profile-who-to-follow[data-promoted]))
+      refute has_element?(view, "#discovery-intro")
+      assert has_element?(view, "#profile-who-to-follow")
+
+      html = render(view)
+      {rail_idx, _} = :binary.match(html, ~s(id="profile-who-to-follow"))
+      {about_idx, _} = :binary.match(html, ~s(id="profile-about"))
+      assert rail_idx > about_idx
+    end
+
+    test "a visitor never gets the promoted treatment", %{conn: conn} do
+      # The viewer follows nobody themselves, but they are not the owner:
+      # promotion is the owner's onboarding, not a viewer state.
+      {conn, _viewer} = create_and_login_user(conn)
+      owner = insert_activated_user()
+      tag = insert(:tag)
+      insert(:user_tag, user: owner, tag: tag)
+      candidate = insert_activated_user()
+      insert(:user_tag, user: candidate, tag: tag)
+
+      {:ok, view, _html} = live(conn, ~p"/#{owner}")
+
+      assert has_element?(view, "#profile-who-to-follow")
+      refute has_element?(view, ~s(#profile-who-to-follow[data-promoted]))
+      refute has_element?(view, "#discovery-intro")
+    end
+
+    test "the fifth follow ticks the checklist live but leaves the card in place",
+         %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      candidate = suggest_to(owner, insert_activated_user())
+      for _ <- 1..4, do: insert(:follow, follower: owner, followee: insert_activated_user())
+
+      {:ok, view, _html} = live(conn, ~p"/#{owner}")
+
+      # Four follows: promoted, and the checklist's follow step is still a
+      # link (an undone step renders as a link, a done one as plain text).
+      assert has_element?(view, ~s(#profile-who-to-follow[data-promoted]))
+      assert has_element?(view, ~s(#profile-completion a[href="#profile-who-to-follow"]))
+
+      view
+      |> element(
+        ~s(#profile-who-to-follow button[phx-click="follow"][phx-value-followee="#{candidate.id}"])
+      )
+      |> render_click()
+
+      # The step completed without a reload...
+      refute has_element?(view, ~s(#profile-completion a[href="#profile-who-to-follow"]))
+      assert render(view) =~ "Follow 5 members"
+      # ...but the promoted card stays where it is: recomputing the placement
+      # mid-click would teleport the rail away under the member's cursor. The
+      # next visit demotes it.
+      assert has_element?(view, ~s(#profile-who-to-follow[data-promoted]))
+    end
+  end
+
+  describe "onboarding checklist 'Follow 5 members' step" do
+    test "links to the rail card and counts existing follows in its hint", %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+      suggest_to(owner, insert_activated_user())
+      for _ <- 1..2, do: insert(:follow, follower: owner, followee: insert_activated_user())
+
+      {:ok, view, _html} = live(conn, ~p"/#{owner}")
+
+      step = view |> element(~s(#profile-completion a[href="#profile-who-to-follow"])) |> render()
+      assert step =~ "Follow 5 members"
+      # The progress hint sits under the label once the count is started.
+      assert render(view) =~ "You already follow 2 members."
+    end
+
+    test "falls back to the most-followed listing when there is nobody to suggest",
+         %{conn: conn} do
+      {conn, owner} = create_and_login_user(conn)
+
+      {:ok, view, _html} = live(conn, ~p"/#{owner}")
+
+      # Alone on the installation: no rail card to jump to, so the step links
+      # to the browsable listing instead of a dead anchor.
+      refute has_element?(view, "#profile-who-to-follow")
+      assert has_element?(view, ~s(#profile-completion a[href="/listings/most_followed_users"]))
+    end
+  end
+
   describe "post type filter without a reload (issue #945)" do
     # An owner with one of each entry kind, viewed anonymously (public posts).
     setup do


### PR DESCRIPTION
**TL;DR** A brand-new member never learned that there are people here to follow: every card on their fresh profile pointed inward. While the owner follows fewer than 5 members, the "Who to follow" card now leads the rail (with an intro line saying the feed is built from followed members), and the onboarding checklist gains a "Follow 5 members" step.

**Where:** `VutuvWeb.UserProfileLive` + `templates/user/show.html.heex` (+ new `UserHTML.who_to_follow_card/1`)
**Now:** the discovery card sits below the fold at the rail's end; the checklist (tag/photo/tagline/first post) has no social step.
**Want/Done:**
- Owner with < 5 follows (`@discovery_follow_target`): promoted card at the top of the rail, `data-promoted` + `#discovery-intro`. Placement is sticky per page view so the fifth follow, made from the card itself, can't teleport it away mid-click; the next visit demotes it.
- Checklist step "Follow 5 members" with a live-updating progress hint, linking to the card's anchor (fallback: `/listings/most_followed_users` when there is nobody to suggest).
- Docs: onboarding section updated; its stale "first 24h" claim corrected to the code's one-hour window.

Smoke-tested in the browser as a fresh member (PIN login, German locale): anchor jump, live follow/unfollow, live checklist tick, translations.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01WuxjFS4tdPd27JziDvbQGU