### PR TITLE
Tags that were really a pasted list or a cut-off sentence are deleted (v7.212.2) [cold-deploy]

### DIFF
--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -37,6 +37,12 @@ defmodule Vutuv.Tags do
   # the sign-up form validates the same ceiling up front.
   @max_user_tags 15
 
+  # Where a tag name stops being a topic and starts being a sentence, used by
+  # the one-time `delete_legacy_overlong_tags/0` cleanup. This is a cleanup
+  # threshold, not a validation: nothing stops a member typing a longer name
+  # today, and the question of whether the composer should cap it is separate.
+  @overlong_tag_length 35
+
   # What separates two tags: a comma, or a line break so a pasted list of tags
   # arrives as a list rather than as one giant name.
   @separators ~r/[,\r\n]+/
@@ -926,4 +932,177 @@ defmodule Vutuv.Tags do
 
   defp holder_count(tag_id),
     do: Repo.aggregate(from(ut in UserTag, where: ut.tag_id == ^tag_id), :count)
+
+  @doc """
+  One-time cleanup of the legacy tags whose own name carries a comma.
+
+  A comma is what separates two tags when a member types a batch — that is the
+  whole of `parse_tag_names/1`'s rule — so a tag *named* "Linux, Debian, Ubuntu,
+  CentOS" is a pasted list from before the rule existed: one row standing in for
+  four topics, matching none of them in a search, and filed under a slug nobody
+  would ever type. There is no reader these serve, so they go rather than get
+  split: guessing which of four topics a member meant to claim is a decision
+  only that member can make, and they can retype the ones they want.
+
+  See `delete_tags_matching/1` for what a deletion takes with it and what stops
+  it. Returns rows deleted per table.
+  """
+  def delete_legacy_comma_tags do
+    delete_tags_matching(from(t in Tag, where: like(t.name, "%,%")))
+  end
+
+  @doc """
+  One-time cleanup of the legacy tags whose name runs to #{@overlong_tag_length}
+  characters or more.
+
+  Past roughly this length a tag name stops being a topic and starts being a
+  sentence — a line lifted out of a job ad or a skills list, pasted whole into
+  the tag field. Two things in the data say so plainly: the longest name in the
+  table is 41 characters, and 159 names sit at exactly 40 with 140 of those
+  ending in a literal "...", the signature of a legacy importer that truncated
+  at 40 and appended an ellipsis. A name cut off mid-word names nothing, matches
+  no search, and cannot be typed by anyone hoping to land on it.
+
+  The threshold is deliberately generous: real compound topics
+  ("Softwareentwicklung", "Projektmanagement") sit well under it, so this takes
+  the phrases and leaves the vocabulary. A member who wants a long name back can
+  retype it.
+
+  See `delete_tags_matching/1` for what a deletion takes with it and what stops
+  it. Returns rows deleted per table.
+  """
+  def delete_legacy_overlong_tags do
+    delete_tags_matching(
+      from(t in Tag, where: fragment("char_length(?) >= ?", t.name, ^@overlong_tag_length))
+    )
+  end
+
+  @doc """
+  Deletes every tag `query` selects, and everything that hung off it.
+
+  A tag goes together with the rows that existed only to tie something to it —
+  the `user_tags` and their endorsements, the `post_tags`, `post_hashtags`,
+  `fediverse_post_tags`, `job_posting_tags` and `tag_follows`. What sits on the
+  far side of those join rows is untouched: a member keeps their account, a post
+  keeps its body, and both simply lose the tag.
+
+  The fan-out is walked from the live foreign keys rather than a list written
+  here, so a table added to the schema after this was written is still accounted
+  for. Anything that would **survive** the delete holding a nulled pointer stops
+  the cleanup with a raise instead: today that is `newsletter_groups.tag_id`
+  (ON DELETE SET NULL), where nulling would quietly widen an audience from
+  "members holding this tag" to "every member" — not a call a cleanup gets to
+  make. Postgres itself blocks any reference it cannot resolve, so the delete is
+  either complete or it does not happen.
+
+  Returns rows deleted per table. Idempotent, and a no-op on a fresh or test
+  database, so the real work only ever happens against production data.
+  """
+  def delete_tags_matching(query) do
+    {:ok, counts} = Repo.transaction(fn -> delete_matching_tags(query) end)
+    counts
+  end
+
+  defp delete_matching_tags(query) do
+    # Resolve the doomed ids up front so the guard below and the delete itself
+    # are provably the same set of tags, rather than two evaluations of one
+    # predicate with a window between them.
+    doomed = Repo.all(from(t in query, select: t.id))
+    {cascading, retaining} = tag_delete_fanout()
+    Enum.each(retaining, &refuse_dangling_reference!(&1, doomed))
+
+    before = row_counts(cascading)
+    Repo.delete_all(from(t in Tag, where: t.id in ^doomed))
+    remaining = row_counts(cascading)
+
+    Map.new(cascading, fn table -> {table, before[table] - remaining[table]} end)
+  end
+
+  # Every table a `tags` delete empties, found by following the foreign keys
+  # that cascade — and transitively their own, so a second-order row like a
+  # `user_tag_endorsements` hanging off a deleted `user_tags` is counted as
+  # well. Returns `{cascading_tables, retaining_refs}`: the tables whose rows go
+  # with the tag, and the references that would outlive it.
+  defp tag_delete_fanout, do: walk_cascade(["tags"], MapSet.new(["tags"]), [])
+
+  defp walk_cascade([], cascading, retaining), do: {MapSet.to_list(cascading), retaining}
+
+  defp walk_cascade([table | rest], cascading, retaining) do
+    {cascades, retains} = Enum.split_with(foreign_keys_to(table), &(&1.on_delete == "c"))
+
+    fresh =
+      cascades
+      |> Enum.map(& &1.table)
+      |> Enum.uniq()
+      |> Enum.reject(&MapSet.member?(cascading, &1))
+
+    walk_cascade(rest ++ fresh, MapSet.union(cascading, MapSet.new(fresh)), retaining ++ retains)
+  end
+
+  # The foreign keys pointing AT `table`, straight from the catalog:
+  # `confdeltype` is the ON DELETE rule ("c" cascade, "n" set null, "a" no
+  # action, "r" restrict, "d" set default).
+  defp foreign_keys_to(table) do
+    %{rows: rows} =
+      Repo.query!(
+        """
+        SELECT c.conrelid::regclass::text, a.attname, c.confdeltype
+        FROM pg_constraint c
+        JOIN unnest(c.conkey) AS k(attnum) ON true
+        JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+        WHERE c.contype = 'f' AND c.confrelid = $1::text::regclass
+        """,
+        [table]
+      )
+
+    Enum.map(rows, fn [child, column, on_delete] ->
+      %{parent: table, table: child, column: column, on_delete: on_delete}
+    end)
+  end
+
+  # A reference straight to `tags` that does not cascade: the row survives the
+  # delete, so the cleanup may only proceed while no such row actually points at
+  # a doomed tag. Fail closed — a pointer we would blank is a product decision.
+  #
+  # `$1::text[]::uuid[]` and not a bare `::uuid[]`: Postgres reports the
+  # parameter type of the latter as `uuid[]`, and Postgrex then demands the raw
+  # 16-byte form, so the readable `019f…` strings `Repo.all` returns would raise
+  # an EncodeError. Casting from text hands Postgres the strings to parse.
+  defp refuse_dangling_reference!(%{parent: "tags", table: table, column: column}, doomed) do
+    %{rows: [[count]]} =
+      Repo.query!(
+        "SELECT count(*) FROM #{table} WHERE #{column} = ANY($1::text[]::uuid[])",
+        [doomed]
+      )
+
+    if count > 0 do
+      raise """
+      #{count} #{table} row(s) reference a doomed tag through #{table}.#{column}, \
+      which does not cascade: deleting the tags would leave those rows behind \
+      pointing at nothing. Decide what should happen to them first — for \
+      #{table}.#{column} that means re-pointing or deleting them by hand — then \
+      run the cleanup again.\
+      """
+    end
+  end
+
+  # The same hazard one level down: a table that outlives the cascade holding a
+  # blanked pointer into it. None exists today, so this is a tripwire for a
+  # foreign key added between now and the day this runs, and refusing outright
+  # is the honest answer — which rows are doomed depends on the whole cascade
+  # path, and no cleanup should guess at it.
+  defp refuse_dangling_reference!(%{parent: parent, table: table, column: column}, _doomed) do
+    raise """
+    #{table}.#{column} references #{parent}, which this cleanup deletes from, \
+    and it does not cascade. That foreign key postdates the cleanup; work out \
+    what those rows should become before deleting these tags.\
+    """
+  end
+
+  defp row_counts(tables) do
+    Map.new(tables, fn table ->
+      %{rows: [[count]]} = Repo.query!("SELECT count(*) FROM #{table}", [])
+      {table, count}
+    end)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.212.1",
+      version: "7.212.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260731184539_delete_legacy_comma_tags.exs
+++ b/priv/repo/migrations/20260731184539_delete_legacy_comma_tags.exs
@@ -1,0 +1,34 @@
+defmodule Vutuv.Repo.Migrations.DeleteLegacyCommaTags do
+  use Ecto.Migration
+
+  alias Vutuv.Tags
+
+  # Deletes the legacy tags whose own name carries a comma — "Linux, Debian,
+  # Ubuntu, CentOS, Red Hat", "suse,vmware,lxc,design,ubuntu". A comma is what
+  # separates two tags when a member types a batch, so each of these is a pasted
+  # list from before that rule: one row standing in for four or five topics,
+  # found by none of them in a search, under a slug nobody would type.
+  #
+  # The work, and the reasoning for deleting rather than splitting them, lives
+  # in Vutuv.Tags.delete_legacy_comma_tags/0 — where it is unit-tested against
+  # real rows, which this migration cannot be: CI and `mix test` migrate an
+  # empty database, so every row-touching line here would be dead code there.
+  #
+  # Data-only (no DDL), so it stays N-1 compatible for the blue/green deploy:
+  # the currently deployed release keeps reading tags.name and the user_tags
+  # pointing at them throughout, and simply finds fewer rows. The implicit
+  # migration transaction makes the whole cleanup all-or-nothing.
+  def up do
+    summary =
+      Tags.delete_legacy_comma_tags()
+      |> Enum.reject(fn {_table, deleted} -> deleted == 0 end)
+      |> Enum.sort()
+      |> Enum.map_join(", ", fn {table, deleted} -> "#{deleted} #{table}" end)
+
+    IO.puts("deleted #{summary}")
+  end
+
+  # The tags and every row that pointed at them are gone; there is nothing left
+  # to reconstruct them from.
+  def down, do: :ok
+end

