### PR TITLE
Screenshots egress through a SOCKS5 vetting proxy, so CDN-styled sites render styled

### DIFF
--- a/docs/architecture/images.md
+++ b/docs/architecture/images.md
@@ -139,19 +139,33 @@ be steered onto `169.254.169.254`, `127.0.0.1:<port>`, or any LAN host and
 publish the rendered result on the attacker's own profile/post card. Validating
 only the seed URL does not help — the browser is what does the fetching.
 
-The guard therefore constrains Chromium itself. `Vutuv.PageScreenshot.capture_framed/2`
-resolves the target host **once** through `Vutuv.Ssrf.vetted_address/1`
-(fail-closed: any resolved internal address refuses the whole capture) and pins
-the browser to that exact IP with `--host-resolver-rules=MAP * <vetted-ip>`.
-Chromium then does no DNS of its own, so every request it makes — the seed page,
-its subresources, and any redirect / meta-refresh / in-page navigation — goes to
-the one vetted public address. This also closes the check-vs-fetch (TOCTOU) DNS
-rebinding window, since there is no second lookup to poison. The real hostname
-still rides in `Host:`/SNI, so the intended page renders; only a *different*
-host is pinned to the wrong address and simply fails to load — an accepted
-fidelity trade for cross-host subresources.
+The guard therefore constrains Chromium itself: **all of its egress runs
+through `Vutuv.Ssrf.SocksProxy`**, a loopback SOCKS5 proxy in the application
+supervision tree. Chromium treats a `socks5://` proxy as remote-DNS (it sends
+each hostname to the proxy inside the CONNECT request instead of resolving it
+locally), so the proxy can resolve-and-vet **every connection** — the seed
+page, each subresource host, any redirect / meta-refresh / in-page-navigation
+target, and IP literals — through `Vutuv.Ssrf.vetted_address/1` /
+`internal_ip?/1` right before dialling it, and dials exactly the IP it vetted
+(no second lookup, so no check-vs-fetch DNS-rebinding window). Internal
+targets are refused per connection. A companion
+`--host-resolver-rules=MAP * ~NOTFOUND,EXCLUDE 127.0.0.1` (Chromium's own
+documented SOCKS recipe) makes any name resolution *outside* the proxy fail,
+and `Vutuv.PageScreenshot` refuses to launch Chromium at all when the proxy
+is down (`:proxy_unavailable`) — every degraded path fails closed.
 
-`Vutuv.Moderation.EvidenceScreenshot` calls `capture/3` without a pin, on
+The proxy replaced the original egress control, `--host-resolver-rules=MAP *
+<vetted-ip>` (v7.141.2): pinning **every** name to the seed's IP was equally
+safe but sent every *subresource* host there too, and most large sites serve
+CSS/JS from a separate CDN domain — GitHub's `github.githubassets.com` fetches
+died on a certificate mismatch, so every GitHub link card screenshotted as
+bare unstyled HTML. Per-connection vetting keeps the same guarantees while
+letting cross-host assets load from their real (vetted) addresses.
+`Vutuv.PageScreenshot.capture_framed/2` still resolves the seed host once up
+front, but only to *classify* it (`:internal_target` poisons the row,
+`:unresolvable_target` is retried).
+
+`Vutuv.Moderation.EvidenceScreenshot` calls `capture/3` without the proxy, on
 purpose: it shoots this installation's *own* host (a profile/evidence page),
 which may legitimately be internal.
 

--- a/lib/vutuv/application.ex
+++ b/lib/vutuv/application.ex
@@ -57,6 +57,13 @@ defmodule Vutuv.Application do
         # Must start after PubSub (it depends on it) and before the Endpoint.
         VutuvWeb.Presence,
         {Task.Supervisor, name: Vutuv.TaskSupervisor},
+        # The loopback SOCKS5 proxy every screenshot-Chromium egresses through
+        # (per-connection SSRF vetting; see its moduledoc for why it replaced
+        # the `MAP *` DNS pin). Starts after the TaskSupervisor (connection
+        # handlers run under it). Unconditional even where captures are off
+        # (tests, air-gapped installs): one idle loopback listener, and the
+        # capture path fails closed on `port/1` when it is missing.
+        Vutuv.Ssrf.SocksProxy,
         # Caches + single-flights the inline social feed fetches (Mastodon,
         # Bluesky). Starts after the TaskSupervisor (its fetch tasks run under
         # it); does no work until a profile visit asks, and the per-provider

--- a/lib/vutuv/page_screenshot.ex
+++ b/lib/vutuv/page_screenshot.ex
@@ -22,6 +22,7 @@ defmodule Vutuv.PageScreenshot do
   alias Vutuv.Repo
   alias Vutuv.SocialFeed.Http
   alias Vutuv.Ssrf
