### PR TITLE
Move clampable text down so that summary doesn't jump

### DIFF
--- a/lib/vutuv_web/live/fediverse_account_live.ex
+++ b/lib/vutuv_web/live/fediverse_account_live.ex
@@ -290,15 +290,15 @@ defmodule VutuvWeb.FediverseAccountLive do
         the same shape every other long remote text on the site wears. --%>
         <details :if={@account.summary} data-remote-summary class="group mt-4">
           <summary class="cursor-pointer list-none">
-            <p class="post-clamp mb-0 whitespace-pre-line break-words text-sm leading-relaxed text-slate-700 group-open:hidden dark:text-slate-300">
-              {@account.summary}
-            </p>
             <span class="mt-1 inline-flex min-h-10 items-center text-xs font-medium text-brand-600 group-open:hidden dark:text-brand-400">
               {gettext("Show the whole description")}
             </span>
             <span class="mt-1 hidden min-h-10 items-center text-xs font-medium text-brand-600 group-open:inline-flex dark:text-brand-400">
               {gettext("Show less")}
             </span>
+            <p class="post-clamp mb-0 whitespace-pre-line break-words text-sm leading-relaxed text-slate-700 group-open:hidden dark:text-slate-300">
+              {@account.summary}
+            </p>
           </summary>
           <p class="mb-0 whitespace-pre-line break-words text-sm leading-relaxed text-slate-700 dark:text-slate-300">
             {@account.summary}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.217.0",
+      version: "7.217.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Fixes #1268

**Note:** I haven't fixed the additional "if the text doesn't exceed the threshold, the collapsed and expanded is always the same, making the toggle unnecessary." problem since it involves counting lines as is done via CSS now and this would not be exactly easy to replicate in Elixir afaik unless we run a headless browser or do some crazy calculations on font sizes and spacings and the like