### PR TITLE
A remote like stays read once it has been read (v7.199.3)

### DIFF
--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -127,6 +127,22 @@ defmodule Vutuv.Activity do
 
     mention_max = select(mention_events(user_id), [mention: m], %{ts: max(m.inserted_at)})
 
+    # Replies and reactions from other networks (issues #1069/#1068). Without
+    # these arms the marker ignores them, so when the newest event is a remote
+    # one the marker lands before it and its badge never clears: /notifications
+    # empties the bell, the next recount on /feed fills it again. `received_at`
+    # is a :utc_datetime, but its column is the same timestamp family as the
+    # inserted_at arms, so the union stays type-consistent.
+    fediverse_reply_max =
+      user_id
+      |> fediverse_reply_events()
+      |> select([note: n], %{ts: max(n.received_at)})
+
+    fediverse_reaction_max =
+      user_id
+      |> fediverse_reaction_events()
+      |> select([note: r], %{ts: max(r.received_at)})
+
     # No self-like filter needed: a member cannot like their own post
     # (enforced in Posts.like_post/2, issue #1030).
     like_max =
@@ -185,6 +201,8 @@ defmodule Vutuv.Activity do
       |> union_all(^reply_max)
       |> union_all(^thread_max)
       |> union_all(^mention_max)
+      |> union_all(^fediverse_reply_max)
+      |> union_all(^fediverse_reaction_max)
       |> union_all(^like_max)
       |> union_all(^moderation_max)
       |> union_all(^image_rejected_max)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.200.0",
+      version: "7.200.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_notes_test.exs
+++ b/test/vutuv/fediverse_notes_test.exs
@@ -775,6 +775,35 @@ defmodule Vutuv.FediverseNotesTest do
     end
   end
 
+  describe "the reply joins the unread badge" do
+    test "reading the notifications page clears it for good", %{user: user, note_url: note_url} do
+      # An older local event pins the read marker: mark_notifications_read/1
+      # anchors the marker to the newest event it knows about, and a source
+      # missing from that anchor query stays "unread" on every recount — the
+      # /notifications -> /feed badge loop.
+      old_follow = insert(:follow, follower: insert(:user), followee: user)
+
+      Repo.update_all(from(f in Vutuv.Social.Follow, where: f.id == ^old_follow.id),
+        set: [inserted_at: ~N[2020-01-01 12:00:00]]
+      )
+
+      Vutuv.Activity.mark_notifications_read(user.id)
+
+      :ok = Fediverse.record_reply(user, create_activity(note_url), remote())
+
+      # Second precision would let a same-second mark tie the note away.
+      Repo.update_all(Note,
+        set: [received_at: DateTime.add(DateTime.utc_now(:second), -300, :second)]
+      )
+
+      assert Vutuv.Activity.unread_notification_count(user.id) == 1
+
+      Vutuv.Activity.mark_notifications_read(user.id)
+
+      assert Vutuv.Activity.unread_notification_count(user.id) == 0
+    end
+  end
+
   describe "the count reaches the action bar" do
     test "engagement_counts/1 carries public replies on their own figure", %{
       user: user,

--- a/test/vutuv/fediverse_reactions_test.exs
+++ b/test/vutuv/fediverse_reactions_test.exs
@@ -279,6 +279,29 @@ defmodule Vutuv.FediverseReactionsTest do
       assert entry.actor_handle == "@alice@social.example"
     end
 
+    test "reading the notifications page clears the badge for good", %{user: user, note: note} do
+      # An older local event pins the read marker: mark_notifications_read/1
+      # anchors the marker to the newest event it knows about, and a source
+      # missing from that anchor query stays "unread" on every recount — the
+      # /notifications -> /feed badge loop.
+      old_follow = insert(:follow, follower: insert(:user), followee: user)
+
+      Repo.update_all(from(f in Vutuv.Social.Follow, where: f.id == ^old_follow.id),
+        set: [inserted_at: ~N[2020-01-01 12:00:00]]
+      )
+
+      Vutuv.Activity.mark_notifications_read(user.id)
+
+      :ok = Fediverse.record_reaction(user, note, "like", @actor)
+      backdate_reaction(DateTime.add(DateTime.utc_now(:second), -300, :second))
+
+      assert Vutuv.Activity.unread_notification_count(user.id) == 1
+
+      Vutuv.Activity.mark_notifications_read(user.id)
+
+      assert Vutuv.Activity.unread_notification_count(user.id) == 0
+    end
+
     test "taking the reaction back takes its notification with it", %{user: user, note: note} do
       :ok = Fediverse.record_reaction(user, note, "like", @actor)
       :ok = Fediverse.remove_reaction(user, note, "like", @actor)
@@ -355,5 +378,11 @@ defmodule Vutuv.FediverseReactionsTest do
       assert [%{"handle" => "fan6", "kind" => "announce"} | _] =
                counts.fediverse_reaction_actors
     end
+  end
+
+  # Timestamps have second precision, so same-second events tie with the read
+  # marker; backdating gives the reaction a distinct, deterministic time.
+  defp backdate_reaction(at) do
+    Repo.update_all(Reaction, set: [received_at: at])
   end
 end


### PR DESCRIPTION
**TL;DR** The notifications read marker ignored fediverse events, so a remote like/reply kept the bell badge coming back forever.

**Where:** `Vutuv.Activity.latest_event_at/1` (the anchor behind `mark_notifications_read/1`)
**Now:** the marker anchors to the newest event of the *local* sources only; when the newest event is a remote reaction or reply, the marker lands before it and the strict `received_at > read_at` count re-lights the badge on every recount — /notifications clears it, /feed brings it back.
**Want:** the fediverse note and reaction sources contribute their MAX `received_at` to the anchor union, like every other source.
**Repro:** 1. receive a like from another network as your newest event  2. open /notifications (badge clears)  3. open /feed → badge is back at 1.

This is the same bug shape that already hit organization roles (#930) and CV updates (#980) — their union arms carry warning comments; the two fediverse sources (#1068/#1069) simply never got theirs. Regression tests in `fediverse_reactions_test.exs` and `fediverse_notes_test.exs` pin an older local follow under the marker, backdate the remote event, and assert the badge stays cleared after `mark_notifications_read/1`.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*