+  alias Vutuv.Ssrf.SocksProxy
 
   @candidate_binaries ~w(chromium chromium-browser google-chrome google-chrome-stable chrome)
   @macos_paths [
@@ -144,18 +145,25 @@ defmodule Vutuv.PageScreenshot do
   internal IP (DNS rebinding, issue #777), so resolve at capture time and refuse
   before handing the URL to Chromium.
 
-  Resolving is done **once** here, and the vetted IP is *pinned* into Chromium
-  via `--host-resolver-rules` (see `capture_args/3`): the browser never does its
-  own DNS lookup, so it cannot be steered onto an internal host by a redirect, a
-  `<meta http-equiv="refresh">`, in-page JavaScript navigation, or a DNS record
-  that flips between our check and Chromium's fetch — the SSRF-via-capture hole
-  of GHSA-mmjf-8cwc-6vwv (CWE-918). A host that resolves only to internal
-  addresses is a permanent property of the URL (`:internal_target`); one that
-  does not resolve at all right now is transient (`:unresolvable_target`), so the
-  caller retries rather than poisoning the row.
+  The resolve here only *classifies* the seed URL — a host resolving solely to
+  internal addresses is a permanent property of the URL (`:internal_target`,
+  never retried); one that does not resolve at all right now is transient
+  (`:unresolvable_target`, the caller retries). The actual SSRF egress control
+  is `Vutuv.Ssrf.SocksProxy`: Chromium is launched with **all** connections
+  forced through that loopback SOCKS5 proxy (see `capture_args/3`), which
+  re-resolves and vets every target — the seed page, each subresource host, any
+  redirect / `<meta refresh>` / JS-navigation destination, and IP literals —
+  right before dialling it, and refuses internal ones. That closes the
+  SSRF-via-capture hole of GHSA-mmjf-8cwc-6vwv (CWE-918) without the collateral
+  of the earlier `MAP * <vetted-ip>` DNS pin, which sent every subresource host
+  to the seed's IP and so broke CSS/JS on any site serving assets from a CDN
+  domain (GitHub screenshotted as bare unstyled HTML). If the proxy is not
+  running, the capture **fails closed** (`:proxy_unavailable`, transient) —
+  Chromium is never launched unprotected.
 
   `Vutuv.Moderation.EvidenceScreenshot` calls `capture/3` directly to shoot the
-  app's own host and is intentionally neither gated nor pinned.
+  app's own host (which may legitimately be internal) and is intentionally
+  neither gated nor proxied.
   """
   def capture_framed(url_value, id) when is_binary(url_value) do
     if host_blocked?(url_value) do
@@ -167,12 +175,25 @@ defmodule Vutuv.PageScreenshot do
 
   defp capture_vetted(url_value, id) do
     case Ssrf.vetted_address(URI.parse(url_value).host) do
-      {:ok, pin_ip} ->
+      {:ok, _public_ip} ->
+        capture_proxied(url_value, id)
+
+      {:error, :internal} ->
+        {:error, :internal_target}
+
+      {:error, :unresolvable} ->
+        {:error, :unresolvable_target}
+    end
+  end
+
+  defp capture_proxied(url_value, id) do
+    case SocksProxy.port() do
+      {:ok, proxy_port} ->
         page_path = tmp_path("page", id, "png")
         framed_path = tmp_path("frame", id, "webp")
 
         try do
-          with :ok <- capture(url_value, page_path, pin_ip: pin_ip),
+          with :ok <- capture(url_value, page_path, proxy_port: proxy_port),
                {:ok, ^framed_path} <- BrowserFrame.wrap(page_path, url_value, framed_path) do
             {:ok, framed_path}
           end
@@ -180,11 +201,12 @@ defmodule Vutuv.PageScreenshot do
           File.rm(page_path)
         end
 
-      {:error, :internal} ->
-        {:error, :internal_target}
-
-      {:error, :unresolvable} ->
-        {:error, :unresolvable_target}
+      {:error, :not_running} ->
+        # Fail closed: without the vetting proxy Chromium would do its own DNS
+        # and egress and could be steered onto an internal host, so no capture
+        # happens at all. An environment failure like a missing Chromium —
+        # transient, logged at :error, the row is not poisoned.
+        {:error, :proxy_unavailable}
     end
   end
 
@@ -349,16 +371,25 @@ defmodule Vutuv.PageScreenshot do
   page that scrolls itself on arrival is captured before those tiles are
   painted and stores a blank image (issue #1033).
 
-  `opts[:pin_ip]` (an `:inet.ip_address/0`) adds
-  `--host-resolver-rules=MAP * <ip>`, which forces **every** name Chromium would
-  resolve during the run — the seed host, its subresources, and any redirect /
-  meta-refresh / JavaScript-navigation target — to the single vetted public IP.
-  That is the SSRF egress control (GHSA-mmjf-8cwc-6vwv): Chromium does no DNS of
-  its own, so it cannot reach an internal address the seed URL was validated
-  against. The real hostname still rides in `Host:`/SNI, so the intended page
-  renders; only a *different* host is pinned to the wrong address and simply
-  fails to load. Omitted (`EvidenceScreenshot` shooting our own host), no rule
-  is added and behaviour is unchanged.
+  `opts[:proxy_port]` routes **all** of Chromium's egress through the loopback
+  SOCKS5 vetting proxy (`Vutuv.Ssrf.SocksProxy`) on that port — the SSRF egress
+  control (GHSA-mmjf-8cwc-6vwv). Two flags, both needed:
+
+    * `--proxy-server=socks5://127.0.0.1:<port>` — Chromium treats `socks5://`
+      as remote-DNS (its network-stack docs): it resolves no hostname itself
+      but sends each one to the proxy in the CONNECT request, so the proxy can
+      resolve-and-vet every connection (seed page, subresources, redirect /
+      meta-refresh / JS-navigation targets, IP literals) right before dialling.
+    * `--host-resolver-rules=MAP * ~NOTFOUND,EXCLUDE 127.0.0.1` — Chromium's
+      own documented companion recipe: any name resolution attempted *outside*
+      the proxy fails, so nothing can slip past the vetting (fail closed).
+
+  This replaced pinning every name to the seed's vetted IP (`MAP * <ip>`),
+  which was equally safe but sent every *subresource* host to the seed's
+  address: on any site serving CSS/JS from a CDN domain those fetches died on
+  a certificate mismatch, and e.g. GitHub pages screenshotted as bare
+  unstyled HTML. Omitted (`EvidenceScreenshot` shooting our own, possibly
+  internal, host), no proxy flags are added and Chromium runs direct.
   """
   def capture_args(url, out_path, opts \\ []) do
     {width, height} = Keyword.get(opts, :window, window_size())
@@ -381,20 +412,16 @@ defmodule Vutuv.PageScreenshot do
       "--user-agent=#{Http.user_agent()}",
       "--window-size=#{width},#{height}",
       "--screenshot=#{out_path}"
-    ] ++ host_resolver_args(Keyword.get(opts, :pin_ip)) ++ [url]
+    ] ++ proxy_args(Keyword.get(opts, :proxy_port)) ++ [url]
   end
 
