### PR TITLE
The composer drops the book and film review form; review posts keep their card (v7.201.0)

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -132,7 +132,7 @@ Everything else has a default (the vutuv.de production value):
 | `FEDIVERSE_MAX_REMOTE_FOLLOWS` | `1000` | How many accounts on other networks one member may follow in total. Every accepted follow is a standing invitation for that server to deliver here, so this is the ceiling on how much inbound traffic one member can subscribe your installation to. Raise it for a small, trusted installation; lower it if inbound volume is the concern |
 | `FEDIVERSE_IMAGE_HOLD_SECONDS` | `90` | How long a post whose picture the AI image scan has not judged yet waits before it federates **without** the picture. This is a ceiling, not the usual wait: the post goes out the moment the scan settles, normally within seconds. It only bites when the scanner is down, and then the choice is "the post without its picture" over "no post at all". Raise it if you run image moderation on slow hardware; irrelevant when `MODERATE_IMAGES` is off |
 | `ACCOUNT_EVENT_RETENTION_DAYS` | `365` | How long the **account-activity log** keeps an event, in days (see `docs/architecture/account-activity.md`). It records what changed on an account, when, from which coarse device (never an IP address), and how it was confirmed, so it is personal data with a clock on it: a year covers the "this happened months ago and I only noticed now" support case without becoming a permanent movement profile. The daily sweeper deletes anything older |
-| `FETCH_BOOK_METADATA` | `true` | `false` turns the catalogue lookups behind post **book reviews** off (the composer's ISBN → title/author/year prefill, the cover image, page count and publisher from Open Library, and an audiobook's running time). The review feature itself keeps working — members type the fields by hand and the card renders without a cover or those details. Set it on installations that must not call out (intranets) |
+| `FETCH_BOOK_METADATA` | `true` | `false` turns the catalogue lookups behind post **book reviews** off (the cover image, page count and publisher from Open Library, and an audiobook's running time). New reviews can no longer be created (the composer's review form was removed), but existing review posts keep rendering their card — with the flag off it shows no cover and none of those details. Set it on installations that must not call out (intranets) |
 | `DNB_SRU_URL` | `https://services.dnb.de/sru/dnb` | Where an **audiobook's running time** is looked up by ISBN: an SRU endpoint answering MARC21-xml (the Deutsche Nationalbibliothek by default — Open Library records no durations). Point it at another catalogue's SRU endpoint, or set it **empty** (`DNB_SRU_URL=`) to switch that one lookup off while the rest of the book metadata keeps working |
 | `AMAZON_DOMAIN` | `www.amazon.de` | The store a book review card's shop link points at (`https://<domain>/dp/<isbn10>`). Set your regional store (`www.amazon.com`, …) — or an **empty** value (`AMAZON_DOMAIN=`) to remove the shop link entirely |
 | `AMAZON_AFFILIATE_TAG` | – | Optional Amazon affiliate tag appended to book review shop links as `?tag=` |
@@ -324,11 +324,11 @@ vutuv runs fine without internet access:
   `:generate_screenshots` (profile link-preview screenshots **and** the
   auto-screenshot for single-link posts — these fetch the linked page and run
   headless Chromium).
-- Set `FETCH_BOOK_METADATA=false`: the book-review ISBN lookup, the cover
-  fetch and the page-count/publisher lookup call Open Library, and an
-  audiobook's running time is read from a library catalogue (`DNB_SRU_URL`).
-  Book and film reviews keep working — the fields are typed by hand and the
-  card renders without a cover and without those details.
+- Set `FETCH_BOOK_METADATA=false`: the cover fetch and the
+  page-count/publisher lookup behind book-review posts call Open Library, and
+  an audiobook's running time is read from a library catalogue (`DNB_SRU_URL`).
+  Existing book and film review posts keep rendering — the card just shows no
+  cover and none of those details.
 - AI image moderation works **fully offline** — Ollama is local inference, no
   cloud involved. Install Ollama on the server, pull the vision model once
   while you still have internet access (`ollama pull qwen3-vl:8b`), and keep
@@ -426,7 +426,8 @@ Worth knowing as an operator:
 - **Your call, your risk.** Whether that quotation argument holds in your
   jurisdiction is your decision as the operator, not vutuv's. If you would
   rather not host third-party covers at all, set `FETCH_BOOK_METADATA=false`:
-  reviews keep working and the card renders a neutral 📖/🎬 tile instead.
+  existing reviews keep rendering and the card shows a neutral 📖/🎬 tile
+  instead.
 
 Note: `bin/vutuv eval` is the supported console entry point; `rpc`/`remote`
 need distribution, which the reference setup disables.

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -346,11 +346,12 @@ back when it opens.
 member per *composer context* — three partial unique indexes enforce that:
 at most one new-post draft, at most one per post being answered, at most one
 per remote reply being answered. The row mirrors the composer's own fields
