### PR TITLE
Fediverse posts get the same link screenshot as member posts (v7.204.0)

### DIFF
--- a/docs/ADMINS.md
+++ b/docs/ADMINS.md
@@ -168,7 +168,8 @@ A few rarely-changed switches are compile-time settings in
 and the Content-Signal headers), `:fetch_gravatar`, `:fetch_mastodon_posts`,
 `:fetch_bluesky_posts`, `:fetch_code_stats` (the profile "Code" card's
 GitHub/GitLab/Codeberg statistics), `:generate_screenshots` (profile link
-previews **and** the auto-screenshot for single-link posts — admins watch the
+previews **and** the auto-screenshot for single-link posts, including cached
+fediverse posts in the feed — admins watch the
 capture queue and browse the gallery at `/admin/screenshots`; a YouTube video
 link stores the video's published thumbnail instead of a capture, fetched
 server-side from YouTube under this same flag), and

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -981,6 +981,29 @@ pictures too (`Media.sync_attachments/3`): a warning added after publishing
 covers them here as well, a removed picture goes with its file, an added one is
 fetched.
 
+### Their link screenshots
+
+A cached post that carries **exactly one URL, no picture and no content
+warning** gets the same auto link screenshot a member's post gets — one shared
+subsystem, `Vutuv.Posts.Screenshots` (see `posts-and-feed.md`), whose
+`post_screenshots` row carries `remote_post_id` instead of `post_id` (a check
+constraint enforces exactly one owner). The reconcile sits inside
+`attach_pictures/2`, after the picture set is on record, so every path that
+mints a cached post — a follower delivery, a boost, a URL lookup — gets it by
+construction, and an author's `Update` re-reconciles (URL changed → re-capture;
+picture or warning added → job and files dropped). The warned-post skip is the
+one remote-only rule: the author closed the lid, and an auto-fetched preview
+would prop it open. Downstream everything is shared (worker, HTTP-200 probe,
+YouTube thumbnail branch, retries, `:generate_screenshots` gate, the
+`/admin/screenshots` views) with two per-owner differences: the AI scan is
+enqueued **owner-less** like the remote-picture scans, and a released capture
+is **not broadcast** — no author is watching a remote post get captured, so the
+card simply shows it on the next feed load. File cleanup rides the same
+`delete_media_for_posts/1` chokepoint as the pictures
+(`Screenshots.delete_for_remote_posts/1`; the rows cascade, the files never
+do), and the card floats the shot beside the text exactly as a member post's
+card does.
+
 ### Liking one of their posts (issue #1164)
 
 The heart on a remote card really federates: `like_remote_post/2` writes the

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -897,6 +897,13 @@ the save is never slowed. The subsystem is `Vutuv.Posts.Screenshots` with the
 the durable queue and the attachment record**: a `pending`/`capturing`/`failed`
 row is work, a `ready` row carries the stored screenshot.
 
+The queue serves **two owners**: a member's post (`post_id`) and a cached
+fediverse post from a followed account (`remote_post_id`,
+`Vutuv.Fediverse.RemotePost`; a check constraint enforces exactly one). The
+remote side's qualifying rule, wiring and cleanup live in
+`fediverse.md` ("Their link screenshots"); everything below — worker, probe,
+YouTube branch, retries, moderation, admin views — is shared.
+
 Some links are deliberately **not** screenshotted. Two are caught in
 `qualifying_url/1` (a pure, no-network check on the request path, so no row is
 ever created): a link to *this* installation's own **`/settings`, `/admin` or

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -76,6 +76,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostDenial
   alias Vutuv.Posts.PostRemoteReply
+  alias Vutuv.Posts.Screenshots
   alias Vutuv.RateLimiter
   alias Vutuv.RemoteHtml
   alias Vutuv.RemoteMedia
@@ -1442,6 +1443,13 @@ defmodule Vutuv.Fediverse do
     post
     |> Media.record_attachments(List.wrap(object["attachment"]), RemotePost.warned?(post))
     |> Media.fetch_async()
+
+    # With the picture set on record the post's link screenshot can be decided:
+    # a single-URL, picture-less, unwarned post enqueues the same durable
+    # capture job a member post gets (`Vutuv.Posts.Screenshots`). Here rather
+    # than beside the callers, so every path that mints a cached post — a
+    # follower delivery, a boost, a URL lookup — gets it by construction.
+    Screenshots.reconcile(post)
   end
 
   @doc """
@@ -1507,7 +1515,7 @@ defmodule Vutuv.Fediverse do
         where: p.audience in ^RemotePost.open_audiences() or f.state == "accepted",
         order_by: [desc: p.published_at, desc: p.id],
         limit: ^fetch_n,
-        preload: [remote_account: a]
+        preload: [:screenshot, remote_account: a]
       )
       |> utc_at_or_before(cursor, :published_at)
       |> Repo.all()
@@ -1549,7 +1557,7 @@ defmodule Vutuv.Fediverse do
         where: p.audience in ^RemotePost.open_audiences(),
         order_by: [desc: r.inserted_at, desc: r.id],
         limit: ^fetch_n,
-        preload: [remote_post: {p, remote_account: a}, user: reposter]
+        preload: [remote_post: {p, [:screenshot, remote_account: a]}, user: reposter]
       )
       |> remote_reposts_at_or_before(cursor)
       |> Repo.all()
@@ -1621,7 +1629,11 @@ defmodule Vutuv.Fediverse do
         # them) and its author (`filter_visible_boosts/2`'s moderation check
         # reads the struct instead of re-fetching the user per row); the rest
         # a card needs is preloaded once for the whole page by `Vutuv.Posts`.
-        preload: [remote_account: a, remote_post: [:remote_account], post: [:denials, :user]]
+        preload: [
+          remote_account: a,
+          remote_post: [:remote_account, :screenshot],
+          post: [:denials, :user]
+        ]
       )
       |> utc_at_or_before(cursor, :announced_at)
       |> Repo.all()
@@ -1785,9 +1797,10 @@ defmodule Vutuv.Fediverse do
     |> Enum.group_by(& &1.remote_post_id)
   end
 
-  @doc "One cached remote post with its account, or nil."
+  @doc "One cached remote post with its account and screenshot, or nil."
   def get_remote_post(id) do
-    UUIDv7.with_cast(id, &Repo.get(RemotePost, &1)) |> Repo.preload(:remote_account)
+    UUIDv7.with_cast(id, &Repo.get(RemotePost, &1))
+    |> Repo.preload([:remote_account, :screenshot])
   end
 
   @doc """
