### PR TITLE
A Fediverse address on this vutuv becomes a plain vutuv follow (v7.206.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -816,9 +816,18 @@ touched:
 2. **the operator blocklist**, checked three times over one follow: on the typed
    host, on the resolved actor URL and on the canonical id the document claims,
    because each hop can land somewhere else than the last.
-3. **an address on this very installation** is refused as `:local_account` and
-   answered with a link to that member's profile. Following a vutuv member is a
-   vutuv follow.
+3. **an address on this very installation never federates.** When it names a
+   member, `follow_local_member/2` creates the plain vutuv follow on the spot
+   and `{:ok, {:local_follow, member}}` comes back — following a vutuv member
+   is a vutuv follow, so that is what happens instead of a signed request to
+   ourselves. The member's own address is refused as `:own_account` (nobody
+   follows themselves, and `Vutuv.Social.Follow`'s changeset enforces the same
+   for every local follow), a handle that resolves to nobody as
+   `:local_account` with a search hand-off. The same short-circuit sits in the
+   profile's remote-follow dialog (`VutuvWeb.RemoteFollowController`) — a
+   visitor whose "own server" is this vutuv gets the local follow (signed in)
+   or the way to it, never a WebFinger of ourselves — and the account lookup
+   page sends a member-naming address to that member's profile.
 4. **an hourly budget** (`FEDIVERSE_REMOTE_FOLLOW_LIMIT`, the
    `claim_reply_budget/1` pattern), so a compromised account cannot walk a
    server's whole member list.

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -71,6 +71,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.RemoteFollow
   alias Vutuv.Fediverse.RemoteImage
   alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Handles
   alias Vutuv.Pages
   alias Vutuv.Posts
   alias Vutuv.Posts.Post
@@ -634,31 +635,107 @@ defmodule Vutuv.Fediverse do
       this account no longer acts out there.
     * `:invalid_address` / `:unreachable` / `:no_actor` — from the address parse
       and the WebFinger lookup (`RemoteFollow`).
-    * `:local_account` — the address names a member of this very installation.
-      Following them is a vutuv follow, not a Fediverse one, and saying so is far
-      more useful than a signed request to ourselves.
+    * `:local_account` — the address is on this very installation but names no
+      member (a typo, a renamed handle).
+    * `:own_account` — the address is the member's very own. Nobody follows
+      themselves, on either network.
     * `:instance_blocked` — the operator shut that server out.
     * `:follow_capped` — the hourly budget is spent.
     * `:follow_limit` — the member is at `max_remote_follows/0`.
-    * `:already_following` — there is a row for this pair already.
+    * `:already_following` — there is a row for this pair already (the same
+      answer whether the pair is a remote follow or a vutuv one).
     * `:unreachable_actor` — WebFinger answered but the actor document did not.
 
-  The state the row starts in is `requested`, because that is the truth: an
-  account that approves its followers by hand may never answer, and a page that
-  showed "Following" for a request nobody accepted would be lying.
+  **An address that names a member of this installation never federates**:
+  following them is a plain vutuv follow, so that is what happens —
+  `follow_local_member/2` runs and `{:ok, {:local_follow, member}}` comes back
+  instead of a follow row. Doing the real thing beats both a signed request to
+  ourselves and a refusal that sends the member off to do it by hand.
+
+  The state a remote row starts in is `requested`, because that is the truth:
+  an account that approves its followers by hand may never answer, and a page
+  that showed "Following" for a request nobody accepted would be lying.
   """
   def follow_remote(%User{} = user, address) do
-    with :ok <- check_can_follow(user),
-         :ok <- check_follow_limit(user),
-         {:ok, account} <- resolve_remote_account(user, address),
-         {:ok, follow} <- insert_remote_follow(user, account) do
-      enqueue(
-        user,
-        [account.inbox_uri],
-        Docs.follow_activity(user, account.actor_uri, follow.follow_activity_id)
-      )
+    case local_follow_target(address) do
+      :remote ->
+        with :ok <- check_can_follow(user),
+             :ok <- check_follow_limit(user),
+             {:ok, account} <- resolve_remote_account(user, address),
+             {:ok, follow} <- insert_remote_follow(user, account) do
+          enqueue(
+            user,
+            [account.inbox_uri],
+            Docs.follow_activity(user, account.actor_uri, follow.follow_activity_id)
+          )
 
-      {:ok, %{follow | remote_account: account}}
+          {:ok, %{follow | remote_account: account}}
+        end
+
+      # A vutuv follow needs no actor key and spends no outbound budget, so
+      # none of the Fediverse gates apply — only the installation switch, which
+      # is what put the member on a Fediverse surface in the first place.
+      {:member, member} ->
+        with :ok <- check_can_resolve(), do: follow_local_member(user, member)
+
+      :unknown_member ->
+        with :ok <- check_can_resolve(), do: {:error, :local_account}
+    end
+  end
+
+  @doc """
+  The vutuv follow behind a Fediverse address that turned out to name a member
+  of this very installation: a plain `Vutuv.Social.follow/2`, no signed
+  request, no remote rows. `follow_remote/2` lands here by itself; the
+  profile's remote-follow dialog calls it directly when the visitor's "own
+  server" is this one.
+
+  Returns `{:ok, {:local_follow, member}}`, or `{:error, :own_account}` /
+  `{:error, :already_following}` / `{:error, :follow_failed}` (the social
+  context refused — a block between the two).
+  """
+  def follow_local_member(%User{id: id}, %User{id: id}), do: {:error, :own_account}
+
+  def follow_local_member(%User{} = user, %User{} = member) do
+    if Social.user_follows_user?(user.id, member.id) do
+      {:error, :already_following}
+    else
+      case Social.follow(user, member.id) do
+        {:ok, _follow} -> {:ok, {:local_follow, member}}
+        {:error, _refused} -> {:error, :follow_failed}
+      end
+    end
+  end
+
+  @doc """
+  The member of this installation a pasted Fediverse address names, or nil —
+  nil for every remote address too, so it doubles as "is this one of ours, and
+  whose". Pure string work plus one lookup; no network.
+
+  The account lookup page uses it to send an address that names a member to
+  their profile instead of explaining why vutuv will not fetch itself.
+  """
+  def local_member_for_address(address) do
+    case local_follow_target(address) do
+      {:member, member} -> member
+      _ -> nil
+    end
+  end
+
+  # Whether the pasted address stays on this installation, answered before any
+  # Fediverse gate: `{:member, user}` when it names a member here,
+  # `:unknown_member` when the host is ours but the handle resolves to nobody,
+  # `:remote` for everything else (including whatever does not parse — the
+  # remote chain owns those refusals).
+  defp local_follow_target(address) do
+    with {:ok, {name, host}} <- RemoteFollow.parse_address(address),
+         true <- local_host?(host) do
+      case Accounts.get_user_by_username(Handles.normalize(name)) do
+        %User{} = member -> {:member, member}
+        nil -> :unknown_member
+      end
+    else
+      _ -> :remote
     end
   end
 

--- a/lib/vutuv_web/components/fediverse_components.ex
+++ b/lib/vutuv_web/components/fediverse_components.ex
@@ -280,10 +280,16 @@ defmodule VutuvWeb.FediverseComponents do
   def refusal_message(:instance_blocked),
     do: gettext("This vutuv does not exchange anything with that server.")
 
-  # The address turned out to name somebody on this very vutuv. The caller adds
-  # where to go instead, since only it knows whether the handle resolved.
+  # The address turned out to be on this very vutuv without naming a member —
+  # one that does resolve is followed here on the spot instead of refused. The
+  # caller adds the search hand-off as the way forward.
   def refusal_message(:local_account),
-    do: gettext("That is an address on this vutuv, not another network.")
+    do: gettext("That address is on this vutuv, but it names no member here.")
+
+  # The member's very own address. The wording has to carry the whole answer:
+  # there is no link or button that makes following yourself sensible.
+  def refusal_message(:own_account),
+    do: gettext("That is your own address. You cannot follow yourself.")
 
   # Deliberately without "it is in the list below": the error keeps the active
   # filter and the table is paged, so the row it points at is often genuinely

--- a/lib/vutuv_web/controllers/remote_follow_controller.ex
+++ b/lib/vutuv_web/controllers/remote_follow_controller.ex
@@ -52,15 +52,77 @@ defmodule VutuvWeb.RemoteFollowController do
   end
 
   defp resolve(conn, user, address) do
-    case RemoteFollow.subscribe_url(address, Docs.acct(user)) do
-      {:ok, url} ->
-        redirect(conn, external: url)
+    if local_address?(address) do
+      follow_here(conn, user)
+    else
+      case RemoteFollow.subscribe_url(address, Docs.acct(user)) do
+        {:ok, url} ->
+          redirect(conn, external: url)
 
-      {:error, reason} ->
+        {:error, reason} ->
+          conn
+          |> put_flash(:error, message(reason, address))
+          |> back_to(user)
+      end
+    end
+  end
+
+  # The visitor's "own server" turned out to be this very vutuv. WebFingering
+  # it would be vutuv resolving itself (issue #1211's shape) and could only
+  # ever route the visitor back here — so no request leaves.
+  defp local_address?(address) do
+    case RemoteFollow.parse_address(address) do
+      {:ok, {_user, host}} -> Fediverse.local_host?(host)
+      _ -> false
+    end
+  end
+
+  # A member of this installation asked to follow this profile "from their own
+  # server", and their own server is us: give them the thing they asked for, a
+  # plain vutuv follow — or, signed out, the way to it.
+  defp follow_here(conn, user) do
+    case conn.assigns[:current_user] do
+      nil ->
         conn
-        |> put_flash(:error, message(reason, address))
+        |> put_flash(
+          :error,
+          gettext(
+            "That address is on this vutuv. Sign in and use the Follow button on this profile."
+          )
+        )
+        |> back_to(user)
+
+      viewer ->
+        conn
+        |> flash_local_follow(user, Fediverse.follow_local_member(viewer, user))
         |> back_to(user)
     end
+  end
+
+  defp flash_local_follow(conn, user, {:ok, {:local_follow, _member}}) do
+    put_flash(
+      conn,
+      :info,
+      gettext("You are on this vutuv yourself, so you now follow @%{handle} right here.",
+        handle: user.username
+      )
+    )
+  end
+
+  defp flash_local_follow(conn, _user, {:error, :own_account}) do
+    put_flash(conn, :error, gettext("That is your own profile. You cannot follow yourself."))
+  end
+
+  defp flash_local_follow(conn, user, {:error, :already_following}) do
+    put_flash(
+      conn,
+      :info,
+      gettext("You already follow @%{handle} here.", handle: user.username)
+    )
+  end
+
+  defp flash_local_follow(conn, _user, {:error, _refused}) do
+    put_flash(conn, :error, gettext("Something went wrong"))
   end
 
   # Same gate the profile card renders on: a member who moved their Fediverse

--- a/lib/vutuv_web/live/fediverse_account_live.ex
+++ b/lib/vutuv_web/live/fediverse_account_live.ex
@@ -216,6 +216,15 @@ defmodule VutuvWeb.FediverseAccountLive do
       {:ok, account} ->
         {:noreply, push_navigate(socket, to: ~p"/system/fediverse/account/#{account.id}")}
 
+      {:error, :local_account} ->
+        # An address on this very vutuv: when it names a member, their page is
+        # their profile, so go there instead of refusing; the refusal stays for
+        # a handle that resolves to nobody.
+        case Fediverse.local_member_for_address(address) do
+          nil -> {:noreply, socket |> assign(:address, address) |> assign(:error, :local_account)}
+          member -> {:noreply, push_navigate(socket, to: ~p"/#{member.username}")}
+        end
+
       {:error, reason} ->
         {:noreply, socket |> assign(:address, address) |> assign(:error, reason)}
     end

--- a/lib/vutuv_web/live/fediverse_following_live.ex
+++ b/lib/vutuv_web/live/fediverse_following_live.ex
@@ -38,12 +38,9 @@ defmodule VutuvWeb.FediverseFollowingLive do
 
   on_mount({VutuvWeb.Live.InitAssigns, :require_login})
 
-  alias Vutuv.Accounts
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.RemoteAccount
-  alias Vutuv.Fediverse.RemoteFollow
-  alias Vutuv.Handles
   alias Vutuv.Pages
 
   @impl true
@@ -58,7 +55,6 @@ defmodule VutuvWeb.FediverseFollowingLive do
      |> assign(:blocked_reason, Fediverse.follow_refusal(user))
      |> assign(:address, "")
      |> assign(:error, nil)
-     |> assign(:local_member, nil)
      |> assign_totals()}
   end
 
@@ -116,6 +112,17 @@ defmodule VutuvWeb.FediverseFollowingLive do
   @impl true
   def handle_event("follow", %{"address" => address}, socket) do
     case Fediverse.follow_remote(socket.assigns.user, address) do
+      # The address turned out to live here, so the member got a plain vutuv
+      # follow instead of a Fediverse request — say so, since the table below
+      # (remote follows only) will not show it.
+      {:ok, {:local_follow, member}} ->
+        {:noreply,
+         socket
+         |> assign(:address, "")
+         |> assign_error(nil)
+         |> put_flash(:info, local_follow_message(member))
+         |> patch_browse(%{}, &browse_path/1)}
+
       {:ok, follow} ->
         # Patch rather than reload in place: it keeps any active filter and
         # drops the `?address=` the search page may have arrived with, so a
@@ -129,7 +136,7 @@ defmodule VutuvWeb.FediverseFollowingLive do
          |> patch_browse(%{}, &browse_path/1)}
 
       {:error, reason} ->
-        {:noreply, socket |> assign(:address, address) |> assign_error(reason, address)}
+        {:noreply, socket |> assign(:address, address) |> assign_error(reason)}
     end
   end
 
@@ -162,28 +169,21 @@ defmodule VutuvWeb.FediverseFollowingLive do
 
   defp browse_path(query), do: ~p"/settings/fediverse/following?#{query}"
 
-  # The refusal, plus the one thing a refusal sometimes needs beyond a sentence:
-  # the member of this very vutuv the address turned out to name. Resolved here
-  # rather than in the template, so the lookup happens once when the answer
-  # arrives instead of on every later re-render while the message stands.
-  defp assign_error(socket, reason, address \\ nil)
-
-  defp assign_error(socket, :local_account, address),
-    do: socket |> assign(:error, :local_account) |> assign(:local_member, local_member(address))
-
-  defp assign_error(socket, reason, _address),
-    do: socket |> assign(:error, reason) |> assign(:local_member, nil)
-
-  defp local_member(address) do
-    with {:ok, {name, _host}} <- RemoteFollow.parse_address(address),
-         %{username: username} <- Accounts.get_user_by_username(Handles.normalize(name)) do
-      username
-    else
-      _ -> nil
-    end
-  end
+  # `:local_account` now only ever means "our host, but nobody's handle" — an
+  # address that really names a member is followed on the spot by
+  # `Fediverse.follow_remote/2` — so no lookup rides along with the refusal any
+  # more; the template's one extra affordance is the search hand-off.
+  defp assign_error(socket, reason), do: assign(socket, :error, reason)
 
   # ── Wording ───────────────────────────────────────────────────────────────
+
+  # The vutuv follow that answered a Fediverse address (the auto-follow): named
+  # by handle, because the address the member typed was one.
+  defp local_follow_message(member) do
+    gettext("@%{handle} is on this vutuv, so you now follow them here.",
+      handle: member.username
+    )
+  end
 
   # A Follow is a request, so the confirmation says what really happened rather
   # than "Following" — and names the account, since the row it just added may be
@@ -267,20 +267,12 @@ defmodule VutuvWeb.FediverseFollowingLive do
               class="mt-4"
             >
               <:error_detail>
-                <%!-- The profile when the handle really resolves to a member,
-                      the search when it does not (a pasted profile URL that is
-                      local but names nothing) — either way a next step, never a
+                <%!-- A local address that named a member was followed on the
+                      spot, so this refusal means the handle resolved to nobody
+                      (a typo, a rename) — the search is the next step, never a
                       sentence that just stops. --%>
                 <.link
-                  :if={@error == :local_account and @local_member}
-                  navigate={~p"/#{@local_member}"}
-                  id="local-member-link"
-                  class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-                >
-                  {gettext("Open their profile")} ›
-                </.link>
-                <.link
-                  :if={@error == :local_account and is_nil(@local_member)}
+                  :if={@error == :local_account}
                   navigate={~p"/search?#{[q: @address]}"}
                   id="local-member-search"
                   class="font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.205.0",
+      version: "7.206.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -9,14 +9,14 @@
 msgid ""
 msgstr "Language: de\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:93
-#: lib/vutuv_web/templates/layout/app.html.heex:93
+#: lib/vutuv_web/controllers/page_controller.ex:98
+#: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen
 msgid "About us"
 msgstr "Impressum"
 
-#: lib/vutuv_web/components/ui.ex:3253
-#: lib/vutuv_web/components/ui.ex:3258
+#: lib/vutuv_web/components/ui.ex:3196
+#: lib/vutuv_web/components/ui.ex:3201
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -35,7 +35,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1376
+#: lib/vutuv_web/templates/user/show.html.heex:1383
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -59,7 +59,7 @@ msgstr "Eine Adresse wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3449
+#: lib/vutuv_web/components/ui.ex:3392
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -77,8 +77,8 @@ msgstr "Adressen"
 msgid "Already a member? Sign in here."
 msgstr "Schon ein Mitglied? Einloggen."
 
-#: lib/vutuv_web/components/ui.ex:3048
-#: lib/vutuv_web/components/ui.ex:3142
+#: lib/vutuv_web/components/ui.ex:2991
+#: lib/vutuv_web/components/ui.ex:3085
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #, elixir-autogen
 msgid "Are you sure?"
@@ -98,13 +98,13 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/agent_docs/markdown.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/templates/user/show.html.heex:1009
+#: lib/vutuv_web/templates/user/show.html.heex:1015
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3042
+#: lib/vutuv_web/components/ui.ex:2985
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -146,7 +146,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1047
+#: lib/vutuv_web/templates/user/show.html.heex:1053
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -156,7 +156,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
 #: lib/vutuv_web/components/post_components.ex:2182
-#: lib/vutuv_web/components/ui.ex:3145
+#: lib/vutuv_web/components/ui.ex:3088
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -205,7 +205,7 @@ msgid "Download"
 msgstr "Download"
 
 #: lib/vutuv_web/components/post_components.ex:2147
-#: lib/vutuv_web/components/ui.ex:3136
+#: lib/vutuv_web/components/ui.ex:3079
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -218,7 +218,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1032
+#: lib/vutuv_web/templates/user/show.html.heex:1038
 #, elixir-autogen
 msgid "Edit"
 msgstr "Ändern"
@@ -291,7 +291,7 @@ msgstr "Nachname eingeben"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3414
+#: lib/vutuv_web/components/ui.ex:3357
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -319,8 +319,8 @@ msgstr "Vorname"
 #: lib/vutuv_web/agent_docs/markdown.ex:506
 #: lib/vutuv_web/agent_docs/text.ex:476
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/fediverse_followers_live.ex:128
-#: lib/vutuv_web/live/notification_live/index.ex:882
+#: lib/vutuv_web/live/fediverse_followers_live.ex:110
+#: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -331,16 +331,16 @@ msgstr "Follower"
 #: lib/vutuv_web/agent_docs/markdown.ex:507
 #: lib/vutuv_web/agent_docs/text.ex:477
 #: lib/vutuv_web/components/fediverse_components.ex:223
-#: lib/vutuv_web/components/ui.ex:1729
-#: lib/vutuv_web/components/ui.ex:1754
-#: lib/vutuv_web/components/ui.ex:1757
-#: lib/vutuv_web/components/ui.ex:1764
-#: lib/vutuv_web/components/ui.ex:1767
-#: lib/vutuv_web/components/ui.ex:1825
+#: lib/vutuv_web/components/ui.ex:1738
+#: lib/vutuv_web/components/ui.ex:1763
+#: lib/vutuv_web/components/ui.ex:1766
+#: lib/vutuv_web/components/ui.ex:1773
+#: lib/vutuv_web/components/ui.ex:1776
+#: lib/vutuv_web/components/ui.ex:1834
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:837
+#: lib/vutuv_web/templates/user/show.html.heex:840
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
@@ -355,7 +355,7 @@ msgstr "Folge ich"
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:67
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:1004
+#: lib/vutuv_web/templates/user/show.html.heex:1010
 #: lib/vutuv_web/views/account_event_text.ex:153
 #, elixir-autogen
 msgid "Gender"
@@ -373,7 +373,7 @@ msgstr "Ihr Gratis-Konto ist in nicht mal 30 Sekunden fertig."
 
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:117
+#: lib/vutuv_web/templates/layout/app.html.heex:121
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:2
 #, elixir-autogen
 msgid "Home"
@@ -468,7 +468,7 @@ msgstr "Einloggen"
 msgid "Middle Name"
 msgstr "Zweiter Vorname"
 
-#: lib/vutuv_web/live/notification_live/index.ex:806
+#: lib/vutuv_web/live/notification_live/index.ex:841
 #, elixir-autogen
 msgid "More"
 msgstr "Mehr"
@@ -485,7 +485,7 @@ msgstr "Mehr"
 msgid "Name"
 msgstr "Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:580
+#: lib/vutuv_web/live/notification_live/index.ex:615
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -624,7 +624,7 @@ msgstr "Provider"
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/vutuv_web/components/ui.ex:3041
+#: lib/vutuv_web/components/ui.ex:2984
 #: lib/vutuv_web/live/organization_live/edit.ex:341
 #: lib/vutuv_web/live/post_live/composer.ex:1780
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -643,11 +643,11 @@ msgstr "Öffentlich"
 msgid "Save"
 msgstr "Speichern"
 
-#: lib/vutuv_web/components/browse_table.ex:167
-#: lib/vutuv_web/live/account_activity_live.ex:194
-#: lib/vutuv_web/live/admin/activity_live.ex:231
+#: lib/vutuv_web/components/browse_table.ex:271
+#: lib/vutuv_web/live/account_activity_live.ex:149
+#: lib/vutuv_web/live/admin/activity_live.ex:193
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
-#: lib/vutuv_web/live/admin/user_live.ex:244
+#: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:37
 #: lib/vutuv_web/live/search_live.ex:378
@@ -656,7 +656,7 @@ msgstr "Speichern"
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
-#: lib/vutuv_web/templates/layout/app.html.heex:122
+#: lib/vutuv_web/templates/layout/app.html.heex:126
 #, elixir-autogen
 msgid "Search"
 msgstr "Suche"
@@ -696,13 +696,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1160
+#: lib/vutuv_web/templates/user/show.html.heex:1167
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1162
+#: lib/vutuv_web/templates/user/show.html.heex:1169
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -746,8 +746,9 @@ msgstr "Code & Repositorys"
 
 #: lib/vutuv_web/controllers/block_controller.ex:34
 #: lib/vutuv_web/controllers/follow_controller.ex:24
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:123
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:115
+#: lib/vutuv_web/live/user_profile_live.ex:153
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
@@ -786,12 +787,12 @@ msgstr ""
 "Der Benutzer %{name} wurde angelegt. Eine E-Mail mit einer PIN wurde "
 "verschickt."
 
-#: lib/vutuv_web/controllers/user_controller.ex:314
+#: lib/vutuv_web/controllers/user_controller.ex:310
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr "User wurde gelöscht."
 
-#: lib/vutuv_web/controllers/user_controller.ex:233
+#: lib/vutuv_web/controllers/user_controller.ex:229
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr "Profil aktualisiert."
@@ -801,12 +802,12 @@ msgstr "Profil aktualisiert."
 msgid "User verified successfully."
 msgstr "User wurde verifiziert."
 
-#: lib/vutuv_web/components/ui.ex:3410
+#: lib/vutuv_web/components/ui.ex:3353
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
-#: lib/vutuv_web/live/admin/user_live.ex:169
-#: lib/vutuv_web/live/notification_live/index.ex:957
+#: lib/vutuv_web/live/admin/user_live.ex:155
+#: lib/vutuv_web/live/notification_live/index.ex:992
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -850,20 +851,20 @@ msgstr "Benutzername"
 msgid "Users"
 msgstr "Benutzer"
 
-#: lib/vutuv_web/components/ui.ex:759
+#: lib/vutuv_web/components/ui.ex:767
 #: lib/vutuv_web/templates/user/show.html.heex:309
 #, elixir-autogen
 msgid "vCard"
 msgstr "vCard"
 
-#: lib/vutuv_web/components/ui.ex:3206
-#: lib/vutuv_web/templates/user/show.html.heex:831
-#: lib/vutuv_web/templates/user/show.html.heex:851
+#: lib/vutuv_web/components/ui.ex:3149
+#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:857
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
 
-#: lib/vutuv_web/components/ui.ex:3490
+#: lib/vutuv_web/components/ui.ex:3433
 #: lib/vutuv_web/controllers/settings_controller.ex:146
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:300
@@ -937,7 +938,7 @@ msgid "You follow back %{name}."
 msgstr "Sie folgen %{name} jetzt zurück."
 
 #: lib/vutuv_web/live/init_assigns.ex:52
-#: lib/vutuv_web/live/post_live/feed.ex:61
+#: lib/vutuv_web/live/post_live/feed.ex:62
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -1010,14 +1011,14 @@ msgstr "+49 30 12345678"
 msgid "http://www.example.com"
 msgstr "https://www.example.com"
 
-#: lib/vutuv/accounts/user.ex:1041
+#: lib/vutuv/accounts/user.ex:1049
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr "Frau"
 
-#: lib/vutuv/accounts/user.ex:1040
+#: lib/vutuv/accounts/user.ex:1048
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1084,12 +1085,12 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:999
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/admin/user_live.ex:388
+#: lib/vutuv_web/live/admin/user_live.ex:359
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen
 msgid "Verify"
@@ -1125,7 +1126,7 @@ msgstr "vutuv Login-PIN"
 msgid "Listings"
 msgstr "Listen"
 
-#: lib/vutuv_web/controllers/page_controller.ex:236
+#: lib/vutuv_web/controllers/page_controller.ex:241
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1153,8 +1154,8 @@ msgstr "100 Usern mit den meisten Followern"
 msgid "Curious? Have a look at the "
 msgstr "Neugierig? Hier ist die Liste "
 
-#: lib/vutuv_web/views/work_experience_html.ex:298
-#: lib/vutuv_web/views/work_experience_html.ex:351
+#: lib/vutuv_web/views/work_experience_html.ex:300
+#: lib/vutuv_web/views/work_experience_html.ex:353
 #, elixir-autogen
 msgid "Present"
 msgstr "Heute"
@@ -1216,7 +1217,7 @@ msgid "Add Localization"
 msgstr "Lokalisierung hinzufügen"
 
 #: lib/vutuv_web/components/organization_components.ex:245
-#: lib/vutuv_web/live/admin/activity_live.ex:191
+#: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
 #: lib/vutuv_web/live/admin/job_live.ex:199
@@ -1231,7 +1232,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/screenshot_live.ex:82
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
-#: lib/vutuv_web/live/admin/user_live.ex:190
+#: lib/vutuv_web/live/admin/user_live.ex:165
 #: lib/vutuv_web/live/shell_live.ex:589
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
@@ -1451,7 +1452,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:402
 #: lib/vutuv_web/agent_docs/text.ex:615
-#: lib/vutuv_web/components/ui.ex:3430
+#: lib/vutuv_web/components/ui.ex:3373
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1488,7 +1489,7 @@ msgstr "Tags"
 
 #: lib/vutuv_web/controllers/email_controller.ex:167
 #: lib/vutuv_web/controllers/session_controller.ex:438
-#: lib/vutuv_web/controllers/user_controller.ex:334
+#: lib/vutuv_web/controllers/user_controller.ex:330
 #: lib/vutuv_web/controllers/username_controller.ex:215
 #, elixir-autogen
 msgid "Too many incorrect attempts."
@@ -1708,8 +1709,8 @@ msgstr "Schauen Sie in Ihr Postfach"
 #: lib/vutuv_web/live/post_live/composer.ex:1311
 #: lib/vutuv_web/live/post_live/composer.ex:1312
 #: lib/vutuv_web/live/post_live/composer.ex:2213
-#: lib/vutuv_web/templates/layout/app.html.heex:155
-#: lib/vutuv_web/templates/layout/app.html.heex:161
+#: lib/vutuv_web/templates/layout/app.html.heex:159
+#: lib/vutuv_web/templates/layout/app.html.heex:165
 #: lib/vutuv_web/views/layout_html.ex:40
 #, elixir-autogen, elixir-format
 msgid "Close"
@@ -1727,16 +1728,16 @@ msgstr "Bestätigen"
 msgid "Confirm account deletion"
 msgstr "Kontolöschung bestätigen"
 
-#: lib/vutuv_web/controllers/page_controller.ex:97
-#: lib/vutuv_web/templates/layout/app.html.heex:89
+#: lib/vutuv_web/controllers/page_controller.ex:102
+#: lib/vutuv_web/templates/layout/app.html.heex:93
 #: lib/vutuv_web/templates/page/index.html.heex:215
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr "Datenschutzerklärung"
 
-#: lib/vutuv_web/controllers/page_controller.ex:103
-#: lib/vutuv_web/templates/layout/app.html.heex:91
+#: lib/vutuv_web/controllers/page_controller.ex:108
+#: lib/vutuv_web/templates/layout/app.html.heex:95
 #: lib/vutuv_web/templates/page/index.html.heex:215
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
@@ -1749,34 +1750,34 @@ msgstr "Nutzungsbedingungen"
 msgid "Delete my account"
 msgstr "Mein Konto löschen"
 
-#: lib/vutuv_web/controllers/user_controller.ex:154
+#: lib/vutuv_web/controllers/user_controller.ex:150
 #: lib/vutuv_web/templates/user/show.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr "Profil bearbeiten"
 
-#: lib/vutuv_web/components/ui.ex:1154
 #: lib/vutuv_web/components/ui.ex:1163
-#: lib/vutuv_web/components/ui.ex:1556
+#: lib/vutuv_web/components/ui.ex:1172
+#: lib/vutuv_web/components/ui.ex:1565
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr "Empfehlen"
 
-#: lib/vutuv_web/components/ui.ex:1694
-#: lib/vutuv_web/components/ui.ex:1694
-#: lib/vutuv_web/components/ui.ex:1711
+#: lib/vutuv_web/components/ui.ex:1703
+#: lib/vutuv_web/components/ui.ex:1703
 #: lib/vutuv_web/components/ui.ex:1720
-#: lib/vutuv_web/components/ui.ex:1736
-#: lib/vutuv_web/components/ui.ex:1773
-#: lib/vutuv_web/components/ui.ex:1776
-#: lib/vutuv_web/components/ui.ex:1783
-#: lib/vutuv_web/components/ui.ex:1786
-#: lib/vutuv_web/components/ui.ex:1859
-#: lib/vutuv_web/live/fediverse_account_live.ex:380
-#: lib/vutuv_web/live/fediverse_following_live.ex:287
+#: lib/vutuv_web/components/ui.ex:1729
+#: lib/vutuv_web/components/ui.ex:1745
+#: lib/vutuv_web/components/ui.ex:1782
+#: lib/vutuv_web/components/ui.ex:1785
+#: lib/vutuv_web/components/ui.ex:1792
+#: lib/vutuv_web/components/ui.ex:1795
+#: lib/vutuv_web/components/ui.ex:1868
+#: lib/vutuv_web/live/fediverse_account_live.ex:387
+#: lib/vutuv_web/live/fediverse_following_live.ex:266
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:403
-#: lib/vutuv_web/templates/user/show.html.heex:948
-#: lib/vutuv_web/templates/user/show.html.heex:1200
+#: lib/vutuv_web/templates/user/show.html.heex:954
+#: lib/vutuv_web/templates/user/show.html.heex:1207
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1801,11 +1802,11 @@ msgid "Log out"
 msgstr "Ausloggen"
 
 #: lib/vutuv_web/components/organization_components.ex:247
-#: lib/vutuv_web/live/admin/activity_live.ex:164
-#: lib/vutuv_web/live/admin/activity_live.ex:213
+#: lib/vutuv_web/live/admin/activity_live.ex:143
+#: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
-#: lib/vutuv_web/live/admin/user_live.ex:168
+#: lib/vutuv_web/live/admin/user_live.ex:154
 #: lib/vutuv_web/live/message_live/index.ex:455
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:55
@@ -1824,7 +1825,7 @@ msgstr "Nachricht"
 #: lib/vutuv_web/live/message_live/index.ex:512
 #: lib/vutuv_web/live/shell_live.ex:497
 #: lib/vutuv_web/live/shell_live.ex:639
-#: lib/vutuv_web/templates/layout/app.html.heex:119
+#: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
@@ -1835,23 +1836,23 @@ msgid "Network"
 msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:338
-#: lib/vutuv_web/components/ui.ex:3255
-#: lib/vutuv_web/live/admin/user_live.ex:311
+#: lib/vutuv_web/components/ui.ex:3198
+#: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr "Hier gibt es noch nichts."
 
-#: lib/vutuv_web/live/notification_live/index.ex:332
+#: lib/vutuv_web/live/notification_live/index.ex:367
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr "Noch nichts Neues."
 
-#: lib/vutuv_web/components/ui.ex:3471
-#: lib/vutuv_web/live/notification_live/index.ex:103
-#: lib/vutuv_web/live/notification_live/index.ex:293
+#: lib/vutuv_web/components/ui.ex:3414
+#: lib/vutuv_web/live/notification_live/index.ex:104
+#: lib/vutuv_web/live/notification_live/index.ex:328
 #: lib/vutuv_web/live/shell_live.ex:508
-#: lib/vutuv_web/templates/layout/app.html.heex:120
+#: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
@@ -1863,7 +1864,7 @@ msgid "Active Members"
 msgstr "Aktive Mitglieder"
 
 #: lib/vutuv_web/live/admin/user_detail_live.ex:99
-#: lib/vutuv_web/live/admin/user_live.ex:358
+#: lib/vutuv_web/live/admin/user_live.ex:329
 #: lib/vutuv_web/templates/email/confirm.html.heex:25
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:17
 #: lib/vutuv_web/views/username_html.ex:66
@@ -1884,12 +1885,12 @@ msgid "Send"
 msgstr "Senden"
 
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:35
-#: lib/vutuv_web/templates/layout/app.html.heex:83
+#: lib/vutuv_web/templates/layout/app.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Source"
 msgstr "Quellcode"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:85
+#: lib/vutuv_web/templates/layout/app.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Submit a bug report or feature request"
 msgstr "Fehler melden oder Feature vorschlagen"
@@ -1913,8 +1914,8 @@ msgstr "Diese E-Mail-Adresse konnte nicht hinzugefügt werden."
 #: lib/vutuv_web/controllers/session_controller.ex:157
 #: lib/vutuv_web/controllers/session_controller.ex:193
 #: lib/vutuv_web/controllers/session_controller.ex:209
-#: lib/vutuv_web/controllers/user_controller.ex:270
-#: lib/vutuv_web/controllers/user_controller.ex:299
+#: lib/vutuv_web/controllers/user_controller.ex:266
+#: lib/vutuv_web/controllers/user_controller.ex:295
 #: lib/vutuv_web/controllers/username_controller.ex:191
 #: lib/vutuv_web/controllers/username_controller.ex:273
 #: lib/vutuv_web/controllers/username_controller.ex:296
@@ -1952,7 +1953,7 @@ msgstr ""
 "Wir haben eine PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie sie "
 "unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1106
+#: lib/vutuv_web/live/post_live/feed.ex:1115
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -1989,29 +1990,29 @@ msgstr "folgt"
 msgid "submit a bug report"
 msgstr "einen Fehlerbericht erstellen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:978
+#: lib/vutuv_web/live/notification_live/index.ex:1013
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr "hat Sie für %{tag} empfohlen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:973
+#: lib/vutuv_web/live/notification_live/index.ex:1008
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr "ist jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:968
+#: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr "folgt Ihnen jetzt."
 
-#: lib/vutuv_web/components/ui.ex:2595
-#: lib/vutuv_web/components/ui.ex:2746
-#: lib/vutuv_web/live/organization_live/index.ex:130
+#: lib/vutuv_web/components/ui.ex:2538
+#: lib/vutuv_web/components/ui.ex:2689
+#: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr "Seitennavigation"
 
-#: lib/vutuv_web/components/ui.ex:3280
+#: lib/vutuv_web/components/ui.ex:3223
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Mehr laden"
@@ -2023,37 +2024,37 @@ msgstr ""
 "Die Adresse selbst kann nicht geändert werden. Um eine andere zu verwenden, "
 "legen Sie sie als neue E-Mail-Adresse an und löschen Sie diese hier."
 
-#: lib/vutuv_web/components/ui.ex:3051
+#: lib/vutuv_web/components/ui.ex:2994
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
 
-#: lib/vutuv_web/components/ui.ex:881
-#: lib/vutuv_web/components/ui.ex:891
+#: lib/vutuv_web/components/ui.ex:890
+#: lib/vutuv_web/components/ui.ex:900
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr "Optionen"
 
-#: lib/vutuv_web/views/work_experience_html.ex:410
+#: lib/vutuv_web/views/work_experience_html.ex:412
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] "%{count} Monat"
 msgstr[1] "%{count} Monate"
 
-#: lib/vutuv_web/views/work_experience_html.ex:413
+#: lib/vutuv_web/views/work_experience_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/views/work_experience_html.ex:529
+#: lib/vutuv_web/views/work_experience_html.ex:496
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr "Dauer in dieser Position"
 
-#: lib/vutuv_web/views/work_experience_html.ex:528
+#: lib/vutuv_web/views/work_experience_html.ex:495
 #, elixir-autogen, elixir-format
 msgid "Total time at this employer"
 msgstr "Gesamtdauer bei diesem Arbeitgeber"
@@ -2068,12 +2069,12 @@ msgstr "Titelbild hinzufügen"
 msgid "Add cover photo"
 msgstr "Titelbild hinzufügen"
 
-#: lib/vutuv_web/components/ui.ex:2350
+#: lib/vutuv_web/components/ui.ex:2293
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr "April"
 
-#: lib/vutuv_web/components/ui.ex:2354
+#: lib/vutuv_web/components/ui.ex:2297
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr "August"
@@ -2098,37 +2099,37 @@ msgstr "Titelbild"
 msgid "Cover photo of %{name}"
 msgstr "Titelbild von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:2358
+#: lib/vutuv_web/components/ui.ex:2301
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr "Dezember"
 
-#: lib/vutuv_web/components/ui.ex:2348
+#: lib/vutuv_web/components/ui.ex:2291
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr "Februar"
 
-#: lib/vutuv_web/components/ui.ex:2347
+#: lib/vutuv_web/components/ui.ex:2290
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr "Januar"
 
-#: lib/vutuv_web/components/ui.ex:2353
+#: lib/vutuv_web/components/ui.ex:2296
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr "Juli"
 
-#: lib/vutuv_web/components/ui.ex:2352
+#: lib/vutuv_web/components/ui.ex:2295
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr "Juni"
 
-#: lib/vutuv_web/components/ui.ex:2349
+#: lib/vutuv_web/components/ui.ex:2292
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr "März"
 
-#: lib/vutuv_web/components/ui.ex:2351
+#: lib/vutuv_web/components/ui.ex:2294
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr "Mai"
@@ -2143,17 +2144,17 @@ msgstr "Mitglied seit %{month} %{year}"
 msgid "Member since %{year}"
 msgstr "Mitglied seit %{year}"
 
-#: lib/vutuv_web/components/ui.ex:2357
+#: lib/vutuv_web/components/ui.ex:2300
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr "November"
 
-#: lib/vutuv_web/components/ui.ex:2356
+#: lib/vutuv_web/components/ui.ex:2299
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr "Oktober"
 
-#: lib/vutuv_web/components/ui.ex:2355
+#: lib/vutuv_web/components/ui.ex:2298
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr "September"
@@ -2175,8 +2176,8 @@ msgstr "Bilder hinzufügen"
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr "Sobald irgendetwas ausgeblendet ist, sehen auch abgemeldete Besucher und Suchmaschinen den Beitrag nicht mehr."
 
-#: lib/vutuv_web/live/post_live/edit.ex:145
-#: lib/vutuv_web/live/post_live/reply.ex:79
+#: lib/vutuv_web/live/post_live/edit.ex:143
+#: lib/vutuv_web/live/post_live/reply.ex:77
 #, elixir-autogen, elixir-format
 msgid "Back to the post"
 msgstr "Zurück zum Beitrag"
@@ -2186,28 +2187,28 @@ msgstr "Zurück zum Beitrag"
 msgid "Cancel upload"
 msgstr "Upload abbrechen"
 
-#: lib/vutuv_web/live/post_live/edit.ex:155
+#: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
 #: lib/vutuv_web/components/post_components.ex:2179
-#: lib/vutuv_web/live/post_live/edit.ex:153
+#: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
 msgstr "Diesen Beitrag endgültig löschen?"
 
-#: lib/vutuv_web/live/post_live/edit.ex:48
-#: lib/vutuv_web/live/post_live/edit.ex:94
+#: lib/vutuv_web/live/post_live/edit.ex:46
+#: lib/vutuv_web/live/post_live/edit.ex:92
 #, elixir-autogen, elixir-format
 msgid "Edit post"
 msgstr "Beitrag bearbeiten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:87
-#: lib/vutuv_web/live/post_live/feed.ex:903
+#: lib/vutuv_web/live/post_live/feed.ex:139
+#: lib/vutuv_web/live/post_live/feed.ex:912
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
-#: lib/vutuv_web/templates/layout/app.html.heex:118
+#: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
 msgstr "Feed"
@@ -2217,7 +2218,7 @@ msgstr "Feed"
 msgid "Follow %{name} to read it."
 msgstr "Folgen Sie %{name}, um ihn zu lesen."
 
-#: lib/vutuv_web/templates/post/show.html.heex:28
+#: lib/vutuv_web/templates/post/show.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Hidden from:"
 msgstr "Verborgen vor:"
@@ -2249,7 +2250,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1045
+#: lib/vutuv_web/live/post_live/feed.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2278,7 +2279,7 @@ msgstr "Personen, die mir nicht folgen"
 msgid "Post"
 msgstr "Posten"
 
-#: lib/vutuv_web/controllers/post_controller.ex:214
+#: lib/vutuv_web/controllers/post_controller.ex:224
 #, elixir-autogen, elixir-format
 msgid "Post deleted successfully."
 msgstr "Beitrag erfolgreich gelöscht."
@@ -2286,11 +2287,11 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/agent_docs/post_doc.ex:127
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
-#: lib/vutuv_web/controllers/user_controller.ex:76
+#: lib/vutuv_web/controllers/user_controller.ex:77
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/fediverse_account_live.ex:387
-#: lib/vutuv_web/live/notification_live/index.ex:804
+#: lib/vutuv_web/live/fediverse_account_live.ex:394
+#: lib/vutuv_web/live/notification_live/index.ex:839
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:200
 #: lib/vutuv_web/live/search_live.ex:530
@@ -2307,7 +2308,7 @@ msgid "Read more"
 msgstr "Weiterlesen"
 
 #: lib/vutuv_web/components/post_components.ex:2565
-#: lib/vutuv_web/live/fediverse_account_live.ex:332
+#: lib/vutuv_web/live/fediverse_account_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
@@ -2328,7 +2329,7 @@ msgstr "Weniger anzeigen"
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/vutuv_web/templates/post/show.html.heex:31
+#: lib/vutuv_web/templates/post/show.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
@@ -2340,18 +2341,14 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:978
+#: lib/vutuv_web/live/post_live/feed.ex:987
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
 msgstr[0] "%{formatted} neuen Beitrag anzeigen"
 msgstr[1] "%{formatted} neue Beiträge anzeigen"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:75
-#: lib/vutuv_web/live/post_live/edit.ex:36
-#: lib/vutuv_web/live/post_live/remote_post_reply.ex:81
-#: lib/vutuv_web/live/post_live/remote_reply.ex:79
-#: lib/vutuv_web/live/post_live/reply.ex:41
+#: lib/vutuv_web/live/init_assigns.ex:81
 #, elixir-autogen, elixir-format
 msgid "Sorry, that page could not be found."
 msgstr "Diese Seite konnte leider nicht gefunden werden."
@@ -2381,7 +2378,7 @@ msgstr "Zu viele Dateien."
 msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
-#: lib/vutuv_web/components/ui.ex:3723
+#: lib/vutuv_web/components/ui.ex:3666
 #: lib/vutuv_web/live/shell_live.ex:551
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2456,15 +2453,13 @@ msgstr "Beiträge von %{name}"
 msgid "View all %{count} posts"
 msgstr "Alle %{count} Beiträge ansehen"
 
-#: lib/vutuv_web/controllers/post_controller.ex:141
+#: lib/vutuv_web/controllers/post_controller.ex:151
 #, elixir-autogen, elixir-format
 msgid "All posts"
 msgstr "Alle Beiträge"
 
 #: lib/vutuv_web/components/post_components.ex:3768
-#: lib/vutuv_web/components/ui.ex:2054
-#: lib/vutuv_web/components/ui.ex:2054
-#: lib/vutuv_web/components/ui.ex:2670
+#: lib/vutuv_web/components/ui.ex:2613
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2482,10 +2477,8 @@ msgstr "Lesezeichen"
 
 #: lib/vutuv_web/components/post_components.ex:1484
 #: lib/vutuv_web/components/post_components.ex:3991
-#: lib/vutuv_web/components/ui.ex:2083
-#: lib/vutuv_web/components/ui.ex:2083
-#: lib/vutuv_web/components/ui.ex:2656
-#: lib/vutuv_web/live/notification_live/index.ex:947
+#: lib/vutuv_web/components/ui.ex:2599
+#: lib/vutuv_web/live/notification_live/index.ex:982
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2493,7 +2486,7 @@ msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:932
 #: lib/vutuv_web/components/post_components.ex:4000
-#: lib/vutuv_web/live/notification_live/index.ex:884
+#: lib/vutuv_web/live/notification_live/index.ex:919
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:559
@@ -2518,8 +2511,6 @@ msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
 #: lib/vutuv_web/components/post_components.ex:3768
-#: lib/vutuv_web/components/ui.ex:2044
-#: lib/vutuv_web/components/ui.ex:2044
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2545,8 +2536,6 @@ msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
 #: lib/vutuv_web/components/post_components.ex:3991
-#: lib/vutuv_web/components/ui.ex:2073
-#: lib/vutuv_web/components/ui.ex:2073
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
@@ -2554,10 +2543,10 @@ msgid "Unlike"
 msgstr "Gefällt mir entfernen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:253
-#: lib/vutuv_web/components/ui.ex:1689
-#: lib/vutuv_web/components/ui.ex:1689
-#: lib/vutuv_web/components/ui.ex:1826
-#: lib/vutuv_web/live/post_live/feed.ex:1095
+#: lib/vutuv_web/components/ui.ex:1698
+#: lib/vutuv_web/components/ui.ex:1698
+#: lib/vutuv_web/components/ui.ex:1835
+#: lib/vutuv_web/live/post_live/feed.ex:1104
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2574,7 +2563,7 @@ msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
 
 #: lib/vutuv_web/components/post_components.ex:327
-#: lib/vutuv_web/live/notification_live/index.ex:885
+#: lib/vutuv_web/live/notification_live/index.ex:920
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr "Antworten"
@@ -2583,8 +2572,8 @@ msgstr "Antworten"
 #: lib/vutuv_web/components/post_components.ex:1536
 #: lib/vutuv_web/components/post_components.ex:4027
 #: lib/vutuv_web/components/post_components.ex:4028
-#: lib/vutuv_web/live/notification_live/index.ex:944
-#: lib/vutuv_web/live/post_live/reply.ex:35
+#: lib/vutuv_web/live/notification_live/index.ex:979
+#: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
@@ -2605,15 +2594,15 @@ msgstr "Solange es geteilte Beiträge oder Antworten gibt, lässt sich der Empf�
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beiträge oder Antworten gibt, bleibt er öffentlich; löschen können Sie ihn weiterhin."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1123
+#: lib/vutuv_web/live/notification_live/index.ex:1158
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
 #: lib/vutuv_web/components/post_components.ex:1621
-#: lib/vutuv_web/live/post_live/remote_post_reply.ex:58
-#: lib/vutuv_web/live/post_live/remote_reply.ex:57
-#: lib/vutuv_web/live/post_live/reply.ex:52
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
+#: lib/vutuv_web/live/post_live/remote_reply.ex:58
+#: lib/vutuv_web/live/post_live/reply.ex:50
 #, elixir-autogen, elixir-format
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
@@ -2686,7 +2675,7 @@ msgstr "Mitglied nicht gefunden."
 msgid "No conversations yet."
 msgstr "Noch keine Unterhaltungen."
 
-#: lib/vutuv_web/components/ui.ex:2226
+#: lib/vutuv_web/components/ui.ex:2169
 #: lib/vutuv_web/live/message_live/index.ex:612
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2800,26 +2789,26 @@ msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1121
+#: lib/vutuv_web/templates/user/show.html.heex:1127
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1378
+#: lib/vutuv_web/templates/user/show.html.heex:1385
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1049
+#: lib/vutuv_web/templates/user/show.html.heex:1055
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:995
+#: lib/vutuv_web/templates/user/show.html.heex:1001
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
@@ -2831,14 +2820,14 @@ msgstr "Persönliche Angaben hinzufügen"
 msgid "Add work experience"
 msgstr "Berufserfahrung hinzufügen"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1193
+#: lib/vutuv_web/live/user_profile_live.ex:1261
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr "Ersten Beitrag schreiben"
 
-#: lib/vutuv_web/components/ui.ex:2834
-#: lib/vutuv_web/components/ui.ex:3208
+#: lib/vutuv_web/components/ui.ex:2777
+#: lib/vutuv_web/components/ui.ex:3151
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
@@ -2850,20 +2839,20 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:928
+#: lib/vutuv_web/live/post_live/feed.ex:937
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr "Beitrag schreiben"
 
-#: lib/vutuv_web/views/user_helpers.ex:118
+#: lib/vutuv_web/views/user_helpers.ex:125
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] "%{count} Tag hinzugefügt."
 msgstr[1] "%{count} Tags hinzugefügt."
 
-#: lib/vutuv_web/views/user_helpers.ex:122
+#: lib/vutuv_web/views/user_helpers.ex:129
 #, elixir-autogen, elixir-format
 msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
 msgstr ""
@@ -2887,13 +2876,13 @@ msgstr[1] "+%{formatted} weitere Tags"
 #: lib/vutuv_web/agent_docs/markdown.ex:508
 #: lib/vutuv_web/agent_docs/text.ex:478
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:883
+#: lib/vutuv_web/live/notification_live/index.ex:918
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr "Vernetzungen"
 
-#: lib/vutuv_web/components/ui.ex:750
+#: lib/vutuv_web/components/ui.ex:758
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr "Markdown"
@@ -2903,7 +2892,7 @@ msgstr "Markdown"
 msgid "No connections yet."
 msgstr "Noch keine Vernetzungen."
 
-#: lib/vutuv_web/components/ui.ex:765
+#: lib/vutuv_web/components/ui.ex:774
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr "Andere Formate"
@@ -2913,7 +2902,7 @@ msgstr "Andere Formate"
 msgid "People who aren't my connections"
 msgstr "Personen, mit denen ich nicht vernetzt bin"
 
-#: lib/vutuv_web/components/ui.ex:751
+#: lib/vutuv_web/components/ui.ex:759
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr "Nur Text"
@@ -2941,22 +2930,22 @@ msgstr "Personen, mit denen Sie nicht vernetzt sind"
 msgid "Open someone's profile to message them."
 msgstr "Öffnen Sie ein Profil, um jemandem zu schreiben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:958
+#: lib/vutuv_web/live/notification_live/index.ex:993
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr "Aktivität"
 
-#: lib/vutuv_web/live/notification_live/index.ex:950
+#: lib/vutuv_web/live/notification_live/index.ex:985
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr "Vernetzung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:943
+#: lib/vutuv_web/live/notification_live/index.ex:978
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr "Empfehlung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:942
+#: lib/vutuv_web/live/notification_live/index.ex:977
 #: lib/vutuv_web/templates/user/show.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2969,7 +2958,7 @@ msgstr[1] "Follower"
 msgid "Welcome to vutuv, %{name}!"
 msgstr "Willkommen bei vutuv, %{name}!"
 
-#: lib/vutuv_web/live/notification_live/index.ex:975
+#: lib/vutuv_web/live/notification_live/index.ex:1010
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr "gefällt Ihr Beitrag."
@@ -3001,12 +2990,12 @@ msgstr "(gelöschtes Konto)"
 msgid "(no text)"
 msgstr "(kein Text)"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1159
+#: lib/vutuv_web/live/notification_live/index.ex:1194
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde bestätigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1160
+#: lib/vutuv_web/live/notification_live/index.ex:1195
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr "Eine Meldung zu Ihrem Inhalt wurde verworfen; er ist wieder sichtbar."
@@ -3038,8 +3027,8 @@ msgstr "Mobbing oder Belästigung"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:296
 #: lib/vutuv_web/agent_docs/text.ex:280
-#: lib/vutuv_web/controllers/page_controller.ex:76
-#: lib/vutuv_web/templates/layout/app.html.heex:87
+#: lib/vutuv_web/controllers/page_controller.ex:81
+#: lib/vutuv_web/templates/layout/app.html.heex:91
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Community guidelines"
@@ -3121,7 +3110,7 @@ msgstr "Familienfreundlich bleiben"
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:951
+#: lib/vutuv_web/live/notification_live/index.ex:986
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3204,8 +3193,8 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1089
-#: lib/vutuv_web/templates/user/show.html.heex:1090
+#: lib/vutuv_web/templates/user/show.html.heex:1095
+#: lib/vutuv_web/templates/user/show.html.heex:1096
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
@@ -3263,7 +3252,7 @@ msgstr ""
 msgid "Private message"
 msgstr "Private Nachricht"
 
-#: lib/vutuv_web/components/ui.ex:3404
+#: lib/vutuv_web/components/ui.ex:3347
 #: lib/vutuv_web/live/shell_live.ex:443
 #: lib/vutuv_web/live/shell_live.ex:644
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3377,7 +3366,7 @@ msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 "Meldungen sind anonym; wir verraten nie, wer gemeldet hat. Unsere Regeln:"
 
-#: lib/vutuv_web/components/ui.ex:2570
+#: lib/vutuv_web/components/ui.ex:2513
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3433,7 +3422,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/moderation_live.ex:53
 #: lib/vutuv_web/live/admin/organization_live.ex:246
 #: lib/vutuv_web/live/admin/screenshot_live.ex:149
-#: lib/vutuv_web/live/admin/user_live.ex:328
+#: lib/vutuv_web/live/admin/user_live.ex:299
 #: lib/vutuv_web/templates/admin/account/index.html.heex:57
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:59
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:19
@@ -3579,12 +3568,12 @@ msgstr "Sie haben das bereits gemeldet. Unser Team kümmert sich darum."
 msgid "You cannot report your own content."
 msgstr "Eigene Inhalte können Sie nicht melden."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1162
+#: lib/vutuv_web/live/notification_live/index.ex:1197
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt gelöscht; der Fall ist abgeschlossen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1161
+#: lib/vutuv_web/live/notification_live/index.ex:1196
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
@@ -3594,7 +3583,7 @@ msgstr "Sie haben gemeldeten Inhalt überarbeitet; der Fall ist abgeschlossen."
 msgid "Your content was reported"
 msgstr "Ihr Inhalt wurde gemeldet"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1163
+#: lib/vutuv_web/live/notification_live/index.ex:1198
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3789,7 +3778,7 @@ msgstr "Verlauf"
 msgid "Open the profile"
 msgstr "Profil öffnen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1187
+#: lib/vutuv_web/live/notification_live/index.ex:1222
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3816,7 +3805,7 @@ msgstr "Besitzer hat den Inhalt bearbeitet"
 msgid "Report filed"
 msgstr "Meldung eingegangen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:953
+#: lib/vutuv_web/live/notification_live/index.ex:988
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr "Schutz nach Meldung"
@@ -3898,7 +3887,7 @@ msgstr "Bestätigt"
 msgid "Waiting for the owner"
 msgstr "Wartet auf den Besitzer"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1192
+#: lib/vutuv_web/live/notification_live/index.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4698,7 +4687,7 @@ msgstr ""
 "beide Richtungen unterbunden. Eine Aufhebung der Blockierung stellt das "
 "Entfernte nicht wieder her."
 
-#: lib/vutuv_web/components/ui.ex:3494
+#: lib/vutuv_web/components/ui.ex:3437
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4742,12 +4731,12 @@ msgid "You have not blocked anyone."
 msgstr "Sie haben niemanden blockiert."
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:244
+#: lib/vutuv_web/live/user_profile_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1050
+#: lib/vutuv_web/live/post_live/feed.ex:1059
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4759,7 +4748,7 @@ msgstr "Mitglieder finden"
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:837
+#: lib/vutuv_web/templates/user/show.html.heex:840
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4805,7 +4794,7 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/agent_docs/text.ex:350
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:480
-#: lib/vutuv_web/live/notification_live/index.ex:805
+#: lib/vutuv_web/live/notification_live/index.ex:840
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:198
@@ -4829,7 +4818,7 @@ msgstr "Ähnliche Namen"
 #: lib/vutuv_web/components/post_components.ex:324
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:803
+#: lib/vutuv_web/live/notification_live/index.ex:838
 #: lib/vutuv_web/live/search_live.ex:197
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -4878,7 +4867,7 @@ msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:46
-#: lib/vutuv_web/live/user_profile_live.ex:1181
+#: lib/vutuv_web/live/user_profile_live.ex:1249
 #: lib/vutuv_web/templates/user/show.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -5303,7 +5292,7 @@ msgstr "\"%{name}\" sperren? Alle seine Tokens funktionieren sofort nicht mehr."
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:92
 #: lib/vutuv_web/live/admin/member_badges.ex:22
-#: lib/vutuv_web/live/admin/user_live.ex:292
+#: lib/vutuv_web/live/admin/user_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Suspended"
 msgstr "Gesperrt"
@@ -5510,12 +5499,12 @@ msgstr "KI-Agenten und LLMs dürfen dieses Profil nutzen"
 msgid "API token (%{date})"
 msgstr "API-Token (%{date})"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:81
+#: lib/vutuv_web/templates/layout/app.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "API documentation"
 msgstr "API-Dokumentation"
 
-#: lib/vutuv_web/components/ui.ex:3533
+#: lib/vutuv_web/components/ui.ex:3476
 #: lib/vutuv_web/controllers/settings_controller.ex:137
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5572,40 +5561,40 @@ msgid "Account menu"
 msgstr "Kontomenü"
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:155
-#: lib/vutuv_web/templates/layout/app.html.heex:124
+#: lib/vutuv_web/templates/layout/app.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:134
+#: lib/vutuv_web/templates/layout/app.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Close menus and dialogs"
 msgstr "Menüs und Dialoge schließen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:131
+#: lib/vutuv_web/templates/layout/app.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr "Allgemeines"
 
 #: lib/vutuv_web/live/shell_live.ex:599
-#: lib/vutuv_web/templates/layout/app.html.heex:150
+#: lib/vutuv_web/templates/layout/app.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr "Tastaturkürzel"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:115
+#: lib/vutuv_web/templates/layout/app.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Navigation"
 msgstr "Navigation"
 
-#: lib/vutuv_web/components/ui.ex:3630
-#: lib/vutuv_web/components/ui.ex:3635
-#: lib/vutuv_web/components/ui.ex:3714
-#: lib/vutuv_web/components/ui.ex:3778
+#: lib/vutuv_web/components/ui.ex:3573
+#: lib/vutuv_web/components/ui.ex:3578
+#: lib/vutuv_web/components/ui.ex:3657
+#: lib/vutuv_web/components/ui.ex:3721
 #: lib/vutuv_web/controllers/settings_controller.ex:53
-#: lib/vutuv_web/live/account_activity_live.ex:155
-#: lib/vutuv_web/live/fediverse_followers_live.ex:126
-#: lib/vutuv_web/live/fediverse_following_live.ex:253
+#: lib/vutuv_web/live/account_activity_live.ex:115
+#: lib/vutuv_web/live/fediverse_followers_live.ex:108
+#: lib/vutuv_web/live/fediverse_following_live.ex:238
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
@@ -5617,17 +5606,17 @@ msgstr "Navigation"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:133
+#: lib/vutuv_web/templates/layout/app.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Show this help"
 msgstr "Diese Hilfe anzeigen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:126
+#: lib/vutuv_web/templates/layout/app.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Write a new post"
 msgstr "Beitrag schreiben"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:121
+#: lib/vutuv_web/templates/layout/app.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Your profile"
 msgstr "Ihr Profil"
@@ -5642,17 +5631,17 @@ msgstr "Profil vervollständigen"
 msgid "A few quick steps so people can find and recognize you."
 msgstr "Ein paar schnelle Schritte, damit andere Sie finden und erkennen."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1183
+#: lib/vutuv_web/live/user_profile_live.ex:1251
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr "Profilfoto hinzufügen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:128
+#: lib/vutuv_web/templates/layout/app.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Next post in the feed"
 msgstr "Nächster Beitrag im Feed"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:129
+#: lib/vutuv_web/templates/layout/app.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
@@ -5663,7 +5652,7 @@ msgstr "Vorheriger Beitrag im Feed"
 msgid "Main navigation"
 msgstr "Hauptnavigation"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:74
+#: lib/vutuv_web/templates/layout/app.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
@@ -5671,8 +5660,8 @@ msgstr "Fußzeilen-Navigation"
 #: lib/vutuv_web/components/post_components.ex:2266
 #: lib/vutuv_web/components/post_components.ex:2318
 #: lib/vutuv_web/components/post_components.ex:2708
-#: lib/vutuv_web/live/notification_live/index.ex:624
-#: lib/vutuv_web/live/post_live/feed.ex:1168
+#: lib/vutuv_web/live/notification_live/index.ex:659
+#: lib/vutuv_web/live/post_live/feed.ex:1177
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5688,7 +5677,7 @@ msgstr "Registrierungsversuch mit Ihrer E-Mail-Adresse"
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr "Ihre Tags (z.B. JavaScript, Kochen, Origami, Katze)"
 
-#: lib/vutuv/accounts/user.ex:1044
+#: lib/vutuv/accounts/user.ex:1052
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5724,10 +5713,10 @@ msgstr "Art der E-Mail-Adresse"
 msgid "About you"
 msgstr "Über Sie"
 
-#: lib/vutuv_web/components/ui.ex:3506
-#: lib/vutuv_web/live/admin/user_live.ex:279
-#: lib/vutuv_web/live/fediverse_followers_live.ex:112
-#: lib/vutuv_web/live/fediverse_following_live.ex:239
+#: lib/vutuv_web/components/ui.ex:3449
+#: lib/vutuv_web/live/admin/user_live.ex:254
+#: lib/vutuv_web/live/fediverse_followers_live.ex:94
+#: lib/vutuv_web/live/fediverse_following_live.ex:224
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:192
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
@@ -5745,7 +5734,7 @@ msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 "Laden Sie alles herunter, was vutuv über Sie speichert, als eine Datei."
 
-#: lib/vutuv_web/components/ui.ex:3441
+#: lib/vutuv_web/components/ui.ex:3384
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5779,7 +5768,7 @@ msgstr "Persönliche Tokens für die vutuv-API."
 msgid "Photos"
 msgstr "Fotos"
 
-#: lib/vutuv_web/components/ui.ex:3488
+#: lib/vutuv_web/components/ui.ex:3431
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privatsphäre"
@@ -5804,7 +5793,7 @@ msgstr "Ansehen"
 msgid "Your name"
 msgstr "Ihr Name"
 
-#: lib/vutuv_web/live/notification_live/index.ex:473
+#: lib/vutuv_web/live/notification_live/index.ex:508
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr "Ihr Beitrag"
@@ -5894,14 +5883,14 @@ msgstr "@%{slug} folgt Ihnen jetzt auf vutuv"
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/vutuv_web/components/ui.ex:3529
+#: lib/vutuv_web/components/ui.ex:3472
 #: lib/vutuv_web/controllers/settings_controller.ex:152
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr "Apps & API-Zugang"
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:886
+#: lib/vutuv_web/live/notification_live/index.ex:921
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -6024,25 +6013,25 @@ msgid "You cannot block yourself."
 msgstr "Sie können sich nicht selbst blockieren."
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:23
-#: lib/vutuv_web/live/user_profile_live.ex:210
+#: lib/vutuv_web/live/user_profile_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Bookmark removed."
 msgstr "Lesezeichen entfernt."
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:19
-#: lib/vutuv_web/live/user_profile_live.ex:207
+#: lib/vutuv_web/live/user_profile_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Bookmarked."
 msgstr "Lesezeichen gesetzt."
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:31
-#: lib/vutuv_web/live/user_profile_live.ex:216
+#: lib/vutuv_web/live/user_profile_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Like removed."
 msgstr "Gefällt mir entfernt."
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:27
-#: lib/vutuv_web/live/user_profile_live.ex:213
+#: lib/vutuv_web/live/user_profile_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Liked."
 msgstr "Gefällt mir."
@@ -6223,7 +6212,7 @@ msgid "Add a passkey"
 msgstr "Passkey hinzufügen"
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/live/fediverse_following_live.ex:241
+#: lib/vutuv_web/live/fediverse_following_live.ex:226
 #: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Added"
@@ -6326,7 +6315,7 @@ msgstr "z. B. MacBook"
 msgid "or"
 msgstr "oder"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1187
+#: lib/vutuv_web/live/user_profile_live.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr "Kurzbeschreibung hinzufügen"
@@ -6362,7 +6351,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1429
+#: lib/vutuv_web/templates/user/show.html.heex:1436
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6408,8 +6397,8 @@ msgstr "Foto verwenden"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1015
-#: lib/vutuv_web/templates/user/show.html.heex:1025
+#: lib/vutuv_web/templates/user/show.html.heex:1021
+#: lib/vutuv_web/templates/user/show.html.heex:1031
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6451,12 +6440,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1136
+#: lib/vutuv_web/templates/user/show.html.heex:1143
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1147
+#: lib/vutuv_web/templates/user/show.html.heex:1154
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6498,7 +6487,7 @@ msgstr "Vorheriger Tag"
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1145
+#: lib/vutuv_web/templates/user/show.html.heex:1152
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6525,9 +6514,9 @@ msgstr "Nach unten"
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/vutuv_web/components/ui.ex:1154
 #: lib/vutuv_web/components/ui.ex:1163
-#: lib/vutuv_web/components/ui.ex:1557
+#: lib/vutuv_web/components/ui.ex:1172
+#: lib/vutuv_web/components/ui.ex:1566
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr "Empfehlung zurücknehmen"
@@ -6554,9 +6543,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1415
-#: lib/vutuv_web/templates/user/show.html.heex:1423
-#: lib/vutuv_web/templates/user/show.html.heex:1435
+#: lib/vutuv_web/templates/user/show.html.heex:1422
+#: lib/vutuv_web/templates/user/show.html.heex:1430
+#: lib/vutuv_web/templates/user/show.html.heex:1442
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6592,11 +6581,11 @@ msgstr "Mitglieder, die %{name} für %{tag} empfohlen haben"
 msgid "No endorsements yet."
 msgstr "Noch keine Empfehlungen."
 
-#: lib/vutuv_web/components/ui.ex:1510
-#: lib/vutuv_web/live/notification_live/index.ex:558
-#: lib/vutuv_web/live/notification_live/index.ex:573
-#: lib/vutuv_web/live/notification_live/index.ex:711
-#: lib/vutuv_web/live/notification_live/index.ex:713
+#: lib/vutuv_web/components/ui.ex:1519
+#: lib/vutuv_web/live/notification_live/index.ex:593
+#: lib/vutuv_web/live/notification_live/index.ex:608
+#: lib/vutuv_web/live/notification_live/index.ex:746
+#: lib/vutuv_web/live/notification_live/index.ex:748
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
@@ -6826,8 +6815,8 @@ msgstr "Auftauen"
 msgid "The raw bounce ledger, newest first."
 msgstr "Das rohe Bounce-Protokoll, neueste zuerst."
 
-#: lib/vutuv_web/live/account_activity_live.ex:126
-#: lib/vutuv_web/live/admin/activity_live.ex:163
+#: lib/vutuv_web/live/account_activity_live.ex:103
+#: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
@@ -6918,8 +6907,8 @@ msgstr ""
 "Schalten Sie einen Schalter aus, geht der passende Opt-out auf den Seiten "
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
-#: lib/vutuv_web/components/ui.ex:2014
-#: lib/vutuv_web/live/fediverse_account_live.ex:374
+#: lib/vutuv_web/components/ui.ex:2023
+#: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6927,7 +6916,7 @@ msgid "Mute"
 msgstr "Stummschalten"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:192
+#: lib/vutuv_web/live/user_profile_live.ex:230
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr "Stummgeschaltet. Die Beiträge erscheinen nicht mehr in Ihrem Feed."
@@ -6942,8 +6931,8 @@ msgstr "Neue Nachrichten und neue Vernetzungen"
 msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
-#: lib/vutuv_web/components/ui.ex:2013
-#: lib/vutuv_web/live/fediverse_account_live.ex:372
+#: lib/vutuv_web/components/ui.ex:2022
+#: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6951,7 +6940,7 @@ msgid "Unmute"
 msgstr "Stummschaltung aufheben"
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:194
+#: lib/vutuv_web/live/user_profile_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -6982,33 +6971,33 @@ msgstr "Beruflich"
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
 
-#: lib/vutuv_web/components/ui.ex:1984
+#: lib/vutuv_web/components/ui.ex:1993
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr "Folgt Ihnen nicht"
 
-#: lib/vutuv_web/components/ui.ex:1978
+#: lib/vutuv_web/components/ui.ex:1987
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr "Folgt Ihnen"
 
-#: lib/vutuv_web/components/ui.ex:1968
+#: lib/vutuv_web/components/ui.ex:1977
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr "Dieses Mitglied folgt Ihnen nicht"
 
-#: lib/vutuv_web/components/ui.ex:1919
-#: lib/vutuv_web/components/ui.ex:1968
+#: lib/vutuv_web/components/ui.ex:1928
+#: lib/vutuv_web/components/ui.ex:1977
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr "Dieses Mitglied folgt Ihnen"
 
-#: lib/vutuv_web/components/ui.ex:1917
+#: lib/vutuv_web/components/ui.ex:1926
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr "Sie folgen einander"
 
-#: lib/vutuv_web/components/ui.ex:1918
+#: lib/vutuv_web/components/ui.ex:1927
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr "Sie folgen diesem Mitglied"
@@ -7127,7 +7116,7 @@ msgstr "Versandprotokoll"
 msgid "Dev email inbox"
 msgstr "Dev-Postfach"
 
-#: lib/vutuv_web/live/admin/user_live.ex:221
+#: lib/vutuv_web/live/admin/user_live.ex:196
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Development:"
@@ -7184,8 +7173,8 @@ msgstr "Filter"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:213
 #: lib/vutuv_web/agent_docs/text.ex:201
-#: lib/vutuv_web/live/account_activity_live.ex:212
-#: lib/vutuv_web/live/admin/activity_live.ex:249
+#: lib/vutuv_web/live/account_activity_live.ex:167
+#: lib/vutuv_web/live/admin/activity_live.ex:211
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #: lib/vutuv_web/templates/settings/filters.html.heex:17
@@ -7212,10 +7201,10 @@ msgstr "Höchstalter"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:592
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:670
 #: lib/vutuv_web/live/admin/user_detail_live.ex:69
-#: lib/vutuv_web/live/admin/user_live.ex:27
-#: lib/vutuv_web/live/admin/user_live.ex:189
-#: lib/vutuv_web/live/admin/user_live.ex:190
-#: lib/vutuv_web/live/admin/user_live.ex:197
+#: lib/vutuv_web/live/admin/user_live.ex:28
+#: lib/vutuv_web/live/admin/user_live.ex:164
+#: lib/vutuv_web/live/admin/user_live.ex:165
+#: lib/vutuv_web/live/admin/user_live.ex:172
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:89
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:45
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:90
@@ -7537,7 +7526,7 @@ msgid_plural "minus %{count} groups"
 msgstr[0] "minus 1 Gruppe"
 msgstr[1] "minus %{count} Gruppen"
 
-#: lib/vutuv_web/live/admin/user_live.ex:229
+#: lib/vutuv_web/live/admin/user_live.ex:204
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "open the dev email inbox"
@@ -7597,13 +7586,13 @@ msgstr "Ihre Mitglieder werden zu dieser hinzugefügt (Vereinigung)."
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr "Seite %{page} von %{pages}, %{total} gesamt"
 
-#: lib/vutuv_web/components/ui.ex:2608
+#: lib/vutuv_web/components/ui.ex:2551
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr "Zurück"
 
-#: lib/vutuv_web/components/ui.ex:2624
+#: lib/vutuv_web/components/ui.ex:2567
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7888,12 +7877,12 @@ msgstr "%{count} Beiträge auf dieser Seite"
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:103
+#: lib/vutuv_web/templates/layout/app.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Deployment: %{date} at %{time}"
 msgstr "Deployment: %{date} um %{time} Uhr"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:103
+#: lib/vutuv_web/templates/layout/app.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Last deployed (Berlin time)"
 msgstr "Zuletzt bereitgestellt (Berliner Zeit)"
@@ -8112,13 +8101,13 @@ msgstr "Neue Mitglieder"
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:832
+#: lib/vutuv_web/live/notification_live/index.ex:867
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr "Heute"
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:835
+#: lib/vutuv_web/live/notification_live/index.ex:870
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr "Gestern"
@@ -8277,42 +8266,42 @@ msgstr ""
 "Konto @%{username} wurde gelöscht. Ein Protokoll wurde per E-Mail an den "
 "Betreiber gesendet."
 
-#: lib/vutuv_web/live/admin/user_live.ex:283
+#: lib/vutuv_web/live/admin/user_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "Admins"
 msgstr "Administratoren"
 
-#: lib/vutuv_web/live/admin/user_live.ex:282
+#: lib/vutuv_web/live/admin/user_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr "Alle Mitglieder"
 
-#: lib/vutuv_web/live/admin/user_live.ex:270
+#: lib/vutuv_web/live/admin/user_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "All registrations"
 msgstr "Alle Registrierungen"
 
-#: lib/vutuv_web/live/admin/user_live.ex:288
+#: lib/vutuv_web/live/admin/user_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Awaiting verification"
 msgstr "Prüfung ausstehend"
 
-#: lib/vutuv_web/components/browse_table.ex:214
-#: lib/vutuv_web/live/account_activity_live.ex:234
-#: lib/vutuv_web/live/admin/activity_live.ex:269
-#: lib/vutuv_web/live/admin/user_live.ex:209
+#: lib/vutuv_web/components/browse_table.ex:318
+#: lib/vutuv_web/live/account_activity_live.ex:189
+#: lib/vutuv_web/live/admin/activity_live.ex:231
+#: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr "Filter zurücksetzen"
 
-#: lib/vutuv_web/live/admin/user_live.ex:90
+#: lib/vutuv_web/live/admin/user_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Could not verify this member."
 msgstr "Dieses Mitglied konnte nicht verifiziert werden."
 
 #: lib/vutuv_web/live/admin/member_badges.ex:24
-#: lib/vutuv_web/live/admin/user_live.ex:295
+#: lib/vutuv_web/live/admin/user_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Deactivated"
 msgstr "Deaktiviert"
@@ -8346,17 +8335,17 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:166
 #: lib/vutuv_web/live/admin/organization_live.ex:171
 #: lib/vutuv_web/live/admin/organization_live.ex:195
-#: lib/vutuv_web/live/admin/user_live.ex:290
+#: lib/vutuv_web/live/admin/user_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Frozen"
 msgstr "Eingefroren"
 
-#: lib/vutuv_web/live/admin/user_live.ex:87
+#: lib/vutuv_web/live/admin/user_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Identity verified. The member has been emailed."
 msgstr "Identität verifiziert. Das Mitglied wurde per E-Mail benachrichtigt."
 
-#: lib/vutuv_web/live/admin/user_live.ex:285
+#: lib/vutuv_web/live/admin/user_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Identity-verified"
 msgstr "Identität verifiziert"
@@ -8370,12 +8359,12 @@ msgstr "Falsche PIN"
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:145
 #: lib/vutuv_web/live/admin/user_detail_live.ex:114
-#: lib/vutuv_web/live/admin/user_live.ex:170
+#: lib/vutuv_web/live/admin/user_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Joined"
 msgstr "Beigetreten"
 
-#: lib/vutuv_web/live/admin/user_live.ex:385
+#: lib/vutuv_web/live/admin/user_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Mark this member's identity as verified? They will be emailed."
 msgstr ""
@@ -8388,12 +8377,12 @@ msgstr ""
 msgid "No accounts match your search."
 msgstr "Keine Konten entsprechen Ihrer Suche."
 
-#: lib/vutuv_web/live/admin/user_live.ex:308
+#: lib/vutuv_web/live/admin/user_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "No members match your filters."
 msgstr "Keine Mitglieder entsprechen Ihren Filtern."
 
-#: lib/vutuv_web/live/admin/user_live.ex:267
+#: lib/vutuv_web/live/admin/user_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Not confirmed"
 msgstr "Nicht bestätigt"
@@ -8409,17 +8398,17 @@ msgstr "Mitgliederübersicht öffnen"
 msgid "PIN expired"
 msgstr "PIN abgelaufen"
 
-#: lib/vutuv_web/live/admin/user_live.ex:265
+#: lib/vutuv_web/live/admin/user_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "PIN registered"
 msgstr "PIN-registriert"
 
-#: lib/vutuv_web/components/ui.ex:2611
+#: lib/vutuv_web/components/ui.ex:2554
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr "Seite %{page} von %{pages}"
 
-#: lib/vutuv_web/live/admin/user_live.ex:262
+#: lib/vutuv_web/live/admin/user_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr "Registrierung"
@@ -8429,7 +8418,7 @@ msgstr "Registrierung"
 msgid "Search and delete"
 msgstr "Suchen und löschen"
 
-#: lib/vutuv_web/live/admin/user_live.ex:213
+#: lib/vutuv_web/live/admin/user_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Search by name, @handle or email, filter and sort. The list updates as you type, and the default shows PIN-registered members, newest first."
 msgstr ""
@@ -8454,13 +8443,13 @@ msgstr ""
 "löschende Konto zu finden."
 
 #: lib/vutuv_web/live/admin/user_detail_live.ex:99
-#: lib/vutuv_web/live/admin/user_live.ex:358
+#: lib/vutuv_web/live/admin/user_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Unconfirmed"
 msgstr "Unbestätigt"
 
 #: lib/vutuv_web/live/admin/member_badges.ex:25
-#: lib/vutuv_web/live/admin/user_live.ex:298
+#: lib/vutuv_web/live/admin/user_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Unreachable"
 msgstr "Nicht erreichbar"
@@ -8472,7 +8461,7 @@ msgstr "Nicht erreichbar"
 msgid "Verified"
 msgstr "Verifiziert"
 
-#: lib/vutuv_web/controllers/user_controller.ex:226
+#: lib/vutuv_web/controllers/user_controller.ex:222
 #, elixir-autogen, elixir-format
 msgid "Your verified badge was removed because you changed your name, gender or date of birth. We re-check identity against those details so members can trust verified profiles and nobody can set up a fake verified account. An admin can verify you again anytime."
 msgstr ""
@@ -8482,9 +8471,9 @@ msgstr ""
 "können und niemand ein gefälschtes verifiziertes Konto anlegen kann. Ein "
 "Admin kann Sie jederzeit erneut verifizieren."
 
-#: lib/vutuv_web/live/admin/activity_live.ex:222
+#: lib/vutuv_web/live/admin/activity_live.ex:184
 #: lib/vutuv_web/live/admin/user_delete_live.ex:127
-#: lib/vutuv_web/live/admin/user_live.ex:253
+#: lib/vutuv_web/live/admin/user_live.ex:228
 #: lib/vutuv_web/templates/admin/account/index.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "name, @handle or email"
@@ -8563,7 +8552,7 @@ msgstr "Abschluss"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3418
+#: lib/vutuv_web/components/ui.ex:3361
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8622,7 +8611,7 @@ msgstr ""
 " was Sie nicht übernehmen möchten. Einträge, die bereits in Ihrem Profil "
 "stehen, sind für Sie abgewählt."
 
-#: lib/vutuv_web/components/ui.ex:3521
+#: lib/vutuv_web/components/ui.ex:3464
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
@@ -8651,7 +8640,7 @@ msgstr "%{items} importiert."
 msgid "Nothing new to import."
 msgstr "Nichts Neues zu importieren."
 
-#: lib/vutuv_web/components/ui.ex:3445
+#: lib/vutuv_web/components/ui.ex:3388
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8745,12 +8734,12 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr "Zu viele Importe. Bitte versuchen Sie es in Kürze erneut."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1226
+#: lib/vutuv_web/live/user_profile_live.ex:1294
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr "Zum Beispiel ein Gedanke zu %{tag}."
 
-#: lib/vutuv_web/components/ui.ex:2880
+#: lib/vutuv_web/components/ui.ex:2823
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8775,7 +8764,7 @@ msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:99
-#: lib/vutuv_web/templates/user/show.html.heex:1282
+#: lib/vutuv_web/templates/user/show.html.heex:1289
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8854,13 +8843,13 @@ msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 "Ziehen Sie Ihre ZIP-Datei hierher oder klicken Sie, um eine auszuwählen."
 
-#: lib/vutuv_web/components/ui.ex:3406
+#: lib/vutuv_web/components/ui.ex:3349
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr "Basisdaten & Fotos"
 
-#: lib/vutuv_web/components/ui.ex:3517
+#: lib/vutuv_web/components/ui.ex:3460
 #: lib/vutuv_web/controllers/settings_controller.ex:114
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8872,9 +8861,9 @@ msgstr "Sprache & Anzeige"
 msgid "More profile sections"
 msgstr "Weitere Profil-Bereiche"
 
-#: lib/vutuv_web/components/ui.ex:3508
+#: lib/vutuv_web/components/ui.ex:3451
 #: lib/vutuv_web/controllers/settings_controller.ex:97
-#: lib/vutuv_web/live/account_activity_live.ex:365
+#: lib/vutuv_web/live/account_activity_live.ex:310
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/totp/new.html.heex:5
@@ -8882,7 +8871,7 @@ msgstr "Weitere Profil-Bereiche"
 msgid "Sign-in & security"
 msgstr "Anmeldung & Sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:3525
+#: lib/vutuv_web/components/ui.ex:3468
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8897,7 +8886,7 @@ msgstr ""
 "Nachrichten und Einstellungen. Sie enthält private Daten, bewahren Sie sie "
 "also sorgfältig auf."
 
-#: lib/vutuv_web/controllers/user_controller.ex:250
+#: lib/vutuv_web/controllers/user_controller.ex:246
 #, elixir-autogen, elixir-format
 msgid "Please type your username exactly as shown to confirm the deletion."
 msgstr ""
@@ -8909,13 +8898,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1135
-#: lib/vutuv_web/live/post_live/feed.ex:1136
+#: lib/vutuv_web/live/post_live/feed.ex:1144
+#: lib/vutuv_web/live/post_live/feed.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1130
+#: lib/vutuv_web/live/post_live/feed.ex:1139
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -8991,7 +8980,7 @@ msgstr ""
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
-#: lib/vutuv_web/templates/layout/app.html.heex:75
+#: lib/vutuv_web/templates/layout/app.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Member directory"
 msgstr "Mitgliederverzeichnis"
@@ -9027,7 +9016,7 @@ msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 "Die Seite %{letter} des Mitgliederverzeichnisses, sortiert nach Nachnamen."
 
-#: lib/vutuv_web/components/ui.ex:767
+#: lib/vutuv_web/components/ui.ex:776
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -9134,19 +9123,19 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/agent_docs/markdown.ex:501
 #: lib/vutuv_web/agent_docs/text.ex:467
 #: lib/vutuv_web/agent_docs/text.ex:471
-#: lib/vutuv_web/components/ui.ex:3498
+#: lib/vutuv_web/components/ui.ex:3441
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:200
 #: lib/vutuv_web/controllers/settings_controller.ex:267
-#: lib/vutuv_web/live/fediverse_followers_live.ex:127
-#: lib/vutuv_web/live/fediverse_following_live.ex:254
+#: lib/vutuv_web/live/fediverse_followers_live.ex:109
+#: lib/vutuv_web/live/fediverse_following_live.ex:239
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:312
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:876
-#: lib/vutuv_web/templates/user/show.html.heex:1187
+#: lib/vutuv_web/templates/user/show.html.heex:882
+#: lib/vutuv_web/templates/user/show.html.heex:1194
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverse"
@@ -9207,19 +9196,19 @@ msgstr ""
 msgid "Category"
 msgstr "Kategorie"
 
-#: lib/vutuv_web/views/work_experience_html.ex:24
+#: lib/vutuv_web/views/work_experience_html.ex:25
 #, elixir-autogen, elixir-format
 msgid "Employment"
 msgstr "Anstellung"
 
 #: lib/vutuv/jobs/job_posting.ex:153
 #: lib/vutuv_web/agent_docs/markdown.ex:658
-#: lib/vutuv_web/views/work_experience_html.ex:26
+#: lib/vutuv_web/views/work_experience_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Internship"
 msgstr "Praktikum"
 
-#: lib/vutuv_web/views/work_experience_html.ex:36
+#: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Internships"
 msgstr "Praktika"
@@ -9231,14 +9220,14 @@ msgstr ""
 "Wählen Sie auf dieser Seite „Größeres Datenarchiv herunterladen“ (Profil, "
 "Positionen, Ehrenämter, Ausbildung, Kenntnisse)."
 
-#: lib/vutuv_web/views/work_experience_html.ex:34
+#: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Professional Experience"
 msgstr "Berufserfahrung"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:659
-#: lib/vutuv_web/views/work_experience_html.ex:30
-#: lib/vutuv_web/views/work_experience_html.ex:37
+#: lib/vutuv_web/views/work_experience_html.ex:31
+#: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Volunteering & hobbies"
 msgstr "Ehrenamt, Hobby & Freiwilligenarbeit"
@@ -9262,19 +9251,19 @@ msgstr "Lebenslauf"
 msgid "Your profile as a CV"
 msgstr "Ihr Profil als Lebenslauf"
 
-#: lib/vutuv_web/views/education_html.ex:28
+#: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Higher Education"
 msgstr "Studium"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:696
-#: lib/vutuv_web/views/education_html.ex:30
+#: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:695
-#: lib/vutuv_web/views/education_html.ex:29
+#: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
 msgstr "Berufsausbildung"
@@ -9297,7 +9286,7 @@ msgstr ""
 "Ihres Browsers (Strg+P oder Cmd+P) und wählen Sie \"Als PDF speichern\", um "
 "eine PDF-Datei zu erhalten."
 
-#: lib/vutuv_web/components/ui.ex:801
+#: lib/vutuv_web/components/ui.ex:810
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr "Lebenslauf-Download"
@@ -9336,7 +9325,7 @@ msgstr "Jeder Download enthält genau die ausgewählten Teile."
 msgid "Header"
 msgstr "Kopfzeile"
 
-#: lib/vutuv_web/components/ui.ex:811
+#: lib/vutuv_web/components/ui.ex:820
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -9374,7 +9363,7 @@ msgstr ""
 "Besuchers enthält nur, was er dort ohnehin sehen kann, und private E-Mail-"
 "Adressen erscheinen nur in Ihrem eigenen."
 
-#: lib/vutuv_web/components/ui.ex:803
+#: lib/vutuv_web/components/ui.ex:812
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -9404,15 +9393,15 @@ msgstr ""
 "Kenntnisse zum Ansehen und Herunterladen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:657
-#: lib/vutuv_web/views/work_experience_html.ex:25
-#: lib/vutuv_web/views/work_experience_html.ex:35
+#: lib/vutuv_web/views/work_experience_html.ex:26
+#: lib/vutuv_web/views/work_experience_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr "Freiberuflich / Selbstständig"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:660
-#: lib/vutuv_web/views/work_experience_html.ex:31
-#: lib/vutuv_web/views/work_experience_html.ex:38
+#: lib/vutuv_web/views/work_experience_html.ex:32
+#: lib/vutuv_web/views/work_experience_html.ex:39
 #, elixir-autogen, elixir-format
 msgid "Other activities"
 msgstr "Sonstige Tätigkeiten"
@@ -9443,14 +9432,12 @@ msgstr "%{job} wird oben in Ihrem Profil angezeigt."
 msgid "Choose automatically instead"
 msgstr "Stattdessen automatisch wählen"
 
-#: lib/vutuv_web/templates/education/card_list.html.heex:93
-#: lib/vutuv_web/views/work_experience_html.ex:682
+#: lib/vutuv_web/views/user_helpers.ex:378
 #, elixir-autogen, elixir-format
 msgid "Show at top of profile"
 msgstr "Oben im Profil anzeigen"
 
-#: lib/vutuv_web/templates/education/card_list.html.heex:84
-#: lib/vutuv_web/views/work_experience_html.ex:673
+#: lib/vutuv_web/views/user_helpers.ex:369
 #, elixir-autogen, elixir-format
 msgid "Shown at the top of your profile"
 msgstr "Wird oben in Ihrem Profil angezeigt"
@@ -9553,8 +9540,8 @@ msgstr "Dieses Tag kann nur von einem Admin entfernt werden."
 msgid "Yes"
 msgstr "Ja"
 
-#: lib/vutuv_web/components/ui.ex:1198
-#: lib/vutuv_web/components/ui.ex:1199
+#: lib/vutuv_web/components/ui.ex:1207
+#: lib/vutuv_web/components/ui.ex:1208
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:64
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9995,18 +9982,18 @@ msgstr "Yoruba"
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
 
-#: lib/vutuv/accounts/user.ex:892
+#: lib/vutuv/accounts/user.ex:900
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
 msgstr "Auf Jobsuche"
 
-#: lib/vutuv_web/views/user_helpers.ex:41
+#: lib/vutuv_web/views/user_helpers.ex:48
 #, elixir-autogen, elixir-format
 msgid "Not open to work"
 msgstr "Nicht offen für Angebote"
 
-#: lib/vutuv/accounts/user.ex:889
+#: lib/vutuv/accounts/user.ex:897
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -10132,7 +10119,7 @@ msgstr "Zertifikate"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3422
+#: lib/vutuv_web/components/ui.ex:3365
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -10269,8 +10256,8 @@ msgstr "Bevorzugt"
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1111
-#: lib/vutuv_web/templates/user/show.html.heex:1112
+#: lib/vutuv_web/templates/user/show.html.heex:1117
+#: lib/vutuv_web/templates/user/show.html.heex:1118
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10467,7 +10454,7 @@ msgstr "Schließen"
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:131
 #: lib/vutuv_web/templates/totp/new.html.heex:58
-#: lib/vutuv_web/templates/user/show.html.heex:912
+#: lib/vutuv_web/templates/user/show.html.heex:918
 #: lib/vutuv_web/templates/username/new.html.heex:27
 #: lib/vutuv_web/templates/username/new.html.heex:114
 #, elixir-autogen, elixir-format
@@ -10478,8 +10465,8 @@ msgstr "Kopiert"
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:134
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
-#: lib/vutuv_web/templates/user/show.html.heex:911
-#: lib/vutuv_web/templates/user/show.html.heex:915
+#: lib/vutuv_web/templates/user/show.html.heex:917
+#: lib/vutuv_web/templates/user/show.html.heex:921
 #: lib/vutuv_web/templates/username/new.html.heex:26
 #: lib/vutuv_web/templates/username/new.html.heex:30
 #: lib/vutuv_web/templates/username/new.html.heex:113
@@ -10559,7 +10546,7 @@ msgstr "Konto gelöscht."
 msgid "Account removed"
 msgstr "Konto entfernt"
 
-#: lib/vutuv_web/live/admin/user_live.ex:104
+#: lib/vutuv_web/live/admin/user_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Account restored. The member can sign in again."
 msgstr "Konto wiederhergestellt. Das Mitglied kann sich wieder anmelden."
@@ -10574,7 +10561,7 @@ msgstr "Als Spam entfernte Konten"
 msgid "Clear-cut spam or abuse?"
 msgstr "Eindeutiger Spam oder Missbrauch?"
 
-#: lib/vutuv_web/live/admin/user_live.ex:107
+#: lib/vutuv_web/live/admin/user_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Could not restore this member."
 msgstr "Dieses Mitglied konnte nicht wiederhergestellt werden."
@@ -10604,17 +10591,17 @@ msgstr ""
 "markiert es als Spam und ist über die Mitgliederliste umkehrbar; das Löschen"
 " ist endgültig."
 
-#: lib/vutuv_web/live/admin/user_live.ex:301
+#: lib/vutuv_web/live/admin/user_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Removed as spam"
 msgstr "Als Spam entfernt"
 
-#: lib/vutuv_web/live/admin/user_live.ex:399
+#: lib/vutuv_web/live/admin/user_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Restore"
 msgstr "Wiederherstellen"
 
-#: lib/vutuv_web/live/admin/user_live.ex:396
+#: lib/vutuv_web/live/admin/user_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Restore this account so the member can sign in again?"
 msgstr ""
@@ -10984,7 +10971,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1256
+#: lib/vutuv_web/templates/user/show.html.heex:1263
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -11246,12 +11233,12 @@ msgstr "PHP, JavaScript, Ruby on Rails"
 msgid "Separate tags with a comma. A tag may be several words long, like Ruby on Rails."
 msgstr "Tags mit Komma trennen. Ein Tag darf aus mehreren Wörtern bestehen, zum Beispiel Ruby on Rails."
 
-#: lib/vutuv_web/views/work_experience_html.ex:426
+#: lib/vutuv_web/views/work_experience_html.ex:428
 #, elixir-autogen, elixir-format
 msgid "%{n}m"
 msgstr "%{n} M."
 
-#: lib/vutuv_web/views/work_experience_html.ex:427
+#: lib/vutuv_web/views/work_experience_html.ex:429
 #, elixir-autogen, elixir-format
 msgid "%{n}y"
 msgstr "%{n} J."
@@ -11406,7 +11393,7 @@ msgid "Preference defaults"
 msgstr "Voreinstellungen"
 
 #: lib/vutuv_web/live/admin/user_detail_live.ex:167
-#: lib/vutuv_web/live/admin/user_live.ex:378
+#: lib/vutuv_web/live/admin/user_live.ex:349
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Preferences"
@@ -11629,19 +11616,19 @@ msgstr ""
 " Konto anlegen kann. Wählen Sie „Niemand“, um den Status zu speichern, ohne "
 "ihn anzuzeigen."
 
-#: lib/vutuv/accounts/user.ex:930
+#: lib/vutuv/accounts/user.ex:938
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr "Alle, auch nicht angemeldete Besucher"
 
-#: lib/vutuv/accounts/user.ex:935
+#: lib/vutuv/accounts/user.ex:943
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr "Niemand"
 
-#: lib/vutuv/accounts/user.ex:933
+#: lib/vutuv/accounts/user.ex:941
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
@@ -11918,7 +11905,7 @@ msgstr "Weisen Sie nach, dass Ihnen %{domain} gehört, um diese Seite zu veröff
 msgid "Remove logo"
 msgstr "Logo entfernen"
 
-#: lib/vutuv_web/live/organization_live/index.ex:91
+#: lib/vutuv_web/live/organization_live/index.ex:83
 #, elixir-autogen, elixir-format
 msgid "Search by name or city"
 msgstr "Nach Name oder Stadt suchen"
@@ -12590,8 +12577,8 @@ msgstr ""
 msgid "Claim a short @handle so this organization has its own root URL, like a member profile. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr "Reservieren Sie ein kurzes @handle, damit diese Organisation wie ein Mitgliedsprofil eine eigene Root-URL bekommt. Buchstaben, Zahlen und Unterstriche, %{min} bis %{max} Zeichen."
 
-#: lib/vutuv_web/live/organization_live/index.ex:78
-#: lib/vutuv_web/live/organization_live/index.ex:109
+#: lib/vutuv_web/live/organization_live/index.ex:70
+#: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:26
 #: lib/vutuv_web/live/organization_live/new.ex:80
 #: lib/vutuv_web/templates/settings/organizations.html.heex:87
@@ -12655,12 +12642,12 @@ msgstr "Stimmt mit einer anderen verifizierten Organisation überein"
 msgid "No organization pages match."
 msgstr "Keine passenden Organisationsseiten."
 
-#: lib/vutuv_web/live/organization_live/index.ex:100
+#: lib/vutuv_web/live/organization_live/index.ex:92
 #, elixir-autogen, elixir-format
 msgid "No organization pages yet. Be the first to add yours."
 msgstr "Noch keine Organisationsseiten. Fügen Sie die erste hinzu."
 
-#: lib/vutuv_web/live/organization_live/index.ex:102
+#: lib/vutuv_web/live/organization_live/index.ex:94
 #, elixir-autogen, elixir-format
 msgid "No organizations found for %{term}."
 msgstr "Keine Organisationen für %{term} gefunden."
@@ -12720,7 +12707,7 @@ msgstr "Organisationsseite"
 msgid "Organization pages"
 msgstr "Organisationsseiten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:954
+#: lib/vutuv_web/live/notification_live/index.ex:989
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr "Organisationsrolle"
@@ -12731,13 +12718,13 @@ msgid "Organization unfrozen."
 msgstr "Organisation wieder freigegeben."
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:3434
+#: lib/vutuv_web/components/ui.ex:3377
 #: lib/vutuv_web/controllers/settings_controller.ex:165
-#: lib/vutuv_web/live/organization_live/index.ex:29
-#: lib/vutuv_web/live/organization_live/index.ex:69
+#: lib/vutuv_web/live/organization_live/index.ex:30
+#: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:455
 #: lib/vutuv_web/live/shell_live.ex:566
-#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/layout/app.html.heex:83
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Organizations"
@@ -12760,7 +12747,7 @@ msgstr ""
 msgid "Please log in to claim an organization page."
 msgstr "Bitte loggen Sie sich ein, um eine Organisationsseite zu beanspruchen."
 
-#: lib/vutuv_web/live/organization_live/index.ex:83
+#: lib/vutuv_web/live/organization_live/index.ex:75
 #, elixir-autogen, elixir-format
 msgid "Search organizations"
 msgstr "Organisationen durchsuchen"
@@ -12831,22 +12818,22 @@ msgstr "Ihre Organisationsseite ist verifiziert und jetzt live."
 msgid "Your organization page was updated."
 msgstr "Ihre Organisationsseite wurde aktualisiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1151
+#: lib/vutuv_web/live/notification_live/index.ex:1186
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr "hat Ihnen eine Rolle bei %{organization} gegeben."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1148
+#: lib/vutuv_web/live/notification_live/index.ex:1183
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr "hat Sie zum Recruiter für %{organization} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1145
+#: lib/vutuv_web/live/notification_live/index.ex:1180
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr "hat Sie zum Administrator von %{organization} gemacht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1142
+#: lib/vutuv_web/live/notification_live/index.ex:1177
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr "hat Sie zum Besitzer von %{organization} gemacht."
@@ -13050,7 +13037,7 @@ msgstr "Halten Sie Strg / Cmd gedrückt, um mehrere auszuwählen."
 msgid "How to apply"
 msgstr "So bewerben Sie sich"
 
-#: lib/vutuv/accounts/user.ex:904
+#: lib/vutuv/accounts/user.ex:912
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -13077,7 +13064,7 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:458
 #: lib/vutuv_web/live/shell_live.ex:457
-#: lib/vutuv_web/templates/layout/app.html.heex:77
+#: lib/vutuv_web/templates/layout/app.html.heex:81
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -13170,7 +13157,7 @@ msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr "Die maschinenlesbaren Formate (.md/.txt/.json/.xml) für KI-Agenten anbieten."
 
-#: lib/vutuv/accounts/user.ex:903
+#: lib/vutuv/accounts/user.ex:911
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -13252,7 +13239,7 @@ msgstr "Anzeige nicht gefunden."
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/vutuv/accounts/user.ex:905
+#: lib/vutuv/accounts/user.ex:913
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:434
 #: lib/vutuv_web/agent_docs/markdown.ex:348
@@ -13510,7 +13497,7 @@ msgstr "In Prüfung"
 msgid "Verification pending"
 msgstr "Verifizierung ausstehend"
 
-#: lib/vutuv_web/live/organization_live/index.ex:71
+#: lib/vutuv_web/live/organization_live/index.ex:63
 #, elixir-autogen, elixir-format
 msgid "Verified pages for companies, associations, schools, public authorities and other groups, not for single people. Every page has a proven web domain, so you know it is really them."
 msgstr "Verifizierte Seiten für Unternehmen, Vereine, Schulen, Behörden und andere Gruppen, nicht für einzelne Personen. Jede Seite hat eine nachgewiesene Web-Domain, sodass Sie wissen, dass es wirklich sie sind."
@@ -13917,8 +13904,8 @@ msgid "Email me"
 msgstr "Benachrichtige mich"
 
 #: lib/vutuv_web/components/saved_search_components.ex:62
-#: lib/vutuv_web/live/account_activity_live.ex:216
-#: lib/vutuv_web/live/admin/activity_live.ex:252
+#: lib/vutuv_web/live/account_activity_live.ex:171
+#: lib/vutuv_web/live/admin/activity_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Everything"
 msgstr "Alles"
@@ -13962,7 +13949,7 @@ msgstr "Suche speichern"
 msgid "Saved search deleted."
 msgstr "Gespeicherte Suche gelöscht."
 
-#: lib/vutuv_web/components/ui.ex:3483
+#: lib/vutuv_web/components/ui.ex:3426
 #: lib/vutuv_web/controllers/settings_controller.ex:433
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -14240,7 +14227,7 @@ msgstr "%{pending} Bild(er) in der Warteschlange; %{rejected} in den letzten 7 T
 msgid "Image awaiting review, visible only to you"
 msgstr "Bild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/live/notification_live/index.ex:952
+#: lib/vutuv_web/live/notification_live/index.ex:987
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -14256,32 +14243,32 @@ msgstr "Keine Bilder in der KI-Prüfung. %{formatted} in den letzten 7 Tagen abg
 msgid "Profile picture awaiting review, visible only to you"
 msgstr "Profilbild wird geprüft, nur für Sie sichtbar"
 
-#: lib/vutuv_web/live/post_live/edit.ex:114
+#: lib/vutuv_web/live/post_live/edit.ex:112
 #, elixir-autogen, elixir-format
 msgid "Link preview screenshot"
 msgstr "Screenshot der Linkvorschau"
 
-#: lib/vutuv_web/live/post_live/edit.ex:135
+#: lib/vutuv_web/live/post_live/edit.ex:133
 #, elixir-autogen, elixir-format
 msgid "Remove screenshot"
 msgstr "Screenshot entfernen"
 
-#: lib/vutuv_web/live/post_live/edit.ex:133
+#: lib/vutuv_web/live/post_live/edit.ex:131
 #, elixir-autogen, elixir-format
 msgid "Remove this screenshot from your post?"
 msgstr "Diesen Screenshot aus Ihrem Beitrag entfernen?"
 
-#: lib/vutuv_web/live/post_live/edit.ex:76
+#: lib/vutuv_web/live/post_live/edit.ex:74
 #, elixir-autogen, elixir-format
 msgid "Screenshot removed."
 msgstr "Screenshot entfernt."
 
-#: lib/vutuv_web/live/post_live/edit.ex:116
+#: lib/vutuv_web/live/post_live/edit.ex:114
 #, elixir-autogen, elixir-format
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr "Dieser Screenshot wurde automatisch aus dem Link in Ihrem Beitrag erstellt. Falls er unbrauchbar ist (zum Beispiel weil ein Cookie-Banner die Seite verdeckt), können Sie ihn entfernen."
 
-#: lib/vutuv/accounts/user.ex:948
+#: lib/vutuv/accounts/user.ex:956
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -14292,19 +14279,19 @@ msgstr "Nur das Alter, ohne das Datum"
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr "Wählen Sie, wie viel von Ihrem Geburtstag Ihr Profil zeigt. „Nur das Alter“ verbirgt das genaue Datum, „Tag und Monat“ verbirgt das Jahr (und Ihr Alter), und „Nicht anzeigen“ speichert ihn weiterhin, hält ihn aber von Ihrem Profil fern."
 
-#: lib/vutuv/accounts/user.ex:951
+#: lib/vutuv/accounts/user.ex:959
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr "Tag und Monat, ohne das Jahr"
 
-#: lib/vutuv/accounts/user.ex:954
+#: lib/vutuv/accounts/user.ex:962
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr "Geburtstag nicht anzeigen"
 
-#: lib/vutuv/accounts/user.ex:945
+#: lib/vutuv/accounts/user.ex:953
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -14327,7 +14314,7 @@ msgstr[1] "%{formatted} Beiträge erwähnen aktuell %{handle} und werden beim Um
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr "Beim Ändern werden alle Erwähnungen Ihres alten Handles in Beiträgen automatisch auf den neuen umgeschrieben und die Verfasser dieser Beiträge benachrichtigt. Ihre alte Profiladresse funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/live/notification_live/index.ex:955
+#: lib/vutuv_web/live/notification_live/index.ex:990
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr "Handle-Änderung"
@@ -14339,7 +14326,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] "Wir haben %{formatted} Beitrag aktualisiert, der Ihren alten Handle erwähnt hat, und dessen Verfasser benachrichtigt."
 msgstr[1] "Wir haben %{formatted} Beiträge aktualisiert, die Ihren alten Handle erwähnt haben, und deren Verfasser benachrichtigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1201
+#: lib/vutuv_web/live/notification_live/index.ex:1236
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr "hat den Handle von @%{old} auf @%{new} geändert."
@@ -14431,16 +14418,16 @@ msgstr ""
 "Personen tauchen in Ihren Vorschlägen auf. Einem Tag folgen Sie auf seiner "
 "Seite."
 
-#: lib/vutuv_web/components/ui.ex:3479
+#: lib/vutuv_web/components/ui.ex:3422
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:1081
+#: lib/vutuv_web/live/post_live/feed.ex:1090
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1096
+#: lib/vutuv_web/live/post_live/feed.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -14484,7 +14471,7 @@ msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzerna
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1222
+#: lib/vutuv_web/templates/user/show.html.heex:1229
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14513,7 +14500,7 @@ msgstr "Messenger wurde geändert."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3464
+#: lib/vutuv_web/components/ui.ex:3407
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -14521,7 +14508,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1220
+#: lib/vutuv_web/templates/user/show.html.heex:1227
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14541,34 +14528,34 @@ msgstr "Messenger von %{name}"
 msgid "Select a messenger"
 msgstr "Messenger auswählen"
 
-#: lib/vutuv_web/components/ui.ex:2966
+#: lib/vutuv_web/components/ui.ex:2909
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] "Meinen Follower darüber informieren"
 msgstr[1] "Meine %{formatted} Follower darüber informieren"
 
-#: lib/vutuv_web/components/ui.ex:2976
+#: lib/vutuv_web/components/ui.ex:2919
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr "Die Benachrichtigung enthält einen Link zu diesem Eintrag. Es wird keine E-Mail verschickt, und das passiert nur bei neuen Einträgen."
 
-#: lib/vutuv_web/live/notification_live/index.ex:956
+#: lib/vutuv_web/live/notification_live/index.ex:991
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr "Lebenslauf-Update"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1221
+#: lib/vutuv_web/live/notification_live/index.ex:1256
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr "hat eine neue Station im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1213
+#: lib/vutuv_web/live/notification_live/index.ex:1248
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr "hat eine neue Ausbildung im Lebenslauf: %{entry}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1218
+#: lib/vutuv_web/live/notification_live/index.ex:1253
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr "hat ein neues Zertifikat im Lebenslauf: %{entry}"
@@ -14593,7 +14580,7 @@ msgstr "Über neue Lebenslauf-Einträge von Personen informieren, denen ich folg
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch immer."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1226
+#: lib/vutuv_web/live/notification_live/index.ex:1261
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
@@ -14630,7 +14617,7 @@ msgstr "E-Book"
 msgid "Film review"
 msgstr "Filmbesprechung"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:441
+#: lib/vutuv_web/live/fediverse_account_live.ex:448
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Look up"
@@ -14708,7 +14695,7 @@ msgstr "Optional: das Zertifikat oder die Lizenz, mit der Sie diese Stelle erlan
 msgid "Qualification"
 msgstr "Qualifikation"
 
-#: lib/vutuv_web/views/work_experience_html.ex:646
+#: lib/vutuv_web/views/work_experience_html.ex:613
 #, elixir-autogen, elixir-format
 msgid "With qualification:"
 msgstr "Mit Qualifikation:"
@@ -14723,45 +14710,45 @@ msgstr "Mit Qualifikation: %{name}"
 msgid "Publisher:"
 msgstr "Verlag:"
 
-#: lib/vutuv_web/live/notification_live/index.ex:824
+#: lib/vutuv_web/live/notification_live/index.ex:859
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] "%{formatted} neue Mitteilung"
 msgstr[1] "%{formatted} neue Mitteilungen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:838
+#: lib/vutuv_web/live/notification_live/index.ex:873
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr "%{day}. %{month} %{year}"
 
-#: lib/vutuv_web/live/notification_live/index.ex:348
+#: lib/vutuv_web/live/notification_live/index.ex:383
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr "Zurückfolgen"
 
-#: lib/vutuv_web/live/notification_live/index.ex:363
+#: lib/vutuv_web/live/notification_live/index.ex:398
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr "Letzte 30 Tage"
 
-#: lib/vutuv_web/live/notification_live/index.ex:790
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/live/notification_live/index.ex:825
+#: lib/vutuv_web/live/notification_live/index.ex:1069
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "und"
 
-#: lib/vutuv_web/live/notification_live/index.ex:971
+#: lib/vutuv_web/live/notification_live/index.ex:1006
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr "sind jetzt mit Ihnen vernetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:966
+#: lib/vutuv_web/live/notification_live/index.ex:1001
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr "folgen Ihnen jetzt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:981
+#: lib/vutuv_web/live/notification_live/index.ex:1016
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
@@ -14771,12 +14758,12 @@ msgstr "hat Sie für %{tags} empfohlen."
 msgid "by:"
 msgstr "von:"
 
-#: lib/vutuv_web/components/ui.ex:1332
+#: lib/vutuv_web/components/ui.ex:1341
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr "Empfohlen von %{name}"
 
-#: lib/vutuv_web/components/ui.ex:1336
+#: lib/vutuv_web/components/ui.ex:1345
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -15008,7 +14995,7 @@ msgstr "Bevorzugte Arbeitsform"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: lib/vutuv_web/live/notification_live/index.ex:760
+#: lib/vutuv_web/live/notification_live/index.ex:795
 #, elixir-autogen, elixir-format
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
@@ -15020,7 +15007,7 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr "Eine automatische Prüfung hat ein Bild aus Ihrem vutuv-Konto entfernt"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1175
+#: lib/vutuv_web/live/notification_live/index.ex:1210
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
@@ -15028,12 +15015,12 @@ msgstr ""
 "familienfreundlich genug für ein Arbeitsumfeld. Sie kann sich irren, "
 "antworten Sie in dem Fall einfach auf unsere E-Mail."
 
-#: lib/vutuv_web/live/notification_live/index.ex:945
+#: lib/vutuv_web/live/notification_live/index.ex:980
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr "Thread-Antwort"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1056
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -15052,29 +15039,29 @@ msgstr "Unterhaltung"
 msgid "Only part of this long conversation is shown."
 msgstr "Von dieser langen Unterhaltung wird nur ein Teil angezeigt."
 
-#: lib/vutuv_web/live/notification_live/index.ex:946
+#: lib/vutuv_web/live/notification_live/index.ex:981
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr "Erwähnung"
 
-#: lib/vutuv_web/live/notification_live/index.ex:1125
+#: lib/vutuv_web/live/notification_live/index.ex:1160
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr "hat Sie in einem Beitrag erwähnt."
 
 #: lib/vutuv_web/live/post_live/composer.ex:1000
-#: lib/vutuv_web/live/post_live/edit.ex:59
+#: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten: jemand hat ihn geliked, geteilt oder beantwortet."
 
 #: lib/vutuv_web/live/post_live/composer.ex:1003
-#: lib/vutuv_web/live/post_live/edit.ex:61
+#: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
 msgstr "Dieser Beitrag lässt sich nicht mehr bearbeiten. Beiträge bleiben nach dem Veröffentlichen %{minutes} Minuten lang änderbar."
 
-#: lib/vutuv_web/live/post_live/edit.ex:100
+#: lib/vutuv_web/live/post_live/edit.ex:98
 #, elixir-autogen, elixir-format
 msgid "A post stays editable for %{minutes} minutes, and only until someone likes, reposts or answers it. You can delete it at any time."
 msgstr ""
@@ -15144,7 +15131,7 @@ msgstr "Konto einfrieren"
 msgid "No accounts are currently frozen."
 msgstr "Zurzeit sind keine Konten eingefroren."
 
-#: lib/vutuv_web/live/post_live/thread.ex:309
+#: lib/vutuv_web/live/post_live/thread.ex:352
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr "Von Anfang an lesen"
@@ -15183,7 +15170,7 @@ msgstr[1] "%{formatted} weitere Antworten anzeigen"
 msgid "This page is no longer available."
 msgstr "Diese Seite ist nicht mehr verfügbar."
 
-#: lib/vutuv_web/live/post_live/thread.ex:301
+#: lib/vutuv_web/live/post_live/thread.ex:344
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr "Dieser Beitrag ist Teil einer Unterhaltung mit %{formatted} Beiträgen."
@@ -15345,7 +15332,7 @@ msgstr "Nach einem Tag filtern"
 msgid "Filter removed."
 msgstr "Filter entfernt."
 
-#: lib/vutuv_web/live/post_live/feed.ex:233
+#: lib/vutuv_web/live/post_live/feed.ex:271
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr "Ausgeblendet: passt zu Ihrem Filter"
@@ -15360,7 +15347,7 @@ msgstr "Blenden Sie Beiträge aus Ihrem Feed aus, die ein Tag tragen oder ein Wo
 msgid "Match whole words only (word/phrase)"
 msgstr "Nur ganze Wörter treffen (Wort/Phrase)"
 
-#: lib/vutuv_web/components/ui.ex:3475
+#: lib/vutuv_web/components/ui.ex:3418
 #: lib/vutuv_web/controllers/settings_controller.ex:513
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -15380,7 +15367,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:242
+#: lib/vutuv_web/live/post_live/feed.ex:280
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -15410,7 +15397,7 @@ msgstr "Diese Ausbildung wird jetzt oben in Ihrem Profil angezeigt."
 msgid "Thread replies"
 msgstr "Thread-Antworten"
 
-#: lib/vutuv_web/live/notification_live/index.ex:536
+#: lib/vutuv_web/live/notification_live/index.ex:571
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr "Thread-Benachrichtigungen abschalten"
@@ -15461,7 +15448,7 @@ msgstr "Sie haben noch nichts stummgeschaltet."
 msgid "You have reached the maximum of %{count} filters."
 msgstr "Sie haben das Maximum von %{count} Filtern erreicht."
 
-#: lib/vutuv_web/live/notification_live/index.ex:531
+#: lib/vutuv_web/live/notification_live/index.ex:566
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr "Sie haben in diesem Thread geschrieben."
@@ -15546,9 +15533,9 @@ msgstr "Blockierte Server"
 msgid "No server is blocked."
 msgstr "Kein Server ist blockiert."
 
-#: lib/vutuv_web/components/browse_table.ex:185
-#: lib/vutuv_web/live/fediverse_followers_live.ex:113
-#: lib/vutuv_web/live/fediverse_following_live.ex:240
+#: lib/vutuv_web/components/browse_table.ex:289
+#: lib/vutuv_web/live/fediverse_followers_live.ex:95
+#: lib/vutuv_web/live/fediverse_following_live.ex:225
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:96
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:147
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:191
@@ -15608,8 +15595,8 @@ msgid "Reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken"
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:45
-#: lib/vutuv_web/live/fediverse_followers_live.ex:124
-#: lib/vutuv_web/live/fediverse_followers_live.ex:134
+#: lib/vutuv_web/live/fediverse_followers_live.ex:106
+#: lib/vutuv_web/live/fediverse_followers_live.ex:116
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Followers from other networks"
@@ -15657,7 +15644,7 @@ msgstr "Ausgeschaltet ist Ihr Profil dort nicht auffindbar und es wird nichts zu
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr "Geben Sie es weiter wie eine E-Mail-Adresse. Jeder bei Mastodon und Co. kann es in die Suche einfügen und Ihnen von dort folgen."
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:150
+#: lib/vutuv_web/live/fediverse_followers_live.ex:127
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
@@ -15731,8 +15718,8 @@ msgstr "Ihre Fediverse-Follower werden weitergeleitet zu:"
 msgid "Send your Fediverse followers to another account. They are asked to follow it instead, and vutuv stops federating your new posts. Your vutuv profile stays exactly as it is, and nothing is deleted."
 msgstr "Schicken Sie Ihre Fediverse-Follower zu einem anderen Konto. Sie werden gebeten, stattdessen diesem zu folgen, und vutuv föderiert Ihre neuen Beiträge nicht mehr. Ihr vutuv-Profil bleibt genau wie es ist, und nichts wird gelöscht."
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:224
-#: lib/vutuv_web/live/fediverse_following_live.ex:460
+#: lib/vutuv_web/live/fediverse_followers_live.ex:201
+#: lib/vutuv_web/live/fediverse_following_live.ex:431
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Back to Fediverse settings"
@@ -15930,27 +15917,27 @@ msgstr "Anwendung bearbeiten"
 msgid "Book an ad"
 msgstr "Anzeige buchen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:880
+#: lib/vutuv_web/templates/user/show.html.heex:886
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr "%{name} hat dieses Fediverse-Konto umgezogen. Folgen Sie stattdessen der neuen Adresse:"
 
-#: lib/vutuv_web/templates/user/show.html.heex:896
+#: lib/vutuv_web/templates/user/show.html.heex:902
 #, elixir-autogen, elixir-format
 msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
 msgstr "Sie sind auf Mastodon oder in einer anderen Fediverse-App? Folgen Sie %{name} von dort aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/templates/user/show.html.heex:933
+#: lib/vutuv_web/templates/user/show.html.heex:939
 #, elixir-autogen, elixir-format
 msgid "Follow from your own server"
 msgstr "Von Ihrem eigenen Server aus folgen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:944
+#: lib/vutuv_web/templates/user/show.html.heex:950
 #, elixir-autogen, elixir-format
 msgid "@you@example.social"
 msgstr "@name@example.social"
 
-#: lib/vutuv_web/templates/user/show.html.heex:952
+#: lib/vutuv_web/templates/user/show.html.heex:958
 #, elixir-autogen, elixir-format
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr "Ihre Adresse wird einmal verwendet, um Sie zum Folgen-Dialog Ihres eigenen Servers zu schicken. Gespeichert wird sie hier nicht."
@@ -15960,22 +15947,22 @@ msgstr "Ihre Adresse wird einmal verwendet, um Sie zum Folgen-Dialog Ihres eigen
 msgid "This profile is not on the Fediverse."
 msgstr "Dieses Profil ist nicht im Fediverse."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:72
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "That is not a Fediverse address. It looks like @you@example.social."
 msgstr "Das ist keine Fediverse-Adresse. Eine sieht so aus: @name@example.social."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:76
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead."
 msgstr "%{server} bietet keinen Folgen-Dialog an. Kopieren Sie stattdessen die Adresse oben und fügen Sie sie in die Suche Ihrer App ein."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:83
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:143
 #, elixir-autogen, elixir-format
 msgid "%{server} did not answer. Copy the handle above and paste it into your app's search instead."
 msgstr "%{server} hat nicht geantwortet. Kopieren Sie stattdessen die Adresse oben und fügen Sie sie in die Suche Ihrer App ein."
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:94
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:154
 #, elixir-autogen, elixir-format
 msgid "Your server"
 msgstr "Ihr Server"
@@ -15986,282 +15973,282 @@ msgstr "Ihr Server"
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
 
-#: lib/vutuv_web/components/ui.ex:3407
+#: lib/vutuv_web/components/ui.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr "Name, Foto, Titelbild, Kurzbeschreibung"
 
-#: lib/vutuv_web/components/ui.ex:3408
+#: lib/vutuv_web/components/ui.ex:3351
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr "avatar profilbild portrait foto bild geburtstag geburtsdatum geschlecht über mich"
 
-#: lib/vutuv_web/components/ui.ex:3412
+#: lib/vutuv_web/components/ui.ex:3355
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr "handle spitzname nutzername umbenennen slug profiladresse url erwähnung"
 
-#: lib/vutuv_web/components/ui.ex:3415
+#: lib/vutuv_web/components/ui.ex:3358
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr "Die Stationen in Ihrem Lebenslauf"
 
-#: lib/vutuv_web/components/ui.ex:3416
+#: lib/vutuv_web/components/ui.ex:3359
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr "lebenslauf cv karriere beruf arbeitgeber position stelle job firma"
 
-#: lib/vutuv_web/components/ui.ex:3419
+#: lib/vutuv_web/components/ui.ex:3362
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr "Schulen, Hochschulen, Abschlüsse"
 
-#: lib/vutuv_web/components/ui.ex:3420
+#: lib/vutuv_web/components/ui.ex:3363
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr "lebenslauf studium schule universität hochschule abschluss ausbildung"
 
-#: lib/vutuv_web/components/ui.ex:3423
+#: lib/vutuv_web/components/ui.ex:3366
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr "Nachweise, mit Belegdokumenten"
 
-#: lib/vutuv_web/components/ui.ex:3424
+#: lib/vutuv_web/components/ui.ex:3367
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr "zertifikat lizenz urkunde diplom nachweis beleg auszeichnung dokument"
 
-#: lib/vutuv_web/components/ui.ex:3426
+#: lib/vutuv_web/components/ui.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr "Sprachkenntnisse"
 
-#: lib/vutuv_web/components/ui.ex:3427
+#: lib/vutuv_web/components/ui.ex:3370
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr "Die Sprachen, die Sie sprechen"
 
-#: lib/vutuv_web/components/ui.ex:3428
+#: lib/vutuv_web/components/ui.ex:3371
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr "sprache sprachen sprechen fließend muttersprache verhandlungssicher"
 
-#: lib/vutuv_web/components/ui.ex:3431
+#: lib/vutuv_web/components/ui.ex:3374
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr "Die Themen, für die Sie bekannt sind"
 
-#: lib/vutuv_web/components/ui.ex:3432
+#: lib/vutuv_web/components/ui.ex:3375
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr "fähigkeit kenntnis thema stichwort schlagwort expertise empfehlung"
 
-#: lib/vutuv_web/components/ui.ex:3435
+#: lib/vutuv_web/components/ui.ex:3378
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr "Organisationsseiten, die Sie verwalten"
 
-#: lib/vutuv_web/components/ui.ex:3436
+#: lib/vutuv_web/components/ui.ex:3379
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr "firma unternehmen arbeitgeber betrieb organisation seite"
 
-#: lib/vutuv_web/components/ui.ex:3439
+#: lib/vutuv_web/components/ui.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: lib/vutuv_web/components/ui.ex:3442
+#: lib/vutuv_web/components/ui.ex:3385
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr "Wo wir Sie erreichen, und welche Adresse öffentlich ist"
 
-#: lib/vutuv_web/components/ui.ex:3443
+#: lib/vutuv_web/components/ui.ex:3386
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr "mail e-mail email adresse hauptadresse primär"
 
-#: lib/vutuv_web/components/ui.ex:3446
+#: lib/vutuv_web/components/ui.ex:3389
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr "Festnetz, Mobil, Fax"
 
-#: lib/vutuv_web/components/ui.ex:3447
+#: lib/vutuv_web/components/ui.ex:3390
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr "telefon handy mobil festnetz fax nummer rufnummer"
 
-#: lib/vutuv_web/components/ui.ex:3450
+#: lib/vutuv_web/components/ui.ex:3393
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr "Postanschriften auf Ihrem Profil"
 
-#: lib/vutuv_web/components/ui.ex:3451
+#: lib/vutuv_web/components/ui.ex:3394
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr "straße stadt ort postleitzahl plz land anschrift karte"
 
-#: lib/vutuv_web/components/ui.ex:3453
+#: lib/vutuv_web/components/ui.ex:3396
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr "Webseiten & Links"
 
-#: lib/vutuv_web/components/ui.ex:3454
+#: lib/vutuv_web/components/ui.ex:3397
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr "Ihre Homepage und weitere Links"
 
-#: lib/vutuv_web/components/ui.ex:3455
+#: lib/vutuv_web/components/ui.ex:3398
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr "url webseite website homepage blog link verifizieren bestätigen rel=me"
 
-#: lib/vutuv_web/components/ui.ex:3457
+#: lib/vutuv_web/components/ui.ex:3400
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr "Social-Media-Profile"
 
-#: lib/vutuv_web/components/ui.ex:3458
+#: lib/vutuv_web/components/ui.ex:3401
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr "Mastodon, Bluesky, GitHub und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:3460
+#: lib/vutuv_web/components/ui.ex:3403
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr "mastodon bluesky github gitlab codeberg linkedin x twitter instagram soziale netzwerke"
 
-#: lib/vutuv_web/components/ui.ex:3465
+#: lib/vutuv_web/components/ui.ex:3408
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr "Signal, Threema, Matrix und die anderen"
 
-#: lib/vutuv_web/components/ui.ex:3466
+#: lib/vutuv_web/components/ui.ex:3409
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr "signal threema matrix xmpp telegram whatsapp chat messenger nachrichten"
 
-#: lib/vutuv_web/components/ui.ex:3469
+#: lib/vutuv_web/components/ui.ex:3412
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr "Mitteilungen & Feed"
 
-#: lib/vutuv_web/components/ui.ex:3472
+#: lib/vutuv_web/components/ui.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr "Welche E-Mails wir schicken, und was die Glocke meldet"
 
-#: lib/vutuv_web/components/ui.ex:3473
+#: lib/vutuv_web/components/ui.ex:3416
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer"
 msgstr "e-mail email mail abbestellen abmelden newsletter glocke benachrichtigung weniger ruhe"
 
-#: lib/vutuv_web/components/ui.ex:3476
+#: lib/vutuv_web/components/ui.ex:3419
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr "Beiträge aus Ihrem Feed heraushalten"
 
-#: lib/vutuv_web/components/ui.ex:3477
+#: lib/vutuv_web/components/ui.ex:3420
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr "stummschalten ausblenden verbergen filter wort begriff tag feed blockieren"
 
-#: lib/vutuv_web/components/ui.ex:3480
+#: lib/vutuv_web/components/ui.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr "Themen, deren Beiträge in Ihrem Feed landen"
 
-#: lib/vutuv_web/components/ui.ex:3481
+#: lib/vutuv_web/components/ui.ex:3424
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr "tag thema abonnieren folgen feed"
 
-#: lib/vutuv_web/components/ui.ex:3484
+#: lib/vutuv_web/components/ui.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr "Job- und Personensuchen, die Ihnen neue Treffer mailen"
 
-#: lib/vutuv_web/components/ui.ex:3485
+#: lib/vutuv_web/components/ui.ex:3428
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr "job stelle stellenangebot suchauftrag suche alarm benachrichtigung merkliste"
 
-#: lib/vutuv_web/components/ui.ex:3491
+#: lib/vutuv_web/components/ui.ex:3434
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr "Suchmaschinen, KI, Online-Status"
 
-#: lib/vutuv_web/components/ui.ex:3492
+#: lib/vutuv_web/components/ui.ex:3435
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr "privatsphäre datenschutz google suchmaschine ki ai llm crawler noindex online punkt öffentlich sichtbar"
 
-#: lib/vutuv_web/components/ui.ex:3495
+#: lib/vutuv_web/components/ui.ex:3438
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr "Personen, die nicht mit Ihnen interagieren können"
 
-#: lib/vutuv_web/components/ui.ex:3496
+#: lib/vutuv_web/components/ui.ex:3439
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr "blockieren sperren bannen stummschalten melden missbrauch belästigung"
 
-#: lib/vutuv_web/components/ui.ex:3509
+#: lib/vutuv_web/components/ui.ex:3452
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr "Passkeys, angemeldete Geräte, Anmeldecodes"
 
-#: lib/vutuv_web/components/ui.ex:3510
+#: lib/vutuv_web/components/ui.ex:3453
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr "passwort kennwort anmelden abmelden login logout sitzung gerät passkey totp 2fa pin sicherheit"
 
-#: lib/vutuv_web/components/ui.ex:3518
+#: lib/vutuv_web/components/ui.ex:3461
 #, elixir-autogen, elixir-format
 msgid "Interface language, maps, how posts are shortened"
 msgstr "Sprache der Oberfläche, Karten, Kürzung von Beiträgen"
 
-#: lib/vutuv_web/components/ui.ex:3519
+#: lib/vutuv_web/components/ui.ex:3462
 #, elixir-autogen, elixir-format
 msgid "german english locale translation map font length hyphenation"
 msgstr "deutsch englisch sprache übersetzung karte schrift länge silbentrennung darstellung"
 
-#: lib/vutuv_web/components/ui.ex:3522
+#: lib/vutuv_web/components/ui.ex:3465
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr "Ihre Daten von LinkedIn übernehmen"
 
-#: lib/vutuv_web/components/ui.ex:3523
+#: lib/vutuv_web/components/ui.ex:3466
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr "linkedin hochladen zip übernehmen importieren umzug"
 
-#: lib/vutuv_web/components/ui.ex:3526
+#: lib/vutuv_web/components/ui.ex:3469
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr "Alles herunterladen, was wir über Sie speichern"
 
-#: lib/vutuv_web/components/ui.ex:3527
+#: lib/vutuv_web/components/ui.ex:3470
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr "herunterladen download dsgvo gdpr daten sicherung json lebenslauf auskunft"
 
-#: lib/vutuv_web/components/ui.ex:3530
+#: lib/vutuv_web/components/ui.ex:3473
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr "Verbundene Apps und Zugriffstoken"
 
-#: lib/vutuv_web/components/ui.ex:3531
+#: lib/vutuv_web/components/ui.ex:3474
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr "api token oauth entwickler verbunden drittanbieter schnittstelle"
 
-#: lib/vutuv_web/components/ui.ex:3534
+#: lib/vutuv_web/components/ui.ex:3477
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr "Ihr Konto und alles darauf entfernen"
 
-#: lib/vutuv_web/components/ui.ex:3535
+#: lib/vutuv_web/components/ui.ex:3478
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr "löschen entfernen schließen kündigen beenden verlassen"
@@ -16423,7 +16410,7 @@ msgstr "Inhaltswarnung"
 
 #: lib/vutuv_web/components/post_components.ex:972
 #: lib/vutuv_web/components/post_components.ex:1145
-#: lib/vutuv_web/live/fediverse_account_live.ex:314
+#: lib/vutuv_web/live/fediverse_account_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
@@ -16445,12 +16432,12 @@ msgstr "Vom Mitglied entfernt"
 msgid "Replies from other networks"
 msgstr "Antworten aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:948
+#: lib/vutuv_web/live/notification_live/index.ex:983
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr "Antwort aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/live/post_live/thread.ex:95
+#: lib/vutuv_web/live/post_live/thread.ex:138
 #, elixir-autogen, elixir-format
 msgid "Reply removed."
 msgstr "Antwort entfernt."
@@ -16466,7 +16453,7 @@ msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
 #: lib/vutuv_web/components/post_components.ex:882
-#: lib/vutuv_web/live/notification_live/index.ex:498
+#: lib/vutuv_web/live/notification_live/index.ex:533
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr "Nur an Sie gesendet, für niemanden sonst sichtbar"
@@ -16486,12 +16473,12 @@ msgstr "Gespeicherte Antworten"
 msgid "Taken down"
 msgstr "Entfernt"
 
-#: lib/vutuv_web/live/post_live/thread.ex:104
+#: lib/vutuv_web/live/post_live/thread.ex:147
 #, elixir-autogen, elixir-format
 msgid "Thank you. The reply was deleted right away."
 msgstr "Danke. Die Antwort wurde sofort gelöscht."
 
-#: lib/vutuv_web/live/post_live/thread.ex:213
+#: lib/vutuv_web/live/post_live/thread.ex:256
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
@@ -16509,15 +16496,15 @@ msgstr "Original ansehen"
 msgid "What"
 msgstr "Was"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:170
+#: lib/vutuv_web/live/fediverse_account_live.ex:168
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:139
-#: lib/vutuv_web/live/post_live/feed.ex:361
-#: lib/vutuv_web/live/post_live/thread.ex:209
+#: lib/vutuv_web/live/post_live/feed.ex:399
+#: lib/vutuv_web/live/post_live/thread.ex:252
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr "Sie haben heute schon viel gemeldet. Bitte versuchen Sie es morgen wieder."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1128
+#: lib/vutuv_web/live/notification_live/index.ex:1163
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr "hat aus einem anderen Netzwerk auf Ihren Beitrag geantwortet."
@@ -16527,49 +16514,47 @@ msgstr "hat aus einem anderen Netzwerk auf Ihren Beitrag geantwortet."
 msgid "All followers"
 msgstr "Alle Follower"
 
-#: lib/vutuv_web/components/browse_table.ex:189
+#: lib/vutuv_web/components/browse_table.ex:293
 #, elixir-autogen, elixir-format
 msgid "All servers"
 msgstr "Alle Server"
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:114
+#: lib/vutuv_web/live/fediverse_followers_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Following since"
 msgstr "Folgt seit"
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:217
+#: lib/vutuv_web/live/fediverse_followers_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "How this list keeps itself honest"
 msgstr "Wie diese Liste aktuell bleibt"
 
-#: lib/vutuv_web/components/browse_table.ex:176
+#: lib/vutuv_web/components/browse_table.ex:280
 #, elixir-autogen, elixir-format
 msgid "name, handle or server"
 msgstr "Name, Handle oder Server"
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:162
+#: lib/vutuv_web/live/fediverse_followers_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "No follower matches that. Try a shorter search, or clear the filters."
 msgstr "Dazu passt kein Follower. Versuchen Sie eine kürzere Suche, oder setzen Sie die Filter zurück."
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:190
+#: lib/vutuv_web/live/fediverse_followers_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Show only followers from this server"
 msgstr "Nur Follower von diesem Server zeigen"
 
-#: lib/vutuv_web/components/browse_table.ex:293
-#: lib/vutuv_web/live/account_activity_live.ex:331
-#: lib/vutuv_web/live/admin/activity_live.ex:357
+#: lib/vutuv_web/components/browse_table.ex:400
 #, elixir-autogen, elixir-format
 msgid "Showing %{first}-%{last} of %{total}."
 msgstr "Angezeigt: %{first}-%{last} von %{total}."
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:143
+#: lib/vutuv_web/live/fediverse_followers_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Everyone on another network who follows your vutuv posts. Only you see this list: the followers collection your profile publishes carries the number, never the names."
 msgstr "Alle, die Ihren vutuv-Beiträgen aus einem anderen Netzwerk folgen. Diese Liste sehen nur Sie: Die Follower-Sammlung, die Ihr Profil veröffentlicht, nennt nur die Anzahl, nie die Namen."
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:219
+#: lib/vutuv_web/live/fediverse_followers_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Accounts that no longer exist on their own server drop off this list by themselves. Names and handles are the ones their server last told us, so a renamed account updates here on its own too."
 msgstr "Konten, die es auf ihrem eigenen Server nicht mehr gibt, verschwinden von selbst aus dieser Liste. Namen und Handles sind die, die uns der jeweilige Server zuletzt gemeldet hat: Ein umbenanntes Konto aktualisiert sich hier also ebenfalls von allein."
@@ -16728,14 +16713,14 @@ msgstr "API-Token erstellt"
 msgid "Access token revoked"
 msgstr "API-Token widerrufen"
 
-#: lib/vutuv_web/components/ui.ex:3512
-#: lib/vutuv_web/live/account_activity_live.ex:40
-#: lib/vutuv_web/live/account_activity_live.ex:154
-#: lib/vutuv_web/live/account_activity_live.ex:155
-#: lib/vutuv_web/live/account_activity_live.ex:160
-#: lib/vutuv_web/live/admin/activity_live.ex:41
-#: lib/vutuv_web/live/admin/activity_live.ex:190
-#: lib/vutuv_web/live/admin/activity_live.ex:191
+#: lib/vutuv_web/components/ui.ex:3455
+#: lib/vutuv_web/live/account_activity_live.ex:42
+#: lib/vutuv_web/live/account_activity_live.ex:114
+#: lib/vutuv_web/live/account_activity_live.ex:115
+#: lib/vutuv_web/live/account_activity_live.ex:120
+#: lib/vutuv_web/live/admin/activity_live.ex:42
+#: lib/vutuv_web/live/admin/activity_live.ex:152
+#: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Account activity"
@@ -16786,7 +16771,7 @@ msgstr "Authenticator-App eingerichtet"
 msgid "Authenticator app turned off"
 msgstr "Authenticator-App ausgeschaltet"
 
-#: lib/vutuv_web/live/admin/activity_live.ex:345
+#: lib/vutuv_web/live/admin/activity_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "By %{name}"
 msgstr "Von %{name}"
@@ -16796,8 +16781,8 @@ msgstr "Von %{name}"
 msgid "CV update notifications"
 msgstr "Benachrichtigungen zu Lebenslauf-Änderungen"
 
-#: lib/vutuv_web/live/account_activity_live.ex:294
-#: lib/vutuv_web/live/admin/activity_live.ex:338
+#: lib/vutuv_web/live/account_activity_live.ex:245
+#: lib/vutuv_web/live/admin/activity_live.ex:295
 #: lib/vutuv_web/templates/admin/experiment/index.html.heex:59
 #: lib/vutuv_web/templates/admin/experiment/index.html.heex:104
 #, elixir-autogen, elixir-format
@@ -16839,7 +16824,7 @@ msgstr "E-Mail-Adresse entfernt"
 msgid "Endorsement emails"
 msgstr "E-Mails zu Empfehlungen"
 
-#: lib/vutuv_web/live/account_activity_live.ex:169
+#: lib/vutuv_web/live/account_activity_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Every change to your account: what changed, exactly when, from which device, and how it was confirmed. If a line surprises you, follow the link at the end of it."
 msgstr "Jede Änderung an Ihrem Konto: was geändert wurde, wann genau, von welchem Gerät und wie es bestätigt wurde. Wenn Sie eine Zeile überrascht, folgen Sie dem Link an ihrem Ende."
@@ -16879,7 +16864,7 @@ msgstr "Filter entfernt"
 msgid "Identity verified"
 msgstr "Identität verifiziert"
 
-#: lib/vutuv_web/live/account_activity_live.ex:349
+#: lib/vutuv_web/live/account_activity_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "If something here was not you"
 msgstr "Wenn etwas hier nicht von Ihnen war"
@@ -16889,7 +16874,7 @@ msgstr "Wenn etwas hier nicht von Ihnen war"
 msgid "Import applied"
 msgstr "Import übernommen"
 
-#: lib/vutuv_web/live/account_activity_live.ex:362
+#: lib/vutuv_web/live/account_activity_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "It is part of your data download, and it is deleted with your account."
 msgstr "Es ist Teil Ihres Datendownloads und wird mit Ihrem Konto gelöscht."
@@ -16919,30 +16904,30 @@ msgstr "Blockierung aufgehoben"
 msgid "New follower emails"
 msgstr "E-Mails zu neuen Followern"
 
-#: lib/vutuv_web/live/admin/activity_live.ex:277
+#: lib/vutuv_web/live/admin/activity_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "No account activity has been recorded yet."
 msgstr "Es wurde noch keine Kontoaktivität aufgezeichnet."
 
-#: lib/vutuv_web/live/account_activity_live.ex:303
+#: lib/vutuv_web/live/account_activity_live.ex:254
 #: lib/vutuv_web/templates/settings/security.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "Not by you"
 msgstr "Nicht von Ihnen"
 
-#: lib/vutuv_web/live/account_activity_live.ex:322
+#: lib/vutuv_web/live/account_activity_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Not you?"
 msgstr "Nicht Sie?"
 
-#: lib/vutuv_web/live/account_activity_live.ex:176
+#: lib/vutuv_web/live/account_activity_live.ex:131
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. The next time you sign in or change a setting, it will be listed here."
 msgstr "Hier ist noch nichts. Wenn Sie sich das nächste Mal anmelden oder eine Einstellung ändern, steht es hier."
 
-#: lib/vutuv_web/live/account_activity_live.ex:243
-#: lib/vutuv_web/live/admin/activity_live.ex:275
-#: lib/vutuv_web/live/fediverse_following_live.ex:342
+#: lib/vutuv_web/live/account_activity_live.ex:198
+#: lib/vutuv_web/live/admin/activity_live.ex:237
+#: lib/vutuv_web/live/fediverse_following_live.ex:313
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr "Dazu passt nichts. Versuchen Sie eine kürzere Suche oder setzen Sie die Filter zurück."
@@ -17007,12 +16992,12 @@ msgstr "Benachrichtigungen zu gespeicherten Suchen"
 msgid "Settings changed by support"
 msgstr "Einstellungen vom Support geändert"
 
-#: lib/vutuv_web/live/admin/activity_live.ex:314
+#: lib/vutuv_web/live/admin/activity_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Show only this member"
 msgstr "Nur dieses Mitglied anzeigen"
 
-#: lib/vutuv_web/live/account_activity_live.ex:351
+#: lib/vutuv_web/live/account_activity_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Sign every other device out, then check which passkeys, codes and email addresses your account has. All of it is on the sign-in & security page."
 msgstr "Melden Sie alle anderen Geräte ab und prüfen Sie dann, welche Passkeys, Codes und E-Mail-Adressen Ihr Konto hat. Das alles finden Sie auf der Seite Anmeldung & Sicherheit."
@@ -17027,7 +17012,7 @@ msgstr "Angemeldet"
 msgid "Signed out"
 msgstr "Abgemeldet"
 
-#: lib/vutuv_web/live/account_activity_live.ex:356
+#: lib/vutuv_web/live/account_activity_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "This log keeps one day of history."
 msgid_plural "This log keeps %{formatted} days of history."
@@ -17059,7 +17044,7 @@ msgstr "Benutzername geändert"
 msgid "Visibility settings changed"
 msgstr "Sichtbarkeitseinstellungen geändert"
 
-#: lib/vutuv_web/live/account_activity_live.ex:266
+#: lib/vutuv_web/live/account_activity_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Was this you?"
 msgstr "Waren Sie das?"
@@ -17074,18 +17059,18 @@ msgstr "Was sich an einem Konto geändert hat, wann, von wo und wie es bestätig
 msgid "What changed on your account, and exactly when."
 msgstr "Was sich an Ihrem Konto geändert hat, und wann genau."
 
-#: lib/vutuv_web/components/ui.ex:3513
+#: lib/vutuv_web/components/ui.ex:3456
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr "Was sich an Ihrem Konto geändert hat, und wann"
 
-#: lib/vutuv_web/live/account_activity_live.ex:127
-#: lib/vutuv_web/live/admin/activity_live.ex:165
+#: lib/vutuv_web/live/account_activity_live.ex:104
+#: lib/vutuv_web/live/admin/activity_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "What happened"
 msgstr "Was geschehen ist"
 
-#: lib/vutuv_web/live/admin/activity_live.ex:379
+#: lib/vutuv_web/live/admin/activity_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "a deleted account"
 msgstr "einem gelöschten Konto"
@@ -17110,7 +17095,7 @@ msgstr "durch den Betreiber"
 msgid "from a signed-in session"
 msgstr "aus einer angemeldeten Sitzung"
 
-#: lib/vutuv_web/components/ui.ex:3515
+#: lib/vutuv_web/components/ui.ex:3458
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr "protokoll verlauf historie chronik audit sicherheit war ich das wer hat wann geaendert geändert log"
@@ -17145,19 +17130,19 @@ msgstr "mit einer per E-Mail geschickten PIN"
 msgid "with your authenticator app"
 msgstr "mit Ihrer Authenticator-App"
 
-#: lib/vutuv_web/live/account_activity_live.ex:265
-#: lib/vutuv_web/live/admin/activity_live.ex:296
+#: lib/vutuv_web/live/account_activity_live.ex:216
+#: lib/vutuv_web/live/admin/activity_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Device"
 msgstr "Gerät"
 
-#: lib/vutuv_web/live/admin/activity_live.ex:197
+#: lib/vutuv_web/live/admin/activity_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "What changed on which account, when, from which device and how it was confirmed - the same log every member sees for themselves. Opening it is recorded in your own activity log."
 msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wie es bestätigt wurde: dasselbe Protokoll, das jedes Mitglied für sich selbst sieht. Dass Sie es öffnen, wird in Ihrem eigenen Aktivitätsprotokoll festgehalten."
 
-#: lib/vutuv_web/live/account_activity_live.ex:203
-#: lib/vutuv_web/live/admin/activity_live.ex:240
+#: lib/vutuv_web/live/account_activity_live.ex:158
+#: lib/vutuv_web/live/admin/activity_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "device or detail"
 msgstr "Gerät oder Detail"
@@ -17182,19 +17167,19 @@ msgstr "Vom Profil lösen"
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
 
-#: lib/vutuv_web/controllers/post_controller.ex:247
+#: lib/vutuv_web/controllers/post_controller.ex:257
 #, elixir-autogen, elixir-format
 msgid "Pinned to the top of your profile."
 msgstr "Oben an Ihr Profil angeheftet."
 
-#: lib/vutuv_web/controllers/post_controller.ex:243
+#: lib/vutuv_web/controllers/post_controller.ex:253
 #, elixir-autogen, elixir-format
 msgid "Pinned to the top of your profile. The post pinned before it is a normal post again."
 msgstr ""
 "Oben an Ihr Profil angeheftet. Der zuvor angeheftete Beitrag ist wieder ein "
 "normaler Beitrag."
 
-#: lib/vutuv_web/controllers/post_controller.ex:264
+#: lib/vutuv_web/controllers/post_controller.ex:274
 #, elixir-autogen, elixir-format
 msgid "Unpinned. The post is a normal post again."
 msgstr "Nicht mehr angeheftet. Der Beitrag ist wieder ein normaler Beitrag."
@@ -17232,7 +17217,7 @@ msgstr ""
 msgid "Apply these settings to all photos"
 msgstr "Diese Einstellungen für alle Fotos übernehmen"
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:96
+#: lib/vutuv_web/live/post_live/remote_reply.ex:91
 #, elixir-autogen, elixir-format
 msgid "Back to the conversation"
 msgstr "Zurück zum Beitrag"
@@ -17395,7 +17380,7 @@ msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakt
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:91
+#: lib/vutuv_web/live/post_live/remote_reply.ex:86
 #, elixir-autogen, elixir-format
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
@@ -17451,8 +17436,8 @@ msgstr "Fotos hinzufügen"
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:937
-#: lib/vutuv_web/live/post_live/feed.ex:938
+#: lib/vutuv_web/live/post_live/feed.ex:946
+#: lib/vutuv_web/live/post_live/feed.ex:947
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
@@ -17538,7 +17523,7 @@ msgstr "Fediverse-Reaktionen"
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
 
-#: lib/vutuv_web/live/notification_live/index.ex:949
+#: lib/vutuv_web/live/notification_live/index.ex:984
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr "Reaktion aus einem anderen Netzwerk"
@@ -17558,21 +17543,21 @@ msgstr ""
 "Mehr speichern wir über diese Menschen nicht: keinen Namen, kein Bild, "
 "keinen Text. Ausschalten löscht, was dafür gespeichert ist."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1002
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 msgstr[1] "gefällt Ihr Beitrag in einem anderen Netzwerk."
 
-#: lib/vutuv_web/live/notification_live/index.ex:1010
+#: lib/vutuv_web/live/notification_live/index.ex:1045
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] "hat aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 msgstr[1] "haben aus einem anderen Netzwerk auf Ihren Beitrag reagiert."
 
-#: lib/vutuv_web/live/notification_live/index.ex:994
+#: lib/vutuv_web/live/notification_live/index.ex:1029
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -17633,10 +17618,10 @@ msgstr "Rücknahme"
 msgid "Photo details"
 msgstr "Fotodetails"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:447
-#: lib/vutuv_web/live/fediverse_following_live.ex:55
-#: lib/vutuv_web/live/fediverse_following_live.ex:251
-#: lib/vutuv_web/live/fediverse_following_live.ex:264
+#: lib/vutuv_web/live/fediverse_account_live.ex:454
+#: lib/vutuv_web/live/fediverse_following_live.ex:52
+#: lib/vutuv_web/live/fediverse_following_live.ex:236
+#: lib/vutuv_web/live/fediverse_following_live.ex:249
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:422
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
@@ -17658,13 +17643,13 @@ msgstr "Ein Konto in einem anderen Netzwerk"
 msgid "Cancel request"
 msgstr "Anfrage zurückziehen"
 
-#: lib/vutuv_web/components/ui.ex:3499
+#: lib/vutuv_web/components/ui.ex:3442
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:114
-#: lib/vutuv_web/live/fediverse_following_live.ex:207
+#: lib/vutuv_web/live/fediverse_account_live.ex:112
+#: lib/vutuv_web/live/fediverse_following_live.ex:192
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Follow request sent to %{account}."
@@ -17690,32 +17675,27 @@ msgstr "Es geht auch andersherum: Fügen Sie die Adresse von jemandem bei Mastod
 msgid "Manage who you follow"
 msgstr "Verwalten, wem Sie folgen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:274
+#: lib/vutuv_web/live/fediverse_following_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Mastodon and the other networks work like email: an address is enough. Paste one here and vutuv asks that server to let you follow the account."
 msgstr "Mastodon und die anderen Netzwerke funktionieren wie E-Mail: Eine Adresse genügt. Fügen Sie hier eine ein, und vutuv fragt den betreffenden Server, ob Sie dem Konto folgen dürfen."
-
-#: lib/vutuv_web/live/fediverse_following_live.ex:301
-#, elixir-autogen, elixir-format
-msgid "Open their profile"
-msgstr "Profil öffnen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:224
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr "Angefragt"
 
-#: lib/vutuv_web/components/browse_table.ex:216
+#: lib/vutuv_web/components/browse_table.ex:320
 #, elixir-autogen, elixir-format
 msgid "Reset sorting"
 msgstr "Sortierung zurücksetzen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:309
+#: lib/vutuv_web/live/fediverse_following_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Search for them here"
 msgstr "Hier nach dieser Person suchen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:371
+#: lib/vutuv_web/live/fediverse_following_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Show only accounts on this server"
 msgstr "Nur Konten auf diesem Server anzeigen"
@@ -17725,12 +17705,12 @@ msgstr "Nur Konten auf diesem Server anzeigen"
 msgid "Sign in to follow this account"
 msgstr "Anmelden, um diesem Konto zu folgen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:356
+#: lib/vutuv_web/live/fediverse_following_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "State"
 msgstr "Status"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:223
+#: lib/vutuv_web/live/fediverse_following_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Stop following %{account}?"
 msgstr "%{account} nicht mehr folgen?"
@@ -17740,7 +17720,7 @@ msgstr "%{account} nicht mehr folgen?"
 msgid "That account could not be loaded from its server. Try again in a little while."
 msgstr "Dieses Konto konnte von seinem Server nicht geladen werden. Versuchen Sie es in Kürze noch einmal."
 
-#: lib/vutuv_web/components/fediverse_components.ex:324
+#: lib/vutuv_web/components/fediverse_components.ex:330
 #, elixir-autogen, elixir-format
 msgid "That did not work. Check the address and try again."
 msgstr "Das hat nicht geklappt. Prüfen Sie die Adresse und versuchen Sie es erneut."
@@ -17755,11 +17735,6 @@ msgstr "Das sieht nicht nach einer Adresse in einem anderen Netzwerk aus. Solche
 msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr "Das ist eine Adresse bei Mastodon oder einem der anderen Netzwerke, deshalb trägt sie hier niemand. Sie können ihr von vutuv aus folgen."
 
-#: lib/vutuv_web/components/fediverse_components.ex:286
-#, elixir-autogen, elixir-format
-msgid "That is an address on this vutuv, not another network."
-msgstr "Das ist eine Adresse auf diesem vutuv, nicht in einem anderen Netzwerk."
-
 #: lib/vutuv_web/components/fediverse_components.ex:275
 #, elixir-autogen, elixir-format
 msgid "That server answered, but it has no account at that address to follow."
@@ -17771,7 +17746,7 @@ msgstr "Der Server hat geantwortet, führt unter dieser Adresse aber kein Konto,
 msgid "That server did not answer. Check the address, and that the server is online."
 msgstr "Der Server hat nicht geantwortet. Prüfen Sie die Adresse und ob der Server erreichbar ist."
 
-#: lib/vutuv_web/components/fediverse_components.ex:321
+#: lib/vutuv_web/components/fediverse_components.ex:327
 #, elixir-autogen, elixir-format
 msgid "The Fediverse is switched off on this vutuv."
 msgstr "Das Fediverse ist auf diesem vutuv abgeschaltet."
@@ -17781,7 +17756,7 @@ msgstr "Das Fediverse ist auf diesem vutuv abgeschaltet."
 msgid "The address you brought along is kept here:"
 msgstr "Die mitgebrachte Adresse bleibt hier stehen:"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:424
+#: lib/vutuv_web/live/fediverse_following_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "The other server decides. Most accounts accept straight away; one that checks its followers by hand stays on \"Requested\" until somebody there says yes."
 msgstr "Der andere Server entscheidet. Die meisten Konten nehmen sofort an; eines, das seine Follower von Hand prüft, bleibt auf „Angefragt“ stehen, bis dort jemand zustimmt."
@@ -17801,18 +17776,18 @@ msgstr "Dieses vutuv tauscht nichts mit diesem Server aus."
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr "Um einem Konto dort draußen zu folgen, brauchen Sie eine eigene Fediverse-Identität: Die Anfrage wird in Ihrem Namen signiert, damit der andere Server weiß, wer fragt."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:130
-#: lib/vutuv_web/live/fediverse_following_live.ex:147
+#: lib/vutuv_web/live/fediverse_account_live.ex:128
+#: lib/vutuv_web/live/fediverse_following_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Unfollowed."
 msgstr "Nicht mehr gefolgt."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:421
+#: lib/vutuv_web/live/fediverse_following_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "What following out there means"
 msgstr "Was Folgen dort draußen bedeutet"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:429
+#: lib/vutuv_web/live/fediverse_following_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "Who you follow is yours alone. Your profile publishes how many accounts you follow out there, never which ones."
 msgstr "Wem Sie folgen, geht nur Sie etwas an. Ihr Profil veröffentlicht, wie vielen Konten Sie dort draußen folgen, nie welchen."
@@ -17822,22 +17797,22 @@ msgstr "Wem Sie folgen, geht nur Sie etwas an. Ihr Profil veröffentlicht, wie v
 msgid "Why is my account on hold?"
 msgstr "Warum ist mein Konto gesperrt?"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:226
+#: lib/vutuv_web/live/fediverse_following_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Withdraw your follow request to %{account}?"
 msgstr "Ihre Follower-Anfrage an %{account} zurückziehen?"
 
-#: lib/vutuv_web/components/fediverse_components.ex:292
+#: lib/vutuv_web/components/fediverse_components.ex:298
 #, elixir-autogen, elixir-format
 msgid "You already follow that account."
 msgstr "Sie folgen diesem Konto bereits."
 
-#: lib/vutuv_web/components/fediverse_components.ex:310
+#: lib/vutuv_web/components/fediverse_components.ex:316
 #, elixir-autogen, elixir-format
 msgid "You are following the most accounts we allow (%{max})."
 msgstr "Sie folgen bereits so vielen Konten, wie hier erlaubt sind (%{max})."
 
-#: lib/vutuv_web/components/fediverse_components.ex:300
+#: lib/vutuv_web/components/fediverse_components.ex:306
 #, elixir-autogen, elixir-format
 msgid "You are not taking part in the Fediverse at the moment, so there is no identity to sign the request with. Open the Fediverse settings to switch it on."
 msgstr "Sie nehmen derzeit nicht am Fediverse teil, deshalb gibt es keine Identität, mit der die Anfrage signiert werden könnte. Schalten Sie die Teilnahme in den Fediverse-Einstellungen ein."
@@ -17854,12 +17829,12 @@ msgid_plural "You follow %{formatted} accounts on other networks"
 msgstr[0] "Sie folgen %{formatted} Konto in einem anderen Netzwerk"
 msgstr[1] "Sie folgen %{formatted} Konten in anderen Netzwerken"
 
-#: lib/vutuv_web/components/fediverse_components.ex:306
+#: lib/vutuv_web/components/fediverse_components.ex:312
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of follow requests in the last hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Follower-Anfragen gesendet. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/fediverse_components.ex:316
+#: lib/vutuv_web/components/fediverse_components.ex:322
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so this account no longer acts out there."
 msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, deshalb tritt dieses Konto dort draußen nicht mehr auf."
@@ -17869,12 +17844,12 @@ msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, desh
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr "Ihr Konto ist derzeit gesperrt, deshalb geht nichts von Ihnen an andere Netzwerke und Sie können dort niemandem folgen. Das endet von selbst, sobald die Sperre abläuft."
 
-#: lib/vutuv_web/components/ui.ex:3501
+#: lib/vutuv_web/components/ui.ex:3444
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr "mastodon activitypub foederation federation follower folgen folge umzug migration entferntes konto"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:258
+#: lib/vutuv_web/live/fediverse_following_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Accounts followed"
 msgstr "Gefolgte Konten"
@@ -17894,9 +17869,9 @@ msgstr "Zwischengespeicherte Beiträge"
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:162
+#: lib/vutuv_web/live/fediverse_account_live.ex:160
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:131
-#: lib/vutuv_web/live/post_live/feed.ex:353
+#: lib/vutuv_web/live/post_live/feed.ex:391
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
@@ -17936,8 +17911,8 @@ msgstr "Von der verfassenden Person als sensibel markiert"
 msgid "Mute %{handle}"
 msgstr "%{handle} stummschalten"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:411
+#: lib/vutuv_web/live/fediverse_account_live.ex:264
+#: lib/vutuv_web/live/post_live/feed.ex:449
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwinden aus Ihrem Feed."
@@ -17952,72 +17927,72 @@ msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:440
+#: lib/vutuv_web/live/fediverse_following_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "To show their posts we keep a copy here for up to six months. If the author deletes or edits something, ours follows; and when you stop following an account, its posts are deleted here at once."
 msgstr "Um die Beiträge zeigen zu können, behalten wir hier bis zu sechs Monate lang eine Kopie. Löscht oder ändert die verfassende Person etwas, zieht unsere Kopie nach; und sobald Sie einem Konto nicht mehr folgen, werden dessen Beiträge hier sofort gelöscht."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:328
+#: lib/vutuv_web/live/fediverse_following_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "You do not follow anybody out there yet. Once you do, what they post appears in your feed among everything else."
 msgstr "Sie folgen dort draußen noch niemandem. Sobald Sie das tun, erscheinen deren Beiträge in Ihrem Feed zwischen allem anderen."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:66
+#: lib/vutuv_web/live/fediverse_account_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "%{name} (another network)"
 msgstr "%{name} (anderes Netzwerk)"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:297
+#: lib/vutuv_web/live/fediverse_account_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "Account on another network"
 msgstr "Konto in einem anderen Netzwerk"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:431
+#: lib/vutuv_web/live/fediverse_account_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr "Ein anderes Konto nachschlagen"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:362
+#: lib/vutuv_web/live/fediverse_account_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr "Stummgeschaltet"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:272
+#: lib/vutuv_web/live/fediverse_account_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr "Noch nichts zwischengespeichert. Die Beiträge erscheinen hier, sobald sie veröffentlicht werden."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:267
+#: lib/vutuv_web/live/fediverse_account_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr "Hier ist nichts. vutuv behält die Beiträge eines Kontos nur, solange jemand hier ihm folgt, und diese Seite ruft von sich aus keine ab."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:433
+#: lib/vutuv_web/live/fediverse_account_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr "Fügen Sie eine Adresse von Mastodon und Co. ein, um die zugehörige Seite hier zu öffnen."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:329
+#: lib/vutuv_web/live/fediverse_account_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr "Ganze Beschreibung anzeigen"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:416
+#: lib/vutuv_web/live/fediverse_account_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr "Die neuesten %{count} werden angezeigt. Der Rest liegt auf dem eigenen Server."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:259
+#: lib/vutuv_web/live/fediverse_account_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts are back in your feed."
 msgstr "Stummschaltung aufgehoben. Die Beiträge sind wieder in Ihrem Feed."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:426
+#: lib/vutuv_web/live/fediverse_account_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr "Vollständiges Profil auf %{host} ansehen"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:276
+#: lib/vutuv_web/live/fediverse_account_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr "Warten darauf, dass der Server Ihre Follower-Anfrage annimmt. Beiträge, die nur an die Follower gerichtet sind, erscheinen danach."
@@ -18194,7 +18169,7 @@ msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noc
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
 
-#: lib/vutuv_web/live/post_live/remote_post_reply.ex:98
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:93
 #, elixir-autogen, elixir-format
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
@@ -18206,7 +18181,7 @@ msgstr ""
 "Dieser Beitrag wurde nur an die Follower dieses Kontos veröffentlicht und "
 "lässt sich hier deshalb nicht mit einem öffentlichen Beitrag beantworten."
 
-#: lib/vutuv_web/live/post_live/remote_post_reply.ex:93
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:88
 #, elixir-autogen, elixir-format
 msgid "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
@@ -18214,9 +18189,9 @@ msgstr ""
 "beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv "
 "nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:195
+#: lib/vutuv_web/live/fediverse_account_live.ex:193
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:110
-#: lib/vutuv_web/live/post_live/feed.ex:389
+#: lib/vutuv_web/live/post_live/feed.ex:427
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr "Repostet. Ihre Follower sehen es jetzt."
@@ -18226,7 +18201,7 @@ msgstr "Repostet. Ihre Follower sehen es jetzt."
 msgid "Moved"
 msgstr "Umgezogen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:217
+#: lib/vutuv_web/live/fediverse_following_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "%{account} moved to another server. Your subscription already went with them — remove this old entry?"
 msgstr ""
@@ -18263,12 +18238,12 @@ msgstr ""
 "speichern wir dafür bis zu sechs Monate. Alles davon lässt sich jederzeit "
 "wieder abschalten."
 
-#: lib/vutuv_web/live/user_profile_live.ex:1204
+#: lib/vutuv_web/live/user_profile_live.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Follow %{count} members"
 msgstr "%{count} Mitgliedern folgen"
 
-#: lib/vutuv_web/live/user_profile_live.ex:1219
+#: lib/vutuv_web/live/user_profile_live.ex:1287
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
@@ -18517,7 +18492,7 @@ msgstr "Einen Beitrag zu holen heißt, seinen Server in Ihrem Namen danach zu fr
 msgid "Its author published this post to their followers alone, so vutuv does not keep a copy of it."
 msgstr "Die verfassende Person hat diesen Beitrag nur an ihre Follower veröffentlicht, deshalb behält vutuv keine Kopie davon."
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:455
+#: lib/vutuv_web/live/fediverse_following_live.ex:426
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "Look up a post by its address"
@@ -18584,7 +18559,7 @@ msgstr "Dieses vutuv bleibt unter sich"
 msgid "Turn on Fediverse participation to look up"
 msgstr "Fediverse-Teilnahme einschalten, um nachzuschlagen"
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:449
+#: lib/vutuv_web/live/fediverse_following_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "Want to answer one particular post rather than follow its author?"
 msgstr "Möchten Sie auf einen bestimmten Beitrag antworten, statt der verfassenden Person zu folgen?"
@@ -18742,12 +18717,12 @@ msgstr "Kacheln füllen"
 msgid "Whole photos"
 msgstr "Ganze Fotos"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:127
+#: lib/vutuv_web/templates/layout/app.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Send the post or message you are writing"
 msgstr "Beitrag oder Nachricht absenden, während Sie schreiben"
 
-#: lib/vutuv_web/templates/layout/app.html.heex:188
+#: lib/vutuv_web/templates/layout/app.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "The single-key shortcuts pause while you type, and are off on phones and tablets."
 msgstr "Die Einzeltasten-Kürzel pausieren, während Sie tippen, und sind auf Telefonen und Tablets aus."
@@ -18771,3 +18746,38 @@ msgstr "Wenn das wiederholt passiert, sagen Sie es uns bitte mit einer Fehlermel
 #, elixir-autogen, elixir-format
 msgid "The most helpful detail in such a report is the exact time of the error. Right now it is %{time}."
 msgstr "Das hilfreichste Detail in so einer Meldung ist die genaue Uhrzeit des Fehlers. Gerade ist es %{time}."
+
+#: lib/vutuv_web/live/fediverse_following_live.ex:183
+#, elixir-autogen, elixir-format
+msgid "@%{handle} is on this vutuv, so you now follow them here."
+msgstr "@%{handle} ist auf diesem vutuv. Sie folgen dem Mitglied jetzt direkt hier."
+
+#: lib/vutuv_web/components/fediverse_components.ex:287
+#, elixir-autogen, elixir-format
+msgid "That address is on this vutuv, but it names no member here."
+msgstr "Diese Adresse gehört zu diesem vutuv, aber es gibt hier kein Mitglied mit diesem Namen."
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:89
+#, elixir-autogen, elixir-format
+msgid "That address is on this vutuv. Sign in and use the Follow button on this profile."
+msgstr "Diese Adresse gehört zu diesem vutuv. Melden Sie sich an, dann können Sie diesem Mitglied direkt hier folgen."
+
+#: lib/vutuv_web/components/fediverse_components.ex:292
+#, elixir-autogen, elixir-format
+msgid "That is your own address. You cannot follow yourself."
+msgstr "Das ist Ihre eigene Adresse. Sie können sich nicht selbst folgen."
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:111
+#, elixir-autogen, elixir-format
+msgid "That is your own profile. You cannot follow yourself."
+msgstr "Das ist Ihr eigenes Profil. Sie können sich nicht selbst folgen."
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:118
+#, elixir-autogen, elixir-format
+msgid "You already follow @%{handle} here."
+msgstr "Sie folgen @%{handle} hier bereits."
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:104
+#, elixir-autogen, elixir-format
+msgid "You are on this vutuv yourself, so you now follow @%{handle} right here."
+msgstr "Sie sind selbst auf diesem vutuv. Sie folgen @%{handle} jetzt direkt hier."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,14 +11,14 @@ msgid ""
 msgstr ""
 "Language: INSERT LANGUAGE HERE\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:93
-#: lib/vutuv_web/templates/layout/app.html.heex:93
+#: lib/vutuv_web/controllers/page_controller.ex:98
+#: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3253
-#: lib/vutuv_web/components/ui.ex:3258
+#: lib/vutuv_web/components/ui.ex:3196
+#: lib/vutuv_web/components/ui.ex:3201
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -37,7 +37,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1376
+#: lib/vutuv_web/templates/user/show.html.heex:1383
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -61,7 +61,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3449
+#: lib/vutuv_web/components/ui.ex:3392
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -79,8 +79,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3048
-#: lib/vutuv_web/components/ui.ex:3142
+#: lib/vutuv_web/components/ui.ex:2991
+#: lib/vutuv_web/components/ui.ex:3085
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #, elixir-autogen
 msgid "Are you sure?"
@@ -100,13 +100,13 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/templates/user/show.html.heex:1009
+#: lib/vutuv_web/templates/user/show.html.heex:1015
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3042
+#: lib/vutuv_web/components/ui.ex:2985
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -146,7 +146,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1047
+#: lib/vutuv_web/templates/user/show.html.heex:1053
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -156,7 +156,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2182
-#: lib/vutuv_web/components/ui.ex:3145
+#: lib/vutuv_web/components/ui.ex:3088
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -205,7 +205,7 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2147
-#: lib/vutuv_web/components/ui.ex:3136
+#: lib/vutuv_web/components/ui.ex:3079
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -218,7 +218,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1032
+#: lib/vutuv_web/templates/user/show.html.heex:1038
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -291,7 +291,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3414
+#: lib/vutuv_web/components/ui.ex:3357
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -319,8 +319,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:506
 #: lib/vutuv_web/agent_docs/text.ex:476
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/fediverse_followers_live.ex:128
-#: lib/vutuv_web/live/notification_live/index.ex:882
+#: lib/vutuv_web/live/fediverse_followers_live.ex:110
+#: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -331,16 +331,16 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:507
 #: lib/vutuv_web/agent_docs/text.ex:477
 #: lib/vutuv_web/components/fediverse_components.ex:223
-#: lib/vutuv_web/components/ui.ex:1729
-#: lib/vutuv_web/components/ui.ex:1754
-#: lib/vutuv_web/components/ui.ex:1757
-#: lib/vutuv_web/components/ui.ex:1764
-#: lib/vutuv_web/components/ui.ex:1767
-#: lib/vutuv_web/components/ui.ex:1825
+#: lib/vutuv_web/components/ui.ex:1738
+#: lib/vutuv_web/components/ui.ex:1763
+#: lib/vutuv_web/components/ui.ex:1766
+#: lib/vutuv_web/components/ui.ex:1773
+#: lib/vutuv_web/components/ui.ex:1776
+#: lib/vutuv_web/components/ui.ex:1834
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:837
+#: lib/vutuv_web/templates/user/show.html.heex:840
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -355,7 +355,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:67
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:1004
+#: lib/vutuv_web/templates/user/show.html.heex:1010
 #: lib/vutuv_web/views/account_event_text.ex:153
 #, elixir-autogen
 msgid "Gender"
@@ -373,7 +373,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:117
+#: lib/vutuv_web/templates/layout/app.html.heex:121
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:2
 #, elixir-autogen
 msgid "Home"
@@ -468,7 +468,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:806
+#: lib/vutuv_web/live/notification_live/index.ex:841
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:580
+#: lib/vutuv_web/live/notification_live/index.ex:615
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3041
+#: lib/vutuv_web/components/ui.ex:2984
 #: lib/vutuv_web/live/organization_live/edit.ex:341
 #: lib/vutuv_web/live/post_live/composer.ex:1780
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -643,11 +643,11 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:167
-#: lib/vutuv_web/live/account_activity_live.ex:194
-#: lib/vutuv_web/live/admin/activity_live.ex:231
+#: lib/vutuv_web/components/browse_table.ex:271
+#: lib/vutuv_web/live/account_activity_live.ex:149
+#: lib/vutuv_web/live/admin/activity_live.ex:193
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
-#: lib/vutuv_web/live/admin/user_live.ex:244
+#: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:37
 #: lib/vutuv_web/live/search_live.ex:378
@@ -656,7 +656,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
-#: lib/vutuv_web/templates/layout/app.html.heex:122
+#: lib/vutuv_web/templates/layout/app.html.heex:126
 #, elixir-autogen
 msgid "Search"
 msgstr ""
@@ -696,13 +696,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1160
+#: lib/vutuv_web/templates/user/show.html.heex:1167
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1162
+#: lib/vutuv_web/templates/user/show.html.heex:1169
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -744,8 +744,9 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:34
 #: lib/vutuv_web/controllers/follow_controller.ex:24
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:123
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:115
+#: lib/vutuv_web/live/user_profile_live.ex:153
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr ""
@@ -782,12 +783,12 @@ msgstr ""
 msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:314
+#: lib/vutuv_web/controllers/user_controller.ex:310
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:233
+#: lib/vutuv_web/controllers/user_controller.ex:229
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr ""
@@ -797,12 +798,12 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3410
+#: lib/vutuv_web/components/ui.ex:3353
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
-#: lib/vutuv_web/live/admin/user_live.ex:169
-#: lib/vutuv_web/live/notification_live/index.ex:957
+#: lib/vutuv_web/live/admin/user_live.ex:155
+#: lib/vutuv_web/live/notification_live/index.ex:992
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -846,20 +847,20 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:759
+#: lib/vutuv_web/components/ui.ex:767
 #: lib/vutuv_web/templates/user/show.html.heex:309
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3206
-#: lib/vutuv_web/templates/user/show.html.heex:831
-#: lib/vutuv_web/templates/user/show.html.heex:851
+#: lib/vutuv_web/components/ui.ex:3149
+#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:857
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3490
+#: lib/vutuv_web/components/ui.ex:3433
 #: lib/vutuv_web/controllers/settings_controller.ex:146
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:300
@@ -927,7 +928,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:52
-#: lib/vutuv_web/live/post_live/feed.ex:61
+#: lib/vutuv_web/live/post_live/feed.ex:62
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -993,14 +994,14 @@ msgstr ""
 msgid "http://www.example.com"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1041
+#: lib/vutuv/accounts/user.ex:1049
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1040
+#: lib/vutuv/accounts/user.ex:1048
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1061,12 +1062,12 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:999
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:388
+#: lib/vutuv_web/live/admin/user_live.ex:359
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen
 msgid "Verify"
@@ -1102,7 +1103,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:236
+#: lib/vutuv_web/controllers/page_controller.ex:241
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1127,8 +1128,8 @@ msgstr ""
 msgid "Curious? Have a look at the "
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:298
-#: lib/vutuv_web/views/work_experience_html.ex:351
+#: lib/vutuv_web/views/work_experience_html.ex:300
+#: lib/vutuv_web/views/work_experience_html.ex:353
 #, elixir-autogen
 msgid "Present"
 msgstr ""
@@ -1190,7 +1191,7 @@ msgid "Add Localization"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:245
-#: lib/vutuv_web/live/admin/activity_live.ex:191
+#: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
 #: lib/vutuv_web/live/admin/job_live.ex:199
@@ -1205,7 +1206,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/screenshot_live.ex:82
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
-#: lib/vutuv_web/live/admin/user_live.ex:190
+#: lib/vutuv_web/live/admin/user_live.ex:165
 #: lib/vutuv_web/live/shell_live.ex:589
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
@@ -1422,7 +1423,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:402
 #: lib/vutuv_web/agent_docs/text.ex:615
-#: lib/vutuv_web/components/ui.ex:3430
+#: lib/vutuv_web/components/ui.ex:3373
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1459,7 +1460,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:167
 #: lib/vutuv_web/controllers/session_controller.ex:438
-#: lib/vutuv_web/controllers/user_controller.ex:334
+#: lib/vutuv_web/controllers/user_controller.ex:330
 #: lib/vutuv_web/controllers/username_controller.ex:215
 #, elixir-autogen
 msgid "Too many incorrect attempts."
@@ -1674,8 +1675,8 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:1311
 #: lib/vutuv_web/live/post_live/composer.ex:1312
 #: lib/vutuv_web/live/post_live/composer.ex:2213
-#: lib/vutuv_web/templates/layout/app.html.heex:155
-#: lib/vutuv_web/templates/layout/app.html.heex:161
+#: lib/vutuv_web/templates/layout/app.html.heex:159
+#: lib/vutuv_web/templates/layout/app.html.heex:165
 #: lib/vutuv_web/views/layout_html.ex:40
 #, elixir-autogen, elixir-format
 msgid "Close"
@@ -1693,16 +1694,16 @@ msgstr ""
 msgid "Confirm account deletion"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:97
-#: lib/vutuv_web/templates/layout/app.html.heex:89
+#: lib/vutuv_web/controllers/page_controller.ex:102
+#: lib/vutuv_web/templates/layout/app.html.heex:93
 #: lib/vutuv_web/templates/page/index.html.heex:215
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:103
-#: lib/vutuv_web/templates/layout/app.html.heex:91
+#: lib/vutuv_web/controllers/page_controller.ex:108
+#: lib/vutuv_web/templates/layout/app.html.heex:95
 #: lib/vutuv_web/templates/page/index.html.heex:215
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
@@ -1715,34 +1716,34 @@ msgstr ""
 msgid "Delete my account"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:154
+#: lib/vutuv_web/controllers/user_controller.ex:150
 #: lib/vutuv_web/templates/user/show.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1154
 #: lib/vutuv_web/components/ui.ex:1163
-#: lib/vutuv_web/components/ui.ex:1556
+#: lib/vutuv_web/components/ui.ex:1172
+#: lib/vutuv_web/components/ui.ex:1565
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1694
-#: lib/vutuv_web/components/ui.ex:1694
-#: lib/vutuv_web/components/ui.ex:1711
+#: lib/vutuv_web/components/ui.ex:1703
+#: lib/vutuv_web/components/ui.ex:1703
 #: lib/vutuv_web/components/ui.ex:1720
-#: lib/vutuv_web/components/ui.ex:1736
-#: lib/vutuv_web/components/ui.ex:1773
-#: lib/vutuv_web/components/ui.ex:1776
-#: lib/vutuv_web/components/ui.ex:1783
-#: lib/vutuv_web/components/ui.ex:1786
-#: lib/vutuv_web/components/ui.ex:1859
-#: lib/vutuv_web/live/fediverse_account_live.ex:380
-#: lib/vutuv_web/live/fediverse_following_live.ex:287
+#: lib/vutuv_web/components/ui.ex:1729
+#: lib/vutuv_web/components/ui.ex:1745
+#: lib/vutuv_web/components/ui.ex:1782
+#: lib/vutuv_web/components/ui.ex:1785
+#: lib/vutuv_web/components/ui.ex:1792
+#: lib/vutuv_web/components/ui.ex:1795
+#: lib/vutuv_web/components/ui.ex:1868
+#: lib/vutuv_web/live/fediverse_account_live.ex:387
+#: lib/vutuv_web/live/fediverse_following_live.ex:266
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:403
-#: lib/vutuv_web/templates/user/show.html.heex:948
-#: lib/vutuv_web/templates/user/show.html.heex:1200
+#: lib/vutuv_web/templates/user/show.html.heex:954
+#: lib/vutuv_web/templates/user/show.html.heex:1207
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1764,11 +1765,11 @@ msgid "Log out"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:247
-#: lib/vutuv_web/live/admin/activity_live.ex:164
-#: lib/vutuv_web/live/admin/activity_live.ex:213
+#: lib/vutuv_web/live/admin/activity_live.ex:143
+#: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
-#: lib/vutuv_web/live/admin/user_live.ex:168
+#: lib/vutuv_web/live/admin/user_live.ex:154
 #: lib/vutuv_web/live/message_live/index.ex:455
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:55
@@ -1787,7 +1788,7 @@ msgstr ""
 #: lib/vutuv_web/live/message_live/index.ex:512
 #: lib/vutuv_web/live/shell_live.ex:497
 #: lib/vutuv_web/live/shell_live.ex:639
-#: lib/vutuv_web/templates/layout/app.html.heex:119
+#: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
@@ -1798,23 +1799,23 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:338
-#: lib/vutuv_web/components/ui.ex:3255
-#: lib/vutuv_web/live/admin/user_live.ex:311
+#: lib/vutuv_web/components/ui.ex:3198
+#: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:332
+#: lib/vutuv_web/live/notification_live/index.ex:367
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3471
-#: lib/vutuv_web/live/notification_live/index.ex:103
-#: lib/vutuv_web/live/notification_live/index.ex:293
+#: lib/vutuv_web/components/ui.ex:3414
+#: lib/vutuv_web/live/notification_live/index.ex:104
+#: lib/vutuv_web/live/notification_live/index.ex:328
 #: lib/vutuv_web/live/shell_live.ex:508
-#: lib/vutuv_web/templates/layout/app.html.heex:120
+#: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
@@ -1826,7 +1827,7 @@ msgid "Active Members"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_detail_live.ex:99
-#: lib/vutuv_web/live/admin/user_live.ex:358
+#: lib/vutuv_web/live/admin/user_live.ex:329
 #: lib/vutuv_web/templates/email/confirm.html.heex:25
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:17
 #: lib/vutuv_web/views/username_html.ex:66
@@ -1847,12 +1848,12 @@ msgid "Send"
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:35
-#: lib/vutuv_web/templates/layout/app.html.heex:83
+#: lib/vutuv_web/templates/layout/app.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Source"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:85
+#: lib/vutuv_web/templates/layout/app.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Submit a bug report or feature request"
 msgstr ""
@@ -1876,8 +1877,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/session_controller.ex:157
 #: lib/vutuv_web/controllers/session_controller.ex:193
 #: lib/vutuv_web/controllers/session_controller.ex:209
-#: lib/vutuv_web/controllers/user_controller.ex:270
-#: lib/vutuv_web/controllers/user_controller.ex:299
+#: lib/vutuv_web/controllers/user_controller.ex:266
+#: lib/vutuv_web/controllers/user_controller.ex:295
 #: lib/vutuv_web/controllers/username_controller.ex:191
 #: lib/vutuv_web/controllers/username_controller.ex:273
 #: lib/vutuv_web/controllers/username_controller.ex:296
@@ -1909,7 +1910,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1106
+#: lib/vutuv_web/live/post_live/feed.ex:1115
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -1946,29 +1947,29 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:978
+#: lib/vutuv_web/live/notification_live/index.ex:1013
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:973
+#: lib/vutuv_web/live/notification_live/index.ex:1008
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:968
+#: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2595
-#: lib/vutuv_web/components/ui.ex:2746
-#: lib/vutuv_web/live/organization_live/index.ex:130
+#: lib/vutuv_web/components/ui.ex:2538
+#: lib/vutuv_web/components/ui.ex:2689
+#: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3280
+#: lib/vutuv_web/components/ui.ex:3223
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -1978,37 +1979,37 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3051
+#: lib/vutuv_web/components/ui.ex:2994
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:881
-#: lib/vutuv_web/components/ui.ex:891
+#: lib/vutuv_web/components/ui.ex:890
+#: lib/vutuv_web/components/ui.ex:900
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:410
+#: lib/vutuv_web/views/work_experience_html.ex:412
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:413
+#: lib/vutuv_web/views/work_experience_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:529
+#: lib/vutuv_web/views/work_experience_html.ex:496
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:528
+#: lib/vutuv_web/views/work_experience_html.ex:495
 #, elixir-autogen, elixir-format
 msgid "Total time at this employer"
 msgstr ""
@@ -2023,12 +2024,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2350
+#: lib/vutuv_web/components/ui.ex:2293
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2354
+#: lib/vutuv_web/components/ui.ex:2297
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2053,37 +2054,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2358
+#: lib/vutuv_web/components/ui.ex:2301
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2348
+#: lib/vutuv_web/components/ui.ex:2291
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2347
+#: lib/vutuv_web/components/ui.ex:2290
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2353
+#: lib/vutuv_web/components/ui.ex:2296
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2352
+#: lib/vutuv_web/components/ui.ex:2295
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2349
+#: lib/vutuv_web/components/ui.ex:2292
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2351
+#: lib/vutuv_web/components/ui.ex:2294
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2098,17 +2099,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2357
+#: lib/vutuv_web/components/ui.ex:2300
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2356
+#: lib/vutuv_web/components/ui.ex:2299
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2355
+#: lib/vutuv_web/components/ui.ex:2298
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2130,8 +2131,8 @@ msgstr ""
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:145
-#: lib/vutuv_web/live/post_live/reply.ex:79
+#: lib/vutuv_web/live/post_live/edit.ex:143
+#: lib/vutuv_web/live/post_live/reply.ex:77
 #, elixir-autogen, elixir-format
 msgid "Back to the post"
 msgstr ""
@@ -2141,28 +2142,28 @@ msgstr ""
 msgid "Cancel upload"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:155
+#: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete post"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2179
-#: lib/vutuv_web/live/post_live/edit.ex:153
+#: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:48
-#: lib/vutuv_web/live/post_live/edit.ex:94
+#: lib/vutuv_web/live/post_live/edit.ex:46
+#: lib/vutuv_web/live/post_live/edit.ex:92
 #, elixir-autogen, elixir-format
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:87
-#: lib/vutuv_web/live/post_live/feed.ex:903
+#: lib/vutuv_web/live/post_live/feed.ex:139
+#: lib/vutuv_web/live/post_live/feed.ex:912
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
-#: lib/vutuv_web/templates/layout/app.html.heex:118
+#: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
 msgstr ""
@@ -2172,7 +2173,7 @@ msgstr ""
 msgid "Follow %{name} to read it."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/show.html.heex:28
+#: lib/vutuv_web/templates/post/show.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Hidden from:"
 msgstr ""
@@ -2204,7 +2205,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1045
+#: lib/vutuv_web/live/post_live/feed.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2231,7 +2232,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:214
+#: lib/vutuv_web/controllers/post_controller.ex:224
 #, elixir-autogen, elixir-format
 msgid "Post deleted successfully."
 msgstr ""
@@ -2239,11 +2240,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/post_doc.ex:127
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
-#: lib/vutuv_web/controllers/user_controller.ex:76
+#: lib/vutuv_web/controllers/user_controller.ex:77
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/fediverse_account_live.ex:387
-#: lib/vutuv_web/live/notification_live/index.ex:804
+#: lib/vutuv_web/live/fediverse_account_live.ex:394
+#: lib/vutuv_web/live/notification_live/index.ex:839
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:200
 #: lib/vutuv_web/live/search_live.ex:530
@@ -2260,7 +2261,7 @@ msgid "Read more"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2565
-#: lib/vutuv_web/live/fediverse_account_live.ex:332
+#: lib/vutuv_web/live/fediverse_account_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2281,7 +2282,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: lib/vutuv_web/templates/post/show.html.heex:31
+#: lib/vutuv_web/templates/post/show.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
@@ -2291,18 +2292,14 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:978
+#: lib/vutuv_web/live/post_live/feed.ex:987
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:75
-#: lib/vutuv_web/live/post_live/edit.ex:36
-#: lib/vutuv_web/live/post_live/remote_post_reply.ex:81
-#: lib/vutuv_web/live/post_live/remote_reply.ex:79
-#: lib/vutuv_web/live/post_live/reply.ex:41
+#: lib/vutuv_web/live/init_assigns.ex:81
 #, elixir-autogen, elixir-format
 msgid "Sorry, that page could not be found."
 msgstr ""
@@ -2332,7 +2329,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3723
+#: lib/vutuv_web/components/ui.ex:3666
 #: lib/vutuv_web/live/shell_live.ex:551
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2407,15 +2404,13 @@ msgstr ""
 msgid "View all %{count} posts"
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:141
+#: lib/vutuv_web/controllers/post_controller.ex:151
 #, elixir-autogen, elixir-format
 msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3768
-#: lib/vutuv_web/components/ui.ex:2054
-#: lib/vutuv_web/components/ui.ex:2054
-#: lib/vutuv_web/components/ui.ex:2670
+#: lib/vutuv_web/components/ui.ex:2613
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2433,10 +2428,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1484
 #: lib/vutuv_web/components/post_components.ex:3991
-#: lib/vutuv_web/components/ui.ex:2083
-#: lib/vutuv_web/components/ui.ex:2083
-#: lib/vutuv_web/components/ui.ex:2656
-#: lib/vutuv_web/live/notification_live/index.ex:947
+#: lib/vutuv_web/components/ui.ex:2599
+#: lib/vutuv_web/live/notification_live/index.ex:982
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2444,7 +2437,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:932
 #: lib/vutuv_web/components/post_components.ex:4000
-#: lib/vutuv_web/live/notification_live/index.ex:884
+#: lib/vutuv_web/live/notification_live/index.ex:919
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:559
@@ -2469,8 +2462,6 @@ msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3768
-#: lib/vutuv_web/components/ui.ex:2044
-#: lib/vutuv_web/components/ui.ex:2044
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2496,8 +2487,6 @@ msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3991
-#: lib/vutuv_web/components/ui.ex:2073
-#: lib/vutuv_web/components/ui.ex:2073
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
@@ -2505,10 +2494,10 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:253
-#: lib/vutuv_web/components/ui.ex:1689
-#: lib/vutuv_web/components/ui.ex:1689
-#: lib/vutuv_web/components/ui.ex:1826
-#: lib/vutuv_web/live/post_live/feed.ex:1095
+#: lib/vutuv_web/components/ui.ex:1698
+#: lib/vutuv_web/components/ui.ex:1698
+#: lib/vutuv_web/components/ui.ex:1835
+#: lib/vutuv_web/live/post_live/feed.ex:1104
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2525,7 +2514,7 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:327
-#: lib/vutuv_web/live/notification_live/index.ex:885
+#: lib/vutuv_web/live/notification_live/index.ex:920
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -2534,8 +2523,8 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1536
 #: lib/vutuv_web/components/post_components.ex:4027
 #: lib/vutuv_web/components/post_components.ex:4028
-#: lib/vutuv_web/live/notification_live/index.ex:944
-#: lib/vutuv_web/live/post_live/reply.ex:35
+#: lib/vutuv_web/live/notification_live/index.ex:979
+#: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
@@ -2556,15 +2545,15 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1123
+#: lib/vutuv_web/live/notification_live/index.ex:1158
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1621
-#: lib/vutuv_web/live/post_live/remote_post_reply.ex:58
-#: lib/vutuv_web/live/post_live/remote_reply.ex:57
-#: lib/vutuv_web/live/post_live/reply.ex:52
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
+#: lib/vutuv_web/live/post_live/remote_reply.ex:58
+#: lib/vutuv_web/live/post_live/reply.ex:50
 #, elixir-autogen, elixir-format
 msgid "Reply to %{handle}"
 msgstr ""
@@ -2637,7 +2626,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2226
+#: lib/vutuv_web/components/ui.ex:2169
 #: lib/vutuv_web/live/message_live/index.ex:612
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2749,26 +2738,26 @@ msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1121
+#: lib/vutuv_web/templates/user/show.html.heex:1127
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1378
+#: lib/vutuv_web/templates/user/show.html.heex:1385
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1049
+#: lib/vutuv_web/templates/user/show.html.heex:1055
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:995
+#: lib/vutuv_web/templates/user/show.html.heex:1001
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
@@ -2780,14 +2769,14 @@ msgstr ""
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1193
+#: lib/vutuv_web/live/user_profile_live.ex:1261
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2834
-#: lib/vutuv_web/components/ui.ex:3208
+#: lib/vutuv_web/components/ui.ex:2777
+#: lib/vutuv_web/components/ui.ex:3151
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
@@ -2799,20 +2788,20 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:928
+#: lib/vutuv_web/live/post_live/feed.ex:937
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:118
+#: lib/vutuv_web/views/user_helpers.ex:125
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_helpers.ex:122
+#: lib/vutuv_web/views/user_helpers.ex:129
 #, elixir-autogen, elixir-format
 msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
 msgstr ""
@@ -2834,13 +2823,13 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:508
 #: lib/vutuv_web/agent_docs/text.ex:478
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:883
+#: lib/vutuv_web/live/notification_live/index.ex:918
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:750
+#: lib/vutuv_web/components/ui.ex:758
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2850,7 +2839,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:765
+#: lib/vutuv_web/components/ui.ex:774
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2860,7 +2849,7 @@ msgstr ""
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:751
+#: lib/vutuv_web/components/ui.ex:759
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2888,22 +2877,22 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:958
+#: lib/vutuv_web/live/notification_live/index.ex:993
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:950
+#: lib/vutuv_web/live/notification_live/index.ex:985
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:943
+#: lib/vutuv_web/live/notification_live/index.ex:978
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:942
+#: lib/vutuv_web/live/notification_live/index.ex:977
 #: lib/vutuv_web/templates/user/show.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2916,7 +2905,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:975
+#: lib/vutuv_web/live/notification_live/index.ex:1010
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2948,12 +2937,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1159
+#: lib/vutuv_web/live/notification_live/index.ex:1194
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1160
+#: lib/vutuv_web/live/notification_live/index.ex:1195
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -2985,8 +2974,8 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:296
 #: lib/vutuv_web/agent_docs/text.ex:280
-#: lib/vutuv_web/controllers/page_controller.ex:76
-#: lib/vutuv_web/templates/layout/app.html.heex:87
+#: lib/vutuv_web/controllers/page_controller.ex:81
+#: lib/vutuv_web/templates/layout/app.html.heex:91
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Community guidelines"
@@ -3059,7 +3048,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:951
+#: lib/vutuv_web/live/notification_live/index.ex:986
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3133,8 +3122,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1089
-#: lib/vutuv_web/templates/user/show.html.heex:1090
+#: lib/vutuv_web/templates/user/show.html.heex:1095
+#: lib/vutuv_web/templates/user/show.html.heex:1096
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -3188,7 +3177,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3404
+#: lib/vutuv_web/components/ui.ex:3347
 #: lib/vutuv_web/live/shell_live.ex:443
 #: lib/vutuv_web/live/shell_live.ex:644
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3299,7 +3288,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2570
+#: lib/vutuv_web/components/ui.ex:2513
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3348,7 +3337,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/moderation_live.ex:53
 #: lib/vutuv_web/live/admin/organization_live.ex:246
 #: lib/vutuv_web/live/admin/screenshot_live.ex:149
-#: lib/vutuv_web/live/admin/user_live.ex:328
+#: lib/vutuv_web/live/admin/user_live.ex:299
 #: lib/vutuv_web/templates/admin/account/index.html.heex:57
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:59
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:19
@@ -3481,12 +3470,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1162
+#: lib/vutuv_web/live/notification_live/index.ex:1197
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1161
+#: lib/vutuv_web/live/notification_live/index.ex:1196
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3496,7 +3485,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1163
+#: lib/vutuv_web/live/notification_live/index.ex:1198
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3680,7 +3669,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1187
+#: lib/vutuv_web/live/notification_live/index.ex:1222
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3705,7 +3694,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:953
+#: lib/vutuv_web/live/notification_live/index.ex:988
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3780,7 +3769,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1192
+#: lib/vutuv_web/live/notification_live/index.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4532,7 +4521,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3494
+#: lib/vutuv_web/components/ui.ex:3437
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4569,12 +4558,12 @@ msgid "You have not blocked anyone."
 msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:244
+#: lib/vutuv_web/live/user_profile_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1050
+#: lib/vutuv_web/live/post_live/feed.ex:1059
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4586,7 +4575,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:837
+#: lib/vutuv_web/templates/user/show.html.heex:840
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4630,7 +4619,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:350
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:480
-#: lib/vutuv_web/live/notification_live/index.ex:805
+#: lib/vutuv_web/live/notification_live/index.ex:840
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:198
@@ -4652,7 +4641,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:324
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:803
+#: lib/vutuv_web/live/notification_live/index.ex:838
 #: lib/vutuv_web/live/search_live.ex:197
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -4701,7 +4690,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:46
-#: lib/vutuv_web/live/user_profile_live.ex:1181
+#: lib/vutuv_web/live/user_profile_live.ex:1249
 #: lib/vutuv_web/templates/user/show.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -5101,7 +5090,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:92
 #: lib/vutuv_web/live/admin/member_badges.ex:22
-#: lib/vutuv_web/live/admin/user_live.ex:292
+#: lib/vutuv_web/live/admin/user_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Suspended"
 msgstr ""
@@ -5288,12 +5277,12 @@ msgstr ""
 msgid "API token (%{date})"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:81
+#: lib/vutuv_web/templates/layout/app.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3533
+#: lib/vutuv_web/components/ui.ex:3476
 #: lib/vutuv_web/controllers/settings_controller.ex:137
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5345,40 +5334,40 @@ msgid "Account menu"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:155
-#: lib/vutuv_web/templates/layout/app.html.heex:124
+#: lib/vutuv_web/templates/layout/app.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:134
+#: lib/vutuv_web/templates/layout/app.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Close menus and dialogs"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:131
+#: lib/vutuv_web/templates/layout/app.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:599
-#: lib/vutuv_web/templates/layout/app.html.heex:150
+#: lib/vutuv_web/templates/layout/app.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:115
+#: lib/vutuv_web/templates/layout/app.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3630
-#: lib/vutuv_web/components/ui.ex:3635
-#: lib/vutuv_web/components/ui.ex:3714
-#: lib/vutuv_web/components/ui.ex:3778
+#: lib/vutuv_web/components/ui.ex:3573
+#: lib/vutuv_web/components/ui.ex:3578
+#: lib/vutuv_web/components/ui.ex:3657
+#: lib/vutuv_web/components/ui.ex:3721
 #: lib/vutuv_web/controllers/settings_controller.ex:53
-#: lib/vutuv_web/live/account_activity_live.ex:155
-#: lib/vutuv_web/live/fediverse_followers_live.ex:126
-#: lib/vutuv_web/live/fediverse_following_live.ex:253
+#: lib/vutuv_web/live/account_activity_live.ex:115
+#: lib/vutuv_web/live/fediverse_followers_live.ex:108
+#: lib/vutuv_web/live/fediverse_following_live.ex:238
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
@@ -5390,17 +5379,17 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:133
+#: lib/vutuv_web/templates/layout/app.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Show this help"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:126
+#: lib/vutuv_web/templates/layout/app.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Write a new post"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:121
+#: lib/vutuv_web/templates/layout/app.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Your profile"
 msgstr ""
@@ -5415,17 +5404,17 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1183
+#: lib/vutuv_web/live/user_profile_live.ex:1251
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:128
+#: lib/vutuv_web/templates/layout/app.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Next post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:129
+#: lib/vutuv_web/templates/layout/app.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Previous post in the feed"
 msgstr ""
@@ -5436,7 +5425,7 @@ msgstr ""
 msgid "Main navigation"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:74
+#: lib/vutuv_web/templates/layout/app.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Footer navigation"
 msgstr ""
@@ -5444,8 +5433,8 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2266
 #: lib/vutuv_web/components/post_components.ex:2318
 #: lib/vutuv_web/components/post_components.ex:2708
-#: lib/vutuv_web/live/notification_live/index.ex:624
-#: lib/vutuv_web/live/post_live/feed.ex:1168
+#: lib/vutuv_web/live/notification_live/index.ex:659
+#: lib/vutuv_web/live/post_live/feed.ex:1177
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5461,7 +5450,7 @@ msgstr ""
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1044
+#: lib/vutuv/accounts/user.ex:1052
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5497,10 +5486,10 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3506
-#: lib/vutuv_web/live/admin/user_live.ex:279
-#: lib/vutuv_web/live/fediverse_followers_live.ex:112
-#: lib/vutuv_web/live/fediverse_following_live.ex:239
+#: lib/vutuv_web/components/ui.ex:3449
+#: lib/vutuv_web/live/admin/user_live.ex:254
+#: lib/vutuv_web/live/fediverse_followers_live.ex:94
+#: lib/vutuv_web/live/fediverse_following_live.ex:224
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:192
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
@@ -5517,7 +5506,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3441
+#: lib/vutuv_web/components/ui.ex:3384
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5551,7 +5540,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3488
+#: lib/vutuv_web/components/ui.ex:3431
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
@@ -5576,7 +5565,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:473
+#: lib/vutuv_web/live/notification_live/index.ex:508
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5664,14 +5653,14 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3529
+#: lib/vutuv_web/components/ui.ex:3472
 #: lib/vutuv_web/controllers/settings_controller.ex:152
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:886
+#: lib/vutuv_web/live/notification_live/index.ex:921
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -5790,25 +5779,25 @@ msgid "You cannot block yourself."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:23
-#: lib/vutuv_web/live/user_profile_live.ex:210
+#: lib/vutuv_web/live/user_profile_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Bookmark removed."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:19
-#: lib/vutuv_web/live/user_profile_live.ex:207
+#: lib/vutuv_web/live/user_profile_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Bookmarked."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:31
-#: lib/vutuv_web/live/user_profile_live.ex:216
+#: lib/vutuv_web/live/user_profile_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Like removed."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:27
-#: lib/vutuv_web/live/user_profile_live.ex:213
+#: lib/vutuv_web/live/user_profile_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Liked."
 msgstr ""
@@ -5983,7 +5972,7 @@ msgid "Add a passkey"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/live/fediverse_following_live.ex:241
+#: lib/vutuv_web/live/fediverse_following_live.ex:226
 #: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Added"
@@ -6080,7 +6069,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1187
+#: lib/vutuv_web/live/user_profile_live.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6116,7 +6105,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1429
+#: lib/vutuv_web/templates/user/show.html.heex:1436
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6160,8 +6149,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1015
-#: lib/vutuv_web/templates/user/show.html.heex:1025
+#: lib/vutuv_web/templates/user/show.html.heex:1021
+#: lib/vutuv_web/templates/user/show.html.heex:1031
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6201,12 +6190,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1136
+#: lib/vutuv_web/templates/user/show.html.heex:1143
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1147
+#: lib/vutuv_web/templates/user/show.html.heex:1154
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6248,7 +6237,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1145
+#: lib/vutuv_web/templates/user/show.html.heex:1152
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6273,9 +6262,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1154
 #: lib/vutuv_web/components/ui.ex:1163
-#: lib/vutuv_web/components/ui.ex:1557
+#: lib/vutuv_web/components/ui.ex:1172
+#: lib/vutuv_web/components/ui.ex:1566
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6302,9 +6291,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1415
-#: lib/vutuv_web/templates/user/show.html.heex:1423
-#: lib/vutuv_web/templates/user/show.html.heex:1435
+#: lib/vutuv_web/templates/user/show.html.heex:1422
+#: lib/vutuv_web/templates/user/show.html.heex:1430
+#: lib/vutuv_web/templates/user/show.html.heex:1442
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6336,11 +6325,11 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1510
-#: lib/vutuv_web/live/notification_live/index.ex:558
-#: lib/vutuv_web/live/notification_live/index.ex:573
-#: lib/vutuv_web/live/notification_live/index.ex:711
-#: lib/vutuv_web/live/notification_live/index.ex:713
+#: lib/vutuv_web/components/ui.ex:1519
+#: lib/vutuv_web/live/notification_live/index.ex:593
+#: lib/vutuv_web/live/notification_live/index.ex:608
+#: lib/vutuv_web/live/notification_live/index.ex:746
+#: lib/vutuv_web/live/notification_live/index.ex:748
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -6552,8 +6541,8 @@ msgstr ""
 msgid "The raw bounce ledger, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:126
-#: lib/vutuv_web/live/admin/activity_live.ex:163
+#: lib/vutuv_web/live/account_activity_live.ex:103
+#: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
@@ -6634,8 +6623,8 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2014
-#: lib/vutuv_web/live/fediverse_account_live.ex:374
+#: lib/vutuv_web/components/ui.ex:2023
+#: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6643,7 +6632,7 @@ msgid "Mute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:192
+#: lib/vutuv_web/live/user_profile_live.ex:230
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
@@ -6658,8 +6647,8 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2013
-#: lib/vutuv_web/live/fediverse_account_live.ex:372
+#: lib/vutuv_web/components/ui.ex:2022
+#: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6667,7 +6656,7 @@ msgid "Unmute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:194
+#: lib/vutuv_web/live/user_profile_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -6697,33 +6686,33 @@ msgstr ""
 msgid "Unmute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1984
+#: lib/vutuv_web/components/ui.ex:1993
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1978
+#: lib/vutuv_web/components/ui.ex:1987
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1968
+#: lib/vutuv_web/components/ui.ex:1977
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1919
-#: lib/vutuv_web/components/ui.ex:1968
+#: lib/vutuv_web/components/ui.ex:1928
+#: lib/vutuv_web/components/ui.ex:1977
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1917
+#: lib/vutuv_web/components/ui.ex:1926
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1918
+#: lib/vutuv_web/components/ui.ex:1927
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -6834,7 +6823,7 @@ msgstr ""
 msgid "Dev email inbox"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:221
+#: lib/vutuv_web/live/admin/user_live.ex:196
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Development:"
@@ -6889,8 +6878,8 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:213
 #: lib/vutuv_web/agent_docs/text.ex:201
-#: lib/vutuv_web/live/account_activity_live.ex:212
-#: lib/vutuv_web/live/admin/activity_live.ex:249
+#: lib/vutuv_web/live/account_activity_live.ex:167
+#: lib/vutuv_web/live/admin/activity_live.ex:211
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #: lib/vutuv_web/templates/settings/filters.html.heex:17
@@ -6917,10 +6906,10 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:592
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:670
 #: lib/vutuv_web/live/admin/user_detail_live.ex:69
-#: lib/vutuv_web/live/admin/user_live.ex:27
-#: lib/vutuv_web/live/admin/user_live.ex:189
-#: lib/vutuv_web/live/admin/user_live.ex:190
-#: lib/vutuv_web/live/admin/user_live.ex:197
+#: lib/vutuv_web/live/admin/user_live.ex:28
+#: lib/vutuv_web/live/admin/user_live.ex:164
+#: lib/vutuv_web/live/admin/user_live.ex:165
+#: lib/vutuv_web/live/admin/user_live.ex:172
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:89
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:45
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:90
@@ -7234,7 +7223,7 @@ msgid_plural "minus %{count} groups"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:229
+#: lib/vutuv_web/live/admin/user_live.ex:204
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "open the dev email inbox"
@@ -7290,13 +7279,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2608
+#: lib/vutuv_web/components/ui.ex:2551
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2624
+#: lib/vutuv_web/components/ui.ex:2567
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7565,12 +7554,12 @@ msgstr ""
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:103
+#: lib/vutuv_web/templates/layout/app.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Deployment: %{date} at %{time}"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:103
+#: lib/vutuv_web/templates/layout/app.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Last deployed (Berlin time)"
 msgstr ""
@@ -7768,13 +7757,13 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:832
+#: lib/vutuv_web/live/notification_live/index.ex:867
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:835
+#: lib/vutuv_web/live/notification_live/index.ex:870
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7919,42 +7908,42 @@ msgstr ""
 msgid "Account @%{username} was deleted. A record was emailed to the operator."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:283
+#: lib/vutuv_web/live/admin/user_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "Admins"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:282
+#: lib/vutuv_web/live/admin/user_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:270
+#: lib/vutuv_web/live/admin/user_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "All registrations"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:288
+#: lib/vutuv_web/live/admin/user_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Awaiting verification"
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:214
-#: lib/vutuv_web/live/account_activity_live.ex:234
-#: lib/vutuv_web/live/admin/activity_live.ex:269
-#: lib/vutuv_web/live/admin/user_live.ex:209
+#: lib/vutuv_web/components/browse_table.ex:318
+#: lib/vutuv_web/live/account_activity_live.ex:189
+#: lib/vutuv_web/live/admin/activity_live.ex:231
+#: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:90
+#: lib/vutuv_web/live/admin/user_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Could not verify this member."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/member_badges.ex:24
-#: lib/vutuv_web/live/admin/user_live.ex:295
+#: lib/vutuv_web/live/admin/user_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Deactivated"
 msgstr ""
@@ -7981,17 +7970,17 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:166
 #: lib/vutuv_web/live/admin/organization_live.ex:171
 #: lib/vutuv_web/live/admin/organization_live.ex:195
-#: lib/vutuv_web/live/admin/user_live.ex:290
+#: lib/vutuv_web/live/admin/user_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Frozen"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:87
+#: lib/vutuv_web/live/admin/user_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Identity verified. The member has been emailed."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:285
+#: lib/vutuv_web/live/admin/user_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Identity-verified"
 msgstr ""
@@ -8005,12 +7994,12 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:145
 #: lib/vutuv_web/live/admin/user_detail_live.ex:114
-#: lib/vutuv_web/live/admin/user_live.ex:170
+#: lib/vutuv_web/live/admin/user_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Joined"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:385
+#: lib/vutuv_web/live/admin/user_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Mark this member's identity as verified? They will be emailed."
 msgstr ""
@@ -8021,12 +8010,12 @@ msgstr ""
 msgid "No accounts match your search."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:308
+#: lib/vutuv_web/live/admin/user_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "No members match your filters."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:267
+#: lib/vutuv_web/live/admin/user_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Not confirmed"
 msgstr ""
@@ -8042,17 +8031,17 @@ msgstr ""
 msgid "PIN expired"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:265
+#: lib/vutuv_web/live/admin/user_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2611
+#: lib/vutuv_web/components/ui.ex:2554
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:262
+#: lib/vutuv_web/live/admin/user_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr ""
@@ -8062,7 +8051,7 @@ msgstr ""
 msgid "Search and delete"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:213
+#: lib/vutuv_web/live/admin/user_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Search by name, @handle or email, filter and sort. The list updates as you type, and the default shows PIN-registered members, newest first."
 msgstr ""
@@ -8078,13 +8067,13 @@ msgid "Type a name, @handle or email to find the account to delete."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_detail_live.ex:99
-#: lib/vutuv_web/live/admin/user_live.ex:358
+#: lib/vutuv_web/live/admin/user_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Unconfirmed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/member_badges.ex:25
-#: lib/vutuv_web/live/admin/user_live.ex:298
+#: lib/vutuv_web/live/admin/user_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Unreachable"
 msgstr ""
@@ -8096,14 +8085,14 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:226
+#: lib/vutuv_web/controllers/user_controller.ex:222
 #, elixir-autogen, elixir-format
 msgid "Your verified badge was removed because you changed your name, gender or date of birth. We re-check identity against those details so members can trust verified profiles and nobody can set up a fake verified account. An admin can verify you again anytime."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/activity_live.ex:222
+#: lib/vutuv_web/live/admin/activity_live.ex:184
 #: lib/vutuv_web/live/admin/user_delete_live.ex:127
-#: lib/vutuv_web/live/admin/user_live.ex:253
+#: lib/vutuv_web/live/admin/user_live.ex:228
 #: lib/vutuv_web/templates/admin/account/index.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "name, @handle or email"
@@ -8182,7 +8171,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3418
+#: lib/vutuv_web/components/ui.ex:3361
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8236,7 +8225,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3521
+#: lib/vutuv_web/components/ui.ex:3464
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8265,7 +8254,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3445
+#: lib/vutuv_web/components/ui.ex:3388
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8356,12 +8345,12 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1226
+#: lib/vutuv_web/live/user_profile_live.ex:1294
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2880
+#: lib/vutuv_web/components/ui.ex:2823
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8382,7 +8371,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:99
-#: lib/vutuv_web/templates/user/show.html.heex:1282
+#: lib/vutuv_web/templates/user/show.html.heex:1289
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8442,13 +8431,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3406
+#: lib/vutuv_web/components/ui.ex:3349
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3517
+#: lib/vutuv_web/components/ui.ex:3460
 #: lib/vutuv_web/controllers/settings_controller.ex:114
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8460,9 +8449,9 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3508
+#: lib/vutuv_web/components/ui.ex:3451
 #: lib/vutuv_web/controllers/settings_controller.ex:97
-#: lib/vutuv_web/live/account_activity_live.ex:365
+#: lib/vutuv_web/live/account_activity_live.ex:310
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/totp/new.html.heex:5
@@ -8470,7 +8459,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3525
+#: lib/vutuv_web/components/ui.ex:3468
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8482,7 +8471,7 @@ msgstr ""
 msgid "The file is in JSON format and includes your profile, posts, messages and settings. It contains private data, so store it carefully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:250
+#: lib/vutuv_web/controllers/user_controller.ex:246
 #, elixir-autogen, elixir-format
 msgid "Please type your username exactly as shown to confirm the deletion."
 msgstr ""
@@ -8492,13 +8481,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1135
-#: lib/vutuv_web/live/post_live/feed.ex:1136
+#: lib/vutuv_web/live/post_live/feed.ex:1144
+#: lib/vutuv_web/live/post_live/feed.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1130
+#: lib/vutuv_web/live/post_live/feed.ex:1139
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8563,7 +8552,7 @@ msgstr ""
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
-#: lib/vutuv_web/templates/layout/app.html.heex:75
+#: lib/vutuv_web/templates/layout/app.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Member directory"
 msgstr ""
@@ -8598,7 +8587,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:767
+#: lib/vutuv_web/components/ui.ex:776
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8693,19 +8682,19 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:501
 #: lib/vutuv_web/agent_docs/text.ex:467
 #: lib/vutuv_web/agent_docs/text.ex:471
-#: lib/vutuv_web/components/ui.ex:3498
+#: lib/vutuv_web/components/ui.ex:3441
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:200
 #: lib/vutuv_web/controllers/settings_controller.ex:267
-#: lib/vutuv_web/live/fediverse_followers_live.ex:127
-#: lib/vutuv_web/live/fediverse_following_live.ex:254
+#: lib/vutuv_web/live/fediverse_followers_live.ex:109
+#: lib/vutuv_web/live/fediverse_following_live.ex:239
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:312
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:876
-#: lib/vutuv_web/templates/user/show.html.heex:1187
+#: lib/vutuv_web/templates/user/show.html.heex:882
+#: lib/vutuv_web/templates/user/show.html.heex:1194
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8759,19 +8748,19 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:24
+#: lib/vutuv_web/views/work_experience_html.ex:25
 #, elixir-autogen, elixir-format
 msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
 #: lib/vutuv_web/agent_docs/markdown.ex:658
-#: lib/vutuv_web/views/work_experience_html.ex:26
+#: lib/vutuv_web/views/work_experience_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Internship"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:36
+#: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Internships"
 msgstr ""
@@ -8781,14 +8770,14 @@ msgstr ""
 msgid "On that page, select \"Download larger data archive\" (profile, positions, volunteering, education, skills)."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:34
+#: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Professional Experience"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:659
-#: lib/vutuv_web/views/work_experience_html.ex:30
-#: lib/vutuv_web/views/work_experience_html.ex:37
+#: lib/vutuv_web/views/work_experience_html.ex:31
+#: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Volunteering & hobbies"
 msgstr ""
@@ -8812,19 +8801,19 @@ msgstr ""
 msgid "Your profile as a CV"
 msgstr ""
 
-#: lib/vutuv_web/views/education_html.ex:28
+#: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Higher Education"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:696
-#: lib/vutuv_web/views/education_html.ex:30
+#: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:695
-#: lib/vutuv_web/views/education_html.ex:29
+#: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
 msgstr ""
@@ -8844,7 +8833,7 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:801
+#: lib/vutuv_web/components/ui.ex:810
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
@@ -8883,7 +8872,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:811
+#: lib/vutuv_web/components/ui.ex:820
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8915,7 +8904,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:803
+#: lib/vutuv_web/components/ui.ex:812
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -8936,15 +8925,15 @@ msgid "The CV of %{name} on vutuv: work experience, education and skills to view
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:657
-#: lib/vutuv_web/views/work_experience_html.ex:25
-#: lib/vutuv_web/views/work_experience_html.ex:35
+#: lib/vutuv_web/views/work_experience_html.ex:26
+#: lib/vutuv_web/views/work_experience_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:660
-#: lib/vutuv_web/views/work_experience_html.ex:31
-#: lib/vutuv_web/views/work_experience_html.ex:38
+#: lib/vutuv_web/views/work_experience_html.ex:32
+#: lib/vutuv_web/views/work_experience_html.ex:39
 #, elixir-autogen, elixir-format
 msgid "Other activities"
 msgstr ""
@@ -8971,14 +8960,12 @@ msgstr ""
 msgid "Choose automatically instead"
 msgstr ""
 
-#: lib/vutuv_web/templates/education/card_list.html.heex:93
-#: lib/vutuv_web/views/work_experience_html.ex:682
+#: lib/vutuv_web/views/user_helpers.ex:378
 #, elixir-autogen, elixir-format
 msgid "Show at top of profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/education/card_list.html.heex:84
-#: lib/vutuv_web/views/work_experience_html.ex:673
+#: lib/vutuv_web/views/user_helpers.ex:369
 #, elixir-autogen, elixir-format
 msgid "Shown at the top of your profile"
 msgstr ""
@@ -9073,8 +9060,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1198
-#: lib/vutuv_web/components/ui.ex:1199
+#: lib/vutuv_web/components/ui.ex:1207
+#: lib/vutuv_web/components/ui.ex:1208
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:64
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9515,18 +9502,18 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:892
+#: lib/vutuv/accounts/user.ex:900
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:41
+#: lib/vutuv_web/views/user_helpers.ex:48
 #, elixir-autogen, elixir-format
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:889
+#: lib/vutuv/accounts/user.ex:897
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9641,7 +9628,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3422
+#: lib/vutuv_web/components/ui.ex:3365
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -9773,8 +9760,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1111
-#: lib/vutuv_web/templates/user/show.html.heex:1112
+#: lib/vutuv_web/templates/user/show.html.heex:1117
+#: lib/vutuv_web/templates/user/show.html.heex:1118
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9958,7 +9945,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:131
 #: lib/vutuv_web/templates/totp/new.html.heex:58
-#: lib/vutuv_web/templates/user/show.html.heex:912
+#: lib/vutuv_web/templates/user/show.html.heex:918
 #: lib/vutuv_web/templates/username/new.html.heex:27
 #: lib/vutuv_web/templates/username/new.html.heex:114
 #, elixir-autogen, elixir-format
@@ -9969,8 +9956,8 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:134
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
-#: lib/vutuv_web/templates/user/show.html.heex:911
-#: lib/vutuv_web/templates/user/show.html.heex:915
+#: lib/vutuv_web/templates/user/show.html.heex:917
+#: lib/vutuv_web/templates/user/show.html.heex:921
 #: lib/vutuv_web/templates/username/new.html.heex:26
 #: lib/vutuv_web/templates/username/new.html.heex:30
 #: lib/vutuv_web/templates/username/new.html.heex:113
@@ -10047,7 +10034,7 @@ msgstr ""
 msgid "Account removed"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:104
+#: lib/vutuv_web/live/admin/user_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Account restored. The member can sign in again."
 msgstr ""
@@ -10062,7 +10049,7 @@ msgstr ""
 msgid "Clear-cut spam or abuse?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:107
+#: lib/vutuv_web/live/admin/user_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Could not restore this member."
 msgstr ""
@@ -10087,17 +10074,17 @@ msgstr ""
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:301
+#: lib/vutuv_web/live/admin/user_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Removed as spam"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:399
+#: lib/vutuv_web/live/admin/user_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Restore"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:396
+#: lib/vutuv_web/live/admin/user_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Restore this account so the member can sign in again?"
 msgstr ""
@@ -10430,7 +10417,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1256
+#: lib/vutuv_web/templates/user/show.html.heex:1263
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10671,12 +10658,12 @@ msgstr ""
 msgid "Separate tags with a comma. A tag may be several words long, like Ruby on Rails."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:426
+#: lib/vutuv_web/views/work_experience_html.ex:428
 #, elixir-autogen, elixir-format
 msgid "%{n}m"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:427
+#: lib/vutuv_web/views/work_experience_html.ex:429
 #, elixir-autogen, elixir-format
 msgid "%{n}y"
 msgstr ""
@@ -10810,7 +10797,7 @@ msgid "Preference defaults"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_detail_live.ex:167
-#: lib/vutuv_web/live/admin/user_live.ex:378
+#: lib/vutuv_web/live/admin/user_live.ex:349
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Preferences"
@@ -11014,19 +11001,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:930
+#: lib/vutuv/accounts/user.ex:938
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:935
+#: lib/vutuv/accounts/user.ex:943
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:933
+#: lib/vutuv/accounts/user.ex:941
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
@@ -11285,7 +11272,7 @@ msgstr ""
 msgid "Remove logo"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:91
+#: lib/vutuv_web/live/organization_live/index.ex:83
 #, elixir-autogen, elixir-format
 msgid "Search by name or city"
 msgstr ""
@@ -11914,8 +11901,8 @@ msgstr ""
 msgid "Claim a short @handle so this organization has its own root URL, like a member profile. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:78
-#: lib/vutuv_web/live/organization_live/index.ex:109
+#: lib/vutuv_web/live/organization_live/index.ex:70
+#: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:26
 #: lib/vutuv_web/live/organization_live/new.ex:80
 #: lib/vutuv_web/templates/settings/organizations.html.heex:87
@@ -11979,12 +11966,12 @@ msgstr ""
 msgid "No organization pages match."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:100
+#: lib/vutuv_web/live/organization_live/index.ex:92
 #, elixir-autogen, elixir-format
 msgid "No organization pages yet. Be the first to add yours."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:102
+#: lib/vutuv_web/live/organization_live/index.ex:94
 #, elixir-autogen, elixir-format
 msgid "No organizations found for %{term}."
 msgstr ""
@@ -12043,7 +12030,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:954
+#: lib/vutuv_web/live/notification_live/index.ex:989
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12054,13 +12041,13 @@ msgid "Organization unfrozen."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:3434
+#: lib/vutuv_web/components/ui.ex:3377
 #: lib/vutuv_web/controllers/settings_controller.ex:165
-#: lib/vutuv_web/live/organization_live/index.ex:29
-#: lib/vutuv_web/live/organization_live/index.ex:69
+#: lib/vutuv_web/live/organization_live/index.ex:30
+#: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:455
 #: lib/vutuv_web/live/shell_live.ex:566
-#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/layout/app.html.heex:83
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Organizations"
@@ -12081,7 +12068,7 @@ msgstr ""
 msgid "Please log in to claim an organization page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:83
+#: lib/vutuv_web/live/organization_live/index.ex:75
 #, elixir-autogen, elixir-format
 msgid "Search organizations"
 msgstr ""
@@ -12146,22 +12133,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1151
+#: lib/vutuv_web/live/notification_live/index.ex:1186
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1148
+#: lib/vutuv_web/live/notification_live/index.ex:1183
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1145
+#: lib/vutuv_web/live/notification_live/index.ex:1180
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1142
+#: lib/vutuv_web/live/notification_live/index.ex:1177
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12360,7 +12347,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:904
+#: lib/vutuv/accounts/user.ex:912
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12387,7 +12374,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:458
 #: lib/vutuv_web/live/shell_live.ex:457
-#: lib/vutuv_web/templates/layout/app.html.heex:77
+#: lib/vutuv_web/templates/layout/app.html.heex:81
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12480,7 +12467,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:903
+#: lib/vutuv/accounts/user.ex:911
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12562,7 +12549,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:905
+#: lib/vutuv/accounts/user.ex:913
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:434
 #: lib/vutuv_web/agent_docs/markdown.ex:348
@@ -12820,7 +12807,7 @@ msgstr ""
 msgid "Verification pending"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:71
+#: lib/vutuv_web/live/organization_live/index.ex:63
 #, elixir-autogen, elixir-format
 msgid "Verified pages for companies, associations, schools, public authorities and other groups, not for single people. Every page has a proven web domain, so you know it is really them."
 msgstr ""
@@ -13225,8 +13212,8 @@ msgid "Email me"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:62
-#: lib/vutuv_web/live/account_activity_live.ex:216
-#: lib/vutuv_web/live/admin/activity_live.ex:252
+#: lib/vutuv_web/live/account_activity_live.ex:171
+#: lib/vutuv_web/live/admin/activity_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Everything"
 msgstr ""
@@ -13267,7 +13254,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3483
+#: lib/vutuv_web/components/ui.ex:3426
 #: lib/vutuv_web/controllers/settings_controller.ex:433
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13536,7 +13523,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:952
+#: lib/vutuv_web/live/notification_live/index.ex:987
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13552,32 +13539,32 @@ msgstr ""
 msgid "Profile picture awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:114
+#: lib/vutuv_web/live/post_live/edit.ex:112
 #, elixir-autogen, elixir-format
 msgid "Link preview screenshot"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:135
+#: lib/vutuv_web/live/post_live/edit.ex:133
 #, elixir-autogen, elixir-format
 msgid "Remove screenshot"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:133
+#: lib/vutuv_web/live/post_live/edit.ex:131
 #, elixir-autogen, elixir-format
 msgid "Remove this screenshot from your post?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:76
+#: lib/vutuv_web/live/post_live/edit.ex:74
 #, elixir-autogen, elixir-format
 msgid "Screenshot removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:116
+#: lib/vutuv_web/live/post_live/edit.ex:114
 #, elixir-autogen, elixir-format
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:948
+#: lib/vutuv/accounts/user.ex:956
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13588,19 +13575,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:951
+#: lib/vutuv/accounts/user.ex:959
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:954
+#: lib/vutuv/accounts/user.ex:962
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:945
+#: lib/vutuv/accounts/user.ex:953
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13623,7 +13610,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:955
+#: lib/vutuv_web/live/notification_live/index.ex:990
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13635,7 +13622,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1201
+#: lib/vutuv_web/live/notification_live/index.ex:1236
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13722,16 +13709,16 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3479
+#: lib/vutuv_web/components/ui.ex:3422
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:1081
+#: lib/vutuv_web/live/post_live/feed.ex:1090
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1096
+#: lib/vutuv_web/live/post_live/feed.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13773,7 +13760,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1222
+#: lib/vutuv_web/templates/user/show.html.heex:1229
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13802,7 +13789,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3464
+#: lib/vutuv_web/components/ui.ex:3407
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13810,7 +13797,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1220
+#: lib/vutuv_web/templates/user/show.html.heex:1227
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13830,34 +13817,34 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2966
+#: lib/vutuv_web/components/ui.ex:2909
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:2976
+#: lib/vutuv_web/components/ui.ex:2919
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:956
+#: lib/vutuv_web/live/notification_live/index.ex:991
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1221
+#: lib/vutuv_web/live/notification_live/index.ex:1256
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1213
+#: lib/vutuv_web/live/notification_live/index.ex:1248
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1218
+#: lib/vutuv_web/live/notification_live/index.ex:1253
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13882,7 +13869,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1226
+#: lib/vutuv_web/live/notification_live/index.ex:1261
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -13919,7 +13906,7 @@ msgstr ""
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:441
+#: lib/vutuv_web/live/fediverse_account_live.ex:448
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Look up"
@@ -13997,7 +13984,7 @@ msgstr ""
 msgid "Qualification"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:646
+#: lib/vutuv_web/views/work_experience_html.ex:613
 #, elixir-autogen, elixir-format
 msgid "With qualification:"
 msgstr ""
@@ -14012,45 +13999,45 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:824
+#: lib/vutuv_web/live/notification_live/index.ex:859
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:838
+#: lib/vutuv_web/live/notification_live/index.ex:873
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:348
+#: lib/vutuv_web/live/notification_live/index.ex:383
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:363
+#: lib/vutuv_web/live/notification_live/index.ex:398
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:790
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/live/notification_live/index.ex:825
+#: lib/vutuv_web/live/notification_live/index.ex:1069
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:971
+#: lib/vutuv_web/live/notification_live/index.ex:1006
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:966
+#: lib/vutuv_web/live/notification_live/index.ex:1001
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:981
+#: lib/vutuv_web/live/notification_live/index.ex:1016
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -14060,12 +14047,12 @@ msgstr ""
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1332
+#: lib/vutuv_web/components/ui.ex:1341
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1336
+#: lib/vutuv_web/components/ui.ex:1345
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14285,7 +14272,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:760
+#: lib/vutuv_web/live/notification_live/index.ex:795
 #, elixir-autogen, elixir-format
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
@@ -14295,17 +14282,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1175
+#: lib/vutuv_web/live/notification_live/index.ex:1210
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:945
+#: lib/vutuv_web/live/notification_live/index.ex:980
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1056
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14324,29 +14311,29 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:946
+#: lib/vutuv_web/live/notification_live/index.ex:981
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1125
+#: lib/vutuv_web/live/notification_live/index.ex:1160
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1000
-#: lib/vutuv_web/live/post_live/edit.ex:59
+#: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1003
-#: lib/vutuv_web/live/post_live/edit.ex:61
+#: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:100
+#: lib/vutuv_web/live/post_live/edit.ex:98
 #, elixir-autogen, elixir-format
 msgid "A post stays editable for %{minutes} minutes, and only until someone likes, reposts or answers it. You can delete it at any time."
 msgstr ""
@@ -14409,7 +14396,7 @@ msgstr ""
 msgid "No accounts are currently frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:309
+#: lib/vutuv_web/live/post_live/thread.ex:352
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr ""
@@ -14448,7 +14435,7 @@ msgstr[1] ""
 msgid "This page is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:301
+#: lib/vutuv_web/live/post_live/thread.ex:344
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr ""
@@ -14610,7 +14597,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:233
+#: lib/vutuv_web/live/post_live/feed.ex:271
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14625,7 +14612,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3475
+#: lib/vutuv_web/components/ui.ex:3418
 #: lib/vutuv_web/controllers/settings_controller.ex:513
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14643,7 +14630,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:242
+#: lib/vutuv_web/live/post_live/feed.ex:280
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14673,7 +14660,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:536
+#: lib/vutuv_web/live/notification_live/index.ex:571
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14724,7 +14711,7 @@ msgstr ""
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:531
+#: lib/vutuv_web/live/notification_live/index.ex:566
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -14809,9 +14796,9 @@ msgstr ""
 msgid "No server is blocked."
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:185
-#: lib/vutuv_web/live/fediverse_followers_live.ex:113
-#: lib/vutuv_web/live/fediverse_following_live.ex:240
+#: lib/vutuv_web/components/browse_table.ex:289
+#: lib/vutuv_web/live/fediverse_followers_live.ex:95
+#: lib/vutuv_web/live/fediverse_following_live.ex:225
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:96
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:147
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:191
@@ -14871,8 +14858,8 @@ msgid "Reactions from other networks"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:45
-#: lib/vutuv_web/live/fediverse_followers_live.ex:124
-#: lib/vutuv_web/live/fediverse_followers_live.ex:134
+#: lib/vutuv_web/live/fediverse_followers_live.ex:106
+#: lib/vutuv_web/live/fediverse_followers_live.ex:116
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Followers from other networks"
@@ -14920,7 +14907,7 @@ msgstr ""
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:150
+#: lib/vutuv_web/live/fediverse_followers_live.ex:127
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
@@ -14994,8 +14981,8 @@ msgstr ""
 msgid "Send your Fediverse followers to another account. They are asked to follow it instead, and vutuv stops federating your new posts. Your vutuv profile stays exactly as it is, and nothing is deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:224
-#: lib/vutuv_web/live/fediverse_following_live.ex:460
+#: lib/vutuv_web/live/fediverse_followers_live.ex:201
+#: lib/vutuv_web/live/fediverse_following_live.ex:431
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Back to Fediverse settings"
@@ -15193,27 +15180,27 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:880
+#: lib/vutuv_web/templates/user/show.html.heex:886
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:896
+#: lib/vutuv_web/templates/user/show.html.heex:902
 #, elixir-autogen, elixir-format
 msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:933
+#: lib/vutuv_web/templates/user/show.html.heex:939
 #, elixir-autogen, elixir-format
 msgid "Follow from your own server"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:944
+#: lib/vutuv_web/templates/user/show.html.heex:950
 #, elixir-autogen, elixir-format
 msgid "@you@example.social"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:952
+#: lib/vutuv_web/templates/user/show.html.heex:958
 #, elixir-autogen, elixir-format
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr ""
@@ -15223,22 +15210,22 @@ msgstr ""
 msgid "This profile is not on the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:72
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "That is not a Fediverse address. It looks like @you@example.social."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:76
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:83
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:143
 #, elixir-autogen, elixir-format
 msgid "%{server} did not answer. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:94
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:154
 #, elixir-autogen, elixir-format
 msgid "Your server"
 msgstr ""
@@ -15249,282 +15236,282 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3407
+#: lib/vutuv_web/components/ui.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3408
+#: lib/vutuv_web/components/ui.ex:3351
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3412
+#: lib/vutuv_web/components/ui.ex:3355
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3415
+#: lib/vutuv_web/components/ui.ex:3358
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3416
+#: lib/vutuv_web/components/ui.ex:3359
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3419
+#: lib/vutuv_web/components/ui.ex:3362
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3420
+#: lib/vutuv_web/components/ui.ex:3363
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3423
+#: lib/vutuv_web/components/ui.ex:3366
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3424
+#: lib/vutuv_web/components/ui.ex:3367
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3426
+#: lib/vutuv_web/components/ui.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3427
+#: lib/vutuv_web/components/ui.ex:3370
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3428
+#: lib/vutuv_web/components/ui.ex:3371
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3431
+#: lib/vutuv_web/components/ui.ex:3374
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3432
+#: lib/vutuv_web/components/ui.ex:3375
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3435
+#: lib/vutuv_web/components/ui.ex:3378
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3436
+#: lib/vutuv_web/components/ui.ex:3379
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3439
+#: lib/vutuv_web/components/ui.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3442
+#: lib/vutuv_web/components/ui.ex:3385
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3443
+#: lib/vutuv_web/components/ui.ex:3386
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3446
+#: lib/vutuv_web/components/ui.ex:3389
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3447
+#: lib/vutuv_web/components/ui.ex:3390
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3450
+#: lib/vutuv_web/components/ui.ex:3393
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3451
+#: lib/vutuv_web/components/ui.ex:3394
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3453
+#: lib/vutuv_web/components/ui.ex:3396
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3454
+#: lib/vutuv_web/components/ui.ex:3397
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3455
+#: lib/vutuv_web/components/ui.ex:3398
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3457
+#: lib/vutuv_web/components/ui.ex:3400
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3458
+#: lib/vutuv_web/components/ui.ex:3401
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3460
+#: lib/vutuv_web/components/ui.ex:3403
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3465
+#: lib/vutuv_web/components/ui.ex:3408
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3466
+#: lib/vutuv_web/components/ui.ex:3409
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3469
+#: lib/vutuv_web/components/ui.ex:3412
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3472
+#: lib/vutuv_web/components/ui.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3473
+#: lib/vutuv_web/components/ui.ex:3416
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3476
+#: lib/vutuv_web/components/ui.ex:3419
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3477
+#: lib/vutuv_web/components/ui.ex:3420
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3480
+#: lib/vutuv_web/components/ui.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3481
+#: lib/vutuv_web/components/ui.ex:3424
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3484
+#: lib/vutuv_web/components/ui.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3485
+#: lib/vutuv_web/components/ui.ex:3428
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3491
+#: lib/vutuv_web/components/ui.ex:3434
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3492
+#: lib/vutuv_web/components/ui.ex:3435
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3495
+#: lib/vutuv_web/components/ui.ex:3438
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3496
+#: lib/vutuv_web/components/ui.ex:3439
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3509
+#: lib/vutuv_web/components/ui.ex:3452
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3510
+#: lib/vutuv_web/components/ui.ex:3453
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3518
+#: lib/vutuv_web/components/ui.ex:3461
 #, elixir-autogen, elixir-format
 msgid "Interface language, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3519
+#: lib/vutuv_web/components/ui.ex:3462
 #, elixir-autogen, elixir-format
 msgid "german english locale translation map font length hyphenation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3522
+#: lib/vutuv_web/components/ui.ex:3465
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3523
+#: lib/vutuv_web/components/ui.ex:3466
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3526
+#: lib/vutuv_web/components/ui.ex:3469
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3527
+#: lib/vutuv_web/components/ui.ex:3470
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3530
+#: lib/vutuv_web/components/ui.ex:3473
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3531
+#: lib/vutuv_web/components/ui.ex:3474
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3534
+#: lib/vutuv_web/components/ui.ex:3477
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3535
+#: lib/vutuv_web/components/ui.ex:3478
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15672,7 +15659,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:972
 #: lib/vutuv_web/components/post_components.ex:1145
-#: lib/vutuv_web/live/fediverse_account_live.ex:314
+#: lib/vutuv_web/live/fediverse_account_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
@@ -15694,12 +15681,12 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:948
+#: lib/vutuv_web/live/notification_live/index.ex:983
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:95
+#: lib/vutuv_web/live/post_live/thread.ex:138
 #, elixir-autogen, elixir-format
 msgid "Reply removed."
 msgstr ""
@@ -15715,7 +15702,7 @@ msgid "Reported as not appropriate"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:882
-#: lib/vutuv_web/live/notification_live/index.ex:498
+#: lib/vutuv_web/live/notification_live/index.ex:533
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -15735,12 +15722,12 @@ msgstr ""
 msgid "Taken down"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:104
+#: lib/vutuv_web/live/post_live/thread.ex:147
 #, elixir-autogen, elixir-format
 msgid "Thank you. The reply was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:213
+#: lib/vutuv_web/live/post_live/thread.ex:256
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr ""
@@ -15758,15 +15745,15 @@ msgstr ""
 msgid "What"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:170
+#: lib/vutuv_web/live/fediverse_account_live.ex:168
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:139
-#: lib/vutuv_web/live/post_live/feed.ex:361
-#: lib/vutuv_web/live/post_live/thread.ex:209
+#: lib/vutuv_web/live/post_live/feed.ex:399
+#: lib/vutuv_web/live/post_live/thread.ex:252
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1128
+#: lib/vutuv_web/live/notification_live/index.ex:1163
 #, elixir-autogen, elixir-format
 msgid "replied to your post from another network."
 msgstr ""
@@ -15776,49 +15763,47 @@ msgstr ""
 msgid "All followers"
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:189
+#: lib/vutuv_web/components/browse_table.ex:293
 #, elixir-autogen, elixir-format
 msgid "All servers"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:114
+#: lib/vutuv_web/live/fediverse_followers_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Following since"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:217
+#: lib/vutuv_web/live/fediverse_followers_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "How this list keeps itself honest"
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:176
+#: lib/vutuv_web/components/browse_table.ex:280
 #, elixir-autogen, elixir-format
 msgid "name, handle or server"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:162
+#: lib/vutuv_web/live/fediverse_followers_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "No follower matches that. Try a shorter search, or clear the filters."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:190
+#: lib/vutuv_web/live/fediverse_followers_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Show only followers from this server"
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:293
-#: lib/vutuv_web/live/account_activity_live.ex:331
-#: lib/vutuv_web/live/admin/activity_live.ex:357
+#: lib/vutuv_web/components/browse_table.ex:400
 #, elixir-autogen, elixir-format
 msgid "Showing %{first}-%{last} of %{total}."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:143
+#: lib/vutuv_web/live/fediverse_followers_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Everyone on another network who follows your vutuv posts. Only you see this list: the followers collection your profile publishes carries the number, never the names."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:219
+#: lib/vutuv_web/live/fediverse_followers_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Accounts that no longer exist on their own server drop off this list by themselves. Names and handles are the ones their server last told us, so a renamed account updates here on its own too."
 msgstr ""
@@ -15973,14 +15958,14 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3512
-#: lib/vutuv_web/live/account_activity_live.ex:40
-#: lib/vutuv_web/live/account_activity_live.ex:154
-#: lib/vutuv_web/live/account_activity_live.ex:155
-#: lib/vutuv_web/live/account_activity_live.ex:160
-#: lib/vutuv_web/live/admin/activity_live.ex:41
-#: lib/vutuv_web/live/admin/activity_live.ex:190
-#: lib/vutuv_web/live/admin/activity_live.ex:191
+#: lib/vutuv_web/components/ui.ex:3455
+#: lib/vutuv_web/live/account_activity_live.ex:42
+#: lib/vutuv_web/live/account_activity_live.ex:114
+#: lib/vutuv_web/live/account_activity_live.ex:115
+#: lib/vutuv_web/live/account_activity_live.ex:120
+#: lib/vutuv_web/live/admin/activity_live.ex:42
+#: lib/vutuv_web/live/admin/activity_live.ex:152
+#: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Account activity"
@@ -16031,7 +16016,7 @@ msgstr ""
 msgid "Authenticator app turned off"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/activity_live.ex:345
+#: lib/vutuv_web/live/admin/activity_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "By %{name}"
 msgstr ""
@@ -16041,8 +16026,8 @@ msgstr ""
 msgid "CV update notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:294
-#: lib/vutuv_web/live/admin/activity_live.ex:338
+#: lib/vutuv_web/live/account_activity_live.ex:245
+#: lib/vutuv_web/live/admin/activity_live.ex:295
 #: lib/vutuv_web/templates/admin/experiment/index.html.heex:59
 #: lib/vutuv_web/templates/admin/experiment/index.html.heex:104
 #, elixir-autogen, elixir-format
@@ -16084,7 +16069,7 @@ msgstr ""
 msgid "Endorsement emails"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:169
+#: lib/vutuv_web/live/account_activity_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Every change to your account: what changed, exactly when, from which device, and how it was confirmed. If a line surprises you, follow the link at the end of it."
 msgstr ""
@@ -16124,7 +16109,7 @@ msgstr ""
 msgid "Identity verified"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:349
+#: lib/vutuv_web/live/account_activity_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "If something here was not you"
 msgstr ""
@@ -16134,7 +16119,7 @@ msgstr ""
 msgid "Import applied"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:362
+#: lib/vutuv_web/live/account_activity_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "It is part of your data download, and it is deleted with your account."
 msgstr ""
@@ -16164,30 +16149,30 @@ msgstr ""
 msgid "New follower emails"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/activity_live.ex:277
+#: lib/vutuv_web/live/admin/activity_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "No account activity has been recorded yet."
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:303
+#: lib/vutuv_web/live/account_activity_live.ex:254
 #: lib/vutuv_web/templates/settings/security.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "Not by you"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:322
+#: lib/vutuv_web/live/account_activity_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Not you?"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:176
+#: lib/vutuv_web/live/account_activity_live.ex:131
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. The next time you sign in or change a setting, it will be listed here."
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:243
-#: lib/vutuv_web/live/admin/activity_live.ex:275
-#: lib/vutuv_web/live/fediverse_following_live.ex:342
+#: lib/vutuv_web/live/account_activity_live.ex:198
+#: lib/vutuv_web/live/admin/activity_live.ex:237
+#: lib/vutuv_web/live/fediverse_following_live.ex:313
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16252,12 +16237,12 @@ msgstr ""
 msgid "Settings changed by support"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/activity_live.ex:314
+#: lib/vutuv_web/live/admin/activity_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Show only this member"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:351
+#: lib/vutuv_web/live/account_activity_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Sign every other device out, then check which passkeys, codes and email addresses your account has. All of it is on the sign-in & security page."
 msgstr ""
@@ -16272,7 +16257,7 @@ msgstr ""
 msgid "Signed out"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:356
+#: lib/vutuv_web/live/account_activity_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "This log keeps one day of history."
 msgid_plural "This log keeps %{formatted} days of history."
@@ -16304,7 +16289,7 @@ msgstr ""
 msgid "Visibility settings changed"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:266
+#: lib/vutuv_web/live/account_activity_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Was this you?"
 msgstr ""
@@ -16319,18 +16304,18 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3513
+#: lib/vutuv_web/components/ui.ex:3456
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:127
-#: lib/vutuv_web/live/admin/activity_live.ex:165
+#: lib/vutuv_web/live/account_activity_live.ex:104
+#: lib/vutuv_web/live/admin/activity_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "What happened"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/activity_live.ex:379
+#: lib/vutuv_web/live/admin/activity_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "a deleted account"
 msgstr ""
@@ -16355,7 +16340,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3515
+#: lib/vutuv_web/components/ui.ex:3458
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16390,19 +16375,19 @@ msgstr ""
 msgid "with your authenticator app"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:265
-#: lib/vutuv_web/live/admin/activity_live.ex:296
+#: lib/vutuv_web/live/account_activity_live.ex:216
+#: lib/vutuv_web/live/admin/activity_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Device"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/activity_live.ex:197
+#: lib/vutuv_web/live/admin/activity_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "What changed on which account, when, from which device and how it was confirmed - the same log every member sees for themselves. Opening it is recorded in your own activity log."
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:203
-#: lib/vutuv_web/live/admin/activity_live.ex:240
+#: lib/vutuv_web/live/account_activity_live.ex:158
+#: lib/vutuv_web/live/admin/activity_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "device or detail"
 msgstr ""
@@ -16427,17 +16412,17 @@ msgstr ""
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:247
+#: lib/vutuv_web/controllers/post_controller.ex:257
 #, elixir-autogen, elixir-format
 msgid "Pinned to the top of your profile."
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:243
+#: lib/vutuv_web/controllers/post_controller.ex:253
 #, elixir-autogen, elixir-format
 msgid "Pinned to the top of your profile. The post pinned before it is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:264
+#: lib/vutuv_web/controllers/post_controller.ex:274
 #, elixir-autogen, elixir-format
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
@@ -16471,7 +16456,7 @@ msgstr ""
 msgid "Apply these settings to all photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:96
+#: lib/vutuv_web/live/post_live/remote_reply.ex:91
 #, elixir-autogen, elixir-format
 msgid "Back to the conversation"
 msgstr ""
@@ -16634,7 +16619,7 @@ msgstr ""
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:91
+#: lib/vutuv_web/live/post_live/remote_reply.ex:86
 #, elixir-autogen, elixir-format
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
@@ -16690,8 +16675,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:937
-#: lib/vutuv_web/live/post_live/feed.ex:938
+#: lib/vutuv_web/live/post_live/feed.ex:946
+#: lib/vutuv_web/live/post_live/feed.ex:947
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
@@ -16777,7 +16762,7 @@ msgstr ""
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:949
+#: lib/vutuv_web/live/notification_live/index.ex:984
 #, elixir-autogen, elixir-format
 msgid "Reaction from another network"
 msgstr ""
@@ -16792,21 +16777,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1002
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1010
+#: lib/vutuv_web/live/notification_live/index.ex:1045
 #, elixir-autogen, elixir-format
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:994
+#: lib/vutuv_web/live/notification_live/index.ex:1029
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -16863,10 +16848,10 @@ msgstr ""
 msgid "Photo details"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:447
-#: lib/vutuv_web/live/fediverse_following_live.ex:55
-#: lib/vutuv_web/live/fediverse_following_live.ex:251
-#: lib/vutuv_web/live/fediverse_following_live.ex:264
+#: lib/vutuv_web/live/fediverse_account_live.ex:454
+#: lib/vutuv_web/live/fediverse_following_live.ex:52
+#: lib/vutuv_web/live/fediverse_following_live.ex:236
+#: lib/vutuv_web/live/fediverse_following_live.ex:249
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:422
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
@@ -16888,13 +16873,13 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3499
+#: lib/vutuv_web/components/ui.ex:3442
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:114
-#: lib/vutuv_web/live/fediverse_following_live.ex:207
+#: lib/vutuv_web/live/fediverse_account_live.ex:112
+#: lib/vutuv_web/live/fediverse_following_live.ex:192
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Follow request sent to %{account}."
@@ -16920,14 +16905,9 @@ msgstr ""
 msgid "Manage who you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:274
+#: lib/vutuv_web/live/fediverse_following_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Mastodon and the other networks work like email: an address is enough. Paste one here and vutuv asks that server to let you follow the account."
-msgstr ""
-
-#: lib/vutuv_web/live/fediverse_following_live.ex:301
-#, elixir-autogen, elixir-format
-msgid "Open their profile"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:224
@@ -16935,17 +16915,17 @@ msgstr ""
 msgid "Requested"
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:216
+#: lib/vutuv_web/components/browse_table.ex:320
 #, elixir-autogen, elixir-format
 msgid "Reset sorting"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:309
+#: lib/vutuv_web/live/fediverse_following_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Search for them here"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:371
+#: lib/vutuv_web/live/fediverse_following_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Show only accounts on this server"
 msgstr ""
@@ -16955,12 +16935,12 @@ msgstr ""
 msgid "Sign in to follow this account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:356
+#: lib/vutuv_web/live/fediverse_following_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "State"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:223
+#: lib/vutuv_web/live/fediverse_following_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Stop following %{account}?"
 msgstr ""
@@ -16970,7 +16950,7 @@ msgstr ""
 msgid "That account could not be loaded from its server. Try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:324
+#: lib/vutuv_web/components/fediverse_components.ex:330
 #, elixir-autogen, elixir-format
 msgid "That did not work. Check the address and try again."
 msgstr ""
@@ -16985,11 +16965,6 @@ msgstr ""
 msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:286
-#, elixir-autogen, elixir-format
-msgid "That is an address on this vutuv, not another network."
-msgstr ""
-
 #: lib/vutuv_web/components/fediverse_components.ex:275
 #, elixir-autogen, elixir-format
 msgid "That server answered, but it has no account at that address to follow."
@@ -17001,7 +16976,7 @@ msgstr ""
 msgid "That server did not answer. Check the address, and that the server is online."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:321
+#: lib/vutuv_web/components/fediverse_components.ex:327
 #, elixir-autogen, elixir-format
 msgid "The Fediverse is switched off on this vutuv."
 msgstr ""
@@ -17011,7 +16986,7 @@ msgstr ""
 msgid "The address you brought along is kept here:"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:424
+#: lib/vutuv_web/live/fediverse_following_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "The other server decides. Most accounts accept straight away; one that checks its followers by hand stays on \"Requested\" until somebody there says yes."
 msgstr ""
@@ -17031,18 +17006,18 @@ msgstr ""
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:130
-#: lib/vutuv_web/live/fediverse_following_live.ex:147
+#: lib/vutuv_web/live/fediverse_account_live.ex:128
+#: lib/vutuv_web/live/fediverse_following_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Unfollowed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:421
+#: lib/vutuv_web/live/fediverse_following_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "What following out there means"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:429
+#: lib/vutuv_web/live/fediverse_following_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "Who you follow is yours alone. Your profile publishes how many accounts you follow out there, never which ones."
 msgstr ""
@@ -17052,22 +17027,22 @@ msgstr ""
 msgid "Why is my account on hold?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:226
+#: lib/vutuv_web/live/fediverse_following_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Withdraw your follow request to %{account}?"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:292
+#: lib/vutuv_web/components/fediverse_components.ex:298
 #, elixir-autogen, elixir-format
 msgid "You already follow that account."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:310
+#: lib/vutuv_web/components/fediverse_components.ex:316
 #, elixir-autogen, elixir-format
 msgid "You are following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:300
+#: lib/vutuv_web/components/fediverse_components.ex:306
 #, elixir-autogen, elixir-format
 msgid "You are not taking part in the Fediverse at the moment, so there is no identity to sign the request with. Open the Fediverse settings to switch it on."
 msgstr ""
@@ -17084,12 +17059,12 @@ msgid_plural "You follow %{formatted} accounts on other networks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:306
+#: lib/vutuv_web/components/fediverse_components.ex:312
 #, elixir-autogen, elixir-format
 msgid "You have sent a lot of follow requests in the last hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:316
+#: lib/vutuv_web/components/fediverse_components.ex:322
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so this account no longer acts out there."
 msgstr ""
@@ -17099,12 +17074,12 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3501
+#: lib/vutuv_web/components/ui.ex:3444
 #, elixir-autogen, elixir-format
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:258
+#: lib/vutuv_web/live/fediverse_following_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Accounts followed"
 msgstr ""
@@ -17124,9 +17099,9 @@ msgstr ""
 msgid "Only for this account's followers"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:162
+#: lib/vutuv_web/live/fediverse_account_live.ex:160
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:131
-#: lib/vutuv_web/live/post_live/feed.ex:353
+#: lib/vutuv_web/live/post_live/feed.ex:391
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
@@ -17166,8 +17141,8 @@ msgstr ""
 msgid "Mute %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:411
+#: lib/vutuv_web/live/fediverse_account_live.ex:264
+#: lib/vutuv_web/live/post_live/feed.ex:449
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr ""
@@ -17182,72 +17157,72 @@ msgstr ""
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:440
+#: lib/vutuv_web/live/fediverse_following_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "To show their posts we keep a copy here for up to six months. If the author deletes or edits something, ours follows; and when you stop following an account, its posts are deleted here at once."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:328
+#: lib/vutuv_web/live/fediverse_following_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "You do not follow anybody out there yet. Once you do, what they post appears in your feed among everything else."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:66
+#: lib/vutuv_web/live/fediverse_account_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "%{name} (another network)"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:297
+#: lib/vutuv_web/live/fediverse_account_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "Account on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:431
+#: lib/vutuv_web/live/fediverse_account_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:362
+#: lib/vutuv_web/live/fediverse_account_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:272
+#: lib/vutuv_web/live/fediverse_account_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:267
+#: lib/vutuv_web/live/fediverse_account_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:433
+#: lib/vutuv_web/live/fediverse_account_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:329
+#: lib/vutuv_web/live/fediverse_account_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:416
+#: lib/vutuv_web/live/fediverse_account_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:259
+#: lib/vutuv_web/live/fediverse_account_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts are back in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:426
+#: lib/vutuv_web/live/fediverse_account_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:276
+#: lib/vutuv_web/live/fediverse_account_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr ""
@@ -17424,7 +17399,7 @@ msgstr ""
 msgid "That post is not here any more."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_post_reply.ex:98
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:93
 #, elixir-autogen, elixir-format
 msgid "Back to the feed"
 msgstr ""
@@ -17434,14 +17409,14 @@ msgstr ""
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_post_reply.ex:93
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:88
 #, elixir-autogen, elixir-format
 msgid "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:195
+#: lib/vutuv_web/live/fediverse_account_live.ex:193
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:110
-#: lib/vutuv_web/live/post_live/feed.ex:389
+#: lib/vutuv_web/live/post_live/feed.ex:427
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr ""
@@ -17451,7 +17426,7 @@ msgstr ""
 msgid "Moved"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:217
+#: lib/vutuv_web/live/fediverse_following_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "%{account} moved to another server. Your subscription already went with them — remove this old entry?"
 msgstr ""
@@ -17476,12 +17451,12 @@ msgstr ""
 msgid "People on Mastodon and other independent networks can then follow this profile, and your public posts appear there. What they answer or share comes back and is shown under your posts, by their account address. A reply from there is stored here for up to six months. You can switch all of it off again at any time."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1204
+#: lib/vutuv_web/live/user_profile_live.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Follow %{count} members"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1219
+#: lib/vutuv_web/live/user_profile_live.ex:1287
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
@@ -17728,7 +17703,7 @@ msgstr ""
 msgid "Its author published this post to their followers alone, so vutuv does not keep a copy of it."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:455
+#: lib/vutuv_web/live/fediverse_following_live.ex:426
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "Look up a post by its address"
@@ -17795,7 +17770,7 @@ msgstr ""
 msgid "Turn on Fediverse participation to look up"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:449
+#: lib/vutuv_web/live/fediverse_following_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "Want to answer one particular post rather than follow its author?"
 msgstr ""
@@ -17953,12 +17928,12 @@ msgstr ""
 msgid "Whole photos"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:127
+#: lib/vutuv_web/templates/layout/app.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Send the post or message you are writing"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:188
+#: lib/vutuv_web/templates/layout/app.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "The single-key shortcuts pause while you type, and are off on phones and tablets."
 msgstr ""
@@ -17981,4 +17956,39 @@ msgstr ""
 #: lib/vutuv_web/views/error_html.ex:54
 #, elixir-autogen, elixir-format
 msgid "The most helpful detail in such a report is the exact time of the error. Right now it is %{time}."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_following_live.ex:183
+#, elixir-autogen, elixir-format
+msgid "@%{handle} is on this vutuv, so you now follow them here."
+msgstr ""
+
+#: lib/vutuv_web/components/fediverse_components.ex:287
+#, elixir-autogen, elixir-format
+msgid "That address is on this vutuv, but it names no member here."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:89
+#, elixir-autogen, elixir-format
+msgid "That address is on this vutuv. Sign in and use the Follow button on this profile."
+msgstr ""
+
+#: lib/vutuv_web/components/fediverse_components.ex:292
+#, elixir-autogen, elixir-format
+msgid "That is your own address. You cannot follow yourself."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:111
+#, elixir-autogen, elixir-format
+msgid "That is your own profile. You cannot follow yourself."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:118
+#, elixir-autogen, elixir-format
+msgid "You already follow @%{handle} here."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:104
+#, elixir-autogen, elixir-format
+msgid "You are on this vutuv yourself, so you now follow @%{handle} right here."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -9,14 +9,14 @@
 msgid ""
 msgstr "Language: en\n"
 
-#: lib/vutuv_web/controllers/page_controller.ex:93
-#: lib/vutuv_web/templates/layout/app.html.heex:93
+#: lib/vutuv_web/controllers/page_controller.ex:98
+#: lib/vutuv_web/templates/layout/app.html.heex:97
 #, elixir-autogen
 msgid "About us"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3253
-#: lib/vutuv_web/components/ui.ex:3258
+#: lib/vutuv_web/components/ui.ex:3196
+#: lib/vutuv_web/components/ui.ex:3201
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -35,7 +35,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1376
+#: lib/vutuv_web/templates/user/show.html.heex:1383
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -59,7 +59,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:67
 #: lib/vutuv_web/agent_docs/text.ex:64
-#: lib/vutuv_web/components/ui.ex:3449
+#: lib/vutuv_web/components/ui.ex:3392
 #: lib/vutuv_web/controllers/address_controller.ex:23
 #: lib/vutuv_web/controllers/address_controller.ex:38
 #: lib/vutuv_web/controllers/address_controller.ex:85
@@ -77,8 +77,8 @@ msgstr ""
 msgid "Already a member? Sign in here."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3048
-#: lib/vutuv_web/components/ui.ex:3142
+#: lib/vutuv_web/components/ui.ex:2991
+#: lib/vutuv_web/components/ui.ex:3085
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
 #, elixir-autogen
 msgid "Are you sure?"
@@ -98,13 +98,13 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/templates/user/show.html.heex:1009
+#: lib/vutuv_web/templates/user/show.html.heex:1015
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:110
-#: lib/vutuv_web/components/ui.ex:3042
+#: lib/vutuv_web/components/ui.ex:2985
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:215
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1138
 #: lib/vutuv_web/live/admin/user_delete_live.ex:212
@@ -144,7 +144,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1047
+#: lib/vutuv_web/templates/user/show.html.heex:1053
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -154,7 +154,7 @@ msgid "Couldn't follow back to %{name}."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2182
-#: lib/vutuv_web/components/ui.ex:3145
+#: lib/vutuv_web/components/ui.ex:3088
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:662
@@ -203,7 +203,7 @@ msgid "Download"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2147
-#: lib/vutuv_web/components/ui.ex:3136
+#: lib/vutuv_web/components/ui.ex:3079
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:149
@@ -216,7 +216,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1032
+#: lib/vutuv_web/templates/user/show.html.heex:1038
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -289,7 +289,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:37
 #: lib/vutuv_web/agent_docs/text.ex:34
-#: lib/vutuv_web/components/ui.ex:3414
+#: lib/vutuv_web/components/ui.ex:3357
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
@@ -317,8 +317,8 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:506
 #: lib/vutuv_web/agent_docs/text.ex:476
 #: lib/vutuv_web/controllers/follower_controller.ex:23
-#: lib/vutuv_web/live/fediverse_followers_live.ex:128
-#: lib/vutuv_web/live/notification_live/index.ex:882
+#: lib/vutuv_web/live/fediverse_followers_live.ex:110
+#: lib/vutuv_web/live/notification_live/index.ex:917
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:148
 #: lib/vutuv_web/templates/follower/index.html.heex:4
 #: lib/vutuv_web/templates/follower/index.html.heex:9
@@ -329,16 +329,16 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:507
 #: lib/vutuv_web/agent_docs/text.ex:477
 #: lib/vutuv_web/components/fediverse_components.ex:223
-#: lib/vutuv_web/components/ui.ex:1729
-#: lib/vutuv_web/components/ui.ex:1754
-#: lib/vutuv_web/components/ui.ex:1757
-#: lib/vutuv_web/components/ui.ex:1764
-#: lib/vutuv_web/components/ui.ex:1767
-#: lib/vutuv_web/components/ui.ex:1825
+#: lib/vutuv_web/components/ui.ex:1738
+#: lib/vutuv_web/components/ui.ex:1763
+#: lib/vutuv_web/components/ui.ex:1766
+#: lib/vutuv_web/components/ui.ex:1773
+#: lib/vutuv_web/components/ui.ex:1776
+#: lib/vutuv_web/components/ui.ex:1834
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:837
+#: lib/vutuv_web/templates/user/show.html.heex:840
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -353,7 +353,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:67
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:1004
+#: lib/vutuv_web/templates/user/show.html.heex:1010
 #: lib/vutuv_web/views/account_event_text.ex:153
 #, elixir-autogen
 msgid "Gender"
@@ -371,7 +371,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:4
-#: lib/vutuv_web/templates/layout/app.html.heex:117
+#: lib/vutuv_web/templates/layout/app.html.heex:121
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:2
 #, elixir-autogen
 msgid "Home"
@@ -466,7 +466,7 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:806
+#: lib/vutuv_web/live/notification_live/index.ex:841
 #, elixir-autogen
 msgid "More"
 msgstr ""
@@ -483,7 +483,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:580
+#: lib/vutuv_web/live/notification_live/index.ex:615
 #: lib/vutuv_web/templates/access_token/new.html.heex:3
 #: lib/vutuv_web/templates/ad/new.html.heex:5
 #: lib/vutuv_web/templates/admin/newsletter/new.html.heex:3
@@ -622,7 +622,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3041
+#: lib/vutuv_web/components/ui.ex:2984
 #: lib/vutuv_web/live/organization_live/edit.ex:341
 #: lib/vutuv_web/live/post_live/composer.ex:1780
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:71
@@ -641,11 +641,11 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:167
-#: lib/vutuv_web/live/account_activity_live.ex:194
-#: lib/vutuv_web/live/admin/activity_live.ex:231
+#: lib/vutuv_web/components/browse_table.ex:271
+#: lib/vutuv_web/live/account_activity_live.ex:149
+#: lib/vutuv_web/live/admin/activity_live.ex:193
 #: lib/vutuv_web/live/admin/user_delete_live.ex:118
-#: lib/vutuv_web/live/admin/user_live.ex:244
+#: lib/vutuv_web/live/admin/user_live.ex:219
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:37
 #: lib/vutuv_web/live/search_live.ex:378
@@ -654,7 +654,7 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
-#: lib/vutuv_web/templates/layout/app.html.heex:122
+#: lib/vutuv_web/templates/layout/app.html.heex:126
 #, elixir-autogen
 msgid "Search"
 msgstr ""
@@ -694,13 +694,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1160
+#: lib/vutuv_web/templates/user/show.html.heex:1167
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1162
+#: lib/vutuv_web/templates/user/show.html.heex:1169
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -742,8 +742,9 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:34
 #: lib/vutuv_web/controllers/follow_controller.ex:24
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:123
 #: lib/vutuv_web/controllers/user_save_controller.ex:45
-#: lib/vutuv_web/live/user_profile_live.ex:115
+#: lib/vutuv_web/live/user_profile_live.ex:153
 #, elixir-autogen
 msgid "Something went wrong"
 msgstr ""
@@ -780,12 +781,12 @@ msgstr ""
 msgid "User %{name} created successfully. An email has been sent with your PIN."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:314
+#: lib/vutuv_web/controllers/user_controller.ex:310
 #, elixir-autogen
 msgid "User deleted successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:233
+#: lib/vutuv_web/controllers/user_controller.ex:229
 #, elixir-autogen
 msgid "User updated successfully."
 msgstr ""
@@ -795,12 +796,12 @@ msgstr ""
 msgid "User verified successfully."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3410
+#: lib/vutuv_web/components/ui.ex:3353
 #: lib/vutuv_web/controllers/username_controller.ex:428
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:837
 #: lib/vutuv_web/live/admin/user_delete_live.ex:144
-#: lib/vutuv_web/live/admin/user_live.ex:169
-#: lib/vutuv_web/live/notification_live/index.ex:957
+#: lib/vutuv_web/live/admin/user_live.ex:155
+#: lib/vutuv_web/live/notification_live/index.ex:992
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:33
 #: lib/vutuv_web/templates/admin/account/index.html.heex:56
 #: lib/vutuv_web/templates/admin/username/form_content.html.heex:10
@@ -844,20 +845,20 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:759
+#: lib/vutuv_web/components/ui.ex:767
 #: lib/vutuv_web/templates/user/show.html.heex:309
 #, elixir-autogen
 msgid "vCard"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3206
-#: lib/vutuv_web/templates/user/show.html.heex:831
-#: lib/vutuv_web/templates/user/show.html.heex:851
+#: lib/vutuv_web/components/ui.ex:3149
+#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:857
 #, elixir-autogen
 msgid "View All"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3490
+#: lib/vutuv_web/components/ui.ex:3433
 #: lib/vutuv_web/controllers/settings_controller.ex:146
 #: lib/vutuv_web/live/job_posting_live/form.ex:561
 #: lib/vutuv_web/live/organization_live/edit.ex:300
@@ -925,7 +926,7 @@ msgid "You follow back %{name}."
 msgstr ""
 
 #: lib/vutuv_web/live/init_assigns.ex:52
-#: lib/vutuv_web/live/post_live/feed.ex:61
+#: lib/vutuv_web/live/post_live/feed.ex:62
 #: lib/vutuv_web/plugs/require_login.ex:20
 #, elixir-autogen
 msgid "You must be logged in to access that page"
@@ -991,14 +992,14 @@ msgstr ""
 msgid "http://www.example.com"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1041
+#: lib/vutuv/accounts/user.ex:1049
 #: lib/vutuv_web/gettext_extraction_anchors.ex:41
 #: lib/vutuv_web/views/invitation_html.ex:17
 #, elixir-autogen
 msgid "Female"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1040
+#: lib/vutuv/accounts/user.ex:1048
 #: lib/vutuv_web/gettext_extraction_anchors.ex:40
 #: lib/vutuv_web/views/invitation_html.ex:16
 #, elixir-autogen
@@ -1059,12 +1060,12 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:999
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:388
+#: lib/vutuv_web/live/admin/user_live.ex:359
 #: lib/vutuv_web/templates/social_media_account/card_list.html.heex:32
 #, elixir-autogen
 msgid "Verify"
@@ -1100,7 +1101,7 @@ msgstr ""
 msgid "Listings"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:236
+#: lib/vutuv_web/controllers/page_controller.ex:241
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:4
 #, elixir-autogen
 msgid "Most Followed Users"
@@ -1125,8 +1126,8 @@ msgstr ""
 msgid "Curious? Have a look at the "
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:298
-#: lib/vutuv_web/views/work_experience_html.ex:351
+#: lib/vutuv_web/views/work_experience_html.ex:300
+#: lib/vutuv_web/views/work_experience_html.ex:353
 #, elixir-autogen
 msgid "Present"
 msgstr ""
@@ -1188,7 +1189,7 @@ msgid "Add Localization"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:245
-#: lib/vutuv_web/live/admin/activity_live.ex:191
+#: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
 #: lib/vutuv_web/live/admin/deliverability_live.ex:96
 #: lib/vutuv_web/live/admin/job_live.ex:199
@@ -1203,7 +1204,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/screenshot_live.ex:82
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
-#: lib/vutuv_web/live/admin/user_live.ex:190
+#: lib/vutuv_web/live/admin/user_live.ex:165
 #: lib/vutuv_web/live/shell_live.ex:589
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
@@ -1420,7 +1421,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:30
 #: lib/vutuv_web/agent_docs/text.ex:402
 #: lib/vutuv_web/agent_docs/text.ex:615
-#: lib/vutuv_web/components/ui.ex:3430
+#: lib/vutuv_web/components/ui.ex:3373
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
 #: lib/vutuv_web/cv/docx.ex:174
@@ -1457,7 +1458,7 @@ msgstr ""
 
 #: lib/vutuv_web/controllers/email_controller.ex:167
 #: lib/vutuv_web/controllers/session_controller.ex:438
-#: lib/vutuv_web/controllers/user_controller.ex:334
+#: lib/vutuv_web/controllers/user_controller.ex:330
 #: lib/vutuv_web/controllers/username_controller.ex:215
 #, elixir-autogen
 msgid "Too many incorrect attempts."
@@ -1672,8 +1673,8 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/composer.ex:1311
 #: lib/vutuv_web/live/post_live/composer.ex:1312
 #: lib/vutuv_web/live/post_live/composer.ex:2213
-#: lib/vutuv_web/templates/layout/app.html.heex:155
-#: lib/vutuv_web/templates/layout/app.html.heex:161
+#: lib/vutuv_web/templates/layout/app.html.heex:159
+#: lib/vutuv_web/templates/layout/app.html.heex:165
 #: lib/vutuv_web/views/layout_html.ex:40
 #, elixir-autogen, elixir-format
 msgid "Close"
@@ -1691,16 +1692,16 @@ msgstr ""
 msgid "Confirm account deletion"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:97
-#: lib/vutuv_web/templates/layout/app.html.heex:89
+#: lib/vutuv_web/controllers/page_controller.ex:102
+#: lib/vutuv_web/templates/layout/app.html.heex:93
 #: lib/vutuv_web/templates/page/index.html.heex:215
 #: lib/vutuv_web/views/admin/legal_page_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Datenschutzerklärung"
 msgstr ""
 
-#: lib/vutuv_web/controllers/page_controller.ex:103
-#: lib/vutuv_web/templates/layout/app.html.heex:91
+#: lib/vutuv_web/controllers/page_controller.ex:108
+#: lib/vutuv_web/templates/layout/app.html.heex:95
 #: lib/vutuv_web/templates/page/index.html.heex:215
 #: lib/vutuv_web/views/admin/legal_page_html.ex:12
 #, elixir-autogen, elixir-format
@@ -1713,34 +1714,34 @@ msgstr ""
 msgid "Delete my account"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:154
+#: lib/vutuv_web/controllers/user_controller.ex:150
 #: lib/vutuv_web/templates/user/show.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Edit profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1154
 #: lib/vutuv_web/components/ui.ex:1163
-#: lib/vutuv_web/components/ui.ex:1556
+#: lib/vutuv_web/components/ui.ex:1172
+#: lib/vutuv_web/components/ui.ex:1565
 #, elixir-autogen, elixir-format
 msgid "Endorse"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1694
-#: lib/vutuv_web/components/ui.ex:1694
-#: lib/vutuv_web/components/ui.ex:1711
+#: lib/vutuv_web/components/ui.ex:1703
+#: lib/vutuv_web/components/ui.ex:1703
 #: lib/vutuv_web/components/ui.ex:1720
-#: lib/vutuv_web/components/ui.ex:1736
-#: lib/vutuv_web/components/ui.ex:1773
-#: lib/vutuv_web/components/ui.ex:1776
-#: lib/vutuv_web/components/ui.ex:1783
-#: lib/vutuv_web/components/ui.ex:1786
-#: lib/vutuv_web/components/ui.ex:1859
-#: lib/vutuv_web/live/fediverse_account_live.ex:380
-#: lib/vutuv_web/live/fediverse_following_live.ex:287
+#: lib/vutuv_web/components/ui.ex:1729
+#: lib/vutuv_web/components/ui.ex:1745
+#: lib/vutuv_web/components/ui.ex:1782
+#: lib/vutuv_web/components/ui.ex:1785
+#: lib/vutuv_web/components/ui.ex:1792
+#: lib/vutuv_web/components/ui.ex:1795
+#: lib/vutuv_web/components/ui.ex:1868
+#: lib/vutuv_web/live/fediverse_account_live.ex:387
+#: lib/vutuv_web/live/fediverse_following_live.ex:266
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:403
-#: lib/vutuv_web/templates/user/show.html.heex:948
-#: lib/vutuv_web/templates/user/show.html.heex:1200
+#: lib/vutuv_web/templates/user/show.html.heex:954
+#: lib/vutuv_web/templates/user/show.html.heex:1207
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1762,11 +1763,11 @@ msgid "Log out"
 msgstr ""
 
 #: lib/vutuv_web/components/organization_components.ex:247
-#: lib/vutuv_web/live/admin/activity_live.ex:164
-#: lib/vutuv_web/live/admin/activity_live.ex:213
+#: lib/vutuv_web/live/admin/activity_live.ex:143
+#: lib/vutuv_web/live/admin/activity_live.ex:175
 #: lib/vutuv_web/live/admin/deliverability_live.ex:119
 #: lib/vutuv_web/live/admin/user_delete_live.ex:143
-#: lib/vutuv_web/live/admin/user_live.ex:168
+#: lib/vutuv_web/live/admin/user_live.ex:154
 #: lib/vutuv_web/live/message_live/index.ex:455
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:32
 #: lib/vutuv_web/templates/admin/account/index.html.heex:55
@@ -1785,7 +1786,7 @@ msgstr ""
 #: lib/vutuv_web/live/message_live/index.ex:512
 #: lib/vutuv_web/live/shell_live.ex:497
 #: lib/vutuv_web/live/shell_live.ex:639
-#: lib/vutuv_web/templates/layout/app.html.heex:119
+#: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
@@ -1796,23 +1797,23 @@ msgid "Network"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:338
-#: lib/vutuv_web/components/ui.ex:3255
-#: lib/vutuv_web/live/admin/user_live.ex:311
+#: lib/vutuv_web/components/ui.ex:3198
+#: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:332
+#: lib/vutuv_web/live/notification_live/index.ex:367
 #, elixir-autogen, elixir-format
 msgid "Nothing new yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3471
-#: lib/vutuv_web/live/notification_live/index.ex:103
-#: lib/vutuv_web/live/notification_live/index.ex:293
+#: lib/vutuv_web/components/ui.ex:3414
+#: lib/vutuv_web/live/notification_live/index.ex:104
+#: lib/vutuv_web/live/notification_live/index.ex:328
 #: lib/vutuv_web/live/shell_live.ex:508
-#: lib/vutuv_web/templates/layout/app.html.heex:120
+#: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Notifications"
@@ -1824,7 +1825,7 @@ msgid "Active Members"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_detail_live.ex:99
-#: lib/vutuv_web/live/admin/user_live.ex:358
+#: lib/vutuv_web/live/admin/user_live.ex:329
 #: lib/vutuv_web/templates/email/confirm.html.heex:25
 #: lib/vutuv_web/templates/user/delete_confirmation.html.heex:17
 #: lib/vutuv_web/views/username_html.ex:66
@@ -1845,12 +1846,12 @@ msgid "Send"
 msgstr ""
 
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:35
-#: lib/vutuv_web/templates/layout/app.html.heex:83
+#: lib/vutuv_web/templates/layout/app.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "Source"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:85
+#: lib/vutuv_web/templates/layout/app.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Submit a bug report or feature request"
 msgstr ""
@@ -1874,8 +1875,8 @@ msgstr ""
 #: lib/vutuv_web/controllers/session_controller.ex:157
 #: lib/vutuv_web/controllers/session_controller.ex:193
 #: lib/vutuv_web/controllers/session_controller.ex:209
-#: lib/vutuv_web/controllers/user_controller.ex:270
-#: lib/vutuv_web/controllers/user_controller.ex:299
+#: lib/vutuv_web/controllers/user_controller.ex:266
+#: lib/vutuv_web/controllers/user_controller.ex:295
 #: lib/vutuv_web/controllers/username_controller.ex:191
 #: lib/vutuv_web/controllers/username_controller.ex:273
 #: lib/vutuv_web/controllers/username_controller.ex:296
@@ -1907,7 +1908,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1106
+#: lib/vutuv_web/live/post_live/feed.ex:1115
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -1944,29 +1945,29 @@ msgstr ""
 msgid "submit a bug report"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:978
+#: lib/vutuv_web/live/notification_live/index.ex:1013
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:973
+#: lib/vutuv_web/live/notification_live/index.ex:1008
 #, elixir-autogen, elixir-format
 msgid "is now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:968
+#: lib/vutuv_web/live/notification_live/index.ex:1003
 #, elixir-autogen, elixir-format
 msgid "started following you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2595
-#: lib/vutuv_web/components/ui.ex:2746
-#: lib/vutuv_web/live/organization_live/index.ex:130
+#: lib/vutuv_web/components/ui.ex:2538
+#: lib/vutuv_web/components/ui.ex:2689
+#: lib/vutuv_web/live/organization_live/index.ex:122
 #, elixir-autogen, elixir-format
 msgid "Pagination"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3280
+#: lib/vutuv_web/components/ui.ex:3223
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -1976,37 +1977,37 @@ msgstr ""
 msgid "The address itself cannot be changed. To use a different one, add it as a new email address and delete this one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3051
+#: lib/vutuv_web/components/ui.ex:2994
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:881
-#: lib/vutuv_web/components/ui.ex:891
+#: lib/vutuv_web/components/ui.ex:890
+#: lib/vutuv_web/components/ui.ex:900
 #, elixir-autogen, elixir-format
 msgid "Options"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:410
+#: lib/vutuv_web/views/work_experience_html.ex:412
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:413
+#: lib/vutuv_web/views/work_experience_html.ex:415
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:529
+#: lib/vutuv_web/views/work_experience_html.ex:496
 #, elixir-autogen, elixir-format
 msgid "Time in this role"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:528
+#: lib/vutuv_web/views/work_experience_html.ex:495
 #, elixir-autogen, elixir-format
 msgid "Total time at this employer"
 msgstr ""
@@ -2021,12 +2022,12 @@ msgstr ""
 msgid "Add cover photo"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2350
+#: lib/vutuv_web/components/ui.ex:2293
 #, elixir-autogen, elixir-format
 msgid "April"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2354
+#: lib/vutuv_web/components/ui.ex:2297
 #, elixir-autogen, elixir-format
 msgid "August"
 msgstr ""
@@ -2051,37 +2052,37 @@ msgstr ""
 msgid "Cover photo of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2358
+#: lib/vutuv_web/components/ui.ex:2301
 #, elixir-autogen, elixir-format
 msgid "December"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2348
+#: lib/vutuv_web/components/ui.ex:2291
 #, elixir-autogen, elixir-format
 msgid "February"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2347
+#: lib/vutuv_web/components/ui.ex:2290
 #, elixir-autogen, elixir-format
 msgid "January"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2353
+#: lib/vutuv_web/components/ui.ex:2296
 #, elixir-autogen, elixir-format
 msgid "July"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2352
+#: lib/vutuv_web/components/ui.ex:2295
 #, elixir-autogen, elixir-format
 msgid "June"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2349
+#: lib/vutuv_web/components/ui.ex:2292
 #, elixir-autogen, elixir-format
 msgid "March"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2351
+#: lib/vutuv_web/components/ui.ex:2294
 #, elixir-autogen, elixir-format
 msgid "May"
 msgstr ""
@@ -2096,17 +2097,17 @@ msgstr ""
 msgid "Member since %{year}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2357
+#: lib/vutuv_web/components/ui.ex:2300
 #, elixir-autogen, elixir-format
 msgid "November"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2356
+#: lib/vutuv_web/components/ui.ex:2299
 #, elixir-autogen, elixir-format
 msgid "October"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2355
+#: lib/vutuv_web/components/ui.ex:2298
 #, elixir-autogen, elixir-format
 msgid "September"
 msgstr ""
@@ -2128,8 +2129,8 @@ msgstr ""
 msgid "As soon as anything is hidden, the post is also invisible to logged-out visitors and search engines."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:145
-#: lib/vutuv_web/live/post_live/reply.ex:79
+#: lib/vutuv_web/live/post_live/edit.ex:143
+#: lib/vutuv_web/live/post_live/reply.ex:77
 #, elixir-autogen, elixir-format
 msgid "Back to the post"
 msgstr ""
@@ -2139,28 +2140,28 @@ msgstr ""
 msgid "Cancel upload"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:155
+#: lib/vutuv_web/live/post_live/edit.ex:153
 #, elixir-autogen, elixir-format
 msgid "Delete post"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2179
-#: lib/vutuv_web/live/post_live/edit.ex:153
+#: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:48
-#: lib/vutuv_web/live/post_live/edit.ex:94
+#: lib/vutuv_web/live/post_live/edit.ex:46
+#: lib/vutuv_web/live/post_live/edit.ex:92
 #, elixir-autogen, elixir-format
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:87
-#: lib/vutuv_web/live/post_live/feed.ex:903
+#: lib/vutuv_web/live/post_live/feed.ex:139
+#: lib/vutuv_web/live/post_live/feed.ex:912
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
-#: lib/vutuv_web/templates/layout/app.html.heex:118
+#: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
 msgstr ""
@@ -2170,7 +2171,7 @@ msgstr ""
 msgid "Follow %{name} to read it."
 msgstr ""
 
-#: lib/vutuv_web/templates/post/show.html.heex:28
+#: lib/vutuv_web/templates/post/show.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Hidden from:"
 msgstr ""
@@ -2202,7 +2203,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1045
+#: lib/vutuv_web/live/post_live/feed.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2229,7 +2230,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:214
+#: lib/vutuv_web/controllers/post_controller.ex:224
 #, elixir-autogen, elixir-format
 msgid "Post deleted successfully."
 msgstr ""
@@ -2237,11 +2238,11 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/post_doc.ex:127
 #: lib/vutuv_web/controllers/post_controller.ex:60
 #: lib/vutuv_web/controllers/post_controller.ex:69
-#: lib/vutuv_web/controllers/user_controller.ex:76
+#: lib/vutuv_web/controllers/user_controller.ex:77
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/fediverse_account_live.ex:387
-#: lib/vutuv_web/live/notification_live/index.ex:804
+#: lib/vutuv_web/live/fediverse_account_live.ex:394
+#: lib/vutuv_web/live/notification_live/index.ex:839
 #: lib/vutuv_web/live/post_live/saved.ex:449
 #: lib/vutuv_web/live/search_live.ex:200
 #: lib/vutuv_web/live/search_live.ex:530
@@ -2258,7 +2259,7 @@ msgid "Read more"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:2565
-#: lib/vutuv_web/live/fediverse_account_live.ex:332
+#: lib/vutuv_web/live/fediverse_account_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
@@ -2279,7 +2280,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: lib/vutuv_web/templates/post/show.html.heex:31
+#: lib/vutuv_web/templates/post/show.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Restricted posts are also hidden from logged-out visitors and search engines."
 msgstr ""
@@ -2289,18 +2290,14 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:978
+#: lib/vutuv_web/live/post_live/feed.ex:987
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:75
-#: lib/vutuv_web/live/post_live/edit.ex:36
-#: lib/vutuv_web/live/post_live/remote_post_reply.ex:81
-#: lib/vutuv_web/live/post_live/remote_reply.ex:79
-#: lib/vutuv_web/live/post_live/reply.ex:41
+#: lib/vutuv_web/live/init_assigns.ex:81
 #, elixir-autogen, elixir-format
 msgid "Sorry, that page could not be found."
 msgstr ""
@@ -2330,7 +2327,7 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3723
+#: lib/vutuv_web/components/ui.ex:3666
 #: lib/vutuv_web/live/shell_live.ex:551
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
@@ -2405,15 +2402,13 @@ msgstr ""
 msgid "View all %{count} posts"
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:141
+#: lib/vutuv_web/controllers/post_controller.ex:151
 #, elixir-autogen, elixir-format
 msgid "All posts"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3768
-#: lib/vutuv_web/components/ui.ex:2054
-#: lib/vutuv_web/components/ui.ex:2054
-#: lib/vutuv_web/components/ui.ex:2670
+#: lib/vutuv_web/components/ui.ex:2613
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
@@ -2431,10 +2426,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1484
 #: lib/vutuv_web/components/post_components.ex:3991
-#: lib/vutuv_web/components/ui.ex:2083
-#: lib/vutuv_web/components/ui.ex:2083
-#: lib/vutuv_web/components/ui.ex:2656
-#: lib/vutuv_web/live/notification_live/index.ex:947
+#: lib/vutuv_web/components/ui.ex:2599
+#: lib/vutuv_web/live/notification_live/index.ex:982
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Like"
@@ -2442,7 +2435,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:932
 #: lib/vutuv_web/components/post_components.ex:4000
-#: lib/vutuv_web/live/notification_live/index.ex:884
+#: lib/vutuv_web/live/notification_live/index.ex:919
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
 #: lib/vutuv_web/live/shell_live.ex:559
@@ -2467,8 +2460,6 @@ msgid "Only public posts can be reposted."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3768
-#: lib/vutuv_web/components/ui.ex:2044
-#: lib/vutuv_web/components/ui.ex:2044
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2494,8 +2485,6 @@ msgid "Undo repost"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:3991
-#: lib/vutuv_web/components/ui.ex:2073
-#: lib/vutuv_web/components/ui.ex:2073
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
@@ -2503,10 +2492,10 @@ msgid "Unlike"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:253
-#: lib/vutuv_web/components/ui.ex:1689
-#: lib/vutuv_web/components/ui.ex:1689
-#: lib/vutuv_web/components/ui.ex:1826
-#: lib/vutuv_web/live/post_live/feed.ex:1095
+#: lib/vutuv_web/components/ui.ex:1698
+#: lib/vutuv_web/components/ui.ex:1698
+#: lib/vutuv_web/components/ui.ex:1835
+#: lib/vutuv_web/live/post_live/feed.ex:1104
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2523,7 +2512,7 @@ msgid "Only public posts can be answered."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:327
-#: lib/vutuv_web/live/notification_live/index.ex:885
+#: lib/vutuv_web/live/notification_live/index.ex:920
 #, elixir-autogen, elixir-format
 msgid "Replies"
 msgstr ""
@@ -2532,8 +2521,8 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:1536
 #: lib/vutuv_web/components/post_components.ex:4027
 #: lib/vutuv_web/components/post_components.ex:4028
-#: lib/vutuv_web/live/notification_live/index.ex:944
-#: lib/vutuv_web/live/post_live/reply.ex:35
+#: lib/vutuv_web/live/notification_live/index.ex:979
+#: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
@@ -2554,15 +2543,15 @@ msgstr ""
 msgid "This post has been reposted or answered. Its audience stays public while reposts or replies exist; you can still delete the post."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1123
+#: lib/vutuv_web/live/notification_live/index.ex:1158
 #, elixir-autogen, elixir-format
 msgid "replied to your post."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1621
-#: lib/vutuv_web/live/post_live/remote_post_reply.ex:58
-#: lib/vutuv_web/live/post_live/remote_reply.ex:57
-#: lib/vutuv_web/live/post_live/reply.ex:52
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
+#: lib/vutuv_web/live/post_live/remote_reply.ex:58
+#: lib/vutuv_web/live/post_live/reply.ex:50
 #, elixir-autogen, elixir-format
 msgid "Reply to %{handle}"
 msgstr ""
@@ -2635,7 +2624,7 @@ msgstr ""
 msgid "No conversations yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2226
+#: lib/vutuv_web/components/ui.ex:2169
 #: lib/vutuv_web/live/message_live/index.ex:612
 #, elixir-autogen, elixir-format
 msgid "Online"
@@ -2747,26 +2736,26 @@ msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1121
+#: lib/vutuv_web/templates/user/show.html.heex:1127
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1378
+#: lib/vutuv_web/templates/user/show.html.heex:1385
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1049
+#: lib/vutuv_web/templates/user/show.html.heex:1055
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:995
+#: lib/vutuv_web/templates/user/show.html.heex:1001
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
@@ -2778,14 +2767,14 @@ msgstr ""
 msgid "Add work experience"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1193
+#: lib/vutuv_web/live/user_profile_live.ex:1261
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write your first post"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2834
-#: lib/vutuv_web/components/ui.ex:3208
+#: lib/vutuv_web/components/ui.ex:2777
+#: lib/vutuv_web/components/ui.ex:3151
 #: lib/vutuv_web/templates/settings/apps.html.heex:14
 #: lib/vutuv_web/templates/settings/apps.html.heex:20
 #: lib/vutuv_web/templates/settings/organizations.html.heex:73
@@ -2797,20 +2786,20 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:928
+#: lib/vutuv_web/live/post_live/feed.ex:937
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:118
+#: lib/vutuv_web/views/user_helpers.ex:125
 #, elixir-autogen, elixir-format
 msgid "Added %{count} tag."
 msgid_plural "Added %{count} tags."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/views/user_helpers.ex:122
+#: lib/vutuv_web/views/user_helpers.ex:129
 #, elixir-autogen, elixir-format
 msgid "Added %{successes} of %{total} tags (the rest were duplicates or invalid)."
 msgstr ""
@@ -2832,13 +2821,13 @@ msgstr[1] ""
 #: lib/vutuv_web/agent_docs/markdown.ex:508
 #: lib/vutuv_web/agent_docs/text.ex:478
 #: lib/vutuv_web/controllers/connection_controller.ex:37
-#: lib/vutuv_web/live/notification_live/index.ex:883
+#: lib/vutuv_web/live/notification_live/index.ex:918
 #: lib/vutuv_web/templates/connection/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:750
+#: lib/vutuv_web/components/ui.ex:758
 #, elixir-autogen, elixir-format
 msgid "Markdown"
 msgstr ""
@@ -2848,7 +2837,7 @@ msgstr ""
 msgid "No connections yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:765
+#: lib/vutuv_web/components/ui.ex:774
 #, elixir-autogen, elixir-format
 msgid "Other formats"
 msgstr ""
@@ -2858,7 +2847,7 @@ msgstr ""
 msgid "People who aren't my connections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:751
+#: lib/vutuv_web/components/ui.ex:759
 #, elixir-autogen, elixir-format
 msgid "Text only"
 msgstr ""
@@ -2886,22 +2875,22 @@ msgstr ""
 msgid "Open someone's profile to message them."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:958
+#: lib/vutuv_web/live/notification_live/index.ex:993
 #, elixir-autogen, elixir-format
 msgid "Activity"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:950
+#: lib/vutuv_web/live/notification_live/index.ex:985
 #, elixir-autogen, elixir-format
 msgid "Connection"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:943
+#: lib/vutuv_web/live/notification_live/index.ex:978
 #, elixir-autogen, elixir-format
 msgid "Endorsement"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:942
+#: lib/vutuv_web/live/notification_live/index.ex:977
 #: lib/vutuv_web/templates/user/show.html.heex:818
 #, elixir-autogen, elixir-format
 msgid "Follower"
@@ -2914,7 +2903,7 @@ msgstr[1] ""
 msgid "Welcome to vutuv, %{name}!"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:975
+#: lib/vutuv_web/live/notification_live/index.ex:1010
 #, elixir-autogen, elixir-format
 msgid "liked your post."
 msgstr ""
@@ -2946,12 +2935,12 @@ msgstr ""
 msgid "(no text)"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1159
+#: lib/vutuv_web/live/notification_live/index.ex:1194
 #, elixir-autogen, elixir-format
 msgid "A report about your content was confirmed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1160
+#: lib/vutuv_web/live/notification_live/index.ex:1195
 #, elixir-autogen, elixir-format
 msgid "A report about your content was dismissed; it is visible again."
 msgstr ""
@@ -2983,8 +2972,8 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:296
 #: lib/vutuv_web/agent_docs/text.ex:280
-#: lib/vutuv_web/controllers/page_controller.ex:76
-#: lib/vutuv_web/templates/layout/app.html.heex:87
+#: lib/vutuv_web/controllers/page_controller.ex:81
+#: lib/vutuv_web/templates/layout/app.html.heex:91
 #: lib/vutuv_web/templates/page/community.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Community guidelines"
@@ -3057,7 +3046,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:136
 #: lib/vutuv_web/live/admin/moderation_live.ex:30
-#: lib/vutuv_web/live/notification_live/index.ex:951
+#: lib/vutuv_web/live/notification_live/index.ex:986
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:46
 #: lib/vutuv_web/templates/admin/moderation/reporters.html.heex:5
 #, elixir-autogen, elixir-format
@@ -3131,8 +3120,8 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1089
-#: lib/vutuv_web/templates/user/show.html.heex:1090
+#: lib/vutuv_web/templates/user/show.html.heex:1095
+#: lib/vutuv_web/templates/user/show.html.heex:1096
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
@@ -3186,7 +3175,7 @@ msgstr ""
 msgid "Private message"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3404
+#: lib/vutuv_web/components/ui.ex:3347
 #: lib/vutuv_web/live/shell_live.ex:443
 #: lib/vutuv_web/live/shell_live.ex:644
 #: lib/vutuv_web/templates/import/new.html.heex:15
@@ -3297,7 +3286,7 @@ msgstr ""
 msgid "Reports are anonymous; we never tell you who reported. Our rules:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2570
+#: lib/vutuv_web/components/ui.ex:2513
 #: lib/vutuv_web/live/admin/moderation_live.ex:89
 #: lib/vutuv_web/templates/moderation_case/index.html.heex:26
 #, elixir-autogen, elixir-format
@@ -3346,7 +3335,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/moderation_live.ex:53
 #: lib/vutuv_web/live/admin/organization_live.ex:246
 #: lib/vutuv_web/live/admin/screenshot_live.ex:149
-#: lib/vutuv_web/live/admin/user_live.ex:328
+#: lib/vutuv_web/live/admin/user_live.ex:299
 #: lib/vutuv_web/templates/admin/account/index.html.heex:57
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:59
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:19
@@ -3479,12 +3468,12 @@ msgstr ""
 msgid "You cannot report your own content."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1162
+#: lib/vutuv_web/live/notification_live/index.ex:1197
 #, elixir-autogen, elixir-format
 msgid "You deleted reported content; the case is closed."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1161
+#: lib/vutuv_web/live/notification_live/index.ex:1196
 #, elixir-autogen, elixir-format
 msgid "You revised reported content; the case is closed."
 msgstr ""
@@ -3494,7 +3483,7 @@ msgstr ""
 msgid "Your content was reported"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1163
+#: lib/vutuv_web/live/notification_live/index.ex:1198
 #, elixir-autogen, elixir-format
 msgid "Your content was reported and is hidden while the report is handled."
 msgstr ""
@@ -3678,7 +3667,7 @@ msgstr ""
 msgid "Open the profile"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1187
+#: lib/vutuv_web/live/notification_live/index.ex:1222
 #, elixir-autogen, elixir-format
 msgid "Our admins found your report unfounded; the paused connection between you two is restored."
 msgstr ""
@@ -3703,7 +3692,7 @@ msgstr ""
 msgid "Report filed"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:953
+#: lib/vutuv_web/live/notification_live/index.ex:988
 #, elixir-autogen, elixir-format
 msgid "Report protection"
 msgstr ""
@@ -3778,7 +3767,7 @@ msgstr ""
 msgid "Waiting for the owner"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1192
+#: lib/vutuv_web/live/notification_live/index.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Your report paused the connection between you two - no contact in either direction for now. If our admins find the report unfounded, this is undone."
 msgstr ""
@@ -4530,7 +4519,7 @@ msgstr ""
 msgid "Block @%{slug}? This removes any follows and connection between you, closes your conversation, and prevents all interaction in both directions. Unblocking will not restore what was removed."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3494
+#: lib/vutuv_web/components/ui.ex:3437
 #: lib/vutuv_web/controllers/block_controller.ex:20
 #: lib/vutuv_web/templates/block/index.html.heex:9
 #: lib/vutuv_web/templates/block/index.html.heex:41
@@ -4567,12 +4556,12 @@ msgid "You have not blocked anyone."
 msgstr ""
 
 #: lib/vutuv_web/controllers/block_controller.ex:89
-#: lib/vutuv_web/live/user_profile_live.ex:244
+#: lib/vutuv_web/live/user_profile_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1050
+#: lib/vutuv_web/live/post_live/feed.ex:1059
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4584,7 +4573,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:837
+#: lib/vutuv_web/templates/user/show.html.heex:840
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4628,7 +4617,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/text.ex:350
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:480
-#: lib/vutuv_web/live/notification_live/index.ex:805
+#: lib/vutuv_web/live/notification_live/index.ex:840
 #: lib/vutuv_web/live/organization_live/show.ex:300
 #: lib/vutuv_web/live/post_live/saved.ex:452
 #: lib/vutuv_web/live/search_live.ex:198
@@ -4650,7 +4639,7 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:324
 #: lib/vutuv_web/live/admin/job_live.ex:159
 #: lib/vutuv_web/live/admin/organization_live.ex:163
-#: lib/vutuv_web/live/notification_live/index.ex:803
+#: lib/vutuv_web/live/notification_live/index.ex:838
 #: lib/vutuv_web/live/search_live.ex:197
 #: lib/vutuv_web/views/qualification_html.ex:90
 #, elixir-autogen, elixir-format
@@ -4699,7 +4688,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:46
-#: lib/vutuv_web/live/user_profile_live.ex:1181
+#: lib/vutuv_web/live/user_profile_live.ex:1249
 #: lib/vutuv_web/templates/user/show.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
@@ -5099,7 +5088,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/api_app_live.ex:92
 #: lib/vutuv_web/live/admin/member_badges.ex:22
-#: lib/vutuv_web/live/admin/user_live.ex:292
+#: lib/vutuv_web/live/admin/user_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Suspended"
 msgstr ""
@@ -5286,12 +5275,12 @@ msgstr ""
 msgid "API token (%{date})"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:81
+#: lib/vutuv_web/templates/layout/app.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "API documentation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3533
+#: lib/vutuv_web/components/ui.ex:3476
 #: lib/vutuv_web/controllers/settings_controller.ex:137
 #: lib/vutuv_web/live/admin/moderation_case_live.ex:421
 #: lib/vutuv_web/live/admin/user_delete_live.ex:33
@@ -5343,40 +5332,40 @@ msgid "Account menu"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/screenshot_live.ex:155
-#: lib/vutuv_web/templates/layout/app.html.heex:124
+#: lib/vutuv_web/templates/layout/app.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:134
+#: lib/vutuv_web/templates/layout/app.html.heex:138
 #, elixir-autogen, elixir-format
 msgid "Close menus and dialogs"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:131
+#: lib/vutuv_web/templates/layout/app.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:599
-#: lib/vutuv_web/templates/layout/app.html.heex:150
+#: lib/vutuv_web/templates/layout/app.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:115
+#: lib/vutuv_web/templates/layout/app.html.heex:119
 #, elixir-autogen, elixir-format
 msgid "Navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3630
-#: lib/vutuv_web/components/ui.ex:3635
-#: lib/vutuv_web/components/ui.ex:3714
-#: lib/vutuv_web/components/ui.ex:3778
+#: lib/vutuv_web/components/ui.ex:3573
+#: lib/vutuv_web/components/ui.ex:3578
+#: lib/vutuv_web/components/ui.ex:3657
+#: lib/vutuv_web/components/ui.ex:3721
 #: lib/vutuv_web/controllers/settings_controller.ex:53
-#: lib/vutuv_web/live/account_activity_live.ex:155
-#: lib/vutuv_web/live/fediverse_followers_live.ex:126
-#: lib/vutuv_web/live/fediverse_following_live.ex:253
+#: lib/vutuv_web/live/account_activity_live.ex:115
+#: lib/vutuv_web/live/fediverse_followers_live.ex:108
+#: lib/vutuv_web/live/fediverse_following_live.ex:238
 #: lib/vutuv_web/live/shell_live.ex:579
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
@@ -5388,17 +5377,17 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:133
+#: lib/vutuv_web/templates/layout/app.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Show this help"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:126
+#: lib/vutuv_web/templates/layout/app.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Write a new post"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:121
+#: lib/vutuv_web/templates/layout/app.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Your profile"
 msgstr ""
@@ -5413,17 +5402,17 @@ msgstr ""
 msgid "A few quick steps so people can find and recognize you."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1183
+#: lib/vutuv_web/live/user_profile_live.ex:1251
 #, elixir-autogen, elixir-format
 msgid "Add a profile photo"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:128
+#: lib/vutuv_web/templates/layout/app.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Next post in the feed"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:129
+#: lib/vutuv_web/templates/layout/app.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Previous post in the feed"
 msgstr ""
@@ -5434,7 +5423,7 @@ msgstr ""
 msgid "Main navigation"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:74
+#: lib/vutuv_web/templates/layout/app.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Footer navigation"
 msgstr ""
@@ -5442,8 +5431,8 @@ msgstr ""
 #: lib/vutuv_web/components/post_components.ex:2266
 #: lib/vutuv_web/components/post_components.ex:2318
 #: lib/vutuv_web/components/post_components.ex:2708
-#: lib/vutuv_web/live/notification_live/index.ex:624
-#: lib/vutuv_web/live/post_live/feed.ex:1168
+#: lib/vutuv_web/live/notification_live/index.ex:659
+#: lib/vutuv_web/live/post_live/feed.ex:1177
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5459,7 +5448,7 @@ msgstr ""
 msgid "Your tags (e.g. JavaScript, Cooking, Origami, Cat)"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:1044
+#: lib/vutuv/accounts/user.ex:1052
 #: lib/vutuv_web/gettext_extraction_anchors.ex:42
 #, elixir-autogen, elixir-format
 msgid "Diverse"
@@ -5495,10 +5484,10 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3506
-#: lib/vutuv_web/live/admin/user_live.ex:279
-#: lib/vutuv_web/live/fediverse_followers_live.ex:112
-#: lib/vutuv_web/live/fediverse_following_live.ex:239
+#: lib/vutuv_web/components/ui.ex:3449
+#: lib/vutuv_web/live/admin/user_live.ex:254
+#: lib/vutuv_web/live/fediverse_followers_live.ex:94
+#: lib/vutuv_web/live/fediverse_following_live.ex:224
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:192
 #: lib/vutuv_web/templates/social_media_account/form_content.html.heex:12
 #, elixir-autogen, elixir-format
@@ -5515,7 +5504,7 @@ msgstr ""
 msgid "Download everything vutuv stores about you, as one file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3441
+#: lib/vutuv_web/components/ui.ex:3384
 #: lib/vutuv_web/controllers/email_controller.ex:31
 #: lib/vutuv_web/controllers/email_controller.ex:50
 #: lib/vutuv_web/controllers/email_controller.ex:202
@@ -5549,7 +5538,7 @@ msgstr ""
 msgid "Photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3488
+#: lib/vutuv_web/components/ui.ex:3431
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
@@ -5574,7 +5563,7 @@ msgstr ""
 msgid "Your name"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:473
+#: lib/vutuv_web/live/notification_live/index.ex:508
 #, elixir-autogen, elixir-format
 msgid "Your post"
 msgstr ""
@@ -5662,14 +5651,14 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3529
+#: lib/vutuv_web/components/ui.ex:3472
 #: lib/vutuv_web/controllers/settings_controller.ex:152
 #, elixir-autogen, elixir-format
 msgid "Apps & API"
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_tag_controller.ex:127
-#: lib/vutuv_web/live/notification_live/index.ex:886
+#: lib/vutuv_web/live/notification_live/index.ex:921
 #: lib/vutuv_web/templates/settings/notifications.html.heex:51
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:6
 #: lib/vutuv_web/templates/user_tag/show.html.heex:17
@@ -5788,25 +5777,25 @@ msgid "You cannot block yourself."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:23
-#: lib/vutuv_web/live/user_profile_live.ex:210
+#: lib/vutuv_web/live/user_profile_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Bookmark removed."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:19
-#: lib/vutuv_web/live/user_profile_live.ex:207
+#: lib/vutuv_web/live/user_profile_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Bookmarked."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:31
-#: lib/vutuv_web/live/user_profile_live.ex:216
+#: lib/vutuv_web/live/user_profile_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Like removed."
 msgstr ""
 
 #: lib/vutuv_web/controllers/user_save_controller.ex:27
-#: lib/vutuv_web/live/user_profile_live.ex:213
+#: lib/vutuv_web/live/user_profile_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Liked."
 msgstr ""
@@ -5981,7 +5970,7 @@ msgid "Add a passkey"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1114
-#: lib/vutuv_web/live/fediverse_following_live.ex:241
+#: lib/vutuv_web/live/fediverse_following_live.ex:226
 #: lib/vutuv_web/views/settings_html.ex:261
 #, elixir-autogen, elixir-format
 msgid "Added"
@@ -6078,7 +6067,7 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1187
+#: lib/vutuv_web/live/user_profile_live.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Add a tagline"
 msgstr ""
@@ -6114,7 +6103,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1429
+#: lib/vutuv_web/templates/user/show.html.heex:1436
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6158,8 +6147,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1015
-#: lib/vutuv_web/templates/user/show.html.heex:1025
+#: lib/vutuv_web/templates/user/show.html.heex:1021
+#: lib/vutuv_web/templates/user/show.html.heex:1031
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6199,12 +6188,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1136
+#: lib/vutuv_web/templates/user/show.html.heex:1143
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1147
+#: lib/vutuv_web/templates/user/show.html.heex:1154
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6246,7 +6235,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1145
+#: lib/vutuv_web/templates/user/show.html.heex:1152
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6271,9 +6260,9 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1154
 #: lib/vutuv_web/components/ui.ex:1163
-#: lib/vutuv_web/components/ui.ex:1557
+#: lib/vutuv_web/components/ui.ex:1172
+#: lib/vutuv_web/components/ui.ex:1566
 #, elixir-autogen, elixir-format
 msgid "Remove endorsement"
 msgstr ""
@@ -6300,9 +6289,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1415
-#: lib/vutuv_web/templates/user/show.html.heex:1423
-#: lib/vutuv_web/templates/user/show.html.heex:1435
+#: lib/vutuv_web/templates/user/show.html.heex:1422
+#: lib/vutuv_web/templates/user/show.html.heex:1430
+#: lib/vutuv_web/templates/user/show.html.heex:1442
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6334,11 +6323,11 @@ msgstr ""
 msgid "No endorsements yet."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1510
-#: lib/vutuv_web/live/notification_live/index.ex:558
-#: lib/vutuv_web/live/notification_live/index.ex:573
-#: lib/vutuv_web/live/notification_live/index.ex:711
-#: lib/vutuv_web/live/notification_live/index.ex:713
+#: lib/vutuv_web/components/ui.ex:1519
+#: lib/vutuv_web/live/notification_live/index.ex:593
+#: lib/vutuv_web/live/notification_live/index.ex:608
+#: lib/vutuv_web/live/notification_live/index.ex:746
+#: lib/vutuv_web/live/notification_live/index.ex:748
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
 msgstr ""
@@ -6550,8 +6539,8 @@ msgstr ""
 msgid "The raw bounce ledger, newest first."
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:126
-#: lib/vutuv_web/live/admin/activity_live.ex:163
+#: lib/vutuv_web/live/account_activity_live.ex:103
+#: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
@@ -6632,8 +6621,8 @@ msgstr ""
 msgid "Turn a switch off and the matching opt-out rides along on the pages and responses about you. With both off, for example:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2014
-#: lib/vutuv_web/live/fediverse_account_live.ex:374
+#: lib/vutuv_web/components/ui.ex:2023
+#: lib/vutuv_web/live/fediverse_account_live.ex:381
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6641,7 +6630,7 @@ msgid "Mute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:49
-#: lib/vutuv_web/live/user_profile_live.ex:192
+#: lib/vutuv_web/live/user_profile_live.ex:230
 #, elixir-autogen, elixir-format
 msgid "Muted. Their posts no longer appear in your feed."
 msgstr ""
@@ -6656,8 +6645,8 @@ msgstr ""
 msgid "Remove this connection? You will stop following them."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2013
-#: lib/vutuv_web/live/fediverse_account_live.ex:372
+#: lib/vutuv_web/components/ui.ex:2022
+#: lib/vutuv_web/live/fediverse_account_live.ex:379
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6665,7 +6654,7 @@ msgid "Unmute"
 msgstr ""
 
 #: lib/vutuv_web/controllers/follow_controller.ex:51
-#: lib/vutuv_web/live/user_profile_live.ex:194
+#: lib/vutuv_web/live/user_profile_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts appear in your feed again."
 msgstr ""
@@ -6695,33 +6684,33 @@ msgstr ""
 msgid "Unmute @%{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1984
+#: lib/vutuv_web/components/ui.ex:1993
 #, elixir-autogen, elixir-format
 msgid "Doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1978
+#: lib/vutuv_web/components/ui.ex:1987
 #, elixir-autogen, elixir-format
 msgid "Follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1968
+#: lib/vutuv_web/components/ui.ex:1977
 #, elixir-autogen, elixir-format
 msgid "This member doesn't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1919
-#: lib/vutuv_web/components/ui.ex:1968
+#: lib/vutuv_web/components/ui.ex:1928
+#: lib/vutuv_web/components/ui.ex:1977
 #, elixir-autogen, elixir-format
 msgid "This member follows you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1917
+#: lib/vutuv_web/components/ui.ex:1926
 #, elixir-autogen, elixir-format
 msgid "You follow each other"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1918
+#: lib/vutuv_web/components/ui.ex:1927
 #, elixir-autogen, elixir-format
 msgid "You follow this member"
 msgstr ""
@@ -6832,7 +6821,7 @@ msgstr ""
 msgid "Dev email inbox"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:221
+#: lib/vutuv_web/live/admin/user_live.ex:196
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Development:"
@@ -6887,8 +6876,8 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:213
 #: lib/vutuv_web/agent_docs/text.ex:201
-#: lib/vutuv_web/live/account_activity_live.ex:212
-#: lib/vutuv_web/live/admin/activity_live.ex:249
+#: lib/vutuv_web/live/account_activity_live.ex:167
+#: lib/vutuv_web/live/admin/activity_live.ex:211
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:296
 #: lib/vutuv_web/templates/settings/filters.html.heex:17
@@ -6915,10 +6904,10 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:592
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:670
 #: lib/vutuv_web/live/admin/user_detail_live.ex:69
-#: lib/vutuv_web/live/admin/user_live.ex:27
-#: lib/vutuv_web/live/admin/user_live.ex:189
-#: lib/vutuv_web/live/admin/user_live.ex:190
-#: lib/vutuv_web/live/admin/user_live.ex:197
+#: lib/vutuv_web/live/admin/user_live.ex:28
+#: lib/vutuv_web/live/admin/user_live.ex:164
+#: lib/vutuv_web/live/admin/user_live.ex:165
+#: lib/vutuv_web/live/admin/user_live.ex:172
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:89
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:45
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:90
@@ -7232,7 +7221,7 @@ msgid_plural "minus %{count} groups"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:229
+#: lib/vutuv_web/live/admin/user_live.ex:204
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "open the dev email inbox"
@@ -7288,13 +7277,13 @@ msgstr ""
 msgid "page %{page} of %{pages}, %{total} total"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2608
+#: lib/vutuv_web/components/ui.ex:2551
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Previous"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2624
+#: lib/vutuv_web/components/ui.ex:2567
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Next"
@@ -7563,12 +7552,12 @@ msgstr ""
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:103
+#: lib/vutuv_web/templates/layout/app.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Deployment: %{date} at %{time}"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:103
+#: lib/vutuv_web/templates/layout/app.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Last deployed (Berlin time)"
 msgstr ""
@@ -7766,13 +7755,13 @@ msgstr ""
 
 #: lib/vutuv_web/components/job_components.ex:173
 #: lib/vutuv_web/live/admin/dashboard_live.ex:230
-#: lib/vutuv_web/live/notification_live/index.ex:832
+#: lib/vutuv_web/live/notification_live/index.ex:867
 #, elixir-autogen, elixir-format
 msgid "Today"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/dashboard_live.ex:234
-#: lib/vutuv_web/live/notification_live/index.ex:835
+#: lib/vutuv_web/live/notification_live/index.ex:870
 #, elixir-autogen, elixir-format
 msgid "Yesterday"
 msgstr ""
@@ -7917,42 +7906,42 @@ msgstr ""
 msgid "Account @%{username} was deleted. A record was emailed to the operator."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:283
+#: lib/vutuv_web/live/admin/user_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "Admins"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:282
+#: lib/vutuv_web/live/admin/user_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "All members"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:270
+#: lib/vutuv_web/live/admin/user_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "All registrations"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:288
+#: lib/vutuv_web/live/admin/user_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Awaiting verification"
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:214
-#: lib/vutuv_web/live/account_activity_live.ex:234
-#: lib/vutuv_web/live/admin/activity_live.ex:269
-#: lib/vutuv_web/live/admin/user_live.ex:209
+#: lib/vutuv_web/components/browse_table.ex:318
+#: lib/vutuv_web/live/account_activity_live.ex:189
+#: lib/vutuv_web/live/admin/activity_live.ex:231
+#: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:90
+#: lib/vutuv_web/live/admin/user_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Could not verify this member."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/member_badges.ex:24
-#: lib/vutuv_web/live/admin/user_live.ex:295
+#: lib/vutuv_web/live/admin/user_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Deactivated"
 msgstr ""
@@ -7979,17 +7968,17 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:166
 #: lib/vutuv_web/live/admin/organization_live.ex:171
 #: lib/vutuv_web/live/admin/organization_live.ex:195
-#: lib/vutuv_web/live/admin/user_live.ex:290
+#: lib/vutuv_web/live/admin/user_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Frozen"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:87
+#: lib/vutuv_web/live/admin/user_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Identity verified. The member has been emailed."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:285
+#: lib/vutuv_web/live/admin/user_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Identity-verified"
 msgstr ""
@@ -8003,12 +7992,12 @@ msgstr ""
 
 #: lib/vutuv_web/live/admin/user_delete_live.ex:145
 #: lib/vutuv_web/live/admin/user_detail_live.ex:114
-#: lib/vutuv_web/live/admin/user_live.ex:170
+#: lib/vutuv_web/live/admin/user_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Joined"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:385
+#: lib/vutuv_web/live/admin/user_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Mark this member's identity as verified? They will be emailed."
 msgstr ""
@@ -8019,12 +8008,12 @@ msgstr ""
 msgid "No accounts match your search."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:308
+#: lib/vutuv_web/live/admin/user_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "No members match your filters."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:267
+#: lib/vutuv_web/live/admin/user_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Not confirmed"
 msgstr ""
@@ -8040,17 +8029,17 @@ msgstr ""
 msgid "PIN expired"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:265
+#: lib/vutuv_web/live/admin/user_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "PIN registered"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2611
+#: lib/vutuv_web/components/ui.ex:2554
 #, elixir-autogen, elixir-format
 msgid "Page %{page} of %{pages}"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:262
+#: lib/vutuv_web/live/admin/user_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr ""
@@ -8060,7 +8049,7 @@ msgstr ""
 msgid "Search and delete"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:213
+#: lib/vutuv_web/live/admin/user_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Search by name, @handle or email, filter and sort. The list updates as you type, and the default shows PIN-registered members, newest first."
 msgstr ""
@@ -8076,13 +8065,13 @@ msgid "Type a name, @handle or email to find the account to delete."
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_detail_live.ex:99
-#: lib/vutuv_web/live/admin/user_live.ex:358
+#: lib/vutuv_web/live/admin/user_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Unconfirmed"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/member_badges.ex:25
-#: lib/vutuv_web/live/admin/user_live.ex:298
+#: lib/vutuv_web/live/admin/user_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Unreachable"
 msgstr ""
@@ -8094,14 +8083,14 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:226
+#: lib/vutuv_web/controllers/user_controller.ex:222
 #, elixir-autogen, elixir-format
 msgid "Your verified badge was removed because you changed your name, gender or date of birth. We re-check identity against those details so members can trust verified profiles and nobody can set up a fake verified account. An admin can verify you again anytime."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/activity_live.ex:222
+#: lib/vutuv_web/live/admin/activity_live.ex:184
 #: lib/vutuv_web/live/admin/user_delete_live.ex:127
-#: lib/vutuv_web/live/admin/user_live.ex:253
+#: lib/vutuv_web/live/admin/user_live.ex:228
 #: lib/vutuv_web/templates/admin/account/index.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "name, @handle or email"
@@ -8180,7 +8169,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:41
 #: lib/vutuv_web/agent_docs/text.ex:38
-#: lib/vutuv_web/components/ui.ex:3418
+#: lib/vutuv_web/components/ui.ex:3361
 #: lib/vutuv_web/controllers/education_controller.ex:43
 #: lib/vutuv_web/controllers/education_controller.ex:60
 #: lib/vutuv_web/controllers/education_controller.ex:140
@@ -8234,7 +8223,7 @@ msgstr ""
 msgid "Here is what we found in your export. Uncheck anything you do not want. Entries already on your profile are unchecked for you."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3521
+#: lib/vutuv_web/components/ui.ex:3464
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -8263,7 +8252,7 @@ msgstr ""
 msgid "Nothing new to import."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3445
+#: lib/vutuv_web/components/ui.ex:3388
 #: lib/vutuv_web/controllers/phone_number_controller.ex:22
 #: lib/vutuv_web/controllers/phone_number_controller.ex:36
 #: lib/vutuv_web/controllers/phone_number_controller.ex:86
@@ -8354,12 +8343,12 @@ msgstr ""
 msgid "Too many imports. Please try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1226
+#: lib/vutuv_web/live/user_profile_live.ex:1294
 #, elixir-autogen, elixir-format
 msgid "For example, a thought on %{tag}."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2880
+#: lib/vutuv_web/components/ui.ex:2823
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:29
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:46
 #: lib/vutuv_web/controllers/admin/user_pref_controller.ex:52
@@ -8380,7 +8369,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:99
-#: lib/vutuv_web/templates/user/show.html.heex:1282
+#: lib/vutuv_web/templates/user/show.html.heex:1289
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8440,13 +8429,13 @@ msgstr ""
 msgid "Drag your ZIP file here, or click to choose one."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3406
+#: lib/vutuv_web/components/ui.ex:3349
 #: lib/vutuv_web/templates/user/edit.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Basics & photos"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3517
+#: lib/vutuv_web/components/ui.ex:3460
 #: lib/vutuv_web/controllers/settings_controller.ex:114
 #: lib/vutuv_web/templates/settings/preferences.html.heex:5
 #, elixir-autogen, elixir-format
@@ -8458,9 +8447,9 @@ msgstr ""
 msgid "More profile sections"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3508
+#: lib/vutuv_web/components/ui.ex:3451
 #: lib/vutuv_web/controllers/settings_controller.ex:97
-#: lib/vutuv_web/live/account_activity_live.ex:365
+#: lib/vutuv_web/live/account_activity_live.ex:310
 #: lib/vutuv_web/templates/login_code/index.html.heex:5
 #: lib/vutuv_web/templates/settings/security.html.heex:11
 #: lib/vutuv_web/templates/totp/new.html.heex:5
@@ -8468,7 +8457,7 @@ msgstr ""
 msgid "Sign-in & security"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3525
+#: lib/vutuv_web/components/ui.ex:3468
 #: lib/vutuv_web/controllers/export_controller.ex:19
 #: lib/vutuv_web/templates/export/index.html.heex:6
 #, elixir-autogen, elixir-format
@@ -8480,7 +8469,7 @@ msgstr ""
 msgid "The file is in JSON format and includes your profile, posts, messages and settings. It contains private data, so store it carefully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/user_controller.ex:250
+#: lib/vutuv_web/controllers/user_controller.ex:246
 #, elixir-autogen, elixir-format
 msgid "Please type your username exactly as shown to confirm the deletion."
 msgstr ""
@@ -8490,13 +8479,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1135
-#: lib/vutuv_web/live/post_live/feed.ex:1136
+#: lib/vutuv_web/live/post_live/feed.ex:1144
+#: lib/vutuv_web/live/post_live/feed.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1130
+#: lib/vutuv_web/live/post_live/feed.ex:1139
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8561,7 +8550,7 @@ msgstr ""
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
 #: lib/vutuv_web/templates/directory/show.html.heex:5
-#: lib/vutuv_web/templates/layout/app.html.heex:75
+#: lib/vutuv_web/templates/layout/app.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Member directory"
 msgstr ""
@@ -8596,7 +8585,7 @@ msgstr[1] ""
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:767
+#: lib/vutuv_web/components/ui.ex:776
 #, elixir-autogen, elixir-format
 msgid "This profile is not offered as a Markdown, text, JSON or XML export."
 msgstr ""
@@ -8691,19 +8680,19 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:501
 #: lib/vutuv_web/agent_docs/text.ex:467
 #: lib/vutuv_web/agent_docs/text.ex:471
-#: lib/vutuv_web/components/ui.ex:3498
+#: lib/vutuv_web/components/ui.ex:3441
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:200
 #: lib/vutuv_web/controllers/settings_controller.ex:267
-#: lib/vutuv_web/live/fediverse_followers_live.ex:127
-#: lib/vutuv_web/live/fediverse_following_live.ex:254
+#: lib/vutuv_web/live/fediverse_followers_live.ex:109
+#: lib/vutuv_web/live/fediverse_following_live.ex:239
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:312
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:876
-#: lib/vutuv_web/templates/user/show.html.heex:1187
+#: lib/vutuv_web/templates/user/show.html.heex:882
+#: lib/vutuv_web/templates/user/show.html.heex:1194
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8757,19 +8746,19 @@ msgstr ""
 msgid "Category"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:24
+#: lib/vutuv_web/views/work_experience_html.ex:25
 #, elixir-autogen, elixir-format
 msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
 #: lib/vutuv_web/agent_docs/markdown.ex:658
-#: lib/vutuv_web/views/work_experience_html.ex:26
+#: lib/vutuv_web/views/work_experience_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Internship"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:36
+#: lib/vutuv_web/views/work_experience_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Internships"
 msgstr ""
@@ -8779,14 +8768,14 @@ msgstr ""
 msgid "On that page, select \"Download larger data archive\" (profile, positions, volunteering, education, skills)."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:34
+#: lib/vutuv_web/views/work_experience_html.ex:35
 #, elixir-autogen, elixir-format
 msgid "Professional Experience"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:659
-#: lib/vutuv_web/views/work_experience_html.ex:30
-#: lib/vutuv_web/views/work_experience_html.ex:37
+#: lib/vutuv_web/views/work_experience_html.ex:31
+#: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Volunteering & hobbies"
 msgstr ""
@@ -8810,19 +8799,19 @@ msgstr ""
 msgid "Your profile as a CV"
 msgstr ""
 
-#: lib/vutuv_web/views/education_html.ex:28
+#: lib/vutuv_web/views/education_html.ex:21
 #, elixir-autogen, elixir-format
 msgid "Higher Education"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:696
-#: lib/vutuv_web/views/education_html.ex:30
+#: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:695
-#: lib/vutuv_web/views/education_html.ex:29
+#: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
 msgstr ""
@@ -8842,7 +8831,7 @@ msgstr ""
 msgid "This is the print view of this CV. Use your browser's print dialog (Ctrl+P or Cmd+P) and choose \"Save as PDF\" to get a PDF file."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:801
+#: lib/vutuv_web/components/ui.ex:810
 #, elixir-autogen, elixir-format
 msgid "CV download"
 msgstr ""
@@ -8881,7 +8870,7 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:811
+#: lib/vutuv_web/components/ui.ex:820
 #: lib/vutuv_web/templates/export/index.html.heex:27
 #, elixir-autogen, elixir-format
 msgid "Open CV"
@@ -8913,7 +8902,7 @@ msgstr ""
 msgid "The CV is public, on your profile: a visitor's download contains only what they can see there anyway, and private email addresses appear only in your own."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:803
+#: lib/vutuv_web/components/ui.ex:812
 #, elixir-autogen, elixir-format
 msgid "This profile as a formatted CV for job applications. Open it to pick what to include, anonymize it, print or download."
 msgstr ""
@@ -8934,15 +8923,15 @@ msgid "The CV of %{name} on vutuv: work experience, education and skills to view
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:657
-#: lib/vutuv_web/views/work_experience_html.ex:25
-#: lib/vutuv_web/views/work_experience_html.ex:35
+#: lib/vutuv_web/views/work_experience_html.ex:26
+#: lib/vutuv_web/views/work_experience_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:660
-#: lib/vutuv_web/views/work_experience_html.ex:31
-#: lib/vutuv_web/views/work_experience_html.ex:38
+#: lib/vutuv_web/views/work_experience_html.ex:32
+#: lib/vutuv_web/views/work_experience_html.ex:39
 #, elixir-autogen, elixir-format
 msgid "Other activities"
 msgstr ""
@@ -8969,14 +8958,12 @@ msgstr ""
 msgid "Choose automatically instead"
 msgstr ""
 
-#: lib/vutuv_web/templates/education/card_list.html.heex:93
-#: lib/vutuv_web/views/work_experience_html.ex:682
+#: lib/vutuv_web/views/user_helpers.ex:378
 #, elixir-autogen, elixir-format
 msgid "Show at top of profile"
 msgstr ""
 
-#: lib/vutuv_web/templates/education/card_list.html.heex:84
-#: lib/vutuv_web/views/work_experience_html.ex:673
+#: lib/vutuv_web/views/user_helpers.ex:369
 #, elixir-autogen, elixir-format
 msgid "Shown at the top of your profile"
 msgstr ""
@@ -9071,8 +9058,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1198
-#: lib/vutuv_web/components/ui.ex:1199
+#: lib/vutuv_web/components/ui.ex:1207
+#: lib/vutuv_web/components/ui.ex:1208
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:64
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
@@ -9513,18 +9500,18 @@ msgstr ""
 msgid "Employment status"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:892
+#: lib/vutuv/accounts/user.ex:900
 #: lib/vutuv_web/gettext_extraction_anchors.ex:48
 #, elixir-autogen, elixir-format
 msgid "Looking for a job"
 msgstr ""
 
-#: lib/vutuv_web/views/user_helpers.ex:41
+#: lib/vutuv_web/views/user_helpers.ex:48
 #, elixir-autogen, elixir-format
 msgid "Not open to work"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:889
+#: lib/vutuv/accounts/user.ex:897
 #: lib/vutuv_web/gettext_extraction_anchors.ex:47
 #, elixir-autogen, elixir-format
 msgid "Open to offers"
@@ -9639,7 +9626,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:45
 #: lib/vutuv_web/agent_docs/text.ex:42
-#: lib/vutuv_web/components/ui.ex:3422
+#: lib/vutuv_web/components/ui.ex:3365
 #: lib/vutuv_web/controllers/qualification_controller.ex:46
 #: lib/vutuv_web/controllers/qualification_controller.ex:65
 #: lib/vutuv_web/controllers/qualification_controller.ex:124
@@ -9771,8 +9758,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1111
-#: lib/vutuv_web/templates/user/show.html.heex:1112
+#: lib/vutuv_web/templates/user/show.html.heex:1117
+#: lib/vutuv_web/templates/user/show.html.heex:1118
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9956,7 +9943,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:131
 #: lib/vutuv_web/templates/totp/new.html.heex:58
-#: lib/vutuv_web/templates/user/show.html.heex:912
+#: lib/vutuv_web/templates/user/show.html.heex:918
 #: lib/vutuv_web/templates/username/new.html.heex:27
 #: lib/vutuv_web/templates/username/new.html.heex:114
 #, elixir-autogen, elixir-format
@@ -9967,8 +9954,8 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:134
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
-#: lib/vutuv_web/templates/user/show.html.heex:911
-#: lib/vutuv_web/templates/user/show.html.heex:915
+#: lib/vutuv_web/templates/user/show.html.heex:917
+#: lib/vutuv_web/templates/user/show.html.heex:921
 #: lib/vutuv_web/templates/username/new.html.heex:26
 #: lib/vutuv_web/templates/username/new.html.heex:30
 #: lib/vutuv_web/templates/username/new.html.heex:113
@@ -10045,7 +10032,7 @@ msgstr ""
 msgid "Account removed"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:104
+#: lib/vutuv_web/live/admin/user_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Account restored. The member can sign in again."
 msgstr ""
@@ -10060,7 +10047,7 @@ msgstr ""
 msgid "Clear-cut spam or abuse?"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:107
+#: lib/vutuv_web/live/admin/user_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Could not restore this member."
 msgstr ""
@@ -10085,17 +10072,17 @@ msgstr ""
 msgid "Remove the account outright, skipping the warning ladder. Deactivating marks it as spam and is reversible from the member browser; deleting is permanent."
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:301
+#: lib/vutuv_web/live/admin/user_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Removed as spam"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:399
+#: lib/vutuv_web/live/admin/user_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Restore"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/user_live.ex:396
+#: lib/vutuv_web/live/admin/user_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Restore this account so the member can sign in again?"
 msgstr ""
@@ -10428,7 +10415,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1256
+#: lib/vutuv_web/templates/user/show.html.heex:1263
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -10669,12 +10656,12 @@ msgstr ""
 msgid "Separate tags with a comma. A tag may be several words long, like Ruby on Rails."
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:426
+#: lib/vutuv_web/views/work_experience_html.ex:428
 #, elixir-autogen, elixir-format
 msgid "%{n}m"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:427
+#: lib/vutuv_web/views/work_experience_html.ex:429
 #, elixir-autogen, elixir-format
 msgid "%{n}y"
 msgstr ""
@@ -10808,7 +10795,7 @@ msgid "Preference defaults"
 msgstr ""
 
 #: lib/vutuv_web/live/admin/user_detail_live.ex:167
-#: lib/vutuv_web/live/admin/user_live.ex:378
+#: lib/vutuv_web/live/admin/user_live.ex:349
 #: lib/vutuv_web/templates/admin/user_pref/show.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Preferences"
@@ -11012,19 +10999,19 @@ msgstr ""
 msgid "\"Signed-in members only\" is the default. It reduces who sees your availability but cannot guarantee it, since anyone can create an account. Choose \"No one\" to keep the status saved without showing it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:930
+#: lib/vutuv/accounts/user.ex:938
 #: lib/vutuv_web/gettext_extraction_anchors.ex:51
 #, elixir-autogen, elixir-format
 msgid "Everyone, including logged-out visitors"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:935
+#: lib/vutuv/accounts/user.ex:943
 #: lib/vutuv_web/gettext_extraction_anchors.ex:53
 #, elixir-autogen, elixir-format
 msgid "No one"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:933
+#: lib/vutuv/accounts/user.ex:941
 #: lib/vutuv_web/gettext_extraction_anchors.ex:52
 #: lib/vutuv_web/live/job_posting_live/form.ex:566
 #, elixir-autogen, elixir-format
@@ -11283,7 +11270,7 @@ msgstr ""
 msgid "Remove logo"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:91
+#: lib/vutuv_web/live/organization_live/index.ex:83
 #, elixir-autogen, elixir-format
 msgid "Search by name or city"
 msgstr ""
@@ -11912,8 +11899,8 @@ msgstr ""
 msgid "Claim a short @handle so this organization has its own root URL, like a member profile. Letters, numbers and underscores, %{min} to %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:78
-#: lib/vutuv_web/live/organization_live/index.ex:109
+#: lib/vutuv_web/live/organization_live/index.ex:70
+#: lib/vutuv_web/live/organization_live/index.ex:101
 #: lib/vutuv_web/live/organization_live/new.ex:26
 #: lib/vutuv_web/live/organization_live/new.ex:80
 #: lib/vutuv_web/templates/settings/organizations.html.heex:87
@@ -11977,12 +11964,12 @@ msgstr ""
 msgid "No organization pages match."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:100
+#: lib/vutuv_web/live/organization_live/index.ex:92
 #, elixir-autogen, elixir-format
 msgid "No organization pages yet. Be the first to add yours."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:102
+#: lib/vutuv_web/live/organization_live/index.ex:94
 #, elixir-autogen, elixir-format
 msgid "No organizations found for %{term}."
 msgstr ""
@@ -12041,7 +12028,7 @@ msgstr ""
 msgid "Organization pages"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:954
+#: lib/vutuv_web/live/notification_live/index.ex:989
 #, elixir-autogen, elixir-format
 msgid "Organization role"
 msgstr ""
@@ -12052,13 +12039,13 @@ msgid "Organization unfrozen."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/organization_doc.ex:91
-#: lib/vutuv_web/components/ui.ex:3434
+#: lib/vutuv_web/components/ui.ex:3377
 #: lib/vutuv_web/controllers/settings_controller.ex:165
-#: lib/vutuv_web/live/organization_live/index.ex:29
-#: lib/vutuv_web/live/organization_live/index.ex:69
+#: lib/vutuv_web/live/organization_live/index.ex:30
+#: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:455
 #: lib/vutuv_web/live/shell_live.ex:566
-#: lib/vutuv_web/templates/layout/app.html.heex:79
+#: lib/vutuv_web/templates/layout/app.html.heex:83
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Organizations"
@@ -12079,7 +12066,7 @@ msgstr ""
 msgid "Please log in to claim an organization page."
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:83
+#: lib/vutuv_web/live/organization_live/index.ex:75
 #, elixir-autogen, elixir-format
 msgid "Search organizations"
 msgstr ""
@@ -12144,22 +12131,22 @@ msgstr ""
 msgid "Your organization page was updated."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1151
+#: lib/vutuv_web/live/notification_live/index.ex:1186
 #, elixir-autogen, elixir-format
 msgid "gave you a role at %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1148
+#: lib/vutuv_web/live/notification_live/index.ex:1183
 #, elixir-autogen, elixir-format
 msgid "made you a recruiter for %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1145
+#: lib/vutuv_web/live/notification_live/index.ex:1180
 #, elixir-autogen, elixir-format
 msgid "made you an admin of %{organization}."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1142
+#: lib/vutuv_web/live/notification_live/index.ex:1177
 #, elixir-autogen, elixir-format
 msgid "made you an owner of %{organization}."
 msgstr ""
@@ -12358,7 +12345,7 @@ msgstr ""
 msgid "How to apply"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:904
+#: lib/vutuv/accounts/user.ex:912
 #: lib/vutuv/jobs/job_posting.ex:163
 #, elixir-autogen, elixir-format
 msgid "Hybrid"
@@ -12385,7 +12372,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:211
 #: lib/vutuv_web/live/post_live/saved.ex:458
 #: lib/vutuv_web/live/shell_live.ex:457
-#: lib/vutuv_web/templates/layout/app.html.heex:77
+#: lib/vutuv_web/templates/layout/app.html.heex:81
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "Jobs"
@@ -12478,7 +12465,7 @@ msgstr ""
 msgid "Offer the machine-readable formats (.md/.txt/.json/.xml) to AI agents."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:903
+#: lib/vutuv/accounts/user.ex:911
 #: lib/vutuv/jobs/job_posting.ex:162
 #, elixir-autogen, elixir-format
 msgid "On-site"
@@ -12560,7 +12547,7 @@ msgstr ""
 msgid "Publish"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:905
+#: lib/vutuv/accounts/user.ex:913
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:434
 #: lib/vutuv_web/agent_docs/markdown.ex:348
@@ -12818,7 +12805,7 @@ msgstr ""
 msgid "Verification pending"
 msgstr ""
 
-#: lib/vutuv_web/live/organization_live/index.ex:71
+#: lib/vutuv_web/live/organization_live/index.ex:63
 #, elixir-autogen, elixir-format
 msgid "Verified pages for companies, associations, schools, public authorities and other groups, not for single people. Every page has a proven web domain, so you know it is really them."
 msgstr ""
@@ -13223,8 +13210,8 @@ msgid "Email me"
 msgstr ""
 
 #: lib/vutuv_web/components/saved_search_components.ex:62
-#: lib/vutuv_web/live/account_activity_live.ex:216
-#: lib/vutuv_web/live/admin/activity_live.ex:252
+#: lib/vutuv_web/live/account_activity_live.ex:171
+#: lib/vutuv_web/live/admin/activity_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Everything"
 msgstr ""
@@ -13265,7 +13252,7 @@ msgstr ""
 msgid "Saved search deleted."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3483
+#: lib/vutuv_web/components/ui.ex:3426
 #: lib/vutuv_web/controllers/settings_controller.ex:433
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:1
 #: lib/vutuv_web/templates/settings/saved_searches.html.heex:3
@@ -13534,7 +13521,7 @@ msgstr ""
 msgid "Image awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:952
+#: lib/vutuv_web/live/notification_live/index.ex:987
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Image review"
@@ -13550,32 +13537,32 @@ msgstr ""
 msgid "Profile picture awaiting review, visible only to you"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:114
+#: lib/vutuv_web/live/post_live/edit.ex:112
 #, elixir-autogen, elixir-format
 msgid "Link preview screenshot"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:135
+#: lib/vutuv_web/live/post_live/edit.ex:133
 #, elixir-autogen, elixir-format
 msgid "Remove screenshot"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:133
+#: lib/vutuv_web/live/post_live/edit.ex:131
 #, elixir-autogen, elixir-format
 msgid "Remove this screenshot from your post?"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:76
+#: lib/vutuv_web/live/post_live/edit.ex:74
 #, elixir-autogen, elixir-format
 msgid "Screenshot removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:116
+#: lib/vutuv_web/live/post_live/edit.ex:114
 #, elixir-autogen, elixir-format
 msgid "This screenshot was captured automatically from the link in your post. If it turned out wrong (for example a cookie banner covering the page), you can remove it."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:948
+#: lib/vutuv/accounts/user.ex:956
 #: lib/vutuv_web/gettext_extraction_anchors.ex:57
 #, elixir-autogen, elixir-format
 msgid "Age only, without the date"
@@ -13586,19 +13573,19 @@ msgstr ""
 msgid "Choose how much of your birthday your profile shows. \"Age only\" hides the exact date, \"Day and month\" hides the year (and your age), and \"Do not show\" keeps it saved but off your profile."
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:951
+#: lib/vutuv/accounts/user.ex:959
 #: lib/vutuv_web/gettext_extraction_anchors.ex:58
 #, elixir-autogen, elixir-format
 msgid "Day and month, without the year"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:954
+#: lib/vutuv/accounts/user.ex:962
 #: lib/vutuv_web/gettext_extraction_anchors.ex:59
 #, elixir-autogen, elixir-format
 msgid "Do not show my birthday"
 msgstr ""
 
-#: lib/vutuv/accounts/user.ex:945
+#: lib/vutuv/accounts/user.ex:953
 #: lib/vutuv_web/gettext_extraction_anchors.ex:56
 #, elixir-autogen, elixir-format
 msgid "Full date and age"
@@ -13621,7 +13608,7 @@ msgstr[1] ""
 msgid "Changing it automatically rewrites every mention of your old handle in posts to the new one and notifies those posts' authors. Your old profile address stops working."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:955
+#: lib/vutuv_web/live/notification_live/index.ex:990
 #, elixir-autogen, elixir-format
 msgid "Handle change"
 msgstr ""
@@ -13633,7 +13620,7 @@ msgid_plural "We updated %{formatted} posts that mentioned your old handle and n
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1201
+#: lib/vutuv_web/live/notification_live/index.ex:1236
 #, elixir-autogen, elixir-format
 msgid "changed their handle from @%{old} to @%{new}."
 msgstr ""
@@ -13720,16 +13707,16 @@ msgstr ""
 msgid "Posts tagged with a tag you follow show up in your feed, and people known for it appear in your suggestions. Follow a tag from its page."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3479
+#: lib/vutuv_web/components/ui.ex:3422
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:1081
+#: lib/vutuv_web/live/post_live/feed.ex:1090
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1096
+#: lib/vutuv_web/live/post_live/feed.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13771,7 +13758,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1222
+#: lib/vutuv_web/templates/user/show.html.heex:1229
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13800,7 +13787,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:59
 #: lib/vutuv_web/agent_docs/text.ex:56
-#: lib/vutuv_web/components/ui.ex:3464
+#: lib/vutuv_web/components/ui.ex:3407
 #: lib/vutuv_web/controllers/messenger_controller.ex:21
 #: lib/vutuv_web/controllers/messenger_controller.ex:36
 #: lib/vutuv_web/templates/messenger/edit.html.heex:4
@@ -13808,7 +13795,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1220
+#: lib/vutuv_web/templates/user/show.html.heex:1227
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13828,34 +13815,34 @@ msgstr ""
 msgid "Select a messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:2966
+#: lib/vutuv_web/components/ui.ex:2909
 #, elixir-autogen, elixir-format
 msgid "Tell my follower about this"
 msgid_plural "Tell my %{formatted} followers about this"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/ui.ex:2976
+#: lib/vutuv_web/components/ui.ex:2919
 #, elixir-autogen, elixir-format
 msgid "They see one notification linking to this entry. No email is sent, and it only ever happens for a new entry."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:956
+#: lib/vutuv_web/live/notification_live/index.ex:991
 #, elixir-autogen, elixir-format
 msgid "CV update"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1221
+#: lib/vutuv_web/live/notification_live/index.ex:1256
 #, elixir-autogen, elixir-format
 msgid "added a new position to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1213
+#: lib/vutuv_web/live/notification_live/index.ex:1248
 #, elixir-autogen, elixir-format
 msgid "added a new education entry to their CV: %{entry}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1218
+#: lib/vutuv_web/live/notification_live/index.ex:1253
 #, elixir-autogen, elixir-format
 msgid "added a new certificate to their CV: %{entry}"
 msgstr ""
@@ -13880,7 +13867,7 @@ msgstr ""
 msgid "When off, you never see this kind of notification, whoever sends it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1226
+#: lib/vutuv_web/live/notification_live/index.ex:1261
 #, elixir-autogen, elixir-format
 msgid "added %{count} new entries to their CV:"
 msgstr ""
@@ -13917,7 +13904,7 @@ msgstr ""
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:441
+#: lib/vutuv_web/live/fediverse_account_live.ex:448
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Look up"
@@ -13995,7 +13982,7 @@ msgstr ""
 msgid "Qualification"
 msgstr ""
 
-#: lib/vutuv_web/views/work_experience_html.ex:646
+#: lib/vutuv_web/views/work_experience_html.ex:613
 #, elixir-autogen, elixir-format
 msgid "With qualification:"
 msgstr ""
@@ -14010,45 +13997,45 @@ msgstr ""
 msgid "Publisher:"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:824
+#: lib/vutuv_web/live/notification_live/index.ex:859
 #, elixir-autogen, elixir-format
 msgid "%{formatted} new notification"
 msgid_plural "%{formatted} new notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:838
+#: lib/vutuv_web/live/notification_live/index.ex:873
 #, elixir-autogen, elixir-format
 msgid "%{month} %{day}, %{year}"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:348
+#: lib/vutuv_web/live/notification_live/index.ex:383
 #, elixir-autogen, elixir-format
 msgid "Follow back"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:363
+#: lib/vutuv_web/live/notification_live/index.ex:398
 #, elixir-autogen, elixir-format
 msgid "Last 30 days"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:790
-#: lib/vutuv_web/live/notification_live/index.ex:1034
+#: lib/vutuv_web/live/notification_live/index.ex:825
+#: lib/vutuv_web/live/notification_live/index.ex:1069
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:971
+#: lib/vutuv_web/live/notification_live/index.ex:1006
 #, elixir-autogen, elixir-format
 msgid "are now connected with you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:966
+#: lib/vutuv_web/live/notification_live/index.ex:1001
 #, elixir-autogen, elixir-format
 msgid "are now following you."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:981
+#: lib/vutuv_web/live/notification_live/index.ex:1016
 #, elixir-autogen, elixir-format
 msgid "endorsed you for %{tags}."
 msgstr ""
@@ -14058,12 +14045,12 @@ msgstr ""
 msgid "by:"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1332
+#: lib/vutuv_web/components/ui.ex:1341
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:1336
+#: lib/vutuv_web/components/ui.ex:1345
 #, elixir-autogen, elixir-format
 msgid "Endorsed by %{name} and %{formatted} other"
 msgid_plural "Endorsed by %{name} and %{formatted} others"
@@ -14283,7 +14270,7 @@ msgstr ""
 msgid "Availability"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:760
+#: lib/vutuv_web/live/notification_live/index.ex:795
 #, elixir-autogen, elixir-format
 msgid "Your automatically assigned vutuv username is {handle}. You can change it any time at {url}."
 msgstr ""
@@ -14293,17 +14280,17 @@ msgstr ""
 msgid "An automated check removed an image from your vutuv account"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1175
+#: lib/vutuv_web/live/notification_live/index.ex:1210
 #, elixir-autogen, elixir-format
 msgid "An AI, not a person, removed %{what}: it judged the image not family-friendly enough for a work environment. It can be wrong, so reply to our email if you disagree."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:945
+#: lib/vutuv_web/live/notification_live/index.ex:980
 #, elixir-autogen, elixir-format
 msgid "Thread reply"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1021
+#: lib/vutuv_web/live/notification_live/index.ex:1056
 #, elixir-autogen, elixir-format
 msgid "replied in a thread you posted in."
 msgid_plural "replied in a thread you posted in."
@@ -14322,29 +14309,29 @@ msgstr ""
 msgid "Only part of this long conversation is shown."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:946
+#: lib/vutuv_web/live/notification_live/index.ex:981
 #, elixir-autogen, elixir-format
 msgid "Mention"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1125
+#: lib/vutuv_web/live/notification_live/index.ex:1160
 #, elixir-autogen, elixir-format
 msgid "mentioned you in a post."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1000
-#: lib/vutuv_web/live/post_live/edit.ex:59
+#: lib/vutuv_web/live/post_live/edit.ex:57
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited: someone has liked, reposted or answered it."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/composer.ex:1003
-#: lib/vutuv_web/live/post_live/edit.ex:61
+#: lib/vutuv_web/live/post_live/edit.ex:59
 #, elixir-autogen, elixir-format
 msgid "This post can no longer be edited. Posts stay editable for %{minutes} minutes after publishing."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/edit.ex:100
+#: lib/vutuv_web/live/post_live/edit.ex:98
 #, elixir-autogen, elixir-format
 msgid "A post stays editable for %{minutes} minutes, and only until someone likes, reposts or answers it. You can delete it at any time."
 msgstr ""
@@ -14407,7 +14394,7 @@ msgstr ""
 msgid "No accounts are currently frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:309
+#: lib/vutuv_web/live/post_live/thread.ex:352
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr ""
@@ -14446,7 +14433,7 @@ msgstr[1] ""
 msgid "This page is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:301
+#: lib/vutuv_web/live/post_live/thread.ex:344
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr ""
@@ -14608,7 +14595,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:233
+#: lib/vutuv_web/live/post_live/feed.ex:271
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14623,7 +14610,7 @@ msgstr ""
 msgid "Match whole words only (word/phrase)"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3475
+#: lib/vutuv_web/components/ui.ex:3418
 #: lib/vutuv_web/controllers/settings_controller.ex:513
 #: lib/vutuv_web/templates/settings/filters.html.heex:1
 #: lib/vutuv_web/templates/settings/filters.html.heex:3
@@ -14641,7 +14628,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:242
+#: lib/vutuv_web/live/post_live/feed.ex:280
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -14671,7 +14658,7 @@ msgstr ""
 msgid "Thread replies"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:536
+#: lib/vutuv_web/live/notification_live/index.ex:571
 #, elixir-autogen, elixir-format
 msgid "Turn off thread notifications"
 msgstr ""
@@ -14722,7 +14709,7 @@ msgstr ""
 msgid "You have reached the maximum of %{count} filters."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:531
+#: lib/vutuv_web/live/notification_live/index.ex:566
 #, elixir-autogen, elixir-format
 msgid "You wrote in this thread."
 msgstr ""
@@ -14807,9 +14794,9 @@ msgstr ""
 msgid "No server is blocked."
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:185
-#: lib/vutuv_web/live/fediverse_followers_live.ex:113
-#: lib/vutuv_web/live/fediverse_following_live.ex:240
+#: lib/vutuv_web/components/browse_table.ex:289
+#: lib/vutuv_web/live/fediverse_followers_live.ex:95
+#: lib/vutuv_web/live/fediverse_following_live.ex:225
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:96
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:147
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:191
@@ -14869,8 +14856,8 @@ msgid "Reactions from other networks"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_followers_live.ex:45
-#: lib/vutuv_web/live/fediverse_followers_live.ex:124
-#: lib/vutuv_web/live/fediverse_followers_live.ex:134
+#: lib/vutuv_web/live/fediverse_followers_live.ex:106
+#: lib/vutuv_web/live/fediverse_followers_live.ex:116
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:15
 #, elixir-autogen, elixir-format
 msgid "Followers from other networks"
@@ -14918,7 +14905,7 @@ msgstr ""
 msgid "Give this out the way you give out an email address. Anyone on Mastodon and friends can paste it into their search and follow you from there."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:150
+#: lib/vutuv_web/live/fediverse_followers_live.ex:127
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
@@ -14992,8 +14979,8 @@ msgstr ""
 msgid "Send your Fediverse followers to another account. They are asked to follow it instead, and vutuv stops federating your new posts. Your vutuv profile stays exactly as it is, and nothing is deleted."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:224
-#: lib/vutuv_web/live/fediverse_following_live.ex:460
+#: lib/vutuv_web/live/fediverse_followers_live.ex:201
+#: lib/vutuv_web/live/fediverse_following_live.ex:431
 #: lib/vutuv_web/templates/settings/fediverse_move.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Back to Fediverse settings"
@@ -15191,27 +15178,27 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:880
+#: lib/vutuv_web/templates/user/show.html.heex:886
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:896
+#: lib/vutuv_web/templates/user/show.html.heex:902
 #, elixir-autogen, elixir-format
 msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:933
+#: lib/vutuv_web/templates/user/show.html.heex:939
 #, elixir-autogen, elixir-format
 msgid "Follow from your own server"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:944
+#: lib/vutuv_web/templates/user/show.html.heex:950
 #, elixir-autogen, elixir-format
 msgid "@you@example.social"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:952
+#: lib/vutuv_web/templates/user/show.html.heex:958
 #, elixir-autogen, elixir-format
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr ""
@@ -15221,22 +15208,22 @@ msgstr ""
 msgid "This profile is not on the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:72
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "That is not a Fediverse address. It looks like @you@example.social."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:76
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:136
 #, elixir-autogen, elixir-format
 msgid "%{server} did not offer a follow dialog. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:83
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:143
 #, elixir-autogen, elixir-format
 msgid "%{server} did not answer. Copy the handle above and paste it into your app's search instead."
 msgstr ""
 
-#: lib/vutuv_web/controllers/remote_follow_controller.ex:94
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:154
 #, elixir-autogen, elixir-format
 msgid "Your server"
 msgstr ""
@@ -15247,282 +15234,282 @@ msgstr ""
 msgid "moved to %{address}"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3407
+#: lib/vutuv_web/components/ui.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Name, photo, cover picture, tagline"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3408
+#: lib/vutuv_web/components/ui.ex:3351
 #, elixir-autogen, elixir-format
 msgid "avatar portrait picture image birthday gender about me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3412
+#: lib/vutuv_web/components/ui.ex:3355
 #, elixir-autogen, elixir-format
 msgid "handle nickname rename slug profile address url mention"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3415
+#: lib/vutuv_web/components/ui.ex:3358
 #, elixir-autogen, elixir-format
 msgid "The jobs and roles on your CV"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3416
+#: lib/vutuv_web/components/ui.ex:3359
 #, elixir-autogen, elixir-format
 msgid "cv resume career employer position title company"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3419
+#: lib/vutuv_web/components/ui.ex:3362
 #, elixir-autogen, elixir-format
 msgid "Schools, universities, degrees"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3420
+#: lib/vutuv_web/components/ui.ex:3363
 #, elixir-autogen, elixir-format
 msgid "cv resume study studies school university degree"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3423
+#: lib/vutuv_web/components/ui.ex:3366
 #, elixir-autogen, elixir-format
 msgid "Credentials, with proof documents"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3424
+#: lib/vutuv_web/components/ui.ex:3367
 #, elixir-autogen, elixir-format
 msgid "certificate licence diploma credential award proof document"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3426
+#: lib/vutuv_web/components/ui.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Language skills"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3427
+#: lib/vutuv_web/components/ui.ex:3370
 #, elixir-autogen, elixir-format
 msgid "The languages you speak"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3428
+#: lib/vutuv_web/components/ui.ex:3371
 #, elixir-autogen, elixir-format
 msgid "language speak spoken fluent native mother tongue"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3431
+#: lib/vutuv_web/components/ui.ex:3374
 #, elixir-autogen, elixir-format
 msgid "The topics you are known for"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3432
+#: lib/vutuv_web/components/ui.ex:3375
 #, elixir-autogen, elixir-format
 msgid "skill topic keyword expertise endorsement"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3435
+#: lib/vutuv_web/components/ui.ex:3378
 #, elixir-autogen, elixir-format
 msgid "Company pages you run"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3436
+#: lib/vutuv_web/components/ui.ex:3379
 #, elixir-autogen, elixir-format
 msgid "company employer firm business organisation page"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3439
+#: lib/vutuv_web/components/ui.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Contact details"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3442
+#: lib/vutuv_web/components/ui.ex:3385
 #, elixir-autogen, elixir-format
 msgid "Where we reach you, and which address is public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3443
+#: lib/vutuv_web/components/ui.ex:3386
 #, elixir-autogen, elixir-format
 msgid "mail e-mail address primary"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3446
+#: lib/vutuv_web/components/ui.ex:3389
 #, elixir-autogen, elixir-format
 msgid "Landline, mobile, fax"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3447
+#: lib/vutuv_web/components/ui.ex:3390
 #, elixir-autogen, elixir-format
 msgid "telephone mobile cell fax number"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3450
+#: lib/vutuv_web/components/ui.ex:3393
 #, elixir-autogen, elixir-format
 msgid "Postal addresses on your profile"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3451
+#: lib/vutuv_web/components/ui.ex:3394
 #, elixir-autogen, elixir-format
 msgid "street city postcode zip country post map"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3453
+#: lib/vutuv_web/components/ui.ex:3396
 #, elixir-autogen, elixir-format
 msgid "Websites & links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3454
+#: lib/vutuv_web/components/ui.ex:3397
 #, elixir-autogen, elixir-format
 msgid "Your homepage and other links"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3455
+#: lib/vutuv_web/components/ui.ex:3398
 #, elixir-autogen, elixir-format
 msgid "url website homepage blog link verify rel=me"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3457
+#: lib/vutuv_web/components/ui.ex:3400
 #, elixir-autogen, elixir-format
 msgid "Social media profiles"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3458
+#: lib/vutuv_web/components/ui.ex:3401
 #, elixir-autogen, elixir-format
 msgid "Mastodon, Bluesky, GitHub and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3460
+#: lib/vutuv_web/components/ui.ex:3403
 #, elixir-autogen, elixir-format
 msgid "mastodon bluesky github gitlab codeberg linkedin x twitter instagram social"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3465
+#: lib/vutuv_web/components/ui.ex:3408
 #, elixir-autogen, elixir-format
 msgid "Signal, Threema, Matrix and the rest"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3466
+#: lib/vutuv_web/components/ui.ex:3409
 #, elixir-autogen, elixir-format
 msgid "signal threema matrix xmpp telegram whatsapp chat messenger"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3469
+#: lib/vutuv_web/components/ui.ex:3412
 #, elixir-autogen, elixir-format
 msgid "Notifications & feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3472
+#: lib/vutuv_web/components/ui.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Which emails we send, and what the bell tells you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3473
+#: lib/vutuv_web/components/ui.ex:3416
 #, elixir-autogen, elixir-format
 msgid "email mail unsubscribe newsletter bell alert quiet fewer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3476
+#: lib/vutuv_web/components/ui.ex:3419
 #, elixir-autogen, elixir-format
 msgid "Keep posts out of your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3477
+#: lib/vutuv_web/components/ui.ex:3420
 #, elixir-autogen, elixir-format
 msgid "mute block hide filter keyword word tag feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3480
+#: lib/vutuv_web/components/ui.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Topics whose posts reach your feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3481
+#: lib/vutuv_web/components/ui.ex:3424
 #, elixir-autogen, elixir-format
 msgid "tag topic subscribe follow feed"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3484
+#: lib/vutuv_web/components/ui.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Job and people searches that email you new matches"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3485
+#: lib/vutuv_web/components/ui.ex:3428
 #, elixir-autogen, elixir-format
 msgid "job alert search agent watchlist"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3491
+#: lib/vutuv_web/components/ui.ex:3434
 #, elixir-autogen, elixir-format
 msgid "Search engines, AI, online status"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3492
+#: lib/vutuv_web/components/ui.ex:3435
 #, elixir-autogen, elixir-format
 msgid "privacy google search engine ai llm crawler noindex online dot public"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3495
+#: lib/vutuv_web/components/ui.ex:3438
 #, elixir-autogen, elixir-format
 msgid "People who cannot interact with you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3496
+#: lib/vutuv_web/components/ui.ex:3439
 #, elixir-autogen, elixir-format
 msgid "block ban mute report abuse harassment stalker"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3509
+#: lib/vutuv_web/components/ui.ex:3452
 #, elixir-autogen, elixir-format
 msgid "Passkeys, signed-in devices, login codes"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3510
+#: lib/vutuv_web/components/ui.ex:3453
 #, elixir-autogen, elixir-format
 msgid "password login sign in log out session device passkey totp 2fa pin"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3518
+#: lib/vutuv_web/components/ui.ex:3461
 #, elixir-autogen, elixir-format
 msgid "Interface language, maps, how posts are shortened"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3519
+#: lib/vutuv_web/components/ui.ex:3462
 #, elixir-autogen, elixir-format
 msgid "german english locale translation map font length hyphenation"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3522
+#: lib/vutuv_web/components/ui.ex:3465
 #, elixir-autogen, elixir-format
 msgid "Take your data over from LinkedIn"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3523
+#: lib/vutuv_web/components/ui.ex:3466
 #, elixir-autogen, elixir-format
 msgid "linkedin upload zip migrate transfer"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3526
+#: lib/vutuv_web/components/ui.ex:3469
 #, elixir-autogen, elixir-format
 msgid "Download everything we store about you"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3527
+#: lib/vutuv_web/components/ui.ex:3470
 #, elixir-autogen, elixir-format
 msgid "download gdpr dsgvo data backup json cv"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3530
+#: lib/vutuv_web/components/ui.ex:3473
 #, elixir-autogen, elixir-format
 msgid "Connected apps and access tokens"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3531
+#: lib/vutuv_web/components/ui.ex:3474
 #, elixir-autogen, elixir-format
 msgid "api token oauth developer connected third party"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3534
+#: lib/vutuv_web/components/ui.ex:3477
 #, elixir-autogen, elixir-format
 msgid "Remove your account and everything on it"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3535
+#: lib/vutuv_web/components/ui.ex:3478
 #, elixir-autogen, elixir-format
 msgid "delete remove close quit cancel leave erase"
 msgstr ""
@@ -15670,7 +15657,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:972
 #: lib/vutuv_web/components/post_components.ex:1145
-#: lib/vutuv_web/live/fediverse_account_live.ex:314
+#: lib/vutuv_web/live/fediverse_account_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
@@ -15692,12 +15679,12 @@ msgstr ""
 msgid "Replies from other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:948
+#: lib/vutuv_web/live/notification_live/index.ex:983
 #, elixir-autogen, elixir-format
 msgid "Reply from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:95
+#: lib/vutuv_web/live/post_live/thread.ex:138
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reply removed."
 msgstr ""
@@ -15713,7 +15700,7 @@ msgid "Reported as not appropriate"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:882
-#: lib/vutuv_web/live/notification_live/index.ex:498
+#: lib/vutuv_web/live/notification_live/index.ex:533
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
 msgstr ""
@@ -15733,12 +15720,12 @@ msgstr ""
 msgid "Taken down"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:104
+#: lib/vutuv_web/live/post_live/thread.ex:147
 #, elixir-autogen, elixir-format
 msgid "Thank you. The reply was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:213
+#: lib/vutuv_web/live/post_live/thread.ex:256
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr ""
@@ -15756,15 +15743,15 @@ msgstr ""
 msgid "What"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:170
+#: lib/vutuv_web/live/fediverse_account_live.ex:168
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:139
-#: lib/vutuv_web/live/post_live/feed.ex:361
-#: lib/vutuv_web/live/post_live/thread.ex:209
+#: lib/vutuv_web/live/post_live/feed.ex:399
+#: lib/vutuv_web/live/post_live/thread.ex:252
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You have reported a lot today. Please try again tomorrow."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1128
+#: lib/vutuv_web/live/notification_live/index.ex:1163
 #, elixir-autogen, elixir-format, fuzzy
 msgid "replied to your post from another network."
 msgstr ""
@@ -15774,49 +15761,47 @@ msgstr ""
 msgid "All followers"
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:189
+#: lib/vutuv_web/components/browse_table.ex:293
 #, elixir-autogen, elixir-format
 msgid "All servers"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:114
+#: lib/vutuv_web/live/fediverse_followers_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Following since"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:217
+#: lib/vutuv_web/live/fediverse_followers_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "How this list keeps itself honest"
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:176
+#: lib/vutuv_web/components/browse_table.ex:280
 #, elixir-autogen, elixir-format
 msgid "name, handle or server"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:162
+#: lib/vutuv_web/live/fediverse_followers_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "No follower matches that. Try a shorter search, or clear the filters."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:190
+#: lib/vutuv_web/live/fediverse_followers_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Show only followers from this server"
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:293
-#: lib/vutuv_web/live/account_activity_live.ex:331
-#: lib/vutuv_web/live/admin/activity_live.ex:357
+#: lib/vutuv_web/components/browse_table.ex:400
 #, elixir-autogen, elixir-format
 msgid "Showing %{first}-%{last} of %{total}."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:143
+#: lib/vutuv_web/live/fediverse_followers_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Everyone on another network who follows your vutuv posts. Only you see this list: the followers collection your profile publishes carries the number, never the names."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_followers_live.ex:219
+#: lib/vutuv_web/live/fediverse_followers_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Accounts that no longer exist on their own server drop off this list by themselves. Names and handles are the ones their server last told us, so a renamed account updates here on its own too."
 msgstr ""
@@ -15971,14 +15956,14 @@ msgstr ""
 msgid "Access token revoked"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3512
-#: lib/vutuv_web/live/account_activity_live.ex:40
-#: lib/vutuv_web/live/account_activity_live.ex:154
-#: lib/vutuv_web/live/account_activity_live.ex:155
-#: lib/vutuv_web/live/account_activity_live.ex:160
-#: lib/vutuv_web/live/admin/activity_live.ex:41
-#: lib/vutuv_web/live/admin/activity_live.ex:190
-#: lib/vutuv_web/live/admin/activity_live.ex:191
+#: lib/vutuv_web/components/ui.ex:3455
+#: lib/vutuv_web/live/account_activity_live.ex:42
+#: lib/vutuv_web/live/account_activity_live.ex:114
+#: lib/vutuv_web/live/account_activity_live.ex:115
+#: lib/vutuv_web/live/account_activity_live.ex:120
+#: lib/vutuv_web/live/admin/activity_live.ex:42
+#: lib/vutuv_web/live/admin/activity_live.ex:152
+#: lib/vutuv_web/live/admin/activity_live.ex:153
 #: lib/vutuv_web/templates/admin/admin/index.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account activity"
@@ -16029,7 +16014,7 @@ msgstr ""
 msgid "Authenticator app turned off"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/activity_live.ex:345
+#: lib/vutuv_web/live/admin/activity_live.ex:302
 #, elixir-autogen, elixir-format, fuzzy
 msgid "By %{name}"
 msgstr ""
@@ -16039,8 +16024,8 @@ msgstr ""
 msgid "CV update notifications"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:294
-#: lib/vutuv_web/live/admin/activity_live.ex:338
+#: lib/vutuv_web/live/account_activity_live.ex:245
+#: lib/vutuv_web/live/admin/activity_live.ex:295
 #: lib/vutuv_web/templates/admin/experiment/index.html.heex:59
 #: lib/vutuv_web/templates/admin/experiment/index.html.heex:104
 #, elixir-autogen, elixir-format, fuzzy
@@ -16082,7 +16067,7 @@ msgstr ""
 msgid "Endorsement emails"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:169
+#: lib/vutuv_web/live/account_activity_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Every change to your account: what changed, exactly when, from which device, and how it was confirmed. If a line surprises you, follow the link at the end of it."
 msgstr ""
@@ -16122,7 +16107,7 @@ msgstr ""
 msgid "Identity verified"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:349
+#: lib/vutuv_web/live/account_activity_live.ex:294
 #, elixir-autogen, elixir-format
 msgid "If something here was not you"
 msgstr ""
@@ -16132,7 +16117,7 @@ msgstr ""
 msgid "Import applied"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:362
+#: lib/vutuv_web/live/account_activity_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "It is part of your data download, and it is deleted with your account."
 msgstr ""
@@ -16162,30 +16147,30 @@ msgstr ""
 msgid "New follower emails"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/activity_live.ex:277
+#: lib/vutuv_web/live/admin/activity_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "No account activity has been recorded yet."
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:303
+#: lib/vutuv_web/live/account_activity_live.ex:254
 #: lib/vutuv_web/templates/settings/security.html.heex:54
 #, elixir-autogen, elixir-format
 msgid "Not by you"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:322
+#: lib/vutuv_web/live/account_activity_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Not you?"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:176
+#: lib/vutuv_web/live/account_activity_live.ex:131
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. The next time you sign in or change a setting, it will be listed here."
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:243
-#: lib/vutuv_web/live/admin/activity_live.ex:275
-#: lib/vutuv_web/live/fediverse_following_live.ex:342
+#: lib/vutuv_web/live/account_activity_live.ex:198
+#: lib/vutuv_web/live/admin/activity_live.ex:237
+#: lib/vutuv_web/live/fediverse_following_live.ex:313
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16250,12 +16235,12 @@ msgstr ""
 msgid "Settings changed by support"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/activity_live.ex:314
+#: lib/vutuv_web/live/admin/activity_live.ex:271
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Show only this member"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:351
+#: lib/vutuv_web/live/account_activity_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Sign every other device out, then check which passkeys, codes and email addresses your account has. All of it is on the sign-in & security page."
 msgstr ""
@@ -16270,7 +16255,7 @@ msgstr ""
 msgid "Signed out"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:356
+#: lib/vutuv_web/live/account_activity_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "This log keeps one day of history."
 msgid_plural "This log keeps %{formatted} days of history."
@@ -16302,7 +16287,7 @@ msgstr ""
 msgid "Visibility settings changed"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:266
+#: lib/vutuv_web/live/account_activity_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Was this you?"
 msgstr ""
@@ -16317,18 +16302,18 @@ msgstr ""
 msgid "What changed on your account, and exactly when."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3513
+#: lib/vutuv_web/components/ui.ex:3456
 #, elixir-autogen, elixir-format
 msgid "What changed on your account, and when"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:127
-#: lib/vutuv_web/live/admin/activity_live.ex:165
+#: lib/vutuv_web/live/account_activity_live.ex:104
+#: lib/vutuv_web/live/admin/activity_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "What happened"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/activity_live.ex:379
+#: lib/vutuv_web/live/admin/activity_live.ex:330
 #, elixir-autogen, elixir-format, fuzzy
 msgid "a deleted account"
 msgstr ""
@@ -16353,7 +16338,7 @@ msgstr ""
 msgid "from a signed-in session"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3515
+#: lib/vutuv_web/components/ui.ex:3458
 #, elixir-autogen, elixir-format
 msgid "log history audit trail security was that me who changed when protocol"
 msgstr ""
@@ -16388,19 +16373,19 @@ msgstr ""
 msgid "with your authenticator app"
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:265
-#: lib/vutuv_web/live/admin/activity_live.ex:296
+#: lib/vutuv_web/live/account_activity_live.ex:216
+#: lib/vutuv_web/live/admin/activity_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Device"
 msgstr ""
 
-#: lib/vutuv_web/live/admin/activity_live.ex:197
+#: lib/vutuv_web/live/admin/activity_live.ex:159
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What changed on which account, when, from which device and how it was confirmed - the same log every member sees for themselves. Opening it is recorded in your own activity log."
 msgstr ""
 
-#: lib/vutuv_web/live/account_activity_live.ex:203
-#: lib/vutuv_web/live/admin/activity_live.ex:240
+#: lib/vutuv_web/live/account_activity_live.ex:158
+#: lib/vutuv_web/live/admin/activity_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "device or detail"
 msgstr ""
@@ -16425,17 +16410,17 @@ msgstr ""
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:247
+#: lib/vutuv_web/controllers/post_controller.ex:257
 #, elixir-autogen, elixir-format
 msgid "Pinned to the top of your profile."
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:243
+#: lib/vutuv_web/controllers/post_controller.ex:253
 #, elixir-autogen, elixir-format
 msgid "Pinned to the top of your profile. The post pinned before it is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/controllers/post_controller.ex:264
+#: lib/vutuv_web/controllers/post_controller.ex:274
 #, elixir-autogen, elixir-format
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
@@ -16469,7 +16454,7 @@ msgstr ""
 msgid "Apply these settings to all photos"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:96
+#: lib/vutuv_web/live/post_live/remote_reply.ex:91
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to the conversation"
 msgstr ""
@@ -16632,7 +16617,7 @@ msgstr ""
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_reply.ex:91
+#: lib/vutuv_web/live/post_live/remote_reply.ex:86
 #, elixir-autogen, elixir-format
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
@@ -16688,8 +16673,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:937
-#: lib/vutuv_web/live/post_live/feed.ex:938
+#: lib/vutuv_web/live/post_live/feed.ex:946
+#: lib/vutuv_web/live/post_live/feed.ex:947
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
@@ -16775,7 +16760,7 @@ msgstr ""
 msgid "From other networks"
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:949
+#: lib/vutuv_web/live/notification_live/index.ex:984
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reaction from another network"
 msgstr ""
@@ -16790,21 +16775,21 @@ msgstr ""
 msgid "Show under each of your posts who out there liked or shared it, by their account address on their own server, linked to that account. Visible to everyone who sees the post. We keep nothing else about these people: no name, no picture, no text. Switching it off deletes what is stored for it."
 msgstr ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1002
+#: lib/vutuv_web/live/notification_live/index.ex:1037
 #, elixir-autogen, elixir-format
 msgid "liked your post on another network."
 msgid_plural "liked your post on another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:1010
+#: lib/vutuv_web/live/notification_live/index.ex:1045
 #, elixir-autogen, elixir-format, fuzzy
 msgid "reacted to your post from another network."
 msgid_plural "reacted to your post from another network."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/notification_live/index.ex:994
+#: lib/vutuv_web/live/notification_live/index.ex:1029
 #, elixir-autogen, elixir-format
 msgid "shared your post on another network."
 msgid_plural "shared your post on another network."
@@ -16861,10 +16846,10 @@ msgstr ""
 msgid "Photo details"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:447
-#: lib/vutuv_web/live/fediverse_following_live.ex:55
-#: lib/vutuv_web/live/fediverse_following_live.ex:251
-#: lib/vutuv_web/live/fediverse_following_live.ex:264
+#: lib/vutuv_web/live/fediverse_account_live.ex:454
+#: lib/vutuv_web/live/fediverse_following_live.ex:52
+#: lib/vutuv_web/live/fediverse_following_live.ex:236
+#: lib/vutuv_web/live/fediverse_following_live.ex:249
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:422
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
@@ -16886,13 +16871,13 @@ msgstr ""
 msgid "Cancel request"
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3499
+#: lib/vutuv_web/components/ui.ex:3442
 #, elixir-autogen, elixir-format
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:114
-#: lib/vutuv_web/live/fediverse_following_live.ex:207
+#: lib/vutuv_web/live/fediverse_account_live.ex:112
+#: lib/vutuv_web/live/fediverse_following_live.ex:192
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Follow request sent to %{account}."
@@ -16918,14 +16903,9 @@ msgstr ""
 msgid "Manage who you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:274
+#: lib/vutuv_web/live/fediverse_following_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Mastodon and the other networks work like email: an address is enough. Paste one here and vutuv asks that server to let you follow the account."
-msgstr ""
-
-#: lib/vutuv_web/live/fediverse_following_live.ex:301
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Open their profile"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:224
@@ -16933,17 +16913,17 @@ msgstr ""
 msgid "Requested"
 msgstr ""
 
-#: lib/vutuv_web/components/browse_table.ex:216
+#: lib/vutuv_web/components/browse_table.ex:320
 #, elixir-autogen, elixir-format
 msgid "Reset sorting"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:309
+#: lib/vutuv_web/live/fediverse_following_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Search for them here"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:371
+#: lib/vutuv_web/live/fediverse_following_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Show only accounts on this server"
 msgstr ""
@@ -16953,12 +16933,12 @@ msgstr ""
 msgid "Sign in to follow this account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:356
+#: lib/vutuv_web/live/fediverse_following_live.ex:327
 #, elixir-autogen, elixir-format, fuzzy
 msgid "State"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:223
+#: lib/vutuv_web/live/fediverse_following_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Stop following %{account}?"
 msgstr ""
@@ -16968,7 +16948,7 @@ msgstr ""
 msgid "That account could not be loaded from its server. Try again in a little while."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:324
+#: lib/vutuv_web/components/fediverse_components.ex:330
 #, elixir-autogen, elixir-format
 msgid "That did not work. Check the address and try again."
 msgstr ""
@@ -16983,11 +16963,6 @@ msgstr ""
 msgid "That is an address on Mastodon or one of the other networks, so nobody here carries it. You can follow it from vutuv."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:286
-#, elixir-autogen, elixir-format
-msgid "That is an address on this vutuv, not another network."
-msgstr ""
-
 #: lib/vutuv_web/components/fediverse_components.ex:275
 #, elixir-autogen, elixir-format
 msgid "That server answered, but it has no account at that address to follow."
@@ -16999,7 +16974,7 @@ msgstr ""
 msgid "That server did not answer. Check the address, and that the server is online."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:321
+#: lib/vutuv_web/components/fediverse_components.ex:327
 #, elixir-autogen, elixir-format
 msgid "The Fediverse is switched off on this vutuv."
 msgstr ""
@@ -17009,7 +16984,7 @@ msgstr ""
 msgid "The address you brought along is kept here:"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:424
+#: lib/vutuv_web/live/fediverse_following_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "The other server decides. Most accounts accept straight away; one that checks its followers by hand stays on \"Requested\" until somebody there says yes."
 msgstr ""
@@ -17029,18 +17004,18 @@ msgstr ""
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:130
-#: lib/vutuv_web/live/fediverse_following_live.ex:147
+#: lib/vutuv_web/live/fediverse_account_live.ex:128
+#: lib/vutuv_web/live/fediverse_following_live.ex:154
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unfollowed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:421
+#: lib/vutuv_web/live/fediverse_following_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "What following out there means"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:429
+#: lib/vutuv_web/live/fediverse_following_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "Who you follow is yours alone. Your profile publishes how many accounts you follow out there, never which ones."
 msgstr ""
@@ -17050,22 +17025,22 @@ msgstr ""
 msgid "Why is my account on hold?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:226
+#: lib/vutuv_web/live/fediverse_following_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Withdraw your follow request to %{account}?"
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:292
+#: lib/vutuv_web/components/fediverse_components.ex:298
 #, elixir-autogen, elixir-format
 msgid "You already follow that account."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:310
+#: lib/vutuv_web/components/fediverse_components.ex:316
 #, elixir-autogen, elixir-format
 msgid "You are following the most accounts we allow (%{max})."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:300
+#: lib/vutuv_web/components/fediverse_components.ex:306
 #, elixir-autogen, elixir-format
 msgid "You are not taking part in the Fediverse at the moment, so there is no identity to sign the request with. Open the Fediverse settings to switch it on."
 msgstr ""
@@ -17082,12 +17057,12 @@ msgid_plural "You follow %{formatted} accounts on other networks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:306
+#: lib/vutuv_web/components/fediverse_components.ex:312
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You have sent a lot of follow requests in the last hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/fediverse_components.ex:316
+#: lib/vutuv_web/components/fediverse_components.ex:322
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so this account no longer acts out there."
 msgstr ""
@@ -17097,12 +17072,12 @@ msgstr ""
 msgid "Your account is on hold at the moment, so nothing of yours goes out to other networks and you cannot follow anybody there. This lifts by itself once the hold ends."
 msgstr ""
 
-#: lib/vutuv_web/components/ui.ex:3501
+#: lib/vutuv_web/components/ui.ex:3444
 #, elixir-autogen, elixir-format, fuzzy
 msgid "mastodon activitypub federation follower following follow move migrate remote account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:258
+#: lib/vutuv_web/live/fediverse_following_live.ex:243
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Accounts followed"
 msgstr ""
@@ -17122,9 +17097,9 @@ msgstr ""
 msgid "Only for this account's followers"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:162
+#: lib/vutuv_web/live/fediverse_account_live.ex:160
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:131
-#: lib/vutuv_web/live/post_live/feed.ex:353
+#: lib/vutuv_web/live/post_live/feed.ex:391
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
@@ -17164,8 +17139,8 @@ msgstr ""
 msgid "Mute %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:257
-#: lib/vutuv_web/live/post_live/feed.ex:411
+#: lib/vutuv_web/live/fediverse_account_live.ex:264
+#: lib/vutuv_web/live/post_live/feed.ex:449
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr ""
@@ -17180,72 +17155,72 @@ msgstr ""
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:440
+#: lib/vutuv_web/live/fediverse_following_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "To show their posts we keep a copy here for up to six months. If the author deletes or edits something, ours follows; and when you stop following an account, its posts are deleted here at once."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:328
+#: lib/vutuv_web/live/fediverse_following_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "You do not follow anybody out there yet. Once you do, what they post appears in your feed among everything else."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:66
+#: lib/vutuv_web/live/fediverse_account_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "%{name} (another network)"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:297
+#: lib/vutuv_web/live/fediverse_account_live.ex:304
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:431
+#: lib/vutuv_web/live/fediverse_account_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:362
+#: lib/vutuv_web/live/fediverse_account_live.ex:369
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Muted"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:272
+#: lib/vutuv_web/live/fediverse_account_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:267
+#: lib/vutuv_web/live/fediverse_account_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:433
+#: lib/vutuv_web/live/fediverse_account_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:329
+#: lib/vutuv_web/live/fediverse_account_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:416
+#: lib/vutuv_web/live/fediverse_account_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:259
+#: lib/vutuv_web/live/fediverse_account_live.ex:266
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unmuted. Their posts are back in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:426
+#: lib/vutuv_web/live/fediverse_account_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:276
+#: lib/vutuv_web/live/fediverse_account_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr ""
@@ -17422,7 +17397,7 @@ msgstr ""
 msgid "That post is not here any more."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_post_reply.ex:98
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:93
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to the feed"
 msgstr ""
@@ -17432,14 +17407,14 @@ msgstr ""
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/remote_post_reply.ex:93
+#: lib/vutuv_web/live/post_live/remote_post_reply.ex:88
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:195
+#: lib/vutuv_web/live/fediverse_account_live.ex:193
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:110
-#: lib/vutuv_web/live/post_live/feed.ex:389
+#: lib/vutuv_web/live/post_live/feed.ex:427
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr ""
@@ -17449,7 +17424,7 @@ msgstr ""
 msgid "Moved"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:217
+#: lib/vutuv_web/live/fediverse_following_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "%{account} moved to another server. Your subscription already went with them — remove this old entry?"
 msgstr ""
@@ -17474,12 +17449,12 @@ msgstr ""
 msgid "People on Mastodon and other independent networks can then follow this profile, and your public posts appear there. What they answer or share comes back and is shown under your posts, by their account address. A reply from there is stored here for up to six months. You can switch all of it off again at any time."
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1204
+#: lib/vutuv_web/live/user_profile_live.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Follow %{count} members"
 msgstr ""
 
-#: lib/vutuv_web/live/user_profile_live.ex:1219
+#: lib/vutuv_web/live/user_profile_live.ex:1287
 #, elixir-autogen, elixir-format
 msgid "You already follow one member."
 msgid_plural "You already follow %{count} members."
@@ -17726,7 +17701,7 @@ msgstr ""
 msgid "Its author published this post to their followers alone, so vutuv does not keep a copy of it."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:455
+#: lib/vutuv_web/live/fediverse_following_live.ex:426
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:229
 #, elixir-autogen, elixir-format
 msgid "Look up a post by its address"
@@ -17793,7 +17768,7 @@ msgstr ""
 msgid "Turn on Fediverse participation to look up"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_following_live.ex:449
+#: lib/vutuv_web/live/fediverse_following_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "Want to answer one particular post rather than follow its author?"
 msgstr ""
@@ -17951,12 +17926,12 @@ msgstr ""
 msgid "Whole photos"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:127
+#: lib/vutuv_web/templates/layout/app.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Send the post or message you are writing"
 msgstr ""
 
-#: lib/vutuv_web/templates/layout/app.html.heex:188
+#: lib/vutuv_web/templates/layout/app.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "The single-key shortcuts pause while you type, and are off on phones and tablets."
 msgstr ""
@@ -17979,4 +17954,39 @@ msgstr ""
 #: lib/vutuv_web/views/error_html.ex:54
 #, elixir-autogen, elixir-format
 msgid "The most helpful detail in such a report is the exact time of the error. Right now it is %{time}."
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_following_live.ex:183
+#, elixir-autogen, elixir-format
+msgid "@%{handle} is on this vutuv, so you now follow them here."
+msgstr ""
+
+#: lib/vutuv_web/components/fediverse_components.ex:287
+#, elixir-autogen, elixir-format
+msgid "That address is on this vutuv, but it names no member here."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:89
+#, elixir-autogen, elixir-format
+msgid "That address is on this vutuv. Sign in and use the Follow button on this profile."
+msgstr ""
+
+#: lib/vutuv_web/components/fediverse_components.ex:292
+#, elixir-autogen, elixir-format
+msgid "That is your own address. You cannot follow yourself."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:111
+#, elixir-autogen, elixir-format
+msgid "That is your own profile. You cannot follow yourself."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:118
+#, elixir-autogen, elixir-format
+msgid "You already follow @%{handle} here."
+msgstr ""
+
+#: lib/vutuv_web/controllers/remote_follow_controller.ex:104
+#, elixir-autogen, elixir-format
+msgid "You are on this vutuv yourself, so you now follow @%{handle} right here."
 msgstr ""

--- a/test/support/endpoint_host_helper.ex
+++ b/test/support/endpoint_host_helper.ex
@@ -1,0 +1,29 @@
+defmodule Vutuv.EndpointHostHelper do
+  @moduledoc """
+  Dresses the test endpoint in a real hostname for the duration of one test.
+
+  Every "is this address on this very installation?" gate compares against
+  `VutuvWeb.Endpoint.host()`, and the test endpoint answers "localhost" — not a
+  valid Fediverse host at all (no dot), so those gates can never fire without
+  this. Phoenix caches the endpoint config, so the app env alone is not enough:
+  `config_change/2` is what re-reads it.
+
+  The endpoint is global state the SQL sandbox does not roll back, so a test
+  module using this must be `async: false`.
+  """
+
+  import ExUnit.Callbacks, only: [on_exit: 1]
+
+  def with_endpoint_host(host) do
+    original = Application.get_env(:vutuv, VutuvWeb.Endpoint)
+    changed = Keyword.put(original, :url, Keyword.put(original[:url] || [], :host, host))
+
+    Application.put_env(:vutuv, VutuvWeb.Endpoint, changed)
+    VutuvWeb.Endpoint.config_change([{VutuvWeb.Endpoint, changed}], [])
+
+    on_exit(fn ->
+      Application.put_env(:vutuv, VutuvWeb.Endpoint, original)
+      VutuvWeb.Endpoint.config_change([{VutuvWeb.Endpoint, original}], [])
+    end)
+  end
+end

--- a/test/vutuv/fediverse_remote_follows_test.exs
+++ b/test/vutuv/fediverse_remote_follows_test.exs
@@ -9,10 +9,14 @@ defmodule Vutuv.FediverseRemoteFollowsTest do
   """
   use Vutuv.DataCase, async: false
 
+  import Vutuv.EndpointHostHelper
+
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Delivery
   alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Social
+  alias Vutuv.Social.Follow, as: SocialFollow
   alias VutuvWeb.Fediverse.Docs
 
   @actor_uri "https://social.example/users/them"
@@ -64,22 +68,6 @@ defmodule Vutuv.FediverseRemoteFollowsTest do
       conn
       |> Plug.Conn.put_resp_content_type(type)
       |> Plug.Conn.send_resp(200, Jason.encode!(body))
-    end)
-  end
-
-  # The endpoint's host, for the one gate that compares an address against this
-  # installation's own name. Phoenix caches the endpoint config, so the app env
-  # alone is not enough — `config_change/2` is what re-reads it.
-  defp with_endpoint_host(host) do
-    original = Application.get_env(:vutuv, VutuvWeb.Endpoint)
-    changed = Keyword.put(original, :url, Keyword.put(original[:url] || [], :host, host))
-
-    Application.put_env(:vutuv, VutuvWeb.Endpoint, changed)
-    VutuvWeb.Endpoint.config_change([{VutuvWeb.Endpoint, changed}], [])
-
-    on_exit(fn ->
-      Application.put_env(:vutuv, VutuvWeb.Endpoint, original)
-      VutuvWeb.Endpoint.config_change([{VutuvWeb.Endpoint, original}], [])
     end)
   end
 
@@ -192,33 +180,96 @@ defmodule Vutuv.FediverseRemoteFollowsTest do
                Fediverse.follow_remote(federated_user(), "@them@social.example")
     end
 
-    test "an address on this very installation is named as a vutuv account" do
+    test "an address on this very installation becomes a vutuv follow, nothing federates" do
       stub_remote(fn _conn -> raise "our own members need no WebFinger lookup" end)
       # The test endpoint answers as "localhost", which is not a Fediverse
       # address at all, so the installation has to wear a real hostname for this
       # gate to be the one that fires.
       with_endpoint_host("vutuv.test")
+      user = federated_user()
       other = insert(:activated_user)
 
-      assert {:error, :local_account} =
-               Fediverse.follow_remote(federated_user(), "@#{other.username}@vutuv.test")
+      assert {:ok, {:local_follow, followed}} =
+               Fediverse.follow_remote(user, "@#{other.username}@vutuv.test")
+
+      assert followed.id == other.id
+      # The plain vutuv follow exists; no signed request, no remote rows.
+      assert Social.user_follows_user?(user.id, other.id)
+      assert Repo.aggregate(Follow, :count) == 0
+      assert Repo.aggregate(RemoteAccount, :count) == 0
+      assert Repo.aggregate(Delivery, :count) == 0
     end
 
     # The `www.` alias is the same installation, and a member pastes whichever
     # spelling their browser gave them. Matching the configured host exactly
     # sent this address off to WebFinger, i.e. had vutuv resolve and follow
     # itself (found on the post lookup in production, issue #1211).
-    test "the www alias of this installation is the same installation" do
+    test "the www alias and a pasted profile URL land the same vutuv follow" do
       stub_remote(fn _conn -> raise "our own members need no WebFinger lookup" end)
       with_endpoint_host("vutuv.test")
-      other = insert(:activated_user)
+      user = federated_user()
+      one = insert(:activated_user)
+      two = insert(:activated_user)
 
-      assert Fediverse.local_host?("https://www.vutuv.test/#{other.username}")
-      assert Fediverse.local_host?("@#{other.username}@www.vutuv.test")
+      assert Fediverse.local_host?("https://www.vutuv.test/#{one.username}")
+      assert Fediverse.local_host?("@#{one.username}@www.vutuv.test")
       refute Fediverse.local_host?("@them@vutuv.test.evil.example")
 
+      assert {:ok, {:local_follow, _}} =
+               Fediverse.follow_remote(user, "@#{one.username}@www.vutuv.test")
+
+      assert {:ok, {:local_follow, _}} =
+               Fediverse.follow_remote(user, "https://www.vutuv.test/@#{two.username}")
+
+      assert Social.user_follows_user?(user.id, one.id)
+      assert Social.user_follows_user?(user.id, two.id)
+    end
+
+    test "one's own address follows nobody" do
+      stub_remote(fn _conn -> raise "our own members need no WebFinger lookup" end)
+      with_endpoint_host("vutuv.test")
+      user = federated_user()
+
+      assert {:error, :own_account} =
+               Fediverse.follow_remote(user, "@#{user.username}@vutuv.test")
+
+      assert Repo.aggregate(SocialFollow, :count) == 0
+      assert Repo.aggregate(Follow, :count) == 0
+    end
+
+    test "a local address that names no member keeps the plain refusal" do
+      stub_remote(fn _conn -> raise "our own members need no WebFinger lookup" end)
+      with_endpoint_host("vutuv.test")
+
       assert {:error, :local_account} =
-               Fediverse.follow_remote(federated_user(), "@#{other.username}@www.vutuv.test")
+               Fediverse.follow_remote(federated_user(), "@ghost@vutuv.test")
+    end
+
+    test "a member already followed on vutuv is told so, not followed twice" do
+      stub_remote(fn _conn -> raise "our own members need no WebFinger lookup" end)
+      with_endpoint_host("vutuv.test")
+      user = federated_user()
+      other = insert(:activated_user)
+      {:ok, _} = Social.follow(user, other.id)
+
+      assert {:error, :already_following} =
+               Fediverse.follow_remote(user, "@#{other.username}@vutuv.test")
+
+      assert Repo.aggregate(SocialFollow, :count) == 1
+    end
+
+    # A vutuv follow needs no actor key, so the "you are not federating" gate
+    # does not apply to an address that turns out to live here.
+    test "a member who does not federate can still land the vutuv follow" do
+      stub_remote(fn _conn -> raise "our own members need no WebFinger lookup" end)
+      with_endpoint_host("vutuv.test")
+      user = insert(:activated_user)
+      other = insert(:activated_user)
+
+      assert {:ok, {:local_follow, _}} =
+               Fediverse.follow_remote(user, "@#{other.username}@vutuv.test")
+
+      assert Social.user_follows_user?(user.id, other.id)
     end
 
     test "a typo is refused before the network is touched" do

--- a/test/vutuv_web/live/fediverse_account_live_test.exs
+++ b/test/vutuv_web/live/fediverse_account_live_test.exs
@@ -7,6 +7,7 @@ defmodule VutuvWeb.FediverseAccountLiveTest do
   use VutuvWeb.ConnCase
 
   import Phoenix.LiveViewTest
+  import Vutuv.EndpointHostHelper
 
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Follow
@@ -261,6 +262,36 @@ defmodule VutuvWeb.FediverseAccountLiveTest do
       {:ok, view, _html} = live(conn, ~p"/feed")
 
       assert has_element?(view, "[data-remote-account='#{acc.id}']")
+    end
+  end
+
+  describe "the lookup box on an address of this very vutuv" do
+    test "an address naming a member opens their profile, not a refusal", %{conn: conn} do
+      with_endpoint_host("vutuv.test")
+      {conn, _user} = create_and_login_user(conn)
+      other = insert_activated_user()
+      acc = account()
+
+      {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+
+      view
+      |> element("#lookup-form")
+      |> render_submit(%{"address" => "@#{other.username}@vutuv.test"})
+
+      assert_redirect(view, "/#{other.username}")
+    end
+
+    test "a handle that names nobody here keeps the refusal", %{conn: conn} do
+      with_endpoint_host("vutuv.test")
+      {conn, _user} = create_and_login_user(conn)
+      acc = account()
+
+      {:ok, view, _html} = live(conn, ~p"/system/fediverse/account/#{acc.id}")
+
+      view |> element("#lookup-form") |> render_submit(%{"address" => "@ghost@vutuv.test"})
+
+      assert has_element?(view, "#lookup-error")
+      assert render(view) =~ "names no member"
     end
   end
 end

--- a/test/vutuv_web/live/fediverse_following_live_test.exs
+++ b/test/vutuv_web/live/fediverse_following_live_test.exs
@@ -9,9 +9,11 @@ defmodule VutuvWeb.FediverseFollowingLiveTest do
   use VutuvWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
+  import Vutuv.EndpointHostHelper
 
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Follow
+  alias Vutuv.Social
 
   @actor_uri "https://social.example/users/them"
 
@@ -203,6 +205,71 @@ defmodule VutuvWeb.FediverseFollowingLiveTest do
       assert has_element?(view, "#follow-address[value='@them@social.example']")
       # Arriving is a GET: nothing may have left the building yet.
       assert Repo.all(from(f in Follow, where: f.user_id == ^user.id)) == []
+    end
+  end
+
+  describe "following an address that lives on this vutuv" do
+    setup %{conn: conn} do
+      # Any outbound request here would be vutuv resolving itself (issue #1211).
+      Application.put_env(:vutuv, :fediverse_req_options,
+        plug: fn _conn -> raise "our own members need no WebFinger lookup" end
+      )
+
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_req_options) end)
+
+      with_endpoint_host("vutuv.test")
+      {conn, user} = federating(conn)
+      %{conn: conn, user: user}
+    end
+
+    test "the member behind the address is followed on vutuv instead", %{conn: conn, user: user} do
+      other = insert_activated_user()
+      {:ok, view, _html} = live(conn, ~p"/settings/fediverse/following")
+
+      view
+      |> element("#follow-form")
+      |> render_submit(%{"address" => "@#{other.username}@vutuv.test"})
+
+      assert Social.user_follows_user?(user.id, other.id)
+      # No Fediverse row, no request row, no refusal: the box simply clears.
+      assert Repo.all(from(f in Follow, where: f.user_id == ^user.id)) == []
+      refute has_element?(view, "#follow-error")
+      refute has_element?(view, "#follow-address[value^='@']")
+    end
+
+    test "one's own address is refused, in words", %{conn: conn, user: user} do
+      {:ok, view, _html} = live(conn, ~p"/settings/fediverse/following")
+
+      view
+      |> element("#follow-form")
+      |> render_submit(%{"address" => "@#{user.username}@vutuv.test"})
+
+      assert has_element?(view, "#follow-error")
+      assert render(view) =~ "yourself"
+      assert Repo.aggregate(Social.Follow, :count) == 0
+    end
+
+    test "the German member reads the German refusal", %{conn: conn, user: user} do
+      {:ok, view, _html} =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de;q=0.9")
+        |> live(~p"/settings/fediverse/following")
+
+      view
+      |> element("#follow-form")
+      |> render_submit(%{"address" => "@#{user.username}@vutuv.test"})
+
+      assert render(view) =~ "nicht selbst folgen"
+    end
+
+    test "an unknown handle on this host still gets the search hand-off", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/settings/fediverse/following")
+
+      view |> element("#follow-form") |> render_submit(%{"address" => "@ghost@vutuv.test"})
+
+      assert has_element?(view, "#follow-error")
+      assert has_element?(view, "#local-member-search")
     end
   end
 

--- a/test/vutuv_web/live/user_profile_fediverse_test.exs
+++ b/test/vutuv_web/live/user_profile_fediverse_test.exs
@@ -8,6 +8,7 @@ defmodule VutuvWeb.UserProfileFediverseTest do
   use VutuvWeb.ConnCase
 
   import Phoenix.LiveViewTest
+  import Vutuv.EndpointHostHelper
 
   alias Vutuv.Social
   alias VutuvWeb.Fediverse.Docs
@@ -234,6 +235,85 @@ defmodule VutuvWeb.UserProfileFediverseTest do
       conn = post(conn, ~p"/#{user}/fediverse/follow", %{"address" => "@them@social.example"})
 
       assert redirected_to(conn) == "/#{user.username}#profile-fediverse"
+    end
+  end
+
+  describe "POST /:slug/fediverse/follow with an address on this very vutuv" do
+    # Whatever happens next, vutuv must not WebFinger itself over it
+    # (issue #1211's shape); the stub proves no request leaves.
+    setup %{conn: conn} do
+      stub_remote(fn _conn -> raise "vutuv must not WebFinger itself" end)
+      with_endpoint_host("vutuv.test")
+      %{conn: conn}
+    end
+
+    test "a signed-in member follows the profile owner on vutuv instead", %{conn: conn} do
+      user = federating_member()
+      {conn, viewer} = create_and_login_user(conn)
+
+      conn =
+        post(conn, ~p"/#{user}/fediverse/follow", %{
+          "address" => "@#{viewer.username}@vutuv.test"
+        })
+
+      assert redirected_to(conn) == "/#{user.username}#profile-fediverse"
+      assert Social.user_follows_user?(viewer.id, user.id)
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "@#{user.username}"
+    end
+
+    test "the German member reads the German confirmation", %{conn: conn} do
+      user = federating_member()
+      {conn, viewer} = create_and_login_user(conn)
+
+      conn =
+        conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de;q=0.9")
+        |> post(~p"/#{user}/fediverse/follow", %{
+          "address" => "@#{viewer.username}@vutuv.test"
+        })
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Sie folgen"
+      assert Social.user_follows_user?(viewer.id, user.id)
+    end
+
+    test "a member already following is told so, and not followed twice", %{conn: conn} do
+      user = federating_member()
+      {conn, viewer} = create_and_login_user(conn)
+      {:ok, _} = Social.follow(viewer, user.id)
+
+      conn =
+        post(conn, ~p"/#{user}/fediverse/follow", %{
+          "address" => "@#{viewer.username}@vutuv.test"
+        })
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "already follow"
+      assert Repo.aggregate(Social.Follow, :count) == 1
+    end
+
+    test "the owner cannot follow themselves", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      {:ok, user} = Vutuv.Accounts.update_user(user, %{"fediverse_followers?" => "true"})
+
+      conn =
+        post(conn, ~p"/#{user}/fediverse/follow", %{
+          "address" => "@#{user.username}@vutuv.test"
+        })
+
+      assert redirected_to(conn) == "/#{user.username}#profile-fediverse"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "yourself"
+      assert Repo.aggregate(Social.Follow, :count) == 0
+    end
+
+    test "a signed-out visitor is pointed at the Follow button, nothing happens", %{conn: conn} do
+      user = federating_member()
+
+      conn =
+        post(conn, ~p"/#{user}/fediverse/follow", %{"address" => "@whoever@vutuv.test"})
+
+      assert redirected_to(conn) == "/#{user.username}#profile-fediverse"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "Sign in"
+      assert Repo.aggregate(Social.Follow, :count) == 0
     end
   end
 end


### PR DESCRIPTION
Members can no longer subscribe to another member's (or their own) Fediverse account on the same installation. `Fediverse.follow_remote/2` now diverts any address whose host is this installation before the Fediverse gates:

- an address naming a member creates the ordinary vutuv follow on the spot (`{:ok, {:local_follow, member}}`), with a confirmation flash on the following page
- the member's own address is refused as `:own_account` (nobody follows themselves; plain follows were already guarded by the changeset)
- an unknown handle keeps the `:local_account` refusal, now with a search hand-off only

The profile's "follow from your own server" dialog short-circuits local addresses too (signed-in members get the local follow of the profile owner, signed-out visitors an explanation) instead of WebFingering ourselves (the #1211 shape), and the account lookup page navigates a member-naming address to that member's profile.

Also: German translations written by hand (one fuzzy msgstr corrected), shared `Vutuv.EndpointHostHelper` test helper, removed an unused `require Logger` warning in the account lifecycle test.

**Hot deploy** (no migrations, no config/dependency/supervision changes). Version v7.206.0.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*