-  # The SSRF pin: map every resolved name to the one vetted IP, or nothing when
-  # unpinned. `MAP * <ip>` still lets Chromium send the correct `Host:`/SNI, so
-  # the seed page renders normally while nothing can be re-resolved elsewhere.
-  defp host_resolver_args(nil), do: []
-  defp host_resolver_args(pin_ip), do: ["--host-resolver-rules=MAP * #{format_pin(pin_ip)}"]
+  defp proxy_args(nil), do: []
 
-  # Chromium's resolver-rule replacement wants a bare IPv4 literal, and a
-  # bracketed IPv6 literal so the optional `:port` suffix stays unambiguous.
-  defp format_pin(pin_ip) do
-    addr = pin_ip |> :inet.ntoa() |> to_string()
-    if tuple_size(pin_ip) == 8, do: "[#{addr}]", else: addr
+  defp proxy_args(proxy_port) do
+    [
+      "--proxy-server=socks5://127.0.0.1:#{proxy_port}",
+      "--host-resolver-rules=MAP * ~NOTFOUND,EXCLUDE 127.0.0.1"
+    ]
   end
 
   @doc "The OS-level ceiling for one Chromium run, in seconds."

--- a/lib/vutuv/ssrf.ex
+++ b/lib/vutuv/ssrf.ex
@@ -20,12 +20,14 @@ defmodule Vutuv.Ssrf do
       a fetcher that then re-resolves the host could get a different, internal
       answer.
     * `vetted_address/1` — resolves once and returns the exact public IP to pin
-      the fetcher to, so there is no second lookup to poison. This closes the
-      TOCTOU for the one fetcher that re-resolved on its own, the headless-capture
-      browser: it is handed the vetted IP via `--host-resolver-rules`
-      (`Vutuv.PageScreenshot`, GHSA-mmjf-8cwc-6vwv / CWE-918) rather than the
-      hostname, and every redirect / `<meta refresh>` / in-page navigation it
-      then makes is pinned to that same address too.
+      the fetcher to, so there is no second lookup to poison. For the one
+      fetcher that resolves on its own, the headless-capture browser, this runs
+      inside `Vutuv.Ssrf.SocksProxy`: Chromium egresses through that loopback
+      SOCKS5 proxy, which hands every connection's hostname to
+      `vetted_address/1` and dials exactly the IP it vetted — per connection,
+      covering redirects / `<meta refresh>` / in-page navigation and
+      subresource hosts (`Vutuv.PageScreenshot`, GHSA-mmjf-8cwc-6vwv /
+      CWE-918).
 
   The resolver is injectable via `config :vutuv, :ssrf_resolver` (a
   `fun(charlist, :inet | :inet6) -> {:ok, [ip]} | {:error, term}`) so tests can
@@ -82,9 +84,9 @@ defmodule Vutuv.Ssrf do
   This is what `resolves_to_internal?/1` cannot do on its own: that predicate only
   *checks* the host, and the fetcher then looked it up again — a second lookup that
   could answer with an internal address (DNS rebinding), the TOCTOU acknowledged in
-  the moduledoc. Handing the fetcher the exact IP we validated (the headless-capture
-  browser gets it via `--host-resolver-rules`) removes that second lookup, so there
-  is no window for the answer to change.
+  the moduledoc. Connecting to the exact IP this function validated (for the
+  headless-capture browser, `Vutuv.Ssrf.SocksProxy` does that per connection)
+  removes that second lookup, so there is no window for the answer to change.
 
     * `{:ok, ip}` — a public IP literal (returns itself, no lookup), or a hostname
       whose resolved addresses are **all** public (returns the first, to pin on).

