### PR TITLE
The member posts.xml URL redirects to the RSS feed (v7.203.2)

### DIFF
--- a/docs/architecture/agents-and-seo.md
+++ b/docs/architecture/agents-and-seo.md
@@ -104,7 +104,10 @@ are engagement rows and never `Post` rows, and replies are filtered by the
 archive's `:posts` predicate in `Vutuv.Posts.recent_public_posts/2` — while
 the site-wide firehose deliberately keeps replies; besides the invisible
 `<link rel="alternate">` autodiscovery the profile's "Other formats" card
-shows a visible RSS chip via its `rss_path` attr), robots.txt names the AI
+shows a visible RSS chip via its `rss_path` attr. `/:slug/posts.xml` — the
+URL readers guess for "posts as XML" — 301s to the member feed instead of
+serving the generic `<post_archive>` agent document, which a feed validator
+rejects; the period-scoped archives keep their XML sibling), robots.txt names the AI
 crawlers and declares draft
 `Content-Signal` directives from the one policy source
 (`VutuvWeb.ContentPolicy`, config `:ai_crawler_policy` — flips robots.txt and

--- a/lib/vutuv_web/controllers/post_controller.ex
+++ b/lib/vutuv_web/controllers/post_controller.ex
@@ -69,9 +69,19 @@ defmodule VutuvWeb.PostController do
           page_title: "#{VutuvWeb.UserHelpers.full_name(author)} · #{gettext("Posts")}"
         )
 
+      {{:ok, nil, _period_label}, :xml} ->
+        # `/:slug/posts.xml` is the URL readers (and the W3C feed validator)
+        # guess for "posts as XML", and the generic <post_archive> document
+        # there validates as no feed at all — so the unscoped archive's XML
+        # sibling is a permanent redirect to the member's RSS feed. The
+        # period-scoped archives below keep the agent XML document.
+        conn
+        |> put_status(:moved_permanently)
+        |> redirect(to: VutuvWeb.Feeds.user_feed_path(author))
+
       {{:ok, period, period_label}, format} ->
         # Agent-format siblings always render the plain archive (no ?type=), so
-        # the .md/.txt/.json/.xml stay one canonical document (drift test).
+        # the .md/.txt/.json stay one canonical document (drift test).
         {posts, total} = Posts.author_posts_page(author, nil, params, period)
         doc = PostDoc.build_archive(author, conn.request_path, posts, total, period_label)
         AgentDocs.send_doc(conn, format, doc)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.203.1",
+      version: "7.203.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
+++ b/test/vutuv_web/agent_docs/agent_docs_drift_test.exs
@@ -846,7 +846,10 @@ defmodule VutuvWeb.AgentDocsDriftTest do
   end
 
   test "post archive: entries and total in every format", %{post: post} do
-    rendered = formats_for("/drift_tester/posts")
+    # No XML document on the unscoped archive: `/:slug/posts.xml` is the
+    # natural feed-URL guess, so it 301s to the RSS feed instead (covered in
+    # feed_controller_test.exs) — the drift contract here is md/txt/json.
+    rendered = formats_for("/drift_tester/posts") |> Map.delete(:xml)
 
     for fact <- ["Greta Gradient", "Suspension bridges are underrated."],
         do: assert_fact_everywhere(rendered, fact)

--- a/test/vutuv_web/controllers/feed_controller_test.exs
+++ b/test/vutuv_web/controllers/feed_controller_test.exs
@@ -167,6 +167,48 @@ defmodule VutuvWeb.FeedControllerTest do
     end
   end
 
+  # `/:slug/posts.xml` is what people (and feed readers) guess for "this
+  # member's posts as XML" — the W3C feed validator was pointed there and
+  # choked on the generic <post_archive> agent document. The unscoped
+  # archive's `.xml` sibling therefore hands the reader the real feed;
+  # the other agent formats and the period-scoped archives are untouched.
+  describe "GET /:slug/posts.xml" do
+    test "redirects permanently to the RSS feed" do
+      conn = get(build_conn(), "/feed_author/posts.xml")
+
+      assert redirected_to(conn, 301) == "/feed_author/posts/feed.xml"
+    end
+
+    test "Accept: application/xml on the archive lands on the feed too" do
+      conn =
+        build_conn()
+        |> put_req_header("accept", "application/xml")
+        |> get("/feed_author/posts")
+
+      assert redirected_to(conn, 301) == "/feed_author/posts/feed.xml"
+    end
+
+    test "the other agent formats still serve the archive document", %{author: author} do
+      create_post!(author, %{"body" => "Archived words"})
+
+      for extension <- [".md", ".txt", ".json"] do
+        conn = get(build_conn(), "/feed_author/posts" <> extension)
+
+        assert conn.status == 200
+        assert conn.resp_body =~ "Archived words"
+      end
+    end
+
+    test "a period-scoped archive keeps its XML document", %{author: author} do
+      post = create_post!(author, %{"body" => "Dated entry"})
+
+      conn = get(build_conn(), "/feed_author/posts/#{post.published_on.year}.xml")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "<post_archive>"
+    end
+  end
+
   describe "GET /posts/feed.xml" do
     test "collects the latest public posts across members", %{author: author} do
       other = insert_activated_user(username: "second_author")


### PR DESCRIPTION
**TL;DR** `/:slug/posts.xml` served the generic `<post_archive>` agent XML and failed W3C feed validation; it now 301s to the real RSS feed at `/:slug/posts/feed.xml`.

**Where:** `PostController.index` (the author post archive's agent-format branch)
**Now:** the W3C validator (and any feed reader) pointed at `posts.xml` gets "Undefined root element: post_archive" plus the `application/xml` media-type warning.
**Want:** `posts.xml` is the URL people naturally guess for a member's feed (nothing in the UI links it), so it redirects permanently to the feed, which validates cleanly and is served as `application/rss+xml`.

Kept unchanged: the `.md`/`.txt`/`.json` archive siblings, the period-scoped archives' XML documents (`/:slug/posts/2026.xml`), and the feed itself. Accept-negotiated `application/xml` on the archive lands on the feed the same way. Tests cover the redirect, the surviving formats and the scoped-archive exception; the drift test's archive contract now spans md/txt/json.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*