-rather than a post: `body` and `tags` are the raw strings in the form, `review`
-is the book/film panel's values, `photos` the per-photo alt/caption/switch
-panel, and `image_ids` names the still-pending `post_images` rows in the
-author's order (the first photo leads the mosaic, so the order **is** the
-layout, which is why it is an array and not a join table).
+rather than a post: `body` and `tags` are the raw strings in the form, `photos`
+the per-photo alt/caption/switch panel, and `image_ids` names the still-pending
+`post_images` rows in the author's order (the first photo leads the mosaic, so
+the order **is** the layout, which is why it is an array and not a join table).
+The `review` column (the retired book/film panel's values) is unused since the
+review form went and gets dropped in a later deploy, like `mode`.
 
 **When it is written.** From every handler that changes the content, debounced
 through `send_update_after/3` to the component itself — so no host LiveView
@@ -686,8 +687,7 @@ single photo it was two dead arrows plus a ⚙ the picture-tap covers. What
 remains on the tile: a remove dot top-right and the crop dot bottom-center.
 Reordering is **pointer drag on the tile itself** — mouse and touch alike
 (hold a tile briefly on touch to lift it; the ◀ ▶ arrow dots that used to be
-the touch path are gone, on Stefan's ask). The book/film review triggers are
-always available (a book review may well carry a photo of the book); the
+the touch path are gone, on Stefan's ask). The
 licence and download pair folds behind the **"Photo details" row** (see
 below). The cover badge appears only from the second photo on, and the amber
 ALT nudge only while a photo has **neither** caption nor alt.
@@ -991,10 +991,13 @@ changes) and an optional `medium` (book:
 print/ebook/audiobook,
 movie: cinema/streaming/disc — "I listened to the audiobook"). The body stays
 plain Markdown; *"this post is a book review"* is simply *"the post has a
-review row"*, never body parsing. The composer's 📖/🎬 triggers open the panel;
-the hidden `kind` field always submits, so closing the panel deletes a stored
-review on save, while attrs without a `:review` key (the API's partial PATCH)
-leave it untouched.
+review row"*, never body parsing. **The composer's review form (the 📖/🎬
+triggers, the panel, the ISBN prefill lookup) was removed 2026-07-30** — no
+new reviews can be created from the UI, but every stored review keeps
+rendering, and the cover/edition background pass keeps serving existing cards.
+The changeset seam is what makes that safe: attrs without a `:review` key
+leave a stored review untouched, which is exactly what the composer's edit
+path now submits.
 
 Every surface that renders the post adds the **review card**
 (`VutuvWeb.PostComponents.review_card/1`). It reads top to bottom the way a

--- a/lib/vutuv/book_metadata.ex
+++ b/lib/vutuv/book_metadata.ex
@@ -1,16 +1,13 @@
 defmodule Vutuv.BookMetadata do
   @moduledoc """
-  ISBN → book facts from Open Library's keyless APIs (no auth, no account),
-  in two flavours for two callers:
+  ISBN → book facts from Open Library's keyless APIs (no auth, no account).
 
-    * `lookup/1` — one request to the books API, the **composer's** review
-      panel prefills its form from it (title, author, year); the author can
-      overwrite everything.
-    * `edition_details/1` — the *edition* record, which is where Open Library
-      actually keeps `number_of_pages` and the publisher (the books API often
-      answers without them). `Vutuv.Posts.ReviewCovers` stores those two on
-      the review while it fetches the cover, since the form has no field for
-      them.
+  `edition_details/1` reads the *edition* record, which is where Open Library
+  keeps `number_of_pages` and the publisher. `Vutuv.Posts.ReviewCovers` stores
+  those two on a review sidecar (`Vutuv.Posts.PostReview`) while it fetches the
+  cover — the background pass that keeps existing review posts' cards complete.
+  (The composer's review form, whose ISBN lookup used to prefill title, author
+  and year from the books API, was removed 2026-07-30.)
 
   An edition with no page count of its own — an audiobook, a scan — borrows
   the count from the **other editions of the same work**: a reader asking how
@@ -18,8 +15,7 @@ defmodule Vutuv.BookMetadata do
   say "190 pages" and mark it as the print edition's.
 
   An installation with `:fetch_book_metadata` off (air-gapped intranets)
-  types the fields by hand; the lookup button then never renders and nothing
-  is fetched. Tests stub HTTP via `:book_metadata_req_options` (a `plug:`
+  fetches nothing. Tests stub HTTP via `:book_metadata_req_options` (a `plug:`
   seam, like the social-feed clients).
   """
 
@@ -40,15 +36,6 @@ defmodule Vutuv.BookMetadata do
   def enabled?, do: Application.get_env(:vutuv, :fetch_book_metadata, true)
 
   @doc """
-  Looks the normalized ISBN-13 up on Open Library's books API. Returns
-  `{:ok, %{title: …, creator: …, year: …}}` (each value may be nil except
-  the title) or `:error` (unknown ISBN, network trouble, flag off).
-  """
-  def lookup(isbn) when is_binary(isbn) do
-    if enabled?(), do: request(isbn), else: :error
-  end
-
-  @doc """
   The edition facts behind an ISBN: `{:ok, %{pages: …, publisher: …}}`, both
   possibly nil, or `:error` (unknown ISBN, network trouble, flag off).
 
@@ -59,32 +46,6 @@ defmodule Vutuv.BookMetadata do
   def edition_details(isbn) when is_binary(isbn) do
     if enabled?(), do: fetch_edition(isbn), else: :error
   end
-
-  defp request(isbn) do
-    [
-      url: "https://openlibrary.org/api/books",
-      params: [bibkeys: "ISBN:#{isbn}", format: "json", jscmd: "data"],
-      receive_timeout: 5_000,
-      retry: false
-    ]
-    |> Keyword.merge(Application.get_env(:vutuv, @req_options_key, []))
-    |> Req.get()
-    |> case do
-      {:ok, %Req.Response{status: 200, body: %{} = body}} -> parse(body["ISBN:#{isbn}"])
-      _other -> :error
-    end
-  end
-
-  defp parse(%{"title" => title} = data) when is_binary(title) and title != "" do
-    {:ok,
-     %{
-       title: title,
-       creator: authors(data["authors"]),
-       year: year(data["publish_date"])
-     }}
-  end
-
-  defp parse(_missing), do: :error
 
   defp fetch_edition(isbn) do
     case get_json("https://openlibrary.org/isbn/#{isbn}.json") do
@@ -127,9 +88,7 @@ defmodule Vutuv.BookMetadata do
 
   # The background pass can afford to wait (and to try again): it runs off the
   # request path, and a lookup lost to one slow answer leaves the card
-  # silently without its facts until somebody edits the post. The composer's
-  # `lookup/1` above keeps its short, no-retry budget — a member is watching
-  # that one.
+  # silently without its facts until somebody edits the post.
   defp get_json(url) do
     [url: url, receive_timeout: 15_000, retry: :transient, max_retries: 1]
     |> Keyword.merge(Application.get_env(:vutuv, @req_options_key, []))
@@ -139,15 +98,6 @@ defmodule Vutuv.BookMetadata do
       _other -> :error
     end
   end
-
-  defp authors(authors) when is_list(authors) do
-    case authors |> Enum.map(& &1["name"]) |> Enum.reject(&(&1 in [nil, ""])) do
-      [] -> nil
-      names -> Enum.join(names, ", ")
-    end
-  end
-
-  defp authors(_other), do: nil
 
   # Open Library lists an edition's publishers as plain strings (the edition
   # record) or as `%{"name" => …}` maps (the books API); the card names the
@@ -170,16 +120,4 @@ defmodule Vutuv.BookMetadata do
 
   defp pages(count) when is_integer(count) and count > 0 and count <= @pages_max, do: count
   defp pages(_other), do: nil
-
-  # publish_date is free text ("March 2009", "1998"): the year is enough.
-  defp year(date) when is_binary(date) do
-    with [year] <- Regex.run(~r/\b(1\d{3}|2\d{3})\b/, date, capture: :first),
-         {int, ""} <- Integer.parse(year) do
-      int
-    else
-      _ -> nil
-    end
-  end
-
-  defp year(_other), do: nil
 end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -3742,7 +3742,7 @@ defmodule Vutuv.Posts do
         |> Repo.insert(
           on_conflict:
             {:replace,
-             [:body, :tags, :license, :review, :image_ids, :photos, :layout, :fill?, :updated_at]},
+             [:body, :tags, :license, :image_ids, :photos, :layout, :fill?, :updated_at]},
           conflict_target: draft_conflict_target(context)
         )
         |> case do

--- a/lib/vutuv/posts/post_draft.ex
+++ b/lib/vutuv/posts/post_draft.ex
@@ -9,10 +9,10 @@ defmodule Vutuv.Posts.PostDraft do
   the way is gone, since there is no longer anything to warn about.
 
   The row mirrors the composer's own fields, not a post: `body` and `tags` are
-  the raw, unparsed strings the form holds (tags become real tags on save), the
-  `review` map is the book/film panel's form values, and `image_ids` names the
-  still-pending `post_images` rows in the author's chosen order — the first one
-  leads the mosaic, so the order is the layout and an array keeps it.
+  the raw, unparsed strings the form holds (tags become real tags on save), and
+  `image_ids` names the still-pending `post_images` rows in the author's chosen
+  order — the first one leads the mosaic, so the order is the layout and an
+  array keeps it.
 
   **A draft belongs to a composer context**, carried by the two nullable
   references: all nil is the feed's new-post composer, `parent_id` is a reply to
@@ -29,8 +29,8 @@ defmodule Vutuv.Posts.PostDraft do
   Nothing here is trusted on restore. `Vutuv.Posts.pending_images/2` re-checks
   every image id against the author's own unattached rows, so a stale or
   tampered list can neither steal a photo nor bring a removed one back, and the
-  post changeset validates body, tags and review on save exactly as it does for
-  a composer that was never reloaded.
+  post changeset validates body and tags on save exactly as it does for a
+  composer that was never reloaded.
   """
 
   use VutuvWeb, :model
@@ -41,9 +41,10 @@ defmodule Vutuv.Posts.PostDraft do
   # field is raw text the member types, not the parsed tag list.
   @max_tags_length 2_000
 
-  # The `mode` column of the composer's retired Text/Fotos tabs still exists
-  # in the table (it has a DB default, so inserts stay fine); it is unused
-  # since the tabs went and gets dropped in a later deploy (N-1 rule).
+  # Two retired columns still exist in the table (both have DB defaults, so
+  # inserts stay fine) and get dropped in a later deploy (N-1 rule): `mode`
+  # (the composer's retired Text/Fotos tabs) and `review` (the retired
+  # book/film review panel's form values).
   schema "post_drafts" do
     belongs_to(:user, Vutuv.Accounts.User)
     belongs_to(:parent, Post)
@@ -52,7 +53,6 @@ defmodule Vutuv.Posts.PostDraft do
     field(:body, :string, default: "")
     field(:tags, :string, default: "")
     field(:license, :string)
-    field(:review, :map, default: %{})
     field(:image_ids, {:array, :binary_id}, default: [])
     field(:photos, :map, default: %{})
     # The chosen bento arrangement (Vutuv.Posts.GalleryLayout); nil = auto.
@@ -76,7 +76,7 @@ defmodule Vutuv.Posts.PostDraft do
   """
   def changeset(draft, attrs) do
     draft
-    |> cast(attrs, [:body, :tags, :license, :review, :image_ids, :photos, :layout, :fill?])
+    |> cast(attrs, [:body, :tags, :license, :image_ids, :photos, :layout, :fill?])
     |> validate_length(:body, max: Post.max_body_length())
     |> validate_length(:tags, max: @max_tags_length)
   end
@@ -87,11 +87,6 @@ defmodule Vutuv.Posts.PostDraft do
   @doc "Whether this draft holds anything worth restoring."
   def any_content?(%__MODULE__{} = draft) do
     String.trim(draft.body) != "" or String.trim(draft.tags) != "" or
-      draft.image_ids != [] or review_kind(draft) != ""
+      draft.image_ids != []
   end
-
-  defp review_kind(%__MODULE__{review: review}) when is_map(review),
-    do: Map.get(review, "kind", "")
-
-  defp review_kind(_draft), do: ""
 end

--- a/lib/vutuv_web/live/post_live/composer.ex
+++ b/lib/vutuv_web/live/post_live/composer.ex
@@ -54,7 +54,6 @@ defmodule VutuvWeb.PostLive.Composer do
 
   use VutuvWeb, :live_component
 
-  alias Vutuv.BookMetadata
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Posts
@@ -63,23 +62,11 @@ defmodule VutuvWeb.PostLive.Composer do
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostDraft
   alias Vutuv.Posts.PostImage
-  alias Vutuv.Posts.PostReview
   alias Vutuv.Uploads.Spec
   alias VutuvWeb.ErrorHelpers
   alias VutuvWeb.PostComponents
 
   @presets ~w(public followers connections only_me custom)
-
-  # The review panel's form values, kept as a plain string-keyed map (the
-  # panel inputs are plain form fields; the changeset runs on save).
-  @empty_review %{
-    "kind" => "",
-    "identifier" => "",
-    "title" => "",
-    "creator" => "",
-    "year" => "",
-    "medium" => ""
-  }
 
   # The debounced autosave firing (issue #1148): `schedule_draft_save/1` sends
   # this to the component itself via `send_update_after/3`, so the write happens
@@ -144,8 +131,6 @@ defmodule VutuvWeb.PostLive.Composer do
     # edit — the fold names the answers in force, and a reconnect that resets
     # the flag hides no data (the values live in assigns and the draft).
     |> assign(:photo_details_open?, false)
-    |> assign(:review, review_values(post))
-    |> assign(:review_lookup_error, nil)
     |> assign(:tags_value, tags_value(post))
     |> assign(:images, images)
     # The per-photo settings the composer is editing (issue #1104), keyed by
@@ -244,7 +229,6 @@ defmodule VutuvWeb.PostLive.Composer do
       socket
       |> assign(:body, draft.body)
       |> assign(:tags_value, draft.tags)
-      |> assign(:review, Map.merge(@empty_review, Map.take(draft.review, review_keys())))
       |> assign(:images, images)
       |> assign(:photos, photo_state_from_draft(draft, images))
       |> assign(:license, PhotoLicense.cast(draft.license || assigns.license))
@@ -287,10 +271,6 @@ defmodule VutuvWeb.PostLive.Composer do
 
   defp photo_state_from_draft(_draft, images), do: photo_state(images)
 
-  # The review panel's own field names, so a stored map cannot smuggle extra
-  # keys into the assign the form and the save path read.
-  defp review_keys, do: Map.keys(@empty_review)
-
   # Queues one autosave. Called from every handler that changes what the
   # composer is holding; the flag collapses a burst into a single write.
   defp schedule_draft_save(socket) do
@@ -323,7 +303,6 @@ defmodule VutuvWeb.PostLive.Composer do
         "body" => assigns.body,
         "tags" => assigns.tags_value,
         "license" => assigns.license,
-        "review" => assigns.review,
         "image_ids" => Enum.map(assigns.images, & &1.id),
         "photos" => Map.new(assigns.photos, fn {id, settings} -> {id, stringify(settings)} end),
         "layout" => assigns.layout,
@@ -527,21 +506,6 @@ defmodule VutuvWeb.PostLive.Composer do
 
   defp stringify(settings), do: Map.new(settings, fn {key, value} -> {to_string(key), value} end)
 
-  # Edit mode prefills the panel from the stored review; the panel is open
-  # exactly when a kind is set.
-  defp review_values(%Post{review: %PostReview{} = review}) do
-    %{
-      "kind" => review.kind,
-      "identifier" => review.identifier || "",
-      "title" => review.title || "",
-      "creator" => review.creator || "",
-      "year" => if(review.year, do: Integer.to_string(review.year), else: ""),
-      "medium" => review.medium || ""
-    }
-  end
-
-  defp review_values(_post), do: @empty_review
-
   # Edit mode: recognize the quick presets in the stored denials; anything
   # else (including a lone "non_followees", which no longer has its own preset)
   # is a custom audience.
@@ -586,7 +550,6 @@ defmodule VutuvWeb.PostLive.Composer do
       |> assign(:body, body)
       |> assign(:tags_value, params["tags"] || socket.assigns.tags_value)
       |> assign(:license, PhotoLicense.cast(params["license"] || socket.assigns.license))
-      |> assign(:review, Map.merge(socket.assigns.review, params["review"] || %{}))
       |> assign(:preset, resolve_preset(params, socket.assigns))
       |> assign(:error, nil)
       # The restore notice has said its piece once the member starts editing;
@@ -634,57 +597,6 @@ defmodule VutuvWeb.PostLive.Composer do
   def handle_event("undeny-user", %{"id" => id}, socket) do
     {:noreply,
      assign(socket, :denied_users, Enum.reject(socket.assigns.denied_users, &(&1.id == id)))}
-  end
-
-  # The 📖/🎬 buttons open the review panel with that kind; the panel's ✕
-  # sets it back to "" (which deletes a stored review on save). The other
-  # field values survive a toggle, so an accidental close loses nothing.
-  def handle_event("review-kind", %{"kind" => kind}, socket) do
-    if kind in ["" | PostReview.kinds()] do
-      # The medium is per-kind (audiobook vs. cinema), so it resets on a
-      # switch; every other field survives an accidental toggle.
-      review = %{socket.assigns.review | "kind" => kind, "medium" => ""}
-
-      {:noreply,
-       socket
-       |> assign(:review, review)
-       |> assign(:review_lookup_error, nil)
-       |> schedule_draft_save()}
-    else
-      {:noreply, socket}
-    end
-  end
-
-  # The ISBN lookup (book panel only, rendered only with :fetch_book_metadata
-  # on): prefills title/creator/year from Open Library. Everything stays
-  # editable — the lookup is convenience, not truth.
-  def handle_event("review-lookup", _params, socket) do
-    review = socket.assigns.review
-
-    with {:ok, isbn} <- Vutuv.Isbn.normalize(review["identifier"] || ""),
-         {:ok, data} <- BookMetadata.lookup(isbn) do
-      filled =
-        Map.merge(review, %{
-          "identifier" => isbn,
-          "title" => data.title,
-          "creator" => data.creator || review["creator"],
-          "year" => if(data.year, do: Integer.to_string(data.year), else: review["year"])
-        })
-
-      {:noreply,
-       socket
-       |> assign(:review, filled)
-       |> assign(:review_lookup_error, nil)
-       |> schedule_draft_save()}
-    else
-      :error ->
-        {:noreply,
-         assign(
-           socket,
-           :review_lookup_error,
-           gettext("Nothing found for this ISBN. Please fill in the fields yourself.")
-         )}
-    end
   end
 
   def handle_event("insert-inline", %{"id" => id}, socket) do
@@ -904,9 +816,8 @@ defmodule VutuvWeb.PostLive.Composer do
       body: params["body"] || "",
       tags: params["tags"] || "",
       license: params["license"] || socket.assigns.license,
-      # The submitted panel fields are the truth; with the panel closed only
-      # the hidden kind ("") arrives, which removes a stored review on save.
-      review: params["review"] || %{"kind" => ""},
+      # No :review key on purpose: the review form is gone, and attrs without
+      # the key leave a post's stored review sidecar untouched on edit.
       denials: denials_payload(socket.assigns),
       image_ids: Enum.map(socket.assigns.images, & &1.id),
       # Event-driven like the person denials (the chips are buttons, not form
@@ -1068,8 +979,6 @@ defmodule VutuvWeb.PostLive.Composer do
     socket
     |> assign(:body, opening_body)
     |> assign(:tags_value, "")
-    |> assign(:review, @empty_review)
-    |> assign(:review_lookup_error, nil)
     |> assign(:images, [])
     |> assign(:photos, %{})
     |> assign(:open_photo, nil)
@@ -1265,8 +1174,8 @@ defmodule VutuvWeb.PostLive.Composer do
   # `%{handles}` becomes the actual handle) rather than dumping the raw msgid
   # prefixed with the field atom ("body mentions a handle …: %{handles}"). Each
   # message is now a self-contained sentence, so the field name is dropped.
-  # traverse_errors walks nested changesets too, so a review-field error (an
-  # invalid ISBN, say) surfaces instead of failing silently.
+  # traverse_errors walks nested changesets too, so an error on an embedded
+  # association surfaces instead of failing silently.
   defp changeset_message(changeset) do
     changeset
     |> Ecto.Changeset.traverse_errors(&ErrorHelpers.translate_error/1)
@@ -1825,114 +1734,10 @@ defmodule VutuvWeb.PostLive.Composer do
             class="mt-3"
           />
 
-          <%!-- The review sidecar (book/film review, Vutuv.Posts.PostReview).
-          The hidden kind always submits — closing the panel deletes a stored
-          review on save; the panel fields join it while open. --%>
-          <input type="hidden" name="post[review][kind]" value={@review["kind"]} />
-
           <%!-- The attached photos as data: form recovery replays these ids
           after a reconnect, and `adopt_recovered_images/2` re-adopts the
           pending rows the re-mount dropped from socket state. --%>
           <input :for={image <- @images} type="hidden" name="post[image_ids][]" value={image.id} />
-
-          <div
-            :if={@review["kind"] != ""}
-            id={"#{@id}-review-panel"}
-            class="mt-4 rounded-xl bg-slate-50 p-4 ring-1 ring-slate-200 dark:bg-slate-800/50 dark:ring-slate-700"
-          >
-            <div class="flex items-center justify-between gap-3">
-              <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">
-                {if @review["kind"] == "movie",
-                  do: "🎬 " <> gettext("Film review"),
-                  else: "📖 " <> gettext("Book review")}
-              </h3>
-              <button
-                type="button"
-                phx-click="review-kind"
-                phx-value-kind=""
-                phx-target={@myself}
-                class="text-sm font-semibold text-slate-500 hover:text-red-600 dark:text-slate-400"
-              >
-                ✕ {gettext("Remove review")}
-              </button>
-            </div>
-
-            <div class="mt-3 flex gap-2">
-              <input
-                type="text"
-                name="post[review][identifier]"
-                value={@review["identifier"]}
-                placeholder={
-                  if @review["kind"] == "movie",
-                    do: gettext("IMDb link or ID"),
-                    else: gettext("ISBN")
-                }
-                class={[input_class(), "flex-1"]}
-              />
-              <button
-                :if={@review["kind"] == "book" and BookMetadata.enabled?()}
-                type="button"
-                id={"#{@id}-review-lookup"}
-                phx-click="review-lookup"
-                phx-target={@myself}
-                phx-disable-with={gettext("Looking up…")}
-                class="shrink-0 rounded-lg bg-slate-100 px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-              >
-                {gettext("Look up")}
-              </button>
-            </div>
-            <p :if={@review_lookup_error} class="mt-1 text-sm text-red-600">
-              {@review_lookup_error}
-            </p>
-
-            <div class="mt-3 grid gap-3 sm:grid-cols-2">
-              <input
-                type="text"
-                name="post[review][title]"
-                value={@review["title"]}
-                placeholder={gettext("Title")}
-                class={input_class()}
-              />
-              <input
-                type="text"
-                name="post[review][creator]"
-                value={@review["creator"]}
-                placeholder={
-                  if @review["kind"] == "movie", do: gettext("Director"), else: gettext("Author(s)")
-                }
-                class={input_class()}
-              />
-            </div>
-
-            <div class="mt-3 grid gap-3 sm:grid-cols-2">
-              <input
-                type="text"
-                name="post[review][year]"
-                value={@review["year"]}
-                inputmode="numeric"
-                placeholder={gettext("Year")}
-                class={input_class()}
-              />
-              <select name="post[review][medium]" class={input_class()}>
-                <option value="">
-                  {if @review["kind"] == "movie",
-                    do: gettext("Watched as… (optional)"),
-                    else: gettext("Read as… (optional)")}
-                </option>
-                <option
-                  :for={medium <- PostReview.media(@review["kind"])}
-                  value={medium}
-                  selected={@review["medium"] == medium}
-                >
-                  {PostComponents.review_medium_label(medium)}
-                </option>
-              </select>
-            </div>
-
-            <p :if={@review["kind"] == "book"} class="mt-2 text-xs text-slate-600 dark:text-slate-400">
-              {gettext("With an ISBN, the post shows the book cover and a shop link automatically.")}
-            </p>
-          </div>
 
           <%!-- Bottom row: the photo picker on the left (once photos are
           attached, the grid's add tile takes over — exactly one upload input
@@ -1955,33 +1760,6 @@ defmodule VutuvWeb.PostLive.Composer do
               📷 {gettext("Add photos")}
               <.live_file_input upload={@uploads.images} class="sr-only" />
             </label>
-
-            <%!-- Review triggers: open the book/film review panel. Emoji-only
-            on phones (the row is tight there), labeled from sm up. --%>
-            <button
-              :if={@review["kind"] == ""}
-              type="button"
-              phx-click="review-kind"
-              phx-value-kind="book"
-              phx-target={@myself}
-              title={gettext("Review a book")}
-              aria-label={gettext("Review a book")}
-              class="inline-flex h-9 items-center gap-1.5 rounded-lg bg-slate-100 px-3 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-            >
-              📖<span class="hidden sm:inline">{gettext("Book")}</span>
-            </button>
-            <button
-              :if={@review["kind"] == ""}
-              type="button"
-              phx-click="review-kind"
-              phx-value-kind="movie"
-              phx-target={@myself}
-              title={gettext("Review a film")}
-              aria-label={gettext("Review a film")}
-              class="inline-flex h-9 items-center gap-1.5 rounded-lg bg-slate-100 px-3 text-sm font-semibold text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-            >
-              🎬<span class="hidden sm:inline">{gettext("Film")}</span>
-            </button>
 
             <div class="ml-auto flex items-center gap-3">
               <span

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.200.7",
+      version: "7.201.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -35,7 +35,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1373
+#: lib/vutuv_web/templates/user/show.html.heex:1376
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -98,7 +98,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/agent_docs/markdown.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/templates/user/show.html.heex:1006
+#: lib/vutuv_web/templates/user/show.html.heex:1009
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
@@ -111,7 +111,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/live/job_posting_live/form.ex:605
 #: lib/vutuv_web/live/organization_live/edit.ex:347
 #: lib/vutuv_web/live/organization_live/new.ex:173
-#: lib/vutuv_web/live/post_live/composer.ex:1429
+#: lib/vutuv_web/live/post_live/composer.ex:1350
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -146,7 +146,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1044
+#: lib/vutuv_web/templates/user/show.html.heex:1047
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -196,7 +196,7 @@ msgid "Disable"
 msgstr "Inaktivieren"
 
 #: lib/vutuv_web/live/cv_live.ex:439
-#: lib/vutuv_web/live/post_live/composer.ex:1753
+#: lib/vutuv_web/live/post_live/composer.ex:1674
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:303
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -218,7 +218,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1029
+#: lib/vutuv_web/templates/user/show.html.heex:1032
 #, elixir-autogen
 msgid "Edit"
 msgstr "Ändern"
@@ -295,7 +295,7 @@ msgstr "Nachname eingeben"
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:556
+#: lib/vutuv_web/templates/user/show.html.heex:559
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -340,7 +340,7 @@ msgstr "Follower"
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:837
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
@@ -355,7 +355,7 @@ msgstr "Folge ich"
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:67
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:1001
+#: lib/vutuv_web/templates/user/show.html.heex:1004
 #: lib/vutuv_web/views/account_event_text.ex:153
 #, elixir-autogen
 msgid "Gender"
@@ -616,7 +616,7 @@ msgstr "Profile von "
 msgid "Provider"
 msgstr "Provider"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1981
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -626,7 +626,7 @@ msgstr "Öffentlich"
 
 #: lib/vutuv_web/components/ui.ex:3041
 #: lib/vutuv_web/live/organization_live/edit.ex:341
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:105
@@ -696,13 +696,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1157
+#: lib/vutuv_web/templates/user/show.html.heex:1160
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1159
+#: lib/vutuv_web/templates/user/show.html.heex:1162
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -857,8 +857,8 @@ msgid "vCard"
 msgstr "vCard"
 
 #: lib/vutuv_web/components/ui.ex:3206
-#: lib/vutuv_web/templates/user/show.html.heex:828
-#: lib/vutuv_web/templates/user/show.html.heex:848
+#: lib/vutuv_web/templates/user/show.html.heex:831
+#: lib/vutuv_web/templates/user/show.html.heex:851
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
@@ -1084,7 +1084,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:990
+#: lib/vutuv_web/templates/user/show.html.heex:993
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1275,7 +1275,7 @@ msgstr "Alle Tag-URLs"
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:550
+#: lib/vutuv_web/templates/user/show.html.heex:553
 #, elixir-autogen
 msgid "All tags"
 msgstr "Alle Tags"
@@ -1477,7 +1477,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:520
+#: lib/vutuv_web/templates/user/show.html.heex:523
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1705,9 +1705,9 @@ msgstr "Schauen Sie in Ihr Postfach"
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1390
-#: lib/vutuv_web/live/post_live/composer.ex:1391
-#: lib/vutuv_web/live/post_live/composer.ex:2423
+#: lib/vutuv_web/live/post_live/composer.ex:1311
+#: lib/vutuv_web/live/post_live/composer.ex:1312
+#: lib/vutuv_web/live/post_live/composer.ex:2213
 #: lib/vutuv_web/templates/layout/app.html.heex:155
 #: lib/vutuv_web/templates/layout/app.html.heex:161
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1775,8 +1775,8 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/live/fediverse_account_live.ex:380
 #: lib/vutuv_web/live/fediverse_following_live.ex:287
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:403
-#: lib/vutuv_web/templates/user/show.html.heex:945
-#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:948
+#: lib/vutuv_web/templates/user/show.html.heex:1200
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1952,7 +1952,7 @@ msgstr ""
 "Wir haben eine PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie sie "
 "unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1057
+#: lib/vutuv_web/live/post_live/feed.ex:1106
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2170,7 +2170,7 @@ msgstr "Markdown wird unterstützt: Fett, Kursiv, Links und Listen."
 msgid "Add images"
 msgstr "Bilder hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2098
+#: lib/vutuv_web/live/post_live/composer.ex:1888
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
@@ -2181,7 +2181,7 @@ msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1673
+#: lib/vutuv_web/live/post_live/composer.ex:1594
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
@@ -2204,7 +2204,7 @@ msgid "Edit post"
 msgstr "Beitrag bearbeiten"
 
 #: lib/vutuv_web/live/post_live/feed.ex:87
-#: lib/vutuv_web/live/post_live/feed.ex:857
+#: lib/vutuv_web/live/post_live/feed.ex:903
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:118
@@ -2222,12 +2222,12 @@ msgstr "Folgen Sie %{name}, um ihn zu lesen."
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2074
+#: lib/vutuv_web/live/post_live/composer.ex:1864
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr "Vor einer bestimmten Person verbergen…"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2002
+#: lib/vutuv_web/live/post_live/composer.ex:1792
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
@@ -2238,41 +2238,41 @@ msgstr "Diesen Beitrag verbergen vor…"
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2044
+#: lib/vutuv_web/live/post_live/composer.ex:1834
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr "Nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1116
-#: lib/vutuv_web/live/post_live/composer.ex:1164
+#: lib/vutuv_web/live/post_live/composer.ex:1037
+#: lib/vutuv_web/live/post_live/composer.ex:1085
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:998
+#: lib/vutuv_web/live/post_live/feed.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 "Hier ist noch nichts. Folgen Sie anderen, um Ihren Feed zu füllen, oder "
 "schreiben Sie Ihren ersten Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1089
+#: lib/vutuv_web/live/post_live/composer.ex:1010
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr "Eines der Bilder konnte nicht angehängt werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2034
+#: lib/vutuv_web/live/post_live/composer.ex:1824
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr "Personen, denen ich nicht folge"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2024
+#: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr "Personen, die mir nicht folgen"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2319,7 +2319,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:2060
+#: lib/vutuv_web/live/post_live/composer.ex:1850
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2335,12 +2335,12 @@ msgstr ""
 "Eingeschränkte Beiträge sind auch für nicht eingeloggte Besucher und "
 "Suchmaschinen unsichtbar."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1988
+#: lib/vutuv_web/live/post_live/composer.ex:1778
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:931
+#: lib/vutuv_web/live/post_live/feed.ex:978
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2356,12 +2356,12 @@ msgstr[1] "%{formatted} neue Beiträge anzeigen"
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1190
+#: lib/vutuv_web/live/post_live/composer.ex:1111
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr "Diese Datei konnte nicht verarbeitet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1071
+#: lib/vutuv_web/live/post_live/composer.ex:992
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr "Die Sichtbarkeitsauswahl ist ungültig."
@@ -2371,12 +2371,12 @@ msgstr "Die Sichtbarkeitsauswahl ist ungültig."
 msgid "This post is for followers of %{name}"
 msgstr "Dieser Beitrag ist für Follower von %{name}"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2572
+#: lib/vutuv_web/live/post_live/composer.ex:2362
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2573
+#: lib/vutuv_web/live/post_live/composer.ex:2363
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
@@ -2390,12 +2390,12 @@ msgstr "Upload fehlgeschlagen."
 msgid "View profile"
 msgstr "Profil ansehen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2141
+#: lib/vutuv_web/live/post_live/composer.ex:1931
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr "Was gibt's Neues?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2142
+#: lib/vutuv_web/live/post_live/composer.ex:1932
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
@@ -2431,17 +2431,17 @@ msgstr "Personen, denen Sie nicht folgen"
 msgid "unknown"
 msgstr "unbekannt"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1810
+#: lib/vutuv_web/live/post_live/composer.ex:1731
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr "Tags, durch Komma getrennt (max. %{max})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2563
+#: lib/vutuv_web/live/post_live/composer.ex:2353
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr "Die Datei ist größer als %{mb} MB."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2567
+#: lib/vutuv_web/live/post_live/composer.ex:2357
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
@@ -2451,7 +2451,7 @@ msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
 msgid "Posts by %{name}"
 msgstr "Beiträge von %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:510
+#: lib/vutuv_web/templates/user/show.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr "Alle %{count} Beiträge ansehen"
@@ -2557,7 +2557,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/components/ui.ex:1689
 #: lib/vutuv_web/components/ui.ex:1689
 #: lib/vutuv_web/components/ui.ex:1826
-#: lib/vutuv_web/live/post_live/feed.ex:1046
+#: lib/vutuv_web/live/post_live/feed.ex:1095
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2594,13 +2594,13 @@ msgstr "Antworten"
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1074
-#: lib/vutuv_web/live/post_live/composer.ex:1978
+#: lib/vutuv_web/live/post_live/composer.ex:995
+#: lib/vutuv_web/live/post_live/composer.ex:1768
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empfängerkreis nicht einschränken."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2105
+#: lib/vutuv_web/live/post_live/composer.ex:1895
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
@@ -2793,45 +2793,45 @@ msgstr "Andere E-Mail-Adresse verwenden"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:760
+#: lib/vutuv_web/templates/user/show.html.heex:763
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1118
+#: lib/vutuv_web/templates/user/show.html.heex:1121
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1375
+#: lib/vutuv_web/templates/user/show.html.heex:1378
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1046
+#: lib/vutuv_web/templates/user/show.html.heex:1049
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:992
+#: lib/vutuv_web/templates/user/show.html.heex:995
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:559
+#: lib/vutuv_web/templates/user/show.html.heex:562
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1080
+#: lib/vutuv_web/live/user_profile_live.ex:1193
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
@@ -2845,12 +2845,12 @@ msgstr "Ersten Beitrag schreiben"
 #: lib/vutuv_web/templates/settings/privacy.html.heex:138
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:219
-#: lib/vutuv_web/templates/user/show.html.heex:550
+#: lib/vutuv_web/templates/user/show.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:882
+#: lib/vutuv_web/live/post_live/feed.ex:928
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2908,7 +2908,7 @@ msgstr "Noch keine Vernetzungen."
 msgid "Other formats"
 msgstr "Andere Formate"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2014
+#: lib/vutuv_web/live/post_live/composer.ex:1804
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
@@ -2957,7 +2957,7 @@ msgid "Endorsement"
 msgstr "Empfehlung"
 
 #: lib/vutuv_web/live/notification_live/index.ex:942
-#: lib/vutuv_web/templates/user/show.html.heex:815
+#: lib/vutuv_web/templates/user/show.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3204,8 +3204,8 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1086
-#: lib/vutuv_web/templates/user/show.html.heex:1087
+#: lib/vutuv_web/templates/user/show.html.heex:1089
+#: lib/vutuv_web/templates/user/show.html.heex:1090
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
@@ -4747,7 +4747,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1003
+#: lib/vutuv_web/live/post_live/feed.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4759,7 +4759,7 @@ msgstr "Mitglieder finden"
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:837
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4878,8 +4878,8 @@ msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:46
-#: lib/vutuv_web/live/user_profile_live.ex:1068
-#: lib/vutuv_web/templates/user/show.html.heex:523
+#: lib/vutuv_web/live/user_profile_live.ex:1181
+#: lib/vutuv_web/templates/user/show.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Tag hinzufügen"
@@ -5556,7 +5556,7 @@ msgstr ""
 "dauerhaft. Wir senden Ihnen zur Bestätigung eine PIN per E-Mail. Es kann "
 "nicht rückgängig gemacht werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1092
+#: lib/vutuv_web/live/post_live/composer.ex:1013
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
@@ -5642,7 +5642,7 @@ msgstr "Profil vervollständigen"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1070
+#: lib/vutuv_web/live/user_profile_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
@@ -5672,7 +5672,7 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:2318
 #: lib/vutuv_web/components/post_components.ex:2708
 #: lib/vutuv_web/live/notification_live/index.ex:624
-#: lib/vutuv_web/live/post_live/feed.ex:1119
+#: lib/vutuv_web/live/post_live/feed.ex:1168
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6326,7 +6326,7 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1074
+#: lib/vutuv_web/live/user_profile_live.ex:1187
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
@@ -6341,7 +6341,7 @@ msgstr "Kurzbeschreibung"
 #: lib/vutuv_web/components/ui.ex:260
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:758
+#: lib/vutuv_web/templates/user/show.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6362,7 +6362,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1426
+#: lib/vutuv_web/templates/user/show.html.heex:1429
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6401,15 +6401,15 @@ msgstr "Foto positionieren"
 msgid "Use photo"
 msgstr "Foto verwenden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1431
+#: lib/vutuv_web/live/post_live/composer.ex:1352
 #: lib/vutuv_web/templates/user/edit.html.heex:51
 #: lib/vutuv_web/templates/user/edit.html.heex:104
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1012
-#: lib/vutuv_web/templates/user/show.html.heex:1022
+#: lib/vutuv_web/templates/user/show.html.heex:1015
+#: lib/vutuv_web/templates/user/show.html.heex:1025
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6451,12 +6451,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1133
+#: lib/vutuv_web/templates/user/show.html.heex:1136
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1144
+#: lib/vutuv_web/templates/user/show.html.heex:1147
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6498,7 +6498,7 @@ msgstr "Vorheriger Tag"
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1142
+#: lib/vutuv_web/templates/user/show.html.heex:1145
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6554,9 +6554,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1412
-#: lib/vutuv_web/templates/user/show.html.heex:1420
-#: lib/vutuv_web/templates/user/show.html.heex:1432
+#: lib/vutuv_web/templates/user/show.html.heex:1415
+#: lib/vutuv_web/templates/user/show.html.heex:1423
+#: lib/vutuv_web/templates/user/show.html.heex:1435
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -8551,7 +8551,7 @@ msgstr[1] "%{count} Berufserfahrungen"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:614
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Ausbildung hinzufügen"
@@ -8576,7 +8576,7 @@ msgstr "Abschluss"
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:608
+#: lib/vutuv_web/templates/user/show.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr "Ausbildung"
@@ -8745,7 +8745,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1113
+#: lib/vutuv_web/live/user_profile_live.ex:1226
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr "Zum Beispiel ein Gedanke zu %{tag}."
@@ -8775,7 +8775,7 @@ msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:99
-#: lib/vutuv_web/templates/user/show.html.heex:1279
+#: lib/vutuv_web/templates/user/show.html.heex:1282
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8909,13 +8909,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1086
-#: lib/vutuv_web/live/post_live/feed.ex:1087
+#: lib/vutuv_web/live/post_live/feed.ex:1135
+#: lib/vutuv_web/live/post_live/feed.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1081
+#: lib/vutuv_web/live/post_live/feed.ex:1130
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -9145,8 +9145,8 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:873
-#: lib/vutuv_web/templates/user/show.html.heex:1184
+#: lib/vutuv_web/templates/user/show.html.heex:876
+#: lib/vutuv_web/templates/user/show.html.heex:1187
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverse"
@@ -9584,7 +9584,7 @@ msgstr "A2 (Grundkenntnisse)"
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:673
+#: lib/vutuv_web/templates/user/show.html.heex:676
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Sprache hinzufügen"
@@ -9808,7 +9808,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:670
+#: lib/vutuv_web/templates/user/show.html.heex:673
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Sprachen"
@@ -10099,7 +10099,7 @@ msgstr[0] "%{count} Zertifikat oder Lizenz"
 msgstr[1] "%{count} Zertifikate oder Lizenzen"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:713
+#: lib/vutuv_web/templates/user/show.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
@@ -10147,7 +10147,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:710
+#: lib/vutuv_web/templates/user/show.html.heex:713
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr "Zertifikate & Lizenzen"
@@ -10269,8 +10269,8 @@ msgstr "Bevorzugt"
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1108
-#: lib/vutuv_web/templates/user/show.html.heex:1109
+#: lib/vutuv_web/templates/user/show.html.heex:1111
+#: lib/vutuv_web/templates/user/show.html.heex:1112
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10467,7 +10467,7 @@ msgstr "Schließen"
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:131
 #: lib/vutuv_web/templates/totp/new.html.heex:58
-#: lib/vutuv_web/templates/user/show.html.heex:909
+#: lib/vutuv_web/templates/user/show.html.heex:912
 #: lib/vutuv_web/templates/username/new.html.heex:27
 #: lib/vutuv_web/templates/username/new.html.heex:114
 #, elixir-autogen, elixir-format
@@ -10478,8 +10478,8 @@ msgstr "Kopiert"
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:134
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
-#: lib/vutuv_web/templates/user/show.html.heex:908
-#: lib/vutuv_web/templates/user/show.html.heex:912
+#: lib/vutuv_web/templates/user/show.html.heex:911
+#: lib/vutuv_web/templates/user/show.html.heex:915
 #: lib/vutuv_web/templates/username/new.html.heex:26
 #: lib/vutuv_web/templates/username/new.html.heex:30
 #: lib/vutuv_web/templates/username/new.html.heex:113
@@ -10984,7 +10984,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1253
+#: lib/vutuv_web/templates/user/show.html.heex:1256
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -13847,7 +13847,6 @@ msgid "Search title, poster or organization"
 msgstr "Titel, Ersteller oder Organisation suchen"
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1881
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
@@ -14370,7 +14369,7 @@ msgstr "Volle Breite"
 msgid "Insert image"
 msgstr "Bild einfügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2542
+#: lib/vutuv_web/live/post_live/composer.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr "In den Text einfügen"
@@ -14434,14 +14433,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3479
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:1032
+#: lib/vutuv_web/live/post_live/feed.ex:1081
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1047
+#: lib/vutuv_web/live/post_live/feed.ex:1096
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -14485,7 +14484,7 @@ msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzerna
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1219
+#: lib/vutuv_web/templates/user/show.html.heex:1222
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14522,7 +14521,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1217
+#: lib/vutuv_web/templates/user/show.html.heex:1220
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14604,19 +14603,8 @@ msgstr "hat %{count} neue Einträge im Lebenslauf:"
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1889
-#, elixir-autogen, elixir-format
-msgid "Author(s)"
-msgstr "Autor(en)"
-
-#: lib/vutuv_web/live/post_live/composer.ex:1959
-#, elixir-autogen, elixir-format
-msgid "Book"
-msgstr "Buch"
-
 #: lib/vutuv_web/agent_docs/markdown.ex:979
 #: lib/vutuv_web/components/post_components.ex:3504
-#: lib/vutuv_web/live/post_live/composer.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
@@ -14631,98 +14619,33 @@ msgstr "Kino"
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1889
-#, elixir-autogen, elixir-format
-msgid "Director"
-msgstr "Regie"
-
 #: lib/vutuv_web/components/post_components.ex:3546
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1971
-#, elixir-autogen, elixir-format
-msgid "Film"
-msgstr "Film"
-
 #: lib/vutuv_web/agent_docs/markdown.ex:979
 #: lib/vutuv_web/components/post_components.ex:3503
-#: lib/vutuv_web/live/post_live/composer.ex:1834
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1855
-#, elixir-autogen, elixir-format
-msgid "IMDb link or ID"
-msgstr "IMDb-Link oder -ID"
-
-#: lib/vutuv_web/live/post_live/composer.ex:1856
-#, elixir-autogen, elixir-format
-msgid "ISBN"
-msgstr "ISBN"
-
 #: lib/vutuv_web/live/fediverse_account_live.ex:441
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:338
-#: lib/vutuv_web/live/post_live/composer.ex:1869
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr "Nachschlagen"
-
-#: lib/vutuv_web/live/post_live/composer.ex:1866
-#, elixir-autogen, elixir-format
-msgid "Looking up…"
-msgstr "Wird nachgeschlagen …"
-
-#: lib/vutuv_web/live/post_live/composer.ex:673
-#, elixir-autogen, elixir-format
-msgid "Nothing found for this ISBN. Please fill in the fields yourself."
-msgstr "Zu dieser ISBN wurde nichts gefunden. Bitte füllen Sie die Felder selbst aus."
 
 #: lib/vutuv_web/components/post_components.ex:3545
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1908
-#, elixir-autogen, elixir-format
-msgid "Read as… (optional)"
-msgstr "Gelesen als … (optional)"
-
-#: lib/vutuv_web/live/post_live/composer.ex:1844
-#, elixir-autogen, elixir-format
-msgid "Remove review"
-msgstr "Besprechung entfernen"
-
-#: lib/vutuv_web/live/post_live/composer.ex:1955
-#: lib/vutuv_web/live/post_live/composer.ex:1956
-#, elixir-autogen, elixir-format
-msgid "Review a book"
-msgstr "Ein Buch besprechen"
-
-#: lib/vutuv_web/live/post_live/composer.ex:1967
-#: lib/vutuv_web/live/post_live/composer.ex:1968
-#, elixir-autogen, elixir-format
-msgid "Review a film"
-msgstr "Einen Film besprechen"
-
 #: lib/vutuv_web/components/post_components.ex:3549
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1907
-#, elixir-autogen, elixir-format
-msgid "Watched as… (optional)"
-msgstr "Gesehen als … (optional)"
-
-#: lib/vutuv_web/live/post_live/composer.ex:1921
-#, elixir-autogen, elixir-format
-msgid "With an ISBN, the post shows the book cover and a shop link automatically."
-msgstr "Mit ISBN zeigt der Beitrag automatisch das Buchcover und einen Shop-Link."
-
-#: lib/vutuv_web/live/post_live/composer.ex:1901
 #: lib/vutuv_web/templates/education/form_content.html.heex:50
 #: lib/vutuv_web/templates/education/form_content.html.heex:51
 #: lib/vutuv_web/templates/education/form_content.html.heex:70
@@ -15139,13 +15062,13 @@ msgstr "Erwähnung"
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1079
+#: lib/vutuv_web/live/post_live/composer.ex:1000
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten: jemand hat ihn geliked, geteilt oder beantwortet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1082
+#: lib/vutuv_web/live/post_live/composer.ex:1003
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -15422,7 +15345,7 @@ msgstr "Nach einem Tag filtern"
 msgid "Filter removed."
 msgstr "Filter entfernt."
 
-#: lib/vutuv_web/live/post_live/feed.ex:216
+#: lib/vutuv_web/live/post_live/feed.ex:233
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr "Ausgeblendet: passt zu Ihrem Filter"
@@ -15457,7 +15380,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:225
+#: lib/vutuv_web/live/post_live/feed.ex:242
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -16007,27 +15930,27 @@ msgstr "Anwendung bearbeiten"
 msgid "Book an ad"
 msgstr "Anzeige buchen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:877
+#: lib/vutuv_web/templates/user/show.html.heex:880
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr "%{name} hat dieses Fediverse-Konto umgezogen. Folgen Sie stattdessen der neuen Adresse:"
 
-#: lib/vutuv_web/templates/user/show.html.heex:893
+#: lib/vutuv_web/templates/user/show.html.heex:896
 #, elixir-autogen, elixir-format
 msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
 msgstr "Sie sind auf Mastodon oder in einer anderen Fediverse-App? Folgen Sie %{name} von dort aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/templates/user/show.html.heex:930
+#: lib/vutuv_web/templates/user/show.html.heex:933
 #, elixir-autogen, elixir-format
 msgid "Follow from your own server"
 msgstr "Von Ihrem eigenen Server aus folgen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:941
+#: lib/vutuv_web/templates/user/show.html.heex:944
 #, elixir-autogen, elixir-format
 msgid "@you@example.social"
 msgstr "@name@example.social"
 
-#: lib/vutuv_web/templates/user/show.html.heex:949
+#: lib/vutuv_web/templates/user/show.html.heex:952
 #, elixir-autogen, elixir-format
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr "Ihre Adresse wird einmal verwendet, um Sie zum Folgen-Dialog Ihres eigenen Servers zu schicken. Gespeichert wird sie hier nicht."
@@ -16588,7 +16511,7 @@ msgstr "Was"
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:170
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:139
-#: lib/vutuv_web/live/post_live/feed.ex:344
+#: lib/vutuv_web/live/post_live/feed.ex:361
 #: lib/vutuv_web/live/post_live/thread.ex:209
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -17304,7 +17227,7 @@ msgstr ""
 "in eckigen Klammern, wie eine Lautschrift geschrieben wird; die Klammern "
 "ergänzen wir für Sie. Bleibt das Feld leer, wird nichts angezeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2555
+#: lib/vutuv_web/live/post_live/composer.ex:2345
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr "Diese Einstellungen für alle Fotos übernehmen"
@@ -17334,12 +17257,12 @@ msgstr "CC BY-SA 4.0 (Namensnennung, gleiche Bedingungen)"
 msgid "CC0 1.0 (no rights reserved)"
 msgstr "CC0 1.0 (keine Rechte vorbehalten)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2222
+#: lib/vutuv_web/live/post_live/composer.ex:2012
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Titelbild"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2415
+#: lib/vutuv_web/live/post_live/composer.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
@@ -17351,27 +17274,27 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 msgid "Download the original"
 msgstr "Original herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1510
+#: lib/vutuv_web/live/post_live/composer.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr "Zum Umsortieren ziehen. Das erste Foto führt die Galerie an."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2492
+#: lib/vutuv_web/live/post_live/composer.ex:2282
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr "Alle Metadaten bleiben erhalten, auch alles, was Ihre Kamera hineingeschrieben hat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2448
+#: lib/vutuv_web/live/post_live/composer.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr "Alle dürfen dieses Foto herunterladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2450
+#: lib/vutuv_web/live/post_live/composer.ex:2240
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr "Volle Auflösung, direkt aus dem Beitrag."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2469
+#: lib/vutuv_web/live/post_live/composer.ex:2259
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr "Nur das Bild"
@@ -17381,7 +17304,7 @@ msgstr "Nur das Bild"
 msgid "Next photo"
 msgstr "Nächstes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2241
+#: lib/vutuv_web/live/post_live/composer.ex:2031
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
@@ -17413,8 +17336,8 @@ msgstr "Foto %{n} von %{total}"
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2194
-#: lib/vutuv_web/live/post_live/composer.ex:2195
+#: lib/vutuv_web/live/post_live/composer.ex:1984
+#: lib/vutuv_web/live/post_live/composer.ex:1985
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
@@ -17431,18 +17354,18 @@ msgstr "Fotos:"
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2254
-#: lib/vutuv_web/live/post_live/composer.ex:2255
+#: lib/vutuv_web/live/post_live/composer.ex:2044
+#: lib/vutuv_web/live/post_live/composer.ex:2045
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr "Foto entfernen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2471
+#: lib/vutuv_web/live/post_live/composer.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qualität unverändert."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1482
+#: lib/vutuv_web/live/post_live/composer.ex:1403
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
@@ -17452,17 +17375,17 @@ msgstr "Kameradaten anzeigen"
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2490
+#: lib/vutuv_web/live/post_live/composer.ex:2280
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr "Die Datei genau so, wie ich sie hochgeladen habe"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2526
+#: lib/vutuv_web/live/post_live/composer.ex:2316
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen Sie das Foto, wenn Sie das nicht möchten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2518
+#: lib/vutuv_web/live/post_live/composer.ex:2308
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
@@ -17487,12 +17410,12 @@ msgstr "Diese Seite nimmt nicht am Fediverse teil."
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1731
+#: lib/vutuv_web/live/post_live/composer.ex:1652
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr "Wer diese Fotos weiterverwenden darf"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1099
+#: lib/vutuv_web/live/post_live/composer.ex:1020
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
@@ -17502,7 +17425,7 @@ msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke gesc
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1113
+#: lib/vutuv_web/live/post_live/composer.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
@@ -17517,76 +17440,76 @@ msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fedive
 msgid "© All rights reserved"
 msgstr "© Alle Rechte vorbehalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1501
-#: lib/vutuv_web/live/post_live/composer.ex:1943
+#: lib/vutuv_web/live/post_live/composer.ex:1422
+#: lib/vutuv_web/live/post_live/composer.ex:1760
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr "Fotos hinzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1726
+#: lib/vutuv_web/live/post_live/composer.ex:1647
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:891
-#: lib/vutuv_web/live/post_live/feed.ex:892
+#: lib/vutuv_web/live/post_live/feed.ex:937
+#: lib/vutuv_web/live/post_live/feed.ex:938
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1459
+#: lib/vutuv_web/live/post_live/composer.ex:1380
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr "Bildunterschrift (optional)"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1327
-#: lib/vutuv_web/live/post_live/composer.ex:1385
+#: lib/vutuv_web/live/post_live/composer.ex:1248
+#: lib/vutuv_web/live/post_live/composer.ex:1306
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr "Entwurf verwerfen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1324
-#: lib/vutuv_web/live/post_live/composer.ex:1382
+#: lib/vutuv_web/live/post_live/composer.ex:1245
+#: lib/vutuv_web/live/post_live/composer.ex:1303
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr "Fotos und Text dieses Entwurfs verwerfen?"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1319
+#: lib/vutuv_web/live/post_live/composer.ex:1240
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr "Weiter, wo Sie aufgehört haben."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1797
+#: lib/vutuv_web/live/post_live/composer.ex:1718
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr "Eine Datei, deren Format sich nicht säubern lässt, wird exakt so weitergegeben, wie sie hochgeladen wurde."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2124
+#: lib/vutuv_web/live/post_live/composer.ex:1914
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr "Pro Foto verschieden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2123
+#: lib/vutuv_web/live/post_live/composer.ex:1913
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr "Original, exakt wie hochgeladen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2122
+#: lib/vutuv_web/live/post_live/composer.ex:1912
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr "Original, ohne Metadaten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2127
+#: lib/vutuv_web/live/post_live/composer.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr "Nur Web-Versionen (%{format})"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1760
+#: lib/vutuv_web/live/post_live/composer.ex:1681
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr "Was Besucher speichern können"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1786
+#: lib/vutuv_web/live/post_live/composer.ex:1707
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -17705,7 +17628,7 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr "Rücknahme"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1714
+#: lib/vutuv_web/live/post_live/composer.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr "Fotodetails"
@@ -17973,7 +17896,7 @@ msgstr "Nur für die Follower dieses Kontos"
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:162
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:131
-#: lib/vutuv_web/live/post_live/feed.ex:336
+#: lib/vutuv_web/live/post_live/feed.ex:353
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
@@ -18014,7 +17937,7 @@ msgid "Mute %{handle}"
 msgstr "%{handle} stummschalten"
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:394
+#: lib/vutuv_web/live/post_live/feed.ex:411
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwinden aus Ihrem Feed."
@@ -18293,7 +18216,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:195
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:110
-#: lib/vutuv_web/live/post_live/feed.ex:372
+#: lib/vutuv_web/live/post_live/feed.ex:389
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr "Repostet. Ihre Follower sehen es jetzt."
@@ -18340,12 +18263,12 @@ msgstr ""
 "speichern wir dafür bis zu sechs Monate. Alles davon lässt sich jederzeit "
 "wieder abschalten."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1091
+#: lib/vutuv_web/live/user_profile_live.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Follow %{count} members"
 msgstr "%{count} Mitgliedern folgen"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1106
+#: lib/vutuv_web/live/user_profile_live.ex:1219
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
@@ -18686,135 +18609,135 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr "Einen nachgeschlagenen Beitrag bewahrt vutuv genauso sechs Monate lang auf wie jeden anderen Beitrag aus einem anderen Netzwerk. Der Server der verfassenden Person wird sonst nichts gefragt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1428
+#: lib/vutuv_web/live/post_live/composer.ex:1349
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr "Zuschnitt übernehmen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1544
+#: lib/vutuv_web/live/post_live/composer.ex:1465
 #, elixir-autogen, elixir-format
 msgid "Auto"
 msgstr "Automatisch"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2300
+#: lib/vutuv_web/live/post_live/composer.ex:2090
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr "Großes Foto links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2301
+#: lib/vutuv_web/live/post_live/composer.ex:2091
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr "Großes Foto rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2306
+#: lib/vutuv_web/live/post_live/composer.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr "Spalten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2303
+#: lib/vutuv_web/live/post_live/composer.ex:2093
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr "Titelbild links"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2304
+#: lib/vutuv_web/live/post_live/composer.ex:2094
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr "Titelbild oben"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2305
+#: lib/vutuv_web/live/post_live/composer.ex:2095
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr "Titelbild rechts"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1424
-#: lib/vutuv_web/live/post_live/composer.ex:2271
-#: lib/vutuv_web/live/post_live/composer.ex:2272
+#: lib/vutuv_web/live/post_live/composer.ex:1345
+#: lib/vutuv_web/live/post_live/composer.ex:2061
+#: lib/vutuv_web/live/post_live/composer.ex:2062
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr "Foto zuschneiden"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2230
+#: lib/vutuv_web/live/post_live/composer.ex:2020
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr "Zugeschnitten"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1355
+#: lib/vutuv_web/live/post_live/composer.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr "Fotos hier ablegen, um sie hinzuzufügen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1522
+#: lib/vutuv_web/live/post_live/composer.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Gallery preview"
 msgstr "Galerie-Vorschau"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2307
+#: lib/vutuv_web/live/post_live/composer.ex:2097
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Raster"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2308
+#: lib/vutuv_web/live/post_live/composer.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr "Mosaik"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1426
+#: lib/vutuv_web/live/post_live/composer.ex:1347
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr "Wählen Sie ein Format, dann verschieben und zoomen Sie. Der gerahmte Ausschnitt ist das, was der Beitrag zeigt."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2299
+#: lib/vutuv_web/live/post_live/composer.ex:2089
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr "Nebeneinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:2302
+#: lib/vutuv_web/live/post_live/composer.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr "Übereinander"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1637
-#: lib/vutuv_web/live/post_live/composer.ex:1638
+#: lib/vutuv_web/live/post_live/composer.ex:1558
+#: lib/vutuv_web/live/post_live/composer.ex:1559
 #, elixir-autogen, elixir-format
 msgid "Swap this photo with another"
 msgstr "Dieses Foto mit einem anderen tauschen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1525
+#: lib/vutuv_web/live/post_live/composer.ex:1446
 #, elixir-autogen, elixir-format
 msgid "Tap two photos to swap them."
 msgstr "Tippen Sie zwei Fotos an, um sie zu tauschen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:390
+#: lib/vutuv_web/live/post_live/composer.ex:381
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr "Das Foto konnte nicht zugeschnitten werden."
 
-#: lib/vutuv_web/live/post_live/composer.ex:2505
+#: lib/vutuv_web/live/post_live/composer.ex:2295
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr "Dieses Foto ist zugeschnitten: Downloads geben das zugeschnittene Bild heraus, die unveränderte Originaldatei bleibt privat."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1430
+#: lib/vutuv_web/live/post_live/composer.ex:1351
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr "Ganzes Foto"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1619
+#: lib/vutuv_web/live/post_live/composer.ex:1540
 #, elixir-autogen, elixir-format
 msgid "Each photo covers its tile and is cropped by it."
 msgstr "Jedes Foto füllt seine Kachel und wird von ihr beschnitten."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1620
+#: lib/vutuv_web/live/post_live/composer.ex:1541
 #, elixir-autogen, elixir-format
 msgid "Each photo shows whole inside its tile."
 msgstr "Jedes Foto ist ganz in seiner Kachel zu sehen."
 
-#: lib/vutuv_web/live/post_live/composer.ex:1615
+#: lib/vutuv_web/live/post_live/composer.ex:1536
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr "Kacheln füllen"
 
-#: lib/vutuv_web/live/post_live/composer.ex:1599
+#: lib/vutuv_web/live/post_live/composer.ex:1520
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr "Ganze Fotos"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -37,7 +37,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1373
+#: lib/vutuv_web/templates/user/show.html.heex:1376
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -100,7 +100,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/templates/user/show.html.heex:1006
+#: lib/vutuv_web/templates/user/show.html.heex:1009
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -113,7 +113,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:605
 #: lib/vutuv_web/live/organization_live/edit.ex:347
 #: lib/vutuv_web/live/organization_live/new.ex:173
-#: lib/vutuv_web/live/post_live/composer.ex:1429
+#: lib/vutuv_web/live/post_live/composer.ex:1350
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -146,7 +146,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1044
+#: lib/vutuv_web/templates/user/show.html.heex:1047
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -196,7 +196,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:439
-#: lib/vutuv_web/live/post_live/composer.ex:1753
+#: lib/vutuv_web/live/post_live/composer.ex:1674
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:303
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -218,7 +218,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1029
+#: lib/vutuv_web/templates/user/show.html.heex:1032
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -295,7 +295,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:556
+#: lib/vutuv_web/templates/user/show.html.heex:559
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -340,7 +340,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:837
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -355,7 +355,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:67
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:1001
+#: lib/vutuv_web/templates/user/show.html.heex:1004
 #: lib/vutuv_web/views/account_event_text.ex:153
 #, elixir-autogen
 msgid "Gender"
@@ -616,7 +616,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1981
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -626,7 +626,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3041
 #: lib/vutuv_web/live/organization_live/edit.ex:341
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:105
@@ -696,13 +696,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1157
+#: lib/vutuv_web/templates/user/show.html.heex:1160
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1159
+#: lib/vutuv_web/templates/user/show.html.heex:1162
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -853,8 +853,8 @@ msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3206
-#: lib/vutuv_web/templates/user/show.html.heex:828
-#: lib/vutuv_web/templates/user/show.html.heex:848
+#: lib/vutuv_web/templates/user/show.html.heex:831
+#: lib/vutuv_web/templates/user/show.html.heex:851
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -1061,7 +1061,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:990
+#: lib/vutuv_web/templates/user/show.html.heex:993
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1249,7 +1249,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:550
+#: lib/vutuv_web/templates/user/show.html.heex:553
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1448,7 +1448,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:520
+#: lib/vutuv_web/templates/user/show.html.heex:523
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1671,9 +1671,9 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1390
-#: lib/vutuv_web/live/post_live/composer.ex:1391
-#: lib/vutuv_web/live/post_live/composer.ex:2423
+#: lib/vutuv_web/live/post_live/composer.ex:1311
+#: lib/vutuv_web/live/post_live/composer.ex:1312
+#: lib/vutuv_web/live/post_live/composer.ex:2213
 #: lib/vutuv_web/templates/layout/app.html.heex:155
 #: lib/vutuv_web/templates/layout/app.html.heex:161
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_account_live.ex:380
 #: lib/vutuv_web/live/fediverse_following_live.ex:287
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:403
-#: lib/vutuv_web/templates/user/show.html.heex:945
-#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:948
+#: lib/vutuv_web/templates/user/show.html.heex:1200
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1909,7 +1909,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1057
+#: lib/vutuv_web/live/post_live/feed.ex:1106
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2125,7 +2125,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2098
+#: lib/vutuv_web/live/post_live/composer.ex:1888
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2136,7 +2136,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1673
+#: lib/vutuv_web/live/post_live/composer.ex:1594
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2159,7 +2159,7 @@ msgid "Edit post"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:87
-#: lib/vutuv_web/live/post_live/feed.ex:857
+#: lib/vutuv_web/live/post_live/feed.ex:903
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:118
@@ -2177,12 +2177,12 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2074
+#: lib/vutuv_web/live/post_live/composer.ex:1864
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2002
+#: lib/vutuv_web/live/post_live/composer.ex:1792
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
@@ -2193,39 +2193,39 @@ msgstr ""
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2044
+#: lib/vutuv_web/live/post_live/composer.ex:1834
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1116
-#: lib/vutuv_web/live/post_live/composer.ex:1164
+#: lib/vutuv_web/live/post_live/composer.ex:1037
+#: lib/vutuv_web/live/post_live/composer.ex:1085
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:998
+#: lib/vutuv_web/live/post_live/feed.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1089
+#: lib/vutuv_web/live/post_live/composer.ex:1010
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2034
+#: lib/vutuv_web/live/post_live/composer.ex:1824
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2024
+#: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2272,7 +2272,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:2060
+#: lib/vutuv_web/live/post_live/composer.ex:1850
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2286,12 +2286,12 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1988
+#: lib/vutuv_web/live/post_live/composer.ex:1778
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:931
+#: lib/vutuv_web/live/post_live/feed.ex:978
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2307,12 +2307,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1190
+#: lib/vutuv_web/live/post_live/composer.ex:1111
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1071
+#: lib/vutuv_web/live/post_live/composer.ex:992
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2322,12 +2322,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2572
+#: lib/vutuv_web/live/post_live/composer.ex:2362
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2573
+#: lib/vutuv_web/live/post_live/composer.ex:2363
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2341,12 +2341,12 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2141
+#: lib/vutuv_web/live/post_live/composer.ex:1931
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2142
+#: lib/vutuv_web/live/post_live/composer.ex:1932
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
@@ -2382,17 +2382,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1810
+#: lib/vutuv_web/live/post_live/composer.ex:1731
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2563
+#: lib/vutuv_web/live/post_live/composer.ex:2353
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2567
+#: lib/vutuv_web/live/post_live/composer.ex:2357
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2402,7 +2402,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:510
+#: lib/vutuv_web/templates/user/show.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2508,7 +2508,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1689
 #: lib/vutuv_web/components/ui.ex:1689
 #: lib/vutuv_web/components/ui.ex:1826
-#: lib/vutuv_web/live/post_live/feed.ex:1046
+#: lib/vutuv_web/live/post_live/feed.ex:1095
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2545,13 +2545,13 @@ msgstr ""
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1074
-#: lib/vutuv_web/live/post_live/composer.ex:1978
+#: lib/vutuv_web/live/post_live/composer.ex:995
+#: lib/vutuv_web/live/post_live/composer.ex:1768
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2105
+#: lib/vutuv_web/live/post_live/composer.ex:1895
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2742,45 +2742,45 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:760
+#: lib/vutuv_web/templates/user/show.html.heex:763
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1118
+#: lib/vutuv_web/templates/user/show.html.heex:1121
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1375
+#: lib/vutuv_web/templates/user/show.html.heex:1378
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1046
+#: lib/vutuv_web/templates/user/show.html.heex:1049
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:992
+#: lib/vutuv_web/templates/user/show.html.heex:995
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:559
+#: lib/vutuv_web/templates/user/show.html.heex:562
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1080
+#: lib/vutuv_web/live/user_profile_live.ex:1193
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
@@ -2794,12 +2794,12 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:138
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:219
-#: lib/vutuv_web/templates/user/show.html.heex:550
+#: lib/vutuv_web/templates/user/show.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:882
+#: lib/vutuv_web/live/post_live/feed.ex:928
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2855,7 +2855,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2014
+#: lib/vutuv_web/live/post_live/composer.ex:1804
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2904,7 +2904,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:942
-#: lib/vutuv_web/templates/user/show.html.heex:815
+#: lib/vutuv_web/templates/user/show.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3133,8 +3133,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1086
-#: lib/vutuv_web/templates/user/show.html.heex:1087
+#: lib/vutuv_web/templates/user/show.html.heex:1089
+#: lib/vutuv_web/templates/user/show.html.heex:1090
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -4574,7 +4574,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1003
+#: lib/vutuv_web/live/post_live/feed.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4586,7 +4586,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:837
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4701,8 +4701,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:46
-#: lib/vutuv_web/live/user_profile_live.ex:1068
-#: lib/vutuv_web/templates/user/show.html.heex:523
+#: lib/vutuv_web/live/user_profile_live.ex:1181
+#: lib/vutuv_web/templates/user/show.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1092
+#: lib/vutuv_web/live/post_live/composer.ex:1013
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5415,7 +5415,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1070
+#: lib/vutuv_web/live/user_profile_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5445,7 +5445,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2318
 #: lib/vutuv_web/components/post_components.ex:2708
 #: lib/vutuv_web/live/notification_live/index.ex:624
-#: lib/vutuv_web/live/post_live/feed.ex:1119
+#: lib/vutuv_web/live/post_live/feed.ex:1168
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6080,7 +6080,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1074
+#: lib/vutuv_web/live/user_profile_live.ex:1187
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6095,7 +6095,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:260
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:758
+#: lib/vutuv_web/templates/user/show.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6116,7 +6116,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1426
+#: lib/vutuv_web/templates/user/show.html.heex:1429
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6153,15 +6153,15 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1431
+#: lib/vutuv_web/live/post_live/composer.ex:1352
 #: lib/vutuv_web/templates/user/edit.html.heex:51
 #: lib/vutuv_web/templates/user/edit.html.heex:104
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1012
-#: lib/vutuv_web/templates/user/show.html.heex:1022
+#: lib/vutuv_web/templates/user/show.html.heex:1015
+#: lib/vutuv_web/templates/user/show.html.heex:1025
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6201,12 +6201,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1133
+#: lib/vutuv_web/templates/user/show.html.heex:1136
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1144
+#: lib/vutuv_web/templates/user/show.html.heex:1147
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6248,7 +6248,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1142
+#: lib/vutuv_web/templates/user/show.html.heex:1145
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6302,9 +6302,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1412
-#: lib/vutuv_web/templates/user/show.html.heex:1420
-#: lib/vutuv_web/templates/user/show.html.heex:1432
+#: lib/vutuv_web/templates/user/show.html.heex:1415
+#: lib/vutuv_web/templates/user/show.html.heex:1423
+#: lib/vutuv_web/templates/user/show.html.heex:1435
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -8170,7 +8170,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:614
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8195,7 +8195,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:608
+#: lib/vutuv_web/templates/user/show.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -8356,7 +8356,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1113
+#: lib/vutuv_web/live/user_profile_live.ex:1226
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
@@ -8382,7 +8382,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:99
-#: lib/vutuv_web/templates/user/show.html.heex:1279
+#: lib/vutuv_web/templates/user/show.html.heex:1282
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8492,13 +8492,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1086
-#: lib/vutuv_web/live/post_live/feed.ex:1087
+#: lib/vutuv_web/live/post_live/feed.ex:1135
+#: lib/vutuv_web/live/post_live/feed.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1081
+#: lib/vutuv_web/live/post_live/feed.ex:1130
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8704,8 +8704,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:873
-#: lib/vutuv_web/templates/user/show.html.heex:1184
+#: lib/vutuv_web/templates/user/show.html.heex:876
+#: lib/vutuv_web/templates/user/show.html.heex:1187
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -9104,7 +9104,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:673
+#: lib/vutuv_web/templates/user/show.html.heex:676
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9328,7 +9328,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:670
+#: lib/vutuv_web/templates/user/show.html.heex:673
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9608,7 +9608,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:713
+#: lib/vutuv_web/templates/user/show.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9656,7 +9656,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:710
+#: lib/vutuv_web/templates/user/show.html.heex:713
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr ""
@@ -9773,8 +9773,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1108
-#: lib/vutuv_web/templates/user/show.html.heex:1109
+#: lib/vutuv_web/templates/user/show.html.heex:1111
+#: lib/vutuv_web/templates/user/show.html.heex:1112
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9958,7 +9958,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:131
 #: lib/vutuv_web/templates/totp/new.html.heex:58
-#: lib/vutuv_web/templates/user/show.html.heex:909
+#: lib/vutuv_web/templates/user/show.html.heex:912
 #: lib/vutuv_web/templates/username/new.html.heex:27
 #: lib/vutuv_web/templates/username/new.html.heex:114
 #, elixir-autogen, elixir-format
@@ -9969,8 +9969,8 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:134
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
-#: lib/vutuv_web/templates/user/show.html.heex:908
-#: lib/vutuv_web/templates/user/show.html.heex:912
+#: lib/vutuv_web/templates/user/show.html.heex:911
+#: lib/vutuv_web/templates/user/show.html.heex:915
 #: lib/vutuv_web/templates/username/new.html.heex:26
 #: lib/vutuv_web/templates/username/new.html.heex:30
 #: lib/vutuv_web/templates/username/new.html.heex:113
@@ -10430,7 +10430,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1253
+#: lib/vutuv_web/templates/user/show.html.heex:1256
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -13157,7 +13157,6 @@ msgid "Search title, poster or organization"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1881
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -13666,7 +13665,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2542
+#: lib/vutuv_web/live/post_live/composer.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13725,14 +13724,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3479
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:1032
+#: lib/vutuv_web/live/post_live/feed.ex:1081
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1047
+#: lib/vutuv_web/live/post_live/feed.ex:1096
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13774,7 +13773,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1219
+#: lib/vutuv_web/templates/user/show.html.heex:1222
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13811,7 +13810,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1217
+#: lib/vutuv_web/templates/user/show.html.heex:1220
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13893,19 +13892,8 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1889
-#, elixir-autogen, elixir-format
-msgid "Author(s)"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1959
-#, elixir-autogen, elixir-format
-msgid "Book"
-msgstr ""
-
 #: lib/vutuv_web/agent_docs/markdown.ex:979
 #: lib/vutuv_web/components/post_components.ex:3504
-#: lib/vutuv_web/live/post_live/composer.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
@@ -13920,53 +13908,21 @@ msgstr ""
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1889
-#, elixir-autogen, elixir-format
-msgid "Director"
-msgstr ""
-
 #: lib/vutuv_web/components/post_components.ex:3546
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1971
-#, elixir-autogen, elixir-format
-msgid "Film"
-msgstr ""
-
 #: lib/vutuv_web/agent_docs/markdown.ex:979
 #: lib/vutuv_web/components/post_components.ex:3503
-#: lib/vutuv_web/live/post_live/composer.ex:1834
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1855
-#, elixir-autogen, elixir-format
-msgid "IMDb link or ID"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1856
-#, elixir-autogen, elixir-format
-msgid "ISBN"
-msgstr ""
-
 #: lib/vutuv_web/live/fediverse_account_live.ex:441
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:338
-#: lib/vutuv_web/live/post_live/composer.ex:1869
 #, elixir-autogen, elixir-format
 msgid "Look up"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1866
-#, elixir-autogen, elixir-format
-msgid "Looking up…"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:673
-#, elixir-autogen, elixir-format
-msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3545
@@ -13974,44 +13930,11 @@ msgstr ""
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1908
-#, elixir-autogen, elixir-format
-msgid "Read as… (optional)"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1844
-#, elixir-autogen, elixir-format
-msgid "Remove review"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1955
-#: lib/vutuv_web/live/post_live/composer.ex:1956
-#, elixir-autogen, elixir-format
-msgid "Review a book"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1967
-#: lib/vutuv_web/live/post_live/composer.ex:1968
-#, elixir-autogen, elixir-format
-msgid "Review a film"
-msgstr ""
-
 #: lib/vutuv_web/components/post_components.ex:3549
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1907
-#, elixir-autogen, elixir-format
-msgid "Watched as… (optional)"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1921
-#, elixir-autogen, elixir-format
-msgid "With an ISBN, the post shows the book cover and a shop link automatically."
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1901
 #: lib/vutuv_web/templates/education/form_content.html.heex:50
 #: lib/vutuv_web/templates/education/form_content.html.heex:51
 #: lib/vutuv_web/templates/education/form_content.html.heex:70
@@ -14411,13 +14334,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1079
+#: lib/vutuv_web/live/post_live/composer.ex:1000
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1082
+#: lib/vutuv_web/live/post_live/composer.ex:1003
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14687,7 +14610,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:216
+#: lib/vutuv_web/live/post_live/feed.ex:233
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14720,7 +14643,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:225
+#: lib/vutuv_web/live/post_live/feed.ex:242
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -15270,27 +15193,27 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:877
+#: lib/vutuv_web/templates/user/show.html.heex:880
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:893
+#: lib/vutuv_web/templates/user/show.html.heex:896
 #, elixir-autogen, elixir-format
 msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:930
+#: lib/vutuv_web/templates/user/show.html.heex:933
 #, elixir-autogen, elixir-format
 msgid "Follow from your own server"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:941
+#: lib/vutuv_web/templates/user/show.html.heex:944
 #, elixir-autogen, elixir-format
 msgid "@you@example.social"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:949
+#: lib/vutuv_web/templates/user/show.html.heex:952
 #, elixir-autogen, elixir-format
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr ""
@@ -15837,7 +15760,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:170
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:139
-#: lib/vutuv_web/live/post_live/feed.ex:344
+#: lib/vutuv_web/live/post_live/feed.ex:361
 #: lib/vutuv_web/live/post_live/thread.ex:209
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16543,7 +16466,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2555
+#: lib/vutuv_web/live/post_live/composer.ex:2345
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16573,12 +16496,12 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2222
+#: lib/vutuv_web/live/post_live/composer.ex:2012
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2415
+#: lib/vutuv_web/live/post_live/composer.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16590,27 +16513,27 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1510
+#: lib/vutuv_web/live/post_live/composer.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2492
+#: lib/vutuv_web/live/post_live/composer.ex:2282
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2448
+#: lib/vutuv_web/live/post_live/composer.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2450
+#: lib/vutuv_web/live/post_live/composer.ex:2240
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2469
+#: lib/vutuv_web/live/post_live/composer.ex:2259
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
@@ -16620,7 +16543,7 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2241
+#: lib/vutuv_web/live/post_live/composer.ex:2031
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16652,8 +16575,8 @@ msgstr ""
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2194
-#: lib/vutuv_web/live/post_live/composer.ex:2195
+#: lib/vutuv_web/live/post_live/composer.ex:1984
+#: lib/vutuv_web/live/post_live/composer.ex:1985
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
@@ -16670,18 +16593,18 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2254
-#: lib/vutuv_web/live/post_live/composer.ex:2255
+#: lib/vutuv_web/live/post_live/composer.ex:2044
+#: lib/vutuv_web/live/post_live/composer.ex:2045
 #, elixir-autogen, elixir-format
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2471
+#: lib/vutuv_web/live/post_live/composer.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1482
+#: lib/vutuv_web/live/post_live/composer.ex:1403
 #, elixir-autogen, elixir-format
 msgid "Show camera settings"
 msgstr ""
@@ -16691,17 +16614,17 @@ msgstr ""
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2490
+#: lib/vutuv_web/live/post_live/composer.ex:2280
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2526
+#: lib/vutuv_web/live/post_live/composer.ex:2316
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2518
+#: lib/vutuv_web/live/post_live/composer.ex:2308
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -16726,12 +16649,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1731
+#: lib/vutuv_web/live/post_live/composer.ex:1652
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1099
+#: lib/vutuv_web/live/post_live/composer.ex:1020
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16741,7 +16664,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1113
+#: lib/vutuv_web/live/post_live/composer.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16756,76 +16679,76 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1501
-#: lib/vutuv_web/live/post_live/composer.ex:1943
+#: lib/vutuv_web/live/post_live/composer.ex:1422
+#: lib/vutuv_web/live/post_live/composer.ex:1760
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1726
+#: lib/vutuv_web/live/post_live/composer.ex:1647
 #, elixir-autogen, elixir-format
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:891
-#: lib/vutuv_web/live/post_live/feed.ex:892
+#: lib/vutuv_web/live/post_live/feed.ex:937
+#: lib/vutuv_web/live/post_live/feed.ex:938
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1459
+#: lib/vutuv_web/live/post_live/composer.ex:1380
 #, elixir-autogen, elixir-format
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1327
-#: lib/vutuv_web/live/post_live/composer.ex:1385
+#: lib/vutuv_web/live/post_live/composer.ex:1248
+#: lib/vutuv_web/live/post_live/composer.ex:1306
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1324
-#: lib/vutuv_web/live/post_live/composer.ex:1382
+#: lib/vutuv_web/live/post_live/composer.ex:1245
+#: lib/vutuv_web/live/post_live/composer.ex:1303
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1319
+#: lib/vutuv_web/live/post_live/composer.ex:1240
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1797
+#: lib/vutuv_web/live/post_live/composer.ex:1718
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2124
+#: lib/vutuv_web/live/post_live/composer.ex:1914
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2123
+#: lib/vutuv_web/live/post_live/composer.ex:1913
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2122
+#: lib/vutuv_web/live/post_live/composer.ex:1912
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2127
+#: lib/vutuv_web/live/post_live/composer.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1760
+#: lib/vutuv_web/live/post_live/composer.ex:1681
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1786
+#: lib/vutuv_web/live/post_live/composer.ex:1707
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16935,7 +16858,7 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1714
+#: lib/vutuv_web/live/post_live/composer.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -17203,7 +17126,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:162
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:131
-#: lib/vutuv_web/live/post_live/feed.ex:336
+#: lib/vutuv_web/live/post_live/feed.ex:353
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
@@ -17244,7 +17167,7 @@ msgid "Mute %{handle}"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:394
+#: lib/vutuv_web/live/post_live/feed.ex:411
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr ""
@@ -17518,7 +17441,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:195
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:110
-#: lib/vutuv_web/live/post_live/feed.ex:372
+#: lib/vutuv_web/live/post_live/feed.ex:389
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr ""
@@ -17553,12 +17476,12 @@ msgstr ""
 msgid "People on Mastodon and other independent networks can then follow this profile, and your public posts appear there. What they answer or share comes back and is shown under your posts, by their account address. A reply from there is stored here for up to six months. You can switch all of it off again at any time."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1091
+#: lib/vutuv_web/live/user_profile_live.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Follow %{count} members"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1106
+#: lib/vutuv_web/live/user_profile_live.ex:1219
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
@@ -17897,135 +17820,135 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1428
+#: lib/vutuv_web/live/post_live/composer.ex:1349
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1544
+#: lib/vutuv_web/live/post_live/composer.ex:1465
 #, elixir-autogen, elixir-format
 msgid "Auto"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2300
+#: lib/vutuv_web/live/post_live/composer.ex:2090
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2301
+#: lib/vutuv_web/live/post_live/composer.ex:2091
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2306
+#: lib/vutuv_web/live/post_live/composer.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2303
+#: lib/vutuv_web/live/post_live/composer.ex:2093
 #, elixir-autogen, elixir-format
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2304
+#: lib/vutuv_web/live/post_live/composer.ex:2094
 #, elixir-autogen, elixir-format
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2305
+#: lib/vutuv_web/live/post_live/composer.ex:2095
 #, elixir-autogen, elixir-format
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1424
-#: lib/vutuv_web/live/post_live/composer.ex:2271
-#: lib/vutuv_web/live/post_live/composer.ex:2272
+#: lib/vutuv_web/live/post_live/composer.ex:1345
+#: lib/vutuv_web/live/post_live/composer.ex:2061
+#: lib/vutuv_web/live/post_live/composer.ex:2062
 #, elixir-autogen, elixir-format
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2230
+#: lib/vutuv_web/live/post_live/composer.ex:2020
 #, elixir-autogen, elixir-format
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1355
+#: lib/vutuv_web/live/post_live/composer.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1522
+#: lib/vutuv_web/live/post_live/composer.ex:1443
 #, elixir-autogen, elixir-format
 msgid "Gallery preview"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2307
+#: lib/vutuv_web/live/post_live/composer.ex:2097
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2308
+#: lib/vutuv_web/live/post_live/composer.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1426
+#: lib/vutuv_web/live/post_live/composer.ex:1347
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2299
+#: lib/vutuv_web/live/post_live/composer.ex:2089
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2302
+#: lib/vutuv_web/live/post_live/composer.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1637
-#: lib/vutuv_web/live/post_live/composer.ex:1638
+#: lib/vutuv_web/live/post_live/composer.ex:1558
+#: lib/vutuv_web/live/post_live/composer.ex:1559
 #, elixir-autogen, elixir-format
 msgid "Swap this photo with another"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1525
+#: lib/vutuv_web/live/post_live/composer.ex:1446
 #, elixir-autogen, elixir-format
 msgid "Tap two photos to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:390
+#: lib/vutuv_web/live/post_live/composer.ex:381
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2505
+#: lib/vutuv_web/live/post_live/composer.ex:2295
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1430
+#: lib/vutuv_web/live/post_live/composer.ex:1351
 #, elixir-autogen, elixir-format
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1619
+#: lib/vutuv_web/live/post_live/composer.ex:1540
 #, elixir-autogen, elixir-format
 msgid "Each photo covers its tile and is cropped by it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1620
+#: lib/vutuv_web/live/post_live/composer.ex:1541
 #, elixir-autogen, elixir-format
 msgid "Each photo shows whole inside its tile."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1615
+#: lib/vutuv_web/live/post_live/composer.ex:1536
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1599
+#: lib/vutuv_web/live/post_live/composer.ex:1520
 #, elixir-autogen, elixir-format
 msgid "Whole photos"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -35,7 +35,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1373
+#: lib/vutuv_web/templates/user/show.html.heex:1376
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -98,7 +98,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/templates/user/show.html.heex:1006
+#: lib/vutuv_web/templates/user/show.html.heex:1009
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -111,7 +111,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_posting_live/form.ex:605
 #: lib/vutuv_web/live/organization_live/edit.ex:347
 #: lib/vutuv_web/live/organization_live/new.ex:173
-#: lib/vutuv_web/live/post_live/composer.ex:1429
+#: lib/vutuv_web/live/post_live/composer.ex:1350
 #: lib/vutuv_web/templates/ad/new.html.heex:136
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:40
 #: lib/vutuv_web/templates/admin/newsletter/form_content.html.heex:57
@@ -144,7 +144,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1044
+#: lib/vutuv_web/templates/user/show.html.heex:1047
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -194,7 +194,7 @@ msgid "Disable"
 msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:439
-#: lib/vutuv_web/live/post_live/composer.ex:1753
+#: lib/vutuv_web/live/post_live/composer.ex:1674
 #: lib/vutuv_web/templates/export/index.html.heex:41
 #: lib/vutuv_web/templates/user/show.html.heex:303
 #: lib/vutuv_web/views/qualification_html.ex:237
@@ -216,7 +216,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1029
+#: lib/vutuv_web/templates/user/show.html.heex:1032
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -293,7 +293,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:556
+#: lib/vutuv_web/templates/user/show.html.heex:559
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -338,7 +338,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:837
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -353,7 +353,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:67
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:1001
+#: lib/vutuv_web/templates/user/show.html.heex:1004
 #: lib/vutuv_web/views/account_event_text.ex:153
 #, elixir-autogen
 msgid "Gender"
@@ -614,7 +614,7 @@ msgstr ""
 msgid "Provider"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1981
+#: lib/vutuv_web/live/post_live/composer.ex:1771
 #: lib/vutuv_web/live/section_reorder_live.ex:265
 #: lib/vutuv_web/templates/email/card_list.html.heex:25
 #: lib/vutuv_web/templates/email/show.html.heex:25
@@ -624,7 +624,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3041
 #: lib/vutuv_web/live/organization_live/edit.ex:341
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:84
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:105
@@ -694,13 +694,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1157
+#: lib/vutuv_web/templates/user/show.html.heex:1160
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1159
+#: lib/vutuv_web/templates/user/show.html.heex:1162
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -851,8 +851,8 @@ msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3206
-#: lib/vutuv_web/templates/user/show.html.heex:828
-#: lib/vutuv_web/templates/user/show.html.heex:848
+#: lib/vutuv_web/templates/user/show.html.heex:831
+#: lib/vutuv_web/templates/user/show.html.heex:851
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -1059,7 +1059,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:990
+#: lib/vutuv_web/templates/user/show.html.heex:993
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1247,7 +1247,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:550
+#: lib/vutuv_web/templates/user/show.html.heex:553
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1446,7 +1446,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:520
+#: lib/vutuv_web/templates/user/show.html.heex:523
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1669,9 +1669,9 @@ msgstr ""
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
 #: lib/vutuv_web/live/admin/organization_live.ex:299
-#: lib/vutuv_web/live/post_live/composer.ex:1390
-#: lib/vutuv_web/live/post_live/composer.ex:1391
-#: lib/vutuv_web/live/post_live/composer.ex:2423
+#: lib/vutuv_web/live/post_live/composer.ex:1311
+#: lib/vutuv_web/live/post_live/composer.ex:1312
+#: lib/vutuv_web/live/post_live/composer.ex:2213
 #: lib/vutuv_web/templates/layout/app.html.heex:155
 #: lib/vutuv_web/templates/layout/app.html.heex:161
 #: lib/vutuv_web/views/layout_html.ex:40
@@ -1739,8 +1739,8 @@ msgstr ""
 #: lib/vutuv_web/live/fediverse_account_live.ex:380
 #: lib/vutuv_web/live/fediverse_following_live.ex:287
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:403
-#: lib/vutuv_web/templates/user/show.html.heex:945
-#: lib/vutuv_web/templates/user/show.html.heex:1197
+#: lib/vutuv_web/templates/user/show.html.heex:948
+#: lib/vutuv_web/templates/user/show.html.heex:1200
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1907,7 +1907,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1057
+#: lib/vutuv_web/live/post_live/feed.ex:1106
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2123,7 +2123,7 @@ msgstr ""
 msgid "Add images"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2098
+#: lib/vutuv_web/live/post_live/composer.ex:1888
 #, elixir-autogen, elixir-format
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
@@ -2134,7 +2134,7 @@ msgstr ""
 msgid "Back to the post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1673
+#: lib/vutuv_web/live/post_live/composer.ex:1594
 #, elixir-autogen, elixir-format
 msgid "Cancel upload"
 msgstr ""
@@ -2157,7 +2157,7 @@ msgid "Edit post"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:87
-#: lib/vutuv_web/live/post_live/feed.ex:857
+#: lib/vutuv_web/live/post_live/feed.ex:903
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:118
@@ -2175,12 +2175,12 @@ msgstr ""
 msgid "Hidden from:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2074
+#: lib/vutuv_web/live/post_live/composer.ex:1864
 #, elixir-autogen, elixir-format
 msgid "Hide from a specific person…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2002
+#: lib/vutuv_web/live/post_live/composer.ex:1792
 #, elixir-autogen, elixir-format
 msgid "Hide this post from…"
 msgstr ""
@@ -2191,39 +2191,39 @@ msgstr ""
 msgid "Limited audience"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2044
+#: lib/vutuv_web/live/post_live/composer.ex:1834
 #, elixir-autogen, elixir-format
 msgid "Logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1116
-#: lib/vutuv_web/live/post_live/composer.ex:1164
+#: lib/vutuv_web/live/post_live/composer.ex:1037
+#: lib/vutuv_web/live/post_live/composer.ex:1085
 #, elixir-autogen, elixir-format
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:998
+#: lib/vutuv_web/live/post_live/feed.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1089
+#: lib/vutuv_web/live/post_live/composer.ex:1010
 #, elixir-autogen, elixir-format
 msgid "One of the images could not be attached."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2034
+#: lib/vutuv_web/live/post_live/composer.ex:1824
 #, elixir-autogen, elixir-format
 msgid "People I don't follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2024
+#: lib/vutuv_web/live/post_live/composer.ex:1814
 #, elixir-autogen, elixir-format
 msgid "People who don't follow me"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:151
-#: lib/vutuv_web/live/post_live/composer.ex:1990
+#: lib/vutuv_web/live/post_live/composer.ex:1780
 #: lib/vutuv_web/views/admin/moderation_html.ex:26
 #, elixir-autogen, elixir-format
 msgid "Post"
@@ -2270,7 +2270,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:242
-#: lib/vutuv_web/live/post_live/composer.ex:2060
+#: lib/vutuv_web/live/post_live/composer.ex:1850
 #: lib/vutuv_web/live/post_live/saved.ex:538
 #: lib/vutuv_web/live/post_live/saved.ex:566
 #: lib/vutuv_web/templates/connection/index.html.heex:40
@@ -2284,12 +2284,12 @@ msgstr ""
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1988
+#: lib/vutuv_web/live/post_live/composer.ex:1778
 #, elixir-autogen, elixir-format
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:931
+#: lib/vutuv_web/live/post_live/feed.ex:978
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2305,12 +2305,12 @@ msgstr[1] ""
 msgid "Sorry, that page could not be found."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1190
+#: lib/vutuv_web/live/post_live/composer.ex:1111
 #, elixir-autogen, elixir-format
 msgid "That file could not be processed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1071
+#: lib/vutuv_web/live/post_live/composer.ex:992
 #, elixir-autogen, elixir-format
 msgid "The audience selection is not valid."
 msgstr ""
@@ -2320,12 +2320,12 @@ msgstr ""
 msgid "This post is for followers of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2572
+#: lib/vutuv_web/live/post_live/composer.ex:2362
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2573
+#: lib/vutuv_web/live/post_live/composer.ex:2363
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -2339,12 +2339,12 @@ msgstr ""
 msgid "View profile"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2141
+#: lib/vutuv_web/live/post_live/composer.ex:1931
 #, elixir-autogen, elixir-format
 msgid "What's new?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2142
+#: lib/vutuv_web/live/post_live/composer.ex:1932
 #, elixir-autogen, elixir-format
 msgid "What's new? Markdown is supported."
 msgstr ""
@@ -2380,17 +2380,17 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1810
+#: lib/vutuv_web/live/post_live/composer.ex:1731
 #, elixir-autogen, elixir-format
 msgid "Tags, separated by commas (max. %{max})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2563
+#: lib/vutuv_web/live/post_live/composer.ex:2353
 #, elixir-autogen, elixir-format
 msgid "File is larger than %{mb} MB."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2567
+#: lib/vutuv_web/live/post_live/composer.ex:2357
 #, elixir-autogen, elixir-format
 msgid "File type not supported (allowed: %{types})."
 msgstr ""
@@ -2400,7 +2400,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:510
+#: lib/vutuv_web/templates/user/show.html.heex:513
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2506,7 +2506,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1689
 #: lib/vutuv_web/components/ui.ex:1689
 #: lib/vutuv_web/components/ui.ex:1826
-#: lib/vutuv_web/live/post_live/feed.ex:1046
+#: lib/vutuv_web/live/post_live/feed.ex:1095
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2543,13 +2543,13 @@ msgstr ""
 msgid "Reply to a deleted post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1074
-#: lib/vutuv_web/live/post_live/composer.ex:1978
+#: lib/vutuv_web/live/post_live/composer.ex:995
+#: lib/vutuv_web/live/post_live/composer.ex:1768
 #, elixir-autogen, elixir-format
 msgid "The audience cannot be restricted while reposts or replies exist."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2105
+#: lib/vutuv_web/live/post_live/composer.ex:1895
 #, elixir-autogen, elixir-format
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
@@ -2740,45 +2740,45 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:760
+#: lib/vutuv_web/templates/user/show.html.heex:763
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1118
+#: lib/vutuv_web/templates/user/show.html.heex:1121
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1375
+#: lib/vutuv_web/templates/user/show.html.heex:1378
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1046
+#: lib/vutuv_web/templates/user/show.html.heex:1049
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:992
+#: lib/vutuv_web/templates/user/show.html.heex:995
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:559
+#: lib/vutuv_web/templates/user/show.html.heex:562
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1080
+#: lib/vutuv_web/live/user_profile_live.ex:1193
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
@@ -2792,12 +2792,12 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:138
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:219
-#: lib/vutuv_web/templates/user/show.html.heex:550
+#: lib/vutuv_web/templates/user/show.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:882
+#: lib/vutuv_web/live/post_live/feed.ex:928
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2853,7 +2853,7 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2014
+#: lib/vutuv_web/live/post_live/composer.ex:1804
 #, elixir-autogen, elixir-format
 msgid "People who aren't my connections"
 msgstr ""
@@ -2902,7 +2902,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:942
-#: lib/vutuv_web/templates/user/show.html.heex:815
+#: lib/vutuv_web/templates/user/show.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3131,8 +3131,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1086
-#: lib/vutuv_web/templates/user/show.html.heex:1087
+#: lib/vutuv_web/templates/user/show.html.heex:1089
+#: lib/vutuv_web/templates/user/show.html.heex:1090
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -4572,7 +4572,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1003
+#: lib/vutuv_web/live/post_live/feed.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4584,7 +4584,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:837
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4699,8 +4699,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:46
-#: lib/vutuv_web/live/user_profile_live.ex:1068
-#: lib/vutuv_web/templates/user/show.html.heex:523
+#: lib/vutuv_web/live/user_profile_live.ex:1181
+#: lib/vutuv_web/templates/user/show.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5327,7 +5327,7 @@ msgstr ""
 msgid "This permanently removes your profile, posts, messages and everything else. We email you a PIN to confirm. It cannot be undone."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1092
+#: lib/vutuv_web/live/post_live/composer.ex:1013
 #, elixir-autogen, elixir-format
 msgid "You can no longer reply to this post."
 msgstr ""
@@ -5413,7 +5413,7 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1070
+#: lib/vutuv_web/live/user_profile_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
@@ -5443,7 +5443,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2318
 #: lib/vutuv_web/components/post_components.ex:2708
 #: lib/vutuv_web/live/notification_live/index.ex:624
-#: lib/vutuv_web/live/post_live/feed.ex:1119
+#: lib/vutuv_web/live/post_live/feed.ex:1168
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6078,7 +6078,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1074
+#: lib/vutuv_web/live/user_profile_live.ex:1187
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6093,7 +6093,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:260
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:758
+#: lib/vutuv_web/templates/user/show.html.heex:761
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6114,7 +6114,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1426
+#: lib/vutuv_web/templates/user/show.html.heex:1429
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6151,15 +6151,15 @@ msgstr ""
 msgid "Use photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1431
+#: lib/vutuv_web/live/post_live/composer.ex:1352
 #: lib/vutuv_web/templates/user/edit.html.heex:51
 #: lib/vutuv_web/templates/user/edit.html.heex:104
 #, elixir-autogen, elixir-format
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1012
-#: lib/vutuv_web/templates/user/show.html.heex:1022
+#: lib/vutuv_web/templates/user/show.html.heex:1015
+#: lib/vutuv_web/templates/user/show.html.heex:1025
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6199,12 +6199,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1133
+#: lib/vutuv_web/templates/user/show.html.heex:1136
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1144
+#: lib/vutuv_web/templates/user/show.html.heex:1147
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6246,7 +6246,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1142
+#: lib/vutuv_web/templates/user/show.html.heex:1145
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6300,9 +6300,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1412
-#: lib/vutuv_web/templates/user/show.html.heex:1420
-#: lib/vutuv_web/templates/user/show.html.heex:1432
+#: lib/vutuv_web/templates/user/show.html.heex:1415
+#: lib/vutuv_web/templates/user/show.html.heex:1423
+#: lib/vutuv_web/templates/user/show.html.heex:1435
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -8168,7 +8168,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:614
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8193,7 +8193,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:608
+#: lib/vutuv_web/templates/user/show.html.heex:611
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -8354,7 +8354,7 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1113
+#: lib/vutuv_web/live/user_profile_live.ex:1226
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
@@ -8380,7 +8380,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:99
-#: lib/vutuv_web/templates/user/show.html.heex:1279
+#: lib/vutuv_web/templates/user/show.html.heex:1282
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8490,13 +8490,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1086
-#: lib/vutuv_web/live/post_live/feed.ex:1087
+#: lib/vutuv_web/live/post_live/feed.ex:1135
+#: lib/vutuv_web/live/post_live/feed.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1081
+#: lib/vutuv_web/live/post_live/feed.ex:1130
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8702,8 +8702,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:873
-#: lib/vutuv_web/templates/user/show.html.heex:1184
+#: lib/vutuv_web/templates/user/show.html.heex:876
+#: lib/vutuv_web/templates/user/show.html.heex:1187
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -9102,7 +9102,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:673
+#: lib/vutuv_web/templates/user/show.html.heex:676
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9326,7 +9326,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:670
+#: lib/vutuv_web/templates/user/show.html.heex:673
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9606,7 +9606,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:713
+#: lib/vutuv_web/templates/user/show.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9654,7 +9654,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:710
+#: lib/vutuv_web/templates/user/show.html.heex:713
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr ""
@@ -9771,8 +9771,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1108
-#: lib/vutuv_web/templates/user/show.html.heex:1109
+#: lib/vutuv_web/templates/user/show.html.heex:1111
+#: lib/vutuv_web/templates/user/show.html.heex:1112
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9956,7 +9956,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:131
 #: lib/vutuv_web/templates/totp/new.html.heex:58
-#: lib/vutuv_web/templates/user/show.html.heex:909
+#: lib/vutuv_web/templates/user/show.html.heex:912
 #: lib/vutuv_web/templates/username/new.html.heex:27
 #: lib/vutuv_web/templates/username/new.html.heex:114
 #, elixir-autogen, elixir-format
@@ -9967,8 +9967,8 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:134
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
-#: lib/vutuv_web/templates/user/show.html.heex:908
-#: lib/vutuv_web/templates/user/show.html.heex:912
+#: lib/vutuv_web/templates/user/show.html.heex:911
+#: lib/vutuv_web/templates/user/show.html.heex:915
 #: lib/vutuv_web/templates/username/new.html.heex:26
 #: lib/vutuv_web/templates/username/new.html.heex:30
 #: lib/vutuv_web/templates/username/new.html.heex:113
@@ -10428,7 +10428,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1253
+#: lib/vutuv_web/templates/user/show.html.heex:1256
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -13155,7 +13155,6 @@ msgid "Search title, poster or organization"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/job_live.ex:264
-#: lib/vutuv_web/live/post_live/composer.ex:1881
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
@@ -13664,7 +13663,7 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2542
+#: lib/vutuv_web/live/post_live/composer.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Insert into text"
 msgstr ""
@@ -13723,14 +13722,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3479
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:1032
+#: lib/vutuv_web/live/post_live/feed.ex:1081
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1047
+#: lib/vutuv_web/live/post_live/feed.ex:1096
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13772,7 +13771,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1219
+#: lib/vutuv_web/templates/user/show.html.heex:1222
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13809,7 +13808,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1217
+#: lib/vutuv_web/templates/user/show.html.heex:1220
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13891,19 +13890,8 @@ msgstr ""
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1889
-#, elixir-autogen, elixir-format
-msgid "Author(s)"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1959
-#, elixir-autogen, elixir-format
-msgid "Book"
-msgstr ""
-
 #: lib/vutuv_web/agent_docs/markdown.ex:979
 #: lib/vutuv_web/components/post_components.ex:3504
-#: lib/vutuv_web/live/post_live/composer.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
@@ -13918,53 +13906,21 @@ msgstr ""
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1889
-#, elixir-autogen, elixir-format
-msgid "Director"
-msgstr ""
-
 #: lib/vutuv_web/components/post_components.ex:3546
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1971
-#, elixir-autogen, elixir-format
-msgid "Film"
-msgstr ""
-
 #: lib/vutuv_web/agent_docs/markdown.ex:979
 #: lib/vutuv_web/components/post_components.ex:3503
-#: lib/vutuv_web/live/post_live/composer.ex:1834
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1855
-#, elixir-autogen, elixir-format
-msgid "IMDb link or ID"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1856
-#, elixir-autogen, elixir-format
-msgid "ISBN"
-msgstr ""
-
 #: lib/vutuv_web/live/fediverse_account_live.ex:441
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:338
-#: lib/vutuv_web/live/post_live/composer.ex:1869
 #, elixir-autogen, elixir-format
 msgid "Look up"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1866
-#, elixir-autogen, elixir-format
-msgid "Looking up…"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:673
-#, elixir-autogen, elixir-format
-msgid "Nothing found for this ISBN. Please fill in the fields yourself."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3545
@@ -13972,44 +13928,11 @@ msgstr ""
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1908
-#, elixir-autogen, elixir-format
-msgid "Read as… (optional)"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1844
-#, elixir-autogen, elixir-format
-msgid "Remove review"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1955
-#: lib/vutuv_web/live/post_live/composer.ex:1956
-#, elixir-autogen, elixir-format
-msgid "Review a book"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1967
-#: lib/vutuv_web/live/post_live/composer.ex:1968
-#, elixir-autogen, elixir-format
-msgid "Review a film"
-msgstr ""
-
 #: lib/vutuv_web/components/post_components.ex:3549
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1907
-#, elixir-autogen, elixir-format
-msgid "Watched as… (optional)"
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1921
-#, elixir-autogen, elixir-format
-msgid "With an ISBN, the post shows the book cover and a shop link automatically."
-msgstr ""
-
-#: lib/vutuv_web/live/post_live/composer.ex:1901
 #: lib/vutuv_web/templates/education/form_content.html.heex:50
 #: lib/vutuv_web/templates/education/form_content.html.heex:51
 #: lib/vutuv_web/templates/education/form_content.html.heex:70
@@ -14409,13 +14332,13 @@ msgstr ""
 msgid "mentioned you in a post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1079
+#: lib/vutuv_web/live/post_live/composer.ex:1000
 #: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1082
+#: lib/vutuv_web/live/post_live/composer.ex:1003
 #: lib/vutuv_web/live/post_live/edit.ex:61
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
@@ -14685,7 +14608,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:216
+#: lib/vutuv_web/live/post_live/feed.ex:233
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14718,7 +14641,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:225
+#: lib/vutuv_web/live/post_live/feed.ex:242
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -15268,27 +15191,27 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:877
+#: lib/vutuv_web/templates/user/show.html.heex:880
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:893
+#: lib/vutuv_web/templates/user/show.html.heex:896
 #, elixir-autogen, elixir-format
 msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:930
+#: lib/vutuv_web/templates/user/show.html.heex:933
 #, elixir-autogen, elixir-format
 msgid "Follow from your own server"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:941
+#: lib/vutuv_web/templates/user/show.html.heex:944
 #, elixir-autogen, elixir-format
 msgid "@you@example.social"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:949
+#: lib/vutuv_web/templates/user/show.html.heex:952
 #, elixir-autogen, elixir-format
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr ""
@@ -15835,7 +15758,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:170
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:139
-#: lib/vutuv_web/live/post_live/feed.ex:344
+#: lib/vutuv_web/live/post_live/feed.ex:361
 #: lib/vutuv_web/live/post_live/thread.ex:209
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16541,7 +16464,7 @@ msgstr ""
 msgid "Optional. Write your name the way it sounds, so someone calling you for the first time gets it right. It shows in square brackets under your name on your profile, the way a transcription is written, and the brackets are added for you. Leave it empty and nothing is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2555
+#: lib/vutuv_web/live/post_live/composer.ex:2345
 #, elixir-autogen, elixir-format
 msgid "Apply these settings to all photos"
 msgstr ""
@@ -16571,12 +16494,12 @@ msgstr ""
 msgid "CC0 1.0 (no rights reserved)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2222
+#: lib/vutuv_web/live/post_live/composer.ex:2012
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2415
+#: lib/vutuv_web/live/post_live/composer.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Describe the photo for people who can't see it"
 msgstr ""
@@ -16588,27 +16511,27 @@ msgstr ""
 msgid "Download the original"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1510
+#: lib/vutuv_web/live/post_live/composer.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Drag to reorder. The first photo leads the gallery."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2492
+#: lib/vutuv_web/live/post_live/composer.ex:2282
 #, elixir-autogen, elixir-format
 msgid "Every metadata field kept, including anything your camera wrote."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2448
+#: lib/vutuv_web/live/post_live/composer.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Everybody may download this photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2450
+#: lib/vutuv_web/live/post_live/composer.ex:2240
 #, elixir-autogen, elixir-format
 msgid "Full resolution, straight from the post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2469
+#: lib/vutuv_web/live/post_live/composer.ex:2259
 #, elixir-autogen, elixir-format
 msgid "Just the picture"
 msgstr ""
@@ -16618,7 +16541,7 @@ msgstr ""
 msgid "Next photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2241
+#: lib/vutuv_web/live/post_live/composer.ex:2031
 #, elixir-autogen, elixir-format
 msgid "No image description yet"
 msgstr ""
@@ -16650,8 +16573,8 @@ msgstr ""
 msgid "Photo is being checked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2194
-#: lib/vutuv_web/live/post_live/composer.ex:2195
+#: lib/vutuv_web/live/post_live/composer.ex:1984
+#: lib/vutuv_web/live/post_live/composer.ex:1985
 #, elixir-autogen, elixir-format
 msgid "Photo options"
 msgstr ""
@@ -16668,18 +16591,18 @@ msgstr ""
 msgid "Previous photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2254
-#: lib/vutuv_web/live/post_live/composer.ex:2255
+#: lib/vutuv_web/live/post_live/composer.ex:2044
+#: lib/vutuv_web/live/post_live/composer.ex:2045
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2471
+#: lib/vutuv_web/live/post_live/composer.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Same pixels, nothing else: location and serial numbers removed, quality untouched."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1482
+#: lib/vutuv_web/live/post_live/composer.ex:1403
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show camera settings"
 msgstr ""
@@ -16689,17 +16612,17 @@ msgstr ""
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2490
+#: lib/vutuv_web/live/post_live/composer.ex:2280
 #, elixir-autogen, elixir-format
 msgid "The file exactly as I uploaded it"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2526
+#: lib/vutuv_web/live/post_live/composer.ex:2316
 #, elixir-autogen, elixir-format
 msgid "This file format can only be handed out as it is. Remove the photo if that is not what you want."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2518
+#: lib/vutuv_web/live/post_live/composer.ex:2308
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
@@ -16724,12 +16647,12 @@ msgstr ""
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1731
+#: lib/vutuv_web/live/post_live/composer.ex:1652
 #, elixir-autogen, elixir-format
 msgid "Who may reuse these photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1099
+#: lib/vutuv_web/live/post_live/composer.ex:1020
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
@@ -16739,7 +16662,7 @@ msgstr ""
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1113
+#: lib/vutuv_web/live/post_live/composer.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
@@ -16754,76 +16677,76 @@ msgstr ""
 msgid "© All rights reserved"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1501
-#: lib/vutuv_web/live/post_live/composer.ex:1943
+#: lib/vutuv_web/live/post_live/composer.ex:1422
+#: lib/vutuv_web/live/post_live/composer.ex:1760
 #, elixir-autogen, elixir-format
 msgid "Add photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1726
+#: lib/vutuv_web/live/post_live/composer.ex:1647
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:891
-#: lib/vutuv_web/live/post_live/feed.ex:892
+#: lib/vutuv_web/live/post_live/feed.ex:937
+#: lib/vutuv_web/live/post_live/feed.ex:938
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1459
+#: lib/vutuv_web/live/post_live/composer.ex:1380
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Caption (optional)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1327
-#: lib/vutuv_web/live/post_live/composer.ex:1385
+#: lib/vutuv_web/live/post_live/composer.ex:1248
+#: lib/vutuv_web/live/post_live/composer.ex:1306
 #, elixir-autogen, elixir-format
 msgid "Discard draft"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1324
-#: lib/vutuv_web/live/post_live/composer.ex:1382
+#: lib/vutuv_web/live/post_live/composer.ex:1245
+#: lib/vutuv_web/live/post_live/composer.ex:1303
 #, elixir-autogen, elixir-format
 msgid "Discard the photos and text of this draft?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1319
+#: lib/vutuv_web/live/post_live/composer.ex:1240
 #, elixir-autogen, elixir-format
 msgid "Picked up where you left off."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1797
+#: lib/vutuv_web/live/post_live/composer.ex:1718
 #, elixir-autogen, elixir-format
 msgid "A file whose format cannot be cleaned is handed out exactly as uploaded."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2124
+#: lib/vutuv_web/live/post_live/composer.ex:1914
 #, elixir-autogen, elixir-format
 msgid "Different per photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2123
+#: lib/vutuv_web/live/post_live/composer.ex:1913
 #, elixir-autogen, elixir-format
 msgid "Original, exactly as uploaded"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2122
+#: lib/vutuv_web/live/post_live/composer.ex:1912
 #, elixir-autogen, elixir-format
 msgid "Original, metadata removed"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2127
+#: lib/vutuv_web/live/post_live/composer.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Web versions only (%{format})"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1760
+#: lib/vutuv_web/live/post_live/composer.ex:1681
 #, elixir-autogen, elixir-format
 msgid "What a visitor can save"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1786
+#: lib/vutuv_web/live/post_live/composer.ex:1707
 #, elixir-autogen, elixir-format
 msgid "This photo carries the location it was taken at, and the exact file hands it over."
 msgid_plural "Some of these photos carry the location they were taken at, and the exact file hands it over."
@@ -16933,7 +16856,7 @@ msgstr ""
 msgid "Withdrawal request"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1714
+#: lib/vutuv_web/live/post_live/composer.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Photo details"
 msgstr ""
@@ -17201,7 +17124,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:162
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:131
-#: lib/vutuv_web/live/post_live/feed.ex:336
+#: lib/vutuv_web/live/post_live/feed.ex:353
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
@@ -17242,7 +17165,7 @@ msgid "Mute %{handle}"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:394
+#: lib/vutuv_web/live/post_live/feed.ex:411
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr ""
@@ -17516,7 +17439,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:195
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:110
-#: lib/vutuv_web/live/post_live/feed.ex:372
+#: lib/vutuv_web/live/post_live/feed.ex:389
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr ""
@@ -17551,12 +17474,12 @@ msgstr ""
 msgid "People on Mastodon and other independent networks can then follow this profile, and your public posts appear there. What they answer or share comes back and is shown under your posts, by their account address. A reply from there is stored here for up to six months. You can switch all of it off again at any time."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1091
+#: lib/vutuv_web/live/user_profile_live.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Follow %{count} members"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1106
+#: lib/vutuv_web/live/user_profile_live.ex:1219
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
@@ -17895,135 +17818,135 @@ msgstr ""
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1428
+#: lib/vutuv_web/live/post_live/composer.ex:1349
 #, elixir-autogen, elixir-format
 msgid "Apply crop"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1544
+#: lib/vutuv_web/live/post_live/composer.ex:1465
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Auto"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2300
+#: lib/vutuv_web/live/post_live/composer.ex:2090
 #, elixir-autogen, elixir-format
 msgid "Big photo left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2301
+#: lib/vutuv_web/live/post_live/composer.ex:2091
 #, elixir-autogen, elixir-format
 msgid "Big photo right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2306
+#: lib/vutuv_web/live/post_live/composer.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Columns"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2303
+#: lib/vutuv_web/live/post_live/composer.ex:2093
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover left"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2304
+#: lib/vutuv_web/live/post_live/composer.ex:2094
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover on top"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2305
+#: lib/vutuv_web/live/post_live/composer.ex:2095
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover right"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1424
-#: lib/vutuv_web/live/post_live/composer.ex:2271
-#: lib/vutuv_web/live/post_live/composer.ex:2272
+#: lib/vutuv_web/live/post_live/composer.ex:1345
+#: lib/vutuv_web/live/post_live/composer.ex:2061
+#: lib/vutuv_web/live/post_live/composer.ex:2062
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Crop photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2230
+#: lib/vutuv_web/live/post_live/composer.ex:2020
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cropped"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1355
+#: lib/vutuv_web/live/post_live/composer.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Drop photos to add them"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1522
+#: lib/vutuv_web/live/post_live/composer.ex:1443
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Gallery preview"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2307
+#: lib/vutuv_web/live/post_live/composer.ex:2097
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2308
+#: lib/vutuv_web/live/post_live/composer.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Mosaic"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1426
+#: lib/vutuv_web/live/post_live/composer.ex:1347
 #, elixir-autogen, elixir-format
 msgid "Pick a shape, then drag and zoom. The framed part is what the post shows."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2299
+#: lib/vutuv_web/live/post_live/composer.ex:2089
 #, elixir-autogen, elixir-format
 msgid "Side by side"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2302
+#: lib/vutuv_web/live/post_live/composer.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Stacked"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1637
-#: lib/vutuv_web/live/post_live/composer.ex:1638
+#: lib/vutuv_web/live/post_live/composer.ex:1558
+#: lib/vutuv_web/live/post_live/composer.ex:1559
 #, elixir-autogen, elixir-format
 msgid "Swap this photo with another"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1525
+#: lib/vutuv_web/live/post_live/composer.ex:1446
 #, elixir-autogen, elixir-format
 msgid "Tap two photos to swap them."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:390
+#: lib/vutuv_web/live/post_live/composer.ex:381
 #, elixir-autogen, elixir-format
 msgid "The photo could not be cropped."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:2505
+#: lib/vutuv_web/live/post_live/composer.ex:2295
 #, elixir-autogen, elixir-format
 msgid "This photo is cropped: downloads hand out the cropped picture, and the untouched upload stays private."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1430
+#: lib/vutuv_web/live/post_live/composer.ex:1351
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photo"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1619
+#: lib/vutuv_web/live/post_live/composer.ex:1540
 #, elixir-autogen, elixir-format
 msgid "Each photo covers its tile and is cropped by it."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1620
+#: lib/vutuv_web/live/post_live/composer.ex:1541
 #, elixir-autogen, elixir-format
 msgid "Each photo shows whole inside its tile."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1615
+#: lib/vutuv_web/live/post_live/composer.ex:1536
 #, elixir-autogen, elixir-format
 msgid "Fill the tiles"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/composer.ex:1599
+#: lib/vutuv_web/live/post_live/composer.ex:1520
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Whole photos"
 msgstr ""

--- a/test/vutuv/book_metadata_test.exs
+++ b/test/vutuv/book_metadata_test.exs
@@ -32,40 +32,6 @@ defmodule Vutuv.BookMetadataTest do
     )
   end
 
-  describe "lookup/1 (the composer's prefill)" do
-    test "parses title, authors and year from the Open Library answer" do
-      stub(%{
-        "ISBN:#{@isbn}" => %{
-          "title" => "Refactoring",
-          "authors" => [%{"name" => "Martin Fowler"}, %{"name" => "Kent Beck"}],
-          "publish_date" => "November 2018"
-        }
-      })
-
-      assert {:ok, %{title: "Refactoring", creator: "Martin Fowler, Kent Beck", year: 2018}} =
-               BookMetadata.lookup(@isbn)
-    end
-
-    test "missing optional fields come back nil" do
-      stub(%{"ISBN:#{@isbn}" => %{"title" => "Nur Titel"}})
-
-      assert {:ok, %{title: "Nur Titel", creator: nil, year: nil}} = BookMetadata.lookup(@isbn)
-    end
-
-    test "an unknown ISBN is :error" do
-      stub(%{})
-
-      assert :error = BookMetadata.lookup(@isbn)
-    end
-
-    test "with the fetch flag off nothing is looked up" do
-      Application.put_env(:vutuv, :fetch_book_metadata, false)
-      stub(%{"ISBN:#{@isbn}" => %{"title" => "Nie geholt"}})
-
-      assert :error = BookMetadata.lookup(@isbn)
-    end
-  end
-
   describe "edition_details/1" do
     test "reads page count and publisher from the edition record" do
       # The edition record — not the books API — is where Open Library keeps

--- a/test/vutuv_web/live/photo_composer_test.exs
+++ b/test/vutuv_web/live/photo_composer_test.exs
@@ -302,15 +302,6 @@ defmodule VutuvWeb.PhotoComposerTest do
       refute has_element?(live, ~s([phx-click="photo-move"]))
     end
 
-    test "the review triggers stay available with photos attached", %{conn: conn, user: user} do
-      # A book review may well carry a photo of the book; with the tabs gone
-      # there is no arrangement left that hides the triggers.
-      live = open_composer(conn)
-      upload_photo!(live, user)
-
-      assert has_element?(live, ~s(button[phx-click="review-kind"][phx-value-kind="book"]))
-    end
-
     test "the alt nudge shows only while a photo has neither caption nor description", %{
       conn: conn,
       user: user

--- a/test/vutuv_web/live/post_review_composer_test.exs
+++ b/test/vutuv_web/live/post_review_composer_test.exs
@@ -1,8 +1,11 @@
 defmodule VutuvWeb.PostReviewComposerTest do
   @moduledoc """
-  The composer's review panel (book/film reviews, `Vutuv.Posts.PostReview`):
-  opening it via the 📖/🎬 triggers, the ISBN lookup prefill, the save round
-  trip onto the feed card, and removing a stored review from the edit page.
+  The composer no longer offers the book/film review form: the 📖/🎬 triggers,
+  the panel and the ISBN lookup are gone (removed 2026-07-30). Existing review
+  posts (`Vutuv.Posts.PostReview`) keep rendering their card everywhere, and
+  editing such a post must leave its stored review untouched — the composer
+  simply submits no `review` key any more, which the changeset reads as "leave
+  it as it is".
   """
 
   use VutuvWeb.ConnCase
@@ -17,141 +20,39 @@ defmodule VutuvWeb.PostReviewComposerTest do
     "title" => "Refactoring",
     "creator" => "Martin Fowler",
     "year" => "2018",
-    "medium" => "audiobook"
+    "medium" => "print"
   }
 
   describe "the feed composer" do
-    test "opens the panel, saves a book review and renders the card", %{conn: conn} do
+    test "renders no review triggers, panel or fields", %{conn: conn} do
       {conn, _user} = create_and_login_user(conn)
       {:ok, live, _html} = live(conn, ~p"/feed")
 
+      live |> element("#open-composer") |> render_click()
+      form_html = live |> element("#composer-form") |> render()
+
+      refute form_html =~ "review-kind"
+      refute form_html =~ "post[review]"
       refute has_element?(live, "#composer-review-panel")
+    end
+  end
 
-      live
-      |> element(~s(button[phx-click="review-kind"][phx-value-kind="book"]))
-      |> render_click()
+  describe "stored reviews" do
+    test "a review post still renders its card in the feed", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
 
-      assert has_element?(live, "#composer-review-panel")
+      {:ok, _post} =
+        Posts.create_post(user, %{body: "Sehr lesenswert.", review: @review_params})
 
-      live
-      |> form("#composer-form", %{
-        "post" => %{"body" => "Sehr lesenswert.", "review" => @review_params}
-      })
-      |> render_submit()
+      {:ok, live, _html} = live(conn, ~p"/feed")
 
       feed_html = live |> element("#feed-posts") |> render()
       assert feed_html =~ "data-review-card"
       assert feed_html =~ "Refactoring"
       assert feed_html =~ "Martin Fowler"
-      assert feed_html =~ "978-3-16-148410-0"
-      assert feed_html =~ "https://www.amazon.de/dp/316148410X"
-
-      # The composer reset also closes the panel for the next post.
-      refute has_element?(live, "#composer-review-panel")
     end
 
-    test "a film review stores the IMDb id and links IMDb", %{conn: conn} do
-      {conn, user} = create_and_login_user(conn)
-      {:ok, live, _html} = live(conn, ~p"/feed")
-
-      live
-      |> element(~s(button[phx-click="review-kind"][phx-value-kind="movie"]))
-      |> render_click()
-
-      live
-      |> form("#composer-form", %{
-        "post" => %{
-          "body" => "Starker Film.",
-          "review" => %{
-            "kind" => "movie",
-            "identifier" => "https://www.imdb.com/title/tt0111161/?ref_=x",
-            "title" => "Die Verurteilten",
-            "creator" => "Frank Darabont",
-            "medium" => "cinema"
-          }
-        }
-      })
-      |> render_submit()
-
-      feed_html = live |> element("#feed-posts") |> render()
-      assert feed_html =~ ~s(data-review-kind="movie")
-      assert feed_html =~ "https://www.imdb.com/title/tt0111161/"
-
-      _ = user
-      review = Vutuv.Repo.one(Vutuv.Posts.PostReview)
-      assert review.identifier == "tt0111161"
-      assert review.medium == "cinema"
-    end
-
-    test "an invalid ISBN surfaces the review error", %{conn: conn} do
-      {conn, _user} = create_and_login_user(conn)
-      {:ok, live, _html} = live(conn, ~p"/feed")
-
-      live
-      |> element(~s(button[phx-click="review-kind"][phx-value-kind="book"]))
-      |> render_click()
-
-      html =
-        live
-        |> form("#composer-form", %{
-          "post" => %{
-            "body" => "Kaputt",
-            "review" => %{"kind" => "book", "identifier" => "12345", "title" => "X"}
-          }
-        })
-        |> render_submit()
-
-      assert html =~ "is not a valid ISBN"
-      assert live |> element("#composer-error") |> render() =~ "is not a valid ISBN"
-    end
-
-    test "the ISBN lookup prefills title, creator and year", %{conn: conn} do
-      Application.put_env(:vutuv, :fetch_book_metadata, true)
-
-      Application.put_env(:vutuv, :book_metadata_req_options,
-        plug: fn plug_conn ->
-          body = %{
-            "ISBN:9783161484100" => %{
-              "title" => "Refactoring",
-              "authors" => [%{"name" => "Martin Fowler"}],
-              "publish_date" => "November 2018"
-            }
-          }
-
-          plug_conn
-          |> Plug.Conn.put_resp_content_type("application/json")
-          |> Plug.Conn.resp(200, Jason.encode!(body))
-        end
-      )
-
-      on_exit(fn ->
-        Application.put_env(:vutuv, :fetch_book_metadata, false)
-        Application.delete_env(:vutuv, :book_metadata_req_options)
-      end)
-
-      {conn, _user} = create_and_login_user(conn)
-      {:ok, live, _html} = live(conn, ~p"/feed")
-
-      live
-      |> element(~s(button[phx-click="review-kind"][phx-value-kind="book"]))
-      |> render_click()
-
-      live
-      |> form("#composer-form", %{
-        "post" => %{"review" => %{"kind" => "book", "identifier" => "978-3-16-148410-0"}}
-      })
-      |> render_change()
-
-      html = live |> element("#composer-review-lookup") |> render_click()
-
-      assert html =~ ~s(value="Refactoring")
-      assert html =~ ~s(value="Martin Fowler")
-      assert html =~ ~s(value="2018")
-    end
-  end
-
-  describe "the edit page" do
-    test "prefills the stored review and removes it via the panel's ✕", %{conn: conn} do
+    test "editing a review post keeps the review", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
 
       {:ok, post} =
@@ -159,19 +60,17 @@ defmodule VutuvWeb.PostReviewComposerTest do
 
       {:ok, live, html} = live(conn, ~p"/posts/#{post.id}/edit")
 
-      assert html =~ ~s(id="composer-review-panel")
-      assert html =~ ~s(value="Refactoring")
+      refute html =~ "composer-review-panel"
+      refute html =~ "post[review]"
 
       live
-      |> element(~s(#composer-review-panel button[phx-click="review-kind"][phx-value-kind=""]))
-      |> render_click()
-
-      live
-      |> form("#composer-form", %{"post" => %{"body" => "Besprochen"}})
+      |> form("#composer-form", %{"post" => %{"body" => "Besprochen, immer noch gut."}})
       |> render_submit()
 
       updated = Posts.get_post(post.id)
-      assert updated.review == nil
+      assert updated.body == "Besprochen, immer noch gut."
+      assert updated.review.title == "Refactoring"
+      assert updated.review.kind == "book"
     end
   end
 end


### PR DESCRIPTION
**TL;DR** The Buch/Film buttons and the whole review form leave the composer; existing review posts keep rendering their card everywhere.

**What changed**
- Composer: the 📖/🎬 triggers, the review panel and the ISBN prefill lookup are gone, along with their events and socket state. `Vutuv.BookMetadata.lookup/1` was composer-only and goes with them (`edition_details/1` stays for the background cover pass).
- Drafts: the composer no longer stores or restores review values; `post_drafts.review` is retired like `mode` (schema field removed now, column drop in a later deploy, N-1 rule).
- Kept: the `PostReview` sidecar, the review card on every surface (HTML, agent formats, JSON-LD, AP Note/RSS), the cover/edition pipeline and its operator flags, now serving existing posts only (`docs/ADMINS.md` reworded).

**Why it is safe for old posts**: the old form always submitted a hidden review kind, and an empty kind deletes a stored review on save. The composer now submits no `review` key at all, which the changeset reads as "leave the sidecar untouched" - so editing an old review post keeps its review. `post_review_composer_test.exs` was rewritten around that guarantee.

**Deploy**: hot (no migrations, no config, no dependency or startup changes). Version bump to v7.201.0.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*