### PR TITLE
A thread's context card says which post it answers, so a mid-conversation block reads right (v7.209.1)

### DIFF
--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -3394,11 +3394,17 @@ defmodule Vutuv.Posts do
 
   defp post_preloads do
     # denials with group/denied_user: the author-facing audience display
-    # names them (never shown to other viewers). reply_ref goes exactly one
-    # level deep (the banner names the direct parent only) — preloading the
-    # parent's own reply_ref would recurse. The parent carries :images + :tags
-    # too: the feed/profile thread nests it as a full post card (its own action
-    # bar, images, tags), not just a one-line excerpt.
+    # names them (never shown to other viewers). The parent carries :images +
+    # :tags too: the feed/profile thread nests it as a full post card (its own
+    # action bar, images, tags), not just a one-line excerpt — which is also why
+    # reply_ref goes two levels deep rather than one. A thread block's topmost
+    # card is always a parent pulled in as context, and when that parent is
+    # itself a reply the block opens mid-conversation; with nothing loaded for
+    # its own banner it rendered as the post that STARTED the thread, so a
+    # profile showed a stranger's answer to a third member as their opening
+    # line. Level two carries only what that banner needs (the grandparent's
+    # author, to name and link) — never the grandparent's own refs, which is
+    # where an unbounded walk up the chain would start.
     [
       :user,
       :images,
@@ -3425,7 +3431,13 @@ defmodule Vutuv.Posts do
           :images,
           :screenshot,
           :review,
-          tags: from(t in Tag, order_by: t.name)
+          tags: from(t in Tag, order_by: t.name),
+          # The nested parent's own "Replying to …" line, local and remote: the
+          # two states it can be in when it is a reply rather than a thread
+          # starter. `parent_post: :user` is deliberately the author alone —
+          # the grandparent is named and linked, never rendered.
+          remote_reply_ref: [remote_post: :remote_account],
+          reply_ref: [:parent_author, parent_post: :user]
         ]
       ]
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.209.0",
+      version: "7.209.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/post_feed_live_test.exs
+++ b/test/vutuv_web/live/post_feed_live_test.exs
@@ -286,6 +286,36 @@ defmodule VutuvWeb.PostFeedLiveTest do
       assert has_element?(live, "#post-actions-post-#{leaf.id}-parent-#{root.id}-like")
     end
 
+    test "a context parent that is itself a reply says who IT answers", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      # Two members the viewer does not follow hold a conversation and the viewer
+      # answers the second of them. Only that answer is on this feed, so the
+      # chain stops one step up and the block's topmost card is a post pulled in
+      # purely as context — itself an answer to a post that is not on the page.
+      opener = other_user()
+      middle = other_user()
+      {:ok, root} = Posts.create_post(opener, %{body: "the post that opened it"})
+      {:ok, parent} = Posts.create_reply(middle, root, %{body: "an answer to the opener"})
+      {:ok, _leaf} = Posts.create_reply(user, parent, %{body: "my answer to that answer"})
+
+      {:ok, live, _html} = live(conn, ~p"/feed")
+
+      # It says so, rather than passing for the post that started the thread.
+      assert has_element?(
+               live,
+               ~s(#feed-posts [data-reply-banner="parent"] a[href="#{Posts.path(root)}"]),
+               "@#{opener.username}"
+             )
+
+      # The viewer's own reply keeps its banner off — the card above it already
+      # shows that relationship.
+      refute has_element?(
+               live,
+               ~s(#feed-posts [data-reply-banner] a[href="#{Posts.path(parent)}"])
+             )
+    end
+
     test "a branching thread nests each reply under the post it answers", %{conn: conn} do
       {conn, user} = create_and_login_user(conn)
       friend = other_user()

--- a/test/vutuv_web/live/user_profile_live_test.exs
+++ b/test/vutuv_web/live/user_profile_live_test.exs
@@ -470,6 +470,41 @@ defmodule VutuvWeb.UserProfileLiveTest do
       # replaces it, so the relationship is shown once, not twice.
       refute has_element?(view, "[data-reply-banner]")
     end
+
+    test "a context parent that is itself a reply says who IT answers", %{conn: conn} do
+      # The thread block's topmost card is a post the page pulled in purely as
+      # context, and when that post is itself a reply it opens mid-conversation.
+      # Without its own "Replying to" banner it reads as the post that started
+      # the thread, so a profile showed a stranger's answer to a third member as
+      # if it were their opening line.
+      {conn, _viewer} = create_and_login_user(conn)
+      owner = insert_activated_user()
+      opener = insert_activated_user()
+      middle = insert_activated_user()
+
+      {:ok, root} = Posts.create_post(opener, %{body: "the post that opened it"})
+      {:ok, parent} = Posts.create_reply(middle, root, %{body: "an answer to the opener"})
+      {:ok, _reply} = Posts.create_reply(owner, parent, %{body: "my answer to that answer"})
+
+      {:ok, view, html} = live(conn, ~p"/#{owner}")
+
+      # The context card names the post it answers and links to it, so the
+      # reader can reach the start of the conversation.
+      assert html =~ "an answer to the opener"
+
+      assert has_element?(
+               view,
+               ~s(#profile-posts [data-reply-banner="parent"] a[href="#{Posts.path(root)}"]),
+               "@#{opener.username}"
+             )
+
+      # The owner's own reply still drops its banner: the parent card above it
+      # already shows that relationship.
+      refute has_element?(
+               view,
+               ~s(#profile-posts [data-reply-banner] a[href="#{Posts.path(parent)}"])
+             )
+    end
   end
 
   describe "midnight day-change refresh" do


### PR DESCRIPTION
**TL;DR** A thread block's topmost card is a post pulled in as context; when that post is itself a reply it rendered with no "Replying to ..." line, so it read as the post that started the thread.

**Where:** `Vutuv.Posts.post_preloads/0`, surfacing in the feed and the profile Beiträge card (`collapse_threads/1` → `<.post_thread_entry>`)

**Now:** the nested `parent_post` was preloaded one level deep, so its own `reply_ref` arrived unloaded, `Posts.reply_ref_state/1` answered `nil`, and the banner the card had already enabled silently rendered nothing.

**Want:** that card names the post it answers and links to it, so a block that opens mid-conversation says so.

**Repro:** A opens a thread, B replies to A, C replies to B. On C's profile the block was `B's reply` + `C's reply`, with B's card looking like the opening post. Seen on https://vutuv.de/victor_mbashia, where another member's answer to a logo-contest post appeared as their opening line and the exchange read as a non sequitur.

```
before                              after
┌───────────────────────────┐       ┌───────────────────────────┐
│ B  We already have a logo │       │ ↩ Replying to @A          │
│                           │       │ B  We already have a logo │
│   └ C  this is great.     │       │                           │
└───────────────────────────┘       │   └ C  this is great.     │
  reads as the thread's start       └───────────────────────────┘
```

The nested parent now preloads exactly what its own banner needs, local and remote: the grandparent's author, to name and to link. It stays finite (one extra level, no further) since the grandparent is named but never rendered, and it costs nothing on a page with no replies.

Verified against a local copy of the production database: the reported ancestor now resolves to `{:parent, <the logo-contest post>}` instead of `nil`. Two tests, one per surface, cover a three-deep chain whose top card is a reply; both fail without the fix.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01B8rmXrBZbN4tH9dfGm8Q2z