--- a/lib/vutuv/ssrf/socks_proxy.ex
+++ b/lib/vutuv/ssrf/socks_proxy.ex
@@ -1,0 +1,316 @@
+defmodule Vutuv.Ssrf.SocksProxy do
+  @moduledoc """
+  A loopback SOCKS5 proxy that vets **every single connection** the
+  headless-capture Chromium makes against `Vutuv.Ssrf` — the SSRF egress
+  control for member-supplied screenshot URLs (GHSA-mmjf-8cwc-6vwv, CWE-918).
+
+  ## Why a proxy at all — the history
+
+  The captured URL is member-supplied, so headless Chromium is an SSRF risk:
+  left to itself it resolves DNS and follows redirects, `<meta refresh>` and
+  JavaScript navigations, and could be steered onto `169.254.169.254`,
+  `127.0.0.1:<port>` or any LAN host and publish the rendered result on the
+  attacker's own link card. Vetting only the seed URL does not help — the
+  *browser* is what fetches.
+
+  The first egress control (v7.141.2) pinned Chromium to the seed host's
+  pre-vetted IP with `--host-resolver-rules=MAP * <ip>`. That closed the DNS
+  side completely, but with a fidelity cost that turned out to be much bigger
+  than "some third-party widget won't load": `MAP *` sends every **subresource
+  host** to the seed's IP too, and most large sites serve their CSS/JS from a
+  separate CDN domain. GitHub loads all styling from `github.githubassets.com`;
+  pinned to `github.com`'s address, that TLS handshake dies on a certificate
+  mismatch (`ERR_CERT_COMMON_NAME_INVALID`) and every GitHub link card
+  screenshotted as bare unstyled 1995-looking HTML. Any site with an asset
+  CDN degraded the same way.
+
+  So the pin was replaced by this proxy: Chromium egresses through it, and the
+  vetting moves from "one IP for the whole run" to "each connection's target is
+  resolved and vetted the moment it is dialled". Cross-host assets now load
+  from their real (vetted) addresses, so the shot looks like the page — while
+  internal targets stay unreachable, connection by connection.
+
+  ## Why SOCKS5 specifically
+
+  Chromium treats a `socks5://` proxy as **remote-DNS** (see its network-stack
+  docs): it does not resolve hostnames itself but sends each one to the proxy
+  inside the CONNECT request. That is exactly the property the vetting needs —
+  the proxy sees the *name*, resolves it once via `Vutuv.Ssrf.vetted_address/1`
+  (fail closed: any internal answer refuses), and then dials the exact IP it
+  just vetted. There is no second lookup anywhere, so the check-vs-fetch
+  (TOCTOU) rebinding window the old pin closed stays closed. SOCKS5 is also
+  the smallest protocol with that property: an HTTP forward proxy would need
+  header parsing and CONNECT special-casing for the same result; TLS is passed
+  through untouched either way (no MITM).
+
+  A CONNECT that names an IP **literal** (ATYP 1/4) is vetted against
+  `Vutuv.Ssrf.internal_ip?/1` directly — which the resolver-rule approach
+  could not reliably cover, since a literal never consults the resolver. So
+  `<img src="http://127.0.0.1:9100/...">` is refused here, by the same guard.
+
+  Chromium is launched with `--host-resolver-rules=MAP * ~NOTFOUND,EXCLUDE
+  127.0.0.1` alongside (Chromium's own documented SOCKS recipe): any name
+  resolution attempted *outside* the proxy fails, so a code path that bypassed
+  the proxy could still not reach the network by name. Both halves fail
+  closed, and so does the caller: `Vutuv.PageScreenshot` refuses to launch
+  Chromium at all when this proxy is not running (`{:error, :not_running}`
+  from `port/1`), rather than degrade to an unvetted capture.
+
+  ## Scope and non-goals
+
+    * Listens on `127.0.0.1` only, on an ephemeral port (read it via
+      `port/1`) — never reachable from outside the host. A local process
+      could relay *outbound* through it, which grants nothing it does not
+      already have; internal targets are refused for it too.
+    * Only `CONNECT` (TCP) is implemented. Chromium needs nothing else here:
+      no remote DNS over UDP (hostnames ride in CONNECT), and QUIC/HTTP3 is
+      not attempted through a SOCKS proxy — sites fall back to TCP.
+    * No authentication (method `0x00`): the trust boundary is the loopback
+      bind, and the vetting applies to every client equally.
+    * `Vutuv.Moderation.EvidenceScreenshot` deliberately does **not** use the
+      proxy — it shoots this installation's *own* host, which may
+      legitimately resolve internally (dev, intranet installs).
+
+  One instance runs in the application supervision tree. The `:vet` option
+  (a `fun({:domain, host} | {:ip, ip_tuple}) -> {:ok, ip} | {:error, term}`)
+  exists for tests only; the default is `default_vet/1` on `Vutuv.Ssrf`.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Vutuv.Ssrf
+
+  @handshake_timeout 10_000
+  @connect_timeout 10_000
+  # A capture's Chromium is force-killed ~30s after launch
+  # (Vutuv.PageScreenshot.capture_seconds/0), closing its proxy connections;
+  # a relay idle this long has lost its client, so close it rather than leak
+  # the handler process.
+  @idle_timeout 120_000
+
+  # SOCKS5 reply codes (RFC 1928 §6).
+  @rep_success 0x00
+  @rep_general_failure 0x01
+  @rep_not_allowed 0x02
+  @rep_network_unreachable 0x03
+  @rep_host_unreachable 0x04
+  @rep_refused 0x05
+  @rep_cmd_not_supported 0x07
+  @rep_atyp_not_supported 0x08
+
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  The loopback TCP port the proxy listens on, as `{:ok, port}` — or
+  `{:error, :not_running}` when the proxy is down, which the capture path
+  must treat as "do not launch Chromium" (fail closed), never as "capture
+  without protection".
+  """
+  def port(server \\ __MODULE__) do
+    {:ok, GenServer.call(server, :port)}
+  catch
+    :exit, _ -> {:error, :not_running}
+  end
+
+  @doc """
+  The production vetting: a hostname goes through `Vutuv.Ssrf.vetted_address/1`
+  (resolve once, refuse if any answer is internal, dial exactly the vetted IP);
+  an IP literal is checked against `Vutuv.Ssrf.internal_ip?/1` directly.
+  """
+  def default_vet({:domain, host}), do: Ssrf.vetted_address(host)
+
+  def default_vet({:ip, ip}) do
+    if Ssrf.internal_ip?(ip), do: {:error, :internal}, else: {:ok, ip}
+  end
+
+  @impl true
+  def init(opts) do
+    vet = Keyword.get(opts, :vet, &default_vet/1)
+
+    {:ok, listen} =
+      :gen_tcp.listen(0, [
+        :binary,
+        ip: {127, 0, 0, 1},
+        active: false,
+        reuseaddr: true,
+        backlog: 64
+      ])
+
+    {:ok, port} = :inet.port(listen)
+    {:ok, _acceptor} = Task.start_link(fn -> accept_loop(listen, vet) end)
+    {:ok, %{listen: listen, port: port}}
+  end
+
+  @impl true
+  def handle_call(:port, _from, state), do: {:reply, state.port, state}
+
+  # Each accepted connection is served by its own supervised task, so a
+  # malformed or hostile client can only ever break its own handler. The
+  # `:go` message gates the handler until socket ownership has transferred
+  # (passive-mode recv is owner-only).
+  defp accept_loop(listen, vet) do
+    case :gen_tcp.accept(listen) do
+      {:ok, client} ->
+        {:ok, pid} =
+          Task.Supervisor.start_child(Vutuv.TaskSupervisor, fn ->
+            receive do
+              {:go, socket} -> serve(socket, vet)
+            after
+              5_000 -> :ok
+            end
+          end)
+
+        :ok = :gen_tcp.controlling_process(client, pid)
+        send(pid, {:go, client})
+        accept_loop(listen, vet)
+
+      # The listen socket died with the GenServer (shutdown/restart): stop.
+      {:error, :closed} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error("socks proxy accept failed: #{inspect(reason)}")
+        accept_loop(listen, vet)
+    end
+  end
+
+  defp serve(client, vet) do
+    with {:ok, methods} <- recv_greeting(client),
+         :ok <- select_no_auth(client, methods),
+         {:ok, target, port} <- read_request(client) do
+      connect_vetted(client, vet, target, port)
+    else
+      {:refuse, rep} -> reply(client, rep)
+      _error -> :ok
+    end
+
+    :gen_tcp.close(client)
+  end
+
+  defp recv_greeting(client) do
+    with {:ok, <<5, n>>} <- :gen_tcp.recv(client, 2, @handshake_timeout),
+         true <- n > 0,
+         {:ok, methods} <- :gen_tcp.recv(client, n, @handshake_timeout) do
+      {:ok, methods}
+    else
+      _malformed -> :error
+    end
+  end
+
+  defp select_no_auth(client, methods) do
+    if :binary.match(methods, <<0>>) == :nomatch do
+      :gen_tcp.send(client, <<5, 0xFF>>)
+      :error
+    else
+      :gen_tcp.send(client, <<5, 0>>)
+    end
+  end
+
+  defp read_request(client) do
+    case :gen_tcp.recv(client, 4, @handshake_timeout) do
+      {:ok, <<5, 1, _rsv, atyp>>} -> read_target(client, atyp)
+      {:ok, <<5, _cmd, _rsv, _atyp>>} -> {:refuse, @rep_cmd_not_supported}
+      _error -> :error
+    end
+  end
+
+  defp read_target(client, atyp) do
+    with {:ok, target} <- read_address(client, atyp),
+         {:ok, <<port::16>>} <- :gen_tcp.recv(client, 2, @handshake_timeout) do
+      {:ok, target, port}
+    else
+      {:refuse, rep} -> {:refuse, rep}
+      _error -> :error
+    end
+  end
+
+  defp read_address(client, 1) do
+    with {:ok, <<a, b, c, d>>} <- :gen_tcp.recv(client, 4, @handshake_timeout) do
+      {:ok, {:ip, {a, b, c, d}}}
+    end
+  end
+
+  defp read_address(client, 3) do
+    with {:ok, <<len>>} <- :gen_tcp.recv(client, 1, @handshake_timeout),
+         true <- len > 0,
+         {:ok, host} <- :gen_tcp.recv(client, len, @handshake_timeout) do
+      {:ok, {:domain, host}}
+    else
+      _malformed -> :error
+    end
+  end
+
+  defp read_address(client, 4) do
+    with {:ok, <<w1::16, w2::16, w3::16, w4::16, w5::16, w6::16, w7::16, w8::16>>} <-
+           :gen_tcp.recv(client, 16, @handshake_timeout) do
+      {:ok, {:ip, {w1, w2, w3, w4, w5, w6, w7, w8}}}
+    end
+  end
+
+  defp read_address(_client, _atyp), do: {:refuse, @rep_atyp_not_supported}
+
+  # The heart of the guard: resolve-and-vet at dial time, connect to exactly
+  # the vetted address (never to what the client asked for by name, and never
+  # via a second lookup).
+  defp connect_vetted(client, vet, target, port) do
+    case vet.(target) do
+      {:ok, ip} -> connect_upstream(client, ip, port)
+      {:error, _refused} -> reply(client, @rep_not_allowed)
+    end
+  end
+
+  defp connect_upstream(client, ip, port) do
+    case :gen_tcp.connect(ip, port, [:binary, active: false], @connect_timeout) do
+      {:ok, upstream} ->
+        reply(client, @rep_success)
+        :ok = :inet.setopts(client, active: :once)
+        :ok = :inet.setopts(upstream, active: :once)
+        relay(client, upstream)
+        :gen_tcp.close(upstream)
+
+      {:error, reason} ->
+        reply(client, connect_rep(reason))
+    end
+  end
+
+  defp connect_rep(:econnrefused), do: @rep_refused
+  defp connect_rep(:timeout), do: @rep_host_unreachable
+  defp connect_rep(:ehostunreach), do: @rep_host_unreachable
+  defp connect_rep(:enetunreach), do: @rep_network_unreachable
+  defp connect_rep(_other), do: @rep_general_failure
+
+  # BND.ADDR/BND.PORT carry no information for a CONNECT client; Chromium
+  # ignores them, so answer the conventional 0.0.0.0:0.
+  defp reply(client, rep) do
+    :gen_tcp.send(client, <<5, rep, 0, 1, 0, 0, 0, 0, 0, 0>>)
+    :ok
+  end
+
+  # Byte pump between client and upstream. `active: :once` per direction gives
+  # backpressure: the next chunk is only asked for after the previous one was
+  # written through.
+  defp relay(a, b) do
+    receive do
+      {:tcp, socket, data} ->
+        other = if socket == a, do: b, else: a
+
+        with :ok <- :gen_tcp.send(other, data),
+             :ok <- :inet.setopts(socket, active: :once) do
+          relay(a, b)
+        end
+
+      {:tcp_closed, _socket} ->
+        :ok
+
+      {:tcp_error, _socket, _reason} ->
+        :ok
+    after
+      @idle_timeout -> :ok
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.207.0",
+      version: "7.207.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/page_screenshot_test.exs
+++ b/test/vutuv/page_screenshot_test.exs
@@ -36,8 +36,9 @@ defmodule Vutuv.PageScreenshotTest do
   end
 
   # A stand-in "Chromium" that records its argv (one element per line, so the