@@ -1848,6 +1861,10 @@ defmodule Vutuv.Fediverse do
   # delete goes through `delete_cached_post/1`, which is the one place a post row
   # is removed.
   defp delete_media_for_posts(post_ids) when is_list(post_ids) do
+    # The auto link screenshots go with the pictures: same "nothing at rest
+    # for a post nobody can reach" promise, same chokepoint.
+    Screenshots.delete_for_remote_posts(post_ids)
+
     from(i in RemoteImage, where: i.remote_post_id in ^post_ids, select: i.id)
     |> Repo.all()
     |> Enum.each(&RemoteMedia.delete_post_image/1)
@@ -2037,7 +2054,8 @@ defmodule Vutuv.Fediverse do
       # fourth audience value cannot open here and close there.
       where: p.audience in ^RemotePost.open_audiences() or exists(accepted),
       order_by: [desc: p.published_at, desc: p.id],
-      limit: ^(@account_page_posts + 1)
+      limit: ^(@account_page_posts + 1),
+      preload: [:screenshot]
     )
     |> Repo.all()
     |> Enum.split(@account_page_posts)
@@ -2323,6 +2341,10 @@ defmodule Vutuv.Fediverse do
         updated
         |> Media.sync_attachments(List.wrap(object["attachment"]), RemotePost.warned?(updated))
         |> Media.fetch_async()
+
+        # …and where the single URL, the picture set or the content warning can
+        # change, each of which enqueues, refreshes or cancels the screenshot.
+        Screenshots.reconcile(updated)
       end
     end
   end

--- a/lib/vutuv/fediverse/remote_post.ex
+++ b/lib/vutuv/fediverse/remote_post.ex
@@ -21,8 +21,12 @@ defmodule Vutuv.Fediverse.RemotePost do
       here was addressed in is simply not stored, so only the three public-ish
       audiences exist.
 
