### PR TITLE
Remote fediverse posts read like normal posts, without the dashed rail (v7.198.4)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -301,7 +301,7 @@ every activity of a member it finds no key for, silently.
     sibling in time order (`VutuvWeb.PostLive.Thread` +
     `PostComponents.remote_reply_card/1`), wearing its own skin so the two worlds
     are told apart without colour: a **slate** initials tile with the 🌐 badge,
-    a **dashed** left rail against the solid connector rail, the name as plain
+    the name as plain
     text beside a `@handle@host` that links out, and **no action bar** (liking a
     note on someone else's server is not a thing that exists). A content warning
     renders as a closed lid. The member also gets a notification: the

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -784,8 +784,6 @@ defmodule VutuvWeb.PostComponents do
     * an initials tile in **slate**, not the brand tint members get, carrying the
       globe badge that issue #1068 established for "another network". No picture
       is ever fetched or hosted: vutuv does not host a third party's image.
-    * a **dashed** left rail down the body, against the solid connector rail the
-      vutuv cards hang from.
     * the author's name as plain text (there is no vutuv profile to link to)
       beside their `@handle@host`, which links out to the account.
     * **no action bar.** Liking, reposting or bookmarking a note that lives on
@@ -913,7 +911,7 @@ defmodule VutuvWeb.PostComponents do
   #
   # The four pieces every card for content from another network is built from,
   # so "this did not come from vutuv" — the slate initials tile with its globe
-  # badge, the lock line, the dashed rail with its content-warning lid, the
+  # badge, the lock line, the body with its content-warning lid, the
   # origin footer — has ONE definition and reads identically wherever it
   # appears. `remote_reply_card/1` (a reply under a member's post) and
   # `remote_post_card/1` (a post by a followed account) differ only in which
@@ -1069,9 +1067,12 @@ defmodule VutuvWeb.PostComponents do
     """
   end
 
-  # The dashed rail and the text down it. `warning` set (a content warning, or
-  # the author's sensitive flag) closes the lid: the text hides behind a click,
-  # which is the one thing that author asked for.
+  # The body text, reading like any post body — the avatar badge, the host chip
+  # and the origin footer say where it came from, so the text is not set apart
+  # as if it were a quotation (the dashed rail it once wore read as an
+  # unexplained decoration). `warning` set (a content warning, or the author's
+  # sensitive flag) closes the lid: the text hides behind a click, which is the
+  # one thing that author asked for.
   attr(:warning, :any, default: nil)
   attr(:text, :string, required: true)
 
@@ -1104,10 +1105,7 @@ defmodule VutuvWeb.PostComponents do
     assigns = assign(assigns, :html, Markdown.render_remote(assigns.text))
 
     ~H"""
-    <div
-      :if={@warning || presence?(@text)}
-      class="mt-1.5 border-l-2 border-dashed border-slate-300 pl-3 dark:border-slate-600"
-    >
+    <div :if={@warning || presence?(@text)} class="mt-1.5">
       <%= if @warning do %>
         <details data-remote-warning class="group">
           <summary class="flex min-h-10 cursor-pointer list-none items-center gap-1 text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -1316,7 +1314,7 @@ defmodule VutuvWeb.PostComponents do
   (issue #1161).
 
   It wears the **same remote skin** as `remote_reply_card/1` — slate initials
-  tile, globe badge, dashed rail, plain text, "View the original" — so "this did
+  tile, globe badge, plain text, "View the original" — so "this did
   not come from vutuv" reads identically wherever it appears, and a member never
   has to learn two visual vocabularies for the same fact.
 

--- a/lib/vutuv_web/live/notification_live/index.ex
+++ b/lib/vutuv_web/live/notification_live/index.ex
@@ -496,9 +496,12 @@ defmodule VutuvWeb.NotificationLive.Index do
           >
             <span aria-hidden="true">🔒</span> {gettext("Sent to you only, visible to nobody else")}
           </p>
+          <%!-- The same solid quote rail the local reply quotes wear — the row's
+          wording already says it came from another network, so the quote needs
+          no dashed variant of its own. --%>
           <div
             data-remote-reply-preview="true"
-            class="border-l-2 border-dashed border-slate-300 pl-2.5 dark:border-slate-600"
+            class="border-l-2 border-slate-200 pl-2.5 dark:border-slate-700"
           >
             <%!-- No `text-*` / `leading-*` here: `.notif-clamp` owns the type
             size and line height, since its box height is counted in them. --%>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.198.3",
+      version: "7.198.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/feed_remote_posts_test.exs
+++ b/test/vutuv_web/live/feed_remote_posts_test.exs
@@ -67,6 +67,19 @@ defmodule VutuvWeb.FeedRemotePostsTest do
     refute has_element?(view, "[data-remote-post='#{post.id}'] [data-post-actions]")
   end
 
+  test "the body reads like a normal post, not a quotation", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    post = cached_post(user)
+
+    {:ok, view, _html} = live(conn, ~p"/feed")
+
+    # The origin is carried by the globe badge, the host chip and the footer
+    # line; the text itself is not set apart behind a dashed quote rail
+    # (removed 2026-07-30 — it read as an unexplained decoration).
+    assert has_element?(view, "[data-remote-post='#{post.id}'] .markdown")
+    refute has_element?(view, "[data-remote-post='#{post.id}'] .border-dashed")
+  end
+
   test "the body is formatted: links are clickable, hashtags reach our tag pages", %{conn: conn} do
     {conn, user} = create_and_login_user(conn)
     # The hashtag grammar is `[A-Za-z0-9_]+`, so the factory's hyphenated name

--- a/test/vutuv_web/live/post_thread_remote_replies_test.exs
+++ b/test/vutuv_web/live/post_thread_remote_replies_test.exs
@@ -94,6 +94,10 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
       assert html =~ "https://social.example/@alice/1"
       # Its own visual language: the slate initials tile, not a member avatar.
       assert html =~ "data-remote-avatar"
+      # But the text itself reads like a normal reply body — the markers above
+      # carry the origin, not a dashed quote rail down the text (2026-07-30).
+      [remote_card] = Regex.run(~r{<article data-fediverse-reply.*?</article>}s, html)
+      refute remote_card =~ "border-dashed"
     end
 
     test "shows no action bar, because none of those actions exist for it", %{post: post} do


### PR DESCRIPTION
**TL;DR** Posts and replies from other networks lose the dashed left border down the body; they now read like any member post.

**Why:** the dashes read as an unexplained decoration, not as information (Stefan, 2026-07-30, with a screenshot from production). The origin is already carried three times over: the globe badge on the avatar, the host chip in the header and the "From another network" footer.

**What changed:**
- `PostComponents.remote_body/1` drops the dashed rail wrapper, so the feed card, the thread reply, the account page and the lookup page all render the body plainly (one definition, all four surfaces).
- The remote-reply quote on /notifications switches from the dashed rail to the **solid** quote rail every other quoted reply on that page wears: there the rail means "quotation", and only the dashed variant was the remote marker.
- Regression tests assert the body renders without `border-dashed` in the feed and the thread.

**Deploy:** hot. Version bump to v7.198.4.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*