-  # space-carrying `--host-resolver-rules=MAP * <ip>` stays one line) and writes
-  # no screenshot. Lets a test assert the exact command line without a browser.
+  # space-carrying `--host-resolver-rules=MAP * ~NOTFOUND,...` stays one line)
+  # and writes no screenshot. Lets a test assert the exact command line without
+  # a browser.
   defp fake_chromium(args_file) do
     path = Path.join(System.tmp_dir!(), "fake-chromium-#{System.unique_integer([:positive])}")
     File.write!(path, "#!/bin/sh\nprintf '%s\\n' \"$@\" > #{args_file}\n")
@@ -79,48 +80,45 @@ defmodule Vutuv.PageScreenshotTest do
     assert "--user-agent=#{Http.user_agent()}" in args
   end
 
-  describe "capture_args/3 host-resolver pinning (SSRF egress control)" do
-    test "no pin IP means no --host-resolver-rules flag (unchanged behaviour)" do
+  describe "capture_args/3 proxy egress (SSRF control)" do
+    test "no proxy port means no proxy and no resolver flags (EvidenceScreenshot's own-host path)" do
       args = Vutuv.PageScreenshot.capture_args("https://example.com", "/tmp/out.png")
+      refute Enum.any?(args, &String.starts_with?(&1, "--proxy-server"))
       refute Enum.any?(args, &String.starts_with?(&1, "--host-resolver-rules"))
     end
 
