### PR TITLE
Fewer, faster queries on the profile and the feed (v7.200.5)

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -460,6 +460,15 @@ Counters are counted live from the `post_likes` / `post_bookmarks` /
 `post_reposts` rows and broadcast as absolute values on the post topic
 (`"post:<id>"`).
 
+The engagement a bar starts from is **batched by its host, never queried per
+card**: the feed decorates each page's entries via `Posts.post_engagement_map/2`
+(one query for the page including nested thread parents), and the profile does
+the same for its Beiträge preview, the nested parents *and* the pinned post
+(`UserProfileLive.attach_engagement/3` → `:posts` entries +
+`:pinned_engagement`). A bar only self-loads when nothing was handed in (a lone
+card on a dead page). `user_profile_perf_test.exs` and the feed's batching test
+fail the build if a host drifts back to one query per card.
+
 Likes and bookmarks work on any visible post **and on any member** — from a
 profile a logged-in visitor can like / bookmark another member (`Vutuv.Social`,
 tables `user_likes` / `user_bookmarks`), a private, silent save that needs no

--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -20,6 +20,17 @@ follow is mutual, and a `<.mute_button>` once you follow the member.
 `/:slug/connections` lists a member's vernetzt people (the owner ends a
 connection by unfollowing).
 
+The profile header reads its three counts through **`Social.social_counts/1`**,
+a union of the same gated count queries the single accessors
+(`follower_count/1` / `followee_count/1` / `connection_count/1`) run — one
+round trip per mount instead of three, and the gates cannot drift because the
+union is built from the singles' own query builders. The header's newest-3
+follower/following previews (`Follow.latest/2`) are served by the
+`follows_(follower|followee)_recency_index` composite indexes
+(`(side_id, inserted_at DESC, id DESC)`), which let the LIMIT stop at the
+first gate-passing rows instead of sorting the member's whole follow set; the
+old single-column follows indexes were dropped as redundant prefixes.
+
 **Mute** is a per-follow flag (`follows.muted`, `<.mute_button>` → PUT
 `/follows/:id/mute`): a muted follow keeps the relationship and any vernetzt
 status but drops the followee's posts out of *your* feed — silent and

--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -125,25 +125,51 @@ defmodule Vutuv.Social do
   # other end is the page owner, who may be a frozen member viewing their own
   # lists through the moderation bypass.
 
