### PR TITLE
The socket mount reuses the dead render's work on the profile and the feed (v7.200.7)

### DIFF
--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -301,6 +301,34 @@ exactly at that moment. A NULL means no note, which is what every account
 predating the feature keeps — the derived feed is otherwise retroactive, and a
 welcome years after the fact would be nonsense.
 
+## The dead-render → socket-mount handoff (profile + feed)
+
+Every LiveView visit computes its data twice: once for the HTML the visitor
+sees immediately (the dead render) and once when the websocket connects and
+`mount/3` runs again in a fresh process — identical data, seconds apart,
+~50 queries each on the profile. **`VutuvWeb.Live.MountHandoff`** (an ETS
+table + sweeper in the supervision tree) lets the dead render pass its
+finished work to the connected mount: the dead mount stashes the assigns it
+computed under `{authenticated viewer id, subject}`, the connected mount
+takes (consumes) them and skips the reload. `UserProfileLive` stashes the
+assigns `load_profile/1` added (diffed, not listed, so new assigns ride
+automatically) and recomputes only the two connected-only slices (social-feed
+ETS reads, code-stats refresh request); `PostLive.Feed` stashes its
+`feed_payload/1` map and rebuilds the stream from it (a consumed
+`LiveStream` struct must never ride a handoff — it would replay empty).
+
+It is deliberately **not a cache**: single-use (`:ets.take/2`, so a
+reconnect after a blip or deploy full-loads), keyed by the *server-side*
+authenticated viewer on both ends (never by anything the client sent;
+anonymous visitors — mostly crawlers whose socket never connects — are never
+stashed for), expired after ~15s, and fail-closed (any miss runs the normal
+full load). The accepted trade: changes landing in the sub-second gap
+between the two renders are not re-read at connect; both pages subscribe to
+their PubSub topics at connect, so the next event heals the snapshot.
+Regression tests in `user_profile_perf_test.exs` and
+`post_feed_live_test.exs` pin both sides: a hit connects on a handful of
+queries, a consumed stash still full-loads.
+
 ## Live member counter
 
 The logged-out landing page shows the **exact** number of members and ticks it

--- a/lib/vutuv/application.ex
+++ b/lib/vutuv/application.ex
@@ -66,6 +66,10 @@ defmodule Vutuv.Application do
         # tests.
         Vutuv.CodeStats.Fetcher,
         Vutuv.RateLimiter,
+        # The single-use dead-render -> socket-mount handoff for the profile
+        # and the feed (owns its ETS table + expiry sweeper). Before the
+        # Endpoint so the table exists for the first request.
+        VutuvWeb.Live.MountHandoff,
         VutuvWeb.Endpoint
       ] ++
         optional_child(:prefs_defaults_cache, Vutuv.Prefs.Cache) ++

