### PR TITLE
A vutuv link jumps to the post, in every spelling it is pasted in (v7.198.3)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1231,8 +1231,28 @@ be pasted and `Vutuv.Fediverse.look_up_post/2` answers each of them:
 | an account address or profile URL | `{:account, address}` — handed to the follow box at `/settings/fediverse/following?address=` |
 | anything else | `{:error, reason}` |
 
-Telling the third apart from the first costs no request: `RemoteFollow.parse_address/1`
-is pure string work and accepts exactly `@you@server`, `you@server` and
+**Our own link is recognised on host plus path, never on a prefix of
+`Endpoint.url()`.** A member pastes what their browser or their mail client gave
+them, and that is the same link in half a dozen spellings: the `www.` alias, a
+trailing slash, a `?utm_source=` a share button appended, a fragment, a shouted
+host, plain `http`. A whole-string prefix match missed every one of them and
+sent an unmistakably local link to the remote path, where this installation made
+a signed request **to itself** and spent a slot of the member's hourly budget
+doing it. The post is resolved by its **id** alone and the caller navigates to
+the current canonical path, so a link carrying a handle its owner has since
+changed still lands on the post; `local_note_post/1` on the boost path still
+requires handle and id to agree, because that one decides whether a post may be
+*redistributed* on a remote actor's say-so rather than where to send a reader.
+
+That fix also moved `local_host?/1`, which now treats a leading `www.` as the
+same site. All four of its callers were asking "is this us" and getting the
+wrong answer for an address anybody can paste: the follow gate offered to follow
+this vutuv from itself, the search page offered the same, and `own_object?/3`
+would accept a document attributing a post to one of our own actors.
+
+Telling the third row apart from the first costs no request:
+`RemoteFollow.parse_address/1` is pure string work and accepts exactly
+`@you@server`, `you@server` and
 `https://server/@you`, and a post URL has one path segment too many for all
 three.
 

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -1107,9 +1107,24 @@ defmodule Vutuv.Fediverse do
   def local_host?(uri) do
     case BlockedInstance.normalize_host(uri) do
       nil -> false
-      host -> host == String.downcase(VutuvWeb.Endpoint.host())
+      host -> same_site?(host, String.downcase(VutuvWeb.Endpoint.host()))
     end
   end
