### PR TITLE
A picked profile photo is frozen into memory at selection time (v7.206.2)

### DIFF
--- a/assets/js/image_crop.js
+++ b/assets/js/image_crop.js
@@ -36,6 +36,39 @@ function register() {
   })
 }
 
+// Freeze the picked file into an in-memory copy (issue #1227, round 2). WebKit
+// streams a picked file from disk only when the form is SENT, and a photo
+// picked from the Photos media library is a temporary export that can be gone
+// by then (the crop dialog and the rest of the form cost minutes) — the body
+// stream then aborts and Safari submits the whole multipart body as zero
+// bytes, a 400 with no way forward. Right now, at selection time, the bytes
+// are provably readable (the crop dialog reads them too), so copy them into a
+// File backed by RAM and swap it into the input: an in-memory File cannot
+// vanish before send. Guarded by identity so a quick re-pick is never
+// clobbered by a stale read, and skipped for absurd sizes the server would
+// reject anyway.
+const FREEZE_MAX_BYTES = 32 * 1024 * 1024
+
+function freezePickedFile(input, file) {
+  if (!file.arrayBuffer || typeof DataTransfer !== "function") return
+  if (file.size === 0 || file.size > FREEZE_MAX_BYTES) return
+
+  file
+    .arrayBuffer()
+    .then((bytes) => {
+      if (!input.files || input.files[0] !== file) return // re-picked meanwhile
+      const copy = new File([bytes], file.name, {
+        type: file.type,
+        lastModified: file.lastModified,
+      })
+      const dt = new DataTransfer()
+      dt.items.add(copy)
+      input.files = dt.files
+      input.dataset.frozenPick = "1"
+    })
+    .catch(() => {}) // unreadable already — leave the plain upload in place
+}
+
 function onFilePicked(input) {
   const file = input.files && input.files[0]
   const hidden = document.getElementById(input.dataset.cropTarget)
@@ -44,6 +77,8 @@ function onFilePicked(input) {
   // sets it again on Save. A new upload must never inherit the old crop.
   if (hidden) hidden.value = ""
   clearPreview(input)
+  delete input.dataset.frozenPick
+  if (file) freezePickedFile(input, file)
 
   if (!file || !file.type.startsWith("image/") || typeof createImageBitmap !== "function") {
     return // leave the plain upload in place

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.206.1",
+      version: "7.206.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/multipart_form_fallback_test.exs
+++ b/test/vutuv_web/multipart_form_fallback_test.exs
@@ -71,5 +71,25 @@ defmodule VutuvWeb.MultipartFormFallbackTest do
 
       assert template =~ "multipart"
     end
+
+    # Round 2 of issue #1227: with a photo selected the form must stay
+    # multipart, and the member's WebKit still sent Content-Length: 0 (Safari
+    # AND the DuckDuckGo browser — the same system WebKit). WebKit streams a
+    # picked file from disk only at send time, and a file picked from the
+    # Photos media library is a temporary export that can vanish before the
+    # member finishes the crop dialog and presses Save — the body stream then
+    # aborts and zero bytes go out. So the crop enhancement freezes the picked
+    # file into an in-memory copy at selection time, when it is provably
+    # readable; an in-memory File is serialized from RAM and cannot vanish.
+    test "image_crop.js freezes a picked photo into memory at selection time" do
+      js = File.read!(Path.expand("../../assets/js/image_crop.js", __DIR__))
+
+      assert js =~ "freezePickedFile",
+             "image_crop.js lost the issue #1227 pick-time in-memory freeze"
+
+      # The mechanism: read the bytes, rebuild the FileList around a copy.
+      assert js =~ "arrayBuffer"
+      assert js =~ "DataTransfer"
+    end
   end
 end


### PR DESCRIPTION
Round 2 of #1227 (do not auto-close; the member confirms first).

**What the capture showed after v7.206.1.** The member's photo upload still 400ed: multipart submits with `Content-Length: 0`, from Safari **and** from the DuckDuckGo browser for macOS — which is WKWebView, i.e. the same system WebKit (605.1.15/26.5.2). Minutes earlier another member's iPhone on the identical WebKit version saved fine through the new urlencoded fallback. So the engine version is innocent; the multipart **file stream** on his Mac is what dies. Both post-fix attempts were multipart, meaning a file was selected — consistent with his comment ("Profilbild-Upload lässt sich nicht speichern").

**The mechanism this targets.** WebKit streams a picked file from disk only at send time. A photo picked from the Photos media library in the file dialog is a temporary export, and by the time the member has been through the crop dialog and the rest of the form it can be gone — the body stream aborts and the browser sends zero bytes. That explains a deterministic failure on his machine across both WebKit browsers while Chrome users upload fine.

**The fix.** `image_crop.js` now freezes the picked file at selection time — reads the bytes (they are provably readable then; the crop dialog reads them too) into an in-memory `File` and swaps it into the input via `DataTransfer`. An in-memory file is serialized from RAM and cannot vanish before send. Identity-guarded against a quick re-pick, capped at 32 MB, and a failed read leaves the plain upload in place exactly as before. No server changes.

**Verified** in a real browser against a dev server: pick → freeze (`data-frozen-pick` set, new File object, same bytes) → crop dialog → real submit → the server logs a genuine `%Plug.Upload{}` with the crop fractions and the avatar stores. `mix precommit` green (6,240 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_014ksBm1P9qsazixAHFeHwMc