### PR TITLE
A boosted post from another network shows its pictures again

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -1665,38 +1665,28 @@ defmodule Vutuv.Fediverse do
   end
 
   @doc """
-  Whether `viewer` may see a cached picture: exactly whether they may see the
-  post it hangs off.
+  Whether `viewer` may see a cached picture: exactly whether they may **read**
+  the post it hangs off (`remote_post_readable?/2`).
 
   A picture URL is the one thing a reader can hand to somebody else, so the
   proxy re-asks this per request rather than trusting that a card rendered it.
+
+  **Readable, not "would it reach them unprompted".** This used to ask for the
+  viewer's own follow of the *author*, which is only one of the four ways a
+  cached post is shown. A **boost** (issue #1167) and a member's **repost**
+  (issue #1166) both carry a post to readers who follow nobody but the sharer —
+  that is their entire purpose, and the purge even spares such a copy for it —
+  and the account page (`account_posts/2`) shows any open post to any signed-in
+  member. So the card rendered and every picture on it 404ed: a boosted photo
+  post came out as a row of broken images. Each of those surfaces is a subset of
+  "readable" (all three require an open audience, or the viewer's own accepted
+  follow), so asking the read question covers them with nothing left to widen —
+  a followers-only post still needs the viewer's own accepted follow.
   """
   def remote_image_visible?(%RemoteImage{remote_post: %RemotePost{} = post}, viewer),
-    do: remote_post_visible?(post, viewer)
+    do: remote_post_readable?(post, viewer)
 
   def remote_image_visible?(_image, _viewer), do: false
-
-  @doc """
-  Whether `viewer` may see a cached post: they follow its author (not muted —
-  a mute is about the feed, not about access), and for a followers-only post
-  that follow is accepted.
-
-  The read half of what `feed_remote_posts/3` and `account_posts/2` enforce in
-  SQL, for the one caller that has a post in hand rather than a query.
-  """
-  def remote_post_visible?(%RemotePost{} = post, %User{id: viewer_id}) do
-    Repo.exists?(
-      from(f in Follow,
-        where: f.user_id == ^viewer_id and f.remote_account_id == ^post.remote_account_id,
-        # The feed's vocabulary (`RemotePost.open?/1`), not a negated literal,
-        # for the reason `account_posts/2` spells out: a fourth audience value
-        # must not open here and close there.
-        where: ^RemotePost.open?(post) or f.state == "accepted"
-      )
-    )
-  end
-
-  def remote_post_visible?(_post, _viewer), do: false
 
   @doc """
   Every picture recorded for `post_ids`, grouped by post id, in the author's
@@ -4035,10 +4025,16 @@ defmodule Vutuv.Fediverse do
   any signed-in member (that is what the account page shows), and a
   followers-only one needs their own accepted follow.
 
-  The read half of what `account_posts/2` enforces in SQL, for a caller holding
-  a post rather than a query. `remote_post_visible?/2` beside it answers the
-  narrower feed question ("would this reach them unprompted"), which also
-  requires a follow — the two are different questions and must not be merged.
+  The read half of what `account_posts/2` enforces in SQL, for the callers
+  holding a post rather than a query: the reply gate above and the picture proxy
+  (`remote_image_visible?/2`).
+
+  Deliberately **not** the narrower feed question ("would this reach them
+  unprompted"), which a follow of the author answers. Every surface that renders
+  a cached post — the feed's own source, a boost, a member's repost, the account
+  page — is a subset of this one, so a gate built from the feed question denies
+  the other three; that is what broke the pictures on boosted posts. Keep new
+  read-side callers on this function.
   """
   def remote_post_readable?(%RemotePost{} = post, %User{id: viewer_id}) do
     RemotePost.open?(post) or

--- a/lib/vutuv_web/controllers/remote_media_controller.ex
+++ b/lib/vutuv_web/controllers/remote_media_controller.ex
@@ -6,9 +6,12 @@ defmodule VutuvWeb.RemoteMediaController do
   Everything is re-checked per request, because a picture URL is the one thing
   a reader can hand to somebody else:
 
