### PR TITLE
The feed only computes its discovery rail for viewports that show it (v7.200.3)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -272,6 +272,37 @@ const Hooks = {
       this.el.scrollTop = this.el.scrollHeight
     },
   },
+  // The feed's desktop discovery rail is hidden under md (48rem), so its
+  // queries are only spent when the viewport actually shows it: the server
+  // renders the aside empty and fills it on "load-rails". Crossing the
+  // breakpoint later (a tablet rotation, a resized window) loads it then;
+  // once loaded it stays loaded, so this only ever fires once per socket.
+  LazyRails: {
+    mounted() {
+      this.mq = window.matchMedia("(min-width: 48rem)")
+      this.onChange = () => {
+        if (this.mq.matches) this.request()
+      }
+      // The listener stays armed for the whole page life: the server ignores
+      // a repeated "load-rails", and un-arming after the first load would
+      // leave a rotated-away-and-back tablet without its rail.
+      this.mq.addEventListener("change", this.onChange)
+      if (this.mq.matches) this.request()
+    },
+    // A reconnect re-mounts the LiveView, which resets the rail to its empty
+    // mount state — and a rejoined hook gets reconnected(), not mounted(), so
+    // the rail would silently vanish on every network blip or deploy without
+    // this second ask.
+    reconnected() {
+      if (this.mq.matches) this.request()
+    },
+    request() {
+      this.pushEvent("load-rails", {})
+    },
+    destroyed() {
+      this.mq.removeEventListener("change", this.onChange)
+    },
+  },
   // Browser-tab title indicator, so a backgrounded tab still shows new activity.
   // ShellLive pushes the state; this hook prefixes document.title:
   //   "(3) vutuv"   unread messages + notifications (exact; shown always)

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -193,6 +193,19 @@ and blocked authors stay out exactly as elsewhere). Following a tag lives in
 `Vutuv.Tags` — see [social-graph.md](social-graph.md). The feed also carries the
 reload-free **"Tags you follow"** rail (chips + a `phx-click` ✕ unfollow).
 
+**The whole discovery rail is lazy.** The rail (Tags you follow / Who to
+follow / Suggested posts) is hidden under `md` yet used to cost the majority of
+the feed's queries on *every* mount — twice per visit (dead + connected), phones
+included. No mount computes it anymore: the aside renders empty with the
+`LazyRails` hook (`#feed-rail`), which sends `"load-rails"` only from a viewport
+that is actually ≥ `md` (and again from `reconnected()`, because a reconnect
+re-mounts the LiveView with the rail back at its empty mount state). So a phone
+never pays for the rail, a desktop pays once per visit, and the dead render —
+the part of the visit the member waits on — skips it for everyone. The
+periodic reshuffle timer is armed in the `"load-rails"` handler, and the rail
+refresh paths (`:refresh_suggestions`, `{:tag_follows_changed, _}`) are gated on
+`:rails_loaded?`, so no side channel fills an unrequested rail.
+
 The composer's body field is the shared **Milkdown WYSIWYG Markdown editor**
 (`VutuvWeb.UI.markdown_editor/1` + the `MarkdownEditor` hook, also used by the
 message composer). It edits Markdown *source* in place — the field stays a

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -69,10 +69,6 @@ defmodule VutuvWeb.PostLive.Feed do
       # Refresh the Berlin-day-relative post stamps ("09:50 Uhr" -> "Gestern,
       # 09:50 Uhr") the moment the German day rolls over at midnight.
       Vutuv.DayClock.subscribe()
-      # Reshuffle the "Who to follow" rail every few minutes while the page stays
-      # open, so a long-lived session keeps seeing fresh suggestions even without
-      # a reload (a new visit reshuffles too, via this same mount).
-      Process.send_after(self(), :refresh_suggestions, @suggestions_refresh)
     end
 
     # The member's private content filters (issue #940): compiled once, applied
@@ -101,11 +97,27 @@ defmodule VutuvWeb.PostLive.Feed do
     # Order/dupes don't matter: the refresh uses stream_insert update_only, which
     # updates existing rows where they sit and ignores ones already gone.
     |> assign(:entries, entries)
-    |> assign_followed_tags()
-    |> assign_who_to_follow()
-    |> assign_discover_posts()
+    |> assign_empty_rails()
     |> stream_configure(:posts, dom_id: &"feed-#{&1.id}")
     |> stream(:posts, entries)