-  def follower_count(user) do
-    Repo.one(
-      from(c in Follow,
-        join: u in assoc(c, :follower),
-        where: account_confirmed_row(u) and not account_hidden_row(u),
-        where: c.followee_id == ^user.id,
-        select: count(c.id)
-      )
+  def follower_count(user), do: Repo.one(follower_count_query(user.id)).total
+
+  def followee_count(user), do: Repo.one(followee_count_query(user.id)).total
+
+  @doc """
+  The three profile-header counts — followers, followees, connections — in one
+  round trip as `%{followers:, followees:, connections:}`: a union of the same
+  three count queries the singles run, so the gates cannot drift. The profile
+  renders all three on every mount (and social-graph refresh), and each single
+  count walks every follow row of the member with a users join, so paying the
+  scan once instead of three times is what this exists for.
+  """
+  def social_counts(%User{id: user_id}) do
+    counts =
+      follower_count_query(user_id)
+      |> union_all(^followee_count_query(user_id))
+      |> union_all(^connection_count_query(user_id))
+      |> Repo.all()
+      |> Map.new(fn %{kind: kind, total: total} -> {kind, total} end)
+
+    %{
+      followers: Map.get(counts, "followers", 0),
+      followees: Map.get(counts, "followees", 0),
+      connections: Map.get(counts, "connections", 0)
+    }
+  end
+
+  # The tagged single-count queries behind both the single accessors and
+  # `social_counts/1`'s union (a union's arms must share one select shape, so
+  # the singles carry the tag too and read `.total` off the one row).
+  defp follower_count_query(user_id) do
+    from(c in Follow,
+      join: u in assoc(c, :follower),
+      where: account_confirmed_row(u) and not account_hidden_row(u),
+      where: c.followee_id == ^user_id,
+      select: %{kind: type(^"followers", :string), total: count(c.id)}
     )
   end
 
-  def followee_count(user) do
-    Repo.one(
-      from(c in Follow,
-        join: u in assoc(c, :followee),
-        where: account_confirmed_row(u) and not account_hidden_row(u),
-        where: c.follower_id == ^user.id,
-        select: count(c.id)
-      )
+  defp followee_count_query(user_id) do
+    from(c in Follow,
+      join: u in assoc(c, :followee),
+      where: account_confirmed_row(u) and not account_hidden_row(u),
+      where: c.follower_id == ^user_id,
+      select: %{kind: type(^"followees", :string), total: count(c.id)}
     )
   end
 
@@ -821,9 +847,12 @@ defmodule Vutuv.Social do
   list.
   """
   def connection_count(%User{id: user_id}) do
+    Repo.one(connection_count_query(user_id)).total
+  end
+
+  defp connection_count_query(user_id) do
     mutual_follows_query(user_id)
-    |> select([out], count(out.id))
-    |> Repo.one()
+    |> select([out], %{kind: type(^"connections", :string), total: count(out.id)})
   end
 
   # The mutual-follow set ordered newest-pair-first and shaped into the

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -99,7 +99,8 @@ defmodule VutuvWeb.PostLive.Composer do
           :parent,
           :remote_note,
           :remote_post,
-          :initial_body
+          :initial_body,
+          :preloaded_draft
         ])
       )
 
@@ -212,7 +213,6 @@ defmodule VutuvWeb.PostLive.Composer do
   # other people have already read is a different promise from keeping a draft.
   defp draftable?(assigns), do: assigns[:post] == nil and assigns[:remote_post] == nil
 
-  # Which composer this is, in the terms `Vutuv.Posts` keys drafts by.
   # Which composer this is, in the terms `Vutuv.Posts` keys drafts by. The
   # answer-to-a-followed-post composer (issue #1165) is deliberately absent: it
   # is not a draft context, for the blue/green reason `Posts.draft_key/1`
@@ -220,11 +220,23 @@ defmodule VutuvWeb.PostLive.Composer do
   # composer's row.
   defp draft_context(assigns), do: assigns[:parent] || assigns[:remote_note]
 
+  # The stored draft this composer restores: what the host already read and
+  # handed in (`preloaded_draft={{:loaded, draft_or_nil}}` — the feed reads it
+  # anyway to decide whether the panel opens), or this composer's own query.
+  # The `{:loaded, ...}` wrapper keeps "host read it and found none" apart from
+  # "host did not pass one".
+  defp stored_draft(assigns) do
+    case assigns[:preloaded_draft] do
+      {:loaded, draft} -> draft
+      _not_handed_in -> Posts.get_draft(assigns.current_user, draft_context(assigns))
+    end
+  end
+
   defp restore_draft(socket) do
     assigns = socket.assigns
 
     with true <- draftable?(assigns),
-         %PostDraft{} = draft <- Posts.get_draft(assigns.current_user, draft_context(assigns)) do
+         %PostDraft{} = draft <- stored_draft(assigns) do
       # The ids are re-checked against the author's own still-pending rows, so a
       # stale list cannot resurrect a photo that was removed or attached since.
       images = Posts.pending_images(assigns.current_user, draft.image_ids)

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -77,6 +77,10 @@ defmodule VutuvWeb.PostLive.Feed do
     page = Posts.feed_page(user, limit: @page_size)
     entries = page.entries |> with_engagement(user) |> mark_filtered(compiled, user.id)
 
+    # Read the stored draft once and hand it to the composer below, which then
+    # skips its own identical query on init.
+    draft = Posts.get_draft(user)
+
     socket
     |> assign(:content_filters, compiled)
     |> assign(:revealed_filters, MapSet.new())
@@ -85,13 +89,14 @@ defmodule VutuvWeb.PostLive.Feed do
     |> assign(:cursor, page.next_cursor)
     |> assign(:empty?, page.entries == [])
     |> assign(:pending_posts, [])
+    |> assign(:draft, draft)
     # The composer starts collapsed to a single "What's new?" button; posting
     # (own activity arriving below) collapses it again. A stored draft opens it
     # instead (issue #1148): the composer will restore that draft, and text
     # hidden behind a collapsed panel is indistinguishable from text that was
     # thrown away. Resolved here rather than announced by the composer so the
     # disconnected render already agrees and the panel never flickers open.
-    |> assign(:composer_open?, Posts.get_draft(socket.assigns.current_user) != nil)
+    |> assign(:composer_open?, draft != nil)
     # The set of entries currently on screen, kept so the midnight :day_changed
     # tick can re-render each stamp in place (streams don't retain their data).
     # Order/dupes don't matter: the refresh uses stream_insert update_only, which
@@ -964,6 +969,7 @@ defmodule VutuvWeb.PostLive.Feed do
               id="composer"
               current_user={@current_user}
               post={nil}
+              preloaded_draft={{:loaded, @draft}}
             />
           </div>
 

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -167,7 +167,7 @@ defmodule VutuvWeb.UserProfileLive do
     {:noreply,
      socket
      |> assign(:post_filter, filter)
-     |> assign(:posts, fetch_profile_posts(socket, filter))
+     |> assign_posts_with_engagement(filter)
      |> assign(
        :post_filter_total,
        Vutuv.Posts.count_author_posts(
@@ -504,11 +504,16 @@ defmodule VutuvWeb.UserProfileLive do
     # of the six overlapping lookups the four header_* helpers used to fire.
     rel = header_relationship(current_user, user)
 
+    # All three header counts in one round trip — each single count walks every
+    # follow row of the member with a users join, and this runs on both mounts
+    # and on every social-graph refresh.
+    counts = Social.social_counts(user)
+
     socket
     |> assign(:user, user)
-    |> assign(:follower_count, Social.follower_count(user))
-    |> assign(:followee_count, Social.followee_count(user))
-    |> assign(:connection_count, Social.connection_count(user))
+    |> assign(:follower_count, counts.followers)
+    |> assign(:followee_count, counts.followees)
+    |> assign(:connection_count, counts.connections)
     |> assign(:header_follow_id, rel.follow_id)
     |> assign(:header_follows_viewer?, rel.follows_viewer?)
     |> assign(:header_connected?, rel.connected?)
@@ -544,6 +549,51 @@ defmodule VutuvWeb.UserProfileLive do
     )
   end
 
+  # Re-fetch the Beiträge preview and hand every shown card its engagement from
+  # one batched query (:posts + :pinned_engagement in one go).
+  defp assign_posts_with_engagement(socket, filter) do
+    {entries, pinned_engagement} =
+      socket
+      |> fetch_profile_posts(filter)
+      |> attach_engagement(socket.assigns[:pinned_post], socket.assigns.current_user)
+
+    socket
+    |> assign(:posts, entries)
+    |> assign(:pinned_engagement, pinned_engagement)
+  end
+
+  # One engagement read for everything the Beiträge card shows — the timeline
+  # entries, the thread parents they nest and the pinned post — so the per-card
+  # action bars render from handed-in data instead of each running the heavy
+  # engagement query on mount (it ran once per card until v7.201). Returns the
+  # decorated entries plus the pinned post's own engagement. A reshared remote
+  # post has no vutuv post (and no action bar), so it passes through untouched.
+  defp attach_engagement(entries, pinned_post, viewer) do
+    ancestor_ids = fn entry -> Enum.map(entry[:ancestors] || [], & &1.id) end
+    local = Enum.reject(entries, &Vutuv.Posts.remote_feed_entry?/1)
+
+    ids =
+      local
+      |> Enum.flat_map(fn entry -> [entry.post.id | ancestor_ids.(entry)] end)
+      |> then(&if(pinned_post, do: [pinned_post.id | &1], else: &1))
+      |> Enum.uniq()
+
+    engagement = if ids == [], do: %{}, else: Vutuv.Posts.post_engagement_map(ids, viewer)
+
+    entries =
+      Enum.map(entries, fn entry ->
+        if Vutuv.Posts.remote_feed_entry?(entry) do
+          entry
+        else
+          entry
+          |> Map.put(:engagement, engagement[entry.post.id])
+          |> Map.put(:ancestor_engagement, Map.take(engagement, ancestor_ids.(entry)))
+        end
+      end)
+
+    {entries, pinned_post && engagement[pinned_post.id]}
+  end
+
   # The Beiträge card shows the pinned post (issue #1110) in its own block above
   # the timeline, so the timeline leaves it out — one post, shown once. Only
   # under the unfiltered "All" tab: the filtered views are the plain timeline and
@@ -573,7 +623,7 @@ defmodule VutuvWeb.UserProfileLive do
       :pinned_post,
       Vutuv.Posts.pinned_post(socket.assigns.user, socket.assigns.current_user)
     )
-    |> then(&assign(&1, :posts, fetch_profile_posts(&1, &1.assigns.post_filter)))
+    |> then(&assign_posts_with_engagement(&1, &1.assigns.post_filter))
   end
 
   # ── Initial load (ports UserController.show_html) ──
@@ -616,6 +666,11 @@ defmodule VutuvWeb.UserProfileLive do
     # timeline, which therefore leaves it out (see profile_posts/4).
     pinned_post = Vutuv.Posts.pinned_post(user, current_user)
 
+    {post_entries, pinned_engagement} =
+      user
+      |> profile_posts(current_user, "all", pinned_post)
+      |> attach_engagement(pinned_post, current_user)
+
     socket
     |> assign(:as_owner?, owner?)
     |> assign(:vcard_full?, private_emails?)
@@ -623,7 +678,8 @@ defmodule VutuvWeb.UserProfileLive do
     |> assign(:user_saved, header_user_saved(current_user, user))
     |> assign(:emails, profile_emails(private_emails?, current_user, user))
     |> assign(:pinned_post, pinned_post)
-    |> assign(:posts, profile_posts(user, current_user, "all", pinned_post))
+    |> assign(:pinned_engagement, pinned_engagement)
+    |> assign(:posts, post_entries)
     |> assign(:posts_total, posts_total)
     # The Beiträge card's type filter (issue #945). Resets to "all" on a full
     # profile reload (mount, block/unblock); a tab click re-fetches in place.

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -442,6 +442,7 @@ the resulting ~200px rail width. --%>
           viewer={@current_user}
           entry_id={"pinned-#{@pinned_post.id}"}
           conn_or_socket={@socket}
+          engagement={@pinned_engagement}
           surface={:flat}
           pinned?
         />
@@ -482,10 +483,12 @@ the resulting ~200px rail width. --%>
             :if={!Vutuv.Posts.remote_feed_entry?(entry)}
             post={entry.post}
             ancestors={entry[:ancestors]}
+            ancestor_engagement={entry[:ancestor_engagement] || %{}}
             reposted_by={entry.reposted_by}
             entry_id={entry.id}
             conn_or_socket={@socket}
             viewer={@current_user}
+            engagement={entry[:engagement]}
             surface={:flat}
           />
         </div>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.200.4",
+      version: "7.200.5",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260730145819_add_follows_recency_indexes.exs
+++ b/priv/repo/migrations/20260730145819_add_follows_recency_indexes.exs
@@ -1,0 +1,66 @@
+defmodule Vutuv.Repo.Migrations.AddFollowsRecencyIndexes do
+  use Ecto.Migration
+
+  # The profile header's follower/following previews (`Follow.latest/2`) read a
+  # member's newest follows with a LIMIT after joining the visibility gate, and
+  # the plain per-side indexes force Postgres to fetch and top-N-sort every one
+  # of the member's follows first (5ms+ for a few hundred rows, on every
+  # profile mount, twice per visit). With recency in the index the scan walks
+  # newest-first and stops as soon as the limit is full: 5.3ms -> 0.2ms on the
+  # production copy. Built CONCURRENTLY (no transaction / migrator lock), and
+  # N-1 compatible: it only speeds up existing queries.
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    create_if_not_exists(
+      index(:follows, ["followee_id", "inserted_at DESC", "id DESC"],
+        name: "follows_followee_recency_index",
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:follows, ["follower_id", "inserted_at DESC", "id DESC"],
+        name: "follows_follower_recency_index",
+        concurrently: true
+      )
+    )
+
+    # Both single-column indexes are now strict prefixes of a wider index
+    # (follower_id also of the follower_id+followee_id unique), so they only
+    # cost write amplification. The old release's queries plan onto the new
+    # composites just as well, so dropping them in the same deploy is N-1 safe.
+    drop_if_exists(
+      index(:follows, [:followee_id], name: "follows_followee_id_index", concurrently: true)
+    )
+
+    drop_if_exists(
+      index(:follows, [:follower_id], name: "follows_follower_id_index", concurrently: true)
+    )
+  end
+
+  def down do
+    create_if_not_exists(
+      index(:follows, [:followee_id], name: "follows_followee_id_index", concurrently: true)
+    )
+
+    create_if_not_exists(
+      index(:follows, [:follower_id], name: "follows_follower_id_index", concurrently: true)
+    )
+
+    drop_if_exists(
+      index(:follows, ["followee_id", "inserted_at DESC", "id DESC"],
+        name: "follows_followee_recency_index",
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:follows, ["follower_id", "inserted_at DESC", "id DESC"],
+        name: "follows_follower_recency_index",
+        concurrently: true
+      )
+    )
+  end
+end

--- a/test/support/query_counter.ex
+++ b/test/support/query_counter.ex
@@ -4,22 +4,29 @@ defmodule Vutuv.QueryCounter do
 
       {result, count} = count_queries(fn -> ... end)
 
+  `matching: regex_or_string` counts only the queries whose SQL matches — for
+  asserting that one specific query shape (e.g. the action-bar engagement
+  SELECT) runs exactly once per render instead of once per card.
+
   Telemetry handlers are global, so under async tests a parallel test's query
   would also fire ours. Ecto runs the handler synchronously in the process
   that called `Repo` (and ConnTest dispatches in the test process), so only
   events emitted from the calling process are counted.
   """
 
-  def count_queries(fun) do
+  def count_queries(fun, opts \\ []) do
     parent = self()
     ref = make_ref()
     handler_id = {__MODULE__, ref}
+    matching = Keyword.get(opts, :matching)
 
     :telemetry.attach(
       handler_id,
       [:vutuv, :repo, :query],
-      fn _event, _measurements, _metadata, _config ->
-        if self() == parent, do: send(parent, {ref, :query})
+      fn _event, _measurements, metadata, _config ->
+        if self() == parent and (matching == nil or metadata.query =~ matching) do
+          send(parent, {ref, :query})
+        end
       end,
       nil
     )

--- a/test/vutuv/social_test.exs
+++ b/test/vutuv/social_test.exs
@@ -130,6 +130,41 @@ defmodule Vutuv.SocialTest do
     end
   end
 
+  describe "social_counts/1" do
+    test "returns all three profile counts in one query, agreeing with the singles" do
+      user = insert(:user, email_confirmed?: true)
+      fan = insert(:user, email_confirmed?: true)
+      friend = insert(:user, email_confirmed?: true)
+      unactivated = insert(:user)
+
+      # fan -> user (follower only); user <-> friend (mutual = a connection);
+      # unactivated -> user must not count.
+      {:ok, _} = Social.follow(fan.id, user.id)
+      {:ok, _} = Social.follow(user.id, friend.id)
+      {:ok, _} = Social.follow(friend.id, user.id)
+      {:ok, _} = Social.follow(unactivated.id, user.id)
+
+      {counts, queries} =
+        Vutuv.QueryCounter.count_queries(fn -> Social.social_counts(user) end)
+
+      assert queries == 1
+
+      assert counts == %{
+               followers: Social.follower_count(user),
+               followees: Social.followee_count(user),
+               connections: Social.connection_count(user)
+             }
+
+      assert counts == %{followers: 2, followees: 1, connections: 1}
+    end
+
+    test "every count is present even when all are zero" do
+      user = insert(:user, email_confirmed?: true)
+
+      assert Social.social_counts(user) == %{followers: 0, followees: 0, connections: 0}
+    end
+  end
+
   describe "follows_page/3" do
     test "lists no moderation-hidden people" do
       user = insert(:user, email_confirmed?: true)

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -79,6 +79,22 @@ defmodule VutuvWeb.PostFeedLiveTest do
       assert many <= few + 2,
              "feed query count grew from #{few} to #{many}; engagement is not batched"
     end
+
+    test "the stored draft is read once per mount, not by feed and composer both", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      :ok = Posts.save_draft(user, nil, %{body: "half-typed"})
+
+      {conn, draft_queries} =
+        Vutuv.QueryCounter.count_queries(
+          fn -> get(conn, ~p"/feed") end,
+          matching: ~r/FROM "post_drafts"/
+        )
+
+      # The feed reads the draft to decide whether the composer panel opens and
+      # hands it to the composer, which must not run the same query again.
+      assert html_response(conn, 200) =~ "composer-panel"
+      assert draft_queries == 1, "expected one post_drafts read per mount, got #{draft_queries}"
+    end
   end
 
   describe "mount" do

--- a/test/vutuv_web/live/user_profile_perf_test.exs
+++ b/test/vutuv_web/live/user_profile_perf_test.exs
@@ -1,0 +1,56 @@
+defmodule VutuvWeb.UserProfilePerfTest do
+  @moduledoc """
+  Query-count regression tests for the profile page (`/:slug`): the Beiträge
+  card's action bars must read from ONE batched engagement query per render
+  (`Posts.post_engagement_map/2`), never one query per shown card — the exact
+  N+1 the feed already guards against in `post_feed_live_test.exs`.
+  """
+  use VutuvWeb.ConnCase
+
+  alias Vutuv.Posts
+
+  # The action-bar engagement SELECT is the only query built from this
+  # hand-written fragment, so its text is a stable signature.
+  @engagement_query ~r/post_likes l WHERE l\.post_id/
+
+  test "profile engagement is one batched query, pinned post and thread included", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+
+    {:ok, pinned} = Posts.create_post(user, %{body: "the showcased post"})
+    {:ok, _} = Posts.pin_to_profile(user, pinned)
+
+    {:ok, parent} = Posts.create_post(user, %{body: "a post worth answering"})
+    {:ok, _reply} = Posts.create_reply(user, parent, %{body: "answering myself"})
+    {:ok, _} = Posts.create_post(user, %{body: "one more post"})
+
+    {conn, engagement_queries} =
+      Vutuv.QueryCounter.count_queries(
+        fn -> get(conn, ~p"/#{user.username}") end,
+        matching: @engagement_query
+      )
+
+    assert html_response(conn, 200) =~ "the showcased post"
+
+    # The timeline preview (3 entries, one nesting its thread parent) plus the
+    # pinned post used to each fire their own engagement query on mount.
+    assert engagement_queries == 1,
+           "expected the profile to batch engagement into one query, got #{engagement_queries}"
+  end
+
+  test "profile query count does not grow with post count", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+
+    {:ok, first} = Posts.create_post(user, %{body: "post 1"})
+    {:ok, _} = Posts.pin_to_profile(user, first)
+
+    {_, few} = Vutuv.QueryCounter.count_queries(fn -> get(conn, ~p"/#{user.username}") end)
+
+    for n <- 2..5, do: {:ok, _} = Posts.create_post(user, %{body: "post #{n}"})
+
+    {_, many} =
+      Vutuv.QueryCounter.count_queries(fn -> recycle(conn) |> get(~p"/#{user.username}") end)
+
+    assert many <= few + 1,
+           "profile query count grew from #{few} to #{many}; engagement is not batched"
+  end
+end


### PR DESCRIPTION
The feed and the profile are the most-visited pages and both felt sluggish. A query survey against the production copy showed the cost is round-trip count, paid twice per visit (dead render + connected mount). This PR removes the worst of it:

**Profile (`/:slug`)**
- The action bars ran the heavy engagement SELECT once per shown card (timeline preview, nested thread parents, pinned post). Now one batched `Posts.post_engagement_map/2` read per render, handed to the bars — the pattern the feed already used. Guarded by the new `user_profile_perf_test.exs`.
- The header's three social counts ran as three separate follows-JOIN-users scans. New `Social.social_counts/1` unions the same three count queries into one round trip; the single-count accessors share the query builders, so the gates cannot drift.
- `Follow.latest/2` (newest-3 follower/following previews) sorted a member's whole follow set per mount. New composite indexes `follows_(followee|follower)_recency_index (side, inserted_at DESC, id DESC)` let the LIMIT stop early: 5.3ms → 0.2ms on the production copy. The redundant single-column follows indexes are dropped.

**Feed (`/feed`)**
- The stored composer draft was read twice per mount (feed + composer). The feed now hands the loaded draft to the composer; new regression test asserts one `post_drafts` read per mount.

**Deploy: cold** — a migration rides along (indexes only, built `CONCURRENTLY`, N-1 safe: it only speeds up existing queries and drops indexes that are strict prefixes of remaining ones).

Measured on the production copy (dead render, wintermeyer): profile 59 → 54 queries per mount with the slowest per-query work eliminated; every saving counts twice per visit. Smoke-tested in a real browser (feed rails, profile follow pill, like toggle on handed-in engagement, visitor view).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01EzdmtAyM4w2v67JgZso8cB