### PR TITLE
Mentions in remote fediverse posts link to their account (v7.207.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -236,14 +236,21 @@ every activity of a member it finds no key for, silently.
   sentence with their name on it does), the Note answers one of *their own*
   posts, the post is public, the sender is within its inbound cap, and there is
   text left once the markup is gone. Same 202 whatever it decides.
-  - **Stored as plain text, never HTML.** `Vutuv.RemoteHtml.to_text/2` (shared
+  - **Stored as plain text, never HTML.** `Vutuv.RemoteHtml.to_text/3` (shared
     with the Mastodon profile feed, so remote HTML is reduced exactly one way)
     drops `<script>`/`<style>` **with their contents**, turns `<br>`/`</p>` into
     line breaks, strips every remaining tag, decodes the base entities once and
     clamps. So no markup a stranger wrote survives into the database, the
     agent-format siblings carry the value unchanged, and the cap is well
     defined. **No avatar is copied**: the card renders initials and links to the
-    origin.
+    origin. One repair on the way through: those networks render a mention as
+    the bare `@user` short form, its full address hiding in the anchor the strip
+    throws away — so every content path hands the object's `Mention` tags along
+    and the reducer widens `@user` to the full `@user@host` (only where the pair
+    is unambiguous, matches the shared entity grammar and is not this very
+    installation), which the renderer below then links like any typed fediverse
+    handle. The Mastodon profile feed normalizes its REST `mentions` to the same
+    shape.
   - **Shown through `VutuvWeb.Markdown.render_remote/1`** — the same renderer
     the Mastodon profile feed uses, so remote text reads one way across the app.
     A post from those networks is largely links, and as raw strings they sat on

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -2335,7 +2335,7 @@ defmodule Vutuv.Fediverse do
       |> Enum.map_join("\n", &("• " <> &1))
 
     [
-      remote_text(object["content"], RemotePost.max_content()),
+      remote_text(object["content"], RemotePost.max_content(), object["tag"]),
       SearchText.normalize_search(options)
     ]
     |> Enum.reject(&is_nil/1)
@@ -2343,7 +2343,8 @@ defmodule Vutuv.Fediverse do
     |> SearchText.normalize_search()
   end
 
-  defp remote_post_text(object), do: remote_text(object["content"], RemotePost.max_content())
+  defp remote_post_text(object),
+    do: remote_text(object["content"], RemotePost.max_content(), object["tag"])
 
   # The body of a post whose author wrote no words: the empty string, when it
   # carries at least one picture (and nil otherwise, which drops the post).
@@ -3198,7 +3199,8 @@ defmodule Vutuv.Fediverse do
     with %{} = object <- note_object(activity["object"]),
          uri when is_binary(uri) <- object["id"],
          %Note{} = note <- Repo.get_by(Note, object_uri: uri, actor_uri: actor_uri),
-         text when text != "" <- remote_text(object["content"], Note.max_content()) do
+         text when text != "" <-
+           remote_text(object["content"], Note.max_content(), object["tag"]) do
       note
       |> Note.changeset(%{
         content_text: text,
@@ -3545,7 +3547,7 @@ defmodule Vutuv.Fediverse do
 
   defp insert_note(user, post, activity, object, actor) do
     uri = object["id"]
-    text = remote_text(object["content"], Note.max_content())
+    text = remote_text(object["content"], Note.max_content(), object["tag"])
     received = DateTime.utc_now(:second)
 
     cond do
@@ -3641,12 +3643,17 @@ defmodule Vutuv.Fediverse do
     end
   end
 
-  defp remote_text(nil, _max), do: nil
+  # `tags` is the object's AP `tag` array: content passes it so a bare `@user`
+  # mention widens to the linkable `@user@host` (see `Vutuv.RemoteHtml`); a
+  # summary is a content warning and stays as written.
+  defp remote_text(html, max, tags \\ [])
 
-  defp remote_text(html, max) when is_binary(html),
-    do: SearchText.normalize_search(RemoteHtml.to_text(html, max))
+  defp remote_text(nil, _max, _tags), do: nil
 
-  defp remote_text(_html, _max), do: nil
+  defp remote_text(html, max, tags) when is_binary(html),
+    do: SearchText.normalize_search(RemoteHtml.to_text(html, max, tags))
+
+  defp remote_text(_html, _max, _tags), do: nil
 
   # The nil UUID can never match a row: "not the author" without a NULL arm,
   # the same trick `Vutuv.Posts.engagement_viewer_id/1` uses.
@@ -3734,7 +3741,7 @@ defmodule Vutuv.Fediverse do
   end
 
   defp apply_refresh(%Note{} = note, {:ok, doc}) do
-    text = remote_text(doc["content"], Note.max_content())
+    text = remote_text(doc["content"], Note.max_content(), doc["tag"])
     still_public? = doc_public?(doc)
 
     cond do
@@ -3886,7 +3893,7 @@ defmodule Vutuv.Fediverse do
   end
 
   defp apply_repost_refresh(%RemotePost{} = post, {:ok, doc}) do
-    text = remote_text(doc["content"], RemotePost.max_content())
+    text = remote_text(doc["content"], RemotePost.max_content(), doc["tag"])
 
     cond do
       not doc_public?(doc) ->

--- a/lib/vutuv/mastodon.ex
+++ b/lib/vutuv/mastodon.ex
@@ -20,6 +20,7 @@ defmodule Vutuv.Mastodon do
 
   require Logger
 
+  alias Vutuv.RemoteHtml
   alias Vutuv.SocialFeed.Feed
   alias Vutuv.SocialFeed.Http
   alias Vutuv.SocialFeed.Post
@@ -181,7 +182,19 @@ defmodule Vutuv.Mastodon do
     cond do
       spoiler != "" -> Post.truncate(spoiler)
       status["sensitive"] == true -> ""
-      true -> text_content(to_string(status["content"] || ""))
+      true -> RemoteHtml.to_text(to_string(status["content"] || ""), nil, mention_tags(status))
+    end
+  end
+
+  # The REST API names each mentioned account in `mentions` — `acct` bare for
+  # a same-server account, `user@host` for a remote one — beside its profile
+  # `url`. Normalized to the AP Mention-tag shape, so `Vutuv.RemoteHtml` widens
+  # the bare `@user` the content shows to the full linkable address either way.
+  defp mention_tags(status) do
+    for %{"acct" => acct, "url" => url} <- List.wrap(status["mentions"]),
+        is_binary(acct),
+        is_binary(url) do
+      %{"type" => "Mention", "name" => "@" <> acct, "href" => url}
     end
   end
 
@@ -193,5 +206,5 @@ defmodule Vutuv.Mastodon do
   Fediverse replies (issue #1069), so remote HTML is turned into text exactly
   one way in this codebase.
   """
-  defdelegate text_content(html), to: Vutuv.RemoteHtml, as: :to_text
+  defdelegate text_content(html), to: RemoteHtml, as: :to_text
 end

--- a/lib/vutuv/remote_html.ex
+++ b/lib/vutuv/remote_html.ex
@@ -4,9 +4,9 @@ defmodule Vutuv.RemoteHtml do
   is willing to store and show: plain text.
 
   Two callers, one rule. `Vutuv.Mastodon` reduces the statuses of a member's own
-  linked account for their profile feed, and `Vutuv.Fediverse` reduces a reply
-  written on another network under a member's post (issue #1069). Both hold text
-  an attacker controls, and neither has any use for the remote markup, so the
+  linked account for their profile feed, and `Vutuv.Fediverse` reduces the posts
+  and replies other networks deliver (issues #1069, #1161). Both hold text an
+  attacker controls, and neither has any use for the remote markup, so the
   answer to "how do we sanitise this safely" is to not keep HTML at all:
 
     * `<script>` and `<style>` elements go **with their contents**,
@@ -27,17 +27,43 @@ defmodule Vutuv.RemoteHtml do
   and that the agent-format siblings can carry unchanged. Links survive as bare
   URLs, which `VutuvWeb.Markdown` linkifies anyway — including the `@user@host`
   handles of those networks, which it maps to the right remote profile.
+
+  **Mentions** need one repair on the way through: those networks render a
+  mention as the bare `@user` short form, while the full address that names the
+  account lives only in the anchor the strip throws away — and in the object's
+  `tag` array. Stripped naively, `@herrkaschke` is just a word, and the renderer
+  deliberately leaves a bare `@name` in remote content unlinked (it would point
+  at whatever vutuv member shares the handle). So `to_text/3` takes those
+  `Mention` tags and widens each short form to the full `@user@host`, which the
+  renderer then links to the remote profile like any typed fediverse handle.
   """
 
+  alias Vutuv.Fediverse
+  alias Vutuv.Mentions
   alias Vutuv.SocialFeed.Post
+
+  # The bare `@user` short form a remote server renders a mention as. The
+  # boundaries mirror the shared entity grammar (`Vutuv.Mentions`): not
+  # mid-token (no email `a@b`, no URL `/@user`), and not the first half of an
+  # already-full `@user@host`.
+  @short_mention ~r{(?<![A-Za-z0-9_@/])@([A-Za-z0-9_]+)(?![A-Za-z0-9_@])}
+
+  # A hostile server could park thousands of Mention tags on one delivery;
+  # nothing real mentions more than a handful.
+  @max_mention_tags 50
 
   @doc """
   Reduces a remote server's HTML to clamped plain text, at most `max`
   characters (the shared social-feed clamp by default).
-  """
-  def to_text(html, max \\ nil)
 
-  def to_text(html, max) when is_binary(html) do
+  `tags` is the object's ActivityPub `tag` value (or the REST `mentions` list
+  normalized to that shape): each `Mention` in it widens the bare `@user` the
+  content shows to the full `@user@host` the renderer can link. Expansion runs
+  before the clamp, so the cap bounds the stored result either way.
+  """
+  def to_text(html, max \\ nil, tags \\ [])
+
+  def to_text(html, max, tags) when is_binary(html) do
     html
     |> String.replace(~r{<(script|style)\b[^>]*>.*?</\1\s*>}is, "")
     # An element left open runs to the end of the document by definition, so
@@ -48,10 +74,11 @@ defmodule Vutuv.RemoteHtml do
     |> HtmlSanitizeEx.strip_tags()
     |> decode_entities()
     |> String.trim()
+    |> expand_mentions(tags)
     |> clamp(max)
   end
 
-  def to_text(_html, _max), do: ""
+  def to_text(_html, _max, _tags), do: ""
 
   defp clamp(text, nil), do: Post.truncate(text)
   defp clamp(text, max), do: Post.truncate(text, max)
@@ -67,5 +94,95 @@ defmodule Vutuv.RemoteHtml do
     |> String.replace("&#39;", "'")
     |> String.replace("&nbsp;", " ")
     |> String.replace("&amp;", "&")
+  end
+
+  defp expand_mentions(text, tags) do
+    map = mention_map(tags)
+
+    if map_size(map) == 0 or not String.contains?(text, "@") do
+      text
+    else
+      Regex.replace(@short_mention, text, fn whole, user ->
+        Map.get(map, String.downcase(user), whole)
+      end)
+    end
+  end
+
+  # short form (downcased) => the one full `@user@host` it names.
+  defp mention_map(tags) do
+    tags
+    |> List.wrap()
+    |> Enum.take(@max_mention_tags)
+    |> Enum.flat_map(&mention_handle/1)
+    |> Enum.group_by(fn {user, _host} -> String.downcase(user) end)
+    |> Enum.flat_map(&expansion/1)
+    |> Map.new()
+  end
+
+  # Two mentioned accounts sharing a short name are indistinguishable in the
+  # stripped text, so neither is expanded — never guess which the author meant.
+  defp expansion({short, pairs}) do
+    case Enum.uniq_by(pairs, fn {_user, host} -> host end) do
+      [{user, host}] -> [{short, "@#{user}@#{host}"}]
+      _ambiguous -> []
+    end
+  end
+
+  defp mention_handle(%{"type" => "Mention", "name" => name, "href" => href})
+       when is_binary(name) and is_binary(href) do
+    with {user, host} <- split_mention(name, href),
+         true <- linkable?(user, host),
+         # A mention of an account on this very installation stays short: the
+         # renderer would link the full form straight back at this server
+         # (`https://host/@user`), which is not a page vutuv serves.
+         false <- Fediverse.local_host?(host) do
+      [{user, host}]
+    else
+      _ -> []
+    end
+  end
+
+  defp mention_handle(_tag), do: []
+
+  # `name` carries the full `user@host` for a cross-server mention and only the
+  # bare user for a same-server one, where the host comes from the href.
+  defp split_mention(name, href) do
+    case name |> String.trim() |> String.trim_leading("@") |> String.split("@") do
+      [user, host] when user != "" and host != "" ->
+        {user, String.downcase(host)}
+
+      [user] when user != "" ->
+        case href_host(href) do
+          nil -> :error
+          host -> {user, host}
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp href_host(href) do
+    case URI.parse(href) do
+      %URI{scheme: scheme, host: host}
+      when scheme in ["http", "https"] and is_binary(host) and host != "" ->
+        String.downcase(host)
+
+      _ ->
+        nil
+    end
+  end
+
+  # Only an expansion the renderer will actually link is worth writing into the
+  # text: the full handle must match the shared entity grammar as one whole
+  # fediverse handle (which also validates both charsets — a dotted Misskey
+  # user name, say, would come out a plain word plus a broken half-link).
+  defp linkable?(user, host) do
+    handle = "@#{user}@#{host}"
+
+    case Regex.run(Mentions.entity_regex(), handle) do
+      [^handle, u, h | _] -> u != "" and h != ""
+      _ -> false
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.206.3",
+      version: "7.207.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_notes_test.exs
+++ b/test/vutuv/fediverse_notes_test.exs
@@ -46,6 +46,7 @@ defmodule Vutuv.FediverseNotesTest do
         "cc" => Keyword.get(opts, :cc, ["#{actor}/followers"])
       }
       |> maybe_put("summary", opts[:summary])
+      |> maybe_put("tag", opts[:tag])
 
     %{
       "type" => "Create",
@@ -278,6 +279,32 @@ defmodule Vutuv.FediverseNotesTest do
 
       assert [%Note{content_text: text}] = Repo.all(Note)
       assert String.length(text) <= Note.max_content()
+    end
+
+    test "a mentioned account is stored as its full fediverse address", %{
+      user: user,
+      note_url: note_url
+    } do
+      content =
+        ~s(<p><a href="https://social.example/@carla" class="u-url mention">@<span>carla</span></a> hat recht.</p>)
+
+      tag = [
+        %{
+          "type" => "Mention",
+          "href" => "https://social.example/users/carla",
+          "name" => "@carla"
+        }
+      ]
+
+      assert :ok =
+               Fediverse.record_reply(
+                 user,
+                 create_activity(note_url, content: content, tag: tag),
+                 remote()
+               )
+
+      assert [%Note{content_text: text}] = Repo.all(Note)
+      assert text == "@carla@social.example hat recht."
     end
 
     test "a content warning is kept as the lid, not folded into the text", %{

--- a/test/vutuv/fediverse_remote_posts_test.exs
+++ b/test/vutuv/fediverse_remote_posts_test.exs
@@ -92,6 +92,35 @@ defmodule Vutuv.FediverseRemotePostsTest do
       assert DateTime.to_date(post.published_at) == ~D[2026-07-20]
     end
 
+    test "a mentioned account is stored as its full fediverse address" do
+      user = member()
+      acc = account()
+      follow(user, acc)
+
+      # Mastodon renders a mention as the bare `@user` short form; the host
+      # needed to link the account rides in the object's Mention tag. Stored
+      # expanded, the renderer links it like any typed `@user@host` handle.
+      activity =
+        create_activity(%{
+          object: %{
+            "content" =>
+              ~s(<p>Starker Track von <a href="https://social.cologne/@herrkaschke" class="u-url mention">@<span>herrkaschke</span></a>.</p>),
+            "tag" => [
+              %{
+                "type" => "Mention",
+                "href" => "https://social.cologne/users/herrkaschke",
+                "name" => "@herrkaschke"
+              }
+            ]
+          }
+        })
+
+      assert :ok = Fediverse.record_remote_post(activity, @actor)
+
+      assert [post] = Repo.all(RemotePost)
+      assert post.content_text == "Starker Track von @herrkaschke@social.cologne."
+    end
+
     test "a redelivery stores no second row, and is a skip" do
       user = member()
       acc = account()

--- a/test/vutuv/mastodon_test.exs
+++ b/test/vutuv/mastodon_test.exs
@@ -136,6 +136,27 @@ defmodule Vutuv.MastodonTest do
       refute_receive {:req, _, _}
     end
 
+    test "a mentioned account is expanded to its full fediverse address" do
+      serve([
+        status(%{
+          "id" => "1",
+          "content" =>
+            ~s(<p>Track von <a href="https://example.social/@herrkaschke" class="u-url mention">@<span>herrkaschke</span></a></p>),
+          "mentions" => [
+            %{
+              "id" => "9",
+              "username" => "herrkaschke",
+              "acct" => "herrkaschke",
+              "url" => "https://example.social/@herrkaschke"
+            }
+          ]
+        })
+      ])
+
+      assert {:ok, %Feed{posts: [post]}} = Mastodon.fetch_posts(@handle)
+      assert post.text == "Track von @herrkaschke@example.social"
+    end
+
     test "custom-emoji shortcodes are stripped from the display name" do
       serve([status(%{})], lookup: %{"display_name" => "Johannes Mirus :verified:"})
       assert {:ok, %Feed{name: "Johannes Mirus"}} = Mastodon.fetch_posts(@handle)

--- a/test/vutuv/remote_html_test.exs
+++ b/test/vutuv/remote_html_test.exs
@@ -56,4 +56,112 @@ defmodule Vutuv.RemoteHtmlTest do
     assert RemoteHtml.to_text(nil) == ""
     assert RemoteHtml.to_text(42) == ""
   end
+
+  describe "mentions expand to their full fediverse address" do
+    # A Mention tag as Mastodon sends one for a same-server account: the name
+    # carries only the bare `@user`, the host lives in the href.
+    @mention %{
+      "type" => "Mention",
+      "href" => "https://social.cologne/users/herrkaschke",
+      "name" => "@herrkaschke"
+    }
+
+    test "a same-server mention takes its host from the tag's href" do
+      html =
+        ~s(<p>Starker Track von <a href="https://social.cologne/@herrkaschke" class="u-url mention">@<span>herrkaschke</span></a>.</p>)
+
+      assert RemoteHtml.to_text(html, nil, [@mention]) ==
+               "Starker Track von @herrkaschke@social.cologne."
+    end
+
+    test "a cross-server mention takes its host from the tag's name" do
+      tag = %{
+        "type" => "Mention",
+        "href" => "https://other.example/users/anna",
+        "name" => "@anna@other.example"
+      }
+
+      assert RemoteHtml.to_text("<p>Hi @anna</p>", nil, [tag]) == "Hi @anna@other.example"
+    end
+
+    test "every occurrence expands, case-insensitively, keeping the tag's spelling" do
+      assert RemoteHtml.to_text("<p>@HERRKASCHKE und @herrkaschke</p>", nil, [@mention]) ==
+               "@herrkaschke@social.cologne und @herrkaschke@social.cologne"
+    end
+
+    test "an already fully-qualified handle is not expanded again" do
+      assert RemoteHtml.to_text("<p>@herrkaschke@social.cologne</p>", nil, [@mention]) ==
+               "@herrkaschke@social.cologne"
+    end
+
+    test "an email address and a URL path are never rewritten" do
+      html = "<p>Mail an post@herrkaschke.de oder social.cologne/@herrkaschke</p>"
+
+      assert RemoteHtml.to_text(html, nil, [@mention]) ==
+               "Mail an post@herrkaschke.de oder social.cologne/@herrkaschke"
+    end
+
+    test "a shorter mention never chews up a longer handle beside it" do
+      short = %{"type" => "Mention", "href" => "https://a.example/users/herr", "name" => "@herr"}
+
+      assert RemoteHtml.to_text("<p>@herr und @herrkaschke</p>", nil, [short, @mention]) ==
+               "@herr@a.example und @herrkaschke@social.cologne"
+    end
+
+    test "two mentioned accounts sharing one short name stay plain (ambiguous)" do
+      other = %{
+        "type" => "Mention",
+        "href" => "https://b.example/users/herrkaschke",
+        "name" => "@herrkaschke"
+      }
+
+      assert RemoteHtml.to_text("<p>@herrkaschke</p>", nil, [@mention, other]) == "@herrkaschke"
+    end
+
+    test "a mention of an account on this very installation stays as written" do
+      # The renderer would link the full form straight back at this server
+      # (`https://host/@user`), which is not a page vutuv serves — so the
+      # short form stays plain, exactly as before. `www.` is us (issue #1211).
+      local = %{
+        "type" => "Mention",
+        "href" => "https://www.localhost/users/stefan",
+        "name" => "@stefan@www.localhost"
+      }
+
+      assert RemoteHtml.to_text("<p>@stefan</p>", nil, [local]) == "@stefan"
+    end
+
+    test "a name the renderer could not link is not expanded" do
+      dotted = %{
+        "type" => "Mention",
+        "href" => "https://misskey.example/@who.else",
+        "name" => "@who.else"
+      }
+
+      assert RemoteHtml.to_text("<p>@who.else</p>", nil, [dotted]) == "@who.else"
+    end
+
+    test "a single tag map (not wrapped in a list) works" do
+      assert RemoteHtml.to_text("<p>@herrkaschke</p>", nil, @mention) ==
+               "@herrkaschke@social.cologne"
+    end
+
+    test "hashtag tags and malformed mention tags are ignored" do
+      tags = [
+        %{"type" => "Hashtag", "name" => "#musik", "href" => "https://social.cologne/tags/musik"},
+        %{"type" => "Mention", "name" => "@x"},
+        %{"type" => "Mention", "href" => "https://social.cologne/users/x"},
+        "not a map"
+      ]
+
+      assert RemoteHtml.to_text("<p>@musik @x</p>", nil, tags) == "@musik @x"
+    end
+
+    test "the clamp still bounds the expanded text" do
+      out = RemoteHtml.to_text("<p>@herrkaschke</p>", 10, [@mention])
+
+      assert String.length(out) == 10
+      assert String.ends_with?(out, "…")
+    end
+  end
 end


### PR DESCRIPTION
**TL;DR** A mention in a remote fediverse post (e.g. `@herrkaschke` in a Mastodon post shown in the feed) is now stored as its full `@user@host` address, which the renderer links to the account on its home server.

**Where:** `Vutuv.RemoteHtml.to_text/3` (the one remote-HTML reducer), the content call sites in `Vutuv.Fediverse` (cached posts, inbound replies, Update/refresh paths) and `Vutuv.Mastodon` (profile feed, REST `mentions` normalized to the AP Mention-tag shape).
**Now:** the remote HTML renders a mention as the bare `@user`; the strip loses the anchor that carried the host, and `render_remote` deliberately leaves a bare `@name` unlinked — so mentioned accounts were dead text.
**Want:** the reducer widens `@user` to `@user@host` from the object's `Mention` tags; `VutuvWeb.Markdown` already links that form to `https://host/@user` — no renderer change.

Guards: expansion only when unambiguous (two accounts sharing one short name stay plain), only when the result matches the shared entity grammar, never for this installation's own host; tag count capped against hostile deliveries; the clamp still bounds the stored text. Already-stored posts keep their short forms and age out via retention.

**Deploy:** hot (no migrations, no config/supervision/deps changes). Version bump to 7.207.0 (minor, user-facing feature).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*