### PR TITLE
A link ends where its text ends (v7.199.1)

### DIFF
--- a/assets/js/markdown_editor.js
+++ b/assets/js/markdown_editor.js
@@ -35,6 +35,7 @@
 import { Editor, rootCtx, defaultValueCtx, editorViewCtx } from "@milkdown/kit/core"
 import {
   commonmark,
+  linkSchema,
   toggleStrongCommand,
   toggleEmphasisCommand,
   toggleInlineCodeCommand,
@@ -100,6 +101,19 @@ const table = [
 ]
 
 const gfmSubset = [gfm.remarkGFMPlugin, ...strikethrough, ...table].flat()
+
+// A link ends where its text ends. ProseMirror marks are "inclusive" by
+// default — typing at a mark's right edge inherits it — and Milkdown's
+// linkSchema doesn't say otherwise, so with the caret at the end of a link
+// the space that was meant to END it (and every word after) joined the link,
+// storing `[https://… more words](https://…)`. A freshly pasted URL only
+// looks immune because it stays plain text until the next re-seed (draft
+// restore, post edit) autolinks it via GFM. Mark registration is last-wins,
+// so this must be `.use`d after the commonmark preset.
+const nonInclusiveLink = linkSchema.extendSchema((prev) => (ctx) => ({
+  ...prev(ctx),
+  inclusive: false,
+}))
 
 // A no-dependency placeholder: decorate the sole empty paragraph so CSS can
 // paint the prompt text (::before reads data-placeholder). Milkdown ships no
@@ -295,6 +309,7 @@ export const MarkdownEditor = {
         })
       })
       .use(commonmark)
+      .use(nonInclusiveLink)
       .use(gfmSubset)
       .use(listener)
       .use(history)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.199.0",
+      version: "7.199.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/markdown_editor_link_test.exs
+++ b/test/vutuv_web/markdown_editor_link_test.exs
@@ -1,0 +1,46 @@
+defmodule VutuvWeb.MarkdownEditorLinkTest do
+  use ExUnit.Case, async: true
+
+  # Paste a URL into the composer, let it become a link (a draft restore, a
+  # post edit or any other server re-seed parses it with GFM autolink), put
+  # the caret at its end and type: the space that is meant to END the link —
+  # and every word after it — joined the link instead, so the stored Markdown
+  # became `[https://example.com more words](https://example.com)`.
+  #
+  # Mechanism: ProseMirror marks are "inclusive" by default (typing at a
+  # mark's right edge inherits it) and Milkdown's commonmark linkSchema does
+  # not say otherwise. The fix extends the link schema with
+  # `inclusive: false`; mark registration is last-wins, so the extension must
+  # be `.use`d after the commonmark preset to replace its link mark.
+  #
+  # There is no JS test runner in this project, so this is a static source
+  # check in the spirit of `markdown_editor_resize_test.exs`.
+
+  @editor_js Path.expand("../../assets/js/markdown_editor.js", __DIR__)
+
+  defp editor_js, do: File.read!(@editor_js)
+
+  defp position_of(js, needle) do
+    case :binary.match(js, needle) do
+      {pos, _len} -> pos
+      :nomatch -> flunk("expected markdown_editor.js to contain `#{needle}`")
+    end
+  end
+
+  test "the link mark schema is extended to be non-inclusive" do
+    assert editor_js() =~ ~r/linkSchema\.extendSchema\([\s\S]{0,200}?inclusive:\s*false/,
+           "markdown_editor.js must extend Milkdown's linkSchema with " <>
+             "`inclusive: false` — without it, typing at the end of a link " <>
+             "(the space after a pasted URL) extends the link over everything " <>
+             "typed after it"
+  end
+
+  test "the non-inclusive link schema is registered after the commonmark preset" do
+    js = editor_js()
+
+    assert position_of(js, ".use(nonInclusiveLink)") > position_of(js, ".use(commonmark)"),
+           "the extended link schema must be `.use`d after `.use(commonmark)`: " <>
+             "Milkdown registers marks last-wins, so used earlier it would be " <>
+             "overwritten by the preset's inclusive default"
+  end
+end


### PR DESCRIPTION
**TL;DR** Typing at the end of a link in the composer pulled the space and every following word into the link; the link mark is now non-inclusive.

**Where:** `assets/js/markdown_editor.js` (Milkdown editor, post + message composer)
**Now:** once a bare URL becomes a link via a re-seed (restored draft, post edit), typing at its end inherits the link mark — ProseMirror marks are "inclusive" by default and Milkdown's `linkSchema` does not override that. Stored source becomes `[https://example.com more words](https://example.com)`.
**Want:** the link stops at its right edge; typed text lands outside it. Typing *inside* a link still edits the link.
**Fix:** extend `linkSchema` with `inclusive: false`, registered after the commonmark preset (mark registration is last-wins). Regression-guarded by `test/vutuv_web/markdown_editor_link_test.exs` (static source check; no JS test runner in this repo).
**Verified:** in Chrome against a restored draft — before: typed text joined the link; after: it lands outside and the stored Markdown stays a bare URL. Mid-link edits still extend the link.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*