### PR TITLE
One Discard draft button over a restored draft, not two (v7.199.2)

### DIFF
--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -1321,6 +1321,7 @@ defmodule VutuvWeb.PostLive.Composer do
               type="button"
               phx-click="discard-draft"
               phx-target={@myself}
+              data-confirm={gettext("Discard the photos and text of this draft?")}
               class="font-semibold underline underline-offset-2 hover:text-brand-900 dark:hover:text-white"
             >
               {gettext("Discard draft")}
@@ -1356,7 +1357,10 @@ defmodule VutuvWeb.PostLive.Composer do
           </div>
           <%!-- Header row, feed compose only: "Discard draft" (while there is
           something to lose) and the corner ✕ that merely collapses the
-          composer. The ✕ carries no phx-target: the event bubbles up to the
+          composer. While the restore notice above is showing, its own
+          "Discard draft" owns the action and this one stays away — with both
+          gates true the button rendered twice, one right above the other
+          (issue #1221); the first edit clears the notice and hands over. The ✕ carries no phx-target: the event bubbles up to the
           feed LiveView that owns the reveal (`close-composer`) — a draft
           always survives it (issue #1135; the server-side draft of #1148
           keeps the photos too, and the feed re-opens over a held draft, so
@@ -1370,7 +1374,7 @@ defmodule VutuvWeb.PostLive.Composer do
             class="-mt-1 mb-2 flex items-center justify-end gap-1"
           >
             <button
-              :if={drafting?(assigns)}
+              :if={drafting?(assigns) and not @restored_draft?}
               type="button"
               id={"#{@id}-discard"}
               phx-click="discard-draft"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.199.1",
+      version: "7.199.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/composer_draft_test.exs
+++ b/test/vutuv_web/live/composer_draft_test.exs
@@ -56,6 +56,29 @@ defmodule VutuvWeb.ComposerDraftTest do
       refute html =~ ~s(id="composer-panel" class="hidden")
     end
 
+    test "a restored draft shows exactly one Discard draft control", %{conn: conn} do
+      # The restore notice carries its own "Discard draft" (issue #1148) and
+      # the feed header shows one while there is something to lose (issue
+      # #1135). After a reload both conditions held, so the composer rendered
+      # the button twice, one right above the other (issue #1221). While the
+      # notice shows, it owns the action; the header button takes over as soon
+      # as the notice steps aside.
+      {conn, _user} = create_and_login_user(conn)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+      type(live, %{"body" => "Ein halber Gedanke"})
+
+      {:ok, reloaded, _html} = live(recycle(conn), ~p"/feed")
+
+      assert has_element?(reloaded, "[data-draft-restored] button[phx-click='discard-draft']")
+      refute has_element?(reloaded, "#composer-discard")
+
+      type(reloaded, %{"body" => "Ein halber Gedanke, weitergeschrieben"})
+
+      refute has_element?(reloaded, "[data-draft-restored]")
+      assert has_element?(reloaded, "#composer-discard")
+    end
+
     test "the notice steps aside as soon as the member edits", %{conn: conn} do
       {conn, _user} = create_and_login_user(conn)
 


### PR DESCRIPTION
**TL;DR** After a reload with a draft, the feed composer rendered two "Discard draft" buttons — the restore notice's (issue #1148) and the header row's (issue #1135) — because both gates were true at once.

**Where:** `VutuvWeb.PostLive.Composer` (feed composer render)
**Now:** restore notice + header both show their own "Discard draft" → doubled button (screenshot in #1221).
**Fix:** while the notice shows, it owns the action and the header button yields (`drafting?/1 and not @restored_draft?`); the first edit clears the notice and hands over, so exactly one control shows in every state. The notice's button also gets the same `data-confirm` its header twin has — while the notice shows it is the only discard control, and it destroys the draft's photos too.
**Test:** `composer_draft_test.exs` asserts exactly one discard control before and after the first edit.

Fixes #1221

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*