### PR TITLE
One counts query per profile mount, and the visibility gate goes index-only (v7.200.6)

### DIFF
--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -20,16 +20,23 @@ follow is mutual, and a `<.mute_button>` once you follow the member.
 `/:slug/connections` lists a member's vernetzt people (the owner ends a
 connection by unfollowing).
 
-The profile header reads its three counts through **`Social.social_counts/1`**,
-a union of the same gated count queries the single accessors
-(`follower_count/1` / `followee_count/1` / `connection_count/1`) run — one
-round trip per mount instead of three, and the gates cannot drift because the
-union is built from the singles' own query builders. The header's newest-3
-follower/following previews (`Follow.latest/2`) are served by the
-`follows_(follower|followee)_recency_index` composite indexes
-(`(side_id, inserted_at DESC, id DESC)`), which let the LIMIT stop at the
-first gate-passing rows instead of sorting the member's whole follow set; the
-old single-column follows indexes were dropped as redundant prefixes.
+The three profile-header counts come from the tagged count queries behind
+**`Social.social_counts/1`** (one union round trip; the single accessors
+`follower_count/1` / `followee_count/1` / `connection_count/1` share the same
+query builders, so the gates cannot drift). On a profile mount they do not
+even run alone: `Social.profile_count_queries/1` hands the three arms to
+`UserProfileLive.profile_counts/2`, which unions them with the nine section
+totals and the viewer-scoped posts total
+(`Posts.author_timeline_count_query/2`) into ONE counts query per mount.
+Two indexes carry the load: the covering visibility index
+`users_visible_covering_index` (`(id) INCLUDE (suspended_until)` on the
+public-visibility predicate) serves the counts' users gate index-only
+(14.3ms → 1.0ms on the production copy), and the
+`follows_(follower|followee)_recency_index` composites
+(`(side_id, inserted_at DESC, id DESC)`) let the header's newest-3
+follower/following previews (`Follow.latest/2`) stop at the first
+gate-passing rows instead of sorting the member's whole follow set; the old
+single-column follows indexes were dropped as redundant prefixes.
 
 **Mute** is a per-follow flag (`follows.muted`, `<.mute_button>` → PUT
 `/follows/:id/mute`): a muted follow keeps the relationship and any vernetzt

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2074,6 +2074,18 @@ defmodule Vutuv.Posts do
   end
 
   @doc """
+  `count_author_posts/3` as a tagged `%{kind: "posts_total", total:}` count
+  query, for a caller folding it into a wider union — the profile mounts fold
+  it into their single per-mount counts query (with the section and social
+  count arms) instead of running it as its own round trip.
+  """
+  def author_timeline_count_query(%User{} = author, viewer, filter \\ :all) do
+    from(s in subquery(author_timeline_query(author, viewer, filter)),
+      select: %{kind: type(^"posts_total", :string), total: count()}
+    )
+  end
+
+  @doc """
   The profile card's "Who to follow" candidate pool: the members who posted
   (replies included) within the last `days` days, ranked by the hearts those
   in-window posts collected, post count breaking ties - at most `limit` of

--- a/lib/vutuv/social.ex
+++ b/lib/vutuv/social.ex
@@ -152,6 +152,20 @@ defmodule Vutuv.Social do
     }
   end
 
+  @doc """
+  The three tagged count queries behind `social_counts/1`, for a caller that
+  folds them into a wider union instead of running them alone — the profile
+  mounts fold them into their single per-mount counts query. Each arm selects
+  `%{kind:, total:}` with kinds `"followers"` / `"followees"` / `"connections"`.
+  """
+  def profile_count_queries(user_id) do
+    [
+      follower_count_query(user_id),
+      followee_count_query(user_id),
+      connection_count_query(user_id)
+    ]
+  end
+
   # The tagged single-count queries behind both the single accessors and
   # `social_counts/1`'s union (a union's arms must share one select shape, so
   # the singles carry the tag too and read `.total` off the one row).
@@ -251,6 +265,28 @@ defmodule Vutuv.Social do
         select: %{id: c.id, muted?: c.muted}
       )
     )
+  end
+
+  @doc """
+  Both directional follow edges between two members in one round trip, as
+  `%{outbound:, inbound:}` — `outbound` the `a → b` edge and `inbound` the
+  `b → a` edge, each `%{id:, muted?:}` or `nil`. The profile header resolves
+  its whole relationship pill (follow id, mute state, follows-you, vernetzt)
+  from exactly these two edges, so it reads them together instead of running
+  `follow_edge/2` twice per mount.
+  """
+  def follow_edges_between(a_id, b_id) do
+    edges =
+      from(c in Follow,
+        where:
+          (c.follower_id == ^a_id and c.followee_id == ^b_id) or
+            (c.follower_id == ^b_id and c.followee_id == ^a_id),
+        select: {c.follower_id, %{id: c.id, muted?: c.muted}}
+      )
+      |> Repo.all()
+      |> Map.new()
+
+    %{outbound: Map.get(edges, a_id), inbound: Map.get(edges, b_id)}
   end
 
   @doc """

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -476,7 +476,7 @@ defmodule VutuvWeb.UserProfileLive do
       )
 
     socket
