### PR TITLE
Revealing the feed's new-post pill marks those posts seen (v7.205.0)

### DIFF
--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -165,9 +165,13 @@ reply to it, and the badge would still insist on one unread notification until
 you opened the page and dismissed it by hand.
 
 The chokepoints are `Vutuv.Posts`'s `engage/4` (like / bookmark / repost, on the
-idempotent repeat too) and `do_create_reply/4` (the parent). Marking broadcasts
-`:notifications_changed`, the shell's recount-from-source signal, rather than
-decrementing a tally, so the badge cannot drift.
+idempotent repeat too), `do_create_reply/4` (the parent), and the feed's "Show N
+new posts" pill: clicking it is the member choosing to look at exactly those
+posts, so `PostLive.Feed`'s reveal marks the whole batch through the plural
+`Activity.mark_posts_seen/2` (one recount broadcast for the batch, not one per
+post). Marking broadcasts `:notifications_changed`, the shell's
+recount-from-source signal, rather than decrementing a tally, so the badge
+cannot drift.
 
 Which events a seen post clears is `Activity.subject_post_id/1`, and it is
 deliberately narrow — only the three kinds whose subject is somebody *else's*

--- a/lib/vutuv/activity.ex
+++ b/lib/vutuv/activity.ex
@@ -228,8 +228,10 @@ defmodule Vutuv.Activity do
   Called from `Vutuv.Posts` whenever a member answers, likes, bookmarks or
   reposts a post: all four are deliberate acts on a post they were looking at,
   which makes "you were mentioned here" or "somebody answered this" news they
-  already have. Idempotent (the four actions are toggles that may fire again),
-  and a no-op for a missing member or post.
+  already have. The feed's "Show N new posts" pill marks the same way (via
+  `mark_posts_seen/2`): revealing a batch is the member choosing to look at
+  exactly those posts. Idempotent (the four actions are toggles that may fire
+  again), and a no-op for a missing member or post.
 
   The badge is not decremented here — `:notifications_changed` tells the shell
   to recount from the source, the same way a silently removed event does, so
@@ -239,15 +241,31 @@ defmodule Vutuv.Activity do
   def mark_post_seen(nil, _post_id), do: :ok
   def mark_post_seen(_user_id, nil), do: :ok
 