--- a/lib/vutuv_web/live/mount_handoff.ex
+++ b/lib/vutuv_web/live/mount_handoff.ex
@@ -1,0 +1,117 @@
+defmodule VutuvWeb.Live.MountHandoff do
+  @moduledoc """
+  The single-use **dead-render → socket-mount handoff** for the expensive
+  LiveView pages (the profile and the feed).
+
+  Every LiveView visit computes its data twice: once for the HTML the visitor
+  sees immediately (the dead render, in the request process) and once when the
+  websocket connects and `mount/3` runs again in a fresh process. The two runs
+  happen within a second or two of each other and compute identical data —
+  ~50 queries each on the profile. This module lets the dead render pass its
+  finished work to the connected mount instead: the dead mount `stash/4`es the
+  assigns it computed, the connected mount `take/2`s them and skips the
+  reload.
+
+  It is deliberately **not a cache** — it is a baton passed exactly once:
+
+    * **Single-use.** `take/2` consumes the entry (`:ets.take/2`), so a later
+      reconnect (network blip, deploy) finds nothing and full-loads. No entry
+      is ever served twice.
+    * **Keyed by the authenticated viewer.** Both sides derive the key from
+      their own server-side authentication (`Vutuv.Sessions` token → user id),
+      never from anything the client sent, so one viewer can never take
+      another's entry. Anonymous visitors are never stashed for — most
+      anonymous dead renders are crawlers whose socket never connects.
+    * **Short-lived.** Entries expire after #{div(15_000, 1000)}s (a sweeper
+      deletes leftovers), so an unclaimed stash — closed tab, crawler —
+      evaporates and the staleness window is bounded by the time between the
+      HTML render and the socket connect.
+    * **Fail closed.** Any miss — expired, consumed, wrong viewer, table not
+      up — answers `:error` and the caller runs its normal full load. The
+      handoff is a fast path, never a requirement.
+
+  What a hit costs in freshness: changes landing in the sub-second gap between
+  the two renders are not re-read at connect (today they are). Both pages
+  subscribe to their PubSub topics at connect, so anything that matters
+  announces itself and heals the snapshot; the trade buys back an entire page
+  load per visit.
+  """
+
+  use GenServer
+
+  @table __MODULE__
+  @ttl_ms 15_000
+  @sweep_ms 10_000
+
+  ## Client API
+
+  @doc """
+  Stores `payload` for the connected mount of `subject` by the same viewer.
+  A nil viewer (anonymous visitor) is a no-op — see the moduledoc. `ttl_ms`
+  is overridable for tests only.
+  """
+  def stash(viewer_id, subject, payload, ttl_ms \\ @ttl_ms)
+
+  def stash(viewer_id, subject, payload, ttl_ms) when is_binary(viewer_id) do
+    :ets.insert(@table, {{viewer_id, subject}, payload, now_ms() + ttl_ms})
+    :ok
+  rescue
+    # Table not up (a script without the app tree): the dead render simply
+    # leaves nothing behind and the connected mount full-loads.
+    ArgumentError -> :ok
+  end
+
+  def stash(_viewer_id, _subject, _payload, _ttl_ms), do: :ok
+
+  @doc """
+  Takes (and consumes) the stashed payload for `{viewer_id, subject}`.
+  `:error` for anything but a fresh hit by the same viewer.
+  """
+  def take(viewer_id, subject) when is_binary(viewer_id) do
+    case :ets.take(@table, {viewer_id, subject}) do
+      [{_key, payload, expires_at}] ->
+        if now_ms() < expires_at, do: {:ok, payload}, else: :error
+
+      [] ->
+        :error
+    end
+  rescue
+    ArgumentError -> :error
+  end
+
+  def take(_viewer_id, _subject), do: :error
+
+  # Monotonic on purpose: TTL is a duration, not a wall-clock moment, so a
+  # clock adjustment can neither extend nor expire an entry.
+  defp now_ms, do: System.monotonic_time(:millisecond)
+
+  ## Table owner + sweeper
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @impl true
+  def init(nil) do
+    :ets.new(@table, [
+      :named_table,
+      :public,
+      :set,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
+
+    schedule_sweep()
+    {:ok, nil}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    now = now_ms()
+    :ets.select_delete(@table, [{{:_, :_, :"$1"}, [{:<, :"$1", now}], [true]}])
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  defp schedule_sweep, do: Process.send_after(self(), :sweep, @sweep_ms)
+end

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -30,6 +30,7 @@ defmodule VutuvWeb.PostLive.Feed do
   alias Vutuv.Social
   alias VutuvWeb.Live.DayClockRestream
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.Live.MountHandoff
   alias VutuvWeb.UserHelpers
 
   @page_size 20
@@ -69,8 +70,24 @@ defmodule VutuvWeb.PostLive.Feed do
       # Refresh the Berlin-day-relative post stamps ("09:50 Uhr" -> "Gestern,
       # 09:50 Uhr") the moment the German day rolls over at midnight.
       Vutuv.DayClock.subscribe()
-    end
 
+      # The dead render stashed its computed page seconds ago
+      # (VutuvWeb.Live.MountHandoff); take it and skip re-running the same
+      # queries. Any miss (expired, consumed, a reconnect) recomputes.
+      case MountHandoff.take(user.id, :feed) do
+        {:ok, payload} -> apply_feed_payload(socket, payload)
+        :error -> apply_feed_payload(socket, feed_payload(user))
+      end
+    else
+      payload = feed_payload(user)
+      MountHandoff.stash(user.id, :feed, payload)
+      apply_feed_payload(socket, payload)
+    end
+  end
+
+  # Everything a feed mount computes, as data — what the dead render hands the
+  # connected mount through the single-use stash.
+  defp feed_payload(user) do
     # The member's private content filters (issue #940): compiled once, applied
     # to every page, and the set of posts they chose to reveal anyway.
     compiled = ContentFilters.compile_for(user)
@@ -81,30 +98,44 @@ defmodule VutuvWeb.PostLive.Feed do
     # skips its own identical query on init.
     draft = Posts.get_draft(user)
 
+    %{
+      content_filters: compiled,
+      more?: page.more?,
+      cursor: page.next_cursor,
+      draft: draft,
+      entries: entries
+    }
+  end
+
+  # The stream is rebuilt here rather than riding the payload: a
+  # %Phoenix.LiveView.LiveStream{} carries per-socket insert state that the
+  # dead render already consumed, so handing the struct itself to the
+  # connected socket would replay as an empty feed.
+  defp apply_feed_payload(socket, payload) do
     socket
-    |> assign(:content_filters, compiled)
+    |> assign(:content_filters, payload.content_filters)
     |> assign(:revealed_filters, MapSet.new())
     |> assign(:page_title, gettext("Feed"))
-    |> assign(:more?, page.more?)
-    |> assign(:cursor, page.next_cursor)
-    |> assign(:empty?, page.entries == [])
+    |> assign(:more?, payload.more?)
+    |> assign(:cursor, payload.cursor)
+    |> assign(:empty?, payload.entries == [])
     |> assign(:pending_posts, [])
-    |> assign(:draft, draft)
+    |> assign(:draft, payload.draft)
     # The composer starts collapsed to a single "What's new?" button; posting
     # (own activity arriving below) collapses it again. A stored draft opens it
     # instead (issue #1148): the composer will restore that draft, and text
     # hidden behind a collapsed panel is indistinguishable from text that was
     # thrown away. Resolved here rather than announced by the composer so the
     # disconnected render already agrees and the panel never flickers open.
-    |> assign(:composer_open?, draft != nil)
+    |> assign(:composer_open?, payload.draft != nil)
     # The set of entries currently on screen, kept so the midnight :day_changed
     # tick can re-render each stamp in place (streams don't retain their data).
     # Order/dupes don't matter: the refresh uses stream_insert update_only, which
     # updates existing rows where they sit and ignores ones already gone.
-    |> assign(:entries, entries)
+    |> assign(:entries, payload.entries)
     |> assign_empty_rails()
     |> stream_configure(:posts, dom_id: &"feed-#{&1.id}")
-    |> stream(:posts, entries)
+    |> stream(:posts, payload.entries)
   end
 
   # The discovery rail (Tags you follow / Who to follow / Suggested posts)

--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -49,6 +49,7 @@ defmodule VutuvWeb.UserProfileLive do
   alias Vutuv.Tags.UserTagEndorsement
   alias VutuvWeb.Fediverse.Docs
   alias VutuvWeb.Live.InitAssigns
+  alias VutuvWeb.Live.MountHandoff
 
   # The controller embeds this LiveView with `live_render/3` (not a `live/3`
   # router route), so `VutuvWeb.Live.InitAssigns` cannot be the on_mount: it
@@ -78,7 +79,7 @@ defmodule VutuvWeb.UserProfileLive do
       # (issue #859), one of "all" / "certification" / "license". Set once here
       # so it survives the PubSub re-renders that rebuild the profile assigns.
       |> assign(:qualifications_tab, "all")
-      |> load_profile()
+      |> mount_profile()
 
     # Only a real visitor triggers the (cached, single-flight) social feed
     # fetches; the disconnected SEO pass stays a no-network render. Rebinds:
@@ -86,6 +87,43 @@ defmodule VutuvWeb.UserProfileLive do
     socket = if connected?(socket), do: request_social_feed_posts(socket), else: socket
 
     {:ok, socket}
+  end
+
+  # The dead render computes the page and stashes the result; the connected
+  # mount — moments later, same authenticated viewer — takes it and skips
+  # re-running the same ~50 queries (`VutuvWeb.Live.MountHandoff`). Any miss
+  # (anonymous viewer, expired, already consumed by an earlier connect, a
+  # reconnect after a blip or deploy) falls back to the plain full load, so
+  # the handoff is a fast path, never a requirement.
+  defp mount_profile(socket) do
+    viewer_id = socket.assigns.current_user && socket.assigns.current_user.id
+    subject = {:profile, socket.assigns.profile_user_id}
+
+    if connected?(socket) do
+      case MountHandoff.take(viewer_id, subject) do
+        {:ok, payload} -> apply_handoff(socket, payload)
+        :error -> load_profile(socket)
+      end
+    else
+      before_keys = Map.keys(socket.assigns)
+      socket = load_profile(socket)
+      # Exactly the assigns load_profile added — diffed, not listed, so an
+      # assign added to load_profile later rides the handoff automatically.
+      MountHandoff.stash(viewer_id, subject, Map.drop(socket.assigns, before_keys))
+      socket
+    end
+  end
+
+  # Apply the dead render's assigns, then recompute the two connected-only
+  # slices the dead pass deliberately left cold: the social-feed card reads
+  # the ETS cache (no network, no DB) and the code-stats card asks for its
+  # background refresh — the same calls load_profile would have made on a
+  # connected socket, working off the payload's preloaded user.
+  defp apply_handoff(socket, payload) do
+    socket
+    |> assign(payload)
+    |> put_social_feed_assigns(payload.user)
+    |> put_code_stats_assigns(payload.user)
   end
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.200.6",
+      version: "7.200.7",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/query_counter.ex
+++ b/test/support/query_counter.ex
@@ -46,4 +46,47 @@ defmodule Vutuv.QueryCounter do
       0 -> acc
     end
   end
+
+  @doc """
+  Like `count_queries/1` but counting queries from EVERY process, not only the
+  caller — for asserting what a LiveView's *connected mount* ran: its queries
+  execute in the view process and in Ecto's parallel-preload tasks, which the
+  caller-filtered counter deliberately ignores. Run `get/2` first (the dead
+  render), then count `live(conn)` (the connect) inside `fun`.
+
+  Only meaningful in a **sync** (`async: false`) test module: an async
+  neighbour's queries would land in the window too.
+  """
+  def count_queries_global(fun) do
+    parent = self()
+    ref = make_ref()
+    handler_id = {__MODULE__, ref}
+
+    :telemetry.attach(
+      handler_id,
+      [:vutuv, :repo, :query],
+      fn _event, _measurements, _metadata, _config ->
+        send(parent, {ref, :query})
+      end,
+      nil
+    )
+
+    try do
+      result = fun.()
+      {result, drain_queries_settled(ref, 0)}
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  # Other processes' telemetry sends may still be in flight when `fun`
+  # returns, so unlike the same-process drain this one waits a beat before
+  # concluding the stream is dry.
+  defp drain_queries_settled(ref, acc) do
+    receive do
+      {^ref, :query} -> drain_queries_settled(ref, acc + 1)
+    after
+      100 -> acc
+    end
+  end
 end

--- a/test/vutuv_web/live/mount_handoff_test.exs
+++ b/test/vutuv_web/live/mount_handoff_test.exs
@@ -1,0 +1,72 @@
+defmodule VutuvWeb.Live.MountHandoffTest do
+  @moduledoc """
+  The single-use dead-render → socket-mount handoff store. Entries are keyed
+  by the *authenticated* viewer plus a subject, consumed on first take and
+  expired after a short TTL, so this can never behave like a general cache:
+  no reuse, no cross-viewer reads, no invalidation logic to get wrong.
+
+  The table is global (a named ETS table), but every test here keys with ids
+  minted per test (UUIDv7), so async modules cannot collide on entries.
+  """
+  use ExUnit.Case, async: true
+
+  alias VutuvWeb.Live.MountHandoff
+
+  defp uid, do: Vutuv.UUIDv7.generate()
+
+  test "a stashed payload is taken exactly once" do
+    viewer = uid()
+    payload = %{posts: [:a, :b], totals: %{jobs: 3}}
+
+    assert :ok = MountHandoff.stash(viewer, {:profile, "p1"}, payload)
+    assert {:ok, ^payload} = MountHandoff.take(viewer, {:profile, "p1"})
+
+    # Single-use: the first take consumed it (a reconnect must full-load).
+    assert :error = MountHandoff.take(viewer, {:profile, "p1"})
+  end
+
+  test "another viewer's key never sees the entry, and does not consume it" do
+    viewer = uid()
+    other = uid()
+
+    :ok = MountHandoff.stash(viewer, :feed, %{entries: []})
+
+    assert :error = MountHandoff.take(other, :feed)
+    assert {:ok, %{entries: []}} = MountHandoff.take(viewer, :feed)
+  end
+
+  test "the same viewer's different subjects are separate entries" do
+    viewer = uid()
+
+    :ok = MountHandoff.stash(viewer, :feed, %{entries: [:feed]})
+    :ok = MountHandoff.stash(viewer, {:profile, "p1"}, %{posts: [:profile]})
+
+    assert {:ok, %{posts: [:profile]}} = MountHandoff.take(viewer, {:profile, "p1"})
+    assert {:ok, %{entries: [:feed]}} = MountHandoff.take(viewer, :feed)
+  end
+
+  test "an expired entry is not served" do
+    viewer = uid()
+
+    # ttl 0: expires the moment it is written (monotonic clock, so this is
+    # deterministic — no wall-clock boundary to flake on).
+    :ok = MountHandoff.stash(viewer, :feed, %{entries: []}, 0)
+
+    assert :error = MountHandoff.take(viewer, :feed)
+  end
+
+  test "an anonymous viewer is never stashed for and never takes" do
+    assert :ok = MountHandoff.stash(nil, :feed, %{entries: []})
+    assert :error = MountHandoff.take(nil, :feed)
+  end
+
+  test "a fresh stash overwrites the previous one for the same key" do
+    viewer = uid()
+
+    :ok = MountHandoff.stash(viewer, :feed, %{entries: [:old]})
+    :ok = MountHandoff.stash(viewer, :feed, %{entries: [:new]})
+
+    assert {:ok, %{entries: [:new]}} = MountHandoff.take(viewer, :feed)
+    assert :error = MountHandoff.take(viewer, :feed)
+  end
+end

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -95,6 +95,34 @@ defmodule VutuvWeb.PostFeedLiveTest do
       assert html_response(conn, 200) =~ "composer-panel"
       assert draft_queries == 1, "expected one post_drafts read per mount, got #{draft_queries}"
     end
+
+    test "the connected mount reuses the dead render's work (handoff)", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      friend = other_user()
+      insert(:follow, follower: user, followee: friend)
+      {:ok, _} = Posts.create_post(friend, %{body: "a handoff post from my friend"})
+
+      # The dead render stashes the computed page; the connect takes it. This
+      # module is sync (ConnCase default), which count_queries_global needs.
+      conn = get(conn, ~p"/feed")
+      assert html_response(conn, 200) =~ "a handoff post from my friend"
+
+      {{:ok, _view, hit_html}, hit} =
+        Vutuv.QueryCounter.count_queries_global(fn -> live(conn) end)
+
+      assert hit_html =~ "a handoff post from my friend"
+
+      # Single-use: a second connect finds the stash consumed and full-loads.
+      {{:ok, _view, miss_html}, miss} =
+        Vutuv.QueryCounter.count_queries_global(fn -> live(conn) end)
+
+      assert miss_html =~ "a handoff post from my friend"
+
+      assert hit <= 15, "handoff-hit feed connect ran #{hit} queries; the handoff was not used"
+
+      assert miss >= hit + 10,
+             "consumed-stash feed connect ran #{miss} vs hit #{hit}; full-load fallback missing?"
+    end
   end
 
   describe "mount" do

--- a/test/vutuv_web/live/user_profile_perf_test.exs
+++ b/test/vutuv_web/live/user_profile_perf_test.exs
@@ -7,6 +7,8 @@ defmodule VutuvWeb.UserProfilePerfTest do
   """
   use VutuvWeb.ConnCase
 
+  import Phoenix.LiveViewTest
+
   alias Vutuv.Posts
 
   # The action-bar engagement SELECT is the only query built from this
@@ -62,6 +64,55 @@ defmodule VutuvWeb.UserProfilePerfTest do
       )
 
     assert standalone_social_counts == 0
+  end
+
+  describe "dead-render → socket-mount handoff" do
+    # These tests count queries globally during the connect window (the
+    # LiveView process + Ecto's parallel preload tasks), so this module must
+    # stay sync (the ConnCase default) — an async neighbour's queries would
+    # land in the window.
+    test "the connected mount reuses the dead render's work", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, _} = Posts.create_post(user, %{body: "handoff post"})
+
+      # The dead render (stashes the payload)...
+      conn = get(conn, ~p"/#{user.username}")
+      assert html_response(conn, 200) =~ "handoff post"
+
+      # ...then the connect takes it: only the socket's own auth and the
+      # shell's badge queries remain.
+      {{:ok, _view, hit_html}, hit} =
+        Vutuv.QueryCounter.count_queries_global(fn -> live(conn) end)
+
+      assert hit_html =~ "handoff post"
+
+      # A second connect on the same rendered page finds the stash consumed
+      # (single-use) and must full-load — still correct, just the slow path.
+      {{:ok, _view, miss_html}, miss} =
+        Vutuv.QueryCounter.count_queries_global(fn -> live(conn) end)
+
+      assert miss_html =~ "handoff post"
+
+      assert hit <= 15, "handoff-hit connect ran #{hit} queries; the handoff was not used"
+
+      assert miss >= hit + 20,
+             "consumed-stash connect ran #{miss} vs hit #{hit}; full-load fallback missing?"
+    end
+
+    test "an anonymous visitor never uses the handoff and still full-loads", %{conn: conn} do
+      owner = insert(:user, email_confirmed?: true)
+      {:ok, _} = Posts.create_post(owner, %{body: "public post"})
+
+      conn = get(conn, ~p"/#{owner.username}")
+
+      {{:ok, _view, html}, connected} =
+        Vutuv.QueryCounter.count_queries_global(fn -> live(conn) end)
+
+      # The fallback path must really run: nothing is stashed for an
+      # anonymous viewer, so the connect loads the whole profile itself.
+      assert html =~ "public post"
+      assert connected > 20
+    end
   end
 
   test "profile query count does not grow with post count", %{conn: conn} do


### PR DESCRIPTION
The single-use **dead-render → socket-mount handoff**, third and last piece of today's perf work (#1231, #1232). Every LiveView visit computes its page twice — once for the immediate HTML, once when the socket connects and `mount/3` runs again. Even after the batching work that is ~50 queries × 2 on the profile. Now the dead render passes its finished work to the connected mount.

**`VutuvWeb.Live.MountHandoff`** (new supervision child: ETS table + expiry sweeper):
- Dead mount **stashes** the assigns it computed, keyed `{authenticated viewer id, subject}` — the key derives from server-side auth on both ends, never from client input; anonymous visitors (mostly crawlers whose socket never connects) are never stashed for.
- Connected mount **takes** (consumes) the entry and skips the reload; it recomputes only the connected-only slices (social-feed ETS reads, code-stats refresh).
- **Not a cache**: single-use (`:ets.take/2` — a reconnect full-loads), ~15s TTL with a sweeper, fail-closed (any miss = normal full load). No invalidation logic exists to get wrong.
- The feed rebuilds its stream from the payload — a consumed `LiveStream` struct must never ride a handoff (it would replay as an empty feed).

Accepted trade (discussed): changes landing in the sub-second gap between the two renders are not re-read at connect; both pages subscribe to PubSub at connect, so the next event heals the snapshot.

**Tests**: unit coverage for single-use/expiry/viewer-isolation; integration tests pin both sides — a handoff-hit connect runs ≤15 queries (global count incl. the shell) where a consumed-stash connect measurably full-loads (≥ hit+20 on the profile). Browser-smoked: profile like-toggle round trip on a handoff-hit socket, reconnect-after-disconnect renders identically on both pages.

**Deploy: cold** — the supervision tree gains the table owner (no migration).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01EzdmtAyM4w2v67JgZso8cB