-    |> put_social_assigns(user)
+    |> put_social_assigns(user, [])
     # The follow step is the one checklist item completable on this very page
     # (the promoted rail's follow buttons), so re-derive the steps and the tick
     # lands live. The checklist's visibility and the rail's promoted spot stay
@@ -490,7 +490,13 @@ defmodule VutuvWeb.UserProfileLive do
   # directional state, and the follower / following previews (plus the per-row
   # work-info and follow-state maps those rows read). Reads current_user /
   # recommended_users off the socket, so set those before piping through here.
-  defp put_social_assigns(socket, user) do
+  #
+  # `opts` lets the mount hand in what it already resolved — `counts:` (from
+  # the one per-mount counts union) and `following:` (the hoisted follow-state
+  # map) — so the initial load re-queries neither; the social-graph refresh
+  # passes only fresh `counts:` and re-reads the follow map, which is exactly
+  # what just changed.
+  defp put_social_assigns(socket, user, opts) do
     current_user = socket.assigns.current_user
 
     followers = Enum.map(user.inbound_follows, & &1.follower)
@@ -500,14 +506,11 @@ defmodule VutuvWeb.UserProfileLive do
       Enum.uniq_by(socket.assigns.recommended_users ++ followers ++ followees, & &1.id)
 
     # The header's whole follow state derives from at most the two directional
-    # follow edges (viewer→owner, owner→viewer); resolve both once here instead
-    # of the six overlapping lookups the four header_* helpers used to fire.
+    # follow edges (viewer→owner, owner→viewer), read together in one query.
     rel = header_relationship(current_user, user)
 
-    # All three header counts in one round trip — each single count walks every
-    # follow row of the member with a users join, and this runs on both mounts
-    # and on every social-graph refresh.
-    counts = Social.social_counts(user)
+    counts = Keyword.get(opts, :counts) || Social.social_counts(user)
+    following = Keyword.get(opts, :following) || following_map(current_user, preview_users)
 
     socket
     |> assign(:user, user)
@@ -521,7 +524,7 @@ defmodule VutuvWeb.UserProfileLive do
     |> assign(:followers, followers)
     |> assign(:followees, followees)
     |> assign(:work_info_by_id, work_information_map(preview_users, 24))
-    |> assign(:following_by_id, following_map(current_user, preview_users))
+    |> assign(:following_by_id, following)
   end
 
   # Re-read the visible tags (with their endorsers), so an endorse / unendorse
@@ -635,13 +638,34 @@ defmodule VutuvWeb.UserProfileLive do
   # discovery outranks their own detail cards.
   @discovery_follow_target 5
 
+  # The "Who to follow" rail's count, how many ranked candidates we draw before
+  # the per-viewer exclusions (self, owner, already-followed, blocked) thin
+  # them, and the recent-output window a candidate must have posted within.
+  # Defined above load_profile/1, which reads them (a module attribute is nil
+  # until the line that sets it).
+  @recommended_count 6
+  @recommended_pool 60
+  @suggested_window_days 28
+
   defp load_profile(socket) do
     current_user = socket.assigns.current_user
     base_user = Repo.get!(User, socket.assigns.profile_user_id)
 
     owner? = !!(current_user && current_user.id == base_user.id)
 