-  There is no avatar column and no picture of any kind. Pictures are issue
-  #1163, and until then the card renders initials and links to the origin.
+  Pictures arrive two ways: the author's own attachments (issue #1163,
+  `Vutuv.Fediverse.Media` / `Vutuv.Fediverse.RemoteImage`), and — for a
+  single-URL post with no attachment and no content warning — the same auto
+  link screenshot a member's post gets (`Vutuv.Posts.Screenshots`, one shared
+  queue keyed here by `remote_post_id`). Both wait behind the AI image gate
+  before anything renders.
   """
 
   use VutuvWeb, :model
@@ -74,6 +78,13 @@ defmodule Vutuv.Fediverse.RemotePost do
     field(:checked_at, :utc_datetime)
 
     belongs_to(:remote_account, Vutuv.Fediverse.RemoteAccount)
+
+    # The pictures the author attached (issue #1163) and the auto link
+    # screenshot for a single-URL, picture-less post — the exact machinery a
+    # member's post gets (`Vutuv.Posts.Screenshots`), keyed here by
+    # `remote_post_id`.
+    has_many(:images, Vutuv.Fediverse.RemoteImage)
+    has_one(:screenshot, Vutuv.Posts.PostScreenshot, foreign_key: :remote_post_id)
   end
 
   @doc "The audiences a stored post can have."

--- a/lib/vutuv/moderation/image_subjects.ex
+++ b/lib/vutuv/moderation/image_subjects.ex
@@ -306,8 +306,10 @@ defmodule Vutuv.Moderation.ImageSubjects do
         ps = Repo.get!(PostScreenshot, scan.subject_id)
         Vutuv.Screenshot.promote_from_quarantine(ps)
         # The card upgrade was deliberately held back at capture time; the
-        # screenshot is only announced once it is released.
-        Vutuv.Posts.broadcast_screenshot_ready(ps.post_id)
+        # screenshot is only announced once it is released. A remote-owned row
+        # (`remote_post_id`) has no member post and nobody watching — its card
+        # simply shows the screenshot on the next feed load.
+        if ps.post_id, do: Vutuv.Posts.broadcast_screenshot_ready(ps.post_id)
         :ok
 
       _ ->
@@ -681,9 +683,11 @@ defmodule Vutuv.Moderation.ImageSubjects do
   end
 
   defp post_screenshot_stranded do
+    # left_join: a row owned by a cached remote post (`remote_post_id`) has no
+    # member post and re-enqueues owner-less, like the remote-image scans.
     from(ps in PostScreenshot,
       as: :subject,
-      join: p in assoc(ps, :post),
+      left_join: p in assoc(ps, :post),
       where: ps.moderation == "pending",
       where: not exists(open_scan_exists("post_screenshot")),
       select: {ps.id, p.user_id, ps.screenshot}

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -2778,7 +2778,7 @@ defmodule Vutuv.Posts do
     # one renders as a blank card on a profile.
     images = Vutuv.Fediverse.list_remote_images(ids)
 
-    from(p in RemotePost, where: p.id in ^ids, preload: [:remote_account])
+    from(p in RemotePost, where: p.id in ^ids, preload: [:remote_account, :screenshot])
     |> Repo.all()
     |> Map.new(&{&1.id, {&1, Map.get(images, &1.id, [])}})
   end

--- a/lib/vutuv/posts/post_screenshot.ex
+++ b/lib/vutuv/posts/post_screenshot.ex
@@ -4,6 +4,13 @@ defmodule Vutuv.Posts.PostScreenshot do
   once captured, the attachment record. Created for a post that carries a single
   URL and no image (see `Vutuv.Posts.Screenshots`).
 
+  **Two owners, one queue.** A row belongs to exactly one of a member's post
+  (`post_id`) or a cached fediverse post from a followed account
+  (`remote_post_id`, `Vutuv.Fediverse.RemotePost`) — a DB check constraint
+  enforces the exactly-one. Everything downstream (worker, capture, YouTube
+  thumbnail, retries, AI moderation, admin views) is shared; only the enqueue
+  trigger and the "who is told when it's ready" differ per owner.
+
   The row is the queue: a `pending`/`capturing`/`failed` row is work the
   `Vutuv.Posts.ScreenshotWorker` drains, so a restart or re-deploy loses
   nothing; a `ready` row carries the stored screenshot. A `dismissed` row is the
@@ -28,6 +35,7 @@ defmodule Vutuv.Posts.PostScreenshot do
 
   schema "post_screenshots" do
     belongs_to(:post, Vutuv.Posts.Post)
+    belongs_to(:remote_post, Vutuv.Fediverse.RemotePost)
 
     field(:url, :string)
     field(:status, :string, default: "pending")

--- a/lib/vutuv/posts/screenshots.ex
+++ b/lib/vutuv/posts/screenshots.ex
@@ -26,11 +26,21 @@ defmodule Vutuv.Posts.Screenshots do
   the thumbnail YouTube publishes for every video instead, frameless
   (`Vutuv.YoutubeThumbnail`), and falls back to the ordinary capture whenever
   that fetch fails.
+
+  **Cached fediverse posts ride the same queue.** A followed account's post
+  (`Vutuv.Fediverse.RemotePost`) qualifies by the same rule — one URL, no
+  picture — plus one of its own: never behind the author's content warning /
+  sensitive flag (the author closed the lid; an auto-preview would prop it
+  open). Its job carries `remote_post_id` instead of `post_id`, and everything
+  downstream is shared, with two per-owner differences: the ready-announcement
+  (nobody is watching a remote post get captured, so no broadcast) and the AI
+  scan's owner (no local member, like the remote-picture scans).
   """
 
   import Ecto.Query
 
   alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Moderation.ImageScans
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostScreenshot
@@ -69,14 +79,26 @@ defmodule Vutuv.Posts.Screenshots do
   Reconciles a post's screenshot job with what the post now is. Enqueues a
   `pending` job when the post carries exactly one URL and no image (refreshing
   the URL if it changed); removes the job (and its files) when the post no
-  longer qualifies. Called after every create/update; idempotent.
+  longer qualifies. Called after every create/update; idempotent. Takes a
+  member's `Post` or a cached fediverse `RemotePost` — both own the same job
+  row, keyed by their own foreign key.
   """
   def reconcile(%Post{} = post) do
     # force: the caller's struct may carry a stale `:screenshot` (nil from create
     # time) even after a prior reconcile inserted the row — reload it so a second
     # reconcile updates the row instead of colliding on the unique post_id.
-    post = Repo.preload(post, [:images, :screenshot], force: true)
+    post
+    |> Repo.preload([:images, :screenshot], force: true)
+    |> reconcile_loaded()
+  end
 
+  def reconcile(%RemotePost{} = post) do
+    post
+    |> Repo.preload([:images, :screenshot], force: true)
+    |> reconcile_loaded()
+  end
+
+  defp reconcile_loaded(post) do
     case qualifying_url(post) do
       {:ok, url} -> enqueue(post, url)
       :none -> cancel(post)
@@ -96,9 +118,20 @@ defmodule Vutuv.Posts.Screenshots do
   `/settings`, `/admin` or `/system` area, or at a screenshot-blocklisted host
   (`Vutuv.PageScreenshot.host_blocked?/1`, e.g. `reddit.com`), does **not**
   qualify — a blocklisted page never screenshots, so no job is even enqueued.
+
+  A cached fediverse post plays by the same rules plus one of its own: a post
+  its author put behind a content warning (or flagged sensitive) never
+  qualifies — the card renders it as a closed lid, and an auto-fetched preview
+  image would prop that lid open.
   """
   def qualifying_url(%Post{images: [], body: body}), do: sole_url_target(body)
   def qualifying_url(%Post{images: images}) when is_list(images), do: :none
+
+  def qualifying_url(%RemotePost{images: [], content_text: text} = post) do
+    if RemotePost.warned?(post), do: :none, else: sole_url_target(text)
+  end
+
+  def qualifying_url(%RemotePost{images: images}) when is_list(images), do: :none
 
   defp sole_url_target(body) do
     case extract_urls(body) do
