### PR TITLE
A fediverse post's closing hashtag line becomes tag chips (v7.210.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -262,6 +262,28 @@ every activity of a member it finds no key for, silently.
     over there it names an account in the fediverse, not the vutuv member who
     happens to share the handle. What is rendered `raw` is our own pipeline's
     sanitized output, exactly as for a member post.
+  - **The closing hashtag line becomes tag chips.** A post over there routinely
+    ends in a line that is nothing but hashtags, because there a tag *is* a word
+    in the text; here a tag is a chip under the post, so that line landed in the
+    middle of the card's prose as a run of blue words and read like a sentence
+    that stopped making sense. `VutuvWeb.Markdown.split_trailing_hashtags/1`
+    lifts it off the end before the body is rendered and
+    `VutuvWeb.PostComponents` renders the tags as the same `<.chip>` row a
+    member's own post gets (`[data-remote-tags]`), linking to `/tags/:slug`
+    through the very gate the inline `#hashtag` uses
+    (`Vutuv.Tags.linkable_slugs/1`), so a chip never lands on an empty tag page
+    — one we do not carry stays a plain chip rather than being dropped. Only a
+    **closing** run is taken (blank lines between hashtag lines go with it); a
+    hashtag inside a sentence, or a hashtag line the author wrote in the middle
+    of a post, stays exactly where they put it and still links inline. The
+    grammar is Unicode-wide (`#München` is an ordinary German hashtag), and a
+    warned post keeps its chips **inside** the content-warning lid: the tags of
+    a post its author covered up are part of what they covered. Only the two
+    fediverse cards do this — the Mastodon/Bluesky teasers in the profile's
+    "Social media posts" card are five-line clamped excerpts inside one
+    stretched link, where a chip row would be both noise and a link inside a
+    link. The stored `content_text` is untouched, so the agent-format siblings
+    and the `.json`/`.xml` exports still carry the hashtags in the text.
   - **Audience** (issue #1071), read from `to`/`cc` on both the Create and the
     Note, handling all three spellings of the public collection. Only `"public"`
     is public; `"followers"`, `"direct"` and `"unknown"` render to the addressed

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -43,6 +43,7 @@ defmodule VutuvWeb.PostComponents do
   alias Vutuv.Posts.PostScreenshot
   alias Vutuv.RemoteMedia
   alias Vutuv.ReviewCover
+  alias Vutuv.Tags
   alias VutuvWeb.FediverseComponents
   alias VutuvWeb.Markdown
 
@@ -1143,11 +1144,23 @@ defmodule VutuvWeb.PostComponents do
   # The lid is a real touch target (`min-h-10`) and says both things: "Show"
   # while it is closed, "Hide" once it is open — a lid you cannot shut again is
   # not a lid.
+  #
+  # The closing hashtag line is lifted out of the text first
+  # (`Markdown.split_trailing_hashtags/1`) and rendered as chips below, so a
+  # post from over there wears its tags the way a member's post does. A warned
+  # post keeps its chips **inside** the lid: the tags of a post its author put
+  # behind a content warning are part of what they covered up.
   defp remote_body(assigns) do
-    assigns = assign(assigns, :html, Markdown.render_remote(assigns.text))
+    {text, hashtags} = Markdown.split_trailing_hashtags(assigns.text)
+
+    assigns =
+      assigns
+      |> assign(:body?, presence?(text))
+      |> assign(:html, Markdown.render_remote(text))
+      |> assign(:tags, remote_tag_chips(hashtags))
 
     ~H"""
-    <div :if={@warning || presence?(@text)} class="mt-1.5">
+    <div :if={@warning || @body? || @tags != []} class="mt-1.5">
       <%= if @warning do %>
         <details data-remote-warning class="group">
           <summary class="flex min-h-10 cursor-pointer list-none items-center gap-1 text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -1160,17 +1173,56 @@ defmodule VutuvWeb.PostComponents do
               {gettext("Hide")}
             </span>
           </summary>
-          <div class="markdown markdown--post mt-1.5 text-sm text-slate-700 dark:text-slate-300">
+          <div
+            :if={@body?}
+            class="markdown markdown--post mt-1.5 text-sm text-slate-700 dark:text-slate-300"
+          >
             {Phoenix.HTML.raw(@html)}
           </div>
+          <.remote_tags tags={@tags} />
         </details>
       <% else %>
-        <div class="markdown markdown--post text-sm text-slate-700 dark:text-slate-300">
+        <div :if={@body?} class="markdown markdown--post text-sm text-slate-700 dark:text-slate-300">
           {Phoenix.HTML.raw(@html)}
         </div>
+        <.remote_tags tags={@tags} />
       <% end %>
     </div>
     """
+  end
+
+  # The hashtags a remote post closed with, as the same brand-tint `<.chip>`
+  # row a member's post gets for its tags — the whole point of lifting them out
+  # of the text (`Markdown.split_trailing_hashtags/1`): one tag vocabulary,
+  # rendered one way, wherever a post came from.
+  attr(:tags, :list, required: true)
+
+  defp remote_tags(assigns) do
+    ~H"""
+    <div :if={@tags != []} data-remote-tags class="mt-2 flex flex-wrap gap-2">
+      <.chip :for={tag <- @tags} navigate={tag.path} data-remote-tag={tag.name}>{tag.name}</.chip>
+    </div>
+    """
+  end
+
+  # A chip links to `/tags/:slug` on exactly the same gate the inline
+  # `#hashtag` uses (`Tags.linkable_slugs/1`: the tag exists here and has at
+  # least one visible member), so a pill never lands on an empty tag page. One
+  # query for the whole row — and the body it came out of is now one hashtag
+  # lighter, so this costs the card no extra lookup.
+  #
+  # A tag we do not carry still gets its chip, as a plain span: dropping it
+  # would silently swallow part of what the author wrote, and rendering it
+  # differently would say something about the tag that is really about us.
+  defp remote_tag_chips([]), do: []
+
+  defp remote_tag_chips(hashtags) do
+    linkable = Tags.linkable_slugs(hashtags)
+
+    Enum.map(hashtags, fn hashtag ->
+      slug = String.downcase(hashtag)
+      %{name: hashtag, path: if(MapSet.member?(linkable, slug), do: ~p"/tags/#{slug}")}
+    end)
   end
 
   # Where it came from and the way on to the real thing. The inner block is for

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -154,6 +154,81 @@ defmodule VutuvWeb.Markdown do
   def render_remote(_), do: ""
 
   @doc """
+  Split remote plain text into `{body, hashtags}`, lifting the closing
+  hashtag line off the end.
+
+  A post on Mastodon and its cousins routinely ends in a line that is nothing
+  but hashtags — `#CSD #Anschlag #Berlin` — because over there a tag *is* a
+  word in the text. Here a tag is a chip below the post, so that line arrived
+  as a run of blue words in the middle of the card's prose and read like a
+  sentence that stopped making sense. The card renders the returned hashtags
+  as `<.chip>` pills instead (`VutuvWeb.PostComponents`), which is the same
+  thing a member's own post does with its tags.
+
+  Only a **closing** run is taken: walking the text back to front, every line
+  that consists solely of hashtags is lifted (blank lines between them go
+  too), and the walk stops at the first line carrying anything else. A hashtag
+  inside a sentence, or a hashtag line the author wrote in the *middle* of a
+  post, therefore stays exactly where it was and still links through
+  `render_remote/1`. Hashtags come back in reading order, in the case the
+  author typed, with repeats dropped case-insensitively.
+
+  The grammar is deliberately wider than the `@entity` regex's ASCII
+  `[A-Za-z0-9_]`: `#München` is an ordinary German hashtag and a line holding
+  one must split like any other. Whether a pill then *links* is a separate
+  question the caller asks `Vutuv.Tags.linkable_slugs/1` — the same gate the
+  body's `#hashtag` linking uses, so a pill links exactly where the inline
+  hashtag would have.
+  """
+  def split_trailing_hashtags(text) when is_binary(text) do
+    if String.contains?(text, "#") do
+      {kept, hashtags} =
+        text |> String.split("\n") |> Enum.reverse() |> take_trailing_hashtag_lines([])
+
+      {kept |> Enum.join("\n") |> String.trim_trailing(),
+       Enum.uniq_by(hashtags, &String.downcase/1)}
+    else
+      {text, []}
+    end
+  end
+
+  def split_trailing_hashtags(_), do: {"", []}
+
+  # Walks the lines back to front. A blank line is passed over rather than
+  # ended on: the hashtag line is nearly always separated from the prose by
+  # one, and it would otherwise stop the walk before the tags are reached.
+  # Those blanks are simply dropped — whatever prose survives is trimmed at the
+  # end anyway, so a text with no closing hashtag line comes back unchanged.
+  defp take_trailing_hashtag_lines([], hashtags), do: {[], hashtags}
+
+  defp take_trailing_hashtag_lines([line | above], hashtags) do
+    cond do
+      String.trim(line) == "" -> take_trailing_hashtag_lines(above, hashtags)
+      hashtag_line?(line) -> take_trailing_hashtag_lines(above, hashtags_in(line) ++ hashtags)
+      true -> {Enum.reverse([line | above]), hashtags}
+    end
+  end
+
+  # A `#` followed by at least one word character, the Unicode reading of
+  # "word" (see `split_trailing_hashtags/1`). Punctuation is not part of a
+  # hashtag, so a line like "Mehr dazu: #Berlin." keeps its full stop and is
+  # therefore not a hashtag line — which is right, it is a sentence.
+  @hashtag_token ~r/^#([\p{L}\p{N}_]+)$/u
+
+  defp hashtag_line?(line) do
+    case String.split(line, ~r/\s+/u, trim: true) do
+      [] -> false
+      tokens -> Enum.all?(tokens, &Regex.match?(@hashtag_token, &1))
+    end
+  end
+
+  defp hashtags_in(line) do
+    line
+    |> String.split(~r/\s+/u, trim: true)
+    |> Enum.map(&String.trim_leading(&1, "#"))
+  end
+
+  @doc """
   Flatten Markdown to **plain text**: the same pipeline a post body runs,
   then the tags dropped and the escapes decoded.
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.209.1",
+      version: "7.210.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/feed_remote_posts_test.exs
+++ b/test/vutuv_web/live/feed_remote_posts_test.exs
@@ -327,4 +327,91 @@ defmodule VutuvWeb.FeedRemotePostsTest do
 
     refute has_element?(view, "[data-remote-post]")
   end
+
+  describe "the closing hashtag line" do
+    # A tag this installation really carries, so the chip may link to its page.
+    # The name is minted per call with an underscore rather than the factory's
+    # hyphenated `unique_tag_name/1`: a hashtag is `[\p{L}\p{N}_]+`, so
+    # "#tag-7" would parse as "#tag" — and a hardcoded literal would deadlock
+    # against another async module inserting the same one.
+    defp linkable_tag do
+      name = "Berlin_#{System.unique_integer([:positive])}"
+      tag = insert(:tag, name: name, slug: String.downcase(name))
+      insert(:user_tag, user: insert(:activated_user), tag: tag)
+      tag
+    end
+
+    test "becomes tag chips instead of a run of words in the prose", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      tag = linkable_tag()
+
+      post =
+        cached_post(user, %{
+          content_text: "Kamen die Gespräche zu spät?\n\n##{tag.name} #Anschlag"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      card = "[data-remote-post='#{post.id}']"
+
+      assert has_element?(view, "#{card} [data-remote-tags]")
+      # A tag we carry reaches its page, the same link a member post's chip has.
+      assert has_element?(
+               view,
+               "#{card} a[data-remote-tag='#{tag.name}'][href='/tags/#{tag.slug}']"
+             )
+
+      # One we do not carry is still shown, just not as a link to an empty page.
+      assert has_element?(view, "#{card} span[data-remote-tag='Anschlag']")
+      # And the line itself is gone from the body.
+      refute has_element?(view, "#{card} .markdown a.hashtag")
+      refute render(view) =~ "##{tag.name}"
+      assert render(view) =~ "Kamen die Gespräche zu spät?"
+    end
+
+    test "a hashtag inside a sentence stays in the sentence", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      tag = linkable_tag()
+
+      post = cached_post(user, %{content_text: "Mehr zu ##{tag.name} gibt es hier"})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      card = "[data-remote-post='#{post.id}']"
+
+      refute has_element?(view, "#{card} [data-remote-tags]")
+      assert has_element?(view, "#{card} .markdown a.hashtag[href='/tags/#{tag.slug}']")
+    end
+
+    test "a warned post keeps its chips behind the lid", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+
+      post =
+        cached_post(user, %{
+          summary: "Politics",
+          sensitive: true,
+          content_text: "Schwerer Stoff.\n\n#Anschlag"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      # The tags of a post its author covered up are part of what they covered.
+      assert has_element?(
+               view,
+               "[data-remote-post='#{post.id}'] [data-remote-warning] [data-remote-tags]"
+             )
+    end
+
+    test "a post that is only hashtags renders as chips and no empty body", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      post = cached_post(user, %{content_text: "#Anschlag #Berlin"})
+
+      {:ok, view, _html} = live(conn, ~p"/feed")
+
+      card = "[data-remote-post='#{post.id}']"
+
+      assert has_element?(view, "#{card} [data-remote-tag='Anschlag']")
+      refute has_element?(view, "#{card} .markdown")
+    end
+  end
 end

--- a/test/vutuv_web/markdown_remote_test.exs
+++ b/test/vutuv_web/markdown_remote_test.exs
@@ -74,4 +74,50 @@ defmodule VutuvWeb.MarkdownRemoteTest do
       refute html =~ "<script"
     end
   end
+
+  describe "split_trailing_hashtags/1" do
+    test "lifts a closing hashtag line off the body" do
+      assert Markdown.split_trailing_hashtags(
+               "Fall Abdul B.\n\nDer Anwalt sagt Report Mainz.\n\n#CSD #Anschlag #Berlin"
+             ) ==
+               {"Fall Abdul B.\n\nDer Anwalt sagt Report Mainz.", ["CSD", "Anschlag", "Berlin"]}
+    end
+
+    test "takes every consecutive closing hashtag line, blank lines and all" do
+      assert Markdown.split_trailing_hashtags("Ein Text\n\n#eins #zwei\n\n#drei\n") ==
+               {"Ein Text", ["eins", "zwei", "drei"]}
+    end
+
+    test "a hashtag line in the middle of the text stays where the author put it" do
+      text = "Oben\n\n#mitten drin\n\nUnten"
+
+      assert Markdown.split_trailing_hashtags(text) == {text, []}
+    end
+
+    test "a closing line that is more than hashtags is left alone" do
+      text = "Ein Text\n\nMehr zu #Berlin gibt es hier"
+
+      assert Markdown.split_trailing_hashtags(text) == {text, []}
+    end
+
+    test "a post that is nothing but hashtags becomes pills and an empty body" do
+      assert Markdown.split_trailing_hashtags("#Crochet #Botanik") ==
+               {"", ["Crochet", "Botanik"]}
+    end
+
+    test "the typed case is kept and a repeat is dropped" do
+      assert Markdown.split_trailing_hashtags("Text\n\n#Berlin #berlin #BERLIN") ==
+               {"Text", ["Berlin"]}
+    end
+
+    test "text without a closing hashtag line comes back unchanged" do
+      assert Markdown.split_trailing_hashtags("Nur ein Satz.") == {"Nur ein Satz.", []}
+      assert Markdown.split_trailing_hashtags("") == {"", []}
+    end
+
+    test "a non-ASCII hashtag counts, so a German closing line splits too" do
+      assert Markdown.split_trailing_hashtags("Text\n\n#München #Grünflächen") ==
+               {"Text", ["München", "Grünflächen"]}
+    end
+  end
 end


### PR DESCRIPTION
**TL;DR** A fediverse post's closing `#CSD #Anschlag #Berlin` line is lifted out of the prose and rendered as the same tag chips a vutuv post gets, with the same `/tags/:slug` links.

**Where:** `VutuvWeb.Markdown.split_trailing_hashtags/1` + `remote_body/1` / `remote_tags/1` in `VutuvWeb.PostComponents` (both fediverse cards: the feed's remote post card and the thread's remote reply card).

**Now:** a post over there ends in a line that is nothing but hashtags, because there a tag *is* a word in the text. It landed in the middle of the card's prose as a run of blue words and read like a sentence that stopped making sense.

**Want:** the tag vocabulary reads one way wherever a post came from.

What it does:

* only a **closing** run of hashtag-only lines is taken (blank lines between them go with it). A hashtag inside a sentence, or a hashtag line the author put in the *middle* of a post, stays exactly where they wrote it and still links inline.
* a chip links to `/tags/:slug` through the very gate the inline `#hashtag` uses (`Tags.linkable_slugs/1` — the tag exists here and has at least one visible member), so it never lands on an empty tag page. One we do not carry keeps its chip as a plain span: dropping it would silently swallow part of what the author wrote.
* the grammar is Unicode-wide, since `#München` is an ordinary German hashtag. Whether such a chip *links* is the separate question above, answered exactly as it is for the inline hashtag today.
* a **warned** post keeps its chips **inside** the content-warning lid: the tags of a post its author covered up are part of what they covered.
* the stored `content_text` is untouched, so the `.md`/`.txt`/`.json`/`.xml` siblings and the exports still carry the hashtags in the text, and the content filters still match against the full text.

Deliberately **not** changed: the profile's "Social media posts" Mastodon/Bluesky teasers. Those are five-line clamped excerpts inside one stretched link, where a chip row would be both noise and a link inside a link.

Tested: 8 unit tests on the split, 4 LiveView tests on the card (linked chip, unlinked chip, hashtag-in-a-sentence, warned post, hashtags-only post). Full `mix precommit` green; verified in a browser against the real cached tagesschau / heise posts in the dev DB.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01Wq6bSzRKHfKuW6nq3YV484