+
+  # `www.` is not another installation. Serving a site at both the apex and its
+  # `www.` alias is the oldest convention on the web, and every caller here asks
+  # "is this us", never "is this byte-identical to the configured host" — so an
+  # exact match sent all four of them the wrong answer for an address a member
+  # can perfectly well paste: the follow gate offered to follow this vutuv from
+  # itself, the search page offered the same, `own_object?/3` accepted a
+  # document attributing a post to one of our own actors, and the post lookup
+  # made a signed GET to our own server (issue #1211, found in production).
+  # Nothing about it is vutuv.de-specific.
+  defp same_site?(host, host), do: true
+  defp same_site?(host, other), do: strip_www(host) == strip_www(other)
+
+  defp strip_www("www." <> rest), do: rest
+  defp strip_www(host), do: host
 
   defp claim_remote_follow_budget(%User{id: user_id}) do
     case RateLimiter.hit(
@@ -4872,28 +4887,33 @@ defmodule Vutuv.Fediverse do
     end
   end
 
-  # A vutuv post URL, recognised the way `local_note_post/1` recognises one:
-  # anchored on our own base URL, so a foreign URL that merely copies the
-  # `/name/posts/id` shape names nothing of ours. None of that path's other
-  # gates apply here — they decide whether a member's post may be
-  # **redistributed** on a remote actor's say-so, where this only decides where
-  # to send a reader. What they may see when they arrive is the permalink's own
-  # business.
+  # A vutuv post URL. Matched on **host plus path**, not on a prefix of
+  # `Endpoint.url()`: a member pastes what their browser or their mail client
+  # gave them, and that is the same link in half a dozen spellings — the `www.`
+  # alias, a trailing slash, a `?utm_source=` a share button appended, a
+  # fragment, a shouted host, plain `http`. Every one of them named a post and
+  # every one of them missed a whole-string prefix match, which sent an
+  # unmistakably local link off to `look_up_remote_post/2`, where this
+  # installation made a signed request to itself and spent a slot of the
+  # member's hourly budget doing it.
+  #
+  # The **id** names the post; the handle in front of it is decoration that goes
+  # stale the moment its owner renames, so the post is resolved by id alone and
+  # the caller navigates to its current canonical path. `local_note_post/1` on
+  # the boost path deliberately does require the pair to agree — but that one
+  # decides whether a member's post may be **redistributed** on a remote actor's
+  # say-so, where this only decides where to send a reader who is already here.
+  # What they may see when they arrive is the permalink's own business.
   defp local_lookup_post(url) do
-    base = String.trim_trailing(VutuvWeb.Endpoint.url(), "/") <> "/"
-    # Without the query and the fragment, so a link carrying a tracking
-    # parameter still resolves to the post it names.
-    uri = URI.parse(url)
-    bare = URI.to_string(%URI{uri | query: nil, fragment: nil})
-
-    with rest when rest != bare <- String.replace_prefix(bare, base, ""),
-         [username, "posts", post_id] <- String.split(rest, "/"),
-         %User{} = user <- Accounts.get_user_by_username(username),
-         %Post{user_id: user_id} = post when user_id == user.id <-
-           UUIDv7.with_cast(post_id, &Repo.get(Post, &1)) do
-      # With its author attached: the caller's next move is `Posts.path/1`, and
-      # the member is already in hand from the segment that named them.
-      %{post | user: user}
+    with true <- local_host?(url),
+         # The query and the fragment are not part of `path`, so a tracking
+         # parameter falls away by itself. `trim: true` drops the leading and a
+         # trailing empty segment in one go.
+         %URI{path: path} when is_binary(path) <- URI.parse(url),
+         [_username, "posts", post_id] <- String.split(path, "/", trim: true),
+         %Post{} = post <- UUIDv7.with_cast(post_id, &Repo.get(Post, &1)) do
+      # With its author attached: the caller's next move is `Posts.path/1`.
+      Repo.preload(post, :user)
     else
       _ -> nil
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.198.2",
+      version: "7.198.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_post_lookup_test.exs
+++ b/test/vutuv/fediverse_post_lookup_test.exs
@@ -239,10 +239,77 @@ defmodule Vutuv.FediversePostLookupTest do
       assert local.id == post.id
     end
 
-    test "a vutuv link that is not a post says so rather than being fetched" do
-      url = "#{VutuvWeb.Endpoint.url()}/some-member"
+    # Every shape a vutuv post link is really pasted in. The point of each is
+    # that it costs **no request**: `refuse_all/0` makes any outbound call fail,
+    # so a case that fell through to the remote path would come back
+    # `:post_unreachable` instead of the post.
+    test "in every shape a vutuv post link is pasted in" do
+      refuse_all()
+      author = insert(:activated_user)
+      post = insert(:post, user: author)
+      host = VutuvWeb.Endpoint.host()
+      viewer = member()
 
-      assert {:error, :local_url} = Fediverse.look_up_post(member(), url)
+      urls = [
+        # The canonical form, and the `www.` alias the same site answers on.
+        "https://#{host}/#{author.username}/posts/#{post.id}",
+        "https://www.#{host}/#{author.username}/posts/#{post.id}",
+        # A trailing slash, a query string a share button appended, a fragment,
+        # a shouted host, and plain http.
+        "https://#{host}/#{author.username}/posts/#{post.id}/",
+        "https://#{host}/#{author.username}/posts/#{post.id}?utm_source=mail",
+        "https://#{host}/#{author.username}/posts/#{post.id}#kommentar",
+        "https://#{String.upcase(host)}/#{author.username}/posts/#{post.id}",
+        "http://#{host}/#{author.username}/posts/#{post.id}"
+      ]
+
+      for url <- urls do
+        assert {:local, local} = Fediverse.look_up_post(viewer, url), "failed for #{url}"
+        assert local.id == post.id, "wrong post for #{url}"
+        # With the author attached, or `Posts.path/1` would raise on the caller.
+        assert local.user.id == author.id
+      end
+    end
+
+    # The id names the post; the handle in front of it is decoration that goes
+    # stale the moment its owner renames. Landing on the post beats a dead end.
+    test "a vutuv post link carrying a stale handle still lands on the post" do
+      refuse_all()
+      author = insert(:activated_user)
+      other = insert(:activated_user)
+      post = insert(:post, user: author)
+      url = "#{VutuvWeb.Endpoint.url()}/#{other.username}/posts/#{post.id}"
+
+      assert {:local, local} = Fediverse.look_up_post(member(), url)
+      assert local.id == post.id
+      assert local.user.id == author.id
+    end
+
+    test "a vutuv link that is not a post says so rather than being fetched" do
+      refuse_all()
+
+      for url <- [
+            "#{VutuvWeb.Endpoint.url()}/some-member",
+            "https://www.#{VutuvWeb.Endpoint.host()}/some-member",
+            "#{VutuvWeb.Endpoint.url()}/some-member/posts/2026/07",
+            "#{VutuvWeb.Endpoint.url()}/some-member/posts/019fb1a9-761a-70f9-aa96-f38b4c428691"
+          ] do
+        assert {:error, :local_url} = Fediverse.look_up_post(member(), url), "failed for #{url}"
+      end
+    end
+
+    test "a local URL claims no slot of the hourly budget" do
+      refuse_all()
+      Application.put_env(:vutuv, :fediverse_lookup_limit, 1)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_lookup_limit) end)
+
+      viewer = member()
+      post = insert(:post, user: insert(:activated_user))
+      url = "https://www.#{VutuvWeb.Endpoint.host()}/whoever/posts/#{post.id}"
+
+      # Ten times over a budget of one: recognising our own link asks nobody
+      # anything, so there is nothing to meter.
+      for _ <- 1..10, do: assert({:local, _} = Fediverse.look_up_post(viewer, url))
     end
 
     test "an account address is handed on rather than refused" do