@@ -142,12 +175,14 @@ defmodule Vutuv.Posts.Screenshots do
     Enum.any?(@internal_path_roots, &(path == &1 or String.starts_with?(path, &1 <> "/")))
   end
 
-  defp enqueue(%Post{screenshot: %PostScreenshot{url: url} = existing}, url) do
+  # The refresh/keep clauses match on the preloaded `:screenshot` alone, so
+  # they serve both owners; only a fresh insert needs to know whose key to set.
+  defp enqueue(%{screenshot: %PostScreenshot{url: url} = existing}, url) do
     # Same URL already queued/captured: leave it (a `ready` row stays ready).
     {:ok, existing}
   end
 
-  defp enqueue(%Post{screenshot: %PostScreenshot{} = existing}, url) do
+  defp enqueue(%{screenshot: %PostScreenshot{} = existing}, url) do
     # The single URL changed: re-capture. Reset to pending and clear the old
     # error/backoff; the stored file is replaced in place on the next capture.
     existing
@@ -162,12 +197,18 @@ defmodule Vutuv.Posts.Screenshots do
     |> Repo.insert()
   end
 
+  defp enqueue(%RemotePost{id: remote_post_id, screenshot: nil}, url) do
+    %PostScreenshot{remote_post_id: remote_post_id}
+    |> PostScreenshot.enqueue_changeset(url)
+    |> Repo.insert()
+  end
+
   # No longer qualifies: drop the row and its files (the render path already
   # ignores it once the post has images, but keeping the row/file would leak).
   # Unlike post deletion, nothing cascades here, so delete the row explicitly.
-  defp cancel(%Post{screenshot: nil}), do: :ok
+  defp cancel(%{screenshot: nil}), do: :ok
 
-  defp cancel(%Post{screenshot: %PostScreenshot{} = existing}) do
+  defp cancel(%{screenshot: %PostScreenshot{} = existing}) do
     Repo.delete(existing)
     delete(existing)
     :ok
@@ -180,6 +221,19 @@ defmodule Vutuv.Posts.Screenshots do
   """
   def delete(%PostScreenshot{} = post_screenshot) do
     Vutuv.Screenshot.delete(post_screenshot)
+  end
+
+  @doc """
+  Deletes the stored screenshot files of cached fediverse posts that are about
+  to be deleted. Called from the one media-wipe chokepoint every cached-post
+  deletion goes through (`Vutuv.Fediverse`), so an upstream `Delete`, a report,
+  a narrowing edit, the retention sweep and an instance block all shed the
+  files; the rows themselves cascade with the `fediverse_posts` foreign key.
+  """
+  def delete_for_remote_posts(remote_post_ids) when is_list(remote_post_ids) do
+    from(ps in PostScreenshot, where: ps.remote_post_id in ^remote_post_ids)
+    |> Repo.all()
+    |> Enum.each(&delete/1)
   end
 
   @doc """
@@ -494,15 +548,28 @@ defmodule Vutuv.Posts.Screenshots do
       |> Repo.update()
 
     if moderation == "approved" do
-      # Open feeds/profiles upgrade the card to show the screenshot with no reload.
-      Vutuv.Posts.broadcast_screenshot_ready(ready.post_id)
+      announce_ready(ready)
     else
-      post = Repo.get!(Post, ready.post_id)
-      ImageScans.enqueue("post_screenshot", ready.id, post.user_id, ready.screenshot)
+      ImageScans.enqueue("post_screenshot", ready.id, owner_user_id(ready), ready.screenshot)
     end
 
     ready
   end
+
+  # Open feeds/profiles upgrade a member post's card to show the screenshot
+  # with no reload. A cached remote post has no author watching their fresh
+  # post and no topic of its own, so it simply shows the screenshot on the
+  # next feed load — no broadcast.
+  defp announce_ready(%PostScreenshot{post_id: post_id}) when is_binary(post_id),
+    do: Vutuv.Posts.broadcast_screenshot_ready(post_id)
+
+  defp announce_ready(%PostScreenshot{}), do: :ok
+
+  # The AI scan's owning member: the post's author, or nobody for a remote
+  # post's capture (the same ownerless shape the "remote_post_image" and
+  # "remote_avatar" scans use).
+  defp owner_user_id(%PostScreenshot{post_id: nil}), do: nil
+  defp owner_user_id(%PostScreenshot{post_id: post_id}), do: Repo.get!(Post, post_id).user_id
 
   defp mark_retry(%PostScreenshot{} = job, reason) do
     attempts = job.attempts + 1
@@ -545,13 +612,20 @@ defmodule Vutuv.Posts.Screenshots do
   defp error_string(reason), do: reason |> inspect() |> String.slice(0, 255)
 
   defp failure_message(job, reason),
-    do: "post screenshot failed for post #{job.post_id} (#{job.url}): #{inspect(reason)}"
+    do: "post screenshot failed for #{owner_label(job)} (#{job.url}): #{inspect(reason)}"
+
+  defp owner_label(%PostScreenshot{post_id: post_id}) when is_binary(post_id),
+    do: "post #{post_id}"
+
+  defp owner_label(%PostScreenshot{remote_post_id: remote_post_id}),
+    do: "remote post #{remote_post_id}"
 
   ## Admin reads
 
   @doc """
   One page of the admin queue view: the unfinished jobs (`pending` / `capturing`
-  / `failed`), newest first, post + author preloaded. Returns `{rows, total}`.
+  / `failed`), newest first, with the owning post + author (or the cached
+  remote post + its account) preloaded. Returns `{rows, total}`.
   Author-`dismissed` tombstones are neither unfinished work nor a gallery item,
   so they are excluded from both admin views.
   """