--- a/priv/repo/migrations/20260731185927_delete_legacy_overlong_tags.exs
+++ b/priv/repo/migrations/20260731185927_delete_legacy_overlong_tags.exs
@@ -1,0 +1,37 @@
+defmodule Vutuv.Repo.Migrations.DeleteLegacyOverlongTags do
+  use Ecto.Migration
+
+  alias Vutuv.Tags
+
+  # Deletes the legacy tags whose name runs to 35 characters or more. Past that
+  # length a name stops being a topic and starts being a sentence lifted out of
+  # a job ad — and 140 of them end in a literal "..." at exactly 40 characters,
+  # where a legacy importer truncated them mid-word. Neither names anything a
+  # reader could search for or type.
+  #
+  # Runs after the comma cleanup, which has already taken the pasted lists, so
+  # the two sets barely overlap by the time this executes. The work and the
+  # reasoning live in Vutuv.Tags.delete_legacy_overlong_tags/0, where they are
+  # unit-tested against real rows — including the 34/35 boundary and a German
+  # name whose umlauts make it longer in bytes than in characters. This
+  # migration cannot be tested that way: CI and `mix test` migrate an empty
+  # database, so every row-touching line here would be dead code there.
+  #
+  # Data-only (no DDL), so it stays N-1 compatible for the blue/green deploy:
+  # the currently deployed release keeps reading tags.name and the user_tags
+  # pointing at them throughout, and simply finds fewer rows. The implicit
+  # migration transaction makes the whole cleanup all-or-nothing.
+  def up do
+    summary =
+      Tags.delete_legacy_overlong_tags()
+      |> Enum.reject(fn {_table, deleted} -> deleted == 0 end)
+      |> Enum.sort()
+      |> Enum.map_join(", ", fn {table, deleted} -> "#{deleted} #{table}" end)
+
+    IO.puts("deleted #{summary}")
+  end
+
+  # The tags and every row that pointed at them are gone; there is nothing left
+  # to reconstruct them from.
+  def down, do: :ok
+end

