### PR TITLE
The admin sign-up pill reads at nav size, not badge size (v7.202.1)

### DIFF
--- a/lib/vutuv_web/live/shell_live.ex
+++ b/lib/vutuv_web/live/shell_live.ex
@@ -470,7 +470,7 @@ defmodule VutuvWeb.ShellLive do
               href={~p"/admin"}
               title={new_members_label(@new_members_today)}
               aria-label={new_members_label(@new_members_today)}
-              class="inline-flex items-center gap-1 rounded-full bg-brand-50 px-2.5 py-1 text-xs font-semibold text-brand-700 hover:bg-brand-100 dark:bg-brand-900/40 dark:text-brand-100 dark:hover:bg-brand-900/70"
+              class="inline-flex items-center gap-1 rounded-full bg-brand-50 px-3 py-1 text-sm font-semibold text-brand-700 hover:bg-brand-100 dark:bg-brand-900/40 dark:text-brand-100 dark:hover:bg-brand-900/70"
             >
               <.icon_user_plus />
               <span class="tabular-nums">{compact_count(@new_members_today)}</span>
@@ -727,7 +727,7 @@ defmodule VutuvWeb.ShellLive do
   # A person with a plus: the "new member" glyph on the admin sign-up pill.
   defp icon_user_plus(assigns) do
     ~H"""
-    <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24" aria-hidden="true">
+    <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24" aria-hidden="true">
       <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 9.374 21c-2.331 0-4.512-.645-6.374-1.766Z" />
     </svg>
     """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.202.0",
+      version: "7.202.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/shell_live_test.exs
+++ b/test/vutuv_web/live/shell_live_test.exs
@@ -699,6 +699,18 @@ defmodule VutuvWeb.ShellLiveTest do
       assert has_element?(german, ~s(#{@pill}[title="1 neues Mitglied heute"]))
     end
 
+    test "renders at the nav's text size, not badge-small", %{conn: conn} do
+      # The pill started life at text-xs and the figure was too small to read
+      # at a glance. It sits between text-sm nav links, so it shares their size.
+      joined_today(1)
+
+      {:ok, view, _html} =
+        live_isolated(conn, VutuvWeb.ShellLive, session: admin_session(admin()))
+
+      assert has_element?(view, "#{@pill}.text-sm")
+      refute has_element?(view, "#{@pill}.text-xs")
+    end
+
     test "re-reads the figure at the Berlin day boundary", %{conn: conn} do
       joined_today(1)
 


### PR DESCRIPTION
The admin-only "new members today" pill in the top bar rendered its figure at text-xs, too small to read at a glance. It sits between the text-sm nav links, so it now shares their size (padding bumped to px-3 to keep the shape balanced), and its user-plus icon grows h-4 → h-5 in step. A shell test pins the pill to the nav's text size so it cannot drift back down.

**Deploy:** hot (LiveView template + test only). **Version:** 7.202.1 (rebased onto v7.202.0 after #1236 merged mid-flight).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*