-    test "a pin IP maps EVERY host Chromium resolves to that one vetted address" do
+    test "a proxy port routes every connection through the loopback SOCKS proxy, DNS included" do
       args =
-        Vutuv.PageScreenshot.capture_args("https://example.com", "/tmp/out.png",
-          pin_ip: {93, 184, 216, 34}
-        )
+        Vutuv.PageScreenshot.capture_args("https://example.com", "/tmp/out.png", proxy_port: 1080)
 
-      # `MAP * <ip>` pins the seed host, its subresources, and any redirect /
-      # <meta refresh> / JS navigation to the single public IP we already
-      # vetted, so Chromium cannot be steered onto an internal host after the
-      # seed URL passed the guard (GHSA-mmjf-8cwc-6vwv).
-      assert "--host-resolver-rules=MAP * 93.184.216.34" in args
+      # Chromium treats `socks5://` as remote-DNS: it sends the proxy each
+      # hostname in CONNECT instead of resolving it locally, which is what
+      # lets the proxy vet every connection (seed, subresources, redirects).
+      assert "--proxy-server=socks5://127.0.0.1:1080" in args
+
+      # Belt and braces from Chromium's own SOCKS recipe: any name resolution
+      # that would happen OUTSIDE the proxy fails (`~NOTFOUND`), so nothing
+      # can slip past the vetting — fail closed, per the safety-check rule.
+      assert "--host-resolver-rules=MAP * ~NOTFOUND,EXCLUDE 127.0.0.1" in args
     end
 
-    test "the URL stays the final positional argument, after the pin flag" do
+    test "the URL stays the final positional argument, after the proxy flags" do
       args =
         Vutuv.PageScreenshot.capture_args("https://example.com/page", "/tmp/out.png",
-          pin_ip: {93, 184, 216, 34}
+          proxy_port: 1080
         )
 
       assert List.last(args) == "https://example.com/page"
     end
-
-    test "an IPv6 pin address is bracketed for the resolver rule" do
-      args =
-        Vutuv.PageScreenshot.capture_args("https://example.com", "/tmp/out.png",
-          pin_ip: {0x2606, 0x2800, 0x220, 1, 0x248, 0x1893, 0x25C8, 0x1946}
-        )
-
-      assert "--host-resolver-rules=MAP * [2606:2800:220:1:248:1893:25c8:1946]" in args
-    end
   end
 
-  test "capture_framed pins Chromium to the host's vetted IP (resolve-once, no re-lookup)" do
-    # A public-looking host that resolves to a public IP: capture_framed must
-    # resolve it ONCE and hand Chromium that exact address, so the browser never
-    # does its own lookup that DNS rebinding could flip to an internal IP.
+  test "capture_framed routes Chromium through the vetting SOCKS proxy" do
+    # A public-looking host that resolves publicly: capture_framed must launch
+    # Chromium with ALL egress forced through the loopback SOCKS proxy, which
+    # re-vets every connection's hostname right before dialling it. (The old
+    # `MAP * <vetted-ip>` pin also sent every SUBRESOURCE host to the seed's
+    # IP, which broke CSS/JS on any site serving assets from a CDN domain —
+    # GitHub pages screenshotted as bare unstyled HTML.)
     Application.put_env(:vutuv, :ssrf_resolver, fn _host, _family ->
       {:ok, [{93, 184, 216, 34}]}
     end)
@@ -135,7 +133,34 @@ defmodule Vutuv.PageScreenshotTest do
     # capture_framed returns an error — but the recorded args are what we assert.
     _ = Vutuv.PageScreenshot.capture_framed("https://public.example/page", "cap1")
 