+  end
+
+  # The discovery rail (Tags you follow / Who to follow / Suggested posts)
+  # costs the majority of the feed's queries and is hidden under md, so no
+  # mount computes it: the dead render ships the aside empty, and the
+  # LazyRails hook asks for the rails with "load-rails" only from a viewport
+  # that actually shows them (>= md, the breakpoint the aside's `md:block`
+  # uses). A phone therefore never pays for the rail at all; a desktop pays
+  # once, over the socket, instead of on both mounts of every visit.
+  defp assign_empty_rails(socket) do
+    socket
+    |> assign(:rails_loaded?, false)
+    |> assign(:followed_tags, [])
+    |> assign(:recommended_users, [])
+    |> assign(:work_info_by_id, %{})
+    |> assign(:following_by_id, %{})
+    |> assign(:suggested_posts_by_id, %{})
+    |> assign(:discover_posts, [])
   end
 
   # The desktop "Tags you follow" rail (issue #872): the member's tag
@@ -424,6 +436,25 @@ defmodule VutuvWeb.PostLive.Feed do
     {:noreply, assign_discover_posts(socket)}
   end
 
+  # The LazyRails hook on the rail aside: this viewport shows the desktop rail
+  # (>= md), so fill it. Once per socket — the reshuffle paths keep it fresh
+  # afterwards — and the periodic reshuffle timer only starts here, so a feed
+  # that never shows the rail never ticks for it either.
+  def handle_event("load-rails", _params, socket) do
+    if socket.assigns.rails_loaded? do
+      {:noreply, socket}
+    else
+      Process.send_after(self(), :refresh_suggestions, @suggestions_refresh)
+
+      {:noreply,
+       socket
+       |> assign(:rails_loaded?, true)
+       |> assign_followed_tags()
+       |> assign_who_to_follow()
+       |> assign_discover_posts()}
+    end
+  end
+
   def handle_event("show-new", _params, socket) do
     pending = socket.assigns.pending_posts
 
@@ -520,8 +551,14 @@ defmodule VutuvWeb.PostLive.Feed do
   # the next tick. Cheap (a ranking query, a follow-edge query and the pooled
   # posts draw, all small), so a 5-minute cadence on an open feed is fine.
   def handle_info(:refresh_suggestions, socket) do
-    Process.send_after(self(), :refresh_suggestions, @suggestions_refresh)
-    {:noreply, socket |> assign_who_to_follow() |> assign_discover_posts()}
+    if socket.assigns.rails_loaded? do
+      Process.send_after(self(), :refresh_suggestions, @suggestions_refresh)
+      {:noreply, socket |> assign_who_to_follow() |> assign_discover_posts()}
+    else
+      # The timer only ever starts in "load-rails", so a stray tick on an
+      # unloaded rail must not become the query bill the laziness avoids.
+      {:noreply, socket}
+    end
   end
 
   # The viewer followed / unfollowed a tag elsewhere (a tag page in another tab,
@@ -529,7 +566,11 @@ defmodule VutuvWeb.PostLive.Feed do
   # open feed reflects it live. Posts already streamed stay; the new tag's posts
   # arrive on the next load, like a fresh person-follow.
   def handle_info({:tag_follows_changed, _}, socket) do
-    {:noreply, socket |> assign_followed_tags() |> assign_who_to_follow()}
+    if socket.assigns.rails_loaded? do
+      {:noreply, socket |> assign_followed_tags() |> assign_who_to_follow()}
+    else
+      {:noreply, socket}
+    end
   end
 
   # The Berlin day rolled over (Vutuv.DayClock at midnight): re-render every