-    * **who may see it.** A post picture is only served to a member the post
-      itself reaches (`Vutuv.Fediverse.remote_post_visible?/2`) — so a
-      followers-only post's photograph is no more public than its text.
+    * **who may see it.** A post picture is served to exactly the members who
+      may read the post itself (`Vutuv.Fediverse.remote_image_visible?/2`) — so
+      a followers-only post's photograph is no more public than its text, and
+      an open one's is no *less* readable than its text either, however the
+      reader met it (their own follow, a boost, a member's repost, the account
+      page).
     * **the AI gate.** An unreleased picture never leaves this proxy, which is
       why there is no quarantine tree for these files.
     * **the exact stored file.** The URL's version segment is the

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.188.0",
+      version: "7.188.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_media_test.exs
+++ b/test/vutuv/fediverse_media_test.exs
@@ -253,17 +253,21 @@ defmodule Vutuv.FediverseMediaTest do
       })
     end
 
-    test "a picture is exactly as visible as its post", %{account: acc, user: user} do
-      public = cached_post(acc)
-      private = cached_post(acc, %{audience: "followers"})
+    test "a picture is exactly as readable as its post", %{account: acc, user: user} do
+      public = %RemoteImage{remote_post: cached_post(acc)}
+      private = %RemoteImage{remote_post: cached_post(acc, %{audience: "followers"})}
 
       stranger = insert(:activated_user)
       follow(user, acc, "requested")
 
-      assert Fediverse.remote_post_visible?(public, user)
+      assert Fediverse.remote_image_visible?(public, user)
       # A request nobody answered does not open the author's restricted posts.
-      refute Fediverse.remote_post_visible?(private, user)
-      refute Fediverse.remote_post_visible?(public, stranger)
+      refute Fediverse.remote_image_visible?(private, user)
+      # An open post is readable by any signed-in member, which is what the
+      # account page already shows: a picture on it must not be stricter than
+      # the text beside it. A boost or a repost reaches such a reader too.
+      assert Fediverse.remote_image_visible?(public, stranger)
+      refute Fediverse.remote_image_visible?(private, stranger)
     end
   end
 

--- a/test/vutuv_web/controllers/remote_media_controller_test.exs
+++ b/test/vutuv_web/controllers/remote_media_controller_test.exs
@@ -4,13 +4,20 @@ defmodule VutuvWeb.RemoteMediaControllerTest do
 
   It is the whole access control for those files, so every refusal it makes is
   tested here rather than asserted in a moduledoc: a signed-out request, a
