### PR TITLE
A reply from another network can be liked, and answering it is a real button (v7.212.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -414,6 +414,37 @@ every activity of a member it finds no key for, silently.
     stored — the same rule the inbox already applies to a signature's `keyId` — and
     `attempt/2` re-checks every row at send time (https, not internal, not
     blocked).
+- **Liking a reply that came from another network** (issue #1270): the same act
+  the heart on a cached post is (#1164, below), one step further down the
+  conversation. `like_note/2` writes the marker (`fediverse_note_likes`, through
+  the shared `Vutuv.Engagement.insert_if_new/3` kernel) and queues a signed
+  `Like` to the reply author's **own** inbox — the address the note already
+  carries for answering, so this costs no network call either; `unlike_note/2`
+  sends the matching `Undo(Like)` with the id the original carried. Everything
+  else is the post path's, deliberately: the same gates
+  (`check_note_like/2`), the same hourly budget (a member's likes are one
+  allowance whichever kind of thing they land on), the same rollback of a capped
+  marker, the same withdrawal when they leave the Fediverse, the same absence of
+  any count, and the same place in the GDPR export. Two differences of its own:
+  - **No audience gate.** A `Like` is addressed to one person and publishes
+    nothing, so a reply sent to the member alone (issue #1071) can be liked
+    exactly as a public one can — the opposite of answering, which is refused
+    there because the answer would be a public vutuv post. What is asked instead
+    is whether the reply is theirs to *read*, which `note_readable?/2` answers in
+    the same terms `list_notes/2` enforces in SQL, since the id in a click is
+    attacker-controlled.
+  - **`:not_deliverable`.** `inbox_uri` is nullable — replies stored before
+    #1070 have none — and a marker written for a `Like` that could never leave
+    would paint a heart the author's server knows nothing about. Such a reply
+    gets no heart at all (`Note.likeable?/1` decides it at render time) rather
+    than one that refuses; they age out with the six-month retention.
+  The card's shape changed with it: answering used to be a `text-xs` word inside
+  the provenance footer, between the server name and "View the original", which
+  is why #1270 was reported as "I have no way to like or answer this". Both acts
+  now sit in a row of their own under the body, at the size every other control
+  in the app is, and the footer says only where the reply came from. The cached
+  post's card was brought into the same shape in the same change, so the two read
+  alike.
 - **Holding a post back until its pictures are vetted** (issue #1070): a post's
   images are invisible until the AI scan releases them
   (`Vutuv.Moderation.ImageScans`), so a Note built the instant the post commits
@@ -1111,6 +1142,11 @@ likes that happened to pass through this installation would read as the real one
 while being a fraction of it. The marker cascades with the cached post, expiry
 included; the like on the author's server stands, and a re-like after expiry
 sends a duplicate every implementation treats as a no-op.
+
+The **reply** heart (issue #1270, its own bullet in the inbound section above)
+is this act on `fediverse_notes` instead of `fediverse_posts`: same activity,
+same addressing, same budget, same withdrawal, same silence about counts. Read
+the two together — a claim that holds for one and not the other is drift.
 
 ### Answering one of their posts (issue #1165)
 

--- a/lib/vutuv/export.ex
+++ b/lib/vutuv/export.ex
@@ -15,6 +15,7 @@ defmodule Vutuv.Export do
   alias Vutuv.Ads.Ad
   alias Vutuv.Chat.{Conversation, Participant}
   alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
   alias Vutuv.Jobs.{JobPostingBookmark, JobPostingLike}
@@ -34,7 +35,9 @@ defmodule Vutuv.Export do
   #    when, from where and how it was confirmed.
   # 6: composer drafts (issue #1148) — posts the member started but never sent.
   # 7: the accounts followed on other networks (issue #1160).
-  @schema_version 7
+  # 8: `fediverse_likes` covers liked **replies** too (issue #1270) and every
+  #    entry names which it is in `kind`.
+  @schema_version 8
 
   def build(%User{} = user) do
     user =
@@ -178,22 +181,46 @@ defmodule Vutuv.Export do
       # own remote followers are deliberately absent: those rows are about other
       # people, and this export is the member's data.
       fediverse_following: fediverse_following(user),
-      # What they liked on other networks (issue #1164). Unambiguously their own
-      # data — an act of theirs, recorded here — so Art. 20 covers it, the same
-      # way the saved_* sections above are covered.
+      # What they liked on other networks (issues #1164 and #1270). Unambiguously
+      # their own data — an act of theirs, recorded here — so Art. 20 covers it,
+      # the same way the saved_* sections above are covered.
       fediverse_likes: fediverse_likes(user)
     }
   end
 
+  # Posts by accounts the member follows and replies written under vutuv posts,
+  # in one list: to the member both are "something on another network I liked",
+  # and splitting them into two sections by which of our tables happens to hold
+  # them would be an export of our schema rather than of their acts. `kind`
+  # names which is which.
   defp fediverse_likes(user) do
+    post_likes(user) ++ note_likes(user)
+  end
+
+  defp post_likes(user) do
     user
     |> Fediverse.list_remote_likes()
     |> Enum.map(fn {post, account} ->
       %{
+        kind: "post",
         post: RemotePost.origin(post),
         author: RemoteAccount.display_handle(account),
         server: account.host,
         at: post.published_at
+      }
+    end)
+  end
+
+  defp note_likes(user) do
+    user
+    |> Fediverse.list_note_likes()
+    |> Enum.map(fn note ->
+      %{
+        kind: "reply",
+        post: Note.origin(note),
+        author: Note.display_handle(note),
+        server: Note.host(note.actor_uri),
+        at: note.received_at
       }
     end)
   end

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -62,6 +62,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.Media
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.NoteEvent
+  alias Vutuv.Fediverse.NoteLike
   alias Vutuv.Fediverse.PostBoost
   alias Vutuv.Fediverse.PostDelivery
   alias Vutuv.Fediverse.PostLike
@@ -968,6 +969,11 @@ defmodule Vutuv.Fediverse do
     # follows would otherwise survive this member leaving, as a record of what
     # they read on another network kept after they asked to be out of it.
     drop_remote_likes(user)
+    # And the ones on replies under vutuv posts (issue #1270), which are the
+    # same act on a different table and must not survive the same decision —
+    # those rows do not hang off a follow at all, so nothing else would ever
+    # take them.
+    drop_note_likes(user)
 
     {count, _} = Repo.delete_all(from(f in Follow, where: f.user_id == ^user.id))
     # Their cached posts existed because this member followed their authors
@@ -4478,6 +4484,216 @@ defmodule Vutuv.Fediverse do
     case post_account(post) do
       %RemoteAccount{actor_uri: uri} -> uri
       _ -> nil
+    end
+  end
+
+  ## Liking a reply from another network (issue #1270)
+  ##
+  ## The same act as the heart above, one step further down the conversation:
+  ## there it is a post by an account the member follows, here it is an answer
+  ## somebody wrote under the member's own post. The activity, the addressing,
+  ## the budget and the reasoning are the post path's unchanged — only the row
+  ## it is keyed to differs, because a note is its own table.
+
+  @doc """
+  Whether `user` may like the stored reply `note`, and when not, which gate
+  refused — `check_remote_like/2`'s vocabulary, plus one of this path's own:
+
+    * `:not_deliverable` — the note carries no inbox address, so a `Like` for it
+      could not leave the building. Replies stored before issue #1070 have none
+      (the column arrived with the answering feature), and for those the card
+      offers no heart at all rather than one that refuses: writing the marker
+      anyway would paint a heart for a like the author's server never hears
+      about, which is the one disagreement a member cannot fix from here.
+    * `:not_visible` — the reply is not one this member may read.
+
+  Deliberately **no audience gate**, unlike answering: a `Like` is addressed to
+  its author alone and publishes nothing, so a reply sent to the member only
+  (issue #1071) can be liked exactly the way a public one can. What the two
+  paths do share is that the id in a click is attacker-controlled, so the read
+  question is asked here and not left to the fact that the LiveView resolved it
+  against its own rendered list.
+
+  Free of side effects, so a render may ask it. The budget is claimed separately.
+  """
+  def check_note_like(%User{} = user, %Note{} = note) do
+    cond do
+      not enabled?() -> {:error, :fediverse_disabled}
+      not Note.likeable?(note) -> {:error, :not_deliverable}
+      not federated?(user) -> {:error, :not_federating}
+      moved?(user) -> {:error, :moved}
+      instance_blocked?(note.actor_uri) -> {:error, :instance_blocked}
+      not note_readable?(note, user) -> {:error, :not_visible}
+      true -> :ok
+    end
+  end
+
+  @doc """
+  Whether `viewer` may read this stored reply: a public one is everybody's,
+  anything else only ever the member whose post it answers.
+
+  The same rule `list_notes/2` enforces in SQL for the conversation, for the
+  callers holding a single row — so a reply nobody else may see cannot be liked
+  (or its existence confirmed) by guessing its id.
+  """
+  def note_readable?(%Note{} = note, %User{id: viewer_id}) do
+    Note.public?(note) or
+      Repo.exists?(from(p in Post, where: p.id == ^note.post_id and p.user_id == ^viewer_id))
+  end
+
+  def note_readable?(_note, _viewer), do: false
+
+  @doc """
+  The member likes a reply from another network: writes the local marker and
+  queues a signed `Like` to its author's own inbox.
+
+  `{:ok, :liked}`, `{:ok, :already}` when the marker was already there (a double
+  tap, or a second tab — no second activity goes out), or the gate's
+  `{:error, reason}`.
+
+  Marker first, activity after, for the reason the post path spells out: a
+  queued activity whose marker failed to write would paint no heart while the
+  author's server counts the like.
+  """
+  def like_note(%User{} = user, %Note{} = note) do
+    # Re-read first, like the post path: the card was rendered at some earlier
+    # moment and the row can be gone by the time the heart is pressed — expiry,
+    # an upstream `Delete`, a takedown, an instance block — and the insert would
+    # then hit the foreign key and take the whole LiveView down with it.
+    with %Note{} = note <- reload_note(note),
+         :ok <- check_note_like(user, note) do
+      case insert_note_marker(user, note) do
+        {:ok, :liked} -> send_note_like(user, note)
+        other -> other
+      end
+    else
+      nil -> {:error, :not_found}
+      {:error, _} = error -> error
+    end
+  end
+
+  # The budget is claimed here rather than before the insert, so a double tap or
+  # a second tab — which writes nothing and sends nothing — does not spend
+  # somebody's slot. It is the **same** hourly budget the post heart claims:
+  # both are one member's like leaving for another network, and metering them
+  # apart would let an hour of one hide inside the other's allowance.
+  defp send_note_like(user, note) do
+    case claim_like_budget(user) do
+      :ok ->
+        deliver_note_like(user, note, &Docs.like_activity/3)
+        {:ok, :liked}
+
+      {:error, _} = capped ->
+        delete_note_marker(user, note)
+        capped
+    end
+  end
+
+  @doc """
+  The member takes the like back: drops the marker and queues the matching
+  `Undo(Like)`.
+
+  `{:ok, :unliked}` or `{:ok, :already}`. No gate and no budget — a withdrawal
+  must not be refusable, and if the member has since stopped federating there is
+  simply nothing to send.
+  """
+  def unlike_note(%User{} = user, %Note{} = note) do
+    if delete_note_marker(user, note) > 0 do
+      deliver_note_like(user, note, &Docs.undo_like_activity/3)
+      {:ok, :unliked}
+    else
+      {:ok, :already}
+    end
+  end
+
+  @doc """
+  Which of `note_ids` this member already likes, as a `MapSet` — one query for a
+  whole conversation rather than one per card.
+  """
+  def liked_note_ids(%User{} = viewer, note_ids) when is_list(note_ids) do
+    from(l in NoteLike,
+      where: l.user_id == ^viewer.id and l.note_id in ^note_ids,
+      select: l.note_id
+    )
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  def liked_note_ids(_viewer, _note_ids), do: MapSet.new()
+
+  @doc """
+  Every reply from another network this member likes — for their GDPR export and
+  for the withdrawal below, which needs the same rows.
+  """
+  def list_note_likes(%User{id: user_id}) do
+    Repo.all(
+      from(l in NoteLike,
+        join: n in Note,
+        on: n.id == l.note_id,
+        where: l.user_id == ^user_id,
+        order_by: [desc: l.id],
+        select: n
+      )
+    )
+  end
+
+  @doc """
+  Withdraws every like this member holds on replies from other networks and
+  drops the markers — the note half of `drop_remote_likes/1`, called from the
+  same place and for the same reason: what stands on other servers under their
+  name goes with the decision to leave rather than after it.
+  """
+  def drop_note_likes(%User{} = user) do
+    Enum.each(list_note_likes(user), fn note ->
+      deliver_note_like(user, note, &Docs.undo_like_activity/3)
+    end)
+
+    {count, _} = Repo.delete_all(from(l in NoteLike, where: l.user_id == ^user.id))
+    count
+  end
+
+  @doc """
+  This stored reply as it is **now**, or nil once the row is gone. Every write
+  path acting on a reply a member is looking at goes through here first, for the
+  reason `reload_remote_post/1` spells out.
+  """
+  def reload_note(%Note{id: id}), do: Repo.get(Note, id)
+
+  # The marker kernel, written through `Vutuv.Engagement.insert_if_new/3` like
+  # every other engagement toggle here: only the inserted row count is an honest
+  # answer to "did this request create the like", and that answer is what decides
+  # whether an activity leaves the building.
+  defp insert_note_marker(user, note) do
+    case Engagement.insert_if_new(
+           NoteLike,
+           %{user_id: user.id, note_id: note.id},
+           [:user_id, :note_id]
+         ) do
+      {:inserted, _row} -> {:ok, :liked}
+      :exists -> {:ok, :already}
+    end
+  end
+
+  # The withdrawal half, answering in the same currency: how many rows really
+  # went, so a second tab's press can be told from a real one.
+  defp delete_note_marker(user, note) do
+    {count, _} =
+      Repo.delete_all(where(NoteLike, [l], l.user_id == ^user.id and l.note_id == ^note.id))
+
+    count
+  end
+
+  # The author's own inbox, never a shared one: a Like is addressed to one
+  # person. `ever_federated?/1` rather than `federated?/1`, so a withdrawal still
+  # reaches the server a member can no longer sign new acts for (issue #1102) —
+  # and nothing is sent at all for a note that never carried an address, which
+  # `check_note_like/2` refuses up front anyway.
+  defp deliver_note_like(%User{} = user, %Note{} = note, builder) do
+    with inbox when is_binary(inbox) <- note.inbox_uri,
+         true <- ever_federated?(user) do
+      enqueue(user, [inbox], builder.(user, note.actor_uri, note.object_uri))
+    else
+      _ -> :skip
     end
   end
 

--- a/lib/vutuv/fediverse/note.ex
+++ b/lib/vutuv/fediverse/note.ex
@@ -101,6 +101,18 @@ defmodule Vutuv.Fediverse.Note do
   def public?(%__MODULE__{}), do: false
 
   @doc """
+  Whether a like on this reply could actually reach its author (issue #1270):
+  we hold the inbox to deliver it to.
+
+  Replies stored before issue #1070 carry none — the column arrived with the
+  answering feature — and for those the card offers no heart rather than one
+  that refuses, because a marker written for a `Like` that never leaves paints a
+  heart the author's server knows nothing about. They age out with the
+  six-month retention.
+  """
+  def likeable?(%__MODULE__{inbox_uri: inbox}), do: is_binary(inbox) and inbox != ""
+
+  @doc """
   How the card names the author: `@handle@host`, the form every one of these
   networks uses. Shared with the follower list and the reaction chips
   (`Vutuv.Fediverse.Handle`), so one person reads the same way everywhere.

--- a/lib/vutuv/fediverse/note_like.ex
+++ b/lib/vutuv/fediverse/note_like.ex
@@ -1,0 +1,34 @@
+defmodule Vutuv.Fediverse.NoteLike do
+  @moduledoc """
+  A member here liked a reply that came from another network (issue #1270) —
+  the sibling of `Vutuv.Fediverse.PostLike`, one step further down the
+  conversation.
+
+  Everything that module says applies unchanged, and is worth repeating in the
+  one place somebody reading this table will look. The row is a **marker, not a
+  tally**: what the author's server counts is the `Like` activity we delivered,
+  and this says only "this member, this reply", so the heart comes back painted
+  on the next page load. Nothing here is public and nothing here is a number —
+  vutuv does not know how many people liked a reply over there, and a count
+  assembled from the likes that happened to pass through this installation
+  would read as the real one while being a fraction of it.
+
+  No changeset, for the same reason: nothing here is user-supplied (both ids
+  come from records the caller already resolved) and the write goes through
+  `Vutuv.Engagement.insert_if_new/3`, whose row count is what decides whether an
+  activity leaves the building.
+
+  It cascades away with the cached reply, which is correct rather than lossy:
+  our copy is a six-month cache, the like on the author's server is not ours to
+  keep alive.
+  """
+
+  use VutuvWeb, :model
+
+  schema "fediverse_note_likes" do
+    belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:note, Vutuv.Fediverse.Note)
+
+    timestamps(updated_at: false)
+  end
+end

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -815,7 +815,18 @@ defmodule VutuvWeb.PostComponents do
         (issue #1069), which sits among them as an ordinary sibling in time
         order and wears its own skin. --%>
         <%= if Map.has_key?(node, :note) do %>
-          <.remote_reply_card note={node.note} owner?={node.owner?} viewer={@viewer} />
+          <%!-- `acts?` unconditionally: the conversation is only ever rendered
+          by `VutuvWeb.PostLive.Thread`, which handles the heart's events — and
+          on its throwaway dead render the buttons are as live as every other
+          `phx-click` on the page, which is to say the moment the socket
+          connects. --%>
+          <.remote_reply_card
+            note={node.note}
+            owner?={node.owner?}
+            viewer={@viewer}
+            liked?={node.liked?}
+            acts?
+          />
         <% else %>
           <.post_card
             post={node.post}
@@ -859,10 +870,17 @@ defmodule VutuvWeb.PostComponents do
       is ever fetched or hosted: vutuv does not host a third party's image.
     * the author's name as plain text (there is no vutuv profile to link to)
       beside their `@handle@host`, which links out to the account.
-    * **no action bar.** Liking, reposting or bookmarking a note that lives on
-      someone else's server is not a thing that exists, so the row is absent
-      rather than dead. What is there instead is where it came from, a link to
-      the original, and the takedown controls.
+    * **two acts, not four.** Answering it and liking it both mean something
+      across the network boundary and both are here (issue #1270); resharing and
+      bookmarking somebody else's reply on somebody else's server do not, so
+      those are absent rather than dead.
+
+  Those two acts sit in a **row of their own under the body**, not in the
+  provenance footer, which is what they were built into first and what made the
+  card read as having no actions at all: a `text-xs` word between the server
+  name and "View the original" is a caption, and nobody presses a caption. They
+  are the size the rest of the app's controls are (issue #1270 was reported as
+  "I have no way to like or answer this").
 
   What is **stored** is plain text (`Vutuv.RemoteHtml` reduced the remote HTML
   at the inbox, and that does not change). What is **shown** is that text run
@@ -877,8 +895,9 @@ defmodule VutuvWeb.PostComponents do
   lid and reveals the text on a click, which is the one thing that author asked
   for.
 
-  Rendered only inside `VutuvWeb.PostLive.Thread`, so the takedown controls are
-  plain `phx-click` events on that LiveView.
+  Rendered inside `VutuvWeb.PostLive.Thread` (the conversation) and, without its
+  acts, as the read-only target of the answering page — so the takedown controls
+  and the heart are plain `phx-click` events on the host LiveView.
   """
   attr(:note, :map, required: true, doc: "a Vutuv.Fediverse.Note")
 
@@ -888,6 +907,14 @@ defmodule VutuvWeb.PostComponents do
   )
 
   attr(:viewer, :any, default: nil, doc: "the logged-in member, or nil")
+
+  attr(:acts?, :boolean,
+    default: false,
+    doc:
+      "whether this surface carries the card's own acts. The conversation does; the answering page, where the card is the read-only thing being answered, does not — a Reply link to the page you are already on is noise, and a heart there would fire an event that page does not handle."
+  )
+
+  attr(:liked?, :boolean, default: false, doc: "whether the viewer already likes this reply")
 
   def remote_reply_card(assigns) do
     note = assigns.note
@@ -904,7 +931,19 @@ defmodule VutuvWeb.PostComponents do
       # Only a public reply can be answered (issue #1070): a private one would
       # mean publishing half of an exchange its author asked to keep to one
       # person, so v1 does not offer it at all.
-      |> assign(:can_reply?, not is_nil(assigns.viewer) and Note.public?(note))
+      |> assign(
+        :can_reply?,
+        assigns.acts? and not is_nil(assigns.viewer) and Note.public?(note)
+      )
+      # A like has no such audience gate (issue #1270) — it is addressed to the
+      # author alone and publishes nothing, so a reply sent to the member only
+      # can be liked too. What it does need is an address to send it to: a reply
+      # stored before issue #1070 carries none, and a heart that could never
+      # leave the building is worse than no heart.
+      |> assign(
+        :can_like?,
+        assigns.acts? and not is_nil(assigns.viewer) and Note.likeable?(note)
+      )
 
     ~H"""
     <%!-- The `id` is this reply's anchor: it has no permalink of its own, so a
@@ -966,23 +1005,54 @@ defmodule VutuvWeb.PostComponents do
 
           <.remote_body warning={@warned? && @note.summary} text={@note.content_text} />
 
-          <.remote_footer host={@host} origin={@origin} label={gettext("View the original")}>
-            <%!-- Answering is the one action on a remote reply that exists, so it
-            sits here in the open beside where the reply came from. The card still
-            has no action bar: liking or resharing something on somebody else's
-            server is not a thing, and an absent row still beats a dead one. Shown
-            to every signed-in member on a public reply — the page behind it is
-            what explains a member who does not federate why they cannot send
-            (issue #1070). --%>
-            <span :if={@can_reply?}>
-              ·
-              <.link
-                navigate={~p"/system/fediverse/reply/#{@note.id}"}
-                data-remote-reply-link={@note.id}
-                class="font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-              >{gettext("Reply")}</.link>
-            </span>
-          </.remote_footer>
+          <%!-- The card's acts (issue #1270), in the open under the body where a
+          reader looks for them, sized as real touch targets. Both are shown to
+          every signed-in member including one who has not switched Fediverse
+          participation on: each is signed with their own key, so for them
+          neither can be sent — but hiding the controls would leave them with no
+          way to find out that any of this exists. Pressing one explains and
+          points at the switch (issue #1070). --%>
+          <div :if={@can_like? or @can_reply?} class="mt-1 flex flex-wrap items-center gap-5">
+            <%!-- A plain toggle with no number beside it, like the one on a
+            cached post: the heart says what the reader did, and the only honest
+            answer to "how many others" is the author's own server, one click
+            away in the footer below. --%>
+            <button
+              :if={@can_like?}
+              type="button"
+              phx-click={if @liked?, do: "unlike-remote-reply", else: "like-remote-reply"}
+              phx-value-id={@note.id}
+              aria-pressed={to_string(@liked?)}
+              data-remote-reply-like={@note.id}
+              data-liked={@liked? && "on"}
+              class={[
+                "inline-flex min-h-10 items-center gap-1.5 text-sm font-medium",
+                if(@liked?,
+                  do: "text-accent",
+                  else: "text-slate-600 hover:text-accent dark:text-slate-400"
+                )
+              ]}
+            >
+              <.icon_heart filled?={@liked?} class="h-5 w-5" />
+              <%!-- One label in both states, with the state carried by the
+              filled heart, the accent colour and `aria-pressed` — German has one
+              word for both, so two labels would have read differently per
+              language, and in German not at all. --%>
+              <span>{gettext("Like")}</span>
+            </button>
+
+            <.link
+              :if={@can_reply?}
+              navigate={~p"/system/fediverse/reply/#{@note.id}"}
+              data-remote-reply-link={@note.id}
+              class="inline-flex min-h-10 items-center gap-1.5 text-sm font-medium text-slate-600 hover:text-brand-700 dark:text-slate-400 dark:hover:text-brand-300"
+            >
+              <.icon_reply class="h-5 w-5" />
+              <span>{gettext("Reply")}</span>
+            </.link>
+          </div>
+
+          <.remote_footer host={@host} origin={@origin} label={gettext("View the original")} />
         </div>
       </div>
     </article>
@@ -1264,8 +1334,10 @@ defmodule VutuvWeb.PostComponents do
     end)
   end
 
-  # Where it came from and the way on to the real thing. The inner block is for
-  # the rare extra action that belongs beside it (answering a reply).
+  # Where it came from and the way on to the real thing — provenance, not
+  # actions: both remote cards' acts live in their own row above this line
+  # (issue #1270). The inner block is what a card needs to add to the
+  # provenance itself.
   attr(:host, :any, default: nil)
   attr(:origin, :string, required: true)
   attr(:label, :string, required: true)
@@ -1596,63 +1668,81 @@ defmodule VutuvWeb.PostComponents do
 
           <.remote_post_images images={@images} />
 
-          <%!-- The one act this card carries (issue #1164). A plain toggle with
-          no number beside it: the heart says what the reader did, and the only
-          honest answer to "how many others" is the author's own server, which
-          is one click away in the footer below. Sized as a real touch target.
+          <%!-- The card's three acts (issues #1164, #1165 and #1166), in one
+          row of real touch targets under the body — the same row, in the same
+          order, the remote reply card wears (issue #1270), so a card from
+          another network reads the same whichever of the two it is.
 
           Shown to every signed-in reader, including one who has not switched
-          Fediverse participation on: the `Like` is signed with their own key,
-          so for them it cannot be sent — but hiding the control would leave
-          them with no way to find that out. Pressing it explains and points at
-          the switch, the same way the reply page does (issue #1070). --%>
-          <button
-            :if={@viewer}
-            type="button"
-            phx-click={if @liked?, do: "unlike-remote-post", else: "like-remote-post"}
-            phx-value-id={@remote_post.id}
-            aria-pressed={to_string(@liked?)}
-            data-remote-like={@liked? && "on"}
-            class={[
-              "mr-4 mt-2 inline-flex min-h-10 items-center gap-1.5 text-sm font-medium",
-              if(@liked?,
-                do: "text-accent",
-                else: "text-slate-600 hover:text-accent dark:text-slate-400"
-              )
-            ]}
-          >
-            <.icon_heart filled?={@liked?} class="h-5 w-5" />
-            <%!-- One label in both states, with the state carried by the filled
-            heart, the accent colour and `aria-pressed` — the same way the local
-            action bar does it. Two labels needed two words, and German has one
-            for both ("Gefällt mir"), so the state would have read differently
-            per language, and in German not at all. --%>
-            <span>{gettext("Like")}</span>
-          </button>
+          Fediverse participation on: each is signed with their own key, so for
+          them none can be sent — but hiding the controls would leave them with
+          no way to find that out. Pressing one explains and points at the
+          switch, the same way the reply page does (issue #1070). --%>
+          <div :if={@viewer} class="mt-1 flex flex-wrap items-center gap-5">
+            <%!-- A plain toggle with no number beside it: the heart says what
+            the reader did, and the only honest answer to "how many others" is
+            the author's own server, one click away in the footer below. --%>
+            <button
+              type="button"
+              phx-click={if @liked?, do: "unlike-remote-post", else: "like-remote-post"}
+              phx-value-id={@remote_post.id}
+              aria-pressed={to_string(@liked?)}
+              data-remote-like={@liked? && "on"}
+              class={[
+                "inline-flex min-h-10 items-center gap-1.5 text-sm font-medium",
+                if(@liked?,
+                  do: "text-accent",
+                  else: "text-slate-600 hover:text-accent dark:text-slate-400"
+                )
+              ]}
+            >
+              <.icon_heart filled?={@liked?} class="h-5 w-5" />
+              <%!-- One label in both states, with the state carried by the filled
+              heart, the accent colour and `aria-pressed` — the same way the local
+              action bar does it. Two labels needed two words, and German has one
+              for both ("Gefällt mir"), so the state would have read differently
+              per language, and in German not at all. --%>
+              <span>{gettext("Like")}</span>
+            </button>
 
-          <%!-- Sharing it onward (issue #1166). Unlike the heart this is a
-          publishing act — everybody who follows the reader here and out there
-          sees it — so it is only offered on an open post: passing on an
-          audience its author narrowed is not ours to do, and a boost is the
-          least reversible way to do it. --%>
-          <button
-            :if={@viewer && RemotePost.open?(@remote_post)}
-            type="button"
-            phx-click={if @reposted?, do: "unrepost-remote-post", else: "repost-remote-post"}
-            phx-value-id={@remote_post.id}
-            aria-pressed={to_string(@reposted?)}
-            data-remote-repost={@reposted? && "on"}
-            class={[
-              "mt-2 inline-flex min-h-10 items-center gap-1.5 text-sm font-medium",
-              if(@reposted?,
-                do: "text-emerald-700 dark:text-emerald-400",
-                else: "text-slate-600 hover:text-emerald-700 dark:text-slate-400"
-              )
-            ]}
-          >
-            <.icon_repost class="h-5 w-5" />
-            <span>{gettext("Repost")}</span>
-          </button>
+            <%!-- Answering (issue #1165). Only on an open post: an answer is a
+            public vutuv post, and republishing the audience a followers-only
+            post's author chose is not ours to do, so there is no control rather
+            than one that refuses. --%>
+            <.link
+              :if={RemotePost.open?(@remote_post)}
+              navigate={~p"/system/fediverse/reply/post/#{@remote_post.id}"}
+              data-remote-post-reply-link={@remote_post.id}
+              class="inline-flex min-h-10 items-center gap-1.5 text-sm font-medium text-slate-600 hover:text-brand-700 dark:text-slate-400 dark:hover:text-brand-300"
+            >
+              <.icon_reply class="h-5 w-5" />
+              <span>{gettext("Reply")}</span>
+            </.link>
+
+            <%!-- Sharing it onward (issue #1166). Unlike the heart this is a
+            publishing act — everybody who follows the reader here and out there
+            sees it — so it too is only offered on an open post: passing on an
+            audience its author narrowed is not ours to do, and a boost is the
+            least reversible way to do it. --%>
+            <button
+              :if={RemotePost.open?(@remote_post)}
+              type="button"
+              phx-click={if @reposted?, do: "unrepost-remote-post", else: "repost-remote-post"}
+              phx-value-id={@remote_post.id}
+              aria-pressed={to_string(@reposted?)}
+              data-remote-repost={@reposted? && "on"}
+              class={[
+                "inline-flex min-h-10 items-center gap-1.5 text-sm font-medium",
+                if(@reposted?,
+                  do: "text-emerald-700 dark:text-emerald-400",
+                  else: "text-slate-600 hover:text-emerald-700 dark:text-slate-400"
+                )
+              ]}
+            >
+              <.icon_repost class="h-5 w-5" />
+              <span>{gettext("Repost")}</span>
+            </button>
+          </div>
 
           <%!-- A poll's options are shown above, but a vote is not something
           vutuv can carry, so the link says what it is actually for. --%>
@@ -1661,27 +1751,7 @@ defmodule VutuvWeb.PostComponents do
             origin={RemotePost.origin(@remote_post)}
             label={origin_label(@remote_post)}
             data-remote-origin
-          >
-            <%!-- Answering (issue #1165) sits beside where the post came from,
-            like the remote reply card's does. Only on an open post: an answer
-            is a public vutuv post, and republishing the audience a
-            followers-only post's author chose is not ours to do, so there is no
-            control rather than one that refuses. Shown to every signed-in
-            member including one who does not federate — the page behind it is
-            what explains why they cannot send yet. --%>
-            <span :if={@viewer && RemotePost.open?(@remote_post)}>
-              ·
-              <%!-- Padded to a finger-sized target rather than left as a
-              `text-xs` word: this is the card's second real action, and it sits
-              right beside a link that leaves the site — a mis-tap there is not
-              a small mistake. --%>
-              <.link
-                navigate={~p"/system/fediverse/reply/post/#{@remote_post.id}"}
-                data-remote-post-reply-link={@remote_post.id}
-                class="inline-flex min-h-10 items-center px-1 font-medium text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
-              >{gettext("Reply")}</.link>
-            </span>
-          </.remote_footer>
+          />
         </div>
       </div>
     </article>
@@ -1706,11 +1776,22 @@ defmodule VutuvWeb.PostComponents do
   who pressed a heart while reading has not asked to be told what the operator
   blocks, and that table's fallback tells them to check an address a like does
   not have.
+
+  `subject` names what was pressed — a cached post (the default) or a reply from
+  another network (issue #1270). It changes exactly one sentence, the one that
+  says the thing is gone; everything else is about the member's own standing and
+  reads the same whichever it was. One table with a subject beats two tables
+  that drift.
   """
-  def like_refusal_message(:like_capped),
+  def like_refusal_message(reason, subject \\ :post)
+
+  def like_refusal_message(:like_capped, _subject),
     do: gettext("That is a lot of likes in one hour. Please try again later.")
 
-  def like_refusal_message(reason) when reason in [:not_found, :not_visible],
+  def like_refusal_message(reason, :reply) when reason in [:not_found, :not_visible],
+    do: gettext("That reply is not here any more.")
+
+  def like_refusal_message(reason, _subject) when reason in [:not_found, :not_visible],
     do: gettext("That post is not here any more.")
 
   # The states a member is in rather than a fact about this act: those already
@@ -1719,11 +1800,11 @@ defmodule VutuvWeb.PostComponents do
   # `federated?/1` is false with the switch already on (an unconfirmed address,
   # a frozen or suspended account). Only its catch-all is overridden, which is
   # about an address a heart does not have.
-  def like_refusal_message(reason)
+  def like_refusal_message(reason, _subject)
       when reason in [:not_federating, :moved, :fediverse_disabled, :instance_blocked],
       do: FediverseComponents.refusal_message(reason)
 
-  def like_refusal_message(_reason), do: gettext("That did not work.")
+  def like_refusal_message(_reason, _subject), do: gettext("That did not work.")
 
   @doc """
   The chrome both "answer something on another network" pages wear: the reply
@@ -1906,6 +1987,14 @@ defmodule VutuvWeb.PostComponents do
         "siblings of that post's own answers, in time order"
   )
 
+  attr(:liked_notes, :any,
+    default: nil,
+    doc:
+      "the note ids the viewer already likes as a MapSet " <>
+        "(Vutuv.Fediverse.liked_note_ids/2), batched by the host so the remote " <>
+        "reply cards' hearts don't each ask for themselves"
+  )
+
   attr(:conn_or_socket, :any, required: true)
 
   def thread_conversation(assigns) do
@@ -1934,6 +2023,7 @@ defmodule VutuvWeb.PostComponents do
   attr(:viewer_follows, :map, default: %{})
   attr(:engagement, :map, default: %{})
   attr(:remote_replies, :map, default: %{})
+  attr(:liked_notes, :any, default: nil)
   attr(:conn_or_socket, :any, required: true)
 
   def thread_window_conversation(assigns) do
@@ -2027,7 +2117,11 @@ defmodule VutuvWeb.PostComponents do
     end)
     |> Posts.thread_forest()
     |> banner_on_roots()
-    |> weave_remote_replies(assigns[:remote_replies] || %{}, assigns.viewer)
+    |> weave_remote_replies(
+      assigns[:remote_replies] || %{},
+      assigns.viewer,
+      assigns[:liked_notes] || MapSet.new()
+    )
   end
 
   # Hangs the replies written on other networks (issue #1069) under the posts
@@ -2038,22 +2132,22 @@ defmodule VutuvWeb.PostComponents do
   # `remote_replies` is `Vutuv.Fediverse.list_notes/2`'s per-post map, already
   # viewer-scoped — a reply addressed to the member alone never reaches anybody
   # else's render.
-  defp weave_remote_replies(nodes, remote, _viewer) when remote == %{}, do: nodes
+  defp weave_remote_replies(nodes, remote, _viewer, _liked) when remote == %{}, do: nodes
 
-  defp weave_remote_replies(nodes, remote, viewer) do
+  defp weave_remote_replies(nodes, remote, viewer, liked) do
     Enum.map(nodes, fn node ->
       children =
         node.children
-        |> weave_remote_replies(remote, viewer)
-        |> merge_remote_nodes(Map.get(remote, node.post.id, []), node.post, viewer)
+        |> weave_remote_replies(remote, viewer, liked)
+        |> merge_remote_nodes(Map.get(remote, node.post.id, []), node.post, viewer, liked)
 
       %{node | children: children}
     end)
   end
 
-  defp merge_remote_nodes(children, [], _post, _viewer), do: children
+  defp merge_remote_nodes(children, [], _post, _viewer, _liked), do: children
 
-  defp merge_remote_nodes(children, notes, post, viewer) do
+  defp merge_remote_nodes(children, notes, post, viewer, liked) do
     owner? = match?(%User{}, viewer) and viewer.id == post.user_id
 
     # An answer to one of these notes (issue #1070) is, underneath, an ordinary
@@ -2067,6 +2161,7 @@ defmodule VutuvWeb.PostComponents do
         %{
           note: note,
           owner?: owner?,
+          liked?: MapSet.member?(liked, note.id),
           children:
             answers
             |> Enum.filter(&(answered_note_id(&1) == note.id))

--- a/lib/vutuv_web/live/post_live/thread.ex
+++ b/lib/vutuv_web/live/post_live/thread.ex
@@ -10,7 +10,10 @@ defmodule VutuvWeb.PostLive.Thread do
   card (`VutuvWeb.PostComponents.remote_reply_card/1`); `Vutuv.Fediverse.list_notes/2`
   scopes them to the viewer, so one addressed to the member alone never reaches
   anybody else's render. Their takedown controls are the `remove-remote-reply` /
-  `report-remote-reply` events below.
+  `report-remote-reply` events below, and their heart (issue #1270) the
+  `like-remote-reply` / `unlike-remote-reply` pair — this host is why the card's
+  acts render here and not on the answering page, which shows the same card
+  read-only.
 
   It renders `Vutuv.Posts.thread_window/3`: a small conversation whole
   (`:all`, the issue #1006 page unchanged), a big one as a **window around
@@ -37,13 +40,20 @@ defmodule VutuvWeb.PostLive.Thread do
   use Phoenix.LiveView
 
   import VutuvWeb.PostComponents,
-    only: [post_card: 1, thread_conversation: 1, thread_window_conversation: 1]
+    only: [
+      post_card: 1,
+      thread_conversation: 1,
+      thread_window_conversation: 1,
+      like_refusal_message: 2
+    ]
 
   import VutuvWeb.UI, only: [card: 1, delimited_count: 1]
 
   use Gettext, backend: VutuvWeb.Gettext
 
+  alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Note
   alias Vutuv.Posts
   alias Vutuv.Social
   alias VutuvWeb.Live.InitAssigns
@@ -148,6 +158,18 @@ defmodule VutuvWeb.PostLive.Thread do
      )}
   end
 
+  # The heart on a reply from another network (issue #1270): the marker is
+  # written here and a signed `Like` goes to its author's own server. Only the
+  # reader's own state is painted — there is no count to update, because vutuv
+  # does not know the reply's real one.
+  def handle_event("like-remote-reply", %{"id" => id}, socket) do
+    {:noreply, toggle_note_like(socket, id, &Fediverse.like_note/2, true)}
+  end
+
+  def handle_event("unlike-remote-reply", %{"id" => id}, socket) do
+    {:noreply, toggle_note_like(socket, id, &Fediverse.unlike_note/2, false)}
+  end
+
   @impl true
   def handle_info({:post_counters, %{post_id: post_id} = payload}, socket) do
     # This host holds the post-topic subscriptions for its cards; the matching
@@ -182,7 +204,11 @@ defmodule VutuvWeb.PostLive.Thread do
     case Posts.get_post(socket.assigns.post_id) do
       nil ->
         # Deleted while the socket lived; the controller 404s the next load.
-        socket |> assign(:window, nil) |> assign(:focus, nil) |> assign(:remote_replies, %{})
+        socket
+        |> assign(:window, nil)
+        |> assign(:focus, nil)
+        |> assign(:remote_replies, %{})
+        |> assign(:liked_notes, MapSet.new())
 
       post ->
         window =
@@ -210,6 +236,15 @@ defmodule VutuvWeb.PostLive.Thread do
         # addressed to the member alone never reaches anybody else's render.
         remote = Fediverse.list_notes(ids, viewer)
 
+        # Which of them this reader already likes (issue #1270) — one query for
+        # the whole window, the way the posts' engagement is batched above.
+        liked_notes =
+          remote
+          |> Map.values()
+          |> List.flatten()
+          |> Enum.map(& &1.id)
+          |> then(&Fediverse.liked_note_ids(viewer, &1))
+
         # The lazy freshness check (issue #1069): ask the origins of the stale
         # public ones whether they are still published there. Deliberately
         # fire-and-forget in a task, so a stranger's slow server can never hold
@@ -225,8 +260,45 @@ defmodule VutuvWeb.PostLive.Thread do
         |> assign(:engagement, Posts.post_engagement_map(ids, viewer))
         |> assign(:viewer_follows, follows)
         |> assign(:remote_replies, remote)
+        |> assign(:liked_notes, liked_notes)
         |> subscribe_shown(ids)
     end
+  end
+
+  # The heart's outcome (issue #1270). The id in a click is attacker-controlled,
+  # so it is resolved against the replies this page really rendered before
+  # anything is written — `Vutuv.Fediverse` re-reads and re-gates it anyway, this
+  # only keeps the page honest about what it is acting on.
+  #
+  # A success repaints the one card from the set in hand rather than re-running
+  # the whole window: nothing else on the page changed, and a like carries no
+  # count for anybody else to see. `{:ok, :already}` (a double tap, a second tab)
+  # lands on the same state as `{:ok, :liked}`, which is the point of it.
+  defp toggle_note_like(socket, id, fun, liked?) do
+    with %User{} = viewer <- socket.assigns.current_user,
+         %Note{} = note <- shown_note(socket, id) do
+      case fun.(viewer, note) do
+        {:ok, _outcome} ->
+          socket
+          |> assign(:notice, nil)
+          |> update(:liked_notes, &toggle_member(&1, note.id, liked?))
+
+        {:error, reason} ->
+          assign(socket, :notice, like_refusal_message(reason, :reply))
+      end
+    else
+      _ -> socket
+    end
+  end
+
+  defp toggle_member(set, id, true), do: MapSet.put(set, id)
+  defp toggle_member(set, id, false), do: MapSet.delete(set, id)
+
+  defp shown_note(socket, id) do
+    socket.assigns.remote_replies
+    |> Map.values()
+    |> List.flatten()
+    |> Enum.find(&(&1.id == id))
   end
 
   # The outcome is shown as an inline notice above the conversation, not as a
@@ -321,6 +393,7 @@ defmodule VutuvWeb.PostLive.Thread do
                 viewer_follows={@viewer_follows}
                 engagement={@engagement}
                 remote_replies={@remote_replies}
+                liked_notes={@liked_notes}
                 auto_scroll?={@auto_scroll?}
                 conn_or_socket={@socket}
               />
@@ -332,6 +405,7 @@ defmodule VutuvWeb.PostLive.Thread do
                 viewer_follows={@viewer_follows}
                 engagement={@engagement}
                 remote_replies={@remote_replies}
+                liked_notes={@liked_notes}
                 auto_scroll?={@auto_scroll?}
                 conn_or_socket={@socket}
               />

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.211.1",
+      version: "7.212.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -156,7 +156,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:2328
+#: lib/vutuv_web/components/post_components.ex:2423
 #: lib/vutuv_web/components/ui.ex:3140
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -205,7 +205,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:2293
+#: lib/vutuv_web/components/post_components.ex:2388
 #: lib/vutuv_web/components/ui.ex:3131
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -654,7 +654,7 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/search_live.ex:378
 #: lib/vutuv_web/live/shell_live.ex:481
 #: lib/vutuv_web/live/shell_live.ex:637
-#: lib/vutuv_web/live/tag_live/timeline.ex:275
+#: lib/vutuv_web/live/tag_live/timeline.ex:278
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
@@ -663,7 +663,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1209
+#: lib/vutuv_web/components/post_components.ex:1279
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1698,7 +1698,7 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/post_components.ex:2774
+#: lib/vutuv_web/components/post_components.ex:2869
 #: lib/vutuv_web/components/ui.ex:244
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1950,7 +1950,7 @@ msgstr ""
 "Wir haben eine PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie sie "
 "unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1214
+#: lib/vutuv_web/live/post_live/feed.ex:1224
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2189,7 +2189,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:2325
+#: lib/vutuv_web/components/post_components.ex:2420
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2201,8 +2201,8 @@ msgstr "Diesen Beitrag endgültig löschen?"
 msgid "Edit post"
 msgstr "Beitrag bearbeiten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:149
-#: lib/vutuv_web/live/post_live/feed.ex:984
+#: lib/vutuv_web/live/post_live/feed.ex:154
+#: lib/vutuv_web/live/post_live/feed.ex:990
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:122
@@ -2230,8 +2230,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:2279
-#: lib/vutuv_web/components/post_components.ex:2281
+#: lib/vutuv_web/components/post_components.ex:2374
+#: lib/vutuv_web/components/post_components.ex:2376
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2247,7 +2247,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1153
+#: lib/vutuv_web/live/post_live/feed.ex:1163
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2298,13 +2298,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2710
-#: lib/vutuv_web/components/post_components.ex:2714
+#: lib/vutuv_web/components/post_components.ex:2805
+#: lib/vutuv_web/components/post_components.ex:2809
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:2711
+#: lib/vutuv_web/components/post_components.ex:2806
 #: lib/vutuv_web/live/fediverse_account_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2312,7 +2312,7 @@ msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:252
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:943
+#: lib/vutuv_web/components/post_components.ex:982
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
@@ -2339,7 +2339,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1073
+#: lib/vutuv_web/live/post_live/feed.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2395,27 +2395,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:2276
+#: lib/vutuv_web/components/post_components.ex:2371
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:3841
+#: lib/vutuv_web/components/post_components.ex:3936
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:3845
+#: lib/vutuv_web/components/post_components.ex:3940
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:3843
+#: lib/vutuv_web/components/post_components.ex:3938
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:3844
+#: lib/vutuv_web/components/post_components.ex:3939
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2456,7 +2456,7 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3925
+#: lib/vutuv_web/components/post_components.ex:4020
 #: lib/vutuv_web/components/ui.ex:2665
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2473,8 +2473,9 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1630
-#: lib/vutuv_web/components/post_components.ex:4148
+#: lib/vutuv_web/components/post_components.ex:1041
+#: lib/vutuv_web/components/post_components.ex:1705
+#: lib/vutuv_web/components/post_components.ex:4243
 #: lib/vutuv_web/components/ui.ex:2651
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #: lib/vutuv_web/templates/user/show.html.heex:192
@@ -2483,7 +2484,7 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:932
-#: lib/vutuv_web/components/post_components.ex:4157
+#: lib/vutuv_web/components/post_components.ex:4252
 #: lib/vutuv_web/live/notification_live/index.ex:940
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2503,37 +2504,37 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:3914
+#: lib/vutuv_web/components/post_components.ex:4009
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:3925
+#: lib/vutuv_web/components/post_components.ex:4020
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1654
-#: lib/vutuv_web/components/post_components.ex:3911
+#: lib/vutuv_web/components/post_components.ex:1743
+#: lib/vutuv_web/components/post_components.ex:4006
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1336
-#: lib/vutuv_web/components/post_components.ex:3288
+#: lib/vutuv_web/components/post_components.ex:1408
+#: lib/vutuv_web/components/post_components.ex:3383
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3911
+#: lib/vutuv_web/components/post_components.ex:4006
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:4148
+#: lib/vutuv_web/components/post_components.ex:4243
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
@@ -2544,7 +2545,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/components/ui.ex:1750
 #: lib/vutuv_web/components/ui.ex:1750
 #: lib/vutuv_web/components/ui.ex:1887
-#: lib/vutuv_web/live/post_live/feed.ex:1203
+#: lib/vutuv_web/live/post_live/feed.ex:1213
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2555,7 +2556,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4296
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2566,17 +2567,17 @@ msgstr "Nur öffentliche Beiträge können beantwortet werden."
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:983
-#: lib/vutuv_web/components/post_components.ex:1682
-#: lib/vutuv_web/components/post_components.ex:4184
-#: lib/vutuv_web/components/post_components.ex:4185
+#: lib/vutuv_web/components/post_components.ex:1051
+#: lib/vutuv_web/components/post_components.ex:1719
+#: lib/vutuv_web/components/post_components.ex:4279
+#: lib/vutuv_web/components/post_components.ex:4280
 #: lib/vutuv_web/live/notification_live/index.ex:1000
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2247
+#: lib/vutuv_web/components/post_components.ex:2342
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2597,7 +2598,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:1767
+#: lib/vutuv_web/components/post_components.ex:1848
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2605,14 +2606,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2223
+#: lib/vutuv_web/components/post_components.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:2217
-#: lib/vutuv_web/components/post_components.ex:2239
-#: lib/vutuv_web/components/post_components.ex:2242
+#: lib/vutuv_web/components/post_components.ex:2312
+#: lib/vutuv_web/components/post_components.ex:2334
+#: lib/vutuv_web/components/post_components.ex:2337
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2837,7 +2838,7 @@ msgstr "Ersten Beitrag schreiben"
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1009
+#: lib/vutuv_web/live/post_live/feed.ex:1015
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2918,7 +2919,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:3842
+#: lib/vutuv_web/components/post_components.ex:3937
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3197,7 +3198,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:2193
+#: lib/vutuv_web/components/post_components.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3276,9 +3277,9 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:953
-#: lib/vutuv_web/components/post_components.ex:1565
-#: lib/vutuv_web/components/post_components.ex:2349
+#: lib/vutuv_web/components/post_components.ex:992
+#: lib/vutuv_web/components/post_components.ex:1637
+#: lib/vutuv_web/components/post_components.ex:2444
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4735,7 +4736,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1158
+#: lib/vutuv_web/live/post_live/feed.ex:1168
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -5658,11 +5659,11 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:2412
-#: lib/vutuv_web/components/post_components.ex:2464
-#: lib/vutuv_web/components/post_components.ex:2854
+#: lib/vutuv_web/components/post_components.ex:2507
+#: lib/vutuv_web/components/post_components.ex:2559
+#: lib/vutuv_web/components/post_components.ex:2949
 #: lib/vutuv_web/live/notification_live/index.ex:680
-#: lib/vutuv_web/live/post_live/feed.ex:1276
+#: lib/vutuv_web/live/post_live/feed.ex:1286
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6043,7 +6044,7 @@ msgid "Name (A-Z)"
 msgstr "Name (A-Z)"
 
 #: lib/vutuv_web/live/post_live/saved.ex:420
-#: lib/vutuv_web/live/tag_live/timeline.ex:376
+#: lib/vutuv_web/live/tag_live/timeline.ex:379
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr "Neueste zuerst"
@@ -6069,7 +6070,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr "Hier ist noch nichts. Personen, die Ihnen gefallen, erscheinen hier."
 
 #: lib/vutuv_web/live/post_live/saved.ex:421
-#: lib/vutuv_web/live/tag_live/timeline.ex:377
+#: lib/vutuv_web/live/tag_live/timeline.ex:380
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr "Älteste zuerst"
@@ -6091,7 +6092,7 @@ msgid "Search saved items"
 msgstr "Gespeicherte durchsuchen"
 
 #: lib/vutuv_web/live/post_live/saved.ex:472
-#: lib/vutuv_web/live/tag_live/timeline.ex:291
+#: lib/vutuv_web/live/tag_live/timeline.ex:294
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr "Sortieren"
@@ -6961,7 +6962,7 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:2346
+#: lib/vutuv_web/components/post_components.ex:2441
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6971,7 +6972,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:2345
+#: lib/vutuv_web/components/post_components.ex:2440
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7678,7 +7679,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
-#: lib/vutuv_web/components/post_components.ex:4070
+#: lib/vutuv_web/components/post_components.ex:4165
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8296,7 +8297,7 @@ msgstr "Prüfung ausstehend"
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:257
-#: lib/vutuv_web/live/tag_live/timeline.ex:321
+#: lib/vutuv_web/live/tag_live/timeline.ex:324
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr "Filter zurücksetzen"
@@ -8904,13 +8905,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1243
-#: lib/vutuv_web/live/post_live/feed.ex:1244
+#: lib/vutuv_web/live/post_live/feed.ex:1253
+#: lib/vutuv_web/live/post_live/feed.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1238
+#: lib/vutuv_web/live/post_live/feed.ex:1248
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -9297,7 +9298,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:3291
+#: lib/vutuv_web/components/post_components.ex:3386
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -13017,7 +13018,7 @@ msgid "Everyone (public)"
 msgstr "Alle (öffentlich)"
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:452
-#: lib/vutuv_web/live/tag_live/timeline.ex:302
+#: lib/vutuv_web/live/tag_live/timeline.ex:305
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -13976,7 +13977,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:1726
+#: lib/vutuv_web/components/post_components.ex:1807
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -14370,7 +14371,7 @@ msgstr "In den Text einfügen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:189
 #: lib/vutuv_web/agent_docs/text.ex:177
-#: lib/vutuv_web/live/tag_live/timeline.ex:248
+#: lib/vutuv_web/live/tag_live/timeline.ex:251
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr "Beiträge mit diesem Tag"
@@ -14427,14 +14428,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3474
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:1189
+#: lib/vutuv_web/live/post_live/feed.ex:1199
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1204
+#: lib/vutuv_web/live/post_live/feed.ex:1214
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -14592,34 +14593,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:3704
+#: lib/vutuv_web/components/post_components.ex:3799
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3661
+#: lib/vutuv_web/components/post_components.ex:3756
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:3705
+#: lib/vutuv_web/components/post_components.ex:3800
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:3707
+#: lib/vutuv_web/components/post_components.ex:3802
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:3703
+#: lib/vutuv_web/components/post_components.ex:3798
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3660
+#: lib/vutuv_web/components/post_components.ex:3755
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14630,12 +14631,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:3702
+#: lib/vutuv_web/components/post_components.ex:3797
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:3706
+#: lib/vutuv_web/components/post_components.ex:3801
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14655,34 +14656,34 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:3743
+#: lib/vutuv_web/components/post_components.ex:3838
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:3773
+#: lib/vutuv_web/components/post_components.ex:3868
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:3774
+#: lib/vutuv_web/components/post_components.ex:3869
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:3772
+#: lib/vutuv_web/components/post_components.ex:3867
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:3732
+#: lib/vutuv_web/components/post_components.ex:3827
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:3779
+#: lib/vutuv_web/components/post_components.ex:3874
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14712,7 +14713,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3546
+#: lib/vutuv_web/components/post_components.ex:3641
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14760,7 +14761,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:3537
+#: lib/vutuv_web/components/post_components.ex:3632
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -15138,7 +15139,7 @@ msgstr "Konto einfrieren"
 msgid "No accounts are currently frozen."
 msgstr "Zurzeit sind keine Konten eingefroren."
 
-#: lib/vutuv_web/live/post_live/thread.ex:352
+#: lib/vutuv_web/live/post_live/thread.ex:426
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr "Von Anfang an lesen"
@@ -15158,14 +15159,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1973
+#: lib/vutuv_web/components/post_components.ex:2063
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1995
+#: lib/vutuv_web/components/post_components.ex:2085
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -15177,7 +15178,7 @@ msgstr[1] "%{formatted} weitere Antworten anzeigen"
 msgid "This page is no longer available."
 msgstr "Diese Seite ist nicht mehr verfügbar."
 
-#: lib/vutuv_web/live/post_live/thread.ex:344
+#: lib/vutuv_web/live/post_live/thread.ex:418
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr "Dieser Beitrag ist Teil einer Unterhaltung mit %{formatted} Beiträgen."
@@ -15192,7 +15193,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:4156
+#: lib/vutuv_web/components/post_components.ex:4251
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15339,7 +15340,7 @@ msgstr "Nach einem Tag filtern"
 msgid "Filter removed."
 msgstr "Filter entfernt."
 
-#: lib/vutuv_web/live/post_live/feed.ex:284
+#: lib/vutuv_web/live/post_live/feed.ex:290
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr "Ausgeblendet: passt zu Ihrem Filter"
@@ -15374,7 +15375,7 @@ msgstr ""
 "Wählen Sie unten einen Abschluss oder eine Schule, um ihn statt eines "
 "Jobtitels oben in Ihrem Profil anzuzeigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:293
+#: lib/vutuv_web/live/post_live/feed.ex:299
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -15905,7 +15906,7 @@ msgstr "Wir senden dorthin eine PIN, um zu bestätigen, dass die Adresse Ihnen g
 msgid "ZIP or postal code"
 msgstr "Postleitzahl"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:309
+#: lib/vutuv_web/live/tag_live/timeline.ex:312
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -16380,21 +16381,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:4115
+#: lib/vutuv_web/components/post_components.ex:4210
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4119
+#: lib/vutuv_web/components/post_components.ex:4214
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:4123
+#: lib/vutuv_web/components/post_components.ex:4218
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16402,7 +16403,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:951
-#: lib/vutuv_web/components/post_components.ex:4074
+#: lib/vutuv_web/components/post_components.ex:4169
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16418,14 +16419,14 @@ msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem 
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:1054
-#: lib/vutuv_web/components/post_components.ex:1278
+#: lib/vutuv_web/components/post_components.ex:1124
+#: lib/vutuv_web/components/post_components.ex:1350
 #: lib/vutuv_web/live/fediverse_account_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:941
+#: lib/vutuv_web/components/post_components.ex:980
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16447,12 +16448,12 @@ msgstr "Antworten aus anderen Netzwerken"
 msgid "Reply from another network"
 msgstr "Antwort aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/live/post_live/thread.ex:138
+#: lib/vutuv_web/live/post_live/thread.ex:148
 #, elixir-autogen, elixir-format
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:950
+#: lib/vutuv_web/components/post_components.ex:989
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16462,7 +16463,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:964
+#: lib/vutuv_web/components/post_components.ex:1003
 #: lib/vutuv_web/live/notification_live/index.ex:534
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16483,19 +16484,19 @@ msgstr "Gespeicherte Antworten"
 msgid "Taken down"
 msgstr "Entfernt"
 
-#: lib/vutuv_web/live/post_live/thread.ex:147
+#: lib/vutuv_web/live/post_live/thread.ex:157
 #, elixir-autogen, elixir-format
 msgid "Thank you. The reply was deleted right away."
 msgstr "Danke. Die Antwort wurde sofort gelöscht."
 
-#: lib/vutuv_web/live/post_live/thread.ex:256
+#: lib/vutuv_web/live/post_live/thread.ex:328
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1112
-#: lib/vutuv_web/components/post_components.ex:969
-#: lib/vutuv_web/components/post_components.ex:1694
+#: lib/vutuv_web/components/post_components.ex:1055
+#: lib/vutuv_web/components/post_components.ex:1764
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16508,8 +16509,8 @@ msgstr "Was"
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:168
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:139
-#: lib/vutuv_web/live/post_live/feed.ex:420
-#: lib/vutuv_web/live/post_live/thread.ex:252
+#: lib/vutuv_web/live/post_live/feed.ex:426
+#: lib/vutuv_web/live/post_live/thread.ex:324
 #: lib/vutuv_web/live/tag_live/timeline.ex:138
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16939,7 +16940,7 @@ msgstr "Hier ist noch nichts. Wenn Sie sich das nächste Mal anmelden oder eine 
 #: lib/vutuv_web/live/account_activity_live.ex:198
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
-#: lib/vutuv_web/live/tag_live/timeline.ex:394
+#: lib/vutuv_web/live/tag_live/timeline.ex:397
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr "Dazu passt nichts. Versuchen Sie eine kürzere Suche oder setzen Sie die Filter zurück."
@@ -17159,22 +17160,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:2205
+#: lib/vutuv_web/components/post_components.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2312
+#: lib/vutuv_web/components/post_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:2320
+#: lib/vutuv_web/components/post_components.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:2306
+#: lib/vutuv_web/components/post_components.ex:2401
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17266,7 +17267,7 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1040
 #: lib/vutuv_web/agent_docs/text.ex:654
-#: lib/vutuv_web/components/post_components.ex:2777
+#: lib/vutuv_web/components/post_components.ex:2872
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
@@ -17296,7 +17297,7 @@ msgstr "Volle Auflösung, direkt aus dem Beitrag."
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/components/post_components.ex:2776
+#: lib/vutuv_web/components/post_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
@@ -17306,29 +17307,29 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:3250
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr "Bisher sehen nur Sie diesen Beitrag."
 
-#: lib/vutuv_web/components/post_components.ex:1779
+#: lib/vutuv_web/components/post_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:3158
+#: lib/vutuv_web/components/post_components.ex:3253
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] "Unsere KI prüft das Foto. Sobald es durch ist, geht der Beitrag von selbst online."
 msgstr[1] "Unsere KI prüft die Fotos, %{done} von %{total} sind durch. Sobald das letzte durch ist, geht der Beitrag von selbst online."
 
-#: lib/vutuv_web/components/post_components.ex:2983
+#: lib/vutuv_web/components/post_components.ex:3078
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:2521
+#: lib/vutuv_web/components/post_components.ex:2616
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17341,12 +17342,12 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1073
 #: lib/vutuv_web/agent_docs/text.ex:641
-#: lib/vutuv_web/components/post_components.ex:3192
+#: lib/vutuv_web/components/post_components.ex:3287
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/post_components.ex:2775
+#: lib/vutuv_web/components/post_components.ex:2870
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
@@ -17367,7 +17368,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1832
+#: lib/vutuv_web/components/post_components.ex:1913
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -17387,7 +17388,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:1823
+#: lib/vutuv_web/components/post_components.ex:1904
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -17397,12 +17398,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:1841
+#: lib/vutuv_web/components/post_components.ex:1922
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:1775
+#: lib/vutuv_web/components/post_components.ex:1856
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -17417,7 +17418,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:1836
+#: lib/vutuv_web/components/post_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -17427,7 +17428,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:1789
+#: lib/vutuv_web/components/post_components.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17448,8 +17449,8 @@ msgstr "Fotos hinzufügen"
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1018
-#: lib/vutuv_web/live/post_live/feed.ex:1019
+#: lib/vutuv_web/live/post_live/feed.ex:1024
+#: lib/vutuv_web/live/post_live/feed.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
@@ -17514,13 +17515,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:969
-#: lib/vutuv_web/components/post_components.ex:4112
+#: lib/vutuv_web/components/post_components.ex:4207
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:967
-#: lib/vutuv_web/components/post_components.ex:4109
+#: lib/vutuv_web/components/post_components.ex:4204
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17530,7 +17531,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:4001
+#: lib/vutuv_web/components/post_components.ex:4096
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17876,20 +17877,20 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1574
+#: lib/vutuv_web/components/post_components.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:160
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:131
-#: lib/vutuv_web/live/post_live/feed.ex:412
+#: lib/vutuv_web/live/post_live/feed.ex:418
 #: lib/vutuv_web/live/tag_live/timeline.ex:130
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:1693
+#: lib/vutuv_web/components/post_components.ex:1763
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17909,23 +17910,23 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1212
+#: lib/vutuv_web/components/post_components.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:1591
+#: lib/vutuv_web/components/post_components.ex:1663
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
 
-#: lib/vutuv_web/components/post_components.ex:1553
+#: lib/vutuv_web/components/post_components.ex:1625
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr "%{handle} stummschalten"
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:264
-#: lib/vutuv_web/live/post_live/feed.ex:470
+#: lib/vutuv_web/live/post_live/feed.ex:476
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwinden aus Ihrem Feed."
@@ -17935,7 +17936,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:1560
+#: lib/vutuv_web/components/post_components.ex:1632
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -18157,27 +18158,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:1381
+#: lib/vutuv_web/components/post_components.ex:1453
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr "Ein Bild ist unterwegs."
 
-#: lib/vutuv_web/components/post_components.ex:1410
+#: lib/vutuv_web/components/post_components.ex:1482
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:1405
+#: lib/vutuv_web/components/post_components.ex:1477
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:1711
+#: lib/vutuv_web/components/post_components.ex:1789
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:1714
+#: lib/vutuv_web/components/post_components.ex:1795
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -18187,7 +18188,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:1827
+#: lib/vutuv_web/components/post_components.ex:1908
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18204,7 +18205,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:193
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:110
-#: lib/vutuv_web/live/post_live/feed.ex:448
+#: lib/vutuv_web/live/post_live/feed.ex:454
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr "Repostet. Ihre Follower sehen es jetzt."
@@ -18955,39 +18956,44 @@ msgstr ""
 msgid "View the conversation"
 msgstr "Unterhaltung ansehen"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:251
+#: lib/vutuv_web/live/tag_live/timeline.ex:254
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
 msgid_plural "%{formatted} posts"
 msgstr[0] "%{formatted} Beitrag"
 msgstr[1] "%{formatted} Beiträge"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:378
+#: lib/vutuv_web/live/tag_live/timeline.ex:381
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr "Meiste Likes"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:402
+#: lib/vutuv_web/live/tag_live/timeline.ex:405
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr "Zu diesem Tag gibt es noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:400
+#: lib/vutuv_web/live/tag_live/timeline.ex:403
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr "Aus anderen Netzwerken gibt es zu diesem Tag noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:397
+#: lib/vutuv_web/live/tag_live/timeline.ex:400
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:334
+#: lib/vutuv_web/live/tag_live/timeline.ex:337
 #, elixir-autogen, elixir-format
 msgid "Posts from other networks carry no public like count here, so they come last in this order."
 msgstr "Zu Beiträgen aus anderen Netzwerken kennen wir hier keine öffentliche Like-Zahl. In dieser Sortierung stehen sie deshalb hinten."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:284
+#: lib/vutuv_web/live/tag_live/timeline.ex:287
 #, elixir-autogen, elixir-format
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
+
+#: lib/vutuv_web/components/post_components.ex:1792
+#, elixir-autogen, elixir-format
+msgid "That reply is not here any more."
+msgstr "Diese Antwort gibt es hier nicht mehr."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -156,7 +156,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2328
+#: lib/vutuv_web/components/post_components.ex:2423
 #: lib/vutuv_web/components/ui.ex:3140
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -205,7 +205,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2293
+#: lib/vutuv_web/components/post_components.ex:2388
 #: lib/vutuv_web/components/ui.ex:3131
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -654,7 +654,7 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:378
 #: lib/vutuv_web/live/shell_live.ex:481
 #: lib/vutuv_web/live/shell_live.ex:637
-#: lib/vutuv_web/live/tag_live/timeline.ex:275
+#: lib/vutuv_web/live/tag_live/timeline.ex:278
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
@@ -663,7 +663,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1209
+#: lib/vutuv_web/components/post_components.ex:1279
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2774
+#: lib/vutuv_web/components/post_components.ex:2869
 #: lib/vutuv_web/components/ui.ex:244
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1907,7 +1907,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1214
+#: lib/vutuv_web/live/post_live/feed.ex:1224
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2144,7 +2144,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2325
+#: lib/vutuv_web/components/post_components.ex:2420
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2156,8 +2156,8 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:149
-#: lib/vutuv_web/live/post_live/feed.ex:984
+#: lib/vutuv_web/live/post_live/feed.ex:154
+#: lib/vutuv_web/live/post_live/feed.ex:990
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:122
@@ -2185,8 +2185,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2279
-#: lib/vutuv_web/components/post_components.ex:2281
+#: lib/vutuv_web/components/post_components.ex:2374
+#: lib/vutuv_web/components/post_components.ex:2376
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2202,7 +2202,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1153
+#: lib/vutuv_web/live/post_live/feed.ex:1163
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2251,13 +2251,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2710
-#: lib/vutuv_web/components/post_components.ex:2714
+#: lib/vutuv_web/components/post_components.ex:2805
+#: lib/vutuv_web/components/post_components.ex:2809
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2711
+#: lib/vutuv_web/components/post_components.ex:2806
 #: lib/vutuv_web/live/fediverse_account_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2265,7 +2265,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:252
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:943
+#: lib/vutuv_web/components/post_components.ex:982
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
@@ -2290,7 +2290,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1073
+#: lib/vutuv_web/live/post_live/feed.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2346,27 +2346,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2276
+#: lib/vutuv_web/components/post_components.ex:2371
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3841
+#: lib/vutuv_web/components/post_components.ex:3936
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3845
+#: lib/vutuv_web/components/post_components.ex:3940
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3843
+#: lib/vutuv_web/components/post_components.ex:3938
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3844
+#: lib/vutuv_web/components/post_components.ex:3939
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2407,7 +2407,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3925
+#: lib/vutuv_web/components/post_components.ex:4020
 #: lib/vutuv_web/components/ui.ex:2665
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2424,8 +2424,9 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1630
-#: lib/vutuv_web/components/post_components.ex:4148
+#: lib/vutuv_web/components/post_components.ex:1041
+#: lib/vutuv_web/components/post_components.ex:1705
+#: lib/vutuv_web/components/post_components.ex:4243
 #: lib/vutuv_web/components/ui.ex:2651
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #: lib/vutuv_web/templates/user/show.html.heex:192
@@ -2434,7 +2435,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:932
-#: lib/vutuv_web/components/post_components.ex:4157
+#: lib/vutuv_web/components/post_components.ex:4252
 #: lib/vutuv_web/live/notification_live/index.ex:940
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2454,37 +2455,37 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3914
+#: lib/vutuv_web/components/post_components.ex:4009
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3925
+#: lib/vutuv_web/components/post_components.ex:4020
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1654
-#: lib/vutuv_web/components/post_components.ex:3911
+#: lib/vutuv_web/components/post_components.ex:1743
+#: lib/vutuv_web/components/post_components.ex:4006
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1336
-#: lib/vutuv_web/components/post_components.ex:3288
+#: lib/vutuv_web/components/post_components.ex:1408
+#: lib/vutuv_web/components/post_components.ex:3383
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3911
+#: lib/vutuv_web/components/post_components.ex:4006
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4148
+#: lib/vutuv_web/components/post_components.ex:4243
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
@@ -2495,7 +2496,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1750
 #: lib/vutuv_web/components/ui.ex:1750
 #: lib/vutuv_web/components/ui.ex:1887
-#: lib/vutuv_web/live/post_live/feed.ex:1203
+#: lib/vutuv_web/live/post_live/feed.ex:1213
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2506,7 +2507,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4296
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2517,17 +2518,17 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:983
-#: lib/vutuv_web/components/post_components.ex:1682
-#: lib/vutuv_web/components/post_components.ex:4184
-#: lib/vutuv_web/components/post_components.ex:4185
+#: lib/vutuv_web/components/post_components.ex:1051
+#: lib/vutuv_web/components/post_components.ex:1719
+#: lib/vutuv_web/components/post_components.ex:4279
+#: lib/vutuv_web/components/post_components.ex:4280
 #: lib/vutuv_web/live/notification_live/index.ex:1000
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2247
+#: lib/vutuv_web/components/post_components.ex:2342
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2548,7 +2549,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1767
+#: lib/vutuv_web/components/post_components.ex:1848
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2556,14 +2557,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2223
+#: lib/vutuv_web/components/post_components.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2217
-#: lib/vutuv_web/components/post_components.ex:2239
-#: lib/vutuv_web/components/post_components.ex:2242
+#: lib/vutuv_web/components/post_components.ex:2312
+#: lib/vutuv_web/components/post_components.ex:2334
+#: lib/vutuv_web/components/post_components.ex:2337
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2786,7 +2787,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1009
+#: lib/vutuv_web/live/post_live/feed.ex:1015
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2865,7 +2866,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3842
+#: lib/vutuv_web/components/post_components.ex:3937
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3126,7 +3127,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2193
+#: lib/vutuv_web/components/post_components.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3201,9 +3202,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:953
-#: lib/vutuv_web/components/post_components.ex:1565
-#: lib/vutuv_web/components/post_components.ex:2349
+#: lib/vutuv_web/components/post_components.ex:992
+#: lib/vutuv_web/components/post_components.ex:1637
+#: lib/vutuv_web/components/post_components.ex:2444
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4562,7 +4563,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1158
+#: lib/vutuv_web/live/post_live/feed.ex:1168
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5431,11 +5432,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2412
-#: lib/vutuv_web/components/post_components.ex:2464
-#: lib/vutuv_web/components/post_components.ex:2854
+#: lib/vutuv_web/components/post_components.ex:2507
+#: lib/vutuv_web/components/post_components.ex:2559
+#: lib/vutuv_web/components/post_components.ex:2949
 #: lib/vutuv_web/live/notification_live/index.ex:680
-#: lib/vutuv_web/live/post_live/feed.ex:1276
+#: lib/vutuv_web/live/post_live/feed.ex:1286
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5809,7 +5810,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:420
-#: lib/vutuv_web/live/tag_live/timeline.ex:376
+#: lib/vutuv_web/live/tag_live/timeline.ex:379
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5835,7 +5836,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:421
-#: lib/vutuv_web/live/tag_live/timeline.ex:377
+#: lib/vutuv_web/live/tag_live/timeline.ex:380
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -5857,7 +5858,7 @@ msgid "Search saved items"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:472
-#: lib/vutuv_web/live/tag_live/timeline.ex:291
+#: lib/vutuv_web/live/tag_live/timeline.ex:294
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr ""
@@ -6676,7 +6677,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2346
+#: lib/vutuv_web/components/post_components.ex:2441
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6686,7 +6687,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2345
+#: lib/vutuv_web/components/post_components.ex:2440
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7369,7 +7370,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4070
+#: lib/vutuv_web/components/post_components.ex:4165
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7938,7 +7939,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:257
-#: lib/vutuv_web/live/tag_live/timeline.ex:321
+#: lib/vutuv_web/live/tag_live/timeline.ex:324
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -8487,13 +8488,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1243
-#: lib/vutuv_web/live/post_live/feed.ex:1244
+#: lib/vutuv_web/live/post_live/feed.ex:1253
+#: lib/vutuv_web/live/post_live/feed.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1238
+#: lib/vutuv_web/live/post_live/feed.ex:1248
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8844,7 +8845,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3291
+#: lib/vutuv_web/components/post_components.ex:3386
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -12327,7 +12328,7 @@ msgid "Everyone (public)"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:452
-#: lib/vutuv_web/live/tag_live/timeline.ex:302
+#: lib/vutuv_web/live/tag_live/timeline.ex:305
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -13280,7 +13281,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1726
+#: lib/vutuv_web/components/post_components.ex:1807
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -13666,7 +13667,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:189
 #: lib/vutuv_web/agent_docs/text.ex:177
-#: lib/vutuv_web/live/tag_live/timeline.ex:248
+#: lib/vutuv_web/live/tag_live/timeline.ex:251
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr ""
@@ -13718,14 +13719,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3474
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:1189
+#: lib/vutuv_web/live/post_live/feed.ex:1199
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1204
+#: lib/vutuv_web/live/post_live/feed.ex:1214
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13881,34 +13882,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3704
+#: lib/vutuv_web/components/post_components.ex:3799
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3661
+#: lib/vutuv_web/components/post_components.ex:3756
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3705
+#: lib/vutuv_web/components/post_components.ex:3800
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3707
+#: lib/vutuv_web/components/post_components.ex:3802
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3703
+#: lib/vutuv_web/components/post_components.ex:3798
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3660
+#: lib/vutuv_web/components/post_components.ex:3755
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13919,12 +13920,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3702
+#: lib/vutuv_web/components/post_components.ex:3797
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3706
+#: lib/vutuv_web/components/post_components.ex:3801
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13944,34 +13945,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3743
+#: lib/vutuv_web/components/post_components.ex:3838
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3773
+#: lib/vutuv_web/components/post_components.ex:3868
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3774
+#: lib/vutuv_web/components/post_components.ex:3869
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3772
+#: lib/vutuv_web/components/post_components.ex:3867
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3732
+#: lib/vutuv_web/components/post_components.ex:3827
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3779
+#: lib/vutuv_web/components/post_components.ex:3874
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14001,7 +14002,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3546
+#: lib/vutuv_web/components/post_components.ex:3641
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14049,7 +14050,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3537
+#: lib/vutuv_web/components/post_components.ex:3632
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14403,7 +14404,7 @@ msgstr ""
 msgid "No accounts are currently frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:352
+#: lib/vutuv_web/live/post_live/thread.ex:426
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr ""
@@ -14423,14 +14424,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1973
+#: lib/vutuv_web/components/post_components.ex:2063
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1995
+#: lib/vutuv_web/components/post_components.ex:2085
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14442,7 +14443,7 @@ msgstr[1] ""
 msgid "This page is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:344
+#: lib/vutuv_web/live/post_live/thread.ex:418
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr ""
@@ -14457,7 +14458,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4156
+#: lib/vutuv_web/components/post_components.ex:4251
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14604,7 +14605,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:284
+#: lib/vutuv_web/live/post_live/feed.ex:290
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14637,7 +14638,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:293
+#: lib/vutuv_web/live/post_live/feed.ex:299
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -15168,7 +15169,7 @@ msgstr ""
 msgid "ZIP or postal code"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:309
+#: lib/vutuv_web/live/tag_live/timeline.ex:312
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -15629,21 +15630,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4115
+#: lib/vutuv_web/components/post_components.ex:4210
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4119
+#: lib/vutuv_web/components/post_components.ex:4214
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4123
+#: lib/vutuv_web/components/post_components.ex:4218
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15651,7 +15652,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:951
-#: lib/vutuv_web/components/post_components.ex:4074
+#: lib/vutuv_web/components/post_components.ex:4169
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15667,14 +15668,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1054
-#: lib/vutuv_web/components/post_components.ex:1278
+#: lib/vutuv_web/components/post_components.ex:1124
+#: lib/vutuv_web/components/post_components.ex:1350
 #: lib/vutuv_web/live/fediverse_account_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:941
+#: lib/vutuv_web/components/post_components.ex:980
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15696,12 +15697,12 @@ msgstr ""
 msgid "Reply from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:138
+#: lib/vutuv_web/live/post_live/thread.ex:148
 #, elixir-autogen, elixir-format
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:950
+#: lib/vutuv_web/components/post_components.ex:989
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15711,7 +15712,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:964
+#: lib/vutuv_web/components/post_components.ex:1003
 #: lib/vutuv_web/live/notification_live/index.ex:534
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15732,19 +15733,19 @@ msgstr ""
 msgid "Taken down"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:147
+#: lib/vutuv_web/live/post_live/thread.ex:157
 #, elixir-autogen, elixir-format
 msgid "Thank you. The reply was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:256
+#: lib/vutuv_web/live/post_live/thread.ex:328
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1112
-#: lib/vutuv_web/components/post_components.ex:969
-#: lib/vutuv_web/components/post_components.ex:1694
+#: lib/vutuv_web/components/post_components.ex:1055
+#: lib/vutuv_web/components/post_components.ex:1764
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15757,8 +15758,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:168
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:139
-#: lib/vutuv_web/live/post_live/feed.ex:420
-#: lib/vutuv_web/live/post_live/thread.ex:252
+#: lib/vutuv_web/live/post_live/feed.ex:426
+#: lib/vutuv_web/live/post_live/thread.ex:324
 #: lib/vutuv_web/live/tag_live/timeline.ex:138
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16184,7 +16185,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:198
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
-#: lib/vutuv_web/live/tag_live/timeline.ex:394
+#: lib/vutuv_web/live/tag_live/timeline.ex:397
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16404,22 +16405,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2205
+#: lib/vutuv_web/components/post_components.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2312
+#: lib/vutuv_web/components/post_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2320
+#: lib/vutuv_web/components/post_components.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2306
+#: lib/vutuv_web/components/post_components.ex:2401
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16505,7 +16506,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1040
 #: lib/vutuv_web/agent_docs/text.ex:654
-#: lib/vutuv_web/components/post_components.ex:2777
+#: lib/vutuv_web/components/post_components.ex:2872
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16535,7 +16536,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2776
+#: lib/vutuv_web/components/post_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16545,29 +16546,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:3250
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1779
+#: lib/vutuv_web/components/post_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3158
+#: lib/vutuv_web/components/post_components.ex:3253
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2983
+#: lib/vutuv_web/components/post_components.ex:3078
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2521
+#: lib/vutuv_web/components/post_components.ex:2616
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16580,12 +16581,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1073
 #: lib/vutuv_web/agent_docs/text.ex:641
-#: lib/vutuv_web/components/post_components.ex:3192
+#: lib/vutuv_web/components/post_components.ex:3287
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2775
+#: lib/vutuv_web/components/post_components.ex:2870
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
@@ -16606,7 +16607,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1832
+#: lib/vutuv_web/components/post_components.ex:1913
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16626,7 +16627,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1823
+#: lib/vutuv_web/components/post_components.ex:1904
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16636,12 +16637,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1841
+#: lib/vutuv_web/components/post_components.ex:1922
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1775
+#: lib/vutuv_web/components/post_components.ex:1856
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16656,7 +16657,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1836
+#: lib/vutuv_web/components/post_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16666,7 +16667,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1789
+#: lib/vutuv_web/components/post_components.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16687,8 +16688,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1018
-#: lib/vutuv_web/live/post_live/feed.ex:1019
+#: lib/vutuv_web/live/post_live/feed.ex:1024
+#: lib/vutuv_web/live/post_live/feed.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
@@ -16753,13 +16754,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:969
-#: lib/vutuv_web/components/post_components.ex:4112
+#: lib/vutuv_web/components/post_components.ex:4207
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:967
-#: lib/vutuv_web/components/post_components.ex:4109
+#: lib/vutuv_web/components/post_components.ex:4204
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16769,7 +16770,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4001
+#: lib/vutuv_web/components/post_components.ex:4096
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -17106,20 +17107,20 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1574
+#: lib/vutuv_web/components/post_components.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:160
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:131
-#: lib/vutuv_web/live/post_live/feed.ex:412
+#: lib/vutuv_web/live/post_live/feed.ex:418
 #: lib/vutuv_web/live/tag_live/timeline.ex:130
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1693
+#: lib/vutuv_web/components/post_components.ex:1763
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -17139,23 +17140,23 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1212
+#: lib/vutuv_web/components/post_components.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1591
+#: lib/vutuv_web/components/post_components.ex:1663
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1553
+#: lib/vutuv_web/components/post_components.ex:1625
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:264
-#: lib/vutuv_web/live/post_live/feed.ex:470
+#: lib/vutuv_web/live/post_live/feed.ex:476
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr ""
@@ -17165,7 +17166,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1560
+#: lib/vutuv_web/components/post_components.ex:1632
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17387,27 +17388,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1381
+#: lib/vutuv_web/components/post_components.ex:1453
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1410
+#: lib/vutuv_web/components/post_components.ex:1482
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1405
+#: lib/vutuv_web/components/post_components.ex:1477
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1711
+#: lib/vutuv_web/components/post_components.ex:1789
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1714
+#: lib/vutuv_web/components/post_components.ex:1795
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17417,7 +17418,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1827
+#: lib/vutuv_web/components/post_components.ex:1908
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17429,7 +17430,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:193
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:110
-#: lib/vutuv_web/live/post_live/feed.ex:448
+#: lib/vutuv_web/live/post_live/feed.ex:454
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr ""
@@ -18163,39 +18164,44 @@ msgstr ""
 msgid "View the conversation"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:251
+#: lib/vutuv_web/live/tag_live/timeline.ex:254
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
 msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:378
+#: lib/vutuv_web/live/tag_live/timeline.ex:381
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:402
+#: lib/vutuv_web/live/tag_live/timeline.ex:405
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:400
+#: lib/vutuv_web/live/tag_live/timeline.ex:403
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:397
+#: lib/vutuv_web/live/tag_live/timeline.ex:400
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:334
+#: lib/vutuv_web/live/tag_live/timeline.ex:337
 #, elixir-autogen, elixir-format
 msgid "Posts from other networks carry no public like count here, so they come last in this order."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:284
+#: lib/vutuv_web/live/tag_live/timeline.ex:287
 #, elixir-autogen, elixir-format
 msgid "word in a post"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1792
+#, elixir-autogen, elixir-format
+msgid "That reply is not here any more."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2328
+#: lib/vutuv_web/components/post_components.ex:2423
 #: lib/vutuv_web/components/ui.ex:3140
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2293
+#: lib/vutuv_web/components/post_components.ex:2388
 #: lib/vutuv_web/components/ui.ex:3131
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -652,7 +652,7 @@ msgstr ""
 #: lib/vutuv_web/live/search_live.ex:378
 #: lib/vutuv_web/live/shell_live.ex:481
 #: lib/vutuv_web/live/shell_live.ex:637
-#: lib/vutuv_web/live/tag_live/timeline.ex:275
+#: lib/vutuv_web/live/tag_live/timeline.ex:278
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:29
@@ -661,7 +661,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1209
+#: lib/vutuv_web/components/post_components.ex:1279
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1662,7 +1662,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2774
+#: lib/vutuv_web/components/post_components.ex:2869
 #: lib/vutuv_web/components/ui.ex:244
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1214
+#: lib/vutuv_web/live/post_live/feed.ex:1224
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2142,7 +2142,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2325
+#: lib/vutuv_web/components/post_components.ex:2420
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2154,8 +2154,8 @@ msgstr ""
 msgid "Edit post"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:149
-#: lib/vutuv_web/live/post_live/feed.ex:984
+#: lib/vutuv_web/live/post_live/feed.ex:154
+#: lib/vutuv_web/live/post_live/feed.ex:990
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:122
@@ -2183,8 +2183,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2279
-#: lib/vutuv_web/components/post_components.ex:2281
+#: lib/vutuv_web/components/post_components.ex:2374
+#: lib/vutuv_web/components/post_components.ex:2376
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2200,7 +2200,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1153
+#: lib/vutuv_web/live/post_live/feed.ex:1163
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2249,13 +2249,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2710
-#: lib/vutuv_web/components/post_components.ex:2714
+#: lib/vutuv_web/components/post_components.ex:2805
+#: lib/vutuv_web/components/post_components.ex:2809
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2711
+#: lib/vutuv_web/components/post_components.ex:2806
 #: lib/vutuv_web/live/fediverse_account_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2263,7 +2263,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:252
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:943
+#: lib/vutuv_web/components/post_components.ex:982
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1073
+#: lib/vutuv_web/live/post_live/feed.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2344,27 +2344,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2276
+#: lib/vutuv_web/components/post_components.ex:2371
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3841
+#: lib/vutuv_web/components/post_components.ex:3936
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3845
+#: lib/vutuv_web/components/post_components.ex:3940
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3843
+#: lib/vutuv_web/components/post_components.ex:3938
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3844
+#: lib/vutuv_web/components/post_components.ex:3939
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2405,7 +2405,7 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3925
+#: lib/vutuv_web/components/post_components.ex:4020
 #: lib/vutuv_web/components/ui.ex:2665
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2422,8 +2422,9 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1630
-#: lib/vutuv_web/components/post_components.ex:4148
+#: lib/vutuv_web/components/post_components.ex:1041
+#: lib/vutuv_web/components/post_components.ex:1705
+#: lib/vutuv_web/components/post_components.ex:4243
 #: lib/vutuv_web/components/ui.ex:2651
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #: lib/vutuv_web/templates/user/show.html.heex:192
@@ -2432,7 +2433,7 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:932
-#: lib/vutuv_web/components/post_components.ex:4157
+#: lib/vutuv_web/components/post_components.ex:4252
 #: lib/vutuv_web/live/notification_live/index.ex:940
 #: lib/vutuv_web/live/post_live/saved.ex:138
 #: lib/vutuv_web/live/post_live/saved.ex:439
@@ -2452,37 +2453,37 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3914
+#: lib/vutuv_web/components/post_components.ex:4009
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3925
+#: lib/vutuv_web/components/post_components.ex:4020
 #: lib/vutuv_web/live/post_live/saved.ex:694
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1654
-#: lib/vutuv_web/components/post_components.ex:3911
+#: lib/vutuv_web/components/post_components.ex:1743
+#: lib/vutuv_web/components/post_components.ex:4006
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1336
-#: lib/vutuv_web/components/post_components.ex:3288
+#: lib/vutuv_web/components/post_components.ex:1408
+#: lib/vutuv_web/components/post_components.ex:3383
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3911
+#: lib/vutuv_web/components/post_components.ex:4006
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4148
+#: lib/vutuv_web/components/post_components.ex:4243
 #: lib/vutuv_web/live/post_live/saved.ex:693
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
@@ -2493,7 +2494,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1750
 #: lib/vutuv_web/components/ui.ex:1750
 #: lib/vutuv_web/components/ui.ex:1887
-#: lib/vutuv_web/live/post_live/feed.ex:1203
+#: lib/vutuv_web/live/post_live/feed.ex:1213
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2504,7 +2505,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4201
+#: lib/vutuv_web/components/post_components.ex:4296
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2515,17 +2516,17 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:983
-#: lib/vutuv_web/components/post_components.ex:1682
-#: lib/vutuv_web/components/post_components.ex:4184
-#: lib/vutuv_web/components/post_components.ex:4185
+#: lib/vutuv_web/components/post_components.ex:1051
+#: lib/vutuv_web/components/post_components.ex:1719
+#: lib/vutuv_web/components/post_components.ex:4279
+#: lib/vutuv_web/components/post_components.ex:4280
 #: lib/vutuv_web/live/notification_live/index.ex:1000
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2247
+#: lib/vutuv_web/components/post_components.ex:2342
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2546,7 +2547,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1767
+#: lib/vutuv_web/components/post_components.ex:1848
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2554,14 +2555,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2223
+#: lib/vutuv_web/components/post_components.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2217
-#: lib/vutuv_web/components/post_components.ex:2239
-#: lib/vutuv_web/components/post_components.ex:2242
+#: lib/vutuv_web/components/post_components.ex:2312
+#: lib/vutuv_web/components/post_components.ex:2334
+#: lib/vutuv_web/components/post_components.ex:2337
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2784,7 +2785,7 @@ msgstr ""
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1009
+#: lib/vutuv_web/live/post_live/feed.ex:1015
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2863,7 +2864,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3842
+#: lib/vutuv_web/components/post_components.ex:3937
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3124,7 +3125,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2193
+#: lib/vutuv_web/components/post_components.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3199,9 +3200,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:953
-#: lib/vutuv_web/components/post_components.ex:1565
-#: lib/vutuv_web/components/post_components.ex:2349
+#: lib/vutuv_web/components/post_components.ex:992
+#: lib/vutuv_web/components/post_components.ex:1637
+#: lib/vutuv_web/components/post_components.ex:2444
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4560,7 +4561,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1158
+#: lib/vutuv_web/live/post_live/feed.ex:1168
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -5429,11 +5430,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2412
-#: lib/vutuv_web/components/post_components.ex:2464
-#: lib/vutuv_web/components/post_components.ex:2854
+#: lib/vutuv_web/components/post_components.ex:2507
+#: lib/vutuv_web/components/post_components.ex:2559
+#: lib/vutuv_web/components/post_components.ex:2949
 #: lib/vutuv_web/live/notification_live/index.ex:680
-#: lib/vutuv_web/live/post_live/feed.ex:1276
+#: lib/vutuv_web/live/post_live/feed.ex:1286
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5807,7 +5808,7 @@ msgid "Name (A-Z)"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:420
-#: lib/vutuv_web/live/tag_live/timeline.ex:376
+#: lib/vutuv_web/live/tag_live/timeline.ex:379
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
@@ -5833,7 +5834,7 @@ msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:421
-#: lib/vutuv_web/live/tag_live/timeline.ex:377
+#: lib/vutuv_web/live/tag_live/timeline.ex:380
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
@@ -5855,7 +5856,7 @@ msgid "Search saved items"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/saved.ex:472
-#: lib/vutuv_web/live/tag_live/timeline.ex:291
+#: lib/vutuv_web/live/tag_live/timeline.ex:294
 #, elixir-autogen, elixir-format
 msgid "Sort"
 msgstr ""
@@ -6674,7 +6675,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2346
+#: lib/vutuv_web/components/post_components.ex:2441
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6684,7 +6685,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2345
+#: lib/vutuv_web/components/post_components.ex:2440
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7367,7 +7368,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4070
+#: lib/vutuv_web/components/post_components.ex:4165
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7936,7 +7937,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:231
 #: lib/vutuv_web/live/admin/user_live.ex:184
 #: lib/vutuv_web/live/job_board_live.ex:257
-#: lib/vutuv_web/live/tag_live/timeline.ex:321
+#: lib/vutuv_web/live/tag_live/timeline.ex:324
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -8485,13 +8486,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1243
-#: lib/vutuv_web/live/post_live/feed.ex:1244
+#: lib/vutuv_web/live/post_live/feed.ex:1253
+#: lib/vutuv_web/live/post_live/feed.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1238
+#: lib/vutuv_web/live/post_live/feed.ex:1248
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8842,7 +8843,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3291
+#: lib/vutuv_web/components/post_components.ex:3386
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -12325,7 +12326,7 @@ msgid "Everyone (public)"
 msgstr ""
 
 #: lib/vutuv_web/live/job_posting_live/form.ex:452
-#: lib/vutuv_web/live/tag_live/timeline.ex:302
+#: lib/vutuv_web/live/tag_live/timeline.ex:305
 #: lib/vutuv_web/templates/education/form_content.html.heex:41
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:63
 #, elixir-autogen, elixir-format
@@ -13278,7 +13279,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1726
+#: lib/vutuv_web/components/post_components.ex:1807
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -13664,7 +13665,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:189
 #: lib/vutuv_web/agent_docs/text.ex:177
-#: lib/vutuv_web/live/tag_live/timeline.ex:248
+#: lib/vutuv_web/live/tag_live/timeline.ex:251
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
 msgstr ""
@@ -13716,14 +13717,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3474
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:1189
+#: lib/vutuv_web/live/post_live/feed.ex:1199
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1204
+#: lib/vutuv_web/live/post_live/feed.ex:1214
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13879,34 +13880,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3704
+#: lib/vutuv_web/components/post_components.ex:3799
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3661
+#: lib/vutuv_web/components/post_components.ex:3756
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3705
+#: lib/vutuv_web/components/post_components.ex:3800
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3707
+#: lib/vutuv_web/components/post_components.ex:3802
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3703
+#: lib/vutuv_web/components/post_components.ex:3798
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3660
+#: lib/vutuv_web/components/post_components.ex:3755
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13917,12 +13918,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3702
+#: lib/vutuv_web/components/post_components.ex:3797
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3706
+#: lib/vutuv_web/components/post_components.ex:3801
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13942,34 +13943,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3743
+#: lib/vutuv_web/components/post_components.ex:3838
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3773
+#: lib/vutuv_web/components/post_components.ex:3868
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3774
+#: lib/vutuv_web/components/post_components.ex:3869
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3772
+#: lib/vutuv_web/components/post_components.ex:3867
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3732
+#: lib/vutuv_web/components/post_components.ex:3827
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3779
+#: lib/vutuv_web/components/post_components.ex:3874
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13999,7 +14000,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3546
+#: lib/vutuv_web/components/post_components.ex:3641
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14047,7 +14048,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3537
+#: lib/vutuv_web/components/post_components.ex:3632
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14401,7 +14402,7 @@ msgstr ""
 msgid "No accounts are currently frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:352
+#: lib/vutuv_web/live/post_live/thread.ex:426
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr ""
@@ -14421,14 +14422,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1973
+#: lib/vutuv_web/components/post_components.ex:2063
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1995
+#: lib/vutuv_web/components/post_components.ex:2085
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14440,7 +14441,7 @@ msgstr[1] ""
 msgid "This page is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:344
+#: lib/vutuv_web/live/post_live/thread.ex:418
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr ""
@@ -14455,7 +14456,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4156
+#: lib/vutuv_web/components/post_components.ex:4251
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14602,7 +14603,7 @@ msgstr ""
 msgid "Filter removed."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:284
+#: lib/vutuv_web/live/post_live/feed.ex:290
 #, elixir-autogen, elixir-format
 msgid "Hidden: matches your filter"
 msgstr ""
@@ -14635,7 +14636,7 @@ msgstr ""
 msgid "Pick a degree or school below to show it at the top of your profile instead of a job title."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:293
+#: lib/vutuv_web/live/post_live/feed.ex:299
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -15166,7 +15167,7 @@ msgstr ""
 msgid "ZIP or postal code"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:309
+#: lib/vutuv_web/live/tag_live/timeline.ex:312
 #: lib/vutuv_web/templates/education/form_content.html.heex:59
 #: lib/vutuv_web/templates/work_experience/form_content.html.heex:81
 #, elixir-autogen, elixir-format
@@ -15627,21 +15628,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4115
+#: lib/vutuv_web/components/post_components.ex:4210
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4119
+#: lib/vutuv_web/components/post_components.ex:4214
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4123
+#: lib/vutuv_web/components/post_components.ex:4218
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15649,7 +15650,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:951
-#: lib/vutuv_web/components/post_components.ex:4074
+#: lib/vutuv_web/components/post_components.ex:4169
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15665,14 +15666,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1054
-#: lib/vutuv_web/components/post_components.ex:1278
+#: lib/vutuv_web/components/post_components.ex:1124
+#: lib/vutuv_web/components/post_components.ex:1350
 #: lib/vutuv_web/live/fediverse_account_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:941
+#: lib/vutuv_web/components/post_components.ex:980
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15694,12 +15695,12 @@ msgstr ""
 msgid "Reply from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:138
+#: lib/vutuv_web/live/post_live/thread.ex:148
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:950
+#: lib/vutuv_web/components/post_components.ex:989
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15709,7 +15710,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:964
+#: lib/vutuv_web/components/post_components.ex:1003
 #: lib/vutuv_web/live/notification_live/index.ex:534
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15730,19 +15731,19 @@ msgstr ""
 msgid "Taken down"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:147
+#: lib/vutuv_web/live/post_live/thread.ex:157
 #, elixir-autogen, elixir-format
 msgid "Thank you. The reply was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:256
+#: lib/vutuv_web/live/post_live/thread.ex:328
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1112
-#: lib/vutuv_web/components/post_components.ex:969
-#: lib/vutuv_web/components/post_components.ex:1694
+#: lib/vutuv_web/components/post_components.ex:1055
+#: lib/vutuv_web/components/post_components.ex:1764
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15755,8 +15756,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:168
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:139
-#: lib/vutuv_web/live/post_live/feed.ex:420
-#: lib/vutuv_web/live/post_live/thread.ex:252
+#: lib/vutuv_web/live/post_live/feed.ex:426
+#: lib/vutuv_web/live/post_live/thread.ex:324
 #: lib/vutuv_web/live/tag_live/timeline.ex:138
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16182,7 +16183,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:198
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
-#: lib/vutuv_web/live/tag_live/timeline.ex:394
+#: lib/vutuv_web/live/tag_live/timeline.ex:397
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16402,22 +16403,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2205
+#: lib/vutuv_web/components/post_components.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2312
+#: lib/vutuv_web/components/post_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2320
+#: lib/vutuv_web/components/post_components.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2306
+#: lib/vutuv_web/components/post_components.ex:2401
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16503,7 +16504,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1040
 #: lib/vutuv_web/agent_docs/text.ex:654
-#: lib/vutuv_web/components/post_components.ex:2777
+#: lib/vutuv_web/components/post_components.ex:2872
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16533,7 +16534,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2776
+#: lib/vutuv_web/components/post_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16543,29 +16544,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3155
+#: lib/vutuv_web/components/post_components.ex:3250
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1779
+#: lib/vutuv_web/components/post_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3158
+#: lib/vutuv_web/components/post_components.ex:3253
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2983
+#: lib/vutuv_web/components/post_components.ex:3078
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2521
+#: lib/vutuv_web/components/post_components.ex:2616
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16578,12 +16579,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1073
 #: lib/vutuv_web/agent_docs/text.ex:641
-#: lib/vutuv_web/components/post_components.ex:3192
+#: lib/vutuv_web/components/post_components.ex:3287
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2775
+#: lib/vutuv_web/components/post_components.ex:2870
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
@@ -16604,7 +16605,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1832
+#: lib/vutuv_web/components/post_components.ex:1913
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16624,7 +16625,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1823
+#: lib/vutuv_web/components/post_components.ex:1904
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16634,12 +16635,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1841
+#: lib/vutuv_web/components/post_components.ex:1922
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1775
+#: lib/vutuv_web/components/post_components.ex:1856
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16654,7 +16655,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1836
+#: lib/vutuv_web/components/post_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16664,7 +16665,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1789
+#: lib/vutuv_web/components/post_components.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16685,8 +16686,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1018
-#: lib/vutuv_web/live/post_live/feed.ex:1019
+#: lib/vutuv_web/live/post_live/feed.ex:1024
+#: lib/vutuv_web/live/post_live/feed.ex:1025
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
@@ -16751,13 +16752,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:969
-#: lib/vutuv_web/components/post_components.ex:4112
+#: lib/vutuv_web/components/post_components.ex:4207
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:967
-#: lib/vutuv_web/components/post_components.ex:4109
+#: lib/vutuv_web/components/post_components.ex:4204
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16767,7 +16768,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4001
+#: lib/vutuv_web/components/post_components.ex:4096
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -17104,20 +17105,20 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1574
+#: lib/vutuv_web/components/post_components.ex:1646
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:160
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:131
-#: lib/vutuv_web/live/post_live/feed.ex:412
+#: lib/vutuv_web/live/post_live/feed.ex:418
 #: lib/vutuv_web/live/tag_live/timeline.ex:130
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1693
+#: lib/vutuv_web/components/post_components.ex:1763
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -17137,23 +17138,23 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1212
+#: lib/vutuv_web/components/post_components.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1591
+#: lib/vutuv_web/components/post_components.ex:1663
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1553
+#: lib/vutuv_web/components/post_components.ex:1625
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mute %{handle}"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:264
-#: lib/vutuv_web/live/post_live/feed.ex:470
+#: lib/vutuv_web/live/post_live/feed.ex:476
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr ""
@@ -17163,7 +17164,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1560
+#: lib/vutuv_web/components/post_components.ex:1632
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17385,27 +17386,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1381
+#: lib/vutuv_web/components/post_components.ex:1453
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1410
+#: lib/vutuv_web/components/post_components.ex:1482
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1405
+#: lib/vutuv_web/components/post_components.ex:1477
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1711
+#: lib/vutuv_web/components/post_components.ex:1789
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1714
+#: lib/vutuv_web/components/post_components.ex:1795
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17415,7 +17416,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1827
+#: lib/vutuv_web/components/post_components.ex:1908
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17427,7 +17428,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:193
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:110
-#: lib/vutuv_web/live/post_live/feed.ex:448
+#: lib/vutuv_web/live/post_live/feed.ex:454
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr ""
@@ -18161,39 +18162,44 @@ msgstr ""
 msgid "View the conversation"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:251
+#: lib/vutuv_web/live/tag_live/timeline.ex:254
 #, elixir-autogen, elixir-format
 msgid "%{formatted} post"
 msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:378
+#: lib/vutuv_web/live/tag_live/timeline.ex:381
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:402
+#: lib/vutuv_web/live/tag_live/timeline.ex:405
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:400
+#: lib/vutuv_web/live/tag_live/timeline.ex:403
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:397
+#: lib/vutuv_web/live/tag_live/timeline.ex:400
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:334
+#: lib/vutuv_web/live/tag_live/timeline.ex:337
 #, elixir-autogen, elixir-format
 msgid "Posts from other networks carry no public like count here, so they come last in this order."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:284
+#: lib/vutuv_web/live/tag_live/timeline.ex:287
 #, elixir-autogen, elixir-format
 msgid "word in a post"
+msgstr ""
+
+#: lib/vutuv_web/components/post_components.ex:1792
+#, elixir-autogen, elixir-format
+msgid "That reply is not here any more."
 msgstr ""

--- a/priv/repo/migrations/20260731163656_create_fediverse_note_likes.exs
+++ b/priv/repo/migrations/20260731163656_create_fediverse_note_likes.exs
@@ -1,0 +1,35 @@
+defmodule Vutuv.Repo.Migrations.CreateFediverseNoteLikes do
+  use Ecto.Migration
+
+  @moduledoc """
+  A member's like of a **reply** that arrived from another network under a vutuv
+  post (issue #1270) — the sibling of `fediverse_post_likes`, one table further
+  down the conversation.
+
+  Same rules as that table, for the same reasons: the row is the local marker
+  and the `Like` delivered to the author's own inbox is what their server
+  counts; there is no count column, because vutuv cannot know a reply's real
+  tally and a figure assembled from the likes that happened to pass through this
+  installation would read as the real one while being a fraction of it; and the
+  row cascades away with the cached reply, whose retention is six months,
+  without anything being lost — a re-like afterwards sends a duplicate every
+  implementation treats as a no-op.
+  """
+
+  def change do
+    create table(:fediverse_note_likes) do
+      add(:user_id, references(:users, on_delete: :delete_all), null: false)
+      add(:note_id, references(:fediverse_notes, on_delete: :delete_all), null: false)
+
+      timestamps(updated_at: false)
+    end
+
+    # The pair is the identity: liking twice is the same like. It also serves
+    # the per-member lookup the conversation batches ("which of the replies on
+    # this page do I already like"), left-most column first.
+    create(unique_index(:fediverse_note_likes, [:user_id, :note_id]))
+    # The cascade's own index: without it every note delete sequentially scans
+    # this table, and the sweeper deletes expired notes in bulk.
+    create(index(:fediverse_note_likes, [:note_id]))
+  end
+end

--- a/test/vutuv/export_test.exs
+++ b/test/vutuv/export_test.exs
@@ -39,7 +39,7 @@ defmodule Vutuv.ExportTest do
 
     data = Export.build(user)
 
-    assert data.schema_version == 7
+    assert data.schema_version == 8
     assert Enum.any?(data.blocked_members, &(&1.member == blocked.username))
     # The private content filters (issue #940) are owner-only, so they ride
     # along in the member's own GDPR export.

--- a/test/vutuv/fediverse_note_likes_test.exs
+++ b/test/vutuv/fediverse_note_likes_test.exs
@@ -1,0 +1,329 @@
+defmodule Vutuv.FediverseNoteLikesTest do
+  @moduledoc """
+  Liking a reply that arrived from another network under a vutuv post (issue
+  #1270): what is stored, what leaves the building, and what refuses.
+
+  The sibling of `Vutuv.FediversePostLikesTest`, and deliberately its shape —
+  the two acts differ only in which row they are keyed to, so a claim that
+  holds there and not here is a drift worth failing on.
+
+  `async: false` — the outbound budget lives in the shared `Vutuv.RateLimiter`
+  ETS table, which the SQL sandbox does not roll back.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.NoteLike
+
+  @actor "https://social.example/users/them"
+  @inbox "https://social.example/users/them/inbox"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  # The member whose post the reply answers. Not the one doing the liking in
+  # most tests — a reply under your own post is the common case, but liking one
+  # is not the owner's privilege.
+  defp author, do: insert(:activated_user)
+
+  defp post_of(user), do: insert(:post, user: user)
+
+  defp note(post, attrs \\ []) do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(%Note{
+      post_id: post.id,
+      object_uri:
+        attrs[:object_uri] || "https://social.example/n/#{System.unique_integer([:positive])}",
+      actor_uri: attrs[:actor_uri] || @actor,
+      origin_url: "https://social.example/@them/1",
+      handle: "them",
+      display_name: "Thea Remote",
+      content_text: "Etwas Lesenswertes.",
+      audience: attrs[:audience] || "public",
+      inbox_uri: Keyword.get(attrs, :inbox_uri, @inbox),
+      received_at: now,
+      checked_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+  end
+
+  # A member who really federates: the Like is signed with their own actor key,
+  # so an actorless member has nothing to send.
+  defp federating_member do
+    user = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    Repo.reload!(user)
+  end
+
+  defp queued do
+    from(d in Delivery, order_by: [asc: d.id])
+    |> Repo.all()
+    |> Enum.map(&Jason.decode!(&1.activity_json))
+  end
+
+  describe "liking" do
+    setup do
+      %{user: federating_member(), note: note(post_of(author()))}
+    end
+
+    test "stores the marker and queues a signed Like to the author's own inbox", ctx do
+      assert {:ok, :liked} = Fediverse.like_note(ctx.user, ctx.note)
+
+      assert Repo.aggregate(NoteLike, :count) == 1
+      assert [delivery] = Repo.all(Delivery)
+      assert delivery.inbox_uri == @inbox
+
+      assert [%{"type" => "Like", "object" => object, "to" => to}] = queued()
+      assert object == ctx.note.object_uri
+      # To the author alone — telling a member's own followers what they liked
+      # would publish a reading habit nobody asked to publish.
+      assert to == [@actor]
+    end
+
+    test "liking twice is one like and one activity", ctx do
+      assert {:ok, :liked} = Fediverse.like_note(ctx.user, ctx.note)
+      assert {:ok, :already} = Fediverse.like_note(ctx.user, ctx.note)
+
+      assert Repo.aggregate(NoteLike, :count) == 1
+      assert length(queued()) == 1
+    end
+
+    test "the member a private reply was addressed to may like it", _ctx do
+      user = federating_member()
+      note = note(post_of(user), audience: "direct")
+
+      # No audience gate here, unlike answering: a Like is addressed to the
+      # author alone and publishes nothing, so it cannot widen what its sender
+      # chose.
+      assert :ok = Fediverse.check_note_like(user, note)
+      assert {:ok, :liked} = Fediverse.like_note(user, note)
+      assert [%{"to" => [@actor]}] = queued()
+    end
+
+    test "which replies a member likes comes back in one query", ctx do
+      other = note(post_of(author()))
+      {:ok, :liked} = Fediverse.like_note(ctx.user, ctx.note)
+
+      liked = Fediverse.liked_note_ids(ctx.user, [ctx.note.id, other.id])
+
+      assert MapSet.member?(liked, ctx.note.id)
+      refute MapSet.member?(liked, other.id)
+      # A logged-out reader likes nothing, and must not blow up asking.
+      assert MapSet.size(Fediverse.liked_note_ids(nil, [ctx.note.id])) == 0
+    end
+  end
+
+  describe "unliking" do
+    setup do
+      user = federating_member()
+      note = note(post_of(author()))
+      {:ok, :liked} = Fediverse.like_note(user, note)
+      %{user: user, note: note}
+    end
+
+    test "drops the marker and queues the matching Undo", ctx do
+      assert {:ok, :unliked} = Fediverse.unlike_note(ctx.user, ctx.note)
+
+      assert Repo.aggregate(NoteLike, :count) == 0
+
+      assert [%{"type" => "Like", "id" => like_id}, %{"type" => "Undo"} = undo] = queued()
+      # The wrapped Like repeats the id the original carried, so the other
+      # server drops that exact activity instead of guessing.
+      assert undo["object"]["id"] == like_id
+      assert undo["object"]["type"] == "Like"
+    end
+
+    test "unliking what was never liked sends nothing", ctx do
+      {:ok, :unliked} = Fediverse.unlike_note(ctx.user, ctx.note)
+      before = length(queued())
+
+      assert {:ok, :already} = Fediverse.unlike_note(ctx.user, ctx.note)
+      assert length(queued()) == before
+    end
+
+    test "a like → unlike → like cycle reuses one stable activity id", ctx do
+      {:ok, :unliked} = Fediverse.unlike_note(ctx.user, ctx.note)
+      {:ok, :liked} = Fediverse.like_note(ctx.user, ctx.note)
+
+      ids = queued() |> Enum.filter(&(&1["type"] == "Like")) |> Enum.map(& &1["id"])
+      assert [id, id] = ids
+    end
+  end
+
+  describe "the gates" do
+    test "a member who does not federate is told so, and nothing goes out" do
+      user = insert(:activated_user)
+      note = note(post_of(author()))
+
+      assert {:error, :not_federating} = Fediverse.check_note_like(user, note)
+      assert {:error, :not_federating} = Fediverse.like_note(user, note)
+      assert queued() == []
+    end
+
+    test "a blocked server refuses, and its replies are gone anyway" do
+      user = federating_member()
+      note = note(post_of(author()), actor_uri: "https://blocked.example/users/them")
+
+      {:ok, _} =
+        Fediverse.block_instance(%{"host" => "blocked.example"}, insert(:user, admin?: true))
+
+      # The gate says so on the struct in hand — a block shuts both directions.
+      assert {:error, :instance_blocked} = Fediverse.check_note_like(user, note)
+      # And the write path never gets that far, because blocking a server also
+      # deletes the replies its members wrote here (`purge_instance/1`). Either
+      # refusal is correct; what matters is that nothing is written or sent.
+      assert {:error, :not_found} = Fediverse.like_note(user, note)
+      assert Repo.aggregate(NoteLike, :count) == 0
+      assert queued() == []
+    end
+
+    test "a reply with no inbox address cannot be liked at all" do
+      user = federating_member()
+      note = note(post_of(author()), inbox_uri: nil)
+
+      # Replies stored before the answering feature carry no address. A marker
+      # written anyway would paint a heart for a Like the author's server never
+      # hears about, so the card offers none — and the write path refuses too,
+      # since the id in a click is the member's to choose.
+      refute Note.likeable?(note)
+      assert {:error, :not_deliverable} = Fediverse.check_note_like(user, note)
+      assert {:error, :not_deliverable} = Fediverse.like_note(user, note)
+      assert Repo.aggregate(NoteLike, :count) == 0
+      assert queued() == []
+    end
+
+    test "a private reply under somebody else's post is refused" do
+      user = federating_member()
+      note = note(post_of(author()), audience: "direct")
+
+      # The id in a click is attacker-controlled, so the gate asks the same
+      # question `list_notes/2` asks in SQL rather than trusting the render.
+      assert {:error, :not_visible} = Fediverse.check_note_like(user, note)
+      assert {:error, :not_visible} = Fediverse.like_note(user, note)
+      assert Repo.aggregate(NoteLike, :count) == 0
+    end
+
+    test "answers instead of crashing when the row went between render and click" do
+      user = federating_member()
+      note = note(post_of(author()))
+      # Expiry, an upstream Delete, a takedown or an instance block took the row
+      # while the card sat on somebody's screen. The insert would otherwise hit
+      # the foreign key and take the LiveView with it.
+      Repo.delete!(note)
+
+      assert {:error, :not_found} = Fediverse.like_note(user, note)
+      assert Repo.aggregate(NoteLike, :count) == 0
+    end
+
+    test "the hourly budget refuses past the limit, and is the post heart's own" do
+      Application.put_env(:vutuv, :fediverse_outbound_like_limit, 1)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_outbound_like_limit) end)
+
+      user = federating_member()
+      post = post_of(author())
+
+      assert {:ok, :liked} = Fediverse.like_note(user, note(post))
+      assert {:error, :like_capped} = Fediverse.like_note(user, note(post))
+    end
+
+    test "a capped like leaves no marker behind" do
+      Application.put_env(:vutuv, :fediverse_outbound_like_limit, 1)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_outbound_like_limit) end)
+
+      user = federating_member()
+      post = post_of(author())
+      {:ok, :liked} = Fediverse.like_note(user, note(post))
+
+      assert {:error, :like_capped} = Fediverse.like_note(user, note(post))
+      # A heart painted for a like that never left is the one disagreement a
+      # member cannot fix from here, so the marker is rolled back.
+      assert Repo.aggregate(NoteLike, :count) == 1
+    end
+
+    test "a repeat that sends nothing does not spend a slot" do
+      Application.put_env(:vutuv, :fediverse_outbound_like_limit, 1)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_outbound_like_limit) end)
+
+      user = federating_member()
+      note = note(post_of(author()))
+
+      assert {:ok, :liked} = Fediverse.like_note(user, note)
+      assert {:ok, :already} = Fediverse.like_note(user, note)
+      assert length(queued()) == 1
+    end
+
+    test "taking a like back is never refused by the budget" do
+      user = federating_member()
+      post = post_of(author())
+      note = note(post)
+      {:ok, :liked} = Fediverse.like_note(user, note)
+
+      Application.put_env(:vutuv, :fediverse_outbound_like_limit, 1)
+      on_exit(fn -> Application.delete_env(:vutuv, :fediverse_outbound_like_limit) end)
+      {:error, :like_capped} = Fediverse.like_note(user, note(post))
+
+      assert {:ok, :unliked} = Fediverse.unlike_note(user, note)
+    end
+  end
+
+  describe "leaving the Fediverse" do
+    test "withdraws every like on a reply and drops the markers" do
+      user = federating_member()
+      note = note(post_of(author()))
+      {:ok, :liked} = Fediverse.like_note(user, note)
+
+      assert Fediverse.drop_note_likes(user) == 1
+
+      assert Repo.aggregate(NoteLike, :count) == 0
+      # What stood on another server under their name goes with the decision
+      # rather than after it.
+      assert [%{"type" => "Like"}, %{"type" => "Undo"}] = queued()
+    end
+
+    test "switching Fediverse participation off takes them with it" do
+      user = federating_member()
+      {:ok, :liked} = Fediverse.like_note(user, note(post_of(author())))
+
+      # The rows about people on other networks go in both directions, and a
+      # note like hangs off no follow, so nothing else would ever take it.
+      Fediverse.drop_remote_follows(user)
+
+      assert Repo.aggregate(NoteLike, :count) == 0
+      assert Enum.any?(queued(), &(&1["type"] == "Undo"))
+    end
+  end
+
+  describe "the reply going away" do
+    test "takes its likes with it, without leaving an orphan" do
+      user = federating_member()
+      note = note(post_of(author()))
+      {:ok, :liked} = Fediverse.like_note(user, note)
+
+      Repo.delete!(note)
+
+      # Our copy is a six-month cache; the like on the author's server is not
+      # ours to keep alive, so the row cascades rather than dangling.
+      assert Repo.aggregate(NoteLike, :count) == 0
+    end
+  end
+
+  describe "the GDPR export" do
+    test "lists a liked reply as the member's own act" do
+      user = federating_member()
+      note = note(post_of(author()))
+      {:ok, :liked} = Fediverse.like_note(user, note)
+
+      assert [entry] = Vutuv.Export.build(user).fediverse_likes
+
+      assert entry.kind == "reply"
+      assert entry.post == note.origin_url
+      assert entry.author == "@them@social.example"
+      assert entry.server == "social.example"
+    end
+  end
+end

--- a/test/vutuv_web/live/post_thread_remote_replies_test.exs
+++ b/test/vutuv_web/live/post_thread_remote_replies_test.exs
@@ -12,6 +12,7 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
   import Phoenix.LiveViewTest
   import Vutuv.PostsHelpers
 
+  alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Note
   alias Vutuv.Posts
 
@@ -46,6 +47,9 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
       content_text: Keyword.get(attrs, :content_text, "Sturdier than they look."),
       summary: Keyword.get(attrs, :summary),
       audience: Keyword.get(attrs, :audience, "public"),
+      # Where an answer — and a Like (issue #1270) — is delivered. Only a reply
+      # stored before issue #1070 has none, which is its own test below.
+      inbox_uri: Keyword.get(attrs, :inbox_uri, "#{@actor}/inbox"),
       received_at: now,
       checked_at: now,
       expires_at: DateTime.add(now, 86_400)
@@ -302,6 +306,113 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
       encoded = inspect(Map.from_struct(event))
       refute encoded =~ "Sturdier than they look."
       refute encoded =~ @actor
+    end
+  end
+
+  describe "the reply's own acts (issue #1270)" do
+    test "a signed-in reader gets a heart and a Reply control", %{post: post, owner: owner} do
+      note = note!(post)
+
+      {:ok, _view, html} = thread_view(post, owner)
+
+      assert html =~ ~s(data-remote-reply-like="#{note.id}")
+      assert html =~ ~s(data-remote-reply-link="#{note.id}")
+      # Both are real controls under the body, not words in the provenance
+      # footer, which is what made the card read as having no actions at all.
+      assert html =~ ~s(phx-click="like-remote-reply")
+    end
+
+    test "a logged-out visitor gets neither", %{post: post} do
+      note!(post)
+
+      {:ok, _view, html} = thread_view(post)
+
+      refute html =~ "data-remote-reply-like"
+      refute html =~ "data-remote-reply-link"
+    end
+
+    test "pressing the heart marks it, and pressing it again takes it back", %{
+      post: post,
+      user: user,
+      owner: owner
+    } do
+      note = note!(post)
+      {:ok, view, _html} = thread_view(post, owner)
+
+      html =
+        view
+        |> element(~s([phx-click="like-remote-reply"][phx-value-id="#{note.id}"]))
+        |> render_click()
+
+      assert html =~ ~s(data-liked="on")
+      assert MapSet.member?(Fediverse.liked_note_ids(user, [note.id]), note.id)
+
+      html =
+        view
+        |> element(~s([phx-click="unlike-remote-reply"][phx-value-id="#{note.id}"]))
+        |> render_click()
+
+      refute html =~ ~s(data-liked="on")
+      refute MapSet.member?(Fediverse.liked_note_ids(user, [note.id]), note.id)
+    end
+
+    test "a reply stored without an inbox address gets no heart", %{post: post, owner: owner} do
+      note = note!(post, inbox_uri: nil)
+
+      {:ok, _view, html} = thread_view(post, owner)
+
+      # A Like for it could never leave the building, and a heart that paints
+      # itself over nothing is worse than no heart. Answering still stands.
+      refute html =~ "data-remote-reply-like"
+      assert html =~ ~s(data-remote-reply-link="#{note.id}")
+    end
+
+    test "a member who does not federate is told why, not left guessing", %{post: post} do
+      note = note!(post)
+      {_other, cookie} = other_member()
+
+      {:ok, view, _html} = thread_view(post, cookie)
+
+      # The control is deliberately shown to them — hiding it would leave them
+      # with no way to find out the capability exists — so the press has to
+      # explain itself.
+      html =
+        view
+        |> element(~s([phx-click="like-remote-reply"][phx-value-id="#{note.id}"]))
+        |> render_click()
+
+      assert html =~ "thread-notice"
+      refute html =~ ~s(data-liked="on")
+      assert Repo.aggregate(Vutuv.Fediverse.NoteLike, :count) == 0
+    end
+
+    # vutuv is a German site, so the German render is the one real visitors get
+    # — and a brand-new msgid is exactly what `gettext.extract --merge` fills in
+    # fuzzily with some unrelated sentence it thinks looks similar. This one was
+    # handed "Diese Antwort können Sie nicht entfernen." ("you cannot remove this
+    # reply"), which is confident nonsense in the right grammatical shape.
+    test "the controls and the refusal read right in German", %{post: post, owner: owner} do
+      note = note!(post)
+
+      {:ok, view, html} =
+        live_isolated(build_conn(), VutuvWeb.PostLive.Thread,
+          session: Map.merge(owner, %{"post_id" => post.id, "locale" => "de"})
+        )
+
+      assert html =~ "Gefällt mir"
+      assert html =~ "Antworten"
+
+      # The reply goes between render and click — expiry, a takedown, an
+      # upstream Delete. The page is holding a card for a row that is no longer
+      # there, which is the one refusal with a wording of its own.
+      Repo.delete!(note)
+
+      refusal =
+        view
+        |> element(~s([phx-click="like-remote-reply"][phx-value-id="#{note.id}"]))
+        |> render_click()
+
+      assert refusal =~ "Diese Antwort gibt es hier nicht mehr."
     end
   end
 end


### PR DESCRIPTION
Closes #1270.

A reply that arrived from another network had no visible action on the post permalink. Liking one was never built — issue #1164 gave the heart to a cached post from a followed account, and a reply is a different table — and answering it existed only as a `text-xs` word wedged between the server name and "View the original", which reads as a caption.

**The card.** Both acts now sit in a row of their own under the body, sized like every other control in the app; the provenance footer says only where the reply came from. The cached post's card was brought into the same shape in the same change, so the two remote cards read alike.

**The like.** `like_note/2` writes a marker (`fediverse_note_likes`, through the shared `Vutuv.Engagement.insert_if_new/3` kernel) and queues a signed `Like` to the reply author's own inbox — the address the note already stores for answering, so it costs no network call — and `unlike_note/2` sends the matching `Undo(Like)` with the id the original carried. Gates, the hourly budget, the rollback of a capped marker, the withdrawal on leaving the Fediverse, the absence of any count and the place in the GDPR export are all the post path's, shared on purpose.

Two differences of its own:

- **No audience gate.** A `Like` is addressed to one person and publishes nothing, so a reply sent to the member alone (#1071) can be liked exactly as a public one can — the opposite of answering, which is refused there because the answer would be a public vutuv post. What is asked instead is whether the reply is theirs to read, in the same terms `list_notes/2` enforces in SQL, since the id in a click is attacker-controlled.
- **`:not_deliverable`.** `inbox_uri` is nullable and replies stored before #1070 have none. Those get no heart at all rather than one that refuses: a marker written for a `Like` that can never leave paints a heart the author's server knows nothing about. They age out with the six-month retention.

**Tests.** A new context test mirrors `fediverse_post_likes_test.exs` claim for claim (what is stored, what leaves, every gate, the cascade, the export), plus LiveView tests for the card: the controls appear for a signed-in reader and not for a visitor, the heart toggles, a reply with no inbox gets none, a non-federating member is told why, and the German render is asserted by name — `gettext.extract --merge` fuzzy-filled the one new msgid with "Diese Antwort können Sie nicht entfernen." ("you cannot remove this reply"), which was written by hand instead.

`mix precommit` green (6388 tests). Migration is a plain addition, so N-1 compatible.

https://claude.ai/code/session_01CFunanSAvyACTQDNTm9D6A

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
