### PR TITLE
The RSS description escapes its HTML layer, validator-clean (v7.204.1)

### DIFF
--- a/lib/vutuv_web/feeds.ex
+++ b/lib/vutuv_web/feeds.ex
@@ -56,7 +56,7 @@ defmodule VutuvWeb.Feeds do
       "  <title>#{Xml.escape(opts[:title])}</title>\n",
       "  <link>#{Xml.escape(opts[:link])}</link>\n",
       ~s(  <atom:link href="#{Xml.escape(opts[:self])}" rel="self" type="application/rss+xml"/>\n),
-      "  <description>#{Xml.escape(opts[:description])}</description>\n",
+      "  <description>#{html_text(opts[:description])}</description>\n",
       last_build_date(posts),
       Enum.map(posts, &item/1),
       "</channel>\n</rss>\n"
@@ -82,7 +82,7 @@ defmodule VutuvWeb.Feeds do
       "    <pubDate>#{rfc1123(post.inserted_at)}</pubDate>\n",
       "    <dc:creator>#{Xml.escape(UserHelpers.full_name(post.user))}</dc:creator>\n",
       Enum.map(post.tags, &"    <category>#{Xml.escape(&1.name)}</category>\n"),
-      "    <description>#{Xml.escape(AgentDocs.excerpt(post.body))}</description>\n",
+      "    <description>#{html_text(AgentDocs.excerpt(post.body))}</description>\n",
       "    <content:encoded><![CDATA[#{cdata_safe(rendered_body(post))}]]></content:encoded>\n",
       "  </item>\n"
     ]
@@ -111,6 +111,12 @@ defmodule VutuvWeb.Feeds do
 
   # A literal "]]>" in the rendered body would close the CDATA section.
   defp cdata_safe(html), do: String.replace(html, "]]>", "]]]]><![CDATA[>")
+
+  # RSS readers interpret <description> as entity-encoded HTML, so plain
+  # text needs an HTML-escape layer under the XML one: a bare `&` that
+  # survives XML-unescaping is invalid HTML (the W3C validator flags it
+  # as "Named entity expected"), and a `<div>` would be read as a tag.
+  defp html_text(text), do: text |> Xml.escape() |> Xml.escape()
 
   defp rfc1123(%NaiveDateTime{} = naive),
     do: Calendar.strftime(naive, "%a, %d %b %Y %H:%M:%S GMT")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.204.0",
+      version: "7.204.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/feed_controller_test.exs
+++ b/test/vutuv_web/controllers/feed_controller_test.exs
@@ -85,6 +85,23 @@ defmodule VutuvWeb.FeedControllerTest do
       assert body =~ ~s(href="#{@base}/tags")
     end
 
+    # RSS readers treat <description> as entity-encoded HTML, so the
+    # plain-text excerpt needs an HTML-escape layer under the XML one:
+    # a bare `&` that survives XML-unescaping is invalid HTML (the W3C
+    # validator flags it as "Named entity expected. Got none."), and an
+    # unescaped `<div>` would be swallowed as a tag instead of shown.
+    test "the description double-escapes & and < so the HTML layer stays valid", %{author: author} do
+      create_post!(author, %{
+        "body" => "Siehe https://example.com/a?b=1&smid=share und <div> Tags"
+      })
+
+      body = build_conn() |> get("/feed_author/posts/feed.xml") |> response(200)
+
+      assert body =~
+               "<description>Siehe https://example.com/a?b=1&amp;amp;smid=share " <>
+                 "und &amp;lt;div&amp;gt; Tags</description>"
+    end
+
     test "pubDate is RFC 1123", %{author: author} do
       create_post!(author, %{"body" => "Dated"})
 


### PR DESCRIPTION
**TL;DR** The W3C feed validator flagged `<description>` in the member RSS feed: a bare `&` (from a URL query string) survived XML-unescaping into the HTML layer.

**Where:** `VutuvWeb.Feeds` (`/:slug/posts/feed.xml` + `/posts/feed.xml`)
**Now:** the plain-text excerpt was only XML-escaped, so readers that parse the description as entity-encoded HTML (per RSS convention) hit "Named entity expected. Got none." — and a literal `<div>` in a post would be swallowed as a tag.
**Want:** HTML-escape first, XML-escape on top for both description elements (channel + item): `&` travels as `&amp;amp;` and decodes back to plain text through both layers. `<content:encoded>` was already correct (real HTML in CDATA).

Test-first: new assertion in `feed_controller_test.exs` covering `&` and `<` in the excerpt.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*