-  reader who does not follow the author, a follow the author never accepted, a
-  picture the AI gate has not cleared, and a URL whose version segment names
-  bytes we no longer store. An unguessable URL is not an access control.
+  followers-only post without an accepted follow, a picture the AI gate has not
+  cleared, and a URL whose version segment names bytes we no longer store. An
+  unguessable URL is not an access control.
+
+  And every *admission*, because the first version of this proxy asked for the
+  viewer's own follow of the author and so 404ed every picture on a boosted or
+  reshared post — a photo post out of the feed came out as broken images. The
+  ways a cached post legitimately reaches a reader are covered one by one below.
   """
   use VutuvWeb.ConnCase, async: true
 
   alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.PostBoost
+  alias Vutuv.Fediverse.PostRepost
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.Fediverse.RemotePost
@@ -81,6 +88,24 @@ defmodule VutuvWeb.RemoteMediaControllerTest do
   defp media_url(%RemoteAccount{} = account),
     do: RemoteMedia.avatar_url(account.id, account.avatar)
 
+  defp other_account do
+    Repo.insert!(%RemoteAccount{
+      actor_uri: "https://other.example/users/them#{System.unique_integer([:positive])}",
+      host: "other.example",
+      handle: "booster",
+      inbox_uri: "https://other.example/inbox"
+    })
+  end
+
+  defp boost(booster, post) do
+    Repo.insert!(%PostBoost{
+      remote_account_id: booster.id,
+      remote_post_id: post.id,
+      activity_id: "https://other.example/a/#{System.unique_integer([:positive])}",
+      announced_at: DateTime.utc_now(:second)
+    })
+  end
+
   defp follow(user, account, state) do
     Repo.insert!(%Follow{
       user_id: user.id,
@@ -109,8 +134,17 @@ defmodule VutuvWeb.RemoteMediaControllerTest do
       assert get(ctx.out, media_url(image)).status == 404
     end
 
-    test "is not served to a signed-in member who follows nobody here", ctx do
+    test "an open post's picture is served to any signed-in member", ctx do
+      # The account page already shows them the post itself, and a boost or a
+      # member's repost carries it into a feed without any follow of the author,
+      # so the picture must not be stricter than the text beside it.
       image = picture(remote_post(ctx.account))
+
+      assert get(ctx.conn, media_url(image)).status == 200
+    end
+
+    test "a followers-only post's picture is not, without a follow", ctx do
+      image = picture(remote_post(ctx.account, "followers"))
 
       assert get(ctx.conn, media_url(image)).status == 404
     end
@@ -141,6 +175,34 @@ defmodule VutuvWeb.RemoteMediaControllerTest do
       Repo.update!(change(image, file: nil, moderation: "rejected"))
 
       assert get(ctx.conn, stale).status == 404
+    end
+
+    test "is served when a followed account boosted the post", ctx do
+      # The normal boost (issue #1167): the reader follows the booster, nobody
+      # here follows the author, and the feed shows them the card all the same.
+      image = picture(remote_post(ctx.account))
+      booster = other_account()
+      boost(booster, %RemotePost{id: image.remote_post_id})
+      follow(ctx.user, booster, "accepted")
+
+      assert get(ctx.conn, media_url(image)).status == 200
+    end
+
+    test "a boost does not widen a followers-only post", ctx do
+      image = picture(remote_post(ctx.account, "followers"))
+      booster = other_account()
+      boost(booster, %RemotePost{id: image.remote_post_id})
+      follow(ctx.user, booster, "accepted")
+
+      assert get(ctx.conn, media_url(image)).status == 404
+    end
+
+    test "is served when a member here reshared the post", ctx do
+      # Issue #1166: the reposter is the reason the reader sees it at all.
+      image = picture(remote_post(ctx.account))
+      Repo.insert!(%PostRepost{user_id: ctx.user.id, remote_post_id: image.remote_post_id})
+
+      assert get(ctx.conn, media_url(image)).status == 200
     end
 
     test "and so does a made-up version segment", ctx do


### PR DESCRIPTION
Pictures on a post that reaches the feed through a **boost** (or through a member's repost) rendered as broken image tiles. Reported from production.

## Why

The card and the proxy that serves the bytes were asking two different questions.

- **Rendering** attaches and shows every released picture on any remote post the feed decided to display (`Vutuv.Posts.attach_remote_images/1` → `VutuvWeb.PostComponents.remote_post_images/1`).
- **Serving** asked `Fediverse.remote_post_visible?/2`, which required the viewer to hold a `Follow` row on **the post's author**.

On a boost nobody here follows the author. That is the entire point of a boost, and `feed_remote_boosts/3` says so itself, scoping to the follow of the *booster*; the purge even spares such a copy because the boost is the only reason it exists. So the follow lookup found nothing and every picture 404ed, while the remote avatar still loaded (its proxy has no per-post audience check) - exactly what the broken card looked like.

The same gap hit two more surfaces: a member's own reshare of a remote post (#1166), and the remote account page, which shows any signed-in member every open post together with its pictures.

## The fix

`remote_image_visible?/2` now delegates to the existing `remote_post_readable?/2`, the question the account page already enforces. All four display surfaces are subsets of it, since each requires an open audience or the viewer's own accepted follow, so this closes the gap **without widening anything**: a followers-only post's picture still needs that member's own accepted follow. `remote_post_visible?/2` had no caller left and is gone (checked repo-wide, not just `lib/` and `test/`).

## Tests

New cases for the boost, the local repost, and a guard that a boost does **not** widen a followers-only post; the first two reproduced the 404 before the change. Two older tests encoded the too-narrow stance and now assert the corrected behaviour, with the reasoning in a comment.

`mix precommit` green (5909 tests).

## Deploy

**Hot deploy**, v7.188.1. No migrations, no config, supervision or dependency changes.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*