-    assert File.read!(args_file) =~ "--host-resolver-rules=MAP * 93.184.216.34"
+    recorded = File.read!(args_file)
+    assert recorded =~ "--proxy-server=socks5://127.0.0.1:"
+    assert recorded =~ "--host-resolver-rules=MAP * ~NOTFOUND,EXCLUDE 127.0.0.1"
+  end
+
+  test "capture_framed fails closed when the vetting proxy is down: no unprotected Chromium" do
+    # Without the proxy Chromium would fall back to its own DNS and egress,
+    # reopening the SSRF hole — so a missing proxy must abort the capture
+    # entirely (as a transient environment failure), never degrade to an
+    # unvetted run.
+    :ok = Supervisor.terminate_child(Vutuv.Supervisor, Vutuv.Ssrf.SocksProxy)
+    on_exit(fn -> Supervisor.restart_child(Vutuv.Supervisor, Vutuv.Ssrf.SocksProxy) end)
+
+    Application.put_env(:vutuv, :ssrf_resolver, fn _host, _family ->
+      {:ok, [{93, 184, 216, 34}]}
+    end)
+
+    args_file =
+      Path.join(System.tmp_dir!(), "chromium-args-#{System.unique_integer([:positive])}")
+
+    on_exit(fn -> File.rm(args_file) end)
+    Application.put_env(:vutuv, :chromium_path, fake_chromium(args_file))
+
+    assert {:error, :proxy_unavailable} =
+             Vutuv.PageScreenshot.capture_framed("https://public.example/page", "cap4")
+
+    # Chromium was never spawned — the whole point of failing closed.
+    refute File.exists?(args_file)
   end
 
   describe "host_blocked?/1 (screenshot blocklist)" do

--- a/test/vutuv/ssrf/socks_proxy_test.exs
+++ b/test/vutuv/ssrf/socks_proxy_test.exs
@@ -1,0 +1,194 @@
+defmodule Vutuv.Ssrf.SocksProxyTest do
+  @moduledoc """
+  The loopback SOCKS5 proxy that headless Chromium captures egress through.
+  Chromium hands it the *hostname* of every connection (the seed page, each
+  subresource host, any redirect target), so each one is resolved and vetted
+  server-side (`Vutuv.Ssrf`) right before connecting — internal targets are
+  refused with REP 0x02 and never dialled. See `Vutuv.Ssrf.SocksProxy` for why
+  this replaced the `--host-resolver-rules=MAP * <ip>` pin.
+
+  Not async: one test drives the default vet through the global `:ssrf_resolver`
+  app env (the same env `Vutuv.PageScreenshotTest` mutates).
+  """
+  use ExUnit.Case, async: false
+
+  alias Vutuv.Ssrf.SocksProxy
+
+  setup do
+    prev_resolver = Application.get_env(:vutuv, :ssrf_resolver)
+    on_exit(fn -> Application.put_env(:vutuv, :ssrf_resolver, prev_resolver) end)
+    :ok
+  end
+
+  test "relays bytes both ways, connecting by hostname to the IP the vet returned" do
+    # The vet sees the hostname (that is the whole point of SOCKS5 over a DNS
+    # pin: per-connection vetting needs the name) and answers with the address
+    # the proxy must dial — here a local echo server standing in for the
+    # vetted public IP.
+    test_pid = self()
+
+    vet = fn target ->
+      send(test_pid, {:vetted, target})
+      {:ok, {127, 0, 0, 1}}
+    end
+
+    proxy_port = start_proxy(vet: vet)
+    echo_port = start_echo_server()
+
+    sock = open_client(proxy_port)
+    handshake(sock)
+    assert connect_request(sock, {:domain, "assets.example"}, echo_port) == 0
+    assert_received {:vetted, {:domain, "assets.example"}}
+
+    :ok = :gen_tcp.send(sock, "ping")
+    assert {:ok, "ping"} = :gen_tcp.recv(sock, 4, 5_000)
+    :ok = :gen_tcp.send(sock, "pong")
+    assert {:ok, "pong"} = :gen_tcp.recv(sock, 4, 5_000)
+  end
+
+  test "a vet refusal answers REP 2 (not allowed by ruleset) and closes without dialling" do
+    proxy_port = start_proxy(vet: fn _target -> {:error, :internal} end)
+
+    sock = open_client(proxy_port)
+    handshake(sock)
+    assert connect_request(sock, {:domain, "rebind.example"}, 443) == 2
+    assert {:error, :closed} = :gen_tcp.recv(sock, 1, 5_000)
+  end
+
+  test "the default vet refuses localhost and internal IP literals without any DNS" do
+    # IP-literal subresources (<img src="http://127.0.0.1/...">) never hit a
+    # resolver, so the old `MAP *` rule could not reliably catch them — the
+    # proxy vets the literal itself.
+    proxy_port = start_proxy()
+
+    for target <- [
+          {:domain, "localhost"},
+          {:ipv4, {127, 0, 0, 1}},
+          {:ipv4, {10, 0, 0, 5}},
+          {:ipv4, {169, 254, 169, 254}},
+          {:ipv6, {0, 0, 0, 0, 0, 0, 0, 1}}
+        ] do
+      sock = open_client(proxy_port)
+      handshake(sock)
+      assert connect_request(sock, target, 80) == 2, "expected refusal for #{inspect(target)}"
+    end
+  end
+
+  test "the default vet refuses a hostname that resolves to an internal address (rebinding)" do
+    Application.put_env(:vutuv, :ssrf_resolver, fn _host, _family -> {:ok, [{10, 0, 0, 5}]} end)
+    proxy_port = start_proxy()
+
+    sock = open_client(proxy_port)
+    handshake(sock)
+    assert connect_request(sock, {:domain, "public-looking.example"}, 443) == 2
+  end
+
+  test "an unreachable vetted target answers REP 5 (connection refused), not a hang" do
+    # Grab an ephemeral port nothing listens on by opening and closing a listener.
+    {:ok, listen} = :gen_tcp.listen(0, ip: {127, 0, 0, 1})
+    {:ok, dead_port} = :inet.port(listen)
+    :ok = :gen_tcp.close(listen)
+
+    proxy_port = start_proxy(vet: fn _target -> {:ok, {127, 0, 0, 1}} end)
+
+    sock = open_client(proxy_port)
+    handshake(sock)
+    assert connect_request(sock, {:domain, "gone.example"}, dead_port) == 5
+  end
+
+  test "a non-CONNECT command is refused with REP 7" do
+    proxy_port = start_proxy()
+
+    sock = open_client(proxy_port)
+    handshake(sock)
+    # CMD 3 = UDP ASSOCIATE; the capture path only ever needs TCP CONNECT.
+    :ok = :gen_tcp.send(sock, <<5, 3, 0, 1, 127, 0, 0, 1, 80::16>>)
+    assert recv_reply(sock) == 7
+  end
+
+  test "a client that cannot do no-auth is turned away" do
+    proxy_port = start_proxy()
+
+    sock = open_client(proxy_port)
+    # Offers only method 0x02 (username/password); the proxy speaks 0x00 only.
+    :ok = :gen_tcp.send(sock, <<5, 1, 2>>)
+    assert {:ok, <<5, 0xFF>>} = :gen_tcp.recv(sock, 2, 5_000)
+    assert {:error, :closed} = :gen_tcp.recv(sock, 1, 5_000)
+  end
+
+  test "port/1 fails closed when the proxy is not running" do
+    # The capture path must refuse to launch Chromium unprotected, so a dead
+    # proxy has to surface as an error, never as a crash or a silent fallback.
+    assert {:error, :not_running} = SocksProxy.port(:socks_proxy_test_no_such_instance)
+  end
+
+  test "the application runs one global instance for the capture path" do
+    assert {:ok, port} = SocksProxy.port()
+    assert is_integer(port)
+  end
+
+  # -- SOCKS5 client + fixture helpers ---------------------------------------
+
+  defp start_proxy(opts \\ []) do
+    name = :"socks_proxy_test_#{System.unique_integer([:positive])}"
+    start_supervised!({SocksProxy, Keyword.put(opts, :name, name)})
+    {:ok, port} = SocksProxy.port(name)
+    port
+  end
+
+  defp open_client(proxy_port) do
+    {:ok, sock} = :gen_tcp.connect({127, 0, 0, 1}, proxy_port, [:binary, active: false])
+    sock
+  end
+
+  defp handshake(sock) do
+    :ok = :gen_tcp.send(sock, <<5, 1, 0>>)
+    assert {:ok, <<5, 0>>} = :gen_tcp.recv(sock, 2, 5_000)
+  end
+
+  defp connect_request(sock, {:domain, host}, port) do
+    :ok = :gen_tcp.send(sock, <<5, 1, 0, 3, byte_size(host), host::binary, port::16>>)
+    recv_reply(sock)
+  end
+
+  defp connect_request(sock, {:ipv4, {a, b, c, d}}, port) do
+    :ok = :gen_tcp.send(sock, <<5, 1, 0, 1, a, b, c, d, port::16>>)
+    recv_reply(sock)
+  end
+
+  defp connect_request(sock, {:ipv6, words}, port) do
+    addr = words |> Tuple.to_list() |> Enum.map_join(&<<&1::16>>)
+    :ok = :gen_tcp.send(sock, <<5, 1, 0, 4, addr::binary, port::16>>)
+    recv_reply(sock)
+  end
+
+  defp recv_reply(sock) do
+    assert {:ok, <<5, rep, 0, 1, _bnd::binary-size(6)>>} = :gen_tcp.recv(sock, 10, 5_000)
+    rep
+  end
+
+  defp start_echo_server do
+    {:ok, listen} =
+      :gen_tcp.listen(0, [:binary, ip: {127, 0, 0, 1}, active: false, reuseaddr: true])
+
+    {:ok, port} = :inet.port(listen)
+    {:ok, _pid} = Task.start_link(fn -> echo_accept(listen) end)
+    port
+  end
+
+  defp echo_accept(listen) do
+    {:ok, conn} = :gen_tcp.accept(listen, 10_000)
+    echo_loop(conn)
+  end
+
+  defp echo_loop(conn) do
+    case :gen_tcp.recv(conn, 0, 10_000) do
+      {:ok, data} ->
+        :ok = :gen_tcp.send(conn, data)
+        echo_loop(conn)
+
+      _closed ->
+        :gen_tcp.close(conn)
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** GitHub link cards screenshotted as bare unstyled HTML because the SSRF pin (`MAP * <ip>`) sent every subresource host to the seed's IP; a loopback SOCKS5 vetting proxy replaces the pin, keeping the SSRF guarantees per connection while CSS/JS load from their real CDN hosts.

