### PR TITLE
YouTube links show the video's thumbnail, not a consent-banner screenshot (v7.203.0)

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -169,7 +169,9 @@ and the Content-Signal headers), `:fetch_gravatar`, `:fetch_mastodon_posts`,
 `:fetch_bluesky_posts`, `:fetch_code_stats` (the profile "Code" card's
 GitHub/GitLab/Codeberg statistics), `:generate_screenshots` (profile link
 previews **and** the auto-screenshot for single-link posts — admins watch the
-capture queue and browse the gallery at `/admin/screenshots`), and
+capture queue and browse the gallery at `/admin/screenshots`; a YouTube video
+link stores the video's published thumbnail instead of a capture, fetched
+server-side from YouTube under this same flag), and
 `:serve_uploads_locally` (see nginx below).
 
 ## systemd

--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -104,6 +104,14 @@ window frame (`Vutuv.BrowserFrame`); see `Vutuv.PageScreenshot`. Needs a
 `chromium`/`chrome` binary on the host (set `CHROMIUM_PATH` if it is not on
 `$PATH`)
 
+One exception skips Chromium entirely: a **YouTube video link** in a post
+stores the thumbnail YouTube publishes for every video instead
+(`Vutuv.YoutubeThumbnail`: keyless oEmbed existence check, then
+`maxresdefault.jpg` → `hqdefault.jpg`), frameless — a capture of the watch
+page only ever shows the cookie-consent banner. Any fetch failure falls back
+to the ordinary capture; see the link-screenshots section in
+[posts-and-feed.md](posts-and-feed.md).
+
 Some hosts never yield a useful shot — they answer a headless capture with a
 login/consent wall or block bots outright — so a **screenshot blocklist**
 (`:screenshot_blocked_hosts`, default `["reddit.com"]`, override with

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -912,6 +912,24 @@ spends no Chromium run at all. The same blocklist gates the profile-link
 previews inside `capture_framed/2` (returning `:blocked_host`, a permanent
 outcome).
 
+**A YouTube video link stores YouTube's own thumbnail instead of a capture.**
+The watch page answers every logged-out request with the cookie-consent
+interstitial, so a screenshot of it only ever shows the banner.
+`Vutuv.YoutubeThumbnail` recognises a video URL (watch / `youtu.be` / shorts /
+live / embed on any of YouTube's hosts, parsed by host + path segments, never
+a string prefix), confirms the video exists via the keyless oEmbed endpoint
+(so a deleted or private video falls through instead of storing YouTube's grey
+placeholder tile), and fetches the static `maxresdefault.jpg`, falling back to
+the always-present `hqdefault.jpg`. The bytes are stored through the same
+uploader **without the browser frame** (the thumbnail is the video's artwork,
+not a web page) and enter AI image moderation like any capture; readers only
+ever see our stored copy, never `img.youtube.com`, so no viewer IP reaches
+Google. Any failure — unknown video, network trouble, a non-image answer —
+falls back to the ordinary capture below. Tests stub the fetch via the
+`:youtube_thumbnail_req_options` seam; the one-shot backfill that re-queued
+the pre-existing banner captures is `Vutuv.Release.requeue_youtube_screenshots/0`
+(`Screenshots.requeue_youtube/0`).
+
 A link that does **not answer a plain HTTP 200** is rejected at capture time by
 `ensure_http_ok/1`, a `redirect: false` GET probe the worker runs before Chromium
 (GET, not HEAD, so a server that 405s HEAD on a real 200 page isn't wrongly

--- a/lib/vutuv/posts/screenshots.ex
+++ b/lib/vutuv/posts/screenshots.ex
@@ -20,6 +20,12 @@ defmodule Vutuv.Posts.Screenshots do
   row is the scope, exactly like a `Url`), so the stored file is the same
   400×264 AVIF thumb with the `/images/screenshot.png` fallback. The capture is
   gated by the `:generate_screenshots` flag (intranet installs run air-gapped).
+
+  **YouTube links don't screenshot.** A watch page always answers with the
+  cookie-consent banner, so a capture never shows the video; the worker stores
+  the thumbnail YouTube publishes for every video instead, frameless
+  (`Vutuv.YoutubeThumbnail`), and falls back to the ordinary capture whenever
+  that fetch fails.
   """
 
   import Ecto.Query
@@ -29,6 +35,7 @@ defmodule Vutuv.Posts.Screenshots do
   alias Vutuv.Posts.PostScreenshot
   alias Vutuv.Repo
   alias Vutuv.SocialFeed.Http
+  alias Vutuv.YoutubeThumbnail
 
   require Logger
 
@@ -231,6 +238,34 @@ defmodule Vutuv.Posts.Screenshots do
 
   def requeue(%PostScreenshot{}), do: {:error, :not_requeueable}
 
+  @doc """
+  Puts every finished job whose URL is a YouTube video back in the queue, so
+  the worker replaces its stored capture with the video's own thumbnail
+  (`Vutuv.YoutubeThumbnail`) — the one-shot backfill for captures from before
+  that existed, which all show YouTube's consent banner. `ready` and `failed`
+  rows alike get a clean pending slate; an author-`dismissed` tombstone stays
+  dismissed (their call, and the thumbnail may be exactly what they removed).
+  Returns the number re-queued. On a release, run it via
+  `Vutuv.Release.requeue_youtube_screenshots/0`.
+  """
+  def requeue_youtube do
+    from(ps in PostScreenshot, where: ps.status in ["ready", "failed"])
+    |> Repo.all()
+    |> Enum.filter(&match?({:ok, _id}, YoutubeThumbnail.video_id(&1.url)))
+    |> Enum.map(fn job ->
+      {:ok, _requeued} =
+        job
+        |> Ecto.Changeset.change(
+          status: "pending",
+          attempts: 0,
+          next_attempt_at: nil,
+          last_error: nil
+        )
+        |> Repo.update()
+    end)
+    |> length()
+  end
+
   @doc "Loads one job by id, raising when it is gone (the admin views' reads)."
   def get_job!(id), do: Repo.get!(PostScreenshot, id)
 
@@ -307,10 +342,54 @@ defmodule Vutuv.Posts.Screenshots do
   defp permanent_failure?({:bad_status, _status}), do: true
   defp permanent_failure?(_reason), do: false
 
-  # The real capture: capture only a plain HTTP-200 link, then reuse the shared
-  # pipeline and store through the same uploader profile links use. Returns the
-  # stored filename + display size.
+  # The real capture. A YouTube video link stores the thumbnail YouTube itself
+  # publishes (a watch-page capture only ever shows the consent banner); every
+  # other link — and any YouTube fetch trouble — takes the Chromium path.
   defp capture_and_store(%PostScreenshot{} = job) do
+    case youtube_capture(job) do
+      {:ok, result} -> {:ok, result}
+      :fallback -> page_capture_and_store(job)
+    end
+  end
+
+  # The YouTube branch: `{:ok, result}` with the stored thumbnail, or
+  # `:fallback` — not a YouTube video URL, a video oEmbed doesn't know
+  # (deleted, private), fetch or store trouble — and the caller then captures
+  # the page like any other link.
+  defp youtube_capture(%PostScreenshot{} = job) do
+    with {:ok, video_id} <- YoutubeThumbnail.video_id(job.url),
+         {:ok, bytes} <- YoutubeThumbnail.fetch(video_id) do
+      store_thumbnail(job, bytes)
+    else
+      :error -> :fallback
+    end
+  end
+
+  # Stored raw — no browser frame: the thumbnail is the video's artwork, not a
+  # captured web page, so browser chrome around it would be a lie.
+  defp store_thumbnail(%PostScreenshot{} = job, bytes) do
+    tmp = Path.join(System.tmp_dir!(), "yt_thumb_#{job.id}.jpg")
+
+    try do
+      File.write!(tmp, bytes)
+      upload = %Plug.Upload{content_type: "image/jpeg", filename: "#{job.id}.jpg", path: tmp}
+
+      case Vutuv.Screenshot.store({upload, job}) do
+        {:ok, file_name} ->
+          {:ok, %{screenshot: file_name, width: @display_width, height: @display_height}}
+
+        {:error, _reason} ->
+          :fallback
+      end
+    after
+      File.rm(tmp)
+    end
+  end
+
+  # The classic capture: capture only a plain HTTP-200 link, then reuse the
+  # shared pipeline and store through the same uploader profile links use.
+  # Returns the stored filename + display size.
+  defp page_capture_and_store(%PostScreenshot{} = job) do
     with :ok <- ensure_http_ok(job.url),
          {:ok, framed_path} <- Vutuv.PageScreenshot.capture_framed(job.url, job.id) do
       upload = %Plug.Upload{

--- a/lib/vutuv/release.ex
+++ b/lib/vutuv/release.ex
@@ -8,6 +8,7 @@ defmodule Vutuv.Release do
   """
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Posts.ReviewCovers
+  alias Vutuv.Posts.Screenshots
   alias Vutuv.Uploads.LegacyRelabel
   alias Vutuv.Uploads.LegacySweeper
   alias Vutuv.Uploads.Regenerator
@@ -239,6 +240,25 @@ defmodule Vutuv.Release do
   defp print_opinion(opinion) do
     verdict = if opinion["safe"], do: "safe", else: "unsafe"
     IO.puts("    - #{verdict} (#{opinion["category"]}): #{opinion["reason"]}")
+  end
+
+  @doc """
+  Re-queues every finished YouTube link screenshot so the worker replaces the
+  old consent-banner captures with the video's own thumbnail — the one-shot
+  backfill after the thumbnail capture shipped
+  (`Vutuv.Posts.Screenshots.requeue_youtube/0`):
+
+      bin/vutuv eval "Vutuv.Release.requeue_youtube_screenshots()"
+  """
+  def requeue_youtube_screenshots do
+    load_app()
+    [repo] = repos()
+
+    {:ok, count, _apps} =
+      Ecto.Migrator.with_repo(repo, fn _repo -> Screenshots.requeue_youtube() end)
+
+    IO.puts("requeue_youtube_screenshots: #{count} job(s) re-queued")
+    count
   end
 
   defp repos do

--- a/lib/vutuv/youtube_thumbnail.ex
+++ b/lib/vutuv/youtube_thumbnail.ex
@@ -1,0 +1,142 @@
+defmodule Vutuv.YoutubeThumbnail do
+  @moduledoc """
+  The preview image YouTube itself publishes for a video, fetched instead of a
+  Chromium capture: youtube.com answers every logged-out watch page with its
+  cookie-consent interstitial, so a screenshot of it shows the banner, never
+  the video. YouTube serves keyless static thumbnails
+  for every video (`img.youtube.com/vi/<id>/…`) and a keyless oEmbed endpoint;
+  the post link-screenshot worker (`Vutuv.Posts.Screenshots`) recognises a
+  YouTube video URL, confirms the video exists via oEmbed, and stores the
+  thumbnail through the normal screenshot uploader — fetched server-side, so a
+  reader's browser never talks to Google. Any failure falls back to the
+  ordinary page screenshot.
+
+  Rides the `:generate_screenshots` gate (the worker only captures at all when
+  it is on), so an air-gapped install fetches nothing. Tests stub HTTP via
+  `:youtube_thumbnail_req_options` (a `plug:` seam, like the worker's probe).
+  """
+
+  alias Vutuv.SocialFeed.Http
+
+  @req_options_key :youtube_thumbnail_req_options
+
+  # A YouTube video id: exactly 11 URL-safe base64 characters.
+  @id_regex ~r/^[A-Za-z0-9_-]{11}$/
+
+  # The video hosts, compared after downcasing and stripping a leading `www.`
+  # or `m.` — matching by the parsed host, never a URL-prefix test (see the
+  # "recognising one of our own URLs" rule; a foreign URL is no different).
+  @video_hosts ~w(youtube.com music.youtube.com youtube-nocookie.com)
+
+  # The static thumbnail sizes to try, best first: maxresdefault (1280×720)
+  # exists only for HD uploads, hqdefault (480×360) for every video.
+  @sizes ~w(maxresdefault hqdefault)
+
+  # A real thumbnail is a couple of hundred KB; a body running into this cap
+  # (the capped collector halts receipt there) is not one.
+  @max_bytes 2 * 1024 * 1024
+
+  @doc """
+  The video id in a YouTube URL: `{:ok, id}` for a watch / `youtu.be` /
+  shorts / live / embed URL on any of YouTube's own hosts, `:error` for
+  everything else (including YouTube pages that are not a single video — a
+  channel, a playlist — which keep the ordinary page screenshot). Parsed with
+  `URI.parse/1` and read by path segments, so a trailing slash, query noise
+  or a fragment never changes the answer.
+  """
+  def video_id(url) when is_binary(url) do
+    uri = URI.parse(url)
+    segments = String.split(uri.path || "", "/", trim: true)
+    id_for(video_host(uri.host), segments, uri.query)
+  end
+
+  def video_id(_other), do: :error
+
+  defp video_host(nil), do: nil
+
+  defp video_host(host) do
+    host
+    |> String.downcase()
+    |> String.replace_prefix("www.", "")
+    |> String.replace_prefix("m.", "")
+  end
+
+  # The share shortener: youtu.be/<id>.
+  defp id_for("youtu.be", [id | _rest], _query), do: validate(id)
+
+  defp id_for(host, ["watch" | _rest], query) when host in @video_hosts,
+    do: validate(watch_v(query))
+
+  defp id_for(host, [kind, id | _rest], _query)
+       when host in @video_hosts and kind in ~w(shorts live embed v),
+       do: validate(id)
+
+  defp id_for(_host, _segments, _query), do: :error
+
+  defp watch_v(nil), do: nil
+  defp watch_v(query), do: URI.decode_query(query)["v"]
+
+  defp validate(id) when is_binary(id) do
+    if Regex.match?(@id_regex, id), do: {:ok, id}, else: :error
+  end
+
+  defp validate(_missing), do: :error
+
+  @doc """
+  The best available thumbnail for a video id: `{:ok, jpeg_bytes}` or
+  `:error`. Two or three requests: the oEmbed endpoint first — a keyless
+  existence check, so a deleted or private video reports `:error` (and the
+  caller screenshots the page) instead of storing YouTube's grey placeholder
+  tile — then `maxresdefault.jpg` (HD uploads only) with `hqdefault.jpg`
+  (always present) as the fallback.
+  """
+  def fetch(video_id) do
+    with :ok <- confirm_video(video_id) do
+      Enum.find_value(@sizes, :error, &thumbnail(video_id, &1))
+    end
+  end
+
+  defp confirm_video(video_id) do
+    watch_url = "https://www.youtube.com/watch?v=#{video_id}"
+    query = URI.encode_query(url: watch_url, format: "json")
+
+    case get("https://www.youtube.com/oembed?" <> query) do
+      {:ok, %Req.Response{status: 200}} -> :ok
+      _other -> :error
+    end
+  end
+
+  defp thumbnail(video_id, size) do
+    case get("https://img.youtube.com/vi/#{video_id}/#{size}.jpg") do
+      {:ok, %Req.Response{status: 200, body: bytes} = resp}
+      when is_binary(bytes) and bytes != "" ->
+        if image?(resp) and byte_size(bytes) < @max_bytes, do: {:ok, bytes}
+
+      _other ->
+        nil
+    end
+  end
+
+  defp image?(resp) do
+    case Req.Response.get_header(resp, "content-type") do
+      [type | _rest] -> String.starts_with?(type, "image/")
+      [] -> false
+    end
+  end
+
+  defp get(url) do
+    [
+      url: url,
+      receive_timeout: 10_000,
+      connect_options: [timeout: 5_000],
+      retry: false,
+      # The bodies are a JSON we never read and a JPEG stored verbatim, so Req
+      # must not decode either (`into:` does not disable the decode step).
+      decode_body: false,
+      into: Vutuv.Http.capped_collector(@max_bytes),
+      headers: [{"user-agent", Http.user_agent()}]
+    ]
+    |> Keyword.merge(Application.get_env(:vutuv, @req_options_key, []))
+    |> Req.get()
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.202.2",
+      version: "7.203.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/posts/screenshots_test.exs
+++ b/test/vutuv/posts/screenshots_test.exs
@@ -482,4 +482,160 @@ defmodule Vutuv.Posts.ScreenshotsTest do
       refute Repo.get_by(PostScreenshot, post_id: post.id)
     end
   end
+
+  describe "deliver_due/1 with a YouTube link (thumbnail instead of Chromium)" do
+    # These run the REAL capture path (no capture: stub): the YouTube fetch is
+    # stubbed via :youtube_thumbnail_req_options, the page probe via
+    # :post_screenshot_req_options, and stored files land in a tmp uploads dir.
+    setup do
+      tmp = Path.join(System.tmp_dir!(), "vutuv_yt_shots_#{System.unique_integer([:positive])}")
+      previous = Application.get_env(:vutuv, :uploads_dir_prefix)
+      Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
+
+      on_exit(fn ->
+        File.rm_rf(tmp)
+
+        if previous,
+          do: Application.put_env(:vutuv, :uploads_dir_prefix, previous),
+          else: Application.delete_env(:vutuv, :uploads_dir_prefix)
+
+        Application.delete_env(:vutuv, :youtube_thumbnail_req_options)
+        Application.delete_env(:vutuv, :post_screenshot_req_options)
+      end)
+
+      # A real (tiny) JPEG: the store path opens it with libvips.
+      fixture = Path.join(tmp, "fixture.jpg")
+      File.mkdir_p!(tmp)
+      {:ok, img} = Image.new(64, 36, color: [200, 30, 30])
+      {:ok, _} = Image.write(img, fixture)
+      jpeg_bytes = File.read!(fixture)
+
+      {:ok, tmp: tmp, jpeg: jpeg_bytes}
+    end
+
+    defp stub_youtube(fun) when is_function(fun),
+      do: Application.put_env(:vutuv, :youtube_thumbnail_req_options, plug: fun)
+
+    defp youtube_post(author),
+      do: create_post!(author, %{body: "https://www.youtube.com/watch?v=EZ05e7EMOLM"})
+
+    test "stores the video's thumbnail raw — no page probe, no Chromium", %{
+      tmp: tmp,
+      jpeg: jpeg
+    } do
+      post = youtube_post(user())
+      {:ok, job} = Screenshots.reconcile(post)
+
+      test_pid = self()
+      maxres = "/vi/EZ05e7EMOLM/maxresdefault.jpg"
+
+      stub_youtube(fn conn ->
+        cond do
+          conn.request_path == "/oembed" ->
+            send(test_pid, :oembed_checked)
+
+            conn
+            |> Plug.Conn.put_resp_content_type("application/json")
+            |> Plug.Conn.send_resp(200, ~s({"title":"stub"}))
+
+          conn.request_path == maxres ->
+            conn
+            |> Plug.Conn.put_resp_content_type("image/jpeg", nil)
+            |> Plug.Conn.send_resp(200, jpeg)
+        end
+      end)
+
+      # If the classic path ran anyway, this probe answer would mark the job
+      # for retry (attempts 1), never ready — so "ready with 0 attempts"
+      # proves the page was neither probed nor captured.
+      stub_probe(500)
+
+      Screenshots.deliver_due(force: true)
+
+      job = Screenshots.get_job!(job.id)
+      assert job.status == "ready"
+      assert job.attempts == 0
+      # The classic path stores .webp (framed capture); the thumbnail is .jpg.
+      assert String.ends_with?(job.screenshot, ".jpg")
+      assert_received :oembed_checked
+
+      thumb_name = "thumb-#{Path.rootname(job.screenshot)}.avif"
+      assert File.exists?(Path.join([tmp, "screenshots", job.id, thumb_name]))
+    end
+
+    test "falls back to the page capture when YouTube doesn't know the video" do
+      post = youtube_post(user())
+      {:ok, job} = Screenshots.reconcile(post)
+
+      stub_youtube(fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("text/plain")
+        |> Plug.Conn.send_resp(404, "Not Found")
+      end)
+
+      # The fallback probes the page; a 301 is a permanent refusal, so hitting
+      # exactly that state proves the classic path took over.
+      stub_probe(301)
+
+      Screenshots.deliver_due(force: true)
+
+      job = Screenshots.get_job!(job.id)
+      assert job.status == "failed"
+      assert job.last_error == ":redirect"
+    end
+
+    test "a non-YouTube link never calls the YouTube seam" do
+      post = url_post(user())
+      {:ok, job} = Screenshots.reconcile(post)
+
+      test_pid = self()
+
+      stub_youtube(fn conn ->
+        send(test_pid, :youtube_called)
+        Plug.Conn.send_resp(conn, 500, "")
+      end)
+
+      stub_probe(301)
+
+      Screenshots.deliver_due(force: true)
+
+      assert Screenshots.get_job!(job.id).status == "failed"
+      refute_received :youtube_called
+    end
+  end
+
+  describe "requeue_youtube/0 (backfill after the thumbnail capture shipped)" do
+    defp youtube_job(author, video_id, status) do
+      post = create_post!(author, %{body: "https://youtu.be/#{video_id}"})
+      {:ok, job} = Screenshots.reconcile(post)
+
+      Repo.update!(
+        Ecto.Changeset.change(job,
+          status: status,
+          attempts: Screenshots.max_attempts(),
+          last_error: ":timeout"
+        )
+      )
+    end
+
+    test "re-queues finished YouTube jobs; other URLs and dismissed rows stay" do
+      author = user()
+
+      yt_ready = youtube_job(author, "AAAAAAAAAA1", "ready")
+      yt_failed = youtube_job(author, "AAAAAAAAAA2", "failed")
+      yt_dismissed = youtube_job(author, "AAAAAAAAAA3", "dismissed")
+      {_post, other_ready} = ready_post(author)
+
+      assert Screenshots.requeue_youtube() == 2
+
+      requeued = Screenshots.get_job!(yt_ready.id)
+      assert requeued.status == "pending"
+      assert requeued.attempts == 0
+      assert requeued.last_error == nil
+
+      assert Screenshots.get_job!(yt_failed.id).status == "pending"
+      assert Screenshots.get_job!(yt_dismissed.id).status == "dismissed"
+      assert Screenshots.get_job!(other_ready.id).status == "ready"
+    end
+  end
 end

--- a/test/vutuv/youtube_thumbnail_test.exs
+++ b/test/vutuv/youtube_thumbnail_test.exs
@@ -1,0 +1,160 @@
+defmodule Vutuv.YoutubeThumbnailTest do
+  @moduledoc """
+  YouTube video-URL recognition and the thumbnail fetch: the oEmbed existence
+  check, the maxresdefault → hqdefault fallback, and the refusal of non-image
+  answers. HTTP is stubbed via the `:youtube_thumbnail_req_options` `plug:`
+  seam (real content-types on every stub, per the ConnTest/stub rule).
+  """
+  # Not async: the fetch tests set the global `:youtube_thumbnail_req_options`.
+  use ExUnit.Case, async: false
+
+  alias Vutuv.YoutubeThumbnail
+
+  @id "EZ05e7EMOLM"
+
+  describe "video_id/1" do
+    test "watch URLs in their common spellings" do
+      for url <- [
+            "https://www.youtube.com/watch?v=#{@id}",
+            "https://youtube.com/watch?v=#{@id}",
+            "http://m.youtube.com/watch?v=#{@id}",
+            "https://YouTube.com/watch?v=#{@id}&t=42s",
+            "https://music.youtube.com/watch?v=#{@id}",
+            "https://www.youtube.com/watch/?v=#{@id}"
+          ] do
+        assert YoutubeThumbnail.video_id(url) == {:ok, @id}, url
+      end
+    end
+
+    test "short link, shorts, live, embed and legacy /v/ forms" do
+      for url <- [
+            "https://youtu.be/#{@id}",
+            "https://youtu.be/#{@id}?t=10",
+            "https://www.youtube.com/shorts/#{@id}",
+            "https://www.youtube.com/live/#{@id}",
+            "https://www.youtube.com/embed/#{@id}",
+            "https://www.youtube-nocookie.com/embed/#{@id}",
+            "https://www.youtube.com/v/#{@id}"
+          ] do
+        assert YoutubeThumbnail.video_id(url) == {:ok, @id}, url
+      end
+    end
+
+    test "everything else is :error" do
+      for url <- [
+            # Foreign hosts, including the lookalike-suffix trick.
+            "https://example.com/watch?v=#{@id}",
+            "https://youtube.com.evil.example/watch?v=#{@id}",
+            "https://notyoutube.com/watch?v=#{@id}",
+            # YouTube pages that are not a single video.
+            "https://www.youtube.com/watch",
+            "https://www.youtube.com/@DevTernity",
+            "https://www.youtube.com/playlist?list=PL0123456789A",
+            "https://www.youtube.com/",
+            # Malformed ids and malformed input (must not raise).
+            "https://www.youtube.com/watch?v=short",
+            "https://www.youtube.com/watch?v=%ZZ",
+            "https://youtu.be/",
+            "not a url at all"
+          ] do
+        assert YoutubeThumbnail.video_id(url) == :error, url
+      end
+
+      assert YoutubeThumbnail.video_id(nil) == :error
+    end
+  end
+
+  describe "fetch/1" do
+    setup do
+      on_exit(fn -> Application.delete_env(:vutuv, :youtube_thumbnail_req_options) end)
+      :ok
+    end
+
+    defp stub(fun), do: Application.put_env(:vutuv, :youtube_thumbnail_req_options, plug: fun)
+
+    # fetch/1 stores nothing itself, so the "JPEG" can be any bytes as long as
+    # the stub answers with the real image content-type.
+    defp jpeg(conn, bytes) do
+      conn
+      |> Plug.Conn.put_resp_content_type("image/jpeg", nil)
+      |> Plug.Conn.send_resp(200, bytes)
+    end
+
+    defp oembed_ok(conn) do
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, ~s({"title":"stub","provider_name":"YouTube"}))
+    end
+
+    test "prefers maxresdefault when YouTube has it" do
+      maxres = "/vi/#{@id}/maxresdefault.jpg"
+
+      stub(fn conn ->
+        cond do
+          conn.request_path == "/oembed" -> oembed_ok(conn)
+          conn.request_path == maxres -> jpeg(conn, "MAXRES")
+        end
+      end)
+
+      assert YoutubeThumbnail.fetch(@id) == {:ok, "MAXRES"}
+    end
+
+    test "falls back to hqdefault when maxresdefault is missing" do
+      maxres = "/vi/#{@id}/maxresdefault.jpg"
+      hq = "/vi/#{@id}/hqdefault.jpg"
+
+      stub(fn conn ->
+        cond do
+          conn.request_path == "/oembed" -> oembed_ok(conn)
+          conn.request_path == maxres -> Plug.Conn.send_resp(conn, 404, "")
+          conn.request_path == hq -> jpeg(conn, "HQ")
+        end
+      end)
+
+      assert YoutubeThumbnail.fetch(@id) == {:ok, "HQ"}
+    end
+
+    test "an unknown video (oEmbed non-200) is :error and no image is fetched" do
+      test_pid = self()
+
+      stub(fn conn ->
+        case conn.request_path do
+          "/oembed" ->
+            conn
+            |> Plug.Conn.put_resp_content_type("text/plain")
+            |> Plug.Conn.send_resp(404, "Not Found")
+
+          path ->
+            send(test_pid, {:image_fetched, path})
+            jpeg(conn, "SHOULD NOT BE ASKED")
+        end
+      end)
+
+      assert YoutubeThumbnail.fetch(@id) == :error
+      refute_received {:image_fetched, _path}
+    end
+
+    test "a non-image answer is :error (a captive portal, say)" do
+      stub(fn conn ->
+        case conn.request_path do
+          "/oembed" ->
+            oembed_ok(conn)
+
+          _image ->
+            conn
+            |> Plug.Conn.put_resp_content_type("text/html")
+            |> Plug.Conn.send_resp(200, "<html>sign in</html>")
+        end
+      end)
+
+      assert YoutubeThumbnail.fetch(@id) == :error
+    end
+
+    test "transport trouble is :error" do
+      # Overriding url: sends every request to a closed local port.
+      Application.put_env(:vutuv, :youtube_thumbnail_req_options, url: "http://127.0.0.1:1")
+
+      assert YoutubeThumbnail.fetch(@id) == :error
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** A single-link post pointing at a YouTube video now stores the thumbnail YouTube publishes for that video instead of a Chromium capture of the watch page, which always showed Google's cookie-consent banner.