-  def mark_post_seen(user_id, post_id) when is_binary(user_id) and is_binary(post_id) do
-    case Engagement.insert_if_new(
-           NotificationPostRead,
-           %{user_id: user_id, post_id: post_id},
-           [:user_id, :post_id]
-         ) do
-      {:inserted, _row} -> broadcast(user_id, :notifications_changed)
-      :exists -> :ok
-    end
+  def mark_post_seen(user_id, post_id) when is_binary(user_id) and is_binary(post_id),
+    do: mark_posts_seen(user_id, [post_id])
+
+  @doc """
+  Batch form of `mark_post_seen/2`, for the feed's "Show N new posts" pill:
+  revealing the batch is one act of looking, so all fresh marks together
+  broadcast a single `:notifications_changed` recount instead of one per post.
+  Same semantics otherwise — idempotent, and silent when nothing was new.
+  """
+  def mark_posts_seen(nil, _post_ids), do: :ok
+
+  def mark_posts_seen(user_id, post_ids) when is_binary(user_id) and is_list(post_ids) do
+    fresh =
+      Enum.count(post_ids, fn post_id ->
+        match?(
+          {:inserted, _row},
+          Engagement.insert_if_new(
+            NotificationPostRead,
+            %{user_id: user_id, post_id: post_id},
+            [:user_id, :post_id]
+          )
+        )
+      end)
+
+    if fresh > 0, do: broadcast(user_id, :notifications_changed), else: :ok
   end
 
   @doc """

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -24,6 +24,7 @@ defmodule VutuvWeb.PostLive.Feed do
   import VutuvWeb.UserHTML, only: [user_row: 1]
 
   alias Phoenix.LiveView.JS
+  alias Vutuv.Activity
   alias Vutuv.ContentFilters
   alias Vutuv.Fediverse
   alias Vutuv.Posts
@@ -481,6 +482,18 @@ defmodule VutuvWeb.PostLive.Feed do
 
   def handle_event("show-new", _params, socket) do
     pending = socket.assigns.pending_posts
+
+    # Revealing the batch is the member choosing to look at exactly these
+    # posts, so a notification whose subject is one of them (the answer to
+    # their post, an answer elsewhere in their thread, the post naming them)
+    # is old news the moment the pill unfolds: the bell recounts over the
+    # :notifications_changed broadcast. Harmless for posts nobody notified
+    # about (the mark is a row no tally consults), and the pattern skips any
+    # future pending entry without a local post to mark.
+    Activity.mark_posts_seen(
+      socket.assigns.current_user.id,
+      for(%{post: %{id: post_id}} <- pending, do: post_id)
+    )
 
     socket =
       pending

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.204.1",
+      version: "7.205.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/engagement_marks_notifications_read_test.exs
+++ b/test/vutuv/engagement_marks_notifications_read_test.exs
@@ -176,6 +176,47 @@ defmodule Vutuv.EngagementMarksNotificationsReadTest do
     end
   end
 
+  describe "mark_posts_seen/2 (the feed's reveal pill)" do
+    # Clicking "Show N new posts" reveals the whole pending batch at once, so
+    # the feed marks them seen in one call: every notification whose subject
+    # is one of the revealed posts stops counting, and the member's open
+    # sessions get ONE recount signal for the batch, not one per post.
+    test "clears the whole batch and recounts once" do
+      me = insert(:user)
+      other = insert(:user)
+      mine = insert(:post, user: me)
+      first = insert(:post, user: other)
+      second = insert(:post, user: insert(:user))
+      insert(:post_reply, post: first, parent_post: mine, parent_author: me)
+      insert(:post_reply, post: second, parent_post: mine, parent_author: me)
+
+      assert Activity.unread_notification_count(me.id) == 2
+
+      Activity.subscribe(me.id)
+      assert :ok = Activity.mark_posts_seen(me.id, [first.id, second.id])
+
+      assert Activity.unread_notification_count(me.id) == 0
+      assert_receive :notifications_changed
+      refute_receive :notifications_changed
+    end
+
+    test "an already-seen batch stays silent (no recount for nothing)" do
+      {me, answer} = answered_post()
+      Activity.mark_post_seen(me.id, answer.id)
+
+      Activity.subscribe(me.id)
+      assert :ok = Activity.mark_posts_seen(me.id, [answer.id])
+
+      refute_receive :notifications_changed
+    end
+
+    test "a nil member or an empty batch is a no-op" do
+      post = insert(:post, user: insert(:user))
+      assert Activity.mark_posts_seen(nil, [post.id]) == :ok
+      assert Activity.mark_posts_seen(Vutuv.UUIDv7.generate(), []) == :ok
+    end
+  end
+
   describe "mark_post_seen/2" do
     test "tells the member's open sessions to recount their badge" do
       me = insert(:user)

--- a/test/vutuv_web/controllers/ad_controller_test.exs
+++ b/test/vutuv_web/controllers/ad_controller_test.exs
@@ -4,17 +4,25 @@ defmodule VutuvWeb.AdControllerTest do
   alias Vutuv.Ads
   alias Vutuv.Repo
 
-  @booking_params %{
-    "day" => Date.to_iso8601(Date.add(Ads.today(), 14)),
-    "content" => "**Acme GmbH** sucht Elixir-Entwickler.",
-    "billing_name" => "Acme GmbH",
-    "billing_company" => "",
-    "billing_street" => "Musterstraße 1",
-    "billing_zip_code" => "10115",
-    "billing_city" => "Berlin",
-    "billing_country" => "Deutschland",
-    "vat_id" => "DE123456789"
-  }
+  # A function, deliberately NOT a module attribute: an attribute's day would
+  # be minted when the file compiles, while assertions read Ads.today() at run
+  # time — across Berlin midnight (22:00 UTC in summer) the two disagree and
+  # the suite fails only in that nightly window (caught on CI 2026-07-30
+  # 22:01 UTC). Each test binds the map ONCE and derives every day it asserts
+  # from that same map, so one clock read serves the whole test.
+  defp booking_params(day \\ Date.add(Ads.today(), 14)) do
+    %{
+      "day" => Date.to_iso8601(day),
+      "content" => "**Acme GmbH** sucht Elixir-Entwickler.",
+      "billing_name" => "Acme GmbH",
+      "billing_company" => "",
+      "billing_street" => "Musterstraße 1",
+      "billing_zip_code" => "10115",
+      "billing_city" => "Berlin",
+      "billing_country" => "Deutschland",
+      "vat_id" => "DE123456789"
+    }
+  end
 
   describe "index (the public offer page)" do
     test "shows price and conditions to anonymous visitors", %{conn: conn} do
@@ -83,7 +91,7 @@ defmodule VutuvWeb.AdControllerTest do
       beyond = Date.add(Ads.last_bookable_day(), 1)
 
       conn =
-        post(conn, ~p"/ads", %{"ad" => Map.put(@booking_params, "day", Date.to_iso8601(beyond))})
+        post(conn, ~p"/ads", %{"ad" => booking_params(beyond)})
 
       assert html_response(conn, 422) =~ "is outside the booking window"
     end
@@ -91,14 +99,14 @@ defmodule VutuvWeb.AdControllerTest do
 
   describe "preview (the check before buying)" do
     test "requires login", %{conn: conn} do
-      conn = post(conn, ~p"/ads/preview", %{"ad" => @booking_params})
+      conn = post(conn, ~p"/ads/preview", %{"ad" => booking_params()})
       assert redirected_to(conn) == "/"
     end
 
     test "tolerates a tampered list-valued param without a 500", %{conn: conn} do
       {conn, _user} = create_and_login_user(conn)
       # A crafted non-scalar value must not crash the hidden-input stringify.
-      params = Map.put(@booking_params, "billing_company", ["x", "y"])
+      params = Map.put(booking_params(), "billing_company", ["x", "y"])
 
       conn = post(conn, ~p"/ads/preview", %{"ad" => params})
       assert conn.status in [200, 422]
@@ -108,7 +116,8 @@ defmodule VutuvWeb.AdControllerTest do
       conn: conn
     } do
       {conn, _user} = create_and_login_user(conn)
-      conn = post(conn, ~p"/ads/preview", %{"ad" => @booking_params})
+      params = booking_params()
+      conn = post(conn, ~p"/ads/preview", %{"ad" => params})
       html = html_response(conn, 200)
 
       # The rendered ad with its mandatory label...
@@ -122,7 +131,7 @@ defmodule VutuvWeb.AdControllerTest do
       refute html =~ "data-ad-close"
 
       # The order summary and both ways forward.
-      assert html =~ @booking_params["day"]
+      assert html =~ params["day"]
       assert html =~ "1,250"
       assert html =~ ~s(action="/ads") or html =~ ~s(action="#{~p"/ads"}")
       assert html =~ ~s(formaction="/ads/new")
@@ -138,7 +147,7 @@ defmodule VutuvWeb.AdControllerTest do
       {conn, _user} = create_and_login_user(conn)
 
       conn =
-        post(conn, ~p"/ads/preview", %{"ad" => Map.put(@booking_params, "billing_name", "")})
+        post(conn, ~p"/ads/preview", %{"ad" => Map.put(booking_params(), "billing_name", "")})
 
       html = html_response(conn, 422)
       assert html =~ "id=\"ad-form\""
@@ -146,10 +155,11 @@ defmodule VutuvWeb.AdControllerTest do
     end
 
     test "an already booked day is caught at preview time", %{conn: conn} do
-      insert(:ad, day: Date.from_iso8601!(@booking_params["day"]))
+      params = booking_params()
+      insert(:ad, day: Date.from_iso8601!(params["day"]))
       {conn, _user} = create_and_login_user(conn)
 
-      conn = post(conn, ~p"/ads/preview", %{"ad" => @booking_params})
+      conn = post(conn, ~p"/ads/preview", %{"ad" => params})
       html = html_response(conn, 422)
 
       assert html =~ "id=\"ad-form\""
@@ -159,11 +169,12 @@ defmodule VutuvWeb.AdControllerTest do
     test "the edit round-trip keeps the entered values", %{conn: conn} do
       {conn, _user} = create_and_login_user(conn)
 
-      conn = post(conn, ~p"/ads/new", %{"ad" => @booking_params})
+      params = booking_params()
+      conn = post(conn, ~p"/ads/new", %{"ad" => params})
       html = html_response(conn, 200)
 
       assert html =~ "id=\"ad-form\""
-      assert html =~ @booking_params["content"]
+      assert html =~ params["content"]
       assert html =~ "Acme GmbH"
     end
   end
@@ -195,21 +206,25 @@ defmodule VutuvWeb.AdControllerTest do
 
   describe "create" do
     test "requires login", %{conn: conn} do
-      conn = post(conn, ~p"/ads", %{"ad" => @booking_params})
+      conn = post(conn, ~p"/ads", %{"ad" => booking_params()})
       assert redirected_to(conn) == "/"
       assert Repo.aggregate(Ads.Ad, :count) == 0
     end
 
     test "books the day and mails the booking (CSRF enforced like a browser)", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
+      params = booking_params()
 
       conn = get(conn, ~p"/ads/new")
-      conn = submit_with_csrf(conn, ~p"/ads", %{"ad" => @booking_params})
+      conn = submit_with_csrf(conn, ~p"/ads", %{"ad" => params})
 
       assert redirected_to(conn) == ~p"/ads/bookings"
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "booked"
 
-      ad = Repo.get_by!(Ads.Ad, day: Date.add(Ads.today(), 14))
+      # The booked day comes from the SAME params map the form submitted, not
+      # from a second Ads.today() read that may sit on the far side of Berlin
+      # midnight (the 2026-07-30 CI failure).
+      ad = Repo.get_by!(Ads.Ad, day: Date.from_iso8601!(params["day"]))
       assert ad.user_id == user.id
       assert ad.price_cents == 125_000
       assert ad.vat_id == "DE123456789"
@@ -218,15 +233,16 @@ defmodule VutuvWeb.AdControllerTest do
 
       assert_received {:email, email}
       assert email.to == [{"Stefan Wintermeyer", "sw@wintermeyer-consulting.de"}]
-      assert email.text_body =~ @booking_params["content"]
+      assert email.text_body =~ params["content"]
       assert email.text_body =~ "Acme GmbH"
     end
 
     test "an already booked day re-renders the form with the error", %{conn: conn} do
-      insert(:ad, day: Date.from_iso8601!(@booking_params["day"]))
+      params = booking_params()
+      insert(:ad, day: Date.from_iso8601!(params["day"]))
       {conn, _user} = create_and_login_user(conn)
 
-      conn = post(conn, ~p"/ads", %{"ad" => @booking_params})
+      conn = post(conn, ~p"/ads", %{"ad" => params})
       html = html_response(conn, 422)
 
       assert html =~ "id=\"ad-form\""

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -8,10 +8,34 @@ defmodule VutuvWeb.PostFeedLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Vutuv.Activity
+  alias Vutuv.Fediverse.Note
   alias Vutuv.Posts
   alias Vutuv.Posts.PostImage
 
   defp other_user(attrs \\ []), do: insert(:user, Keyword.merge([email_confirmed?: true], attrs))
+
+  # A stored public reply from another network, the way the inbox writes one
+  # (it feeds the "fediverse_reply" arm of the unread notification count).
+  defp insert_note!(post) do
+    now = DateTime.utc_now(:second)
+    actor = "https://social.example/users/alice#{System.unique_integer([:positive])}"
+
+    %Note{post_id: post.id}
+    |> Note.changeset(%{
+      object_uri: "#{actor}/statuses/#{System.unique_integer([:positive])}",
+      actor_uri: actor,
+      inbox_uri: "#{actor}/inbox",
+      handle: "alice",
+      display_name: "Alice Anders",
+      content_text: "Guter Punkt.",
+      audience: "public",
+      received_at: now,
+      checked_at: now,
+      expires_at: DateTime.add(now, 183 * 86_400)
+    })
+    |> Repo.insert!()
+  end
 
   # The discovery rail renders with the page again (the v7.200.3 laziness was
   # undone — see FeedRailsTest); the helper name survives at the call sites.
@@ -1188,6 +1212,81 @@ defmodule VutuvWeb.PostFeedLiveTest do
       html = render(live)
       refute html =~ "Show 1 new post"
       refute html =~ "fleeting"
+    end
+  end
+
+  describe "revealing pending posts clears their notifications" do
+    # Clicking "Show N new posts" is the member choosing to look at exactly
+    # those posts, so a notification whose subject is one of them (the answer
+    # to their post, an answer elsewhere in their thread, the post naming
+    # them) must stop counting as unread the moment the pill unfolds — the
+    # bell badge recounts over the existing :notifications_changed signal.
+    test "a pending reply's unread notification clears on reveal", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      friend = other_user()
+      insert(:follow, follower: user, followee: friend)
+      {:ok, mine} = Posts.create_post(user, %{body: "my open question"})
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      # A fresh registration already carries its own welcome notification, so
+      # the tests count relative to that baseline.
+      base = Activity.unread_notification_count(user.id)
+
+      {:ok, _reply} = Posts.create_reply(friend, mine, %{body: "the answer, live"})
+
+      assert render(live) =~ "Show 1 new post"
+      assert Activity.unread_notification_count(user.id) == base + 1
+
+      live |> element("#show-new-posts") |> render_click()
+
+      assert render(live) =~ "the answer, live"
+      assert Activity.unread_notification_count(user.id) == base
+    end
+
+    test "a pending mention's unread notification clears on reveal", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      friend = other_user()
+      insert(:follow, follower: user, followee: friend)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+      base = Activity.unread_notification_count(user.id)
+
+      {:ok, _post} = Posts.create_post(friend, %{body: "Ask @#{user.username} about it."})
+
+      assert render(live) =~ "Show 1 new post"
+      assert Activity.unread_notification_count(user.id) == base + 1
+
+      live |> element("#show-new-posts") |> render_click()
+
+      assert Activity.unread_notification_count(user.id) == base
+    end
+
+    test "revealing leaves notifications about other posts unread", %{conn: conn} do
+      # The reveal marks exactly the revealed posts — a reply from another
+      # network (a fediverse Note on the member's post) never sits behind the
+      # pill (remote replies live on the post's thread page), so revealing an
+      # unrelated pending post must not swallow its notification.
+      {conn, user} = create_and_login_user(conn)
+      friend = other_user()
+      insert(:follow, follower: user, followee: friend)
+      {:ok, mine} = Posts.create_post(user, %{body: "federated far and wide"})
+      insert_note!(mine)
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      # Baseline includes the welcome notification and the fediverse reply.
+      base = Activity.unread_notification_count(user.id)
+
+      {:ok, _post} = Posts.create_post(friend, %{body: "unrelated news"})
+
+      assert render(live) =~ "Show 1 new post"
+      assert Activity.unread_notification_count(user.id) == base
+
+      live |> element("#show-new-posts") |> render_click()
+
+      assert render(live) =~ "unrelated news"
+      assert Activity.unread_notification_count(user.id) == base
     end
   end
 


### PR DESCRIPTION
**TL;DR** Clicking "Show N new posts" on /feed now clears the bell-badge notifications about exactly those posts.

**Where:** `VutuvWeb.PostLive.Feed` (`show-new`) + `Vutuv.Activity`
**Now:** revealing a pending reply/mention left its notification unread until a manual visit to /notifications.
**Want:** the reveal is the member choosing to look at those posts, so they run through the same per-post read exception (`notification_post_reads`) that answering, liking, bookmarking and reposting already use.

Details:

- New batched `Activity.mark_posts_seen/2`: the whole revealed batch broadcasts one `:notifications_changed` recount instead of one per post; `mark_post_seen/2` now delegates to it.
- Clears the three kinds whose subject is somebody else's post (reply, thread, mention), matching `Activity.subject_post_id/1`. Everything else stays unread, including fediverse replies/reactions, which never sit behind the pill (remote replies live on the post's thread page, remote posts join the feed only on a reload).
- /notifications keeps listing every row; only the unread tally changes.
- Tests: `mark_posts_seen/2` unit coverage + three /feed LiveView tests driving the real `#show-new-posts` click; `docs/architecture/realtime.md` updated.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*