@@ -592,7 +666,7 @@ defmodule Vutuv.Posts.Screenshots do
       base
       |> order_by(^order)
       |> Vutuv.Pages.paginate(params, total, @per_page)
-      |> preload(post: :user)
+      |> preload(post: :user, remote_post: :remote_account)
       |> Repo.all()
 
     {rows, total}

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -1375,6 +1375,7 @@ defmodule VutuvWeb.PostComponents do
       assigns
       |> assign(:account, account)
       |> assign(:initials, name_initials(account.name || account.handle))
+      |> assign(:link_screenshot, remote_link_screenshot(post, assigns.images))
 
     ~H"""
     <article data-remote-post={@remote_post.id} data-audience={@remote_post.audience}>
@@ -1440,13 +1441,25 @@ defmodule VutuvWeb.PostComponents do
             {gettext("Only for this account's followers")}
           </.remote_restricted_note>
 
-          <.remote_body
-            warning={
-              RemotePost.warned?(@remote_post) &&
-                (@remote_post.summary || gettext("Marked as sensitive by its author"))
-            }
-            text={@remote_post.content_text}
-          />
+          <%!-- The auto link screenshot floats beside the text exactly as on a
+          member post's card, ahead of the body (a float only wraps what
+          follows it); the flow-root fence keeps a tall shot beside a short
+          body from spilling over the action bar below. A warned post never
+          has one, so the float can never sit beside a closed lid. --%>
+          <div class="flow-root">
+            <.link_screenshot_image
+              :if={@link_screenshot}
+              screenshot={@link_screenshot}
+              class="float-right mb-1 ml-4 mt-1.5 w-2/5 sm:w-1/3"
+            />
+            <.remote_body
+              warning={
+                RemotePost.warned?(@remote_post) &&
+                  (@remote_post.summary || gettext("Marked as sensitive by its author"))
+              }
+              text={@remote_post.content_text}
+            />
+          </div>
 
           <.remote_post_images images={@images} />
 
@@ -3245,6 +3258,17 @@ defmodule VutuvWeb.PostComponents do
   end
 
   defp link_screenshot(_post), do: nil
+
+  # The remote twin of `link_screenshot/1`, for a cached fediverse post: its
+  # ready screenshot when the card shows no pictures and the author raised no
+  # content warning. The reconcile enforces those on the queue side; this
+  # re-check guards a row from before an edit and, via the struct pattern, a
+  # caller that did not preload `:screenshot` (NotLoaded matches nothing).
+  defp remote_link_screenshot(%{screenshot: %PostScreenshot{} = ps} = post, []) do
+    if not RemotePost.warned?(post) and PostScreenshot.ready?(ps), do: ps
+  end
+
+  defp remote_link_screenshot(_post, _images), do: nil
 
   # Whether the PREVIEW needs the float-wrap body layout for the link screenshot
   # (a height clamp instead of a line clamp, since `-webkit-line-clamp` cannot

--- a/lib/vutuv_web/live/admin/screenshot_live.ex
+++ b/lib/vutuv_web/live/admin/screenshot_live.ex
@@ -19,6 +19,8 @@ defmodule VutuvWeb.Admin.ScreenshotLive do
 
   import VutuvWeb.UserHelpers, only: [full_name: 1]
 
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Posts
   alias Vutuv.Posts.Screenshots
   alias Vutuv.Posts.ScreenshotWorker
@@ -122,9 +124,26 @@ defmodule VutuvWeb.Admin.ScreenshotLive do
                 />
               </a>
               <p class="mt-2 truncate text-sm">
-                <.link navigate={Posts.path(ps.post)} class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300">
+                <%!-- A member's post links to its permalink; a cached fediverse
+                post has none here, so its origin page stands in. --%>
+                <.link
+                  :if={ps.post}
+                  navigate={Posts.path(ps.post)}
+                  class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+                >
                   {gettext("Post by %{name}", name: full_name(ps.post.user))}
                 </.link>
+                <a
+                  :if={ps.remote_post}
+                  href={RemotePost.origin(ps.remote_post)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+                >
+                  {gettext("Post by %{name}",
+                    name: RemoteAccount.display_handle(ps.remote_post.remote_account)
+                  )}
+                </a>
               </p>
               <p class="breakwrap text-xs text-slate-600 dark:text-slate-400">
                 <a href={ps.url} target="_blank" rel="noopener">{ps.url}</a>
@@ -162,9 +181,17 @@ defmodule VutuvWeb.Admin.ScreenshotLive do
                     <a href={ps.url} target="_blank" rel="noopener">{ps.url}</a>
                   </td>
                   <td>
-                    <.link navigate={Posts.path(ps.post)}>
+                    <.link :if={ps.post} navigate={Posts.path(ps.post)}>
                       @{ps.post.user.username}
                     </.link>
+                    <a
+                      :if={ps.remote_post}
+                      href={RemotePost.origin(ps.remote_post)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {RemoteAccount.display_handle(ps.remote_post.remote_account)}
+                    </a>
                   </td>
                   <td class="tabular-nums">{ps.attempts}</td>
                   <td class="breakwrap text-slate-600 dark:text-slate-400">{ps.last_error}</td>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.203.2",
+      version: "7.204.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260730214311_add_remote_post_to_post_screenshots.exs
+++ b/priv/repo/migrations/20260730214311_add_remote_post_to_post_screenshots.exs
@@ -1,0 +1,27 @@
+defmodule Vutuv.Repo.Migrations.AddRemotePostToPostScreenshots do
+  use Ecto.Migration
+
+  # A cached fediverse post (a followed account's post, `fediverse_posts`) can
+  # now own a link-screenshot job too, so `post_screenshots` gets a second,
+  # mutually exclusive owner column. Additive + a NOT NULL drop, so the
+  # currently deployed release keeps working (N-1 compatible): it only ever
+  # writes `post_id` rows, which satisfy the new exactly-one-owner check.
+  def change do
+    alter table(:post_screenshots) do
+      # The type stays; this is only ALTER COLUMN ... DROP NOT NULL.
+      modify(:post_id, :binary_id, null: true, from: {:binary_id, null: false})
+      add(:remote_post_id, references(:fediverse_posts, on_delete: :delete_all))
+    end
+
+    # One screenshot per cached post, like the one-per-post index beside it.
+    create(unique_index(:post_screenshots, [:remote_post_id]))
+
+    # Exactly one owner: a row is a member post's or a cached remote post's,
+    # never both and never neither.
+    create(
+      constraint(:post_screenshots, :post_screenshots_exactly_one_owner,
+        check: "(post_id IS NULL) <> (remote_post_id IS NULL)"
+      )
+    )
+  end
+end

--- a/test/vutuv/fediverse_account_lifecycle_test.exs
+++ b/test/vutuv/fediverse_account_lifecycle_test.exs
@@ -13,8 +13,6 @@ defmodule Vutuv.FediverseAccountLifecycleTest do
   """
   use Vutuv.DataCase, async: false
 