**Where:** `Vutuv.YoutubeThumbnail` (new) + the capture branch in `Vutuv.Posts.Screenshots`
**Now:** the watch page answers every logged-out request with the consent interstitial, so the stored screenshot only ever shows the banner.
**Want/Done:** the worker recognises YouTube video URLs (watch, youtu.be, shorts, live, embed - parsed host + path segments, never a string prefix), confirms the video exists via the keyless oEmbed endpoint, fetches `maxresdefault.jpg` with `hqdefault.jpg` as fallback, and stores it through the same uploader + AI moderation gate - **frameless** (it is the video's artwork, not a web page). Fetched server-side, so readers never talk to `img.youtube.com`. Any failure (unknown/private video, network trouble, non-image answer) falls back to the ordinary page capture.

Everything rides the existing `:generate_screenshots` flag, so air-gapped installs fetch nothing new. Tests stub HTTP via a `:youtube_thumbnail_req_options` plug seam; the worker path is covered end to end (thumbnail stored raw, fallback wiring, non-YouTube links untouched), and the fetch was verified once against the real video from the report (106 KB maxres JPEG; a nonexistent id correctly falls through).

**After deploy**, backfill the existing banner captures once:

```
bin/vutuv eval "Vutuv.Release.requeue_youtube_screenshots()"
```

Ready/failed YouTube jobs are re-queued and re-captured with the new logic; author-dismissed rows stay dismissed.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*