--- a/test/vutuv/tags_test.exs
+++ b/test/vutuv/tags_test.exs
@@ -1,5 +1,10 @@
 defmodule Vutuv.TagsTest do
   use Vutuv.DataCase, async: true
+  alias Vutuv.Accounts.User
+  alias Vutuv.Newsletters.NewsletterGroup
+  alias Vutuv.Posts.Post
+  alias Vutuv.Posts.PostHashtag
+  alias Vutuv.Posts.PostTag
   alias Vutuv.Tags
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.TagFollow
@@ -1093,6 +1098,174 @@ defmodule Vutuv.TagsTest do
 
       tag = Repo.get_by!(Tag, slug: String.downcase(name))
       refute Tags.indexable_tag?(tag)
+    end
+  end
+
+  describe "delete_legacy_comma_tags/0" do
+    defp comma_tag, do: insert(:tag, name: unique_tag_name("Linux, Debian, Ubuntu"))
+
+    test "deletes the tag and every row that only tied something to it" do
+      holder = insert(:activated_user)
+      endorser = insert(:activated_user)
+      follower = insert(:activated_user)
+      post = insert(:post)
+      tag = comma_tag()
+
+      user_tag = insert(:user_tag, user: holder, tag: tag)
+      endorsement = insert(:user_tag_endorsement, user: endorser, user_tag: user_tag)
+      follow = insert(:tag_follow, user: follower, tag: tag)
+      post_tag = Repo.insert!(%PostTag{post_id: post.id, tag_id: tag.id})
+      hashtag = Repo.insert!(%PostHashtag{post_id: post.id, tag_id: tag.id})
+
+      counts = Tags.delete_legacy_comma_tags()
+
+      refute Repo.get(Tag, tag.id)
+      refute Repo.get(UserTag, user_tag.id)
+      refute Repo.get(UserTagEndorsement, endorsement.id)
+      refute Repo.get(TagFollow, follow.id)
+      refute Repo.get(PostTag, post_tag.id)
+      refute Repo.get(PostHashtag, hashtag.id)
+
+      # Nothing on the far side of a join row goes with it: the member keeps
+      # their account and their endorsement history, the post keeps its body.
+      # They only lose a tag that never named one topic to begin with.
+      assert Repo.get(User, holder.id)
+      assert Repo.get(User, endorser.id)
+      assert Repo.get(Post, post.id)
+
+      assert counts["tags"] == 1
+      assert counts["user_tags"] == 1
+      assert counts["user_tag_endorsements"] == 1
+      assert counts["post_tags"] == 1
+      assert counts["post_hashtags"] == 1
+      assert counts["tag_follows"] == 1
+    end
+
+    test "leaves a comma-free tag and everything hanging off it alone" do
+      holder = insert(:activated_user)
+      keep = insert(:tag, name: unique_tag_name("Elixir"))
+      kept_user_tag = insert(:user_tag, user: holder, tag: keep)
+      _doomed = comma_tag()
+
+      counts = Tags.delete_legacy_comma_tags()
+
+      assert Repo.get(Tag, keep.id)
+      assert Repo.get(UserTag, kept_user_tag.id)
+      assert counts["tags"] == 1
+      assert counts["user_tags"] == 0
+    end
+
+    test "deletes an unattached comma tag" do
+      tag = comma_tag()
+
+      assert %{"tags" => 1} = Tags.delete_legacy_comma_tags()
+      refute Repo.get(Tag, tag.id)
+    end
+
+    test "refuses rather than silently widen a newsletter group's audience" do
+      tag = comma_tag()
+
+      # newsletter_groups.tag_id is ON DELETE SET NULL, so the group would
+      # survive the tag with its criteria quietly changed from "members holding
+      # this tag" to "every member". A cleanup does not get to make that call.
+      group = Repo.insert!(%NewsletterGroup{name: "Comma tag audience", tag_id: tag.id})
+
+      assert_raise RuntimeError, ~r/newsletter_groups\.tag_id/, fn ->
+        Tags.delete_legacy_comma_tags()
+      end
+
+      assert Repo.get(Tag, tag.id)
+      assert Repo.get(NewsletterGroup, group.id).tag_id == tag.id
+    end
+
+    test "is idempotent" do
+      comma_tag()
+
+      assert %{"tags" => 1} = Tags.delete_legacy_comma_tags()
+      assert %{"tags" => 0} = Tags.delete_legacy_comma_tags()
+    end
+  end
+
+  describe "delete_legacy_overlong_tags/0" do
+    # A name of exactly `len` characters, unique per call so async modules never
+    # collide on the tags_lower_name_index.
+    defp tag_of_length(len) do
+      suffix = "-#{System.unique_integer([:positive])}"
+      insert(:tag, name: String.duplicate("a", len - String.length(suffix)) <> suffix)
+    end
+
+    test "deletes a 35-character name and every row that only tied something to it" do
+      holder = insert(:activated_user)
+      endorser = insert(:activated_user)
+      post = insert(:post)
+      tag = tag_of_length(35)
+
+      user_tag = insert(:user_tag, user: holder, tag: tag)
+      endorsement = insert(:user_tag_endorsement, user: endorser, user_tag: user_tag)
+      post_tag = Repo.insert!(%PostTag{post_id: post.id, tag_id: tag.id})
+
+      counts = Tags.delete_legacy_overlong_tags()
+
+      refute Repo.get(Tag, tag.id)
+      refute Repo.get(UserTag, user_tag.id)
+      refute Repo.get(UserTagEndorsement, endorsement.id)
+      refute Repo.get(PostTag, post_tag.id)
+
+      assert Repo.get(User, holder.id)
+      assert Repo.get(Post, post.id)
+
+      assert counts["tags"] == 1
+      assert counts["user_tags"] == 1
+      assert counts["user_tag_endorsements"] == 1
+      assert counts["post_tags"] == 1
+    end
+
+    test "cuts at 35 exactly: 34 stays, 35 and longer go" do
+      short = tag_of_length(34)
+      boundary = tag_of_length(35)
+      long = tag_of_length(41)
+
+      assert %{"tags" => 2} = Tags.delete_legacy_overlong_tags()
+
+      assert Repo.get(Tag, short.id)
+      refute Repo.get(Tag, boundary.id)
+      refute Repo.get(Tag, long.id)
+    end
+
+    test "counts characters, not bytes, so umlauts do not shorten a name" do
+      # 34 characters, but well over 35 bytes in UTF-8 — a byte-length test
+      # would delete this German name while leaving its ASCII twin of the same
+      # length alone.
+      suffix = "-#{System.unique_integer([:positive])}"
+      umlauts = String.duplicate("ä", 10)
+      name = umlauts <> String.duplicate("a", 34 - 10 - String.length(suffix)) <> suffix
+
+      assert String.length(name) == 34
+      assert byte_size(name) > 35
+
+      tag = insert(:tag, name: name)
+
+      assert %{"tags" => 0} = Tags.delete_legacy_overlong_tags()
+      assert Repo.get(Tag, tag.id)
+    end
+
+    test "refuses rather than silently widen a newsletter group's audience" do
+      tag = tag_of_length(40)
+      group = Repo.insert!(%NewsletterGroup{name: "Overlong tag audience", tag_id: tag.id})
+
+      assert_raise RuntimeError, ~r/newsletter_groups\.tag_id/, fn ->
+        Tags.delete_legacy_overlong_tags()
+      end
+
+      assert Repo.get(Tag, tag.id)
+      assert Repo.get(NewsletterGroup, group.id).tag_id == tag.id
+    end
+
+    test "is idempotent" do
+      tag_of_length(40)
+
+      assert %{"tags" => 1} = Tags.delete_legacy_overlong_tags()
+      assert %{"tags" => 0} = Tags.delete_legacy_overlong_tags()
     end
   end
 end