-  require Logger
-
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.RemoteAccount

--- a/test/vutuv/fediverse_remote_post_screenshots_test.exs
+++ b/test/vutuv/fediverse_remote_post_screenshots_test.exs
@@ -1,0 +1,382 @@
+defmodule Vutuv.FediverseRemotePostScreenshotsTest do
+  @moduledoc """
+  Link screenshots for cached fediverse posts — the remote twin of
+  `Vutuv.Posts.ScreenshotsTest`: a followed account's single-URL, picture-less,
+  unwarned post rides the same `post_screenshots` queue a member post uses
+  (one shared worker, capture, YouTube branch and AI gate; only the enqueue
+  trigger and the ready-announcement differ).
+
+  `async: false` — `record_remote_post/2` touches the shared `Vutuv.RateLimiter`
+  ETS table, and several tests flip the global `:moderate_images` /
+  `:uploads_dir_prefix` env.
+  """
+  use Vutuv.DataCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Moderation.ImageScan
+  alias Vutuv.Moderation.ImageSubjects
+  alias Vutuv.Posts.PostScreenshot
+  alias Vutuv.Posts.Screenshots
+
+  @actor "https://pics.example/users/shooter"
+  @public "https://www.w3.org/ns/activitystreams#Public"
+  @followers @actor <> "/followers"
+  @url "https://blog.example/entry"
+  @picture "https://pics.example/media/1.jpg"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp account do
+    Repo.insert!(%RemoteAccount{
+      actor_uri: @actor,
+      host: "pics.example",
+      handle: "shooter",
+      name: "Shooter",
+      inbox_uri: "https://pics.example/users/shooter/inbox"
+    })
+  end
+
+  defp member, do: insert(:activated_user, fediverse_followers?: true)
+
+  defp follow(user, account) do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: account.id,
+      state: "accepted",
+      muted: false,
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/#{account.id}"
+    })
+  end
+
+  defp create_activity(overrides \\ %{}) do
+    object =
+      Map.merge(
+        %{
+          "id" => "https://pics.example/posts/1",
+          "type" => "Note",
+          "attributedTo" => @actor,
+          "content" => "<p>Read #{@url} now</p>",
+          "url" => "https://pics.example/@shooter/1",
+          "published" => "2026-07-20T09:00:00Z",
+          "to" => [@public],
+          "cc" => [@followers]
+        },
+        Map.get(overrides, :object, %{})
+      )
+
+    Map.merge(
+      %{"type" => "Create", "actor" => @actor, "object" => object},
+      Map.drop(overrides, [:object])
+    )
+  end
+
+  defp update_activity(object_overrides) do
+    %{
+      "type" => "Update",
+      "actor" => @actor,
+      "object" =>
+        Map.merge(
+          %{
+            "id" => "https://pics.example/posts/1",
+            "type" => "Note",
+            "content" => "<p>Read #{@url} now</p>",
+            "to" => [@public],
+            "cc" => [@followers]
+          },
+          object_overrides
+        )
+    }
+  end
+
+  # A followed account whose single-URL post has just arrived; returns the row.
+  defp recorded_post(overrides \\ %{}) do
+    follow(member(), account())
+    assert :ok = Fediverse.record_remote_post(create_activity(overrides), @actor)
+    Repo.get_by!(RemotePost, remote_account_id: Repo.get_by!(RemoteAccount, actor_uri: @actor).id)
+  end
+
+  defp job_of(%RemotePost{id: id}), do: Repo.get_by(PostScreenshot, remote_post_id: id)
+
+  # The captured-and-released state, as `ready_post/1` in the member twin.
+  defp make_ready(%PostScreenshot{} = job, moderation \\ "approved") do
+    {:ok, ready} =
+      job
+      |> Ecto.Changeset.change(
+        status: "ready",
+        screenshot: "0123456789ab.avif",
+        moderation: moderation
+      )
+      |> Repo.update()
+
+    ready
+  end
+
+  defp ok_capture,
+    do: fn _job -> {:ok, %{screenshot: "0123456789ab.avif", width: 400, height: 264}} end
+
+  describe "record_remote_post/2 (enqueue on arrival)" do
+    test "a single-URL, picture-less post enqueues a pending capture job" do
+      post = recorded_post()
+
+      job = job_of(post)
+      assert job.status == "pending"
+      assert job.url == @url
+      assert is_nil(job.post_id)
+    end
+
+    test "the URL survives the HTML link markup Mastodon really sends" do
+      content =
+        ~s(<p>Read <a href="#{@url}"><span class="invisible">https://</span>) <>
+          ~s(<span class="ellipsis">blog.example/en</span><span class="invisible">try</span></a></p>)
+
+      post = recorded_post(%{object: %{"content" => content}})
+
+      assert job_of(post).url == @url
+    end
+
+    test "a post with a picture attachment gets no job" do
+      attachment = %{"type" => "Document", "mediaType" => "image/jpeg", "url" => @picture}
+      post = recorded_post(%{object: %{"attachment" => [attachment]}})
+
+      assert is_nil(job_of(post))
+    end
+
+    test "a content warning or the sensitive flag gets no job" do
+      warned = recorded_post(%{object: %{"summary" => "CW: politics"}})
+      assert is_nil(job_of(warned))
+
+      sensitive_activity =
+        create_activity(%{object: %{"sensitive" => true, "id" => "https://pics.example/posts/2"}})
+
+      assert :ok = Fediverse.record_remote_post(sensitive_activity, @actor)
+      sensitive = Repo.get_by!(RemotePost, object_uri: "https://pics.example/posts/2")
+      assert is_nil(job_of(sensitive))
+    end
+
+    test "two distinct URLs get no job" do
+      content = "<p>Read #{@url} and https://other.example/page</p>"
+      post = recorded_post(%{object: %{"content" => content}})
+
+      assert is_nil(job_of(post))
+    end
+
+    test "a redelivery keeps the one existing job" do
+      post = recorded_post()
+      job = job_of(post)
+
+      assert :skip = Fediverse.record_remote_post(create_activity(), @actor)
+
+      assert Repo.aggregate(PostScreenshot, :count) == 1
+      assert job_of(post).id == job.id
+    end
+  end
+
+  describe "update_remote_post/2 (reconcile on edit)" do
+    test "an edit that changes the single URL resets the job to the new one" do
+      post = recorded_post()
+      make_ready(job_of(post))
+
+      edit = update_activity(%{"content" => "<p>Moved: https://blog.example/moved</p>"})
+      assert :ok = Fediverse.update_remote_post(edit, @actor)
+
+      job = job_of(post)
+      assert job.status == "pending"
+      assert job.url == "https://blog.example/moved"
+    end
+
+    test "an edit that adds a content warning cancels the job" do
+      post = recorded_post()
+      assert job_of(post)
+
+      edit = update_activity(%{"summary" => "CW now"})
+      assert :ok = Fediverse.update_remote_post(edit, @actor)
+
+      assert is_nil(job_of(post))
+    end
+
+    test "an edit that adds a picture cancels the job" do
+      post = recorded_post()
+      assert job_of(post)
+
+      attachment = %{"type" => "Document", "mediaType" => "image/jpeg", "url" => @picture}
+      edit = update_activity(%{"attachment" => [attachment]})
+      assert :ok = Fediverse.update_remote_post(edit, @actor)
+
+      assert is_nil(job_of(post))
+    end
+
+    test "an edit that brings the first URL enqueues a job" do
+      post = recorded_post(%{object: %{"content" => "<p>No link yet.</p>"}})
+      assert is_nil(job_of(post))
+
+      edit = update_activity(%{"content" => "<p>Now: #{@url}</p>"})
+      assert :ok = Fediverse.update_remote_post(edit, @actor)
+
+      assert job_of(post).url == @url
+    end
+  end
+
+  describe "deletion cleans the files" do
+    setup do
+      tmp = Path.join(System.tmp_dir!(), "vutuv_rps_#{System.unique_integer([:positive])}")
+      previous = Application.get_env(:vutuv, :uploads_dir_prefix)
+      Application.put_env(:vutuv, :uploads_dir_prefix, tmp)
+
+      on_exit(fn ->
+        File.rm_rf(tmp)
+
+        if previous,
+          do: Application.put_env(:vutuv, :uploads_dir_prefix, previous),
+          else: Application.delete_env(:vutuv, :uploads_dir_prefix)
+      end)
+
+      {:ok, tmp: tmp}
+    end
+
+    defp stored_files(job) do
+      dir = Vutuv.Uploads.disk_dir("screenshots/#{job.id}")
+      File.mkdir_p!(dir)
+      File.write!(Path.join(dir, "thumb-0123456789ab.avif"), "avif")
+      dir
+    end
+
+    test "an upstream Delete removes the row and the stored files" do
+      post = recorded_post()
+      dir = stored_files(make_ready(job_of(post)))
+
+      assert :ok = Fediverse.delete_remote_post(@actor, post.object_uri)
+
+      refute Repo.get(RemotePost, post.id)
+      assert Repo.aggregate(PostScreenshot, :count) == 0
+      refute File.exists?(dir)
+    end
+
+    test "the retention sweep removes the files too" do
+      post = recorded_post()
+      dir = stored_files(make_ready(job_of(post)))
+
+      future = DateTime.add(DateTime.utc_now(:second), 200 * 86_400, :second)
+      assert Fediverse.expire_due_remote_posts(future) == 1
+
+      refute Repo.get(RemotePost, post.id)
+      assert Repo.aggregate(PostScreenshot, :count) == 0
+      refute File.exists?(dir)
+    end
+  end
+
+  describe "deliver_due/1 (the shared queue drains remote jobs)" do
+    test "a successful capture marks the remote-owned job ready" do
+      post = recorded_post()
+
+      Screenshots.deliver_due(force: true, capture: ok_capture())
+
+      job = job_of(post)
+      assert job.status == "ready"
+      assert job.screenshot == "0123456789ab.avif"
+      # :moderate_images is off in tests, so the capture releases immediately.
+      assert PostScreenshot.ready?(job)
+    end
+
+    test "with the AI gate on, the scan is enqueued with no owning member" do
+      Application.put_env(:vutuv, :moderate_images, true)
+      on_exit(fn -> Application.put_env(:vutuv, :moderate_images, false) end)
+
+      post = recorded_post()
+      Screenshots.deliver_due(force: true, capture: ok_capture())
+
+      job = job_of(post)
+      assert job.moderation == "pending"
+      refute PostScreenshot.ready?(job)
+
+      scan = Repo.get_by!(ImageScan, kind: "post_screenshot", subject_id: job.id)
+      assert is_nil(scan.owner_user_id)
+      assert scan.fingerprint == job.screenshot
+    end
+  end
+
+  describe "moderation verdicts on a remote-owned row" do
+    test "an approval releases the screenshot (and needs no member post)" do
+      post = recorded_post()
+      job = make_ready(job_of(post), "pending")
+
+      scan = %ImageScan{
+        kind: "post_screenshot",
+        subject_id: job.id,
+        fingerprint: job.screenshot
+      }
+
+      assert :ok = ImageSubjects.apply_approved(scan)
+      assert PostScreenshot.ready?(job_of(post))
+    end
+
+    test "a rejection clears the capture" do
+      post = recorded_post()
+      job = make_ready(job_of(post), "pending")
+
+      scan = %ImageScan{
+        kind: "post_screenshot",
+        subject_id: job.id,
+        fingerprint: job.screenshot
+      }
+
+      assert :ok = ImageSubjects.apply_rejected(scan)
+
+      job = job_of(post)
+      assert job.status == "failed"
+      assert job.moderation == "rejected"
+      assert is_nil(job.screenshot)
+    end
+
+    test "a stranded pending row is found for re-enqueue, owner-less" do
+      post = recorded_post()
+      job = make_ready(job_of(post), "pending")
+
+      assert {"post_screenshot", job.id, nil, job.screenshot} in ImageSubjects.stranded_pending()
+    end
+  end
+
+  describe "rendering" do
+    defp card(post) do
+      render_component(&VutuvWeb.PostComponents.remote_post_card/1,
+        remote_post: Repo.preload(post, [:remote_account, :screenshot], force: true),
+        viewer: nil,
+        images: []
+      )
+    end
+
+    test "a released screenshot renders on the card" do
+      post = recorded_post()
+      make_ready(job_of(post))
+
+      html = card(post)
+      assert html =~ "data-link-screenshot"
+      assert html =~ "/screenshots/#{job_of(post).id}/thumb-0123456789ab.avif"
+    end
+
+    test "an unreleased or missing capture renders nothing" do
+      post = recorded_post()
+      refute card(post) =~ "data-link-screenshot"
+
+      make_ready(job_of(post), "pending")
+      refute card(post) =~ "data-link-screenshot"
+    end
+
+    test "the feed source preloads the screenshot" do
+      user = member()
+      acc = account()
+      follow(user, acc)
+      assert :ok = Fediverse.record_remote_post(create_activity(), @actor)
+
+      assert [entry] = Fediverse.feed_remote_posts(user, 10, nil)
+      assert %PostScreenshot{} = entry.remote_post.screenshot
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** A cached fediverse post with exactly one URL, no picture and no content warning now gets the same auto link screenshot (and YouTube thumbnail) a member's post gets — one shared `post_screenshots` queue with two owners.

**Why:** remote posts never went through `Vutuv.Posts`, so `Screenshots.reconcile/1` never saw them and a single-link post from another network rendered bare (asked by Stefan after seeing exactly that in the feed).

**How:**
- `post_screenshots` gains a nullable `remote_post_id` (FK to `fediverse_posts`), `post_id` becomes nullable, a check constraint enforces exactly one owner. Worker, probe, YouTube branch, retries, AI gate and `/admin/screenshots` are shared.
- The reconcile sits inside `Fediverse.attach_pictures/2`, so every path that mints a cached post (follower delivery, boost, URL lookup) gets it by construction; an author's `Update` re-reconciles.
- Remote-only rules: warned/sensitive posts never qualify (the author closed the lid), the AI scan is enqueued owner-less, and a released capture is not broadcast (nobody is watching; previously the shared code would have crashed on the nil `post_id`).
- File cleanup rides the `delete_media_for_posts/1` chokepoint (upstream Delete, report, narrowing edit, expiry sweep, instance block).
- The card floats the shot beside the text via the shared `link_screenshot_image`, same classes as member posts.

**Deploy:** cold (new migration). N-1 safe: additive + a NOT NULL drop; the previous release only writes `post_id` rows, which satisfy the new constraint.

**Tests:** 20 new in `test/vutuv/fediverse_remote_post_screenshots_test.exs`; full `mix precommit` green. Also removes an unused `require Logger` that warned on every test run.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*