-    totals = assoc_totals(base_user)
+    # Every count the page renders — the nine section totals, the three social
+    # counts and the posts total — in ONE union query per mount (they were
+    # three separate round trips, the three most expensive queries on the page).
+    counts = profile_counts(base_user, current_user)
+    totals = section_totals(counts)
+    posts_total = Map.get(counts, "posts_total", 0)
+
+    social_counts = %{
+      followers: Map.get(counts, "followers", 0),
+      followees: Map.get(counts, "followees", 0),
+      connections: Map.get(counts, "connections", 0)
+    }
+
     user = preload_user_for_show(base_user, owner?)
 
     private_emails? = private_emails?(current_user, user)
@@ -657,9 +681,24 @@ defmodule VutuvWeb.UserProfileLive do
         user.profile_work_experience_id
       )
 
-    recommended_users = recommended_users(user, current_user)
+    # One follow-state lookup serves both the "Who to follow" filter and the
+    # preview rows' follow buttons: the candidates and the follower/followee
+    # previews are resolved against the viewer together, instead of
+    # `following_map/2` running once for each.
+    followers = Enum.map(user.inbound_follows, & &1.follower)
+    followees = Enum.map(user.outbound_follows, & &1.followee)
+    candidates = Vutuv.Posts.top_recent_posters(@suggested_window_days, @recommended_pool)
 
-    posts_total = Vutuv.Posts.count_author_posts(user, current_user)
+    following =
+      following_map(
+        current_user,
+        Enum.uniq_by(candidates ++ followers ++ followees, & &1.id)
+      )
+
+    recommended_users =
+      candidates
+      |> suggestable(user, current_user, following)
+      |> Enum.take(@recommended_count)
 
     # The showcased post (issue #1110), scoped to this viewer: a pin that is
     # restricted, frozen or gone simply isn't there. It renders above the
@@ -717,8 +756,11 @@ defmodule VutuvWeb.UserProfileLive do
     )
     |> assign(:totals, totals)
     # Builds the social slice (counts, header pill state, follow previews); reads
-    # :current_user / :recommended_users set above, so it goes last.
-    |> put_social_assigns(user)
+    # :current_user / :recommended_users set above, so it goes last. The counts
+    # and the follow-state map were already resolved above (the counts union,
+    # the hoisted following_map), so the mount hands them in instead of
+    # re-querying; the refresh path passes neither and queries fresh.
+    |> put_social_assigns(user, counts: social_counts, following: following)
     # The rail promotion and the checklist's follow step both read the followee
     # count put_social_assigns just computed. The promotion is deliberately set
     # only here, never on the social-graph refresh: the fifth follow, made from
@@ -983,13 +1025,14 @@ defmodule VutuvWeb.UserProfileLive do
 
   # The viewer's header follow relationship, resolved from at most the two
   # directional follow edges — the viewer's outbound edge to the owner and the
-  # owner's inbound edge back — returned as one map. Replaces four helpers that
-  # re-read the same edges six times (two follow_id, the two-exists connected?,
-  # and a follow_edge for the mute state).
+  # owner's inbound edge back — read together in one query
+  # (`Social.follow_edges_between/2`) and returned as one map. Replaces four
+  # helpers that re-read the same edges six times (two follow_id, the
+  # two-exists connected?, and a follow_edge for the mute state).
   defp header_relationship(current_user, user) do
     if current_user && current_user.id != user.id do