@@ -1021,8 +1062,10 @@ defmodule VutuvWeb.PostLive.Feed do
         <%!-- Desktop-only rail (hidden under md, where the grid is one column):
         the profile-style "Who to follow" card (suggestions the viewer doesn't
         already follow; a live follow, no reload, drops the row and surfaces the
-        next) plus the "Other formats" card — the same aside the profile shows. --%>
-        <aside class="hidden space-y-6 md:block">
+        next) plus the "Other formats" card — the same aside the profile shows.
+        The discovery cards load lazily: the LazyRails hook sends "load-rails"
+        once the viewport is >= md, so a phone never computes them. --%>
+        <aside id="feed-rail" phx-hook="LazyRails" class="hidden space-y-6 md:block">
           <%!-- "Tags you follow" (issue #872): the viewer's tag subscriptions,
           each a chip linking to the tag page with a reload-free ✕ unfollow. Sits
           at the top of the rail because it is the viewer's own state and the

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.200.2",
+      version: "7.200.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/feed_rails_lazy_test.exs
+++ b/test/vutuv_web/live/feed_rails_lazy_test.exs
@@ -1,0 +1,111 @@
+defmodule VutuvWeb.PostLive.FeedRailsLazyTest do
+  use VutuvWeb.ConnCase, async: true
+
+  # The feed's discovery rail (Tags you follow / Who to follow / Suggested
+  # posts) is desktop-only (hidden under md) yet used to cost the majority of
+  # the feed's queries on every mount — twice per visit, phones included. It
+  # is now lazy: neither the dead render nor the connected mount computes it;
+  # the LazyRails hook reports a rail-showing viewport with "load-rails" and
+  # only that event fills the aside. Phones never send it.
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Posts
+  alias Vutuv.Tags
+
+  defp seed_rails(user) do
+    tag = insert(:tag)
+    Tags.follow_tag(user, tag)
+
+    popular = insert(:activated_user, first_name: "Pop", last_name: "Ular")
+    insert(:follow, follower: insert(:activated_user), followee: popular)
+    {:ok, post} = Posts.create_post(popular, %{body: "something worth discovering"})
+
+    %{tag: tag, popular: popular, post: post}
+  end
+
+  test "the dead render ships the aside empty, with the hook anchor", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    seed_rails(user)
+
+    html = conn |> get(~p"/feed") |> html_response(200)
+
+    assert html =~ ~s(id="feed-rail")
+    assert html =~ ~s(phx-hook="LazyRails")
+    assert html =~ ~s(id="feed-other-formats")
+    refute html =~ ~s(id="followed-tags")
+    refute html =~ ~s(id="who-to-follow")
+    refute html =~ ~s(id="discover-posts")
+  end
+
+  test "the connected mount alone still leaves the rail empty", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    seed_rails(user)
+
+    {:ok, view, _html} = live(conn, ~p"/feed")
+
+    refute has_element?(view, "#followed-tags")
+    refute has_element?(view, "#who-to-follow")
+    refute has_element?(view, "#discover-posts")
+  end
+
+  test "load-rails fills all three rail cards", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    %{tag: tag, popular: popular, post: post} = seed_rails(user)
+
+    {:ok, view, _html} = live(conn, ~p"/feed")
+    view |> element("#feed-rail") |> render_hook("load-rails")
+
+    assert has_element?(view, "#followed-tag-#{tag.id}")
+    assert has_element?(view, ~s(#who-to-follow a[href="/#{popular.username}"]))
+
+    assert has_element?(
+             view,
+             ~s(#discover-posts a[href="/#{popular.username}/posts/#{post.id}"])
+           )
+  end
+
+  test "a second load-rails is a no-op, not a recompute", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    %{popular: popular} = seed_rails(user)
+
+    {:ok, view, _html} = live(conn, ~p"/feed")
+    view |> element("#feed-rail") |> render_hook("load-rails")
+    view |> element("#feed-rail") |> render_hook("load-rails")
+
+    assert has_element?(view, ~s(#who-to-follow a[href="/#{popular.username}"]))
+  end
+
+  test "the loaded rail stays live: unfollowing a tag drops its chip", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    %{tag: tag} = seed_rails(user)
+
+    {:ok, view, _html} = live(conn, ~p"/feed")
+    view |> element("#feed-rail") |> render_hook("load-rails")
+
+    view
+    |> element(~s(#followed-tag-#{tag.id} button[phx-click="unfollow_tag"]))
+    |> render_click()
+
+    refute has_element?(view, "#followed-tag-#{tag.id}")
+    refute Tags.tag_followed?(user, tag)
+  end
+
+  test "rail refresh signals before load-rails leave the rail empty", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    seed_rails(user)
+
+    {:ok, view, _html} = live(conn, ~p"/feed")
+
+    # A tag followed in another tab and the periodic reshuffle tick both
+    # redraw the rail on an open feed — but only once the viewport asked for
+    # it. A phone's feed must not be made to pay the rail queries sideways.
+    send(view.pid, {:tag_follows_changed, %{}})
+    send(view.pid, :refresh_suggestions)
+    render(view)
+
+    refute has_element?(view, "#followed-tags")
+    refute has_element?(view, "#who-to-follow")
+    refute has_element?(view, "#discover-posts")
+  end
+end

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -13,6 +13,15 @@ defmodule VutuvWeb.PostFeedLiveTest do
 
   defp other_user(attrs \\ []), do: insert(:user, Keyword.merge([email_confirmed?: true], attrs))
 
+  # The discovery rail is lazy (see FeedRailsLazyTest): a real browser's
+  # LazyRails hook requests it once the viewport is >= md. The rail tests
+  # stand in for the hook.
+  defp live_feed_with_rails(conn) do
+    {:ok, view, _html} = live(conn, ~p"/feed")
+    html = view |> element("#feed-rail") |> render_hook("load-rails")
+    {:ok, view, html}
+  end
+
   # Where `text` first shows up in the rendered feed — how the thread tests
   # assert reading order without parsing the whole card tree.
   defp position(html, text) do
@@ -700,7 +709,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
       # most_followed_users ranks by follower count, so give them one follower.
       insert(:follow, follower: other_user(), followee: popular)
 
-      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, live, _html} = live_feed_with_rails(conn)
 
       assert has_element?(live, ~s(#who-to-follow a[href="/#{popular.username}"]))
       assert has_element?(live, ~s(#who-to-follow button[phx-value-followee="#{popular.id}"]))
@@ -716,7 +725,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
       recent = insert(:post, user: popular, body: "What I am working on")
       for post <- [old, recent], do: :ok = Vutuv.Posts.like_post(other_user(), post)
 
-      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, live, _html} = live_feed_with_rails(conn)
 
       samples = ~s(#who-to-follow [data-suggested-posts="#{popular.id}"])
       assert has_element?(live, ~s(#{samples} a[href="/#{popular.username}/posts/#{recent.id}"]))
@@ -733,7 +742,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
       insert(:follow, follower: user, followee: already)
       insert(:follow, follower: other_user(), followee: fresh)
 
-      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, live, _html} = live_feed_with_rails(conn)
 
       assert Vutuv.Social.user_follows_user?(user.id, already.id)
       assert has_element?(live, ~s(#who-to-follow a[href="/#{fresh.username}"]))
@@ -745,7 +754,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
       popular = other_user(first_name: "Pop", last_name: "Ular")
       insert(:follow, follower: other_user(), followee: popular)
 
-      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, live, _html} = live_feed_with_rails(conn)
 
       live
       |> element(~s(#who-to-follow button[phx-value-followee="#{popular.id}"]))
@@ -775,7 +784,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
       # exceed the 6 shown at once — a fixed top-6 ordering never would.
       shown =
         Enum.reduce(1..12, MapSet.new(), fn _i, acc ->
-          {:ok, live, _html} = live(recycle(conn), ~p"/feed")
+          {:ok, live, _html} = live_feed_with_rails(recycle(conn))
 
           pool
           |> Enum.filter(&has_element?(live, ~s(#who-to-follow a[href="/#{&1.username}"])))
@@ -790,11 +799,11 @@ defmodule VutuvWeb.PostFeedLiveTest do
       popular = other_user(first_name: "Pop", last_name: "Ular")
       insert(:follow, follower: other_user(), followee: popular)
 
-      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, live, _html} = live_feed_with_rails(conn)
       assert has_element?(live, ~s(#who-to-follow a[href="/#{popular.username}"]))
 
-      # The mount schedules a refresh timer; firing it by hand must recompute the
-      # rail (and not crash), keeping the eligible suggestion visible.
+      # "load-rails" schedules a refresh timer; firing it by hand must recompute
+      # the rail (and not crash), keeping the eligible suggestion visible.
       send(live.pid, :refresh_suggestions)
       _ = render(live)
 
@@ -810,7 +819,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
       author = other_user(first_name: "New", last_name: "Voice")
       {:ok, post} = Posts.create_post(author, %{body: "something worth discovering"})
 
-      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, live, _html} = live_feed_with_rails(conn)
 
       assert has_element?(live, ~s(#discover-posts a[href="/#{author.username}"]))
 
@@ -833,7 +842,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
       {:ok, german_post} = Posts.create_post(german, %{body: "deutsche Worte"})
       {:ok, fresh_post} = Posts.create_post(fresh, %{body: "fresh words"})
 
-      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, live, _html} = live_feed_with_rails(conn)
 
       assert has_element?(
                live,
@@ -854,7 +863,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
     test "hides the card when nothing is eligible", %{conn: conn} do
       {conn, _user} = create_and_login_user(conn)
 
-      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, live, _html} = live_feed_with_rails(conn)
 
       refute has_element?(live, "#discover-posts")
     end
@@ -868,7 +877,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
           body: "# **Zwischenüberschrift**\n\nA second paragraph that must stay visible."
         })
 
-      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, live, _html} = live_feed_with_rails(conn)
       html = render(live)
 
       body = ~s(#discover-posts .markdown--post)
@@ -901,7 +910,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
           body: "Eine Digitalisierungsstrategie für unternehmenseigene Softwareentwicklung."
         })
 
-      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, live, _html} = live_feed_with_rails(conn)
 
       # Browser hyphenation is switched on for the narrow rail column via the
       # `.markdown--post` seam (auto on desktop too, not just the phone default),
@@ -929,7 +938,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
           {author, post}
         end
 
-      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, live, _html} = live_feed_with_rails(conn)
 
       # Over several reshuffles the union of shown permalinks must exceed the 5
       # shown at once — a fixed pick never would.
@@ -952,7 +961,7 @@ defmodule VutuvWeb.PostFeedLiveTest do
       author = other_user(first_name: "New", last_name: "Voice")
       {:ok, post} = Posts.create_post(author, %{body: "still discoverable"})
 
-      {:ok, live, _html} = live(conn, ~p"/feed")
+      {:ok, live, _html} = live_feed_with_rails(conn)
 
       assert has_element?(
                live,

--- a/test/vutuv_web/live/post_live/feed_followed_tags_test.exs
+++ b/test/vutuv_web/live/post_live/feed_followed_tags_test.exs
@@ -9,13 +9,22 @@ defmodule VutuvWeb.PostLive.FeedFollowedTagsTest do
 
   alias Vutuv.Tags
 
+  # The discovery rail is lazy (see FeedRailsLazyTest): a real browser's
+  # LazyRails hook requests it once the viewport is >= md. These tests stand
+  # in for the hook.
+  defp live_feed_with_rails(conn) do
+    {:ok, view, _html} = live(conn, ~p"/feed")
+    html = view |> element("#feed-rail") |> render_hook("load-rails")
+    {:ok, view, html}
+  end
+
   describe "Tags you follow rail" do
     test "renders the followed-tag chips and unfollows one with no reload", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       tag = insert(:tag)
       Tags.follow_tag(user, tag)
 
-      {:ok, view, html} = live(conn, ~p"/feed")
+      {:ok, view, html} = live_feed_with_rails(conn)
       assert html =~ "Tags you follow"
       assert has_element?(view, "#followed-tag-#{tag.id}")
 
@@ -29,7 +38,7 @@ defmodule VutuvWeb.PostLive.FeedFollowedTagsTest do
 
     test "the rail is absent when the member follows no tags", %{conn: conn} do
       {conn, _user} = create_and_login_user(conn)
-      {:ok, view, _html} = live(conn, ~p"/feed")
+      {:ok, view, _html} = live_feed_with_rails(conn)
       refute has_element?(view, "#followed-tags")
     end
   end
@@ -44,7 +53,7 @@ defmodule VutuvWeb.PostLive.FeedFollowedTagsTest do
       ut = insert(:user_tag, user: candidate, tag: tag)
       insert(:user_tag_endorsement, user_tag: ut, user: insert(:activated_user))
 
-      {:ok, view, _html} = live(conn, ~p"/feed")
+      {:ok, view, _html} = live_feed_with_rails(conn)
       assert has_element?(view, "#who-to-follow")
       assert render(view) =~ "Tagged Person"
     end


### PR DESCRIPTION
**TL;DR** The /feed discovery rail (hidden under `md`) was ~20 of the 57 queries of every feed render, paid twice per visit, phones included. It now loads lazily over the socket, only for viewports that actually show it.

**Where:** `VutuvWeb.PostLive.Feed` + a `LazyRails` hook in `assets/js/app.js`
**Now:** every /feed mount (dead render *and* connected mount) computed Tags you follow / Who to follow / Suggested posts, so a phone paid the rail queries twice for markup `hidden md:block` never shows, and the dead render everyone waits on carried them too.
**Want:** the aside ships empty; the hook pushes `load-rails` once `matchMedia("(min-width: 48rem)")` matches, and again from `reconnected()` (a reconnect re-mounts the LiveView with empty rails while a rejoined hook never runs `mounted()`). The handler is idempotent via `:rails_loaded?`; the reshuffle timer and the sideways refresh paths (`:refresh_suggestions`, `{:tag_follows_changed, _}`) are gated on it.

Measured on the prod-copy dev DB: dead render 57 → 37 queries, the connected mount saves the same again, a phone visit no longer touches the rail queries at all. Covered by `feed_rails_lazy_test.exs`; the existing rail tests stand in for the hook via `live_feed_with_rails/1`. Smoke-tested in Chrome against a worktree dev server: rails appear on a desktop viewport, survive a `liveSocket.disconnect()/connect()` round trip, and the dead render ships without them.

Hot deploy, version v7.200.3.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01BmbxczY6eUqZwqWJjgp6rn