--- a/test/vutuv/fediverse_remote_follows_test.exs
+++ b/test/vutuv/fediverse_remote_follows_test.exs
@@ -204,6 +204,23 @@ defmodule Vutuv.FediverseRemoteFollowsTest do
                Fediverse.follow_remote(federated_user(), "@#{other.username}@vutuv.test")
     end
 
+    # The `www.` alias is the same installation, and a member pastes whichever
+    # spelling their browser gave them. Matching the configured host exactly
+    # sent this address off to WebFinger, i.e. had vutuv resolve and follow
+    # itself (found on the post lookup in production, issue #1211).
+    test "the www alias of this installation is the same installation" do
+      stub_remote(fn _conn -> raise "our own members need no WebFinger lookup" end)
+      with_endpoint_host("vutuv.test")
+      other = insert(:activated_user)
+
+      assert Fediverse.local_host?("https://www.vutuv.test/#{other.username}")
+      assert Fediverse.local_host?("@#{other.username}@www.vutuv.test")
+      refute Fediverse.local_host?("@them@vutuv.test.evil.example")
+
+      assert {:error, :local_account} =
+               Fediverse.follow_remote(federated_user(), "@#{other.username}@www.vutuv.test")
+    end
+
     test "a typo is refused before the network is touched" do
       stub_remote(fn _conn -> raise "an invalid address must never be resolved" end)
 


### PR DESCRIPTION
Follow-up to #1211, found on production right after v7.197.0 went live.

**The bug.** Pasting a vutuv post link into the lookup box jumped to the permalink only when the link was spelled exactly the way `Endpoint.url()` is configured. Verified live:

| Pasted | Before | After |
| --- | --- | --- |
| `https://vutuv.de/wintermeyer/posts/<id>` | jumps to the permalink | jumps to the permalink |
| `https://www.vutuv.de/wintermeyer/posts/<id>` | *"Der Server hat nicht geantwortet."* | jumps to the permalink |

The `www.` alias missed the whole-string prefix match, fell through to the remote path, and had this installation make a signed ActivityPub GET **to itself**. That request gets nginx's 301, `ap_get` has `redirect: false`, so the member was told their own site was unreachable - having just spent a slot of their hourly lookup budget on it. Every older link and every newsletter carries the `www.` form.

**The fix.** A prefix of `Endpoint.url()` was the wrong test. A member pastes what their browser or their mail client gave them, and that is the same link in half a dozen spellings, so the match is now **host plus path**: the `www.` alias, a trailing slash, a `?utm_source=` a share button appended, a fragment, a shouted host and plain `http` all resolve now.

The post is resolved by its **id** alone. The handle in front of it is decoration that goes stale the moment its owner renames, and landing on the post beats a dead end. `local_note_post/1` on the boost path still requires handle and id to agree, because that one decides whether a post may be *redistributed* on a remote actor's say-so rather than where to send a reader who is already here.

**The root cause sat one level down.** `local_host?/1` compared the host byte for byte. All four of its callers ask "is this us", and all four had the wrong answer for an address anybody can paste:

- the follow gate offered to follow this vutuv from itself (`@member@www.vutuv.de` went to WebFinger instead of answering `:local_account`),
- the search page offered the same,
- `own_object?/3` would accept a document attributing a post to one of our own actors,
- and the post lookup made the self-request above.

It now treats a leading `www.` as the same site. That is the oldest convention on the web and nothing about it is vutuv.de-specific, so other installations get the same fix.

**Tests.** One table-driven test walks all seven spellings and asserts each costs **no** outbound request (the HTTP stub is set to fail, so a case falling through to the remote path would come back `:post_unreachable`); one asserts a stale handle still lands on the post; one asserts a local URL claims no budget slot (ten lookups against a budget of one); and one in the remote-follows suite pins `local_host?/1` plus the follow gate on the `www.` form. `mix precommit` green, 6122 tests.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_019PhQvstR4D89qeWgRq3NR6