### PR DESCRIPTION
Deletes two classes of legacy tag that never named a topic, together with everything that only existed to tie something to them.

**Version:** v7.212.2 · **Deploy:** cold (two new Ecto migrations)

## Why

A comma is what separates two tags when a member types a batch, so a tag whose own *name* carries one is a list that was never split. `Linux, Debian, Ubuntu, CentOS, Red Hat` is one row standing in for five topics, found by none of them in a search, under a slug nobody would type.

Past 35 characters a name stops being a topic and starts being a sentence lifted out of a job ad. 140 of those end in a literal `...` at exactly 40 characters, where a legacy importer truncated them mid-word, so they name nothing at all.

They are deleted rather than split: guessing which of five topics a member meant to claim is a decision only that member can make, and retyping the ones they want is easy.

## How it avoids leaving anything dangling

The fan-out is walked from the **live foreign keys** rather than a list written into the cleanup, so a table added to the schema later is still accounted for, and second-order rows are caught (an endorsement hangs off a `user_tag`, not off the tag).

Anything that would *survive* the delete holding a blanked pointer stops the cleanup with a raise instead of proceeding. Today that is `newsletter_groups.tag_id`, which is `ON DELETE SET NULL`: nulling it would quietly widen a Rundbrief audience from "members holding this tag" to "every member", which is not a call a data cleanup gets to make.

The logic lives in `Vutuv.Tags`, not inside the migrations, so it can be tested at all — CI and `mix test` migrate an empty database, which makes every row-touching line of a migration dead code there. Tests cover the join-table fan-out, the newsletter refusal, idempotency, the 34/35 boundary, and a German name whose umlauts make it longer in bytes than in characters.

## Dry-run against `vutuv1_dev`

The only place the row-touching branches actually execute:

| | comma tags | 35+ chars |
|---|---|---|
| `tags` | 222 | 297 |
| `user_tags` | 64 | 206 |
| `user_tag_endorsements` | 12 | 27 |

`post_tags`, `post_hashtags`, `fediverse_post_tags`, `job_posting_tags`, `tag_follows`, `newsletter_groups`, `users` and `posts` were untouched, and an orphan hunt across the whole tag graph came back empty. Longest remaining tag name is 34 characters. Members and posts on the far side of a deleted join row keep everything but the tag.

## N-1

Both migrations are data-only with no DDL, so the currently deployed release keeps reading `tags.name` and the `user_tags` pointing at them, and simply finds fewer rows.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