**Why:** The v7.141.2 egress control (`--host-resolver-rules=MAP * <vetted-ip>`, GHSA-mmjf-8cwc-6vwv) pinned *every* hostname Chromium resolves to the seed's IP. Sites serving assets from a CDN domain (GitHub: `github.githubassets.com`) failed the TLS handshake on a certificate mismatch and rendered as 1995-style bare HTML.

**How:** New `Vutuv.Ssrf.SocksProxy` in the supervision tree. Chromium runs with `--proxy-server=socks5://127.0.0.1:<port>` (socks5:// = remote DNS, each hostname rides in CONNECT) plus `--host-resolver-rules=MAP * ~NOTFOUND,EXCLUDE 127.0.0.1` so nothing can resolve outside the proxy. The proxy resolves and vets every connection via `Vutuv.Ssrf` (hostnames *and* IP literals) and dials exactly the vetted IP — no second lookup, DNS-rebinding TOCTOU stays closed. A missing proxy aborts the capture (fail closed). `EvidenceScreenshot` stays unproxied on purpose (shoots our own, possibly internal, host).

Verified end to end: real `capture_framed/2` of a GitHub issue page now renders fully styled through the proxy; `http://127.0.0.1:4000/` is still refused before Chromium launches. Full rationale in the `SocksProxy` moduledoc and `docs/architecture/images.md`.

**Deploy:** cold (new supervision-tree child). Version: **7.206.4**.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*