### PR TITLE
The two experiment-counter test modules run sync, ending a deadlock flake (v7.206.3)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.206.2",
+      version: "7.206.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/experiments_test.exs
+++ b/test/vutuv/experiments_test.exs
@@ -1,5 +1,13 @@
 defmodule Vutuv.ExperimentsTest do
-  use Vutuv.DataCase, async: true
+  @moduledoc """
+  `async: false` on purpose: these tests upsert the same `experiment_stats`
+  rows (the fixed production variants "stube"/"knapp" on today's Berlin day)
+  as `VutuvWeb.LandingExperimentTest`, and two async modules incrementing the
+  same unique-key rows in opposite orders deadlock (40P01) — the lost
+  increment then fails the counting assertions. The variant names are
+  production data, not test literals, so they cannot be uniquified per module.
+  """
+  use Vutuv.DataCase, async: false
 
   alias Vutuv.BerlinTime
   alias Vutuv.Experiments

--- a/test/vutuv_web/controllers/landing_experiment_test.exs
+++ b/test/vutuv_web/controllers/landing_experiment_test.exs
@@ -8,8 +8,15 @@ defmodule VutuvWeb.LandingExperimentTest do
   sign-up POST *and* the PIN round trip, both of which renew the session — so
   the confirmation tests walk the real registration flow rather than poking
   the context directly.
+
+  `async: false` on purpose: these tests upsert the same `experiment_stats`
+  rows (the fixed production variants "stube"/"knapp" on today's Berlin day)
+  as `Vutuv.ExperimentsTest`, and two async modules incrementing the same
+  unique-key rows in opposite orders deadlock (40P01) — the lost increment
+  then fails the counting assertions. The variant names are production data,
+  not test literals, so they cannot be uniquified per module.
   """
-  use VutuvWeb.ConnCase, async: true
+  use VutuvWeb.ConnCase, async: false
 
   alias Vutuv.Experiments
 


### PR DESCRIPTION
`VutuvWeb.LandingExperimentTest` and `Vutuv.ExperimentsTest` both upsert the same `experiment_stats` rows (the fixed production variants `stube`/`knapp` on today's Berlin day) and both ran `async: true`. Two async modules incrementing the same unique-key rows in opposite orders deadlock (40P01 — the exact pattern the test guidelines codify); the counter increment that loses the deadlock is dropped and the counting assertions fail. This just turned a routine pre-push gate red with two failures unrelated to the change being pushed.

The variant names are production data, not test literals, so they cannot be uniquified per module. Per the guideline, every module touching the shared rows goes `async: false`, with the reason in the moduledoc so nobody flips it back for speed. `mix precommit` green (6,240 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_014ksBm1P9qsazixAHFeHwMc