### PR TITLE
Fileless multipart forms submit urlencoded, dodging Safari's empty-body bug (v7.206.1)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1574,6 +1574,40 @@ document.addEventListener("keydown", (e) => {
     .forEach((menu) => menu.removeAttribute("open"))
 })
 
+// Multipart enctype fallback (issue #1227). One member's Safari submitted the
+// multipart profile form with a declared boundary but a zero-byte body on
+// every attempt (Content-Length: 0 in the nginx capture), while every
+// urlencoded form from the same browser worked: WebKit builds a multipart body
+// as a stream it cannot always replay, a urlencoded body is in-memory and
+// survives. Multipart only buys file transport, so when no file is actually
+// selected the form downgrades to urlencoded at submit time — and the empty
+// file inputs are disabled for that one submission, so the request carries the
+// exact params a fileless multipart submit produces. Capture phase, before the
+// browser serializes the form; LiveView forms own their submits and are
+// skipped. The re-enable runs a tick later: the entry list is built
+// synchronously after dispatch, and a submit some other handler cancels must
+// not leave the inputs disabled.
+function multipartEnctypeFallback(e) {
+  const form = e.target
+  if (!(form instanceof HTMLFormElement) || form.hasAttribute("phx-submit")) return
+
+  const wasMultipart =
+    form.enctype === "multipart/form-data" || form.dataset.multipartForm === "1"
+  if (!wasMultipart) return
+  form.dataset.multipartForm = "1"
+
+  const fileInputs = [...form.querySelectorAll("input[type=file]")]
+  const hasFiles = fileInputs.some((input) => input.files && input.files.length > 0)
+  form.enctype = hasFiles ? "multipart/form-data" : "application/x-www-form-urlencoded"
+  if (hasFiles) return
+
+  const disabled = fileInputs.filter((input) => !input.disabled)
+  disabled.forEach((input) => (input.disabled = true))
+  setTimeout(() => disabled.forEach((input) => (input.disabled = false)), 0)
+}
+
+document.addEventListener("submit", multipartEnctypeFallback, true)
+
 // Avatar fallback. A user's stored avatar file can be missing — a legacy row
 // whose image was never imported, a failed upload, a derived version not yet
 // regenerated — so the <img> 404s and the browser draws a broken-image icon.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.206.0",
+      version: "7.206.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/multipart_form_fallback_test.exs
+++ b/test/vutuv_web/multipart_form_fallback_test.exs
@@ -1,0 +1,73 @@
+defmodule VutuvWeb.MultipartFormFallbackTest do
+  use VutuvWeb.ConnCase
+
+  alias Vutuv.Accounts.User
+
+  # Issue #1227: one member's Safari (26.5.2, macOS) submitted the multipart
+  # Basics & photos form with a declared boundary but a zero-byte body on every
+  # attempt (nginx capture, 2026-07-31 05:41/05:42 UTC: `Content-Length: 0`),
+  # while every urlencoded form from the same browser worked. WebKit builds a
+  # multipart body as a stream it cannot always replay; a urlencoded body is
+  # in-memory and survives. So app.js switches a multipart form to urlencoded
+  # at submit time whenever no file is actually selected — the only thing
+  # multipart buys is file transport. These tests pin both halves of that
+  # contract.
+
+  describe "the urlencoded profile save (the JS fallback's request shape)" do
+    setup %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      %{conn: conn, user: user}
+    end
+
+    # In a urlencoded submit an `<input type="file">` degrades to a text value,
+    # so `user[avatar]` arrives as "" instead of being absent. The server must
+    # treat that exactly like a multipart submit with no file.
+    test "saves the text fields when the file params arrive as empty strings",
+         %{conn: conn, user: user} do
+      conn =
+        put(conn, ~p"/settings/profile",
+          user: %{
+            "avatar" => "",
+            "avatar_crop" => "",
+            "cover_photo" => "",
+            "cover_crop" => "",
+            "first_name" => "Rene",
+            "headline" => "Saved without multipart"
+          }
+        )
+
+      assert redirected_to(conn) == "/#{user.username}"
+
+      updated = Repo.get!(User, user.id)
+      assert updated.first_name == "Rene"
+      assert updated.headline == "Saved without multipart"
+    end
+
+    test "an empty-string avatar param never clears a stored avatar",
+         %{conn: conn, user: user} do
+      user = Repo.update!(Ecto.Changeset.change(user, avatar: "existing.avif"))
+
+      put(conn, ~p"/settings/profile",
+        user: %{"avatar" => "", "avatar_crop" => "", "first_name" => "Rene"}
+      )
+
+      assert Repo.get!(User, user.id).avatar == "existing.avif"
+    end
+  end
+
+  describe "the client half" do
+    test "app.js downgrades a fileless multipart form to urlencoded at submit time" do
+      js = File.read!(Path.expand("../../assets/js/app.js", __DIR__))
+
+      assert js =~ "multipartEnctypeFallback",
+             "app.js lost the issue #1227 submit-time enctype fallback"
+
+      assert js =~ ~s(application/x-www-form-urlencoded)
+    end
+
+    test "the profile basics form stays multipart (the fallback's target)" do
+      template = File.read!(Path.expand("../../lib/vutuv_web/templates/user/edit.html.heex", __DIR__))
+      assert template =~ "multipart"
+    end
+  end
+end

--- a/test/vutuv_web/multipart_form_fallback_test.exs
+++ b/test/vutuv_web/multipart_form_fallback_test.exs
@@ -66,7 +66,9 @@ defmodule VutuvWeb.MultipartFormFallbackTest do
     end
 
     test "the profile basics form stays multipart (the fallback's target)" do
-      template = File.read!(Path.expand("../../lib/vutuv_web/templates/user/edit.html.heex", __DIR__))
+      template =
+        File.read!(Path.expand("../../lib/vutuv_web/templates/user/edit.html.heex", __DIR__))
+
       assert template =~ "multipart"
     end
   end


### PR DESCRIPTION
Closes #1227.

**The diagnosis.** The nginx body capture set up yesterday caught the member's two retries this morning (2026-07-31 05:41/05:42 UTC): his Safari 26.5.2 declares a multipart boundary but sends `Content-Length: 0` — a zero-byte body. The form data never leaves his browser, so no server-side handling can recover it; the 400 is the only honest answer to an empty request. Every urlencoded form from the same browser works (his whole session log confirms it), and a healthy Chrome save captured the full multipart body fine. WebKit builds multipart bodies as a stream it cannot always replay (a retry on a stale keep-alive connection goes out body-less); urlencoded bodies are in-memory and survive.

**The fix.** Multipart only buys file transport. app.js now downgrades any non-LiveView multipart form to urlencoded at submit time when no file is actually selected, disabling the empty file inputs for that one submission so the request carries exactly the params a fileless multipart submit produces. With a file chosen, multipart stays. The server needed no change: file fields are not in the changeset cast list and only a `%Plug.Upload{}` is ever stored — the new tests pin that contract (including that an empty-string avatar param can never clear a stored avatar).

**Verified** end to end in a real browser against a dev server: a fileless save arrives as urlencoded PUT with no file params and persists (server log + DB checked); a DataTransfer-injected file flips the form back to multipart; the disabled inputs re-enable after a cancelled submit. `mix precommit` green (6239 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_014ksBm1P9qsazixAHFeHwMc