-      outbound = Social.follow_edge(current_user.id, user.id)
-      inbound = Social.follow_edge(user.id, current_user.id)
+      %{outbound: outbound, inbound: inbound} =
+        Social.follow_edges_between(current_user.id, user.id)
 
       %{
         follow_id: outbound && outbound.id,
@@ -1058,24 +1101,38 @@ defmodule VutuvWeb.UserProfileLive do
     |> preload(endorsements: ^UserTagEndorsement.visible_with_endorser())
   end
 
-  # The five section totals ("N total, showing 3") in one round trip instead of
-  # five separate count queries: a union_all of per-section counts, keyed back to
-  # the totals map. Each count returns exactly one row (0 when empty), so every
-  # section is always present.
-  defp assoc_totals(%User{id: uid}) do
-    counts =
-      section_count(UserTag, uid, "user_tags")
-      |> union_all(^section_count(WorkExperience, uid, "jobs"))
-      |> union_all(^section_count(Education, uid, "educations"))
-      |> union_all(^section_count(Language, uid, "languages"))
-      |> union_all(^section_count(Qualification, uid, "qualifications"))
-      |> union_all(^section_count(PhoneNumber, uid, "numbers"))
-      |> union_all(^section_count(Messenger, uid, "messengers"))
-      |> union_all(^section_count(Url, uid, "links"))
-      |> union_all(^section_count(Address, uid, "addresses"))
-      |> Repo.all()
-      |> Map.new(fn %{section: section, total: total} -> {section, total} end)
+  # Every count the profile renders, in ONE round trip: the nine section
+  # totals ("N total, showing 3"), the three social-graph counts
+  # (`Social.profile_count_queries/1`) and the viewer-scoped posts total
+  # (`Posts.author_timeline_count_query/2`) — a 13-arm union_all keyed back to
+  # a `kind => total` map. They used to run as three separate queries (and
+  # before that, as sixteen), which made counting the most expensive thing on
+  # the page after the preloads. Each arm returns exactly one row (0 when
+  # empty), so every kind is always present.
+  defp profile_counts(%User{id: uid} = user, viewer) do
+    [first | rest] =
+      [
+        section_count(UserTag, uid, "user_tags"),
+        section_count(WorkExperience, uid, "jobs"),
+        section_count(Education, uid, "educations"),
+        section_count(Language, uid, "languages"),
+        section_count(Qualification, uid, "qualifications"),
+        section_count(PhoneNumber, uid, "numbers"),
+        section_count(Messenger, uid, "messengers"),
+        section_count(Url, uid, "links"),
+        section_count(Address, uid, "addresses")
+      ] ++
+        Social.profile_count_queries(uid) ++
+        [Vutuv.Posts.author_timeline_count_query(user, viewer)]
 
+    rest
+    |> Enum.reduce(first, fn arm, acc -> union_all(acc, ^arm) end)
+    |> Repo.all()
+    |> Map.new(fn %{kind: kind, total: total} -> {kind, total} end)
+  end
+
+  # The section-totals map the template reads, from the combined counts.
+  defp section_totals(counts) do
     %{
       user_tags: Map.get(counts, "user_tags", 0),
       jobs: Map.get(counts, "jobs", 0),
@@ -1089,10 +1146,10 @@ defmodule VutuvWeb.UserProfileLive do
     }
   end
 
-  defp section_count(schema, uid, section) do
+  defp section_count(schema, uid, kind) do
     from(r in schema,
       where: r.user_id == ^uid,
-      select: %{section: type(^section, :string), total: count()}
+      select: %{kind: type(^kind, :string), total: count()}
     )
   end
 
@@ -1186,19 +1243,14 @@ defmodule VutuvWeb.UserProfileLive do
       @onboarding_window_seconds
   end
 
-  # The rail's count, and how many ranked candidates we draw before the
-  # per-viewer exclusions (self, owner, already-followed, blocked) thin them.
-  @recommended_count 6
-  @recommended_pool 60
+  # The candidate window (@suggested_window_days, defined at the top with its
+  # siblings): only members who posted within it are suggested at all. The
+  # card promises that following fills your feed, and a silent account cannot
+  # keep that promise - strict on purpose, a thin (or empty) card is more
+  # honest than padding it with inactive accounts.
 
-  # The candidate window: only members who posted within it are suggested at
-  # all. The card promises that following fills your feed, and a silent
-  # account cannot keep that promise - strict on purpose, a thin (or empty)
-  # card is more honest than padding it with inactive accounts.
-  @suggested_window_days 28
-
-  # The "Who to follow" rail: the window's most-hearted recent posters
-  # (`Posts.top_recent_posters/2` - members who posted in the last
+  # The "Who to follow" rail draws from the window's most-hearted recent
+  # posters (`Posts.top_recent_posters/2` - members who posted in the last
   # @suggested_window_days days, ranked by the hearts those posts collected),
   # minus everyone the rail must never suggest: the profile owner, the
   # `viewer` themselves, anyone the viewer *already follows* (suggesting them
@@ -1207,20 +1259,11 @@ defmodule VutuvWeb.UserProfileLive do
   # follow state. This replaced a most-followed/topical-tag source: follower
   # totals reward the past, but the card's promise is a feed with something
   # in it, which only current, liked output can keep.
-  defp recommended_users(user, viewer) do
-    candidates = Vutuv.Posts.top_recent_posters(@suggested_window_days, @recommended_pool)
-
-    candidates
-    |> suggestable(user, viewer)
-    |> Enum.take(@recommended_count)
-  end
-
-  # Keep only members the rail may suggest: not the profile owner, not the viewer,
-  # not anyone the viewer already follows (one batched lookup via `following_map`),
-  # and not a member the viewer blocked / who blocked them (the follow would be
-  # refused as :blocked and the suggestion would just reappear).
-  defp suggestable(candidates, user, viewer) do
-    following = following_map(viewer, candidates)
+  #
+  # `following` is the hoisted follow-state map load_profile resolved once for
+  # the candidates AND the preview rows together — this filter and the rows'
+  # follow buttons read the same lookup.
+  defp suggestable(candidates, user, viewer, following) do
     # `viewer` is nil for a logged-out visitor; a nil id never equals a real UUID,
     # so the comparison stays a plain boolean (a bare `viewer && …` would yield nil
     # and blow up the strict `or`).

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.200.5",
+      version: "7.200.6",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260730153109_cover_visible_users_index.exs
+++ b/priv/repo/migrations/20260730153109_cover_visible_users_index.exs
@@ -1,0 +1,51 @@
+defmodule Vutuv.Repo.Migrations.CoverVisibleUsersIndex do
+  use Ecto.Migration
+
+  # `users_visible_index` (20260725170422) made the public-visibility gate an
+  # index question, but the gated queries also read `suspended_until` (the one
+  # time-dependent arm that cannot live in the predicate), so every pass over
+  # the ~5.5k visible members still fetched their heap rows — a bitmap heap
+  # scan over 1,228 blocks, ~12ms inside each follower/followee count on the
+  # profile. Rebuilding the index with `INCLUDE (suspended_until)` turns that
+  # pass into an index-only scan: the same count measured 14.3ms -> 0.99ms on
+  # the production copy. (Index-only needs a reasonably fresh visibility map;
+  # until autovacuum catches up the plan just does a few heap fetches, which
+  # is still far cheaper than fetching every row.)
+  #
+  # Keep the predicate in step with `Vutuv.Moderation.Query`'s two macros —
+  # `visibility_index_test.exs` fails when the implication breaks. N-1 safe:
+  # the old release's queries plan onto the new index identically (same
+  # predicate, wider payload); both exist only for the moment between the two
+  # steps. Built CONCURRENTLY, so no transaction / migrator lock.
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @visible_predicate ~s|("email_confirmed?" IS NULL OR "email_confirmed?") AND frozen_at IS NULL AND deactivated_at IS NULL AND unreachable_at IS NULL|
+
+  def up do
+    create_if_not_exists(
+      index(:users, [:id],
+        name: "users_visible_covering_index",
+        include: [:suspended_until],
+        where: @visible_predicate,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(index(:users, [:id], name: "users_visible_index", concurrently: true))
+  end
+
+  def down do
+    execute("""
+    CREATE INDEX IF NOT EXISTS users_visible_index ON users (id)
+    WHERE ("email_confirmed?" IS NULL OR "email_confirmed?")
+      AND frozen_at IS NULL
+      AND deactivated_at IS NULL
+      AND unreachable_at IS NULL
+    """)
+
+    drop_if_exists(
+      index(:users, [:id], name: "users_visible_covering_index", concurrently: true)
+    )
+  end
+end

--- a/test/vutuv/moderation/visibility_index_test.exs
+++ b/test/vutuv/moderation/visibility_index_test.exs
@@ -1,7 +1,8 @@
 defmodule Vutuv.Moderation.VisibilityIndexTest do
   @moduledoc """
-  Guards `users_visible_index` (migration
-  `20260725170422_add_users_visibility_partial_index`) against drift.
+  Guards `users_visible_covering_index` (migrations
+  `20260725170422_add_users_visibility_partial_index` +
+  `20260730153109_cover_visible_users_index`) against drift.
 
   The partial index spells the public-visibility gate a second time, in SQL,
   so Postgres can serve the ~55 query sites that filter on
@@ -23,7 +24,7 @@ defmodule Vutuv.Moderation.VisibilityIndexTest do
 
   alias Vutuv.Accounts.User
 
-  @index "users_visible_index"
+  @index "users_visible_covering_index"
 
   test "the visibility gate is still covered by #{@index}" do
     query = from(u in User, where: account_confirmed_row(u) and not account_hidden_row(u))

--- a/test/vutuv/social_test.exs
+++ b/test/vutuv/social_test.exs
@@ -165,6 +165,35 @@ defmodule Vutuv.SocialTest do
     end
   end
 
+  describe "follow_edges_between/2" do
+    test "both directional edges in one query" do
+      a = insert(:user, email_confirmed?: true)
+      b = insert(:user, email_confirmed?: true)
+
+      {:ok, outbound} = Social.follow(a.id, b.id)
+
+      {edges, queries} =
+        Vutuv.QueryCounter.count_queries(fn -> Social.follow_edges_between(a.id, b.id) end)
+
+      assert queries == 1
+      assert edges == %{outbound: %{id: outbound.id, muted?: false}, inbound: nil}
+
+      {:ok, inbound} = Social.follow(b.id, a.id)
+
+      assert %{outbound: %{id: _}, inbound: %{id: inbound_id, muted?: false}} =
+               Social.follow_edges_between(a.id, b.id)
+
+      assert inbound_id == inbound.id
+    end
+
+    test "no edges means two nils" do
+      a = insert(:user, email_confirmed?: true)
+      b = insert(:user, email_confirmed?: true)
+
+      assert Social.follow_edges_between(a.id, b.id) == %{outbound: nil, inbound: nil}
+    end
+  end
+
   describe "follows_page/3" do
     test "lists no moderation-hidden people" do
       user = insert(:user, email_confirmed?: true)

--- a/test/vutuv_web/live/user_profile_perf_test.exs
+++ b/test/vutuv_web/live/user_profile_perf_test.exs
@@ -37,6 +37,33 @@ defmodule VutuvWeb.UserProfilePerfTest do
            "expected the profile to batch engagement into one query, got #{engagement_queries}"
   end
 
+  test "all profile counts run as one union query", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    {:ok, _} = Posts.create_post(user, %{body: "counted post"})
+
+    # The merged counts union is the only statement that counts both a profile
+    # section (user_tags) and the social graph (follows) in one query; the
+    # section totals, the three social counts and the posts total used to be
+    # three separate round trips per mount.
+    {conn, union_queries} =
+      Vutuv.QueryCounter.count_queries(
+        fn -> get(conn, ~p"/#{user.username}") end,
+        matching: ~r/FROM "user_tags"[\s\S]*UNION ALL[\s\S]*FROM "follows"/
+      )
+
+    assert html_response(conn, 200) =~ "counted post"
+    assert union_queries == 1
+
+    # And the standalone count shapes it replaced are gone from the mount.
+    {conn, standalone_social_counts} =
+      Vutuv.QueryCounter.count_queries(
+        fn -> recycle(conn) |> get(~p"/#{user.username}") end,
+        matching: ~r/^SELECT count\(f0\."id"\) FROM "follows"/
+      )
+
+    assert standalone_social_counts == 0
+  end
+
   test "profile query count does not grow with post count", %{conn: conn} do
     {conn, user} = create_and_login_user(conn)
 


### PR DESCRIPTION
Follow-up to #1231, answering "do we really need 54 queries?" — the three most expensive queries left on the profile were all counts, so they are now one, and the index they lean on got a covering rebuild.

- **One 13-arm counts union per mount**: the nine section totals + the three social counts (`Social.profile_count_queries/1`) + the viewer-scoped posts total (`Posts.author_timeline_count_query/2`) run as a single query (`UserProfileLive.profile_counts/2`). They were three round trips and the top three by cost; the arms share the singles' query builders, so the gates cannot drift. Guarded by a new test in `user_profile_perf_test.exs`.
- **`users_visible_covering_index`**: the partial visibility index now carries `INCLUDE (suspended_until)`, so the gated counts' pass over the ~5,570 visible members is an index-only scan instead of a 1,228-block bitmap heap scan — **14.3ms → 0.99ms** measured on the production copy. The same gate guards ~55 query sites (search, listings, feed author checks), which all inherit the cheaper plan. Old index dropped in the same migration; `visibility_index_test.exs` now guards the new name.
- **`Social.follow_edges_between/2`**: the header pill's two directional edges in one query.
- **`following_map` hoisted**: one follow-state lookup serves the who-to-follow filter and the preview rows together.

**Deploy: cold** — a migration rides along (index swap only, `CONCURRENTLY`, N-1 safe: same predicate, wider payload, old release plans onto it identically).

Cumulative today: profile 59 → 51 queries per mount; the counts union executes in 3.7ms where the three queries it replaces took ~19ms; warm-median DB telemetry per mount 64 → 37ms. Every saving counts twice per visit (dead + connected mount).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01EzdmtAyM4w2v67JgZso8cB