### PR TITLE
A post or reply from another network carries all four actions, in the vutuv bar (v7.213.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -445,6 +445,31 @@ every activity of a member it finds no key for, silently.
   in the app is, and the footer says only where the reply came from. The cached
   post's card was brought into the same shape in the same change, so the two read
   alike.
+- **Passing a reply on** (issue #1275): `repost_note/2` is `repost_remote_post/2`
+  one table over — the marker (`fediverse_note_reposts`), a signed `Announce` of
+  the reply's own id to the resharer's followers with its author in `cc`, the
+  matching `Undo(Announce)`, the shared hourly boost budget, the withdrawal on
+  leaving. Public replies only, and for the reshare the audience question is
+  asked **first**: no setting of the member's own could make a private reply
+  shareable, so pointing them at one would be a lie. Unlike the like beside it
+  this row is also **read**: `feed_remote_reply_reposts/3` is the feed's seventh
+  source, so a reply somebody here vouched for reaches readers who never opened
+  that conversation, carrying the same "Reposted by" line a reshared post does.
+  That second remote row shape is why `Vutuv.Posts.remote_reply_entry?/1` exists
+  and why every reader of `entry.remote_post` has to ask it first.
+- **Saving one for yourself** (issue #1276): `fediverse_bookmarks`, **one** table
+  for both kinds (two nullable owner columns and a check constraint, the
+  `post_screenshots` pattern) because a bookmark has no audience question, no
+  activity and no per-kind read — it is only ever "what did this member save",
+  which wants the two interleaved. It is the one act here that asks nothing of
+  the member's Fediverse standing: nothing is signed, so a member who does not
+  federate at all can still keep what they read. The gate is the read question
+  alone. Its indexes are deliberately **not partial**: `ON CONFLICT` cannot infer
+  a partial unique index (Postgres answers 42P10), and the whole marker fabric is
+  built on that inference. They surface under `/bookmarks` on an "Other networks"
+  tab — its own tab rather than mixed into the saved posts, because that list has
+  no vutuv author for the "by name" sort and pages a different table, so one
+  stream would need a union pager to stay honest about `more?`.
 - **Holding a post back until its pictures are vetted** (issue #1070): a post's
   images are invisible until the AI scan releases them
   (`Vutuv.Moderation.ImageScans`), so a Note built the instant the post commits
@@ -1147,6 +1172,19 @@ The **reply** heart (issue #1270, its own bullet in the inbound section above)
 is this act on `fediverse_notes` instead of `fediverse_posts`: same activity,
 same addressing, same budget, same withdrawal, same silence about counts. Read
 the two together — a claim that holds for one and not the other is drift.
+
+That pairing is now structural rather than a convention. All six outbound acts
+on something from another network — like, reshare and bookmark, on a cached post
+and on a reply — run through **one** `outbound_act/3` (reload, gate, marker,
+budget, activity, roll back on refusal) over **one** marker fabric parameterized
+by the column that names the subject, and each act is a map naming only what is
+its own. The bar that draws them is one LiveComponent
+(`VutuvWeb.PostLive.RemoteActionsComponent`) wearing the local action bar's
+geometry to the pixel, so a card from another network offers the same four acts
+in the same places as a vutuv post — with no counts, the one deliberate
+difference. Before that, each of the seven hosts that render these cards carried
+its own copy of every handler, which is how the two cards drifted to two and
+three acts in the first place.
 
 ### Answering one of their posts (issue #1165)
 

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -50,6 +50,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Engagement
   alias Vutuv.Fediverse.Actor
   alias Vutuv.Fediverse.BlockedInstance
+  alias Vutuv.Fediverse.Bookmark
   alias Vutuv.Fediverse.Deliverer
   alias Vutuv.Fediverse.Delivery
   alias Vutuv.Fediverse.DeliveryFailure
@@ -63,6 +64,7 @@ defmodule Vutuv.Fediverse do
   alias Vutuv.Fediverse.Note
   alias Vutuv.Fediverse.NoteEvent
   alias Vutuv.Fediverse.NoteLike
+  alias Vutuv.Fediverse.NoteRepost
   alias Vutuv.Fediverse.PostBoost
   alias Vutuv.Fediverse.PostDelivery
   alias Vutuv.Fediverse.PostLike
@@ -974,6 +976,10 @@ defmodule Vutuv.Fediverse do
     # those rows do not hang off a follow at all, so nothing else would ever
     # take them.
     drop_note_likes(user)
+    # And what they passed on (issue #1275). A reshare stands on other people's
+    # servers under this member's name, so it goes with the decision to leave
+    # exactly as the cached-post boosts do.
+    drop_note_reposts(user)
 
     {count, _} = Repo.delete_all(from(f in Follow, where: f.user_id == ^user.id))
     # Their cached posts existed because this member followed their authors
@@ -4332,38 +4338,72 @@ defmodule Vutuv.Fediverse do
   no heart while the author's server counts the like, which is the one
   disagreement a member cannot fix from here.
   """
-  def like_remote_post(%User{} = user, %RemotePost{} = post) do
-    # Re-read first. The card was rendered at some earlier moment and the row
-    # can be gone by the time the heart is pressed — expiry, an upstream
-    # `Delete`, another member's report, an instance block — and the insert
-    # would then hit the foreign key and take the whole LiveView down with it.
-    # `on_conflict: :nothing` suppresses the *unique* violation, never this one.
-    with %RemotePost{} = post <- reload_remote_post(post),
-         :ok <- check_remote_like(user, post) do
-      case insert_remote_marker(PostLike, user, post, :liked) do
-        {:ok, :liked} -> send_like(user, post)
-        other -> other
-      end
-    else
-      nil -> {:error, :not_found}
-      {:error, _} = error -> error
-    end
-  end
+  def like_remote_post(%User{} = user, %RemotePost{} = post),
+    do: outbound_act(user, post, remote_post_like())
 
   # The budget is claimed here rather than before the insert, so a double tap or
   # a second tab — which writes nothing and sends nothing — does not spend
   # somebody's slot. A refusal rolls the marker back: a heart painted for a like
   # that never left is the one disagreement a member cannot fix from here.
-  defp send_like(user, post) do
-    case claim_like_budget(user) do
-      :ok ->
-        deliver_like(user, post, &Docs.like_activity/3)
-        {:ok, :liked}
+  # The four acts, each naming only what is its own (see `outbound_act/3`).
+  defp remote_post_like do
+    %{
+      reload: &reload_remote_post/1,
+      gate: &check_remote_like/2,
+      schema: PostLike,
+      fk: :remote_post_id,
+      budget: &claim_like_budget/1,
+      deliver: fn user, post -> deliver_like(user, post, &Docs.like_activity/3) end,
+      undo: fn user, post -> deliver_like(user, post, &Docs.undo_like_activity/3) end,
+      written: :liked,
+      undone: :unliked
+    }
+  end
 
-      {:error, _} = capped ->
-        delete_remote_marker(PostLike, user, post)
-        capped
-    end
+  defp remote_post_repost do
+    %{
+      reload: &reload_remote_post/1,
+      gate: &check_remote_repost/2,
+      schema: PostRepost,
+      fk: :remote_post_id,
+      budget: &claim_boost_budget/1,
+      deliver: fn user, post -> deliver_boost(user, post, &Docs.announce_remote_activity/4) end,
+      undo: fn user, post -> deliver_boost(user, post, &Docs.undo_announce_remote_activity/4) end,
+      written: :reposted,
+      undone: :unreposted
+    }
+  end
+
+  defp note_like do
+    %{
+      reload: &reload_note/1,
+      gate: &check_note_like/2,
+      schema: NoteLike,
+      fk: :note_id,
+      budget: &claim_like_budget/1,
+      deliver: fn user, note -> deliver_note_like(user, note, &Docs.like_activity/3) end,
+      undo: fn user, note -> deliver_note_like(user, note, &Docs.undo_like_activity/3) end,
+      written: :liked,
+      undone: :unliked
+    }
+  end
+
+  defp note_repost do
+    %{
+      reload: &reload_note/1,
+      gate: &check_note_repost/2,
+      schema: NoteRepost,
+      fk: :note_id,
+      budget: &claim_boost_budget/1,
+      deliver: fn user, note ->
+        deliver_note_boost(user, note, &Docs.announce_remote_activity/4)
+      end,
+      undo: fn user, note ->
+        deliver_note_boost(user, note, &Docs.undo_announce_remote_activity/4)
+      end,
+      written: :reposted,
+      undone: :unreposted
+    }
   end
 
   @doc """
@@ -4392,21 +4432,15 @@ defmodule Vutuv.Fediverse do
   must not be refusable, and if the member has since stopped federating there
   is simply nothing to send, which `deliver_like/3` handles by finding no actor.
   """
-  def unlike_remote_post(%User{} = user, %RemotePost{} = post) do
-    if delete_remote_marker(PostLike, user, post) > 0 do
-      deliver_like(user, post, &Docs.undo_like_activity/3)
-      {:ok, :unliked}
-    else
-      {:ok, :already}
-    end
-  end
+  def unlike_remote_post(%User{} = user, %RemotePost{} = post),
+    do: outbound_undo(user, post, remote_post_like())
 
   @doc """
   Which of `post_ids` this member already likes, as a `MapSet` — one query for a
   whole feed page rather than one per card.
   """
   def liked_remote_post_ids(%User{} = viewer, post_ids) when is_list(post_ids),
-    do: remote_marker_ids(PostLike, viewer, post_ids)
+    do: marker_ids(PostLike, :remote_post_id, viewer, post_ids)
 
   def liked_remote_post_ids(_viewer, _post_ids), do: MapSet.new()
 
@@ -4423,11 +4457,242 @@ defmodule Vutuv.Fediverse do
   # Here that answer decides whether an activity leaves the building. Nothing
   # needs a changeset — both ids come from records the caller already resolved.
   # `written` is what the caller calls a row that really landed.
-  defp insert_remote_marker(schema, user, post, written) do
+  # ## One outbound act, four callers
+  #
+  # Liking a cached post, resharing it, liking a reply and resharing a reply are
+  # the same steps in the same order: re-read the subject (the card was rendered
+  # at some earlier moment and the row can be gone — expiry, an upstream
+  # `Delete`, a takedown, an instance block — and the insert would then hit the
+  # foreign key and take the whole LiveView down with it; `on_conflict: :nothing`
+  # suppresses the *unique* violation, never this one), ask that act's gate,
+  # write the marker, and — only when the row really is new — claim an hourly
+  # slot and queue the activity, rolling the marker back if the budget refuses.
+  #
+  # That last order is the load-bearing part: a marker standing for an activity
+  # that never left paints a heart (or a reshare) the other server knows nothing
+  # about, which is the one disagreement a member cannot fix from here. And a
+  # repeat — a double tap, a second tab — writes nothing, sends nothing and
+  # therefore spends no slot.
+  #
+  # What differs per act is named in `act` and nothing else: the reload, the
+  # gate, the marker table and its subject column, which budget it spends, how
+  # the activity is addressed, and the word for a row that really landed.
+  defp outbound_act(user, subject, act) do
+    with subject when not is_nil(subject) <- act.reload.(subject),
+         :ok <- act.gate.(user, subject),
+         {:ok, written} when written == act.written <-
+           insert_marker(act.schema, act.fk, user, subject.id, act.written) do
+      claim_and_deliver(user, subject, act)
+    else
+      nil -> {:error, :not_found}
+      {:ok, :already} -> {:ok, :already}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp claim_and_deliver(user, subject, act) do
+    case act.budget.(user) do
+      :ok ->
+        act.deliver.(user, subject)
+        {:ok, act.written}
+
+      {:error, _} = capped ->
+        delete_marker(act.schema, act.fk, user, subject.id)
+        capped
+    end
+  end
+
+  # The withdrawal half, in one place for the same four callers: drop the row,
+  # and queue the `Undo` only when a row really went (so a second tab's press
+  # sends nothing). Never gated and never budgeted — refusing to let somebody
+  # take an act back because they have been busy would be an odd shape of limit,
+  # and it must still go out once the member has stopped federating, which the
+  # deliverers handle through `ever_federated?/1` (issue #1102).
+  defp outbound_undo(user, subject, act) do
+    if delete_marker(act.schema, act.fk, user, subject.id) > 0 do
+      act.undo.(user, subject)
+      {:ok, act.undone}
+    else
+      {:ok, :already}
+    end
+  end
+
+  ## Saving something from another network for yourself (issue #1276)
+  ##
+  ## The one act on these cards that stays here. Nothing is signed, nothing is
+  ## addressed, nothing leaves the building — so unlike every other act in this
+  ## module it asks nothing of the member's Fediverse standing, spends no hourly
+  ## budget and has no `Undo` to send. What it does share is the marker fabric
+  ## below and the read gate: you may only save what you may read, since the id
+  ## in a click is the member's to choose.
+
+  @doc """
+  Whether `user` may save this cached post or reply — the read question and
+  nothing else.
+
+  Deliberately not `check_remote_like/2`: a bookmark is private and local, so
+  the installation switch, the member's own participation and the operator
+  blocklist have no bearing on it. A member who does not federate at all can
+  still keep something they read.
+  """
+  def check_bookmark(%User{} = user, %RemotePost{} = post) do
+    if remote_post_readable?(post, user), do: :ok, else: {:error, :not_visible}
+  end
+
+  def check_bookmark(%User{} = user, %Note{} = note) do
+    if note_readable?(note, user), do: :ok, else: {:error, :not_visible}
+  end
+
+  @doc """
+  Saves a cached post. `{:ok, :bookmarked}`, `{:ok, :already}`, or the gate's
+  `{:error, reason}`.
+  """
+  def bookmark_remote_post(%User{} = user, %RemotePost{} = post),
+    do: outbound_act(user, post, remote_post_bookmark())
+
+  @doc "Drops the bookmark. `{:ok, :unbookmarked}` or `{:ok, :already}`."
+  def unbookmark_remote_post(%User{} = user, %RemotePost{} = post),
+    do: outbound_undo(user, post, remote_post_bookmark())
+
+  @doc "Saves a reply from another network."
+  def bookmark_note(%User{} = user, %Note{} = note),
+    do: outbound_act(user, note, note_bookmark())
+
+  @doc "Drops the bookmark on a reply."
+  def unbookmark_note(%User{} = user, %Note{} = note),
+    do: outbound_undo(user, note, note_bookmark())
+
+  @doc "Which of `post_ids` this member has saved, as a `MapSet`."
+  def bookmarked_remote_post_ids(%User{} = viewer, post_ids) when is_list(post_ids),
+    do: marker_ids(Bookmark, :remote_post_id, viewer, post_ids)
+
+  def bookmarked_remote_post_ids(_viewer, _post_ids), do: MapSet.new()
+
+  @doc "Which of `note_ids` this member has saved, as a `MapSet`."
+  def bookmarked_note_ids(%User{} = viewer, note_ids) when is_list(note_ids),
+    do: marker_ids(Bookmark, :note_id, viewer, note_ids)
+
+  def bookmarked_note_ids(_viewer, _note_ids), do: MapSet.new()
+
+  @doc """
+  One page of what this member saved from other networks, newest first, as feed
+  entries — the same shape `/bookmarks` already streams for vutuv posts, so that
+  page can interleave the three kinds by saved-at time.
+
+  `q` filters on the saved text, which is the only thing there is to search: a
+  cached post and a reply both carry plain text and nothing else we could match
+  a member's own words against.
+  """
+  def saved_from_networks(%User{id: user_id}, opts \\ []) do
+    q = opts[:q]
+
+    from(b in Bookmark,
+      left_join: p in RemotePost,
+      on: p.id == b.remote_post_id,
+      left_join: a in RemoteAccount,
+      on: a.id == p.remote_account_id,
+      left_join: n in Note,
+      on: n.id == b.note_id,
+      where: b.user_id == ^user_id,
+      order_by: [desc: b.inserted_at, desc: b.id],
+      preload: [remote_post: {p, remote_account: a}, note: n]
+    )
+    |> saved_matching(q)
+    |> Repo.all()
+    |> Enum.map(&saved_entry/1)
+  end
+
+  defp saved_matching(query, q) when is_binary(q) and q != "" do
+    like = "%" <> String.replace(q, ~r/[%_]/, "") <> "%"
+
+    where(
+      query,
+      [b, p, a, n],
+      ilike(p.content_text, ^like) or ilike(n.content_text, ^like) or ilike(a.handle, ^like) or
+        ilike(n.handle, ^like)
+    )
+  end
+
+  defp saved_matching(query, _q), do: query
+
+  # The saved row as a feed entry: `at` is when it was **saved**, not when it was
+  # written, because that is the order the page is in and the order the member
+  # remembers.
+  defp saved_entry(%Bookmark{remote_post: %RemotePost{} = post} = bookmark),
+    do: %{
+      id: "saved-remote-post-#{bookmark.id}",
+      post: nil,
+      remote_post: post,
+      reposted_by: nil,
+      at: bookmark.inserted_at
+    }
+
+  defp saved_entry(%Bookmark{note: %Note{} = note} = bookmark),
+    do: %{
+      id: "saved-remote-reply-#{bookmark.id}",
+      post: nil,
+      note: note,
+      reposted_by: nil,
+      at: bookmark.inserted_at
+    }
+
+  # A bookmark spends no budget and sends nothing, so the two act fields the
+  # fabric needs are the identity: claim nothing, deliver nothing. Naming them
+  # here rather than special-casing `outbound_act/3` keeps that function with one
+  # shape for all six acts.
+  defp remote_post_bookmark do
+    %{
+      reload: &reload_remote_post/1,
+      gate: &check_bookmark/2,
+      schema: Bookmark,
+      fk: :remote_post_id,
+      budget: fn _user -> :ok end,
+      deliver: fn _user, _post -> :skip end,
+      undo: fn _user, _post -> :skip end,
+      written: :bookmarked,
+      undone: :unbookmarked
+    }
+  end
+
+  defp note_bookmark do
+    %{
+      reload: &reload_note/1,
+      gate: &check_bookmark/2,
+      schema: Bookmark,
+      fk: :note_id,
+      budget: fn _user -> :ok end,
+      deliver: fn _user, _note -> :skip end,
+      undo: fn _user, _note -> :skip end,
+      written: :bookmarked,
+      undone: :unbookmarked
+    }
+  end
+
+  # ## One marker fabric for everything that came from another network
+  #
+  # A member's like of a cached post, their reshare of it, their like of a reply
+  # and their reshare of a reply are the **same three database operations** four
+  # times over — write the row if it is not there, drop it and say whether it
+  # really went, and ask which of a page's subjects are marked. The only thing
+  # that differs is which column names the subject (`remote_post_id` for a
+  # cached post, `note_id` for a reply), so that column is the parameter and
+  # there is one of each operation rather than eight.
+  #
+  # Everything above them stays per-subject on purpose: the gates ask different
+  # questions and the activities are addressed differently. This is the layer
+  # where they genuinely are identical.
+
+  # The join-row kernel every other engagement toggle here writes through
+  # (`Vutuv.Engagement`), for the reason `insert_reaction/3` spells out:
+  # `Repo.insert(on_conflict: :nothing)` cannot say whether the row landed,
+  # because the v7 id is minted in Elixir and the struct comes back looking
+  # identical either way, so only the inserted row count is an honest answer.
+  # Here that answer decides whether an activity leaves the building.
+  defp insert_marker(schema, fk, user, subject_id, written) do
     case Engagement.insert_if_new(
            schema,
-           %{user_id: user.id, remote_post_id: post.id},
-           [:user_id, :remote_post_id]
+           Map.new([{:user_id, user.id}, {fk, subject_id}]),
+           [:user_id, fk]
          ) do
       {:inserted, _row} -> {:ok, written}
       :exists -> {:ok, :already}
@@ -4436,19 +4701,21 @@ defmodule Vutuv.Fediverse do
 
   # The withdrawal half, answering in the same currency: how many rows really
   # went, so a second tab's press can be told from a real one.
-  defp delete_remote_marker(schema, user, post) do
+  defp delete_marker(schema, fk, user, subject_id) do
     {count, _} =
-      Repo.delete_all(where(schema, [r], r.user_id == ^user.id and r.remote_post_id == ^post.id))
+      Repo.delete_all(
+        from(r in schema, where: r.user_id == ^user.id and field(r, ^fk) == ^subject_id)
+      )
 
     count
   end
 
-  # Which of `post_ids` this member has marked — one query per feed page rather
+  # Which of `subject_ids` this member has marked — one query per page rather
   # than one per card.
-  defp remote_marker_ids(schema, %User{id: user_id}, post_ids) do
+  defp marker_ids(schema, fk, %User{id: user_id}, subject_ids) do
     from(r in schema,
-      where: r.user_id == ^user_id and r.remote_post_id in ^post_ids,
-      select: r.remote_post_id
+      where: r.user_id == ^user_id and field(r, ^fk) in ^subject_ids,
+      select: field(r, ^fk)
     )
     |> Repo.all()
     |> MapSet.new()
@@ -4555,39 +4822,14 @@ defmodule Vutuv.Fediverse do
   queued activity whose marker failed to write would paint no heart while the
   author's server counts the like.
   """
-  def like_note(%User{} = user, %Note{} = note) do
-    # Re-read first, like the post path: the card was rendered at some earlier
-    # moment and the row can be gone by the time the heart is pressed — expiry,
-    # an upstream `Delete`, a takedown, an instance block — and the insert would
-    # then hit the foreign key and take the whole LiveView down with it.
-    with %Note{} = note <- reload_note(note),
-         :ok <- check_note_like(user, note) do
-      case insert_note_marker(user, note) do
-        {:ok, :liked} -> send_note_like(user, note)
-        other -> other
-      end
-    else
-      nil -> {:error, :not_found}
-      {:error, _} = error -> error
-    end
-  end
+  def like_note(%User{} = user, %Note{} = note),
+    do: outbound_act(user, note, note_like())
 
   # The budget is claimed here rather than before the insert, so a double tap or
   # a second tab — which writes nothing and sends nothing — does not spend
   # somebody's slot. It is the **same** hourly budget the post heart claims:
   # both are one member's like leaving for another network, and metering them
   # apart would let an hour of one hide inside the other's allowance.
-  defp send_note_like(user, note) do
-    case claim_like_budget(user) do
-      :ok ->
-        deliver_note_like(user, note, &Docs.like_activity/3)
-        {:ok, :liked}
-
-      {:error, _} = capped ->
-        delete_note_marker(user, note)
-        capped
-    end
-  end
 
   @doc """
   The member takes the like back: drops the marker and queues the matching
@@ -4597,27 +4839,15 @@ defmodule Vutuv.Fediverse do
   must not be refusable, and if the member has since stopped federating there is
   simply nothing to send.
   """
-  def unlike_note(%User{} = user, %Note{} = note) do
-    if delete_note_marker(user, note) > 0 do
-      deliver_note_like(user, note, &Docs.undo_like_activity/3)
-      {:ok, :unliked}
-    else
-      {:ok, :already}
-    end
-  end
+  def unlike_note(%User{} = user, %Note{} = note),
+    do: outbound_undo(user, note, note_like())
 
   @doc """
   Which of `note_ids` this member already likes, as a `MapSet` — one query for a
   whole conversation rather than one per card.
   """
-  def liked_note_ids(%User{} = viewer, note_ids) when is_list(note_ids) do
-    from(l in NoteLike,
-      where: l.user_id == ^viewer.id and l.note_id in ^note_ids,
-      select: l.note_id
-    )
-    |> Repo.all()
-    |> MapSet.new()
-  end
+  def liked_note_ids(%User{} = viewer, note_ids) when is_list(note_ids),
+    do: marker_ids(NoteLike, :note_id, viewer, note_ids)
 
   def liked_note_ids(_viewer, _note_ids), do: MapSet.new()
 
@@ -4663,25 +4893,6 @@ defmodule Vutuv.Fediverse do
   # every other engagement toggle here: only the inserted row count is an honest
   # answer to "did this request create the like", and that answer is what decides
   # whether an activity leaves the building.
-  defp insert_note_marker(user, note) do
-    case Engagement.insert_if_new(
-           NoteLike,
-           %{user_id: user.id, note_id: note.id},
-           [:user_id, :note_id]
-         ) do
-      {:inserted, _row} -> {:ok, :liked}
-      :exists -> {:ok, :already}
-    end
-  end
-
-  # The withdrawal half, answering in the same currency: how many rows really
-  # went, so a second tab's press can be told from a real one.
-  defp delete_note_marker(user, note) do
-    {count, _} =
-      Repo.delete_all(where(NoteLike, [l], l.user_id == ^user.id and l.note_id == ^note.id))
-
-    count
-  end
 
   # The author's own inbox, never a shared one: a Like is addressed to one
   # person. `ever_federated?/1` rather than `federated?/1`, so a withdrawal still
@@ -4692,6 +4903,162 @@ defmodule Vutuv.Fediverse do
     with inbox when is_binary(inbox) <- note.inbox_uri,
          true <- ever_federated?(user) do
       enqueue(user, [inbox], builder.(user, note.actor_uri, note.object_uri))
+    else
+      _ -> :skip
+    end
+  end
+
+  ## Passing a reply from another network on (issue #1275)
+  ##
+  ## `repost_remote_post/2` (issue #1166) for a note. Same activity, same
+  ## addressing, same budget — and one thing the like beside it does not have:
+  ## the reshare is a **feed source**, because a button that publishes to other
+  ## servers and shows nothing on the site it was pressed on is a button that
+  ## did nothing as far as the member can tell.
+
+  @doc """
+  Whether `user` may pass this reply on, and when not, which gate refused —
+  `check_note_like/2`'s vocabulary plus the one a publishing act adds:
+
+    * `:note_not_public` — its author addressed it to the member alone (issue
+      #1071). A reshare hands it to everybody who follows the resharer here and
+      out there, and passing on an audience its author narrowed is not ours to
+      do, so the card offers no control there rather than one that refuses.
+
+  The audience question is asked **first**, for the reason the cached post's
+  gate spells out: no setting of the member's own could ever make a private
+  reply shareable, so telling them to go and switch something on would be a lie.
+  """
+  def check_note_repost(%User{} = user, %Note{} = note) do
+    if Note.public?(note),
+      do: check_note_like(user, note),
+      else: {:error, :note_not_public}
+  end
+
+  @doc """
+  The member passes a reply on: writes the row and queues a signed `Announce` to
+  their own followers (and the reply's author, so that server learns of it).
+
+  `{:ok, :reposted}`, `{:ok, :already}`, or the gate's `{:error, reason}`. The
+  reply is re-read first, like the heart's: the row can be gone by the time the
+  button is pressed and the audience can have narrowed, and neither may be
+  decided from the struct the page rendered with.
+  """
+  def repost_note(%User{} = user, %Note{} = note),
+    do: outbound_act(user, note, note_repost())
+
+  @doc """
+  The member takes the reshare back: drops the row and queues the matching
+  `Undo(Announce)`.
+
+  No gate and no budget, like unliking — a withdrawal must not be refusable, and
+  it must go out even once the member has stopped federating (issue #1102).
+  """
+  def unrepost_note(%User{} = user, %Note{} = note),
+    do: outbound_undo(user, note, note_repost())
+
+  @doc """
+  Which of `note_ids` this member has passed on, as a `MapSet` — one query for a
+  whole page rather than one per card.
+  """
+  def reposted_note_ids(%User{} = viewer, note_ids) when is_list(note_ids),
+    do: marker_ids(NoteRepost, :note_id, viewer, note_ids)
+
+  def reposted_note_ids(_viewer, _note_ids), do: MapSet.new()
+
+  @doc """
+  Withdraws every reshare of a reply this member holds and drops the rows — the
+  note half of what leaving the Fediverse means for `Announce`, called beside
+  `drop_note_likes/1`.
+  """
+  def drop_note_reposts(%User{} = user) do
+    Enum.each(list_note_reposts(user), fn note ->
+      deliver_note_boost(user, note, &Docs.undo_announce_remote_activity/4)
+    end)
+
+    {count, _} = Repo.delete_all(from(r in NoteRepost, where: r.user_id == ^user.id))
+    count
+  end
+
+  @doc "Every reply this member has passed on — for the withdrawal above."
+  def list_note_reposts(%User{id: user_id}) do
+    Repo.all(
+      from(r in NoteRepost,
+        join: n in Note,
+        on: n.id == r.note_id,
+        where: r.user_id == ^user_id,
+        order_by: [desc: r.id],
+        select: n
+      )
+    )
+  end
+
+  @doc """
+  The seventh feed source (issue #1275): **replies** from another network that
+  people the viewer follows **here** have passed on.
+
+  The exact twin of `feed_remote_reposts/3` one table over, and scoped the same
+  way — to the resharer, never to any follow of the author, because being
+  vouched for by somebody here is the whole reason this row reaches a member who
+  follows nobody out there. Stamped with the reshare time: what is new is the
+  sharing.
+  """
+  def feed_remote_reply_reposts(%User{id: viewer_id}, fetch_n, cursor) do
+    if enabled?() do
+      from(r in NoteRepost,
+        join: n in Note,
+        on: n.id == r.note_id,
+        join: resharer in User,
+        on: resharer.id == r.user_id,
+        where: r.user_id == ^viewer_id or r.user_id in subquery(unmuted_followees(viewer_id)),
+        # A resharer who is not in good standing amplifies nothing — the same
+        # stricter rule the cached-post reshare source applies, and for the same
+        # reason: carrying a third party's words into other people's feeds is
+        # exactly what a frozen or suspended account must not keep doing.
+        where:
+          r.user_id == ^viewer_id or
+            (account_confirmed_row(resharer) and not account_hidden_row(resharer)),
+        # Only ever what the resharer could have shared: the audience gate is the
+        # same one that let them press the button, re-asked here because a note's
+        # audience can be narrowed by an upstream `Update` after the fact.
+        where: n.audience == "public",
+        order_by: [desc: r.inserted_at, desc: r.id],
+        preload: [note: n, user: resharer]
+      )
+      |> limit(^fetch_n)
+      |> note_reposts_at_or_before(cursor)
+      |> Repo.all()
+      |> Enum.map(&remote_reply_repost_entry/1)
+    else
+      []
+    end
+  end
+
+  defp note_reposts_at_or_before(query, nil), do: query
+
+  defp note_reposts_at_or_before(query, %{at: at}),
+    do: where(query, [r], r.inserted_at <= ^at)
+
+  defp remote_reply_repost_entry(%NoteRepost{} = repost) do
+    %{
+      id: "remote-reply-repost-#{repost.id}",
+      post: nil,
+      note: repost.note,
+      reposted_by: repost.user,
+      at: repost.inserted_at
+    }
+  end
+
+  # The resharer's own audience — that is the act — plus the reply's author, so
+  # their server learns of it, exactly as `deliver_boost/3` addresses a cached
+  # post's. The author's inbox is the one the note already carries; a note with
+  # none still reaches the resharer's followers, which is the whole audience that
+  # matters here (a `Like` has no such fallback, which is why it refuses).
+  defp deliver_note_boost(%User{} = user, %Note{} = note, builder) do
+    with true <- ever_federated?(user),
+         [_ | _] = inboxes <-
+           Enum.uniq(delivery_inboxes(user) ++ List.wrap(note.inbox_uri)) do
+      enqueue(user, inboxes, builder.(user, note.actor_uri, note.object_uri, note.audience))
     else
       _ -> :skip
     end
@@ -5545,18 +5912,8 @@ defmodule Vutuv.Fediverse do
   button is pressed, and the audience can have narrowed, and neither may be
   decided from the struct the page rendered with.
   """
-  def repost_remote_post(%User{} = user, %RemotePost{} = post) do
-    with %RemotePost{} = post <- reload_remote_post(post),
-         :ok <- check_remote_repost(user, post) do
-      case insert_remote_marker(PostRepost, user, post, :reposted) do
-        {:ok, :reposted} -> send_announce(user, post)
-        other -> other
-      end
-    else
-      nil -> {:error, :not_found}
-      {:error, _} = error -> error
-    end
-  end
+  def repost_remote_post(%User{} = user, %RemotePost{} = post),
+    do: outbound_act(user, post, remote_post_repost())
 
   @doc """
   The member takes the boost back: drops the row and queues the matching
@@ -5566,37 +5923,17 @@ defmodule Vutuv.Fediverse do
   it must go out even once the member has stopped federating (issue #1102), which
   `deliver_boost/3` handles through `ever_federated?/1`.
   """
-  def unrepost_remote_post(%User{} = user, %RemotePost{} = post) do
-    if delete_remote_marker(PostRepost, user, post) > 0 do
-      deliver_boost(user, post, &Docs.undo_announce_remote_activity/4)
-      {:ok, :unreposted}
-    else
-      {:ok, :already}
-    end
-  end
+  def unrepost_remote_post(%User{} = user, %RemotePost{} = post),
+    do: outbound_undo(user, post, remote_post_repost())
 
   @doc """
   Which of `post_ids` this member has reposted, as a `MapSet` — one query per
   feed page rather than one per card.
   """
   def reposted_remote_post_ids(%User{} = viewer, post_ids) when is_list(post_ids),
-    do: remote_marker_ids(PostRepost, viewer, post_ids)
+    do: marker_ids(PostRepost, :remote_post_id, viewer, post_ids)
 
   def reposted_remote_post_ids(_viewer, _post_ids), do: MapSet.new()
-
-  # See `send_like/1`: the budget is claimed once the row is really new, and a
-  # refusal rolls it back rather than leaving a boost painted that never left.
-  defp send_announce(user, post) do
-    case claim_boost_budget(user) do
-      :ok ->
-        deliver_boost(user, post, &Docs.announce_remote_activity/4)
-        {:ok, :reposted}
-
-      {:error, _} = capped ->
-        delete_remote_marker(PostRepost, user, post)
-        capped
-    end
-  end
 
   # An Announce goes to the reposter's own audience — that is the act — plus the
   # original author, so their server learns of the boost. The one place this

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -4517,6 +4517,101 @@ defmodule Vutuv.Fediverse do
     end
   end
 
+  ## What a card from another network can do — one vocabulary for both kinds
+  ##
+  ## `VutuvWeb.PostLive.RemoteActionsComponent` is the only caller. It renders
+  ## the same bar for a cached post and for a reply, so it needs to ask about
+  ## both in the same words rather than branching on the struct at every step —
+  ## the branching lives here, once, beside the acts it dispatches to.
+
+  @doc """
+  Performs one act on one subject: `act` is `"like"`, `"repost"` or
+  `"bookmark"`, and `on?` says whether it is being switched on or taken back.
+
+  The one entry point the action bar calls, so the bar never has to know which
+  of six public functions the pair it holds maps to. Each of those keeps its own
+  name and its own doc — this only routes.
+  """
+  def toggle_engagement(%User{} = user, %Note{} = note, act, on?),
+    do: apply(__MODULE__, note_act_fun(act, on?), [user, note])
+
+  def toggle_engagement(%User{} = user, %RemotePost{} = post, act, on?),
+    do: apply(__MODULE__, post_act_fun(act, on?), [user, post])
+
+  def toggle_engagement(nil, _subject, _act, _on?), do: {:error, :not_signed_in}
+
+  defp note_act_fun("like", true), do: :like_note
+  defp note_act_fun("like", false), do: :unlike_note
+  defp note_act_fun("repost", true), do: :repost_note
+  defp note_act_fun("repost", false), do: :unrepost_note
+  defp note_act_fun("bookmark", true), do: :bookmark_note
+  defp note_act_fun("bookmark", false), do: :unbookmark_note
+
+  defp post_act_fun("like", true), do: :like_remote_post
+  defp post_act_fun("like", false), do: :unlike_remote_post
+  defp post_act_fun("repost", true), do: :repost_remote_post
+  defp post_act_fun("repost", false), do: :unrepost_remote_post
+  defp post_act_fun("bookmark", true), do: :bookmark_remote_post
+  defp post_act_fun("bookmark", false), do: :unbookmark_remote_post
+
+  @doc """
+  The three marks for a page of subjects as **one lookup fun**: three batched
+  reads up front, then a map read per card.
+
+  Every host that draws more than one card from another network uses this — the
+  feed, the permalink conversation, the account page, the tag timeline — so
+  "what has this reader already done with these" is three queries per page
+  wherever it is asked, and the bars never each ask for themselves. A single
+  card (the URL lookup) can skip it: `VutuvWeb.PostLive.RemoteActionsComponent`
+  loads its own when the host hands it nothing.
+
+  Takes either kind of subject, or a mixed list.
+  """
+  def mark_lookup(subjects, viewer) do
+    liked = liked_ids(viewer, subjects)
+    reposted = reposted_ids(viewer, subjects)
+    bookmarked = bookmarked_ids(viewer, subjects)
+
+    fn subject ->
+      %{
+        liked?: MapSet.member?(liked, subject.id),
+        reposted?: MapSet.member?(reposted, subject.id),
+        bookmarked?: MapSet.member?(bookmarked, subject.id)
+      }
+    end
+  end
+
+  @doc "Which of these subjects the viewer likes — the batch read, either kind."
+  def liked_ids(viewer, subjects), do: batch_ids(viewer, subjects, NoteLike, PostLike)
+
+  @doc "Which of these subjects the viewer has passed on."
+  def reposted_ids(viewer, subjects), do: batch_ids(viewer, subjects, NoteRepost, PostRepost)
+
+  @doc "Which of these subjects the viewer has saved."
+  def bookmarked_ids(viewer, subjects), do: batch_ids(viewer, subjects, Bookmark, Bookmark)
+
+  # One subject or a list of them, of either kind. A mixed list is split, since
+  # the two kinds live in different columns (and, for the bookmarks, different
+  # columns of the same table).
+  defp batch_ids(nil, _subjects, _note_schema, _post_schema), do: MapSet.new()
+
+  defp batch_ids(%User{} = viewer, subject, note_schema, post_schema) when not is_list(subject),
+    do: batch_ids(viewer, [subject], note_schema, post_schema)
+
+  defp batch_ids(%User{} = viewer, subjects, note_schema, post_schema) do
+    {notes, posts} = Enum.split_with(subjects, &match?(%Note{}, &1))
+
+    MapSet.union(
+      ids_for(note_schema, :note_id, viewer, notes),
+      ids_for(post_schema, :remote_post_id, viewer, posts)
+    )
+  end
+
+  defp ids_for(_schema, _fk, _viewer, []), do: MapSet.new()
+
+  defp ids_for(schema, fk, viewer, subjects),
+    do: marker_ids(schema, fk, viewer, Enum.map(subjects, & &1.id))
+
   ## Saving something from another network for yourself (issue #1276)
   ##
   ## The one act on these cards that stays here. Nothing is signed, nothing is

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -4680,6 +4680,8 @@ defmodule Vutuv.Fediverse do
   """
   def saved_from_networks(%User{id: user_id}, opts \\ []) do
     q = opts[:q]
+    limit = Keyword.get(opts, :limit, 20)
+    offset = Keyword.get(opts, :offset, 0)
 
     from(b in Bookmark,
       left_join: p in RemotePost,
@@ -4693,9 +4695,15 @@ defmodule Vutuv.Fediverse do
       preload: [remote_post: {p, remote_account: a}, note: n]
     )
     |> saved_matching(q)
+    |> limit(^(limit + 1))
+    |> offset(^offset)
     |> Repo.all()
     |> Enum.map(&saved_entry/1)
   end
+
+  @doc "How many things this member saved from other networks."
+  def saved_from_networks_count(%User{id: user_id}),
+    do: Repo.aggregate(from(b in Bookmark, where: b.user_id == ^user_id), :count)
 
   defp saved_matching(query, q) when is_binary(q) and q != "" do
     like = "%" <> String.replace(q, ~r/[%_]/, "") <> "%"

--- a/lib/vutuv/fediverse/bookmark.ex
+++ b/lib/vutuv/fediverse/bookmark.ex
@@ -1,0 +1,33 @@
+defmodule Vutuv.Fediverse.Bookmark do
+  @moduledoc """
+  A member saved something from another network for themselves (issue #1276) —
+  a cached post by a followed account, or a reply that arrived under a vutuv
+  post.
+
+  **One schema for both kinds**, where the like and reshare markers have one
+  each. The reason is in the migration and worth repeating: those two are read
+  by queries that join their own subject and its own audience rules, and the
+  reshare is a feed source; a bookmark federates nothing, is addressed to
+  nobody, and is only ever read as "what did this member save", which wants the
+  two kinds in one list rather than two. Exactly one of `remote_post_id` /
+  `note_id` is set, and a check constraint says so.
+
+  It is also the one act on these cards that asks nothing of the member's
+  Fediverse standing: no actor is needed because nothing is signed and nothing
+  leaves the building.
+
+  No changeset, like every marker here — both ids come from records the caller
+  already resolved, and the write goes through
+  `Vutuv.Engagement.insert_if_new/3`.
+  """
+
+  use VutuvWeb, :model
+
+  schema "fediverse_bookmarks" do
+    belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:remote_post, Vutuv.Fediverse.RemotePost)
+    belongs_to(:note, Vutuv.Fediverse.Note)
+
+    timestamps(updated_at: false)
+  end
+end

--- a/lib/vutuv/fediverse/note_repost.ex
+++ b/lib/vutuv/fediverse/note_repost.ex
@@ -1,0 +1,28 @@
+defmodule Vutuv.Fediverse.NoteRepost do
+  @moduledoc """
+  A member here passed a reply from another network on to their own followers
+  (issue #1275) — the sibling of `Vutuv.Fediverse.PostRepost`, keyed to a
+  `Vutuv.Fediverse.Note` instead of a cached post.
+
+  Unlike the like markers beside it, this row is **read as well as written**: it
+  is a feed source (`Vutuv.Fediverse.feed_remote_reply_reposts/3`), because a
+  reshare that reached nobody here would be a button that does nothing on the
+  site the member pressed it on. What it carries is the whole entry — the reply
+  itself is joined off `note_id`, and `inserted_at` is the entry's time, since
+  what is new is the sharing and not the reply.
+
+  No changeset, like every other marker here: both ids come from records the
+  caller already resolved, and the write goes through
+  `Vutuv.Engagement.insert_if_new/3`, whose row count decides whether an
+  `Announce` leaves the building.
+  """
+
+  use VutuvWeb, :model
+
+  schema "fediverse_note_reposts" do
+    belongs_to(:user, Vutuv.Accounts.User)
+    belongs_to(:note, Vutuv.Fediverse.Note)
+
+    timestamps(updated_at: false)
+  end
+end

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1812,20 +1812,16 @@ defmodule Vutuv.Posts do
     |> Enum.uniq_by(& &1.remote_post.id)
   end
 
-  # Which of the page's remote posts the reader already likes (issue #1164),
-  # read once for the whole page. It rides the entry rather than a socket-level
-  # set because the feed re-renders a card by re-inserting its entry into the
-  # stream, so the state a card draws from has to live on the entry it draws.
+  # What the reader has already done with each of the page's remote posts
+  # (issues #1164, #1166 and #1276), read once for the whole page. It rides the
+  # entry rather than a socket-level set because the feed re-renders a card by
+  # re-inserting its entry into the stream, so the state a card draws from has
+  # to live on the entry it draws.
   defp attach_remote_likes(remote, viewer) do
-    ids = Enum.map(remote, & &1.remote_post.id)
-    liked = Vutuv.Fediverse.liked_remote_post_ids(viewer, ids)
-    reposted = Vutuv.Fediverse.reposted_remote_post_ids(viewer, ids)
+    posts = Enum.map(remote, & &1.remote_post)
+    marks = Vutuv.Fediverse.mark_lookup(posts, viewer)
 
-    Enum.map(remote, fn entry ->
-      entry
-      |> Map.put(:liked?, MapSet.member?(liked, entry.remote_post.id))
-      |> Map.put(:reposted?, MapSet.member?(reposted, entry.remote_post.id))
-    end)
+    Enum.map(remote, &Map.put(&1, :marks, marks.(&1.remote_post)))
   end
 
   # The pictures of the remote half (issue #1163), read once for the whole page

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -1692,6 +1692,7 @@ defmodule Vutuv.Posts do
     [
       &Vutuv.Fediverse.feed_remote_posts(viewer, &1, &2),
       &Vutuv.Fediverse.feed_remote_reposts(viewer, &1, &2),
+      &Vutuv.Fediverse.feed_remote_reply_reposts(viewer, &1, &2),
       &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2, only: :remote)
     ]
   end
@@ -1709,7 +1710,13 @@ defmodule Vutuv.Posts do
       # Sixth: what the accounts the viewer follows out there have
       # re-shared (issue #1167) — a large part of what any account
       # contributes, and invisible here until now.
-      &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2)
+      &Vutuv.Fediverse.feed_remote_boosts(viewer, &1, &2),
+      # Seventh: **replies** from another network that people here have
+      # passed on (issue #1275). The same act as the fifth source one table
+      # over: a reply arrived under somebody's vutuv post, a member here
+      # thought it worth carrying, and that is how it reaches readers who
+      # never opened that conversation.
+      &Vutuv.Fediverse.feed_remote_reply_reposts(viewer, &1, &2)
     ]
   end
 
@@ -1844,7 +1851,15 @@ defmodule Vutuv.Posts do
   through it first, because a remote entry has no author, no thread and no
   engagement here.
   """
-  def remote_feed_entry?(entry), do: not is_nil(entry[:remote_post])
+  def remote_feed_entry?(entry), do: not is_nil(entry[:remote_post]) or remote_reply_entry?(entry)
+
+  @doc """
+  Whether this row is a **reply** from another network rather than a cached post
+  (issue #1275). The second remote row shape, and the one every reader of
+  `entry.remote_post` has to be asked first — that field is nil here, and the
+  card, the content filter and the id all come from `entry.note` instead.
+  """
+  def remote_reply_entry?(entry), do: not is_nil(entry[:note])
 
   defp feed_post_items(%User{id: viewer_id} = viewer, fetch_n, cursor) do
     from(p in Post,

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -825,7 +825,7 @@ defmodule VutuvWeb.PostComponents do
             owner?={node.owner?}
             viewer={@viewer}
             liked?={node.liked?}
-            acts?
+            acts={[:like, :reply]}
           />
         <% else %>
           <.post_card
@@ -908,13 +908,15 @@ defmodule VutuvWeb.PostComponents do
 
   attr(:viewer, :any, default: nil, doc: "the logged-in member, or nil")
 
-  attr(:acts?, :boolean,
-    default: false,
+  attr(:acts, :list,
+    default: [],
     doc:
-      "whether this surface carries the card's own acts. The conversation does; the answering page, where the card is the read-only thing being answered, does not — a Reply link to the page you are already on is noise, and a heart there would fire an event that page does not handle."
+      "which acts this surface carries, in the `remote_actions/1` vocabulary. The conversation takes `[:like, :reply]`; the answering page takes none, since the card there is the read-only thing being answered — a Reply link to the page you are already on is noise, and a heart would fire an event that page does not handle."
   )
 
   attr(:liked?, :boolean, default: false, doc: "whether the viewer already likes this reply")
+  attr(:reposted?, :boolean, default: false, doc: "whether the viewer already passed it on")
+  attr(:bookmarked?, :boolean, default: false, doc: "whether the viewer already saved it")
 
   def remote_reply_card(assigns) do
     note = assigns.note
@@ -928,22 +930,6 @@ defmodule VutuvWeb.PostComponents do
       |> assign(:initials, name_initials(note.display_name || note.handle))
       |> assign(:public?, Note.public?(note))
       |> assign(:warned?, Note.warned?(note))
-      # Only a public reply can be answered (issue #1070): a private one would
-      # mean publishing half of an exchange its author asked to keep to one
-      # person, so v1 does not offer it at all.
-      |> assign(
-        :can_reply?,
-        assigns.acts? and not is_nil(assigns.viewer) and Note.public?(note)
-      )
-      # A like has no such audience gate (issue #1270) — it is addressed to the
-      # author alone and publishes nothing, so a reply sent to the member only
-      # can be liked too. What it does need is an address to send it to: a reply
-      # stored before issue #1070 carries none, and a heart that could never
-      # leave the building is worse than no heart.
-      |> assign(
-        :can_like?,
-        assigns.acts? and not is_nil(assigns.viewer) and Note.likeable?(note)
-      )
 
     ~H"""
     <%!-- The `id` is this reply's anchor: it has no permalink of its own, so a
@@ -1005,52 +991,23 @@ defmodule VutuvWeb.PostComponents do
 
           <.remote_body warning={@warned? && @note.summary} text={@note.content_text} />
 
-          <%!-- The card's acts (issue #1270), in the open under the body where a
-          reader looks for them, sized as real touch targets. Both are shown to
-          every signed-in member including one who has not switched Fediverse
-          participation on: each is signed with their own key, so for them
-          neither can be sent — but hiding the controls would leave them with no
-          way to find out that any of this exists. Pressing one explains and
-          points at the switch (issue #1070). --%>
-          <div :if={@can_like? or @can_reply?} class="mt-1 flex flex-wrap items-center gap-5">
-            <%!-- A plain toggle with no number beside it, like the one on a
-            cached post: the heart says what the reader did, and the only honest
-            answer to "how many others" is the author's own server, one click
-            away in the footer below. --%>
-            <button
-              :if={@can_like?}
-              type="button"
-              phx-click={if @liked?, do: "unlike-remote-reply", else: "like-remote-reply"}
-              phx-value-id={@note.id}
-              aria-pressed={to_string(@liked?)}
-              data-remote-reply-like={@note.id}
-              data-liked={@liked? && "on"}
-              class={[
-                "inline-flex min-h-10 items-center gap-1.5 text-sm font-medium",
-                if(@liked?,
-                  do: "text-accent",
-                  else: "text-slate-600 hover:text-accent dark:text-slate-400"
-                )
-              ]}
-            >
-              <.icon_heart filled?={@liked?} class="h-5 w-5" />
-              <%!-- One label in both states, with the state carried by the
-              filled heart, the accent colour and `aria-pressed` — German has one
-              word for both, so two labels would have read differently per
-              language, and in German not at all. --%>
-              <span>{gettext("Like")}</span>
-            </button>
-
-            <.link
-              :if={@can_reply?}
-              navigate={~p"/system/fediverse/reply/#{@note.id}"}
-              data-remote-reply-link={@note.id}
-              class="inline-flex min-h-10 items-center gap-1.5 text-sm font-medium text-slate-600 hover:text-brand-700 dark:text-slate-400 dark:hover:text-brand-300"
-            >
-              <.icon_reply class="h-5 w-5" />
-              <span>{gettext("Reply")}</span>
-            </.link>
-          </div>
+          <%!-- The card's acts (issue #1270), in the open under the body where
+          a reader looks for them and sized as real touch targets. One component
+          for both remote cards (`remote_actions/1` below), so a reply and a
+          cached post carry the same row in the same order. --%>
+          <.remote_actions
+            :if={@acts != []}
+            kind="remote-reply"
+            subject_id={@note.id}
+            viewer={@viewer}
+            liked?={@liked?}
+            reposted?={@reposted?}
+            bookmarked?={@bookmarked?}
+            like?={Note.likeable?(@note)}
+            reply_to={@public? && ~p"/system/fediverse/reply/#{@note.id}"}
+            repost?={@public?}
+            acts={@acts}
+          />
 
           <.remote_footer host={@host} origin={@origin} label={gettext("View the original")} />
         </div>
@@ -1334,6 +1291,204 @@ defmodule VutuvWeb.PostComponents do
     end)
   end
 
+  @doc """
+  The action row **both** cards from another network wear — a reply under a
+  member's post and a cached post by a followed account (issues #1270, #1275
+  and #1276).
+
+  One definition, because "what can I do with this" is exactly what must not
+  differ between the two: to a reader they are the same kind of object, and a
+  heart that is a button on one card and a footnote on the other is a bug
+  waiting to be reported. It was, twice — first as "I have no way to like or
+  answer the answer on that page", then as "and what about the repost and
+  bookmark?".
+
+  The order is the local action bar's: like, reply, repost, bookmark. Each
+  control renders only where the act exists at all, which is a fact about the
+  **subject**, never about the reader:
+
+    * **like** — needs an address to deliver to (`like?`); a reply stored before
+      issue #1070 carries none.
+    * **reply** and **repost** — public subjects only (`reply_to`, `repost?`).
+      An answer is a public vutuv post and a reshare is publishing, and passing
+      on an audience its author narrowed is not ours to do, so there is no
+      control rather than one that refuses.
+    * **bookmark** — always, for any signed-in reader. The one act that stays
+      here: nothing is sent and nothing is addressed, so it asks nothing of the
+      member's Fediverse standing.
+
+  Everything the reader *is* — federating or not, moved, on a server the
+  operator blocked — is deliberately **not** asked here. Those controls render
+  and the press explains itself, because hiding them leaves a member no way to
+  find out the capability exists (issue #1070's rule, applied to all four).
+
+  `kind` names the events, so one row drives two hosts: `"remote-reply"` gives
+  `like-remote-reply` / `unlike-remote-reply` and so on, `"remote-post"` the
+  `…-remote-post` pairs the feed and the account page already handle.
+  """
+  attr(:kind, :string, required: true, values: ~w(remote-reply remote-post))
+  attr(:subject_id, :string, required: true, doc: "rides every control as phx-value-id")
+  attr(:viewer, :any, default: nil, doc: "the logged-in member, or nil for no row at all")
+  attr(:liked?, :boolean, default: false)
+  attr(:reposted?, :boolean, default: false)
+  attr(:bookmarked?, :boolean, default: false)
+  attr(:like?, :boolean, default: true, doc: "false where a Like could not be delivered at all")
+  attr(:reply_to, :any, default: nil, doc: "the answering page's path, or nil/false for none")
+  attr(:repost?, :boolean, default: false)
+
+  attr(:acts, :list,
+    default: [:like, :reply, :repost],
+    doc:
+      "which acts this host handles. A control whose `phx-click` nobody handles " <>
+        "crashes a LiveView and does nothing at all on a dead controller page, so " <>
+        "the host says what it can take rather than the card assuming. Every host " <>
+        "gets the full set once the row moves into its own LiveComponent (issue #1276)."
+  )
+
+  def remote_actions(assigns) do
+    ~H"""
+    <%!-- The local action bar's own geometry, deliberately to the pixel
+    (`post_actions/1` above): `justify-between` spreads the controls across the
+    column's full width, `-mx-2` cancels the outer buttons' `px-2` so the first
+    and last glyphs line up with the column edges, and every control is the
+    same icon-only rounded target with the same hover fill. A post from another
+    network is a post; a reader should not have to learn a second bar for it.
+    That it once read as icon-plus-label, huddled at the left, was reported as
+    exactly that: "das soll alles einheitlich sein". --%>
+    <div
+      :if={@viewer}
+      class="-mx-2 mt-3 flex items-center justify-between gap-2 text-slate-600 dark:text-slate-400"
+    >
+      <%!-- No number beside any of them, which is the one place this bar
+      departs from the local one — and it departs by leaving something out, not
+      by looking different. vutuv cannot know how many people liked or shared
+      something on somebody else's server, and a figure assembled from what
+      happened to pass through this installation would read as the real one. The
+      author's own server is one click away in the footer below. --%>
+      <.remote_action
+        :if={@like?}
+        act="like"
+        kind={@kind}
+        subject_id={@subject_id}
+        on?={@liked?}
+        on_class="text-accent"
+        label={gettext("Like")}
+        shown={:like in @acts}
+      >
+        <.icon_heart filled?={@liked?} />
+      </.remote_action>
+
+      <%!-- A link, not a toggle: answering opens its own page, which is where a
+      member who does not federate yet is told so before they type. --%>
+      <.remote_action_link
+        href={@reply_to}
+        subject_id={@subject_id}
+        label={gettext("Reply")}
+        shown={@reply_to && :reply in @acts}
+      >
+        <.icon_reply />
+      </.remote_action_link>
+
+      <.remote_action
+        :if={@repost?}
+        act="repost"
+        kind={@kind}
+        subject_id={@subject_id}
+        on?={@reposted?}
+        on_class="text-brand-600 dark:text-brand-300"
+        label={if @reposted?, do: gettext("Undo repost"), else: gettext("Repost")}
+        shown={:repost in @acts}
+      >
+        <.icon_repost />
+      </.remote_action>
+
+      <.remote_action
+        act="bookmark"
+        kind={@kind}
+        subject_id={@subject_id}
+        on?={@bookmarked?}
+        on_class="text-brand-600 dark:text-brand-300"
+        label={if @bookmarked?, do: gettext("Remove bookmark"), else: gettext("Bookmark")}
+        shown={:bookmark in @acts}
+      >
+        <.icon_bookmark filled?={@bookmarked?} />
+      </.remote_action>
+    </div>
+    """
+  end
+
+  # One control in that bar. `shown` decides whether it is rendered or merely
+  # **held open** as an invisible placeholder: the four controls are spread by
+  # `justify-between`, so dropping one would slide the rest along the row and the
+  # bars on two neighbouring cards would no longer line up — which is half of
+  # what made the fediverse card look like a different component. An act this
+  # card cannot carry keeps its slot and gives up its glyph.
+  attr(:act, :string, required: true, values: ~w(like repost bookmark))
+  attr(:kind, :string, required: true)
+  attr(:subject_id, :string, required: true)
+  attr(:on?, :boolean, required: true)
+  attr(:on_class, :string, required: true)
+  attr(:label, :string, required: true)
+  attr(:shown, :any, default: true)
+  slot(:inner_block, required: true)
+
+  defp remote_action(%{shown: shown} = assigns) when shown in [nil, false] do
+    ~H"""
+    <span aria-hidden="true" class="inline-flex px-2 py-1"><span class="h-5 w-5"></span></span>
+    """
+  end
+
+  defp remote_action(assigns) do
+    ~H"""
+    <button
+      type="button"
+      phx-click={"#{if @on?, do: "un", else: ""}#{@act}-#{@kind}"}
+      phx-value-id={@subject_id}
+      aria-pressed={to_string(@on?)}
+      aria-label={@label}
+      title={@label}
+      data-remote-act={@act}
+      data-remote-id={@subject_id}
+      data-on={@on? && "on"}
+      class={[
+        "inline-flex items-center gap-1.5 rounded-lg px-2 py-1 text-sm hover:bg-slate-100 dark:hover:bg-slate-800",
+        # components.css colors bare `a, button` brand-600, which beats the
+        # wrapper's inherited slate — so the state color sits on the button.
+        if(@on?, do: @on_class, else: "text-slate-600 dark:text-slate-400")
+      ]}
+    >
+      {render_slot(@inner_block)}
+    </button>
+    """
+  end
+
+  # The answering control: the same slot and the same look, but a link.
+  attr(:href, :any, required: true)
+  attr(:subject_id, :string, required: true)
+  attr(:label, :string, required: true)
+  attr(:shown, :any, default: true)
+  slot(:inner_block, required: true)
+
+  defp remote_action_link(%{shown: shown} = assigns) when shown in [nil, false] do
+    ~H"""
+    <span aria-hidden="true" class="inline-flex px-2 py-1"><span class="h-5 w-5"></span></span>
+    """
+  end
+
+  defp remote_action_link(assigns) do
+    ~H"""
+    <.link
+      navigate={@href}
+      aria-label={@label}
+      title={@label}
+      data-remote-reply-link={@subject_id}
+      class="inline-flex items-center gap-1.5 rounded-lg px-2 py-1 text-sm text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+    >
+      {render_slot(@inner_block)}
+    </.link>
+    """
+  end
+
   # Where it came from and the way on to the real thing — provenance, not
   # actions: both remote cards' acts live in their own row above this line
   # (issue #1270). The inner block is what a card needs to add to the
@@ -1556,6 +1711,11 @@ defmodule VutuvWeb.PostComponents do
     doc: "whether the viewer has reshared this post (issue #1166); batched by the caller"
   )
 
+  attr(:bookmarked?, :boolean,
+    default: false,
+    doc: "whether the viewer has saved this post (issue #1276); batched by the caller"
+  )
+
   attr(:reposted_by, :any,
     default: nil,
     doc: "the member whose reshare put this card in the reader's feed, or nil"
@@ -1668,81 +1828,20 @@ defmodule VutuvWeb.PostComponents do
 
           <.remote_post_images images={@images} />
 
-          <%!-- The card's three acts (issues #1164, #1165 and #1166), in one
-          row of real touch targets under the body — the same row, in the same
-          order, the remote reply card wears (issue #1270), so a card from
-          another network reads the same whichever of the two it is.
-
-          Shown to every signed-in reader, including one who has not switched
-          Fediverse participation on: each is signed with their own key, so for
-          them none can be sent — but hiding the controls would leave them with
-          no way to find that out. Pressing one explains and points at the
-          switch, the same way the reply page does (issue #1070). --%>
-          <div :if={@viewer} class="mt-1 flex flex-wrap items-center gap-5">
-            <%!-- A plain toggle with no number beside it: the heart says what
-            the reader did, and the only honest answer to "how many others" is
-            the author's own server, one click away in the footer below. --%>
-            <button
-              type="button"
-              phx-click={if @liked?, do: "unlike-remote-post", else: "like-remote-post"}
-              phx-value-id={@remote_post.id}
-              aria-pressed={to_string(@liked?)}
-              data-remote-like={@liked? && "on"}
-              class={[
-                "inline-flex min-h-10 items-center gap-1.5 text-sm font-medium",
-                if(@liked?,
-                  do: "text-accent",
-                  else: "text-slate-600 hover:text-accent dark:text-slate-400"
-                )
-              ]}
-            >
-              <.icon_heart filled?={@liked?} class="h-5 w-5" />
-              <%!-- One label in both states, with the state carried by the filled
-              heart, the accent colour and `aria-pressed` — the same way the local
-              action bar does it. Two labels needed two words, and German has one
-              for both ("Gefällt mir"), so the state would have read differently
-              per language, and in German not at all. --%>
-              <span>{gettext("Like")}</span>
-            </button>
-
-            <%!-- Answering (issue #1165). Only on an open post: an answer is a
-            public vutuv post, and republishing the audience a followers-only
-            post's author chose is not ours to do, so there is no control rather
-            than one that refuses. --%>
-            <.link
-              :if={RemotePost.open?(@remote_post)}
-              navigate={~p"/system/fediverse/reply/post/#{@remote_post.id}"}
-              data-remote-post-reply-link={@remote_post.id}
-              class="inline-flex min-h-10 items-center gap-1.5 text-sm font-medium text-slate-600 hover:text-brand-700 dark:text-slate-400 dark:hover:text-brand-300"
-            >
-              <.icon_reply class="h-5 w-5" />
-              <span>{gettext("Reply")}</span>
-            </.link>
-
-            <%!-- Sharing it onward (issue #1166). Unlike the heart this is a
-            publishing act — everybody who follows the reader here and out there
-            sees it — so it too is only offered on an open post: passing on an
-            audience its author narrowed is not ours to do, and a boost is the
-            least reversible way to do it. --%>
-            <button
-              :if={RemotePost.open?(@remote_post)}
-              type="button"
-              phx-click={if @reposted?, do: "unrepost-remote-post", else: "repost-remote-post"}
-              phx-value-id={@remote_post.id}
-              aria-pressed={to_string(@reposted?)}
-              data-remote-repost={@reposted? && "on"}
-              class={[
-                "inline-flex min-h-10 items-center gap-1.5 text-sm font-medium",
-                if(@reposted?,
-                  do: "text-emerald-700 dark:text-emerald-400",
-                  else: "text-slate-600 hover:text-emerald-700 dark:text-slate-400"
-                )
-              ]}
-            >
-              <.icon_repost class="h-5 w-5" />
-              <span>{gettext("Repost")}</span>
-            </button>
-          </div>
+          <%!-- The card's acts, in the one row both remote cards share
+          (`remote_actions/1`) — issues #1164, #1165, #1166 and #1276. --%>
+          <.remote_actions
+            kind="remote-post"
+            subject_id={@remote_post.id}
+            viewer={@viewer}
+            liked?={@liked?}
+            reposted?={@reposted?}
+            bookmarked?={@bookmarked?}
+            reply_to={
+              RemotePost.open?(@remote_post) && ~p"/system/fediverse/reply/post/#{@remote_post.id}"
+            }
+            repost?={RemotePost.open?(@remote_post)}
+          />
 
           <%!-- A poll's options are shown above, but a vote is not something
           vutuv can carry, so the link says what it is actually for. --%>

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -920,6 +920,12 @@ defmodule VutuvWeb.PostComponents do
       "the viewer's like/repost/bookmark flags for this subject when the host batched them (`Vutuv.Fediverse.liked_ids/2` and friends); nil lets the bar load its own."
   )
 
+  attr(:reposted_by, :any,
+    default: nil,
+    doc:
+      "the member whose reshare put this reply in the reader's feed (issue #1275), or nil in a conversation, where it stands under the post it answers"
+  )
+
   def remote_reply_card(assigns) do
     note = assigns.note
 
@@ -944,6 +950,15 @@ defmodule VutuvWeb.PostComponents do
       id={Fediverse.reply_anchor(@note.id)}
       class="scroll-mt-24"
     >
+      <%!-- Why this reply is in the reader's feed: somebody they follow here
+      passed it on (issue #1275). The same line a reshared post wears, so
+      "somebody carried this to you" reads identically whatever was carried. --%>
+      <.reshare_line
+        :if={@reposted_by}
+        name={full_name(@reposted_by)}
+        navigate={~p"/#{@reposted_by.username}"}
+        data-reshared-reply
+      />
       <div class="flex items-start gap-3">
         <.remote_avatar initials={@initials} />
 

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -824,8 +824,8 @@ defmodule VutuvWeb.PostComponents do
             note={node.note}
             owner?={node.owner?}
             viewer={@viewer}
-            liked?={node.liked?}
-            acts={[:like, :reply]}
+            marks={node.marks}
+            live?
           />
         <% else %>
           <.post_card
@@ -908,15 +908,17 @@ defmodule VutuvWeb.PostComponents do
 
   attr(:viewer, :any, default: nil, doc: "the logged-in member, or nil")
 
-  attr(:acts, :list,
-    default: [],
+  attr(:live?, :boolean,
+    default: false,
     doc:
-      "which acts this surface carries, in the `remote_actions/1` vocabulary. The conversation takes `[:like, :reply]`; the answering page takes none, since the card there is the read-only thing being answered — a Reply link to the page you are already on is noise, and a heart would fire an event that page does not handle."
+      "whether this surface is a LiveView that can host the action bar. False on a dead controller page, where a LiveComponent cannot render at all, and on the answering page, where the card is the read-only thing being answered."
   )
 
-  attr(:liked?, :boolean, default: false, doc: "whether the viewer already likes this reply")
-  attr(:reposted?, :boolean, default: false, doc: "whether the viewer already passed it on")
-  attr(:bookmarked?, :boolean, default: false, doc: "whether the viewer already saved it")
+  attr(:marks, :any,
+    default: nil,
+    doc:
+      "the viewer's like/repost/bookmark flags for this subject when the host batched them (`Vutuv.Fediverse.liked_ids/2` and friends); nil lets the bar load its own."
+  )
 
   def remote_reply_card(assigns) do
     note = assigns.note
@@ -991,22 +993,20 @@ defmodule VutuvWeb.PostComponents do
 
           <.remote_body warning={@warned? && @note.summary} text={@note.content_text} />
 
-          <%!-- The card's acts (issue #1270), in the open under the body where
-          a reader looks for them and sized as real touch targets. One component
-          for both remote cards (`remote_actions/1` below), so a reply and a
-          cached post carry the same row in the same order. --%>
-          <.remote_actions
-            :if={@acts != []}
-            kind="remote-reply"
-            subject_id={@note.id}
+          <%!-- The card's acts, in the open under the body where a reader
+          looks for them (issues #1270, #1275, #1276). The bar owns its own
+          state and its own events, so this card — and every host that renders
+          it — hands it the subject and nothing else. `live?` is false on a dead
+          controller page, where a LiveComponent cannot render and its buttons
+          would do nothing anyway, and on the answering page, where this card is
+          the read-only thing being answered. --%>
+          <.live_component
+            :if={@live? and @viewer}
+            module={VutuvWeb.PostLive.RemoteActionsComponent}
+            id={"remote-actions-note-#{@note.id}"}
+            subject={@note}
             viewer={@viewer}
-            liked?={@liked?}
-            reposted?={@reposted?}
-            bookmarked?={@bookmarked?}
-            like?={Note.likeable?(@note)}
-            reply_to={@public? && ~p"/system/fediverse/reply/#{@note.id}"}
-            repost?={@public?}
-            acts={@acts}
+            marks={@marks}
           />
 
           <.remote_footer host={@host} origin={@origin} label={gettext("View the original")} />
@@ -1326,7 +1326,7 @@ defmodule VutuvWeb.PostComponents do
   `like-remote-reply` / `unlike-remote-reply` and so on, `"remote-post"` the
   `…-remote-post` pairs the feed and the account page already handle.
   """
-  attr(:kind, :string, required: true, values: ~w(remote-reply remote-post))
+  attr(:target, :any, required: true, doc: "the RemoteActionsComponent that handles the presses")
   attr(:subject_id, :string, required: true, doc: "rides every control as phx-value-id")
   attr(:viewer, :any, default: nil, doc: "the logged-in member, or nil for no row at all")
   attr(:liked?, :boolean, default: false)
@@ -1335,15 +1335,6 @@ defmodule VutuvWeb.PostComponents do
   attr(:like?, :boolean, default: true, doc: "false where a Like could not be delivered at all")
   attr(:reply_to, :any, default: nil, doc: "the answering page's path, or nil/false for none")
   attr(:repost?, :boolean, default: false)
-
-  attr(:acts, :list,
-    default: [:like, :reply, :repost],
-    doc:
-      "which acts this host handles. A control whose `phx-click` nobody handles " <>
-        "crashes a LiveView and does nothing at all on a dead controller page, so " <>
-        "the host says what it can take rather than the card assuming. Every host " <>
-        "gets the full set once the row moves into its own LiveComponent (issue #1276)."
-  )
 
   def remote_actions(assigns) do
     ~H"""
@@ -1368,12 +1359,11 @@ defmodule VutuvWeb.PostComponents do
       <.remote_action
         :if={@like?}
         act="like"
-        kind={@kind}
+        target={@target}
         subject_id={@subject_id}
         on?={@liked?}
         on_class="text-accent"
         label={gettext("Like")}
-        shown={:like in @acts}
       >
         <.icon_heart filled?={@liked?} />
       </.remote_action>
@@ -1384,7 +1374,7 @@ defmodule VutuvWeb.PostComponents do
         href={@reply_to}
         subject_id={@subject_id}
         label={gettext("Reply")}
-        shown={@reply_to && :reply in @acts}
+        shown={@reply_to}
       >
         <.icon_reply />
       </.remote_action_link>
@@ -1392,24 +1382,22 @@ defmodule VutuvWeb.PostComponents do
       <.remote_action
         :if={@repost?}
         act="repost"
-        kind={@kind}
+        target={@target}
         subject_id={@subject_id}
         on?={@reposted?}
         on_class="text-brand-600 dark:text-brand-300"
         label={if @reposted?, do: gettext("Undo repost"), else: gettext("Repost")}
-        shown={:repost in @acts}
       >
         <.icon_repost />
       </.remote_action>
 
       <.remote_action
         act="bookmark"
-        kind={@kind}
+        target={@target}
         subject_id={@subject_id}
         on?={@bookmarked?}
         on_class="text-brand-600 dark:text-brand-300"
         label={if @bookmarked?, do: gettext("Remove bookmark"), else: gettext("Bookmark")}
-        shown={:bookmark in @acts}
       >
         <.icon_bookmark filled?={@bookmarked?} />
       </.remote_action>
@@ -1424,7 +1412,7 @@ defmodule VutuvWeb.PostComponents do
   # what made the fediverse card look like a different component. An act this
   # card cannot carry keeps its slot and gives up its glyph.
   attr(:act, :string, required: true, values: ~w(like repost bookmark))
-  attr(:kind, :string, required: true)
+  attr(:target, :any, required: true)
   attr(:subject_id, :string, required: true)
   attr(:on?, :boolean, required: true)
   attr(:on_class, :string, required: true)
@@ -1442,8 +1430,9 @@ defmodule VutuvWeb.PostComponents do
     ~H"""
     <button
       type="button"
-      phx-click={"#{if @on?, do: "un", else: ""}#{@act}-#{@kind}"}
-      phx-value-id={@subject_id}
+      phx-click="toggle"
+      phx-target={@target}
+      phx-value-act={@act}
       aria-pressed={to_string(@on?)}
       aria-label={@label}
       title={@label}
@@ -1701,19 +1690,16 @@ defmodule VutuvWeb.PostComponents do
     doc: "the post's released pictures (issue #1163); the caller batches the read"
   )
 
-  attr(:liked?, :boolean,
+  attr(:live?, :boolean,
     default: false,
-    doc: "whether the viewer already likes this post (issue #1164); batched by the caller"
+    doc:
+      "whether this surface is a LiveView that can host the action bar. False on a dead controller page, where a LiveComponent cannot render at all, and on the answering page, where the card is the read-only thing being answered."
   )
 
-  attr(:reposted?, :boolean,
-    default: false,
-    doc: "whether the viewer has reshared this post (issue #1166); batched by the caller"
-  )
-
-  attr(:bookmarked?, :boolean,
-    default: false,
-    doc: "whether the viewer has saved this post (issue #1276); batched by the caller"
+  attr(:marks, :any,
+    default: nil,
+    doc:
+      "the viewer's like/repost/bookmark flags for this post when the host batched them; nil lets the bar load its own."
   )
 
   attr(:reposted_by, :any,
@@ -1828,19 +1814,16 @@ defmodule VutuvWeb.PostComponents do
 
           <.remote_post_images images={@images} />
 
-          <%!-- The card's acts, in the one row both remote cards share
-          (`remote_actions/1`) — issues #1164, #1165, #1166 and #1276. --%>
-          <.remote_actions
-            kind="remote-post"
-            subject_id={@remote_post.id}
+          <%!-- The same bar, from the same component (issues #1164, #1165,
+          #1166 and #1276) — a reply and a cached post are the same kind of
+          thing to a reader, so "what can I do with this" has one definition. --%>
+          <.live_component
+            :if={@live? and @viewer}
+            module={VutuvWeb.PostLive.RemoteActionsComponent}
+            id={"remote-actions-post-#{@remote_post.id}"}
+            subject={@remote_post}
             viewer={@viewer}
-            liked?={@liked?}
-            reposted?={@reposted?}
-            bookmarked?={@bookmarked?}
-            reply_to={
-              RemotePost.open?(@remote_post) && ~p"/system/fediverse/reply/post/#{@remote_post.id}"
-            }
-            repost?={RemotePost.open?(@remote_post)}
+            marks={@marks}
           />
 
           <%!-- A poll's options are shown above, but a vote is not something
@@ -2086,12 +2069,12 @@ defmodule VutuvWeb.PostComponents do
         "siblings of that post's own answers, in time order"
   )
 
-  attr(:liked_notes, :any,
+  attr(:note_marks, :any,
     default: nil,
     doc:
-      "the note ids the viewer already likes as a MapSet " <>
-        "(Vutuv.Fediverse.liked_note_ids/2), batched by the host so the remote " <>
-        "reply cards' hearts don't each ask for themselves"
+      "a fun from a note to its `%{liked?:, reposted?:, bookmarked?:}` map, " <>
+        "batched by the host so the remote reply cards' bars don't each ask " <>
+        "for themselves (`Vutuv.Fediverse.liked_ids/2` and friends)"
   )
 
   attr(:conn_or_socket, :any, required: true)
@@ -2122,7 +2105,7 @@ defmodule VutuvWeb.PostComponents do
   attr(:viewer_follows, :map, default: %{})
   attr(:engagement, :map, default: %{})
   attr(:remote_replies, :map, default: %{})
-  attr(:liked_notes, :any, default: nil)
+  attr(:note_marks, :any, default: nil)
   attr(:conn_or_socket, :any, required: true)
 
   def thread_window_conversation(assigns) do
@@ -2219,7 +2202,7 @@ defmodule VutuvWeb.PostComponents do
     |> weave_remote_replies(
       assigns[:remote_replies] || %{},
       assigns.viewer,
-      assigns[:liked_notes] || MapSet.new()
+      assigns[:note_marks] || fn _note -> nil end
     )
   end
 
@@ -2231,22 +2214,22 @@ defmodule VutuvWeb.PostComponents do
   # `remote_replies` is `Vutuv.Fediverse.list_notes/2`'s per-post map, already
   # viewer-scoped — a reply addressed to the member alone never reaches anybody
   # else's render.
-  defp weave_remote_replies(nodes, remote, _viewer, _liked) when remote == %{}, do: nodes
+  defp weave_remote_replies(nodes, remote, _viewer, _marks) when remote == %{}, do: nodes
 
-  defp weave_remote_replies(nodes, remote, viewer, liked) do
+  defp weave_remote_replies(nodes, remote, viewer, marks) do
     Enum.map(nodes, fn node ->
       children =
         node.children
-        |> weave_remote_replies(remote, viewer, liked)
-        |> merge_remote_nodes(Map.get(remote, node.post.id, []), node.post, viewer, liked)
+        |> weave_remote_replies(remote, viewer, marks)
+        |> merge_remote_nodes(Map.get(remote, node.post.id, []), node.post, viewer, marks)
 
       %{node | children: children}
     end)
   end
 
-  defp merge_remote_nodes(children, [], _post, _viewer, _liked), do: children
+  defp merge_remote_nodes(children, [], _post, _viewer, _marks), do: children
 
-  defp merge_remote_nodes(children, notes, post, viewer, liked) do
+  defp merge_remote_nodes(children, notes, post, viewer, marks) do
     owner? = match?(%User{}, viewer) and viewer.id == post.user_id
 
     # An answer to one of these notes (issue #1070) is, underneath, an ordinary
@@ -2260,7 +2243,7 @@ defmodule VutuvWeb.PostComponents do
         %{
           note: note,
           owner?: owner?,
-          liked?: MapSet.member?(liked, note.id),
+          marks: marks.(note),
           children:
             answers
             |> Enum.filter(&(answered_note_id(&1) == note.id))

--- a/lib/vutuv_web/live/fediverse_account_live.ex
+++ b/lib/vutuv_web/live/fediverse_account_live.ex
@@ -89,8 +89,7 @@ defmodule VutuvWeb.FediverseAccountLive do
     # Which of them the reader already likes (issue #1164), read once for the
     # page. Unlike the feed this page holds its posts in a plain assign, so a
     # set beside them redraws every card on a toggle, which is what we want.
-    |> assign(:liked, Fediverse.liked_remote_post_ids(viewer, ids))
-    |> assign(:reposted, Fediverse.reposted_remote_post_ids(viewer, ids))
+    |> assign(:marks, Fediverse.mark_lookup(posts, viewer))
     |> assign(:more?, more?)
   end
 
@@ -176,28 +175,6 @@ defmodule VutuvWeb.FediverseAccountLive do
   # The heart (issue #1164): the local marker plus a signed `Like` to this
   # account's own inbox. Only the reader's own state changes — there is no
   # count on the card, because the real one lives on their server.
-  def handle_event("like-remote-post", %{"id" => id}, socket) do
-    {:noreply, toggle_remote_act(socket, id, &Fediverse.like_remote_post/2)}
-  end
-
-  def handle_event("unlike-remote-post", %{"id" => id}, socket) do
-    {:noreply, toggle_remote_act(socket, id, &Fediverse.unlike_remote_post/2)}
-  end
-
-  # Sharing one of their posts onward (issue #1166), the same act the feed card
-  # offers. Publishing, so it says so — but only when the reshare really
-  # happened, never over the top of a refusal or a second tab's press.
-  def handle_event("repost-remote-post", %{"id" => id}, socket) do
-    {:noreply,
-     toggle_remote_act(socket, id, &Fediverse.repost_remote_post/2,
-       flash: {:reposted, gettext("Reposted. Your followers see it now.")}
-     )}
-  end
-
-  def handle_event("unrepost-remote-post", %{"id" => id}, socket) do
-    {:noreply, toggle_remote_act(socket, id, &Fediverse.unrepost_remote_post/2)}
-  end
-
   def handle_event("mute-remote-account", %{"id" => account_id}, socket) do
     viewer = socket.assigns.current_user
     :ok = Fediverse.set_remote_follow_mute(viewer, account_id, true)
@@ -240,26 +217,6 @@ defmodule VutuvWeb.FediverseAccountLive do
   # what the database says — a second tab that liked the same post is then not
   # contradicted by this one. `:flash` is an `{outcome, message}` the act
   # announces itself with, and only when that outcome really came back.
-  defp toggle_remote_act(socket, remote_post_id, action, opts \\ []) do
-    case Enum.find(socket.assigns.posts, &(&1.id == remote_post_id)) do
-      nil ->
-        socket
-
-      post ->
-        post = %{post | remote_account: socket.assigns.account}
-
-        case action.(socket.assigns.current_user, post) do
-          {:ok, outcome} -> socket |> load_posts() |> flash_outcome(opts[:flash], outcome)
-          {:error, reason} -> put_flash(socket, :error, like_refusal_message(reason))
-        end
-    end
-  end
-
-  defp flash_outcome(socket, {outcome, message}, outcome),
-    do: put_flash(socket, :info, message)
-
-  defp flash_outcome(socket, _flash, _outcome), do: socket
-
   defp mute_message(true),
     do: gettext("Muted. You still follow them; their posts leave your feed.")
 
@@ -410,10 +367,10 @@ defmodule VutuvWeb.FediverseAccountLive do
                   it is the one account, already in hand. --%>
             <div :for={post <- @posts} class="py-4 first:pt-0 last:pb-0">
               <.remote_post_card
+            live?
                 remote_post={%{post | remote_account: @account}}
                 images={Map.get(@images, post.id, [])}
-                liked?={MapSet.member?(@liked, post.id)}
-                reposted?={MapSet.member?(@reposted, post.id)}
+                marks={@marks.(post)}
                 viewer={@current_user}
               />
             </div>

--- a/lib/vutuv_web/live/fediverse_lookup_live.ex
+++ b/lib/vutuv_web/live/fediverse_lookup_live.ex
@@ -62,8 +62,6 @@ defmodule VutuvWeb.FediverseLookupLive do
     socket
     |> assign(:post, nil)
     |> assign(:images, [])
-    |> assign(:liked?, false)
-    |> assign(:reposted?, false)
     |> assign(:follow, nil)
   end
 
@@ -94,25 +92,6 @@ defmodule VutuvWeb.FediverseLookupLive do
   # a URL the member has since corrected.
   def handle_event("typing", %{"url" => url}, socket) do
     {:noreply, socket |> assign(:url, url) |> assign(:error, nil)}
-  end
-
-  def handle_event("like-remote-post", _params, socket) do
-    {:noreply, act(socket, &Fediverse.like_remote_post/2)}
-  end
-
-  def handle_event("unlike-remote-post", _params, socket) do
-    {:noreply, act(socket, &Fediverse.unlike_remote_post/2)}
-  end
-
-  def handle_event("repost-remote-post", _params, socket) do
-    {:noreply,
-     act(socket, &Fediverse.repost_remote_post/2,
-       flash: {:reposted, gettext("Reposted. Your followers see it now.")}
-     )}
-  end
-
-  def handle_event("unrepost-remote-post", _params, socket) do
-    {:noreply, act(socket, &Fediverse.unrepost_remote_post/2)}
   end
 
   # The card is reportable here like everywhere else. It matters more here than
@@ -169,28 +148,6 @@ defmodule VutuvWeb.FediverseLookupLive do
   # re-read rather than nudged, so what the page draws is what the database
   # says. No `phx-value-id` is trusted: there is exactly one post here, it is the
   # one the socket already holds, and an act pushed at an empty page is nothing.
-  defp act(socket, action, opts \\ [])
-
-  defp act(%{assigns: %{post: nil}} = socket, _action, _opts), do: socket
-
-  defp act(socket, action, opts) do
-    case action.(socket.assigns.current_user, socket.assigns.post) do
-      {:ok, outcome} -> socket |> reload_result() |> flash_outcome(opts[:flash], outcome)
-      {:error, reason} -> put_flash(socket, :error, like_refusal_message(reason))
-    end
-  end
-
-  defp flash_outcome(socket, {outcome, message}, outcome),
-    do: put_flash(socket, :info, message)
-
-  defp flash_outcome(socket, _flash, _outcome), do: socket
-
-  defp reload_result(socket) do
-    case Fediverse.get_remote_post(socket.assigns.post.id) do
-      nil -> clear_result(socket)
-      post -> load_result(socket, post)
-    end
-  end
 
   defp load_result(socket, post) do
     viewer = socket.assigns.current_user
@@ -356,10 +313,9 @@ defmodule VutuvWeb.FediverseLookupLive do
       under a flash that says it did. --%>
       <.card :if={@post} id="lookup-result">
         <.remote_post_card
+            live?
           remote_post={@post}
           images={@images}
-          liked?={@liked?}
-          reposted?={@reposted?}
           mute?={@follow != nil}
           viewer={@current_user}
         />

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -439,7 +439,8 @@ defmodule VutuvWeb.PostLive.Feed do
 
     muted =
       Enum.filter(socket.assigns.entries, fn entry ->
-        Posts.remote_feed_entry?(entry) and entry.remote_post.remote_account_id == account_id
+        Posts.remote_feed_entry?(entry) and not Posts.remote_reply_entry?(entry) and
+          entry.remote_post.remote_account_id == account_id
       end)
 
     {:noreply,
@@ -792,7 +793,7 @@ defmodule VutuvWeb.PostLive.Feed do
       # plain text: the member muted a word because they do not want to read it,
       # and where it was written changes nothing about that.
       Posts.remote_feed_entry?(entry) ->
-        ContentFilters.filtered_text(entry.remote_post.content_text, compiled)
+        ContentFilters.filtered_text(remote_entry_text(entry), compiled)
 
       # Never the member's own posts. A remote post cannot reach this arm: it has
       # no author here, so the exemption has nothing to match on.
@@ -809,7 +810,11 @@ defmodule VutuvWeb.PostLive.Feed do
   # network (issue #1161) by its row id — it is not a `%Post{}` and has no post
   # id to key on.
   defp filter_key(entry) do
-    if Posts.remote_feed_entry?(entry), do: entry.remote_post.id, else: entry.post.id
+    cond do
+      Posts.remote_reply_entry?(entry) -> entry.note.id
+      Posts.remote_feed_entry?(entry) -> entry.remote_post.id
+      true -> entry.post.id
+    end
   end
 
   # Whether the reader's filters currently hide this entry: it matched one, and
@@ -849,10 +854,19 @@ defmodule VutuvWeb.PostLive.Feed do
   # an assign being flipped: a stream item redraws only when its own entry is
   # handed back, which is also why the state rides the entry. `:flash` is an
   # `{outcome, message}` the act announces itself with when it really happened.
+  # The text a content filter matches on, whichever remote shape the row is.
+  defp remote_entry_text(entry) do
+    if Posts.remote_reply_entry?(entry),
+      do: entry.note.content_text,
+      else: entry.remote_post.content_text
+  end
+
   # "This row is the cached post with that id" — the one predicate the three
   # scans over `:entries` that single a remote post out all read from.
   defp remote_entry?(entry, remote_post_id),
-    do: Posts.remote_feed_entry?(entry) and entry.remote_post.id == remote_post_id
+    do:
+      Posts.remote_feed_entry?(entry) and not Posts.remote_reply_entry?(entry) and
+        entry.remote_post.id == remote_post_id
 
   # The entries carrying a vutuv post. A cached post from another network has
   # `post: nil`, so every batch read and every scan that reaches for
@@ -1053,6 +1067,17 @@ defmodule VutuvWeb.PostLive.Feed do
                   the reader can still open, instead of vanishing (a silently
                   shorter feed confuses and breaks reply threads). --%>
                   <.filtered_placeholder pattern={entry.filtered_by} key={filter_key(entry)} />
+                <% Posts.remote_reply_entry?(entry) -> %>
+                  <%!-- A reply from another network that somebody here passed
+                  on (issue #1275). The same card the conversation draws, with
+                  the reshare line above it — what is new is the sharing. --%>
+                  <.remote_reply_card
+                    note={entry.note}
+                    viewer={@current_user}
+                    marks={entry[:marks]}
+                    reposted_by={entry.reposted_by}
+                    live?
+                  />
                 <% Posts.remote_feed_entry?(entry) -> %>
                   <%!-- A post by an account the reader follows out there: the
                   same remote skin the reply cards wear, one federating heart

--- a/lib/vutuv_web/live/post_live/feed.ex
+++ b/lib/vutuv_web/live/post_live/feed.ex
@@ -431,35 +431,6 @@ defmodule VutuvWeb.PostLive.Feed do
     end
   end
 
-  # The heart on a post from another network (issue #1164): the marker is
-  # written here and a signed `Like` goes to the author's own server. Only the
-  # reader's own state is painted — there is no count to update, because vutuv
-  # does not know the post's real one.
-  def handle_event("like-remote-post", %{"id" => id}, socket) do
-    {:noreply, toggle_remote_flag(socket, id, :liked?, true, &Fediverse.like_remote_post/2)}
-  end
-
-  def handle_event("unlike-remote-post", %{"id" => id}, socket) do
-    {:noreply, toggle_remote_flag(socket, id, :liked?, false, &Fediverse.unlike_remote_post/2)}
-  end
-
-  # Sharing a post from another network onward (issue #1166). Unlike the heart
-  # this is a publishing act, so it says so rather than only painting a button:
-  # what changed is who else can now see this, which is not visible from here.
-  def handle_event("repost-remote-post", %{"id" => id}, socket) do
-    {:noreply,
-     toggle_remote_flag(socket, id, :reposted?, true, &Fediverse.repost_remote_post/2,
-       # Only when the act really happened, so a second tab pressing the same
-       # button does not announce a reshare that was already standing.
-       flash: {:reposted, gettext("Reposted. Your followers see it now.")}
-     )}
-  end
-
-  def handle_event("unrepost-remote-post", %{"id" => id}, socket) do
-    {:noreply,
-     toggle_remote_flag(socket, id, :reposted?, false, &Fediverse.unrepost_remote_post/2)}
-  end
-
   # "Not this account today": the private, reversible lever beside Report. The
   # follow survives; its posts leave this feed, so every row from that account
   # goes in the same round trip rather than lingering until the next reload.
@@ -878,33 +849,6 @@ defmodule VutuvWeb.PostLive.Feed do
   # an assign being flipped: a stream item redraws only when its own entry is
   # handed back, which is also why the state rides the entry. `:flash` is an
   # `{outcome, message}` the act announces itself with when it really happened.
-  defp toggle_remote_flag(socket, remote_post_id, key, value, action, opts \\ []) do
-    with %{} = entry <- Enum.find(socket.assigns.entries, &remote_entry?(&1, remote_post_id)),
-         {:ok, outcome} <- action.(socket.assigns.current_user, entry.remote_post) do
-      updated = Map.put(entry, key, value)
-
-      socket
-      |> flash_outcome(opts[:flash], outcome)
-      |> update(:entries, &replace_remote_entry(&1, updated))
-      |> stream_insert(:posts, updated, update_only: true)
-    else
-      {:error, reason} -> put_flash(socket, :error, like_refusal_message(reason))
-      _ -> socket
-    end
-  end
-
-  defp flash_outcome(socket, {outcome, message}, outcome),
-    do: put_flash(socket, :info, message)
-
-  defp flash_outcome(socket, _flash, _outcome), do: socket
-
-  # By the entry's own id, not by the post's. Two entries can carry the same
-  # cached post (a direct one and a reshare), and replacing "every entry with
-  # this post" wrote one identity over both — losing the reshare's id and its
-  # "Reposted by" line, and leaving the stream unable to find either again.
-  defp replace_remote_entry(entries, %{id: id} = updated),
-    do: Enum.map(entries, &if(&1.id == id, do: updated, else: &1))
-
   # "This row is the cached post with that id" — the one predicate the three
   # scans over `:entries` that single a remote post out all read from.
   defp remote_entry?(entry, remote_post_id),
@@ -1115,10 +1059,10 @@ defmodule VutuvWeb.PostLive.Feed do
                   (issue #1164; replies and boosts are #1165/#1166), and its own
                   report control. --%>
                   <.remote_post_card
+            live?
                     remote_post={entry.remote_post}
                     images={entry[:images] || []}
-                    liked?={entry[:liked?] == true}
-                    reposted?={entry[:reposted?] == true}
+                    marks={entry[:marks]}
                     reposted_by={entry[:reposted_by]}
                     boosted_by={entry[:boosted_by]}
                     viewer={@current_user}

--- a/lib/vutuv_web/live/post_live/remote_actions_component.ex
+++ b/lib/vutuv_web/live/post_live/remote_actions_component.ex
@@ -1,0 +1,170 @@
+defmodule VutuvWeb.PostLive.RemoteActionsComponent do
+  @moduledoc """
+  The action bar on a card from another network — a reply that arrived under a
+  member's post or a cached post by a followed account — as an **in-process
+  LiveComponent** (issues #1275 and #1276).
+
+  It exists for the reason `VutuvWeb.PostLive.ActionsComponent` exists one card
+  over, and it was built after the same complaint. Seven hosts render these
+  cards (the feed, the permalink conversation, the account page, the URL lookup,
+  the tag timeline, the two answering pages) and every act used to mean a fresh
+  copy of the same `handle_event` clause in each of them — which is why the
+  reply card had two acts while the post card had three, why the answering pages
+  rendered buttons that would have crashed them, and why a dead controller page
+  rendered buttons that silently did nothing. Adding the bookmark would have
+  meant seven more copies.
+
+  So the bar owns its own state and its own events. A host renders it and
+  handles **nothing**; what it may hand in is the marks it already batched
+  (`marks`), which the feed and the conversation do because they draw many cards
+  at once. Without them the bar loads its own three point lookups, which is what
+  the single-card pages want anyway.
+
+  What it deliberately does not do is subscribe to anything. There is no live
+  counter to tick: vutuv does not know how many people on other servers liked or
+  reshared a thing, so this bar shows the reader's own state and nothing else
+  (`remote_actions/1` says the same in the markup).
+
+  A refusal is explained **here**, inline under the bar, rather than as a flash.
+  Two of the hosts are embedded LiveViews whose flash never reaches the toast
+  tray in the dead layout, so a `put_flash/3` would be swallowed on exactly the
+  page where the reply card lives.
+  """
+  use VutuvWeb, :live_component
+
+  import VutuvWeb.PostComponents, only: [remote_actions: 1, like_refusal_message: 2]
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.RemotePost
+
+  @impl true
+  def update(assigns, socket) do
+    {:ok,
+     socket
+     |> assign(:id, assigns.id)
+     |> assign(:subject, assigns.subject)
+     |> assign(:viewer, assigns[:viewer])
+     |> assign_new(:notice, fn -> nil end)
+     # `assign_new`, like the local bar: the first pass takes what the host
+     # batched (or loads its own), and later host re-renders keep the copy this
+     # bar may have toggled since — re-applying a stale preload would undo the
+     # reader's just-clicked state.
+     |> assign_new(:marks, fn -> marks(assigns[:marks], assigns.subject, assigns[:viewer]) end)}
+  end
+
+  # The three flags, from what the host batched or from this bar's own lookups.
+  defp marks(%{} = batched, _subject, _viewer), do: batched
+  defp marks(_none, _subject, nil), do: %{liked?: false, reposted?: false, bookmarked?: false}
+
+  defp marks(_none, subject, viewer) do
+    %{
+      liked?: marked?(Fediverse.liked_ids(viewer, subject), subject),
+      reposted?: marked?(Fediverse.reposted_ids(viewer, subject), subject),
+      bookmarked?: marked?(Fediverse.bookmarked_ids(viewer, subject), subject)
+    }
+  end
+
+  defp marked?(ids, subject), do: MapSet.member?(ids, subject.id)
+
+  @impl true
+  def handle_event("toggle", %{"act" => act}, socket) do
+    %{subject: subject, viewer: viewer, marks: marks} = socket.assigns
+    on? = Map.fetch!(marks, flag(act))
+
+    case Fediverse.toggle_engagement(viewer, subject, act, not on?) do
+      {:ok, outcome} ->
+        {:noreply,
+         socket
+         |> assign(:notice, confirmation(outcome))
+         |> assign(:marks, Map.put(marks, flag(act), not on?))}
+
+      {:error, reason} ->
+        {:noreply, assign(socket, :notice, like_refusal_message(reason, subject_kind(subject)))}
+    end
+  end
+
+  # Resharing is the one act that says something back. The heart and the
+  # bookmark are their own confirmation — the glyph fills in and that IS what
+  # happened — but a reshare's effect is elsewhere: it goes to people who follow
+  # the reader here and out there, and their own feed does not show it back to
+  # them, so a silent button leaves them unsure whether it worked. Only on the
+  # act itself, never on the repeat that wrote nothing.
+  defp confirmation(:reposted), do: gettext("Reposted. Your followers see it now.")
+  defp confirmation(_outcome), do: nil
+
+  defp flag("like"), do: :liked?
+  defp flag("repost"), do: :reposted?
+  defp flag("bookmark"), do: :bookmarked?
+
+  defp subject_kind(%Note{}), do: :reply
+  defp subject_kind(%RemotePost{}), do: :post
+
+  # Which acts this subject can carry at all — a fact about the **subject**,
+  # never about the reader: what a member may do is decided by the gates when
+  # they press, and hiding a control would leave them no way to find out the
+  # capability exists (issue #1070). What is answered here is narrower, whether
+  # the act is possible for this thing in the first place:
+  #
+  #   * `like?` — a reply needs a stored inbox to deliver the `Like` to; one
+  #     saved before issue #1070 has none, and a heart that could never leave
+  #     the building is worse than no heart. A cached post always has its
+  #     author's.
+  #   * `reply_to` / `repost?` — public subjects only. An answer is a public
+  #     vutuv post and a reshare is publishing, so passing on an audience its
+  #     author narrowed is not ours to do.
+  #
+  # Bookmarking is absent because it is always possible: it stays here, sends
+  # nothing, and asks nothing of anybody's standing. It lives on this side of
+  # the house rather than in `Vutuv.Fediverse` because two thirds of it is a
+  # route.
+  defp offered_acts(%Note{} = note) do
+    %{
+      like?: Note.likeable?(note),
+      reply_to: Note.public?(note) && ~p"/system/fediverse/reply/#{note.id}",
+      repost?: Note.public?(note)
+    }
+  end
+
+  defp offered_acts(%RemotePost{} = post) do
+    open? = RemotePost.open?(post)
+
+    %{
+      like?: true,
+      reply_to: open? && ~p"/system/fediverse/reply/post/#{post.id}",
+      repost?: open?
+    }
+  end
+
+  @impl true
+  def render(assigns) do
+    assigns = assign(assigns, :offer, offered_acts(assigns.subject))
+
+    ~H"""
+    <div>
+      <.remote_actions
+        target={@myself}
+        subject_id={@subject.id}
+        viewer={@viewer}
+        liked?={@marks.liked?}
+        reposted?={@marks.reposted?}
+        bookmarked?={@marks.bookmarked?}
+        like?={@offer.like?}
+        reply_to={@offer.reply_to}
+        repost?={@offer.repost?}
+      />
+      <%!-- Beside the control that refused, in the reader's own words. The one
+      refusal a member can act on says what to do about it; the rest say only
+      that it did not work (`like_refusal_message/2`). --%>
+      <p
+        :if={@notice}
+        role="status"
+        data-remote-notice
+        class="mt-1 text-xs text-slate-600 dark:text-slate-400"
+      >
+        {@notice}
+      </p>
+    </div>
+    """
+  end
+end

--- a/lib/vutuv_web/live/post_live/saved.ex
+++ b/lib/vutuv_web/live/post_live/saved.ex
@@ -24,6 +24,7 @@ defmodule VutuvWeb.PostLive.Saved do
   import VutuvWeb.UserHelpers, only: [full_name: 1]
 
   alias Vutuv.Accounts.User
+  alias Vutuv.Fediverse
   alias Vutuv.Jobs
   alias Vutuv.Organizations
   alias Vutuv.Posts
@@ -52,7 +53,8 @@ defmodule VutuvWeb.PostLive.Saved do
      |> stream(:posts, [])
      |> stream(:people, [])
      |> stream(:organizations, [])
-     |> stream(:jobs, [])}
+     |> stream(:jobs, [])
+     |> stream(:networks, [])}
   end
 
   @impl true
@@ -97,31 +99,60 @@ defmodule VutuvWeb.PostLive.Saved do
       sort: socket.assigns.sort
     ]
 
-    case {socket.assigns.live_action, socket.assigns.type} do
-      {:likes, :posts} ->
-        {:posts, Posts.liked_posts_page(user, opts)}
+    page(socket.assigns.type, socket.assigns.live_action, user, opts)
+  end
 
-      {:bookmarks, :posts} ->
-        {:posts, Posts.bookmarked_posts_page(user, opts)}
+  # One clause per sub-tab, each branching on which of the two hubs it is —
+  # rather than one `case` over the pair, which grows a branch every time either
+  # axis does and had already outgrown what one function should carry.
+  defp page(:posts, :likes, user, opts), do: {:posts, Posts.liked_posts_page(user, opts)}
+  defp page(:posts, :bookmarks, user, opts), do: {:posts, Posts.bookmarked_posts_page(user, opts)}
+  defp page(:people, :likes, user, opts), do: {:people, Social.liked_users_page(user, opts)}
 
-      {:likes, :people} ->
-        {:people, Social.liked_users_page(user, opts)}
+  defp page(:people, :bookmarks, user, opts),
+    do: {:people, Social.bookmarked_users_page(user, opts)}
 
-      {:bookmarks, :people} ->
-        {:people, Social.bookmarked_users_page(user, opts)}
+  defp page(:organizations, action, user, opts),
+    do: {:organizations, Organizations.saved_organizations_page(user, kind(action), opts)}
 
-      {:likes, :organizations} ->
-        {:organizations, Organizations.saved_organizations_page(user, :like, opts)}
+  defp page(:jobs, action, user, opts),
+    do: {:jobs, Jobs.saved_job_postings_page(user, kind(action), opts)}
 
-      {:bookmarks, :organizations} ->
-        {:organizations, Organizations.saved_organizations_page(user, :bookmark, opts)}
+  defp page(:networks, action, user, opts),
+    do: {:networks, saved_networks_page(action, user, opts)}
 
-      {:likes, :jobs} ->
-        {:jobs, Jobs.saved_job_postings_page(user, :like, opts)}
+  defp kind(:likes), do: :like
+  defp kind(:bookmarks), do: :bookmark
 
-      {:bookmarks, :jobs} ->
-        {:jobs, Jobs.saved_job_postings_page(user, :bookmark, opts)}
-    end
+  # What they saved from other networks (issue #1276). Its own sub-tab rather
+  # than mixed into the posts, and deliberately: this list has no vutuv author
+  # to sort by (the "by name" order the others offer is meaningless here) and it
+  # pages a different table, so merging the two would need a union pager to stay
+  # honest about `more?`. A tab is the smaller, truer answer; the things
+  # themselves read as the same cards.
+  #
+  # Nothing from another network is *liked* into a list — a like out there is a
+  # message to its author, not a shelf of your own — so that half is empty by
+  # construction and the tab is not offered under Likes at all.
+  #
+  # Returns the same `%{entries:, more?:, next_offset:}` shape every other
+  # loader here does: it asks for one row more than it shows and drops it, which
+  # answers "is there another page" without a second count.
+  defp saved_networks_page(:likes, _user, opts),
+    do: %{entries: [], more?: false, next_offset: Keyword.fetch!(opts, :offset)}
+
+  defp saved_networks_page(:bookmarks, user, opts) do
+    limit = Keyword.fetch!(opts, :limit)
+    offset = Keyword.fetch!(opts, :offset)
+
+    rows =
+      Fediverse.saved_from_networks(user,
+        q: Keyword.get(opts, :search),
+        limit: limit,
+        offset: offset
+      )
+
+    %{entries: Enum.take(rows, limit), more?: length(rows) > limit, next_offset: offset + limit}
   end
 
   defp subscribe_posts(entries), do: Enum.each(entries, &Posts.subscribe_post(&1.id))
@@ -129,6 +160,7 @@ defmodule VutuvWeb.PostLive.Saved do
   defp parse_type("people"), do: :people
   defp parse_type("organizations"), do: :organizations
   defp parse_type("jobs"), do: :jobs
+  defp parse_type("networks"), do: :networks
   defp parse_type(_), do: :posts
 
   defp parse_sort("oldest"), do: :oldest
@@ -413,7 +445,17 @@ defmodule VutuvWeb.PostLive.Saved do
   defp type_param(:people), do: "people"
   defp type_param(:organizations), do: "organizations"
   defp type_param(:jobs), do: "jobs"
+  defp type_param(:networks), do: "networks"
   defp type_param(_posts), do: false
+
+  defp networks_empty_text(q) when is_binary(q) and q != "",
+    do: gettext("Nothing saved from other networks matches that.")
+
+  defp networks_empty_text(_q),
+    do:
+      gettext(
+        "Nothing saved from other networks yet. The bookmark on a post or reply from another network keeps it here."
+      )
 
   defp sort_options do
     [
@@ -457,6 +499,17 @@ defmodule VutuvWeb.PostLive.Saved do
           <.subtab patch={saved_path(@live_action, :jobs, @q, @sort)} active?={@type == :jobs} id="subtab-jobs">
             {gettext("Jobs")}
           </.subtab>
+          <%!-- Only under Bookmarks (issue #1276): a like on something from
+          another network is a message to its author, not a shelf of your own,
+          so there is no such list to offer. --%>
+          <.subtab
+            :if={@live_action == :bookmarks}
+            patch={saved_path(@live_action, :networks, @q, @sort)}
+            active?={@type == :networks}
+            id="subtab-networks"
+          >
+            {gettext("Other networks")}
+          </.subtab>
         </nav>
 
         <.form for={%{}} id="saved-filter" phx-change="filter" class="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -494,6 +547,30 @@ defmodule VutuvWeb.PostLive.Saved do
                   conn_or_socket={@socket}
                   engagement={Map.get(@post_engagement, post.id)}
                   surface={:flat}
+                />
+              </div>
+            </.post_list>
+          <% @type == :networks -> %>
+            <%!-- The very cards these things wear everywhere else, so a saved
+            reply and a saved post read here exactly as they did where they were
+            saved — including their action bars, which is how a bookmark is
+            taken back from this page. --%>
+            <.post_list id="saved-networks" phx-update="stream" data-post-list>
+              <p class="hidden py-4 text-slate-600 dark:text-slate-400 only:block" id="saved-networks-empty">
+                {networks_empty_text(@q)}
+              </p>
+              <div :for={{dom_id, entry} <- @streams.networks} id={dom_id} class={post_row_class()}>
+                <.remote_reply_card
+                  :if={Posts.remote_reply_entry?(entry)}
+                  note={entry.note}
+                  viewer={@current_user}
+                  live?
+                />
+                <.remote_post_card
+                  :if={not Posts.remote_reply_entry?(entry)}
+                  remote_post={entry.remote_post}
+                  viewer={@current_user}
+                  live?
                 />
               </div>
             </.post_list>

--- a/lib/vutuv_web/live/post_live/thread.ex
+++ b/lib/vutuv_web/live/post_live/thread.ex
@@ -40,20 +40,13 @@ defmodule VutuvWeb.PostLive.Thread do
   use Phoenix.LiveView
 
   import VutuvWeb.PostComponents,
-    only: [
-      post_card: 1,
-      thread_conversation: 1,
-      thread_window_conversation: 1,
-      like_refusal_message: 2
-    ]
+    only: [post_card: 1, thread_conversation: 1, thread_window_conversation: 1]
 
   import VutuvWeb.UI, only: [card: 1, delimited_count: 1]
 
   use Gettext, backend: VutuvWeb.Gettext
 
-  alias Vutuv.Accounts.User
   alias Vutuv.Fediverse
-  alias Vutuv.Fediverse.Note
   alias Vutuv.Posts
   alias Vutuv.Social
   alias VutuvWeb.Live.InitAssigns
@@ -158,18 +151,6 @@ defmodule VutuvWeb.PostLive.Thread do
      )}
   end
 
-  # The heart on a reply from another network (issue #1270): the marker is
-  # written here and a signed `Like` goes to its author's own server. Only the
-  # reader's own state is painted — there is no count to update, because vutuv
-  # does not know the reply's real one.
-  def handle_event("like-remote-reply", %{"id" => id}, socket) do
-    {:noreply, toggle_note_like(socket, id, &Fediverse.like_note/2, true)}
-  end
-
-  def handle_event("unlike-remote-reply", %{"id" => id}, socket) do
-    {:noreply, toggle_note_like(socket, id, &Fediverse.unlike_note/2, false)}
-  end
-
   @impl true
   def handle_info({:post_counters, %{post_id: post_id} = payload}, socket) do
     # This host holds the post-topic subscriptions for its cards; the matching
@@ -208,7 +189,7 @@ defmodule VutuvWeb.PostLive.Thread do
         |> assign(:window, nil)
         |> assign(:focus, nil)
         |> assign(:remote_replies, %{})
-        |> assign(:liked_notes, MapSet.new())
+        |> assign(:note_marks, Fediverse.mark_lookup([], nil))
 
       post ->
         window =
@@ -236,14 +217,10 @@ defmodule VutuvWeb.PostLive.Thread do
         # addressed to the member alone never reaches anybody else's render.
         remote = Fediverse.list_notes(ids, viewer)
 
-        # Which of them this reader already likes (issue #1270) — one query for
-        # the whole window, the way the posts' engagement is batched above.
-        liked_notes =
-          remote
-          |> Map.values()
-          |> List.flatten()
-          |> Enum.map(& &1.id)
-          |> then(&Fediverse.liked_note_ids(viewer, &1))
+        # What this reader has already done with each of them — three batched
+        # reads for the whole window rather than three per card, the way the
+        # posts' engagement is batched above.
+        note_marks = remote |> Map.values() |> List.flatten() |> Fediverse.mark_lookup(viewer)
 
         # The lazy freshness check (issue #1069): ask the origins of the stale
         # public ones whether they are still published there. Deliberately
@@ -260,45 +237,9 @@ defmodule VutuvWeb.PostLive.Thread do
         |> assign(:engagement, Posts.post_engagement_map(ids, viewer))
         |> assign(:viewer_follows, follows)
         |> assign(:remote_replies, remote)
-        |> assign(:liked_notes, liked_notes)
+        |> assign(:note_marks, note_marks)
         |> subscribe_shown(ids)
     end
-  end
-
-  # The heart's outcome (issue #1270). The id in a click is attacker-controlled,
-  # so it is resolved against the replies this page really rendered before
-  # anything is written — `Vutuv.Fediverse` re-reads and re-gates it anyway, this
-  # only keeps the page honest about what it is acting on.
-  #
-  # A success repaints the one card from the set in hand rather than re-running
-  # the whole window: nothing else on the page changed, and a like carries no
-  # count for anybody else to see. `{:ok, :already}` (a double tap, a second tab)
-  # lands on the same state as `{:ok, :liked}`, which is the point of it.
-  defp toggle_note_like(socket, id, fun, liked?) do
-    with %User{} = viewer <- socket.assigns.current_user,
-         %Note{} = note <- shown_note(socket, id) do
-      case fun.(viewer, note) do
-        {:ok, _outcome} ->
-          socket
-          |> assign(:notice, nil)
-          |> update(:liked_notes, &toggle_member(&1, note.id, liked?))
-
-        {:error, reason} ->
-          assign(socket, :notice, like_refusal_message(reason, :reply))
-      end
-    else
-      _ -> socket
-    end
-  end
-
-  defp toggle_member(set, id, true), do: MapSet.put(set, id)
-  defp toggle_member(set, id, false), do: MapSet.delete(set, id)
-
-  defp shown_note(socket, id) do
-    socket.assigns.remote_replies
-    |> Map.values()
-    |> List.flatten()
-    |> Enum.find(&(&1.id == id))
   end
 
   # The outcome is shown as an inline notice above the conversation, not as a
@@ -393,7 +334,7 @@ defmodule VutuvWeb.PostLive.Thread do
                 viewer_follows={@viewer_follows}
                 engagement={@engagement}
                 remote_replies={@remote_replies}
-                liked_notes={@liked_notes}
+                note_marks={@note_marks}
                 auto_scroll?={@auto_scroll?}
                 conn_or_socket={@socket}
               />
@@ -405,7 +346,7 @@ defmodule VutuvWeb.PostLive.Thread do
                 viewer_follows={@viewer_follows}
                 engagement={@engagement}
                 remote_replies={@remote_replies}
-                liked_notes={@liked_notes}
+                note_marks={@note_marks}
                 auto_scroll?={@auto_scroll?}
                 conn_or_socket={@socket}
               />

--- a/lib/vutuv_web/live/tag_live/timeline.ex
+++ b/lib/vutuv_web/live/tag_live/timeline.ex
@@ -343,9 +343,10 @@ defmodule VutuvWeb.TagLive.Timeline do
         <div :for={{dom_id, entry} <- @streams.entries} id={dom_id} class={post_row_class()}>
           <%= if Posts.remote_feed_entry?(entry) do %>
             <.remote_post_card
+            live?
               remote_post={entry.remote_post}
               images={entry[:images] || []}
-              liked?={entry[:liked?] == true}
+              marks={entry[:marks]}
               viewer={@current_user}
               mute?={false}
             />

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -473,6 +473,7 @@ the resulting ~200px rail width. --%>
           that kill the LiveView. The place to act on such a post is the feed or
           the account page, both one click away through the card itself. --%>
           <.remote_post_card
+            live?
             :if={Vutuv.Posts.remote_feed_entry?(entry)}
             remote_post={entry.remote_post}
             images={entry[:images] || []}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.212.2",
+      version: "7.213.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -36,7 +36,7 @@ msgstr "Eintrag hinzufügen"
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1377
+#: lib/vutuv_web/templates/user/show.html.heex:1378
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -99,7 +99,7 @@ msgstr "Geburtstag"
 #: lib/vutuv_web/agent_docs/markdown.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/templates/user/show.html.heex:1009
+#: lib/vutuv_web/templates/user/show.html.heex:1010
 #, elixir-autogen
 msgid "Birthday"
 msgstr "Geburtstag"
@@ -147,7 +147,7 @@ msgstr "Wählen Sie einen Typ aus"
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1047
+#: lib/vutuv_web/templates/user/show.html.heex:1048
 #, elixir-autogen
 msgid "Contact"
 msgstr "Kontakt"
@@ -156,7 +156,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:2423
+#: lib/vutuv_web/components/post_components.ex:2520
 #: lib/vutuv_web/components/ui.ex:3140
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -205,7 +205,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:2388
+#: lib/vutuv_web/components/post_components.ex:2485
 #: lib/vutuv_web/components/ui.ex:3131
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -219,7 +219,7 @@ msgstr "Download"
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1032
+#: lib/vutuv_web/templates/user/show.html.heex:1033
 #, elixir-autogen
 msgid "Edit"
 msgstr "Ändern"
@@ -296,7 +296,7 @@ msgstr "Nachname eingeben"
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:559
+#: lib/vutuv_web/templates/user/show.html.heex:560
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -341,7 +341,7 @@ msgstr "Follower"
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:835
 #, elixir-autogen
 msgid "Following"
 msgstr "Folge ich"
@@ -356,7 +356,7 @@ msgstr "Folge ich"
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:67
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:1004
+#: lib/vutuv_web/templates/user/show.html.heex:1005
 #: lib/vutuv_web/views/account_event_text.ex:153
 #, elixir-autogen
 msgid "Gender"
@@ -663,7 +663,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1279
+#: lib/vutuv_web/components/post_components.ex:1251
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -698,13 +698,13 @@ msgstr "Slug"
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1161
+#: lib/vutuv_web/templates/user/show.html.heex:1162
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1164
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr "Profil hinzufügen"
@@ -860,8 +860,8 @@ msgid "vCard"
 msgstr "vCard"
 
 #: lib/vutuv_web/components/ui.ex:3201
-#: lib/vutuv_web/templates/user/show.html.heex:828
-#: lib/vutuv_web/templates/user/show.html.heex:851
+#: lib/vutuv_web/templates/user/show.html.heex:829
+#: lib/vutuv_web/templates/user/show.html.heex:852
 #, elixir-autogen
 msgid "View All"
 msgstr "Alle anzeigen"
@@ -1087,7 +1087,7 @@ msgstr "Diese Seite ist für Sie gesperrt."
 msgid "An error occurred"
 msgstr "Es gab einen Fehler."
 
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:994
 #, elixir-autogen
 msgid "General Info"
 msgstr "Allgemeines"
@@ -1278,7 +1278,7 @@ msgstr "Alle Tag-URLs"
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:553
+#: lib/vutuv_web/templates/user/show.html.heex:554
 #, elixir-autogen
 msgid "All tags"
 msgstr "Alle Tags"
@@ -1480,7 +1480,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:523
+#: lib/vutuv_web/templates/user/show.html.heex:524
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1698,7 +1698,7 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/post_components.ex:2869
+#: lib/vutuv_web/components/post_components.ex:2966
 #: lib/vutuv_web/components/ui.ex:244
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1770,11 +1770,11 @@ msgstr "Empfehlen"
 #: lib/vutuv_web/components/ui.ex:1844
 #: lib/vutuv_web/components/ui.ex:1847
 #: lib/vutuv_web/components/ui.ex:1920
-#: lib/vutuv_web/live/fediverse_account_live.ex:387
+#: lib/vutuv_web/live/fediverse_account_live.ex:344
 #: lib/vutuv_web/live/fediverse_following_live.ex:266
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:403
-#: lib/vutuv_web/templates/user/show.html.heex:948
-#: lib/vutuv_web/templates/user/show.html.heex:1201
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:359
+#: lib/vutuv_web/templates/user/show.html.heex:949
+#: lib/vutuv_web/templates/user/show.html.heex:1202
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1950,7 +1950,7 @@ msgstr ""
 "Wir haben eine PIN an Ihre neue E-Mail-Adresse geschickt. Geben Sie sie "
 "unten ein, um die Adresse zu bestätigen."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1224
+#: lib/vutuv_web/live/post_live/feed.ex:1193
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2189,7 +2189,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:2420
+#: lib/vutuv_web/components/post_components.ex:2517
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2202,7 +2202,7 @@ msgid "Edit post"
 msgstr "Beitrag bearbeiten"
 
 #: lib/vutuv_web/live/post_live/feed.ex:154
-#: lib/vutuv_web/live/post_live/feed.ex:990
+#: lib/vutuv_web/live/post_live/feed.ex:948
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:122
@@ -2230,8 +2230,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:2374
-#: lib/vutuv_web/components/post_components.ex:2376
+#: lib/vutuv_web/components/post_components.ex:2471
+#: lib/vutuv_web/components/post_components.ex:2473
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2247,7 +2247,7 @@ msgstr "Nicht eingeloggte Besucher"
 msgid "No more than %{max} images per post."
 msgstr "Höchstens %{max} Bilder pro Beitrag."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1163
+#: lib/vutuv_web/live/post_live/feed.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2287,9 +2287,9 @@ msgstr "Beitrag erfolgreich gelöscht."
 #: lib/vutuv_web/controllers/user_controller.ex:77
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/fediverse_account_live.ex:394
+#: lib/vutuv_web/live/fediverse_account_live.ex:351
 #: lib/vutuv_web/live/notification_live/index.ex:860
-#: lib/vutuv_web/live/post_live/saved.ex:449
+#: lib/vutuv_web/live/post_live/saved.ex:491
 #: lib/vutuv_web/live/search_live.ex:200
 #: lib/vutuv_web/live/search_live.ex:530
 #: lib/vutuv_web/templates/settings/preferences.html.heex:118
@@ -2298,29 +2298,29 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2805
-#: lib/vutuv_web/components/post_components.ex:2809
+#: lib/vutuv_web/components/post_components.ex:2902
+#: lib/vutuv_web/components/post_components.ex:2906
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:2806
-#: lib/vutuv_web/live/fediverse_account_live.ex:339
+#: lib/vutuv_web/components/post_components.ex:2903
+#: lib/vutuv_web/live/fediverse_account_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr "Weniger anzeigen"
 
 #: lib/vutuv_web/components/fediverse_components.ex:252
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:982
+#: lib/vutuv_web/components/post_components.ex:985
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:242
 #: lib/vutuv_web/live/post_live/composer.ex:1850
-#: lib/vutuv_web/live/post_live/saved.ex:538
-#: lib/vutuv_web/live/post_live/saved.ex:566
+#: lib/vutuv_web/live/post_live/saved.ex:615
+#: lib/vutuv_web/live/post_live/saved.ex:643
 #: lib/vutuv_web/templates/connection/index.html.heex:40
 #: lib/vutuv_web/views/settings_html.ex:275
 #, elixir-autogen, elixir-format
@@ -2339,7 +2339,7 @@ msgstr ""
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1083
+#: lib/vutuv_web/live/post_live/feed.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2395,27 +2395,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:2371
+#: lib/vutuv_web/components/post_components.ex:2468
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:3936
+#: lib/vutuv_web/components/post_components.ex:4033
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:3940
+#: lib/vutuv_web/components/post_components.ex:4037
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:3938
+#: lib/vutuv_web/components/post_components.ex:4035
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:3939
+#: lib/vutuv_web/components/post_components.ex:4036
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2446,7 +2446,7 @@ msgstr "Dateityp wird nicht unterstützt (erlaubt: %{types})."
 msgid "Posts by %{name}"
 msgstr "Beiträge von %{name}"
 
-#: lib/vutuv_web/templates/user/show.html.heex:513
+#: lib/vutuv_web/templates/user/show.html.heex:514
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr "Alle %{count} Beiträge ansehen"
@@ -2456,7 +2456,8 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:4020
+#: lib/vutuv_web/components/post_components.ex:1415
+#: lib/vutuv_web/components/post_components.ex:4117
 #: lib/vutuv_web/components/ui.ex:2665
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2464,8 +2465,8 @@ msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:933
-#: lib/vutuv_web/live/post_live/saved.ex:139
-#: lib/vutuv_web/live/post_live/saved.ex:442
+#: lib/vutuv_web/live/post_live/saved.ex:171
+#: lib/vutuv_web/live/post_live/saved.ex:484
 #: lib/vutuv_web/live/shell_live.ex:490
 #: lib/vutuv_web/live/shell_live.ex:556
 #: lib/vutuv_web/views/admin/report_html.ex:38
@@ -2473,9 +2474,8 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1041
-#: lib/vutuv_web/components/post_components.ex:1705
-#: lib/vutuv_web/components/post_components.ex:4243
+#: lib/vutuv_web/components/post_components.ex:1381
+#: lib/vutuv_web/components/post_components.ex:4340
 #: lib/vutuv_web/components/ui.ex:2651
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #: lib/vutuv_web/templates/user/show.html.heex:192
@@ -2484,58 +2484,60 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:932
-#: lib/vutuv_web/components/post_components.ex:4252
+#: lib/vutuv_web/components/post_components.ex:4349
 #: lib/vutuv_web/live/notification_live/index.ex:940
-#: lib/vutuv_web/live/post_live/saved.ex:138
-#: lib/vutuv_web/live/post_live/saved.ex:439
+#: lib/vutuv_web/live/post_live/saved.ex:170
+#: lib/vutuv_web/live/post_live/saved.ex:481
 #: lib/vutuv_web/live/shell_live.ex:559
 #: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Likes"
 msgstr "Likes"
 
-#: lib/vutuv_web/live/post_live/saved.ex:581
+#: lib/vutuv_web/live/post_live/saved.ex:658
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Posts you bookmark show up here."
 msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 
-#: lib/vutuv_web/live/post_live/saved.ex:578
+#: lib/vutuv_web/live/post_live/saved.ex:655
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:4009
+#: lib/vutuv_web/components/post_components.ex:4106
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:4020
-#: lib/vutuv_web/live/post_live/saved.ex:694
+#: lib/vutuv_web/components/post_components.ex:1415
+#: lib/vutuv_web/components/post_components.ex:4117
+#: lib/vutuv_web/live/post_live/saved.ex:771
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1743
-#: lib/vutuv_web/components/post_components.ex:4006
+#: lib/vutuv_web/components/post_components.ex:1404
+#: lib/vutuv_web/components/post_components.ex:4103
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1408
-#: lib/vutuv_web/components/post_components.ex:3383
+#: lib/vutuv_web/components/post_components.ex:1567
+#: lib/vutuv_web/components/post_components.ex:3480
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4006
+#: lib/vutuv_web/components/post_components.ex:1404
+#: lib/vutuv_web/components/post_components.ex:4103
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:4243
-#: lib/vutuv_web/live/post_live/saved.ex:693
+#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/live/post_live/saved.ex:770
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Unlike"
@@ -2545,7 +2547,7 @@ msgstr "Gefällt mir entfernen"
 #: lib/vutuv_web/components/ui.ex:1750
 #: lib/vutuv_web/components/ui.ex:1750
 #: lib/vutuv_web/components/ui.ex:1887
-#: lib/vutuv_web/live/post_live/feed.ex:1213
+#: lib/vutuv_web/live/post_live/feed.ex:1182
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2556,7 +2558,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:4296
+#: lib/vutuv_web/components/post_components.ex:4393
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2567,17 +2569,16 @@ msgstr "Nur öffentliche Beiträge können beantwortet werden."
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1051
-#: lib/vutuv_web/components/post_components.ex:1719
-#: lib/vutuv_web/components/post_components.ex:4279
-#: lib/vutuv_web/components/post_components.ex:4280
+#: lib/vutuv_web/components/post_components.ex:1391
+#: lib/vutuv_web/components/post_components.ex:4376
+#: lib/vutuv_web/components/post_components.ex:4377
 #: lib/vutuv_web/live/notification_live/index.ex:1000
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2342
+#: lib/vutuv_web/components/post_components.ex:2439
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2598,7 +2599,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:1848
+#: lib/vutuv_web/components/post_components.ex:1945
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2606,14 +2607,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2318
+#: lib/vutuv_web/components/post_components.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:2312
-#: lib/vutuv_web/components/post_components.ex:2334
-#: lib/vutuv_web/components/post_components.ex:2337
+#: lib/vutuv_web/components/post_components.ex:2409
+#: lib/vutuv_web/components/post_components.ex:2431
+#: lib/vutuv_web/components/post_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2781,38 +2782,38 @@ msgstr "Andere E-Mail-Adresse verwenden"
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:764
+#: lib/vutuv_web/templates/user/show.html.heex:765
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr "Link hinzufügen"
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1121
+#: lib/vutuv_web/templates/user/show.html.heex:1122
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr "Telefonnummer hinzufügen"
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1379
+#: lib/vutuv_web/templates/user/show.html.heex:1380
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr "Adresse hinzufügen"
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1049
+#: lib/vutuv_web/templates/user/show.html.heex:1050
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr "E-Mail-Adresse hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:995
+#: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr "Persönliche Angaben hinzufügen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:562
+#: lib/vutuv_web/templates/user/show.html.heex:563
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2833,12 +2834,12 @@ msgstr "Ersten Beitrag schreiben"
 #: lib/vutuv_web/templates/settings/privacy.html.heex:138
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:219
-#: lib/vutuv_web/templates/user/show.html.heex:553
+#: lib/vutuv_web/templates/user/show.html.heex:554
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Verwalten"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1015
+#: lib/vutuv_web/live/post_live/feed.ex:973
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2919,7 +2920,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:3937
+#: lib/vutuv_web/components/post_components.ex:4034
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -2945,7 +2946,7 @@ msgid "Endorsement"
 msgstr "Empfehlung"
 
 #: lib/vutuv_web/live/notification_live/index.ex:998
-#: lib/vutuv_web/templates/user/show.html.heex:812
+#: lib/vutuv_web/templates/user/show.html.heex:813
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3192,13 +3193,13 @@ msgstr "Nichts zu sehen, keiner Ihrer Inhalte ist derzeit gemeldet."
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1089
 #: lib/vutuv_web/templates/user/show.html.heex:1090
+#: lib/vutuv_web/templates/user/show.html.heex:1091
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:2288
+#: lib/vutuv_web/components/post_components.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3277,9 +3278,9 @@ msgstr "Abgelehnt"
 msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
-#: lib/vutuv_web/components/post_components.ex:992
-#: lib/vutuv_web/components/post_components.ex:1637
-#: lib/vutuv_web/components/post_components.ex:2444
+#: lib/vutuv_web/components/post_components.ex:995
+#: lib/vutuv_web/components/post_components.ex:1798
+#: lib/vutuv_web/components/post_components.ex:2541
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4736,7 +4737,7 @@ msgstr "Sie haben niemanden blockiert."
 msgid "You unblocked @%{slug}."
 msgstr "Sie haben die Blockierung von @%{slug} aufgehoben."
 
-#: lib/vutuv_web/live/post_live/feed.ex:1168
+#: lib/vutuv_web/live/post_live/feed.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr "Entdecken Sie Mitglieder zum Folgen"
@@ -4748,7 +4749,7 @@ msgstr "Mitglieder finden"
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folgt"
@@ -4796,7 +4797,7 @@ msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 #: lib/vutuv_web/components/ui.ex:480
 #: lib/vutuv_web/live/notification_live/index.ex:861
 #: lib/vutuv_web/live/organization_live/show.ex:300
-#: lib/vutuv_web/live/post_live/saved.ex:452
+#: lib/vutuv_web/live/post_live/saved.ex:494
 #: lib/vutuv_web/live/search_live.ex:198
 #: lib/vutuv_web/live/search_live.ex:472
 #, elixir-autogen, elixir-format
@@ -4869,7 +4870,7 @@ msgstr "sucht nur in Vornamen (nachname: für Nachnamen)"
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/live/user_profile_live.ex:1249
-#: lib/vutuv_web/templates/user/show.html.heex:526
+#: lib/vutuv_web/templates/user/show.html.heex:527
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr "Tag hinzufügen"
@@ -5659,11 +5660,11 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:2507
-#: lib/vutuv_web/components/post_components.ex:2559
-#: lib/vutuv_web/components/post_components.ex:2949
+#: lib/vutuv_web/components/post_components.ex:2604
+#: lib/vutuv_web/components/post_components.ex:2656
+#: lib/vutuv_web/components/post_components.ex:3046
 #: lib/vutuv_web/live/notification_live/index.ex:680
-#: lib/vutuv_web/live/post_live/feed.ex:1286
+#: lib/vutuv_web/live/post_live/feed.ex:1255
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -6038,60 +6039,60 @@ msgstr "Gefällt mir entfernt."
 msgid "Liked."
 msgstr "Gefällt mir."
 
-#: lib/vutuv_web/live/post_live/saved.ex:422
+#: lib/vutuv_web/live/post_live/saved.ex:464
 #, elixir-autogen, elixir-format
 msgid "Name (A-Z)"
 msgstr "Name (A-Z)"
 
-#: lib/vutuv_web/live/post_live/saved.ex:420
-#: lib/vutuv_web/live/tag_live/timeline.ex:379
+#: lib/vutuv_web/live/post_live/saved.ex:462
+#: lib/vutuv_web/live/tag_live/timeline.ex:380
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr "Neueste zuerst"
 
-#: lib/vutuv_web/live/post_live/saved.ex:591
+#: lib/vutuv_web/live/post_live/saved.ex:668
 #, elixir-autogen, elixir-format
 msgid "No saved people match your search."
 msgstr "Keine gespeicherten Personen passen zu Ihrer Suche."
 
-#: lib/vutuv_web/live/post_live/saved.ex:583
+#: lib/vutuv_web/live/post_live/saved.ex:660
 #, elixir-autogen, elixir-format
 msgid "No saved posts match your search."
 msgstr "Keine gespeicherten Beiträge passen zu Ihrer Suche."
 
-#: lib/vutuv_web/live/post_live/saved.ex:589
+#: lib/vutuv_web/live/post_live/saved.ex:666
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. People you bookmark show up here."
 msgstr "Hier ist noch nichts. Personen mit Lesezeichen erscheinen hier."
 
-#: lib/vutuv_web/live/post_live/saved.ex:586
+#: lib/vutuv_web/live/post_live/saved.ex:663
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. People you like show up here."
 msgstr "Hier ist noch nichts. Personen, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/live/post_live/saved.ex:421
-#: lib/vutuv_web/live/tag_live/timeline.ex:380
+#: lib/vutuv_web/live/post_live/saved.ex:463
+#: lib/vutuv_web/live/tag_live/timeline.ex:381
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr "Älteste zuerst"
 
-#: lib/vutuv_web/live/post_live/saved.ex:437
+#: lib/vutuv_web/live/post_live/saved.ex:479
 #, elixir-autogen, elixir-format
 msgid "Saved items"
 msgstr "Gespeicherte Elemente"
 
-#: lib/vutuv_web/live/post_live/saved.ex:447
+#: lib/vutuv_web/live/post_live/saved.ex:489
 #, elixir-autogen, elixir-format
 msgid "Saved type"
 msgstr "Art der gespeicherten Inhalte"
 
-#: lib/vutuv_web/live/post_live/saved.ex:468
-#: lib/vutuv_web/live/post_live/saved.ex:469
+#: lib/vutuv_web/live/post_live/saved.ex:521
+#: lib/vutuv_web/live/post_live/saved.ex:522
 #, elixir-autogen, elixir-format
 msgid "Search saved items"
 msgstr "Gespeicherte durchsuchen"
 
-#: lib/vutuv_web/live/post_live/saved.ex:472
+#: lib/vutuv_web/live/post_live/saved.ex:525
 #: lib/vutuv_web/live/tag_live/timeline.ex:294
 #, elixir-autogen, elixir-format
 msgid "Sort"
@@ -6336,7 +6337,7 @@ msgstr "Kurzbeschreibung"
 #: lib/vutuv_web/components/ui.ex:260
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:762
+#: lib/vutuv_web/templates/user/show.html.heex:763
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6357,7 +6358,7 @@ msgstr[1] "Beiträge"
 msgid "After choosing a file you can reposition and zoom it."
 msgstr "Nach der Auswahl einer Datei können Sie sie verschieben und zoomen."
 
-#: lib/vutuv_web/templates/user/show.html.heex:1430
+#: lib/vutuv_web/templates/user/show.html.heex:1431
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr "Auch auf"
@@ -6403,8 +6404,8 @@ msgstr "Foto verwenden"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1015
-#: lib/vutuv_web/templates/user/show.html.heex:1025
+#: lib/vutuv_web/templates/user/show.html.heex:1016
+#: lib/vutuv_web/templates/user/show.html.heex:1026
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6446,12 +6447,12 @@ msgstr "Tagesbericht für %{day}"
 msgid "Jump to a day"
 msgstr "Zu einem Tag springen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1137
+#: lib/vutuv_web/templates/user/show.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr "E-Mails verwalten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1148
+#: lib/vutuv_web/templates/user/show.html.heex:1149
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr "Telefon verwalten"
@@ -6493,7 +6494,7 @@ msgstr "Vorheriger Tag"
 msgid "Reposts"
 msgstr "Reposts"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1146
+#: lib/vutuv_web/templates/user/show.html.heex:1147
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr "Alle Telefonnummern anzeigen"
@@ -6549,9 +6550,9 @@ msgstr "Anzuzeigende Kartendienste"
 msgid "Maps"
 msgstr "Karten"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1416
-#: lib/vutuv_web/templates/user/show.html.heex:1424
-#: lib/vutuv_web/templates/user/show.html.heex:1436
+#: lib/vutuv_web/templates/user/show.html.heex:1417
+#: lib/vutuv_web/templates/user/show.html.heex:1425
+#: lib/vutuv_web/templates/user/show.html.heex:1437
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr "In %{name} öffnen"
@@ -6914,7 +6915,7 @@ msgstr ""
 "und Antworten über Sie mit. Mit beiden aus zum Beispiel:"
 
 #: lib/vutuv_web/components/ui.ex:2075
-#: lib/vutuv_web/live/fediverse_account_live.ex:381
+#: lib/vutuv_web/live/fediverse_account_live.ex:338
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6938,7 +6939,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr "Diese Vernetzung entfernen? Sie folgen der Person dann nicht mehr."
 
 #: lib/vutuv_web/components/ui.ex:2074
-#: lib/vutuv_web/live/fediverse_account_live.ex:379
+#: lib/vutuv_web/live/fediverse_account_live.ex:336
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6962,7 +6963,7 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:2441
+#: lib/vutuv_web/components/post_components.ex:2538
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6972,7 +6973,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:2440
+#: lib/vutuv_web/components/post_components.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7679,7 +7680,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
-#: lib/vutuv_web/components/post_components.ex:4165
+#: lib/vutuv_web/components/post_components.ex:4262
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8547,7 +8548,7 @@ msgstr[1] "%{count} Berufserfahrungen"
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:614
+#: lib/vutuv_web/templates/user/show.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr "Ausbildung hinzufügen"
@@ -8572,7 +8573,7 @@ msgstr "Abschluss"
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:612
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr "Ausbildung"
@@ -8771,7 +8772,7 @@ msgid "Loading posts"
 msgstr "Beiträge werden geladen"
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:99
-#: lib/vutuv_web/templates/user/show.html.heex:1283
+#: lib/vutuv_web/templates/user/show.html.heex:1284
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr "Social-Media-Beiträge"
@@ -8905,13 +8906,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr "Geben Sie zur Bestätigung Ihren Benutzernamen ein:"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1253
-#: lib/vutuv_web/live/post_live/feed.ex:1254
+#: lib/vutuv_web/live/post_live/feed.ex:1222
+#: lib/vutuv_web/live/post_live/feed.ex:1223
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr "Andere Beiträge anzeigen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1248
+#: lib/vutuv_web/live/post_live/feed.ex:1217
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr "Vorgeschlagene Beiträge"
@@ -9141,8 +9142,8 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:876
-#: lib/vutuv_web/templates/user/show.html.heex:1188
+#: lib/vutuv_web/templates/user/show.html.heex:877
+#: lib/vutuv_web/templates/user/show.html.heex:1189
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr "Fediverse"
@@ -9298,7 +9299,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:3386
+#: lib/vutuv_web/components/post_components.ex:3483
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9578,7 +9579,7 @@ msgstr "A2 (Grundkenntnisse)"
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:676
+#: lib/vutuv_web/templates/user/show.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr "Sprache hinzufügen"
@@ -9802,7 +9803,7 @@ msgstr "Sprache erfolgreich aktualisiert."
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:673
+#: lib/vutuv_web/templates/user/show.html.heex:674
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr "Sprachen"
@@ -10093,7 +10094,7 @@ msgstr[0] "%{count} Zertifikat oder Lizenz"
 msgstr[1] "%{count} Zertifikate oder Lizenzen"
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:716
+#: lib/vutuv_web/templates/user/show.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
@@ -10141,7 +10142,7 @@ msgstr "Zertifikate"
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:713
+#: lib/vutuv_web/templates/user/show.html.heex:714
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr "Zertifikate & Lizenzen"
@@ -10263,8 +10264,8 @@ msgstr "Bevorzugt"
 msgid "Preferred contact language"
 msgstr "Bevorzugte Kontaktsprache"
 
-#: lib/vutuv_web/templates/user/show.html.heex:1111
 #: lib/vutuv_web/templates/user/show.html.heex:1112
+#: lib/vutuv_web/templates/user/show.html.heex:1113
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr "+%{code} ist die Ländervorwahl von %{region}"
@@ -10461,7 +10462,7 @@ msgstr "Schließen"
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:131
 #: lib/vutuv_web/templates/totp/new.html.heex:58
-#: lib/vutuv_web/templates/user/show.html.heex:912
+#: lib/vutuv_web/templates/user/show.html.heex:913
 #: lib/vutuv_web/templates/username/new.html.heex:27
 #: lib/vutuv_web/templates/username/new.html.heex:114
 #, elixir-autogen, elixir-format
@@ -10472,8 +10473,8 @@ msgstr "Kopiert"
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:134
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
-#: lib/vutuv_web/templates/user/show.html.heex:911
-#: lib/vutuv_web/templates/user/show.html.heex:915
+#: lib/vutuv_web/templates/user/show.html.heex:912
+#: lib/vutuv_web/templates/user/show.html.heex:916
 #: lib/vutuv_web/templates/username/new.html.heex:26
 #: lib/vutuv_web/templates/username/new.html.heex:30
 #: lib/vutuv_web/templates/username/new.html.heex:113
@@ -10978,7 +10979,7 @@ msgstr[1] "%{formatted} Sterne"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1257
+#: lib/vutuv_web/templates/user/show.html.heex:1258
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -12659,17 +12660,17 @@ msgstr "Noch keine Organisationsseiten. Fügen Sie die erste hinzu."
 msgid "No organizations found for %{term}."
 msgstr "Keine Organisationen für %{term} gefunden."
 
-#: lib/vutuv_web/live/post_live/saved.ex:600
+#: lib/vutuv_web/live/post_live/saved.ex:677
 #, elixir-autogen, elixir-format
 msgid "No saved organizations match your search."
 msgstr "Keine gespeicherten Organisationen passen zu Ihrer Suche."
 
-#: lib/vutuv_web/live/post_live/saved.ex:597
+#: lib/vutuv_web/live/post_live/saved.ex:674
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Organizations you bookmark show up here."
 msgstr "Hier ist noch nichts. Organisationen mit Lesezeichen erscheinen hier."
 
-#: lib/vutuv_web/live/post_live/saved.ex:594
+#: lib/vutuv_web/live/post_live/saved.ex:671
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Organizations you like show up here."
 msgstr ""
@@ -12729,7 +12730,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/controllers/settings_controller.ex:165
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
-#: lib/vutuv_web/live/post_live/saved.ex:455
+#: lib/vutuv_web/live/post_live/saved.ex:497
 #: lib/vutuv_web/live/shell_live.ex:566
 #: lib/vutuv_web/templates/layout/app.html.heex:83
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
@@ -13070,7 +13071,7 @@ msgstr "Stellenbezeichnung"
 #: lib/vutuv_web/components/saved_search_components.ex:56
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
-#: lib/vutuv_web/live/post_live/saved.ex:458
+#: lib/vutuv_web/live/post_live/saved.ex:500
 #: lib/vutuv_web/live/shell_live.ex:457
 #: lib/vutuv_web/templates/layout/app.html.heex:81
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
@@ -13145,17 +13146,17 @@ msgstr "Neue Anzeige"
 msgid "Nice to have"
 msgstr "Wünschenswert"
 
-#: lib/vutuv_web/live/post_live/saved.ex:607
+#: lib/vutuv_web/live/post_live/saved.ex:684
 #, elixir-autogen, elixir-format
 msgid "No saved jobs match your search."
 msgstr "Keine gespeicherten Jobs passen zu Ihrer Suche."
 
-#: lib/vutuv_web/live/post_live/saved.ex:605
+#: lib/vutuv_web/live/post_live/saved.ex:682
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Jobs you bookmark show up here."
 msgstr "Hier ist noch nichts. Jobs mit Lesezeichen erscheinen hier."
 
-#: lib/vutuv_web/live/post_live/saved.ex:602
+#: lib/vutuv_web/live/post_live/saved.ex:679
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr "Hier ist noch nichts. Jobs, die Ihnen gefallen, erscheinen hier."
@@ -13977,7 +13978,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:1807
+#: lib/vutuv_web/components/post_components.ex:1904
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -14428,14 +14429,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3474
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:1199
+#: lib/vutuv_web/live/post_live/feed.ex:1168
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr "Tags, denen Sie folgen"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1214
+#: lib/vutuv_web/live/post_live/feed.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr "#%{tag} entfolgen"
@@ -14479,7 +14480,7 @@ msgstr "Signal und WhatsApp akzeptieren eine Telefonnummer oder einen Benutzerna
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1223
+#: lib/vutuv_web/templates/user/show.html.heex:1224
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr "Messenger hinzufügen"
@@ -14516,7 +14517,7 @@ msgstr "Messenger wurde geändert."
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1221
+#: lib/vutuv_web/templates/user/show.html.heex:1222
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr "Messenger"
@@ -14593,50 +14594,50 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:3799
+#: lib/vutuv_web/components/post_components.ex:3896
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3756
+#: lib/vutuv_web/components/post_components.ex:3853
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:3800
+#: lib/vutuv_web/components/post_components.ex:3897
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:3802
+#: lib/vutuv_web/components/post_components.ex:3899
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:3798
+#: lib/vutuv_web/components/post_components.ex:3895
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3755
+#: lib/vutuv_web/components/post_components.ex:3852
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:448
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:338
+#: lib/vutuv_web/live/fediverse_account_live.ex:405
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:3797
+#: lib/vutuv_web/components/post_components.ex:3894
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:3801
+#: lib/vutuv_web/components/post_components.ex:3898
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14656,34 +14657,34 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:3838
+#: lib/vutuv_web/components/post_components.ex:3935
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:3868
+#: lib/vutuv_web/components/post_components.ex:3965
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:3869
+#: lib/vutuv_web/components/post_components.ex:3966
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:3867
+#: lib/vutuv_web/components/post_components.ex:3964
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:3827
+#: lib/vutuv_web/components/post_components.ex:3924
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:3874
+#: lib/vutuv_web/components/post_components.ex:3971
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14713,7 +14714,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3641
+#: lib/vutuv_web/components/post_components.ex:3738
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14761,7 +14762,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:3632
+#: lib/vutuv_web/components/post_components.ex:3729
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -15139,7 +15140,7 @@ msgstr "Konto einfrieren"
 msgid "No accounts are currently frozen."
 msgstr "Zurzeit sind keine Konten eingefroren."
 
-#: lib/vutuv_web/live/post_live/thread.ex:426
+#: lib/vutuv_web/live/post_live/thread.ex:367
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr "Von Anfang an lesen"
@@ -15159,14 +15160,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2063
+#: lib/vutuv_web/components/post_components.ex:2160
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2085
+#: lib/vutuv_web/components/post_components.ex:2182
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -15178,7 +15179,7 @@ msgstr[1] "%{formatted} weitere Antworten anzeigen"
 msgid "This page is no longer available."
 msgstr "Diese Seite ist nicht mehr verfügbar."
 
-#: lib/vutuv_web/live/post_live/thread.ex:418
+#: lib/vutuv_web/live/post_live/thread.ex:359
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr "Dieser Beitrag ist Teil einer Unterhaltung mit %{formatted} Beiträgen."
@@ -15193,7 +15194,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:4251
+#: lib/vutuv_web/components/post_components.ex:4348
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15660,7 +15661,7 @@ msgstr "Geben Sie es weiter wie eine E-Mail-Adresse. Jeder bei Mastodon und Co. 
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr "Noch niemand. Posten Sie Ihr Handle dort, wo andere es sehen, dann tauchen die ersten Follower hier auf."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:413
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:369
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Related"
@@ -15928,27 +15929,27 @@ msgstr "Anwendung bearbeiten"
 msgid "Book an ad"
 msgstr "Anzeige buchen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:880
+#: lib/vutuv_web/templates/user/show.html.heex:881
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr "%{name} hat dieses Fediverse-Konto umgezogen. Folgen Sie stattdessen der neuen Adresse:"
 
-#: lib/vutuv_web/templates/user/show.html.heex:896
+#: lib/vutuv_web/templates/user/show.html.heex:897
 #, elixir-autogen, elixir-format
 msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
 msgstr "Sie sind auf Mastodon oder in einer anderen Fediverse-App? Folgen Sie %{name} von dort aus, dann landen die öffentlichen Beiträge in Ihrer Timeline. Ein vutuv-Konto brauchen Sie dafür nicht."
 
-#: lib/vutuv_web/templates/user/show.html.heex:933
+#: lib/vutuv_web/templates/user/show.html.heex:934
 #, elixir-autogen, elixir-format
 msgid "Follow from your own server"
 msgstr "Von Ihrem eigenen Server aus folgen"
 
-#: lib/vutuv_web/templates/user/show.html.heex:944
+#: lib/vutuv_web/templates/user/show.html.heex:945
 #, elixir-autogen, elixir-format
 msgid "@you@example.social"
 msgstr "@name@example.social"
 
-#: lib/vutuv_web/templates/user/show.html.heex:952
+#: lib/vutuv_web/templates/user/show.html.heex:953
 #, elixir-autogen, elixir-format
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr "Ihre Adresse wird einmal verwendet, um Sie zum Folgen-Dialog Ihres eigenen Servers zu schicken. Gespeichert wird sie hier nicht."
@@ -16381,21 +16382,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:4210
+#: lib/vutuv_web/components/post_components.ex:4307
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4214
+#: lib/vutuv_web/components/post_components.ex:4311
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:4218
+#: lib/vutuv_web/components/post_components.ex:4315
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16403,7 +16404,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:951
-#: lib/vutuv_web/components/post_components.ex:4169
+#: lib/vutuv_web/components/post_components.ex:4266
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16419,14 +16420,14 @@ msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem 
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/vutuv_web/components/post_components.ex:1124
-#: lib/vutuv_web/components/post_components.ex:1350
-#: lib/vutuv_web/live/fediverse_account_live.ex:321
+#: lib/vutuv_web/components/post_components.ex:1096
+#: lib/vutuv_web/components/post_components.ex:1509
+#: lib/vutuv_web/live/fediverse_account_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr "Aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/components/post_components.ex:980
+#: lib/vutuv_web/components/post_components.ex:983
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr "Diese Antwort aus Ihrem Beitrag entfernen?"
@@ -16448,12 +16449,12 @@ msgstr "Antworten aus anderen Netzwerken"
 msgid "Reply from another network"
 msgstr "Antwort aus einem anderen Netzwerk"
 
-#: lib/vutuv_web/live/post_live/thread.ex:148
+#: lib/vutuv_web/live/post_live/thread.ex:141
 #, elixir-autogen, elixir-format
 msgid "Reply removed."
 msgstr "Antwort entfernt."
 
-#: lib/vutuv_web/components/post_components.ex:989
+#: lib/vutuv_web/components/post_components.ex:992
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
@@ -16463,7 +16464,7 @@ msgstr "Diese Antwort als unangemessen melden? Sie wird sofort gelöscht."
 msgid "Reported as not appropriate"
 msgstr "Als unangemessen gemeldet"
 
-#: lib/vutuv_web/components/post_components.ex:1003
+#: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/notification_live/index.ex:534
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -16484,19 +16485,19 @@ msgstr "Gespeicherte Antworten"
 msgid "Taken down"
 msgstr "Entfernt"
 
-#: lib/vutuv_web/live/post_live/thread.ex:157
+#: lib/vutuv_web/live/post_live/thread.ex:150
 #, elixir-autogen, elixir-format
 msgid "Thank you. The reply was deleted right away."
 msgstr "Danke. Die Antwort wurde sofort gelöscht."
 
-#: lib/vutuv_web/live/post_live/thread.ex:328
+#: lib/vutuv_web/live/post_live/thread.ex:269
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1112
-#: lib/vutuv_web/components/post_components.ex:1055
-#: lib/vutuv_web/components/post_components.ex:1764
+#: lib/vutuv_web/components/post_components.ex:1027
+#: lib/vutuv_web/components/post_components.ex:1861
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16507,10 +16508,10 @@ msgstr "Original ansehen"
 msgid "What"
 msgstr "Was"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:168
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:139
+#: lib/vutuv_web/live/fediverse_account_live.ex:167
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:118
 #: lib/vutuv_web/live/post_live/feed.ex:426
-#: lib/vutuv_web/live/post_live/thread.ex:324
+#: lib/vutuv_web/live/post_live/thread.ex:265
 #: lib/vutuv_web/live/tag_live/timeline.ex:138
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16940,7 +16941,7 @@ msgstr "Hier ist noch nichts. Wenn Sie sich das nächste Mal anmelden oder eine 
 #: lib/vutuv_web/live/account_activity_live.ex:198
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
-#: lib/vutuv_web/live/tag_live/timeline.ex:397
+#: lib/vutuv_web/live/tag_live/timeline.ex:398
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr "Dazu passt nichts. Versuchen Sie eine kürzere Suche oder setzen Sie die Filter zurück."
@@ -17160,22 +17161,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:2300
+#: lib/vutuv_web/components/post_components.ex:2397
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2504
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:2415
+#: lib/vutuv_web/components/post_components.ex:2512
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:2401
+#: lib/vutuv_web/components/post_components.ex:2498
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17267,7 +17268,7 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1040
 #: lib/vutuv_web/agent_docs/text.ex:654
-#: lib/vutuv_web/components/post_components.ex:2872
+#: lib/vutuv_web/components/post_components.ex:2969
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
@@ -17297,7 +17298,7 @@ msgstr "Volle Auflösung, direkt aus dem Beitrag."
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/components/post_components.ex:2871
+#: lib/vutuv_web/components/post_components.ex:2968
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
@@ -17307,29 +17308,29 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3250
+#: lib/vutuv_web/components/post_components.ex:3347
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr "Bisher sehen nur Sie diesen Beitrag."
 
-#: lib/vutuv_web/components/post_components.ex:1860
+#: lib/vutuv_web/components/post_components.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:3253
+#: lib/vutuv_web/components/post_components.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] "Unsere KI prüft das Foto. Sobald es durch ist, geht der Beitrag von selbst online."
 msgstr[1] "Unsere KI prüft die Fotos, %{done} von %{total} sind durch. Sobald das letzte durch ist, geht der Beitrag von selbst online."
 
-#: lib/vutuv_web/components/post_components.ex:3078
+#: lib/vutuv_web/components/post_components.ex:3175
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:2616
+#: lib/vutuv_web/components/post_components.ex:2713
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17342,12 +17343,12 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1073
 #: lib/vutuv_web/agent_docs/text.ex:641
-#: lib/vutuv_web/components/post_components.ex:3287
+#: lib/vutuv_web/components/post_components.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/post_components.ex:2870
+#: lib/vutuv_web/components/post_components.ex:2967
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
@@ -17368,7 +17369,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:1913
+#: lib/vutuv_web/components/post_components.ex:2010
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -17388,7 +17389,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:1904
+#: lib/vutuv_web/components/post_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -17398,12 +17399,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:1922
+#: lib/vutuv_web/components/post_components.ex:2019
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:1856
+#: lib/vutuv_web/components/post_components.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -17418,7 +17419,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:1917
+#: lib/vutuv_web/components/post_components.ex:2014
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -17428,7 +17429,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:1870
+#: lib/vutuv_web/components/post_components.ex:1967
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17449,8 +17450,8 @@ msgstr "Fotos hinzufügen"
 msgid "Licence"
 msgstr "Lizenz"
 
-#: lib/vutuv_web/live/post_live/feed.ex:1024
-#: lib/vutuv_web/live/post_live/feed.ex:1025
+#: lib/vutuv_web/live/post_live/feed.ex:982
+#: lib/vutuv_web/live/post_live/feed.ex:983
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr "Fotos posten"
@@ -17515,13 +17516,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:969
-#: lib/vutuv_web/components/post_components.ex:4207
+#: lib/vutuv_web/components/post_components.ex:4304
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:967
-#: lib/vutuv_web/components/post_components.ex:4204
+#: lib/vutuv_web/components/post_components.ex:4301
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17531,7 +17532,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:4096
+#: lib/vutuv_web/components/post_components.ex:4193
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17631,11 +17632,11 @@ msgstr "Rücknahme"
 msgid "Photo details"
 msgstr "Fotodetails"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:454
+#: lib/vutuv_web/live/fediverse_account_live.ex:411
 #: lib/vutuv_web/live/fediverse_following_live.ex:52
 #: lib/vutuv_web/live/fediverse_following_live.ex:236
 #: lib/vutuv_web/live/fediverse_following_live.ex:249
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:422
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:378
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
@@ -17661,9 +17662,9 @@ msgstr "Anfrage zurückziehen"
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr "Konten auf Mastodon folgen, und von dort gefolgt werden"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:112
+#: lib/vutuv_web/live/fediverse_account_live.ex:111
 #: lib/vutuv_web/live/fediverse_following_live.ex:192
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:158
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Follow request sent to %{account}."
 msgstr "Follower-Anfrage an %{account} gesendet."
@@ -17754,7 +17755,7 @@ msgid "That server answered, but it has no account at that address to follow."
 msgstr "Der Server hat geantwortet, führt unter dieser Adresse aber kein Konto, dem man folgen könnte."
 
 #: lib/vutuv_web/components/fediverse_components.ex:272
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:260
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "That server did not answer. Check the address, and that the server is online."
 msgstr "Der Server hat nicht geantwortet. Prüfen Sie die Adresse und ob der Server erreichbar ist."
@@ -17789,7 +17790,7 @@ msgstr "Dieses vutuv tauscht nichts mit diesem Server aus."
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr "Um einem Konto dort draußen zu folgen, brauchen Sie eine eigene Fediverse-Identität: Die Anfrage wird in Ihrem Namen signiert, damit der andere Server weiß, wer fragt."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:128
+#: lib/vutuv_web/live/fediverse_account_live.ex:127
 #: lib/vutuv_web/live/fediverse_following_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Unfollowed."
@@ -17877,20 +17878,20 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1646
+#: lib/vutuv_web/components/post_components.ex:1807
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:160
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:131
+#: lib/vutuv_web/live/fediverse_account_live.ex:159
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:110
 #: lib/vutuv_web/live/post_live/feed.ex:418
 #: lib/vutuv_web/live/tag_live/timeline.ex:130
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:1763
+#: lib/vutuv_web/components/post_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17910,23 +17911,23 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1282
+#: lib/vutuv_web/components/post_components.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:1663
+#: lib/vutuv_web/components/post_components.ex:1824
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
 
-#: lib/vutuv_web/components/post_components.ex:1625
+#: lib/vutuv_web/components/post_components.ex:1786
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr "%{handle} stummschalten"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:264
-#: lib/vutuv_web/live/post_live/feed.ex:476
+#: lib/vutuv_web/live/fediverse_account_live.ex:221
+#: lib/vutuv_web/live/post_live/feed.ex:448
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwinden aus Ihrem Feed."
@@ -17936,7 +17937,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:1632
+#: lib/vutuv_web/components/post_components.ex:1793
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17956,57 +17957,57 @@ msgstr "Sie folgen dort draußen noch niemandem. Sobald Sie das tun, erscheinen 
 msgid "%{name} (another network)"
 msgstr "%{name} (anderes Netzwerk)"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:304
+#: lib/vutuv_web/live/fediverse_account_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Account on another network"
 msgstr "Konto in einem anderen Netzwerk"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:438
+#: lib/vutuv_web/live/fediverse_account_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr "Ein anderes Konto nachschlagen"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:369
+#: lib/vutuv_web/live/fediverse_account_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr "Stummgeschaltet"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:279
+#: lib/vutuv_web/live/fediverse_account_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr "Noch nichts zwischengespeichert. Die Beiträge erscheinen hier, sobald sie veröffentlicht werden."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:274
+#: lib/vutuv_web/live/fediverse_account_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr "Hier ist nichts. vutuv behält die Beiträge eines Kontos nur, solange jemand hier ihm folgt, und diese Seite ruft von sich aus keine ab."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:440
+#: lib/vutuv_web/live/fediverse_account_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr "Fügen Sie eine Adresse von Mastodon und Co. ein, um die zugehörige Seite hier zu öffnen."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:336
+#: lib/vutuv_web/live/fediverse_account_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr "Ganze Beschreibung anzeigen"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:423
+#: lib/vutuv_web/live/fediverse_account_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr "Die neuesten %{count} werden angezeigt. Der Rest liegt auf dem eigenen Server."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:266
+#: lib/vutuv_web/live/fediverse_account_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts are back in your feed."
 msgstr "Stummschaltung aufgehoben. Die Beiträge sind wieder in Ihrem Feed."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:433
+#: lib/vutuv_web/live/fediverse_account_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr "Vollständiges Profil auf %{host} ansehen"
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:283
+#: lib/vutuv_web/live/fediverse_account_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr "Warten darauf, dass der Server Ihre Follower-Anfrage annimmt. Beiträge, die nur an die Follower gerichtet sind, erscheinen danach."
@@ -18017,7 +18018,7 @@ msgid "You redirected your Fediverse followers to another account, so this one n
 msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, deshalb folgt dieses Konto dort draußen niemandem mehr."
 
 #: lib/vutuv_web/components/fediverse_components.ex:183
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:240
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Your account move"
 msgstr "Ihr Kontoumzug"
@@ -18158,27 +18159,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:1453
+#: lib/vutuv_web/components/post_components.ex:1612
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr "Ein Bild ist unterwegs."
 
-#: lib/vutuv_web/components/post_components.ex:1482
+#: lib/vutuv_web/components/post_components.ex:1641
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:1477
+#: lib/vutuv_web/components/post_components.ex:1636
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:1789
+#: lib/vutuv_web/components/post_components.ex:1886
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:1795
+#: lib/vutuv_web/components/post_components.ex:1892
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -18188,7 +18189,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:1908
+#: lib/vutuv_web/components/post_components.ex:2005
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18203,9 +18204,7 @@ msgstr ""
 "beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv "
 "nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:193
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:110
-#: lib/vutuv_web/live/post_live/feed.ex:454
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:93
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr "Repostet. Ihre Follower sehen es jetzt."
@@ -18486,22 +18485,22 @@ msgstr "Symbole"
 msgid "Travel & places"
 msgstr "Reisen & Orte"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:320
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Address of the post"
 msgstr "Adresse des Beitrags"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:237
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings"
 msgstr "Fediverse-Einstellungen"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:221
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "Fetching a post asks its server for it in your name, signed with your own key, so there is no such thing as an anonymous lookup here."
 msgstr "Einen Beitrag zu holen heißt, seinen Server in Ihrem Namen danach zu fragen, signiert mit Ihrem eigenen Schlüssel. Ein anonymes Nachschlagen gibt es hier deshalb nicht."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:267
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Its author published this post to their followers alone, so vutuv does not keep a copy of it."
 msgstr "Die verfassende Person hat diesen Beitrag nur an ihre Follower veröffentlicht, deshalb behält vutuv keine Kopie davon."
@@ -18513,17 +18512,17 @@ msgid "Look up a post by its address"
 msgstr "Einen Beitrag über seine Adresse nachschlagen"
 
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:54
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:284
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Look up a post from another network"
 msgstr "Einen Beitrag aus einem anderen Netzwerk nachschlagen"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:416
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Looking for an account rather than a single post?"
 msgstr "Suchen Sie ein Konto statt eines einzelnen Beitrags?"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:287
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "Paste the address of a post on Mastodon and friends. vutuv fetches it, shows it here, and you can answer, like or repost it as if it had arrived on its own."
 msgstr "Fügen Sie die Adresse eines Beitrags aus Mastodon und Co. ein. vutuv holt ihn, zeigt ihn hier an, und Sie können darauf antworten, ihn mögen oder teilen, als wäre er von selbst hier gelandet."
@@ -18533,42 +18532,42 @@ msgstr "Fügen Sie die Adresse eines Beitrags aus Mastodon und Co. ein. vutuv ho
 msgid "Read something out there that you want to answer from here?"
 msgstr "Etwas dort draußen gelesen, worauf Sie von hier aus antworten möchten?"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:252
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "That does not look like a link to a post. Copy the address of the post itself, for example https://server/@name/12345."
 msgstr "Das sieht nicht nach dem Link zu einem Beitrag aus. Kopieren Sie die Adresse des Beitrags selbst, zum Beispiel https://server/@name/12345."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:257
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "That is a link on this vutuv, not on another network."
 msgstr "Das ist ein Link auf dieses vutuv, nicht auf ein anderes Netzwerk."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:408
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr "Die Seite dieses Kontos hier"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:263
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "There is no post to show at that address."
 msgstr "Unter dieser Adresse gibt es keinen Beitrag zu sehen."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:216
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "This account no longer acts out there"
 msgstr "Dieses Konto ist dort draußen nicht mehr aktiv"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:233
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with other networks. That is an operator setting, not yours."
 msgstr "Dieses vutuv tauscht nichts mit anderen Netzwerken aus. Das ist eine Einstellung des Betreibers, nicht Ihre."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:217
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "This vutuv stays to itself"
 msgstr "Dieses vutuv bleibt unter sich"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:215
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:172
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to look up"
 msgstr "Fediverse-Teilnahme einschalten, um nachzuschlagen"
@@ -18578,22 +18577,22 @@ msgstr "Fediverse-Teilnahme einschalten, um nachzuschlagen"
 msgid "Want to answer one particular post rather than follow its author?"
 msgstr "Möchten Sie auf einen bestimmten Beitrag antworten, statt der verfassenden Person zu folgen?"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:373
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Who wrote this"
 msgstr "Wer das geschrieben hat"
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:272
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "You have looked a lot of posts up in the last hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Beiträge nachgeschlagen. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:227
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so nothing is fetched or sent from this one any more."
 msgstr "Sie haben Ihre Fediverse-Follower auf ein anderes Konto umgeleitet, deshalb wird von diesem Konto aus nichts mehr geholt und nichts mehr gesendet."
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:426
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr "Einen nachgeschlagenen Beitrag bewahrt vutuv genauso sechs Monate lang auf wie jeden anderen Beitrag aus einem anderen Netzwerk. Der Server der verfassenden Person wird sonst nichts gefragt."
@@ -18963,22 +18962,22 @@ msgid_plural "%{formatted} posts"
 msgstr[0] "%{formatted} Beitrag"
 msgstr[1] "%{formatted} Beiträge"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:381
+#: lib/vutuv_web/live/tag_live/timeline.ex:382
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr "Meiste Likes"
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:405
+#: lib/vutuv_web/live/tag_live/timeline.ex:406
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr "Zu diesem Tag gibt es noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:403
+#: lib/vutuv_web/live/tag_live/timeline.ex:404
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr "Aus anderen Netzwerken gibt es zu diesem Tag noch keine Beiträge."
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:400
+#: lib/vutuv_web/live/tag_live/timeline.ex:401
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
@@ -18993,7 +18992,22 @@ msgstr "Zu Beiträgen aus anderen Netzwerken kennen wir hier keine öffentliche 
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:1792
+#: lib/vutuv_web/components/post_components.ex:1889
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
+
+#: lib/vutuv_web/live/post_live/saved.ex:452
+#, elixir-autogen, elixir-format
+msgid "Nothing saved from other networks matches that."
+msgstr "Dazu haben Sie nichts aus anderen Netzwerken gespeichert."
+
+#: lib/vutuv_web/live/post_live/saved.ex:456
+#, elixir-autogen, elixir-format
+msgid "Nothing saved from other networks yet. The bookmark on a post or reply from another network keeps it here."
+msgstr "Noch nichts aus anderen Netzwerken gespeichert. Das Lesezeichen an einem Beitrag oder einer Antwort aus einem anderen Netzwerk hebt ihn hier auf."
+
+#: lib/vutuv_web/live/post_live/saved.ex:511
+#, elixir-autogen, elixir-format
+msgid "Other networks"
+msgstr "Andere Netzwerke"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -38,7 +38,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1377
+#: lib/vutuv_web/templates/user/show.html.heex:1378
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -101,7 +101,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/templates/user/show.html.heex:1009
+#: lib/vutuv_web/templates/user/show.html.heex:1010
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -147,7 +147,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1047
+#: lib/vutuv_web/templates/user/show.html.heex:1048
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -156,7 +156,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2423
+#: lib/vutuv_web/components/post_components.ex:2520
 #: lib/vutuv_web/components/ui.ex:3140
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -205,7 +205,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2388
+#: lib/vutuv_web/components/post_components.ex:2485
 #: lib/vutuv_web/components/ui.ex:3131
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -219,7 +219,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1032
+#: lib/vutuv_web/templates/user/show.html.heex:1033
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -296,7 +296,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:559
+#: lib/vutuv_web/templates/user/show.html.heex:560
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -341,7 +341,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:835
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -356,7 +356,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:67
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:1004
+#: lib/vutuv_web/templates/user/show.html.heex:1005
 #: lib/vutuv_web/views/account_event_text.ex:153
 #, elixir-autogen
 msgid "Gender"
@@ -663,7 +663,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1279
+#: lib/vutuv_web/components/post_components.ex:1251
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -698,13 +698,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1161
+#: lib/vutuv_web/templates/user/show.html.heex:1162
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1164
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -856,8 +856,8 @@ msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3201
-#: lib/vutuv_web/templates/user/show.html.heex:828
-#: lib/vutuv_web/templates/user/show.html.heex:851
+#: lib/vutuv_web/templates/user/show.html.heex:829
+#: lib/vutuv_web/templates/user/show.html.heex:852
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -1064,7 +1064,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:994
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1252,7 +1252,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:553
+#: lib/vutuv_web/templates/user/show.html.heex:554
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1451,7 +1451,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:523
+#: lib/vutuv_web/templates/user/show.html.heex:524
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2869
+#: lib/vutuv_web/components/post_components.ex:2966
 #: lib/vutuv_web/components/ui.ex:244
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1736,11 +1736,11 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1844
 #: lib/vutuv_web/components/ui.ex:1847
 #: lib/vutuv_web/components/ui.ex:1920
-#: lib/vutuv_web/live/fediverse_account_live.ex:387
+#: lib/vutuv_web/live/fediverse_account_live.ex:344
 #: lib/vutuv_web/live/fediverse_following_live.ex:266
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:403
-#: lib/vutuv_web/templates/user/show.html.heex:948
-#: lib/vutuv_web/templates/user/show.html.heex:1201
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:359
+#: lib/vutuv_web/templates/user/show.html.heex:949
+#: lib/vutuv_web/templates/user/show.html.heex:1202
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1907,7 +1907,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1224
+#: lib/vutuv_web/live/post_live/feed.ex:1193
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2144,7 +2144,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2420
+#: lib/vutuv_web/components/post_components.ex:2517
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2157,7 +2157,7 @@ msgid "Edit post"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:154
-#: lib/vutuv_web/live/post_live/feed.ex:990
+#: lib/vutuv_web/live/post_live/feed.ex:948
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:122
@@ -2185,8 +2185,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2374
-#: lib/vutuv_web/components/post_components.ex:2376
+#: lib/vutuv_web/components/post_components.ex:2471
+#: lib/vutuv_web/components/post_components.ex:2473
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2202,7 +2202,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1163
+#: lib/vutuv_web/live/post_live/feed.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2240,9 +2240,9 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:77
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/fediverse_account_live.ex:394
+#: lib/vutuv_web/live/fediverse_account_live.ex:351
 #: lib/vutuv_web/live/notification_live/index.ex:860
-#: lib/vutuv_web/live/post_live/saved.ex:449
+#: lib/vutuv_web/live/post_live/saved.ex:491
 #: lib/vutuv_web/live/search_live.ex:200
 #: lib/vutuv_web/live/search_live.ex:530
 #: lib/vutuv_web/templates/settings/preferences.html.heex:118
@@ -2251,29 +2251,29 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2805
-#: lib/vutuv_web/components/post_components.ex:2809
+#: lib/vutuv_web/components/post_components.ex:2902
+#: lib/vutuv_web/components/post_components.ex:2906
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2806
-#: lib/vutuv_web/live/fediverse_account_live.ex:339
+#: lib/vutuv_web/components/post_components.ex:2903
+#: lib/vutuv_web/live/fediverse_account_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:252
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:982
+#: lib/vutuv_web/components/post_components.ex:985
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:242
 #: lib/vutuv_web/live/post_live/composer.ex:1850
-#: lib/vutuv_web/live/post_live/saved.ex:538
-#: lib/vutuv_web/live/post_live/saved.ex:566
+#: lib/vutuv_web/live/post_live/saved.ex:615
+#: lib/vutuv_web/live/post_live/saved.ex:643
 #: lib/vutuv_web/templates/connection/index.html.heex:40
 #: lib/vutuv_web/views/settings_html.ex:275
 #, elixir-autogen, elixir-format
@@ -2290,7 +2290,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1083
+#: lib/vutuv_web/live/post_live/feed.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2346,27 +2346,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2371
+#: lib/vutuv_web/components/post_components.ex:2468
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3936
+#: lib/vutuv_web/components/post_components.ex:4033
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3940
+#: lib/vutuv_web/components/post_components.ex:4037
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3938
+#: lib/vutuv_web/components/post_components.ex:4035
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3939
+#: lib/vutuv_web/components/post_components.ex:4036
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2397,7 +2397,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:513
+#: lib/vutuv_web/templates/user/show.html.heex:514
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2407,7 +2407,8 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4020
+#: lib/vutuv_web/components/post_components.ex:1415
+#: lib/vutuv_web/components/post_components.ex:4117
 #: lib/vutuv_web/components/ui.ex:2665
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2415,8 +2416,8 @@ msgid "Bookmark"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:933
-#: lib/vutuv_web/live/post_live/saved.ex:139
-#: lib/vutuv_web/live/post_live/saved.ex:442
+#: lib/vutuv_web/live/post_live/saved.ex:171
+#: lib/vutuv_web/live/post_live/saved.ex:484
 #: lib/vutuv_web/live/shell_live.ex:490
 #: lib/vutuv_web/live/shell_live.ex:556
 #: lib/vutuv_web/views/admin/report_html.ex:38
@@ -2424,9 +2425,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1041
-#: lib/vutuv_web/components/post_components.ex:1705
-#: lib/vutuv_web/components/post_components.ex:4243
+#: lib/vutuv_web/components/post_components.ex:1381
+#: lib/vutuv_web/components/post_components.ex:4340
 #: lib/vutuv_web/components/ui.ex:2651
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #: lib/vutuv_web/templates/user/show.html.heex:192
@@ -2435,58 +2435,60 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:932
-#: lib/vutuv_web/components/post_components.ex:4252
+#: lib/vutuv_web/components/post_components.ex:4349
 #: lib/vutuv_web/live/notification_live/index.ex:940
-#: lib/vutuv_web/live/post_live/saved.ex:138
-#: lib/vutuv_web/live/post_live/saved.ex:439
+#: lib/vutuv_web/live/post_live/saved.ex:170
+#: lib/vutuv_web/live/post_live/saved.ex:481
 #: lib/vutuv_web/live/shell_live.ex:559
 #: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Likes"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:581
+#: lib/vutuv_web/live/post_live/saved.ex:658
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Posts you bookmark show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:578
+#: lib/vutuv_web/live/post_live/saved.ex:655
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4009
+#: lib/vutuv_web/components/post_components.ex:4106
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4020
-#: lib/vutuv_web/live/post_live/saved.ex:694
+#: lib/vutuv_web/components/post_components.ex:1415
+#: lib/vutuv_web/components/post_components.ex:4117
+#: lib/vutuv_web/live/post_live/saved.ex:771
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1743
-#: lib/vutuv_web/components/post_components.ex:4006
+#: lib/vutuv_web/components/post_components.ex:1404
+#: lib/vutuv_web/components/post_components.ex:4103
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1408
-#: lib/vutuv_web/components/post_components.ex:3383
+#: lib/vutuv_web/components/post_components.ex:1567
+#: lib/vutuv_web/components/post_components.ex:3480
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4006
+#: lib/vutuv_web/components/post_components.ex:1404
+#: lib/vutuv_web/components/post_components.ex:4103
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4243
-#: lib/vutuv_web/live/post_live/saved.ex:693
+#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/live/post_live/saved.ex:770
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Unlike"
@@ -2496,7 +2498,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1750
 #: lib/vutuv_web/components/ui.ex:1750
 #: lib/vutuv_web/components/ui.ex:1887
-#: lib/vutuv_web/live/post_live/feed.ex:1213
+#: lib/vutuv_web/live/post_live/feed.ex:1182
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2507,7 +2509,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4296
+#: lib/vutuv_web/components/post_components.ex:4393
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2518,17 +2520,16 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1051
-#: lib/vutuv_web/components/post_components.ex:1719
-#: lib/vutuv_web/components/post_components.ex:4279
-#: lib/vutuv_web/components/post_components.ex:4280
+#: lib/vutuv_web/components/post_components.ex:1391
+#: lib/vutuv_web/components/post_components.ex:4376
+#: lib/vutuv_web/components/post_components.ex:4377
 #: lib/vutuv_web/live/notification_live/index.ex:1000
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2342
+#: lib/vutuv_web/components/post_components.ex:2439
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2549,7 +2550,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1848
+#: lib/vutuv_web/components/post_components.ex:1945
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2557,14 +2558,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2318
+#: lib/vutuv_web/components/post_components.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2312
-#: lib/vutuv_web/components/post_components.ex:2334
-#: lib/vutuv_web/components/post_components.ex:2337
+#: lib/vutuv_web/components/post_components.ex:2409
+#: lib/vutuv_web/components/post_components.ex:2431
+#: lib/vutuv_web/components/post_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2730,38 +2731,38 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:764
+#: lib/vutuv_web/templates/user/show.html.heex:765
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1121
+#: lib/vutuv_web/templates/user/show.html.heex:1122
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1379
+#: lib/vutuv_web/templates/user/show.html.heex:1380
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1049
+#: lib/vutuv_web/templates/user/show.html.heex:1050
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:995
+#: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:562
+#: lib/vutuv_web/templates/user/show.html.heex:563
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2782,12 +2783,12 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:138
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:219
-#: lib/vutuv_web/templates/user/show.html.heex:553
+#: lib/vutuv_web/templates/user/show.html.heex:554
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1015
+#: lib/vutuv_web/live/post_live/feed.ex:973
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2866,7 +2867,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3937
+#: lib/vutuv_web/components/post_components.ex:4034
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2892,7 +2893,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:998
-#: lib/vutuv_web/templates/user/show.html.heex:812
+#: lib/vutuv_web/templates/user/show.html.heex:813
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3121,13 +3122,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1089
 #: lib/vutuv_web/templates/user/show.html.heex:1090
+#: lib/vutuv_web/templates/user/show.html.heex:1091
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2288
+#: lib/vutuv_web/components/post_components.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3202,9 +3203,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:992
-#: lib/vutuv_web/components/post_components.ex:1637
-#: lib/vutuv_web/components/post_components.ex:2444
+#: lib/vutuv_web/components/post_components.ex:995
+#: lib/vutuv_web/components/post_components.ex:1798
+#: lib/vutuv_web/components/post_components.ex:2541
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4563,7 +4564,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1168
+#: lib/vutuv_web/live/post_live/feed.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4575,7 +4576,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4621,7 +4622,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:480
 #: lib/vutuv_web/live/notification_live/index.ex:861
 #: lib/vutuv_web/live/organization_live/show.ex:300
-#: lib/vutuv_web/live/post_live/saved.ex:452
+#: lib/vutuv_web/live/post_live/saved.ex:494
 #: lib/vutuv_web/live/search_live.ex:198
 #: lib/vutuv_web/live/search_live.ex:472
 #, elixir-autogen, elixir-format
@@ -4692,7 +4693,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/live/user_profile_live.ex:1249
-#: lib/vutuv_web/templates/user/show.html.heex:526
+#: lib/vutuv_web/templates/user/show.html.heex:527
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5432,11 +5433,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2507
-#: lib/vutuv_web/components/post_components.ex:2559
-#: lib/vutuv_web/components/post_components.ex:2949
+#: lib/vutuv_web/components/post_components.ex:2604
+#: lib/vutuv_web/components/post_components.ex:2656
+#: lib/vutuv_web/components/post_components.ex:3046
 #: lib/vutuv_web/live/notification_live/index.ex:680
-#: lib/vutuv_web/live/post_live/feed.ex:1286
+#: lib/vutuv_web/live/post_live/feed.ex:1255
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5804,60 +5805,60 @@ msgstr ""
 msgid "Liked."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:422
+#: lib/vutuv_web/live/post_live/saved.ex:464
 #, elixir-autogen, elixir-format
 msgid "Name (A-Z)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:420
-#: lib/vutuv_web/live/tag_live/timeline.ex:379
+#: lib/vutuv_web/live/post_live/saved.ex:462
+#: lib/vutuv_web/live/tag_live/timeline.ex:380
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:591
+#: lib/vutuv_web/live/post_live/saved.ex:668
 #, elixir-autogen, elixir-format
 msgid "No saved people match your search."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:583
+#: lib/vutuv_web/live/post_live/saved.ex:660
 #, elixir-autogen, elixir-format
 msgid "No saved posts match your search."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:589
+#: lib/vutuv_web/live/post_live/saved.ex:666
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. People you bookmark show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:586
+#: lib/vutuv_web/live/post_live/saved.ex:663
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:421
-#: lib/vutuv_web/live/tag_live/timeline.ex:380
+#: lib/vutuv_web/live/post_live/saved.ex:463
+#: lib/vutuv_web/live/tag_live/timeline.ex:381
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:437
+#: lib/vutuv_web/live/post_live/saved.ex:479
 #, elixir-autogen, elixir-format
 msgid "Saved items"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:447
+#: lib/vutuv_web/live/post_live/saved.ex:489
 #, elixir-autogen, elixir-format
 msgid "Saved type"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:468
-#: lib/vutuv_web/live/post_live/saved.ex:469
+#: lib/vutuv_web/live/post_live/saved.ex:521
+#: lib/vutuv_web/live/post_live/saved.ex:522
 #, elixir-autogen, elixir-format
 msgid "Search saved items"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:472
+#: lib/vutuv_web/live/post_live/saved.ex:525
 #: lib/vutuv_web/live/tag_live/timeline.ex:294
 #, elixir-autogen, elixir-format
 msgid "Sort"
@@ -6090,7 +6091,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:260
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:762
+#: lib/vutuv_web/templates/user/show.html.heex:763
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6111,7 +6112,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1430
+#: lib/vutuv_web/templates/user/show.html.heex:1431
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6155,8 +6156,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1015
-#: lib/vutuv_web/templates/user/show.html.heex:1025
+#: lib/vutuv_web/templates/user/show.html.heex:1016
+#: lib/vutuv_web/templates/user/show.html.heex:1026
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6196,12 +6197,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1137
+#: lib/vutuv_web/templates/user/show.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1148
+#: lib/vutuv_web/templates/user/show.html.heex:1149
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6243,7 +6244,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1146
+#: lib/vutuv_web/templates/user/show.html.heex:1147
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6297,9 +6298,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1416
-#: lib/vutuv_web/templates/user/show.html.heex:1424
-#: lib/vutuv_web/templates/user/show.html.heex:1436
+#: lib/vutuv_web/templates/user/show.html.heex:1417
+#: lib/vutuv_web/templates/user/show.html.heex:1425
+#: lib/vutuv_web/templates/user/show.html.heex:1437
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6630,7 +6631,7 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2075
-#: lib/vutuv_web/live/fediverse_account_live.ex:381
+#: lib/vutuv_web/live/fediverse_account_live.ex:338
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6654,7 +6655,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2074
-#: lib/vutuv_web/live/fediverse_account_live.ex:379
+#: lib/vutuv_web/live/fediverse_account_live.ex:336
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6677,7 +6678,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2441
+#: lib/vutuv_web/components/post_components.ex:2538
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6687,7 +6688,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2440
+#: lib/vutuv_web/components/post_components.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7370,7 +7371,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4165
+#: lib/vutuv_web/components/post_components.ex:4262
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8166,7 +8167,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:614
+#: lib/vutuv_web/templates/user/show.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8191,7 +8192,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:612
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -8378,7 +8379,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:99
-#: lib/vutuv_web/templates/user/show.html.heex:1283
+#: lib/vutuv_web/templates/user/show.html.heex:1284
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8488,13 +8489,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1253
-#: lib/vutuv_web/live/post_live/feed.ex:1254
+#: lib/vutuv_web/live/post_live/feed.ex:1222
+#: lib/vutuv_web/live/post_live/feed.ex:1223
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1248
+#: lib/vutuv_web/live/post_live/feed.ex:1217
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8700,8 +8701,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:876
-#: lib/vutuv_web/templates/user/show.html.heex:1188
+#: lib/vutuv_web/templates/user/show.html.heex:877
+#: lib/vutuv_web/templates/user/show.html.heex:1189
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8845,7 +8846,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3386
+#: lib/vutuv_web/components/post_components.ex:3483
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9098,7 +9099,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:676
+#: lib/vutuv_web/templates/user/show.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9322,7 +9323,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:673
+#: lib/vutuv_web/templates/user/show.html.heex:674
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9602,7 +9603,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:716
+#: lib/vutuv_web/templates/user/show.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9650,7 +9651,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:713
+#: lib/vutuv_web/templates/user/show.html.heex:714
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr ""
@@ -9767,8 +9768,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1111
 #: lib/vutuv_web/templates/user/show.html.heex:1112
+#: lib/vutuv_web/templates/user/show.html.heex:1113
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9952,7 +9953,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:131
 #: lib/vutuv_web/templates/totp/new.html.heex:58
-#: lib/vutuv_web/templates/user/show.html.heex:912
+#: lib/vutuv_web/templates/user/show.html.heex:913
 #: lib/vutuv_web/templates/username/new.html.heex:27
 #: lib/vutuv_web/templates/username/new.html.heex:114
 #, elixir-autogen, elixir-format
@@ -9963,8 +9964,8 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:134
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
-#: lib/vutuv_web/templates/user/show.html.heex:911
-#: lib/vutuv_web/templates/user/show.html.heex:915
+#: lib/vutuv_web/templates/user/show.html.heex:912
+#: lib/vutuv_web/templates/user/show.html.heex:916
 #: lib/vutuv_web/templates/username/new.html.heex:26
 #: lib/vutuv_web/templates/username/new.html.heex:30
 #: lib/vutuv_web/templates/username/new.html.heex:113
@@ -10424,7 +10425,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1257
+#: lib/vutuv_web/templates/user/show.html.heex:1258
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -11983,17 +11984,17 @@ msgstr ""
 msgid "No organizations found for %{term}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:600
+#: lib/vutuv_web/live/post_live/saved.ex:677
 #, elixir-autogen, elixir-format
 msgid "No saved organizations match your search."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:597
+#: lib/vutuv_web/live/post_live/saved.ex:674
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Organizations you bookmark show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:594
+#: lib/vutuv_web/live/post_live/saved.ex:671
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Organizations you like show up here."
 msgstr ""
@@ -12052,7 +12053,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:165
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
-#: lib/vutuv_web/live/post_live/saved.ex:455
+#: lib/vutuv_web/live/post_live/saved.ex:497
 #: lib/vutuv_web/live/shell_live.ex:566
 #: lib/vutuv_web/templates/layout/app.html.heex:83
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
@@ -12380,7 +12381,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:56
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
-#: lib/vutuv_web/live/post_live/saved.ex:458
+#: lib/vutuv_web/live/post_live/saved.ex:500
 #: lib/vutuv_web/live/shell_live.ex:457
 #: lib/vutuv_web/templates/layout/app.html.heex:81
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
@@ -12455,17 +12456,17 @@ msgstr ""
 msgid "Nice to have"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:607
+#: lib/vutuv_web/live/post_live/saved.ex:684
 #, elixir-autogen, elixir-format
 msgid "No saved jobs match your search."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:605
+#: lib/vutuv_web/live/post_live/saved.ex:682
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Jobs you bookmark show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:602
+#: lib/vutuv_web/live/post_live/saved.ex:679
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
@@ -13281,7 +13282,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1807
+#: lib/vutuv_web/components/post_components.ex:1904
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -13719,14 +13720,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3474
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:1199
+#: lib/vutuv_web/live/post_live/feed.ex:1168
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1214
+#: lib/vutuv_web/live/post_live/feed.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13768,7 +13769,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1223
+#: lib/vutuv_web/templates/user/show.html.heex:1224
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13805,7 +13806,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1221
+#: lib/vutuv_web/templates/user/show.html.heex:1222
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13882,50 +13883,50 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3799
+#: lib/vutuv_web/components/post_components.ex:3896
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3756
+#: lib/vutuv_web/components/post_components.ex:3853
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3800
+#: lib/vutuv_web/components/post_components.ex:3897
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3802
+#: lib/vutuv_web/components/post_components.ex:3899
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3798
+#: lib/vutuv_web/components/post_components.ex:3895
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3755
+#: lib/vutuv_web/components/post_components.ex:3852
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:448
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:338
+#: lib/vutuv_web/live/fediverse_account_live.ex:405
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3797
+#: lib/vutuv_web/components/post_components.ex:3894
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3801
+#: lib/vutuv_web/components/post_components.ex:3898
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13945,34 +13946,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3838
+#: lib/vutuv_web/components/post_components.ex:3935
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3868
+#: lib/vutuv_web/components/post_components.ex:3965
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3869
+#: lib/vutuv_web/components/post_components.ex:3966
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3867
+#: lib/vutuv_web/components/post_components.ex:3964
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3827
+#: lib/vutuv_web/components/post_components.ex:3924
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3874
+#: lib/vutuv_web/components/post_components.ex:3971
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14002,7 +14003,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3641
+#: lib/vutuv_web/components/post_components.ex:3738
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14050,7 +14051,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3632
+#: lib/vutuv_web/components/post_components.ex:3729
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14404,7 +14405,7 @@ msgstr ""
 msgid "No accounts are currently frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:426
+#: lib/vutuv_web/live/post_live/thread.ex:367
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr ""
@@ -14424,14 +14425,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2063
+#: lib/vutuv_web/components/post_components.ex:2160
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2085
+#: lib/vutuv_web/components/post_components.ex:2182
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14443,7 +14444,7 @@ msgstr[1] ""
 msgid "This page is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:418
+#: lib/vutuv_web/live/post_live/thread.ex:359
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr ""
@@ -14458,7 +14459,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4251
+#: lib/vutuv_web/components/post_components.ex:4348
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14923,7 +14924,7 @@ msgstr ""
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:413
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:369
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Related"
@@ -15191,27 +15192,27 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:880
+#: lib/vutuv_web/templates/user/show.html.heex:881
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:896
+#: lib/vutuv_web/templates/user/show.html.heex:897
 #, elixir-autogen, elixir-format
 msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:933
+#: lib/vutuv_web/templates/user/show.html.heex:934
 #, elixir-autogen, elixir-format
 msgid "Follow from your own server"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:944
+#: lib/vutuv_web/templates/user/show.html.heex:945
 #, elixir-autogen, elixir-format
 msgid "@you@example.social"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:952
+#: lib/vutuv_web/templates/user/show.html.heex:953
 #, elixir-autogen, elixir-format
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr ""
@@ -15630,21 +15631,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4210
+#: lib/vutuv_web/components/post_components.ex:4307
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4214
+#: lib/vutuv_web/components/post_components.ex:4311
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4218
+#: lib/vutuv_web/components/post_components.ex:4315
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15652,7 +15653,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:951
-#: lib/vutuv_web/components/post_components.ex:4169
+#: lib/vutuv_web/components/post_components.ex:4266
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15668,14 +15669,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1124
-#: lib/vutuv_web/components/post_components.ex:1350
-#: lib/vutuv_web/live/fediverse_account_live.ex:321
+#: lib/vutuv_web/components/post_components.ex:1096
+#: lib/vutuv_web/components/post_components.ex:1509
+#: lib/vutuv_web/live/fediverse_account_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:980
+#: lib/vutuv_web/components/post_components.ex:983
 #, elixir-autogen, elixir-format
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15697,12 +15698,12 @@ msgstr ""
 msgid "Reply from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:148
+#: lib/vutuv_web/live/post_live/thread.ex:141
 #, elixir-autogen, elixir-format
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:989
+#: lib/vutuv_web/components/post_components.ex:992
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15712,7 +15713,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1003
+#: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/notification_live/index.ex:534
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15733,19 +15734,19 @@ msgstr ""
 msgid "Taken down"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:157
+#: lib/vutuv_web/live/post_live/thread.ex:150
 #, elixir-autogen, elixir-format
 msgid "Thank you. The reply was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:328
+#: lib/vutuv_web/live/post_live/thread.ex:269
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1112
-#: lib/vutuv_web/components/post_components.ex:1055
-#: lib/vutuv_web/components/post_components.ex:1764
+#: lib/vutuv_web/components/post_components.ex:1027
+#: lib/vutuv_web/components/post_components.ex:1861
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15756,10 +15757,10 @@ msgstr ""
 msgid "What"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:168
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:139
+#: lib/vutuv_web/live/fediverse_account_live.ex:167
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:118
 #: lib/vutuv_web/live/post_live/feed.ex:426
-#: lib/vutuv_web/live/post_live/thread.ex:324
+#: lib/vutuv_web/live/post_live/thread.ex:265
 #: lib/vutuv_web/live/tag_live/timeline.ex:138
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16185,7 +16186,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:198
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
-#: lib/vutuv_web/live/tag_live/timeline.ex:397
+#: lib/vutuv_web/live/tag_live/timeline.ex:398
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16405,22 +16406,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2300
+#: lib/vutuv_web/components/post_components.ex:2397
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2504
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2415
+#: lib/vutuv_web/components/post_components.ex:2512
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2401
+#: lib/vutuv_web/components/post_components.ex:2498
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16506,7 +16507,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1040
 #: lib/vutuv_web/agent_docs/text.ex:654
-#: lib/vutuv_web/components/post_components.ex:2872
+#: lib/vutuv_web/components/post_components.ex:2969
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16536,7 +16537,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2871
+#: lib/vutuv_web/components/post_components.ex:2968
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16546,29 +16547,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3250
+#: lib/vutuv_web/components/post_components.ex:3347
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1860
+#: lib/vutuv_web/components/post_components.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3253
+#: lib/vutuv_web/components/post_components.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3078
+#: lib/vutuv_web/components/post_components.ex:3175
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2616
+#: lib/vutuv_web/components/post_components.ex:2713
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16581,12 +16582,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1073
 #: lib/vutuv_web/agent_docs/text.ex:641
-#: lib/vutuv_web/components/post_components.ex:3287
+#: lib/vutuv_web/components/post_components.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2870
+#: lib/vutuv_web/components/post_components.ex:2967
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
@@ -16607,7 +16608,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1913
+#: lib/vutuv_web/components/post_components.ex:2010
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16627,7 +16628,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1904
+#: lib/vutuv_web/components/post_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16637,12 +16638,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1922
+#: lib/vutuv_web/components/post_components.ex:2019
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1856
+#: lib/vutuv_web/components/post_components.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16657,7 +16658,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1917
+#: lib/vutuv_web/components/post_components.ex:2014
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16667,7 +16668,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1870
+#: lib/vutuv_web/components/post_components.ex:1967
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16688,8 +16689,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1024
-#: lib/vutuv_web/live/post_live/feed.ex:1025
+#: lib/vutuv_web/live/post_live/feed.ex:982
+#: lib/vutuv_web/live/post_live/feed.ex:983
 #, elixir-autogen, elixir-format
 msgid "Post photos"
 msgstr ""
@@ -16754,13 +16755,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:969
-#: lib/vutuv_web/components/post_components.ex:4207
+#: lib/vutuv_web/components/post_components.ex:4304
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:967
-#: lib/vutuv_web/components/post_components.ex:4204
+#: lib/vutuv_web/components/post_components.ex:4301
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16770,7 +16771,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4096
+#: lib/vutuv_web/components/post_components.ex:4193
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16861,11 +16862,11 @@ msgstr ""
 msgid "Photo details"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:454
+#: lib/vutuv_web/live/fediverse_account_live.ex:411
 #: lib/vutuv_web/live/fediverse_following_live.ex:52
 #: lib/vutuv_web/live/fediverse_following_live.ex:236
 #: lib/vutuv_web/live/fediverse_following_live.ex:249
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:422
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:378
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
@@ -16891,9 +16892,9 @@ msgstr ""
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:112
+#: lib/vutuv_web/live/fediverse_account_live.ex:111
 #: lib/vutuv_web/live/fediverse_following_live.ex:192
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:158
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Follow request sent to %{account}."
 msgstr ""
@@ -16984,7 +16985,7 @@ msgid "That server answered, but it has no account at that address to follow."
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:272
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:260
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "That server did not answer. Check the address, and that the server is online."
 msgstr ""
@@ -17019,7 +17020,7 @@ msgstr ""
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:128
+#: lib/vutuv_web/live/fediverse_account_live.ex:127
 #: lib/vutuv_web/live/fediverse_following_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Unfollowed."
@@ -17107,20 +17108,20 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1646
+#: lib/vutuv_web/components/post_components.ex:1807
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:160
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:131
+#: lib/vutuv_web/live/fediverse_account_live.ex:159
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:110
 #: lib/vutuv_web/live/post_live/feed.ex:418
 #: lib/vutuv_web/live/tag_live/timeline.ex:130
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1763
+#: lib/vutuv_web/components/post_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -17140,23 +17141,23 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1282
+#: lib/vutuv_web/components/post_components.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1663
+#: lib/vutuv_web/components/post_components.ex:1824
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1625
+#: lib/vutuv_web/components/post_components.ex:1786
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:264
-#: lib/vutuv_web/live/post_live/feed.ex:476
+#: lib/vutuv_web/live/fediverse_account_live.ex:221
+#: lib/vutuv_web/live/post_live/feed.ex:448
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr ""
@@ -17166,7 +17167,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1632
+#: lib/vutuv_web/components/post_components.ex:1793
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17186,57 +17187,57 @@ msgstr ""
 msgid "%{name} (another network)"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:304
+#: lib/vutuv_web/live/fediverse_account_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Account on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:438
+#: lib/vutuv_web/live/fediverse_account_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:369
+#: lib/vutuv_web/live/fediverse_account_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:279
+#: lib/vutuv_web/live/fediverse_account_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:274
+#: lib/vutuv_web/live/fediverse_account_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:440
+#: lib/vutuv_web/live/fediverse_account_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:336
+#: lib/vutuv_web/live/fediverse_account_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:423
+#: lib/vutuv_web/live/fediverse_account_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:266
+#: lib/vutuv_web/live/fediverse_account_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Unmuted. Their posts are back in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:433
+#: lib/vutuv_web/live/fediverse_account_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:283
+#: lib/vutuv_web/live/fediverse_account_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr ""
@@ -17247,7 +17248,7 @@ msgid "You redirected your Fediverse followers to another account, so this one n
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:183
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:240
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Your account move"
 msgstr ""
@@ -17388,27 +17389,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1453
+#: lib/vutuv_web/components/post_components.ex:1612
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1482
+#: lib/vutuv_web/components/post_components.ex:1641
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1477
+#: lib/vutuv_web/components/post_components.ex:1636
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1789
+#: lib/vutuv_web/components/post_components.ex:1886
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1795
+#: lib/vutuv_web/components/post_components.ex:1892
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17418,7 +17419,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1908
+#: lib/vutuv_web/components/post_components.ex:2005
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17428,9 +17429,7 @@ msgstr ""
 msgid "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:193
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:110
-#: lib/vutuv_web/live/post_live/feed.ex:454
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:93
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr ""
@@ -17697,22 +17696,22 @@ msgstr ""
 msgid "Travel & places"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:320
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "Address of the post"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:237
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:221
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "Fetching a post asks its server for it in your name, signed with your own key, so there is no such thing as an anonymous lookup here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:267
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Its author published this post to their followers alone, so vutuv does not keep a copy of it."
 msgstr ""
@@ -17724,17 +17723,17 @@ msgid "Look up a post by its address"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:54
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:284
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Look up a post from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:416
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Looking for an account rather than a single post?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:287
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "Paste the address of a post on Mastodon and friends. vutuv fetches it, shows it here, and you can answer, like or repost it as if it had arrived on its own."
 msgstr ""
@@ -17744,42 +17743,42 @@ msgstr ""
 msgid "Read something out there that you want to answer from here?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:252
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "That does not look like a link to a post. Copy the address of the post itself, for example https://server/@name/12345."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:257
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "That is a link on this vutuv, not on another network."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:408
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:263
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "There is no post to show at that address."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:216
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "This account no longer acts out there"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:233
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "This vutuv does not exchange anything with other networks. That is an operator setting, not yours."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:217
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "This vutuv stays to itself"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:215
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:172
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to look up"
 msgstr ""
@@ -17789,22 +17788,22 @@ msgstr ""
 msgid "Want to answer one particular post rather than follow its author?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:373
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Who wrote this"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:272
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "You have looked a lot of posts up in the last hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:227
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "You redirected your Fediverse followers to another account, so nothing is fetched or sent from this one any more."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:426
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
@@ -18171,22 +18170,22 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:381
+#: lib/vutuv_web/live/tag_live/timeline.ex:382
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:405
+#: lib/vutuv_web/live/tag_live/timeline.ex:406
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:403
+#: lib/vutuv_web/live/tag_live/timeline.ex:404
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:400
+#: lib/vutuv_web/live/tag_live/timeline.ex:401
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
@@ -18201,7 +18200,22 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1792
+#: lib/vutuv_web/components/post_components.ex:1889
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/saved.ex:452
+#, elixir-autogen, elixir-format
+msgid "Nothing saved from other networks matches that."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/saved.ex:456
+#, elixir-autogen, elixir-format
+msgid "Nothing saved from other networks yet. The bookmark on a post or reply from another network keeps it here."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/saved.ex:511
+#, elixir-autogen, elixir-format
+msgid "Other networks"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -36,7 +36,7 @@ msgstr ""
 #: lib/vutuv_web/templates/address/card_list.html.heex:16
 #: lib/vutuv_web/templates/address/show.html.heex:2
 #: lib/vutuv_web/templates/address/show.html.heex:7
-#: lib/vutuv_web/templates/user/show.html.heex:1377
+#: lib/vutuv_web/templates/user/show.html.heex:1378
 #, elixir-autogen
 msgid "Address"
 msgid_plural "Addresses"
@@ -99,7 +99,7 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:486
 #: lib/vutuv_web/agent_docs/text.ex:455
 #: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/templates/user/show.html.heex:1009
+#: lib/vutuv_web/templates/user/show.html.heex:1010
 #, elixir-autogen
 msgid "Birthday"
 msgstr ""
@@ -145,7 +145,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/card_list.html.heex:6
 #: lib/vutuv_web/templates/messenger/form_content.html.heex:12
 #: lib/vutuv_web/templates/messenger/show.html.heex:21
-#: lib/vutuv_web/templates/user/show.html.heex:1047
+#: lib/vutuv_web/templates/user/show.html.heex:1048
 #, elixir-autogen
 msgid "Contact"
 msgstr ""
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2423
+#: lib/vutuv_web/components/post_components.ex:2520
 #: lib/vutuv_web/components/ui.ex:3140
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2388
+#: lib/vutuv_web/components/post_components.ex:2485
 #: lib/vutuv_web/components/ui.ex:3131
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -217,7 +217,7 @@ msgstr ""
 #: lib/vutuv_web/templates/dev_app/edit.html.heex:7
 #: lib/vutuv_web/templates/dev_app/show.html.heex:58
 #: lib/vutuv_web/templates/moderation_case/show.html.heex:45
-#: lib/vutuv_web/templates/user/show.html.heex:1032
+#: lib/vutuv_web/templates/user/show.html.heex:1033
 #, elixir-autogen
 msgid "Edit"
 msgstr ""
@@ -294,7 +294,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/work_experience_controller.ex:44
 #: lib/vutuv_web/controllers/work_experience_controller.ex:61
 #: lib/vutuv_web/controllers/work_experience_controller.ex:152
-#: lib/vutuv_web/templates/user/show.html.heex:559
+#: lib/vutuv_web/templates/user/show.html.heex:560
 #: lib/vutuv_web/templates/work_experience/edit.html.heex:4
 #: lib/vutuv_web/templates/work_experience/index.html.heex:10
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:4
@@ -339,7 +339,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/followee_controller.ex:23
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:835
 #, elixir-autogen
 msgid "Following"
 msgstr ""
@@ -354,7 +354,7 @@ msgstr ""
 #: lib/vutuv_web/templates/invitation/new.html.heex:58
 #: lib/vutuv_web/templates/page/index.html.heex:67
 #: lib/vutuv_web/templates/user/edit.html.heex:125
-#: lib/vutuv_web/templates/user/show.html.heex:1004
+#: lib/vutuv_web/templates/user/show.html.heex:1005
 #: lib/vutuv_web/views/account_event_text.ex:153
 #, elixir-autogen
 msgid "Gender"
@@ -661,7 +661,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1279
+#: lib/vutuv_web/components/post_components.ex:1251
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -696,13 +696,13 @@ msgstr ""
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/new.html.heex:4
 #: lib/vutuv_web/templates/social_media_account/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1161
+#: lib/vutuv_web/templates/user/show.html.heex:1162
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
 #: lib/vutuv_web/templates/social_media_account/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:1163
+#: lib/vutuv_web/templates/user/show.html.heex:1164
 #, elixir-autogen, elixir-format
 msgid "Add a profile"
 msgstr ""
@@ -854,8 +854,8 @@ msgid "vCard"
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3201
-#: lib/vutuv_web/templates/user/show.html.heex:828
-#: lib/vutuv_web/templates/user/show.html.heex:851
+#: lib/vutuv_web/templates/user/show.html.heex:829
+#: lib/vutuv_web/templates/user/show.html.heex:852
 #, elixir-autogen
 msgid "View All"
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:993
+#: lib/vutuv_web/templates/user/show.html.heex:994
 #, elixir-autogen
 msgid "General Info"
 msgstr ""
@@ -1250,7 +1250,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/tag/index.html.heex:2
 #: lib/vutuv_web/templates/tag/index.html.heex:1
-#: lib/vutuv_web/templates/user/show.html.heex:553
+#: lib/vutuv_web/templates/user/show.html.heex:554
 #, elixir-autogen
 msgid "All tags"
 msgstr ""
@@ -1449,7 +1449,7 @@ msgstr ""
 #: lib/vutuv_web/templates/tag/index.html.heex:1
 #: lib/vutuv_web/templates/tag/show.html.heex:23
 #: lib/vutuv_web/templates/tag/show.html.heex:25
-#: lib/vutuv_web/templates/user/show.html.heex:523
+#: lib/vutuv_web/templates/user/show.html.heex:524
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:4
 #: lib/vutuv_web/templates/user_tag/index.html.heex:26
 #: lib/vutuv_web/templates/user_tag/manage.html.heex:4
@@ -1662,7 +1662,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2869
+#: lib/vutuv_web/components/post_components.ex:2966
 #: lib/vutuv_web/components/ui.ex:244
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1734,11 +1734,11 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1844
 #: lib/vutuv_web/components/ui.ex:1847
 #: lib/vutuv_web/components/ui.ex:1920
-#: lib/vutuv_web/live/fediverse_account_live.ex:387
+#: lib/vutuv_web/live/fediverse_account_live.ex:344
 #: lib/vutuv_web/live/fediverse_following_live.ex:266
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:403
-#: lib/vutuv_web/templates/user/show.html.heex:948
-#: lib/vutuv_web/templates/user/show.html.heex:1201
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:359
+#: lib/vutuv_web/templates/user/show.html.heex:949
+#: lib/vutuv_web/templates/user/show.html.heex:1202
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "We sent a PIN to your new email address. Enter it below to confirm the address."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1224
+#: lib/vutuv_web/live/post_live/feed.ex:1193
 #: lib/vutuv_web/views/user_html.ex:206
 #, elixir-autogen, elixir-format
 msgid "Who to follow"
@@ -2142,7 +2142,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2420
+#: lib/vutuv_web/components/post_components.ex:2517
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2155,7 +2155,7 @@ msgid "Edit post"
 msgstr ""
 
 #: lib/vutuv_web/live/post_live/feed.ex:154
-#: lib/vutuv_web/live/post_live/feed.ex:990
+#: lib/vutuv_web/live/post_live/feed.ex:948
 #: lib/vutuv_web/live/shell_live.ex:430
 #: lib/vutuv_web/live/shell_live.ex:635
 #: lib/vutuv_web/templates/layout/app.html.heex:122
@@ -2183,8 +2183,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2374
-#: lib/vutuv_web/components/post_components.ex:2376
+#: lib/vutuv_web/components/post_components.ex:2471
+#: lib/vutuv_web/components/post_components.ex:2473
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2200,7 +2200,7 @@ msgstr ""
 msgid "No more than %{max} images per post."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1163
+#: lib/vutuv_web/live/post_live/feed.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Follow people to fill your feed, or write your first post."
 msgstr ""
@@ -2238,9 +2238,9 @@ msgstr ""
 #: lib/vutuv_web/controllers/user_controller.ex:77
 #: lib/vutuv_web/gettext_extraction_anchors.ex:79
 #: lib/vutuv_web/live/admin/dashboard_live.ex:149
-#: lib/vutuv_web/live/fediverse_account_live.ex:394
+#: lib/vutuv_web/live/fediverse_account_live.ex:351
 #: lib/vutuv_web/live/notification_live/index.ex:860
-#: lib/vutuv_web/live/post_live/saved.ex:449
+#: lib/vutuv_web/live/post_live/saved.ex:491
 #: lib/vutuv_web/live/search_live.ex:200
 #: lib/vutuv_web/live/search_live.ex:530
 #: lib/vutuv_web/templates/settings/preferences.html.heex:118
@@ -2249,29 +2249,29 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2805
-#: lib/vutuv_web/components/post_components.ex:2809
+#: lib/vutuv_web/components/post_components.ex:2902
+#: lib/vutuv_web/components/post_components.ex:2906
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2806
-#: lib/vutuv_web/live/fediverse_account_live.ex:339
+#: lib/vutuv_web/components/post_components.ex:2903
+#: lib/vutuv_web/live/fediverse_account_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Show less"
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:252
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
-#: lib/vutuv_web/components/post_components.ex:982
+#: lib/vutuv_web/components/post_components.ex:985
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
 #: lib/vutuv_web/live/organization_live/roles.ex:242
 #: lib/vutuv_web/live/post_live/composer.ex:1850
-#: lib/vutuv_web/live/post_live/saved.ex:538
-#: lib/vutuv_web/live/post_live/saved.ex:566
+#: lib/vutuv_web/live/post_live/saved.ex:615
+#: lib/vutuv_web/live/post_live/saved.ex:643
 #: lib/vutuv_web/templates/connection/index.html.heex:40
 #: lib/vutuv_web/views/settings_html.ex:275
 #, elixir-autogen, elixir-format
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1083
+#: lib/vutuv_web/live/post_live/feed.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} new post"
 msgid_plural "Show %{formatted} new posts"
@@ -2344,27 +2344,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2371
+#: lib/vutuv_web/components/post_components.ex:2468
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3936
+#: lib/vutuv_web/components/post_components.ex:4033
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3940
+#: lib/vutuv_web/components/post_components.ex:4037
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3938
+#: lib/vutuv_web/components/post_components.ex:4035
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3939
+#: lib/vutuv_web/components/post_components.ex:4036
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2395,7 +2395,7 @@ msgstr ""
 msgid "Posts by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:513
+#: lib/vutuv_web/templates/user/show.html.heex:514
 #, elixir-autogen, elixir-format
 msgid "View all %{count} posts"
 msgstr ""
@@ -2405,7 +2405,8 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4020
+#: lib/vutuv_web/components/post_components.ex:1415
+#: lib/vutuv_web/components/post_components.ex:4117
 #: lib/vutuv_web/components/ui.ex:2665
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2413,8 +2414,8 @@ msgid "Bookmark"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:933
-#: lib/vutuv_web/live/post_live/saved.ex:139
-#: lib/vutuv_web/live/post_live/saved.ex:442
+#: lib/vutuv_web/live/post_live/saved.ex:171
+#: lib/vutuv_web/live/post_live/saved.ex:484
 #: lib/vutuv_web/live/shell_live.ex:490
 #: lib/vutuv_web/live/shell_live.ex:556
 #: lib/vutuv_web/views/admin/report_html.ex:38
@@ -2422,9 +2423,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1041
-#: lib/vutuv_web/components/post_components.ex:1705
-#: lib/vutuv_web/components/post_components.ex:4243
+#: lib/vutuv_web/components/post_components.ex:1381
+#: lib/vutuv_web/components/post_components.ex:4340
 #: lib/vutuv_web/components/ui.ex:2651
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #: lib/vutuv_web/templates/user/show.html.heex:192
@@ -2433,58 +2433,60 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:932
-#: lib/vutuv_web/components/post_components.ex:4252
+#: lib/vutuv_web/components/post_components.ex:4349
 #: lib/vutuv_web/live/notification_live/index.ex:940
-#: lib/vutuv_web/live/post_live/saved.ex:138
-#: lib/vutuv_web/live/post_live/saved.ex:439
+#: lib/vutuv_web/live/post_live/saved.ex:170
+#: lib/vutuv_web/live/post_live/saved.ex:481
 #: lib/vutuv_web/live/shell_live.ex:559
 #: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Likes"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:581
+#: lib/vutuv_web/live/post_live/saved.ex:658
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Posts you bookmark show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:578
+#: lib/vutuv_web/live/post_live/saved.ex:655
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4009
+#: lib/vutuv_web/components/post_components.ex:4106
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4020
-#: lib/vutuv_web/live/post_live/saved.ex:694
+#: lib/vutuv_web/components/post_components.ex:1415
+#: lib/vutuv_web/components/post_components.ex:4117
+#: lib/vutuv_web/live/post_live/saved.ex:771
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1743
-#: lib/vutuv_web/components/post_components.ex:4006
+#: lib/vutuv_web/components/post_components.ex:1404
+#: lib/vutuv_web/components/post_components.ex:4103
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1408
-#: lib/vutuv_web/components/post_components.ex:3383
+#: lib/vutuv_web/components/post_components.ex:1567
+#: lib/vutuv_web/components/post_components.ex:3480
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4006
+#: lib/vutuv_web/components/post_components.ex:1404
+#: lib/vutuv_web/components/post_components.ex:4103
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4243
-#: lib/vutuv_web/live/post_live/saved.ex:693
+#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/live/post_live/saved.ex:770
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "Unlike"
@@ -2494,7 +2496,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:1750
 #: lib/vutuv_web/components/ui.ex:1750
 #: lib/vutuv_web/components/ui.ex:1887
-#: lib/vutuv_web/live/post_live/feed.ex:1213
+#: lib/vutuv_web/live/post_live/feed.ex:1182
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -2505,7 +2507,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4296
+#: lib/vutuv_web/components/post_components.ex:4393
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2516,17 +2518,16 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1051
-#: lib/vutuv_web/components/post_components.ex:1719
-#: lib/vutuv_web/components/post_components.ex:4279
-#: lib/vutuv_web/components/post_components.ex:4280
+#: lib/vutuv_web/components/post_components.ex:1391
+#: lib/vutuv_web/components/post_components.ex:4376
+#: lib/vutuv_web/components/post_components.ex:4377
 #: lib/vutuv_web/live/notification_live/index.ex:1000
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2342
+#: lib/vutuv_web/components/post_components.ex:2439
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2547,7 +2548,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1848
+#: lib/vutuv_web/components/post_components.ex:1945
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2555,14 +2556,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2318
+#: lib/vutuv_web/components/post_components.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2312
-#: lib/vutuv_web/components/post_components.ex:2334
-#: lib/vutuv_web/components/post_components.ex:2337
+#: lib/vutuv_web/components/post_components.ex:2409
+#: lib/vutuv_web/components/post_components.ex:2431
+#: lib/vutuv_web/components/post_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2728,38 +2729,38 @@ msgstr ""
 
 #: lib/vutuv_web/templates/url/manage.html.heex:8
 #: lib/vutuv_web/templates/url/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:764
+#: lib/vutuv_web/templates/user/show.html.heex:765
 #, elixir-autogen, elixir-format
 msgid "Add a link"
 msgstr ""
 
 #: lib/vutuv_web/templates/phone_number/manage.html.heex:8
 #: lib/vutuv_web/templates/phone_number/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1121
+#: lib/vutuv_web/templates/user/show.html.heex:1122
 #, elixir-autogen, elixir-format
 msgid "Add a phone number"
 msgstr ""
 
 #: lib/vutuv_web/templates/address/manage.html.heex:8
 #: lib/vutuv_web/templates/address/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1379
+#: lib/vutuv_web/templates/user/show.html.heex:1380
 #, elixir-autogen, elixir-format
 msgid "Add an address"
 msgstr ""
 
 #: lib/vutuv_web/templates/email/manage.html.heex:8
 #: lib/vutuv_web/templates/email/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1049
+#: lib/vutuv_web/templates/user/show.html.heex:1050
 #, elixir-autogen, elixir-format
 msgid "Add an email address"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:995
+#: lib/vutuv_web/templates/user/show.html.heex:996
 #, elixir-autogen, elixir-format
 msgid "Add personal details"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:562
+#: lib/vutuv_web/templates/user/show.html.heex:563
 #: lib/vutuv_web/templates/work_experience/manage.html.heex:8
 #: lib/vutuv_web/templates/work_experience/new.html.heex:5
 #, elixir-autogen, elixir-format
@@ -2780,12 +2781,12 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/privacy.html.heex:138
 #: lib/vutuv_web/templates/settings/security.html.heex:20
 #: lib/vutuv_web/templates/settings/security.html.heex:219
-#: lib/vutuv_web/templates/user/show.html.heex:553
+#: lib/vutuv_web/templates/user/show.html.heex:554
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1015
+#: lib/vutuv_web/live/post_live/feed.ex:973
 #: lib/vutuv_web/templates/user/show.html.heex:425
 #, elixir-autogen, elixir-format
 msgid "Write a post"
@@ -2864,7 +2865,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3937
+#: lib/vutuv_web/components/post_components.ex:4034
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2890,7 +2891,7 @@ msgid "Endorsement"
 msgstr ""
 
 #: lib/vutuv_web/live/notification_live/index.ex:998
-#: lib/vutuv_web/templates/user/show.html.heex:812
+#: lib/vutuv_web/templates/user/show.html.heex:813
 #, elixir-autogen, elixir-format
 msgid "Follower"
 msgid_plural "Followers"
@@ -3119,13 +3120,13 @@ msgstr ""
 msgid "Nudity, violence or other content that does not belong on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1089
 #: lib/vutuv_web/templates/user/show.html.heex:1090
+#: lib/vutuv_web/templates/user/show.html.heex:1091
 #, elixir-autogen, elixir-format
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2288
+#: lib/vutuv_web/components/post_components.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3200,9 +3201,9 @@ msgstr ""
 msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:992
-#: lib/vutuv_web/components/post_components.ex:1637
-#: lib/vutuv_web/components/post_components.ex:2444
+#: lib/vutuv_web/components/post_components.ex:995
+#: lib/vutuv_web/components/post_components.ex:1798
+#: lib/vutuv_web/components/post_components.ex:2541
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -4561,7 +4562,7 @@ msgstr ""
 msgid "You unblocked @%{slug}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1168
+#: lib/vutuv_web/live/post_live/feed.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Discover people to follow"
 msgstr ""
@@ -4573,7 +4574,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/followee/index.html.heex:4
 #: lib/vutuv_web/templates/followee/index.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:834
+#: lib/vutuv_web/templates/user/show.html.heex:835
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -4619,7 +4620,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:480
 #: lib/vutuv_web/live/notification_live/index.ex:861
 #: lib/vutuv_web/live/organization_live/show.ex:300
-#: lib/vutuv_web/live/post_live/saved.ex:452
+#: lib/vutuv_web/live/post_live/saved.ex:494
 #: lib/vutuv_web/live/search_live.ex:198
 #: lib/vutuv_web/live/search_live.ex:472
 #, elixir-autogen, elixir-format
@@ -4690,7 +4691,7 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:388
 #: lib/vutuv_web/live/tag_new_live.ex:46
 #: lib/vutuv_web/live/user_profile_live.ex:1249
-#: lib/vutuv_web/templates/user/show.html.heex:526
+#: lib/vutuv_web/templates/user/show.html.heex:527
 #, elixir-autogen, elixir-format
 msgid "Add a tag"
 msgstr ""
@@ -5430,11 +5431,11 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2507
-#: lib/vutuv_web/components/post_components.ex:2559
-#: lib/vutuv_web/components/post_components.ex:2949
+#: lib/vutuv_web/components/post_components.ex:2604
+#: lib/vutuv_web/components/post_components.ex:2656
+#: lib/vutuv_web/components/post_components.ex:3046
 #: lib/vutuv_web/live/notification_live/index.ex:680
-#: lib/vutuv_web/live/post_live/feed.ex:1286
+#: lib/vutuv_web/live/post_live/feed.ex:1255
 #: lib/vutuv_web/views/user_html.ex:111
 #, elixir-autogen, elixir-format
 msgid "View post"
@@ -5802,60 +5803,60 @@ msgstr ""
 msgid "Liked."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:422
+#: lib/vutuv_web/live/post_live/saved.ex:464
 #, elixir-autogen, elixir-format
 msgid "Name (A-Z)"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:420
-#: lib/vutuv_web/live/tag_live/timeline.ex:379
+#: lib/vutuv_web/live/post_live/saved.ex:462
+#: lib/vutuv_web/live/tag_live/timeline.ex:380
 #, elixir-autogen, elixir-format
 msgid "Newest first"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:591
+#: lib/vutuv_web/live/post_live/saved.ex:668
 #, elixir-autogen, elixir-format
 msgid "No saved people match your search."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:583
+#: lib/vutuv_web/live/post_live/saved.ex:660
 #, elixir-autogen, elixir-format
 msgid "No saved posts match your search."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:589
+#: lib/vutuv_web/live/post_live/saved.ex:666
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. People you bookmark show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:586
+#: lib/vutuv_web/live/post_live/saved.ex:663
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. People you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:421
-#: lib/vutuv_web/live/tag_live/timeline.ex:380
+#: lib/vutuv_web/live/post_live/saved.ex:463
+#: lib/vutuv_web/live/tag_live/timeline.ex:381
 #, elixir-autogen, elixir-format
 msgid "Oldest first"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:437
+#: lib/vutuv_web/live/post_live/saved.ex:479
 #, elixir-autogen, elixir-format
 msgid "Saved items"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:447
+#: lib/vutuv_web/live/post_live/saved.ex:489
 #, elixir-autogen, elixir-format
 msgid "Saved type"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:468
-#: lib/vutuv_web/live/post_live/saved.ex:469
+#: lib/vutuv_web/live/post_live/saved.ex:521
+#: lib/vutuv_web/live/post_live/saved.ex:522
 #, elixir-autogen, elixir-format
 msgid "Search saved items"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:472
+#: lib/vutuv_web/live/post_live/saved.ex:525
 #: lib/vutuv_web/live/tag_live/timeline.ex:294
 #, elixir-autogen, elixir-format
 msgid "Sort"
@@ -6088,7 +6089,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:260
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:29
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:88
-#: lib/vutuv_web/templates/user/show.html.heex:762
+#: lib/vutuv_web/templates/user/show.html.heex:763
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgid_plural "Links"
@@ -6109,7 +6110,7 @@ msgstr[1] ""
 msgid "After choosing a file you can reposition and zoom it."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1430
+#: lib/vutuv_web/templates/user/show.html.heex:1431
 #, elixir-autogen, elixir-format
 msgid "Also on"
 msgstr ""
@@ -6153,8 +6154,8 @@ msgstr ""
 msgid "Zoom"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1015
-#: lib/vutuv_web/templates/user/show.html.heex:1025
+#: lib/vutuv_web/templates/user/show.html.heex:1016
+#: lib/vutuv_web/templates/user/show.html.heex:1026
 #, elixir-autogen, elixir-format
 msgid "%{count} year old"
 msgid_plural "%{count} years old"
@@ -6194,12 +6195,12 @@ msgstr ""
 msgid "Jump to a day"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1137
+#: lib/vutuv_web/templates/user/show.html.heex:1138
 #, elixir-autogen, elixir-format
 msgid "Manage emails"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1148
+#: lib/vutuv_web/templates/user/show.html.heex:1149
 #, elixir-autogen, elixir-format
 msgid "Manage phone numbers"
 msgstr ""
@@ -6241,7 +6242,7 @@ msgstr ""
 msgid "Reposts"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1146
+#: lib/vutuv_web/templates/user/show.html.heex:1147
 #, elixir-autogen, elixir-format
 msgid "View all phone numbers"
 msgstr ""
@@ -6295,9 +6296,9 @@ msgstr ""
 msgid "Maps"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1416
-#: lib/vutuv_web/templates/user/show.html.heex:1424
-#: lib/vutuv_web/templates/user/show.html.heex:1436
+#: lib/vutuv_web/templates/user/show.html.heex:1417
+#: lib/vutuv_web/templates/user/show.html.heex:1425
+#: lib/vutuv_web/templates/user/show.html.heex:1437
 #, elixir-autogen, elixir-format
 msgid "Open in %{name}"
 msgstr ""
@@ -6628,7 +6629,7 @@ msgid "Turn a switch off and the matching opt-out rides along on the pages and r
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2075
-#: lib/vutuv_web/live/fediverse_account_live.ex:381
+#: lib/vutuv_web/live/fediverse_account_live.ex:338
 #: lib/vutuv_web/templates/settings/filters.html.heex:58
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6652,7 +6653,7 @@ msgid "Remove this connection? You will stop following them."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:2074
-#: lib/vutuv_web/live/fediverse_account_live.ex:379
+#: lib/vutuv_web/live/fediverse_account_live.ex:336
 #: lib/vutuv_web/templates/settings/filters.html.heex:81
 #: lib/vutuv_web/templates/user/show.html.heex:185
 #, elixir-autogen, elixir-format
@@ -6675,7 +6676,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2441
+#: lib/vutuv_web/components/post_components.ex:2538
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6685,7 +6686,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2440
+#: lib/vutuv_web/components/post_components.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7368,7 +7369,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4165
+#: lib/vutuv_web/components/post_components.ex:4262
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8164,7 +8165,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/templates/education/manage.html.heex:8
 #: lib/vutuv_web/templates/education/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:614
+#: lib/vutuv_web/templates/user/show.html.heex:615
 #, elixir-autogen, elixir-format
 msgid "Add education"
 msgstr ""
@@ -8189,7 +8190,7 @@ msgstr ""
 #: lib/vutuv_web/templates/education/show.html.heex:6
 #: lib/vutuv_web/templates/import/new.html.heex:10
 #: lib/vutuv_web/templates/import/preview.html.heex:23
-#: lib/vutuv_web/templates/user/show.html.heex:611
+#: lib/vutuv_web/templates/user/show.html.heex:612
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -8376,7 +8377,7 @@ msgid "Loading posts"
 msgstr ""
 
 #: lib/vutuv_web/templates/settings/privacy.html.heex:99
-#: lib/vutuv_web/templates/user/show.html.heex:1283
+#: lib/vutuv_web/templates/user/show.html.heex:1284
 #, elixir-autogen, elixir-format
 msgid "Social media posts"
 msgstr ""
@@ -8486,13 +8487,13 @@ msgstr ""
 msgid "Type your username to confirm:"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1253
-#: lib/vutuv_web/live/post_live/feed.ex:1254
+#: lib/vutuv_web/live/post_live/feed.ex:1222
+#: lib/vutuv_web/live/post_live/feed.ex:1223
 #, elixir-autogen, elixir-format
 msgid "Show other posts"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1248
+#: lib/vutuv_web/live/post_live/feed.ex:1217
 #, elixir-autogen, elixir-format
 msgid "Suggested posts"
 msgstr ""
@@ -8698,8 +8699,8 @@ msgstr ""
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
 #: lib/vutuv_web/templates/settings/fediverse_confirm.html.heex:9
-#: lib/vutuv_web/templates/user/show.html.heex:876
-#: lib/vutuv_web/templates/user/show.html.heex:1188
+#: lib/vutuv_web/templates/user/show.html.heex:877
+#: lib/vutuv_web/templates/user/show.html.heex:1189
 #, elixir-autogen, elixir-format
 msgid "Fediverse"
 msgstr ""
@@ -8843,7 +8844,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3386
+#: lib/vutuv_web/components/post_components.ex:3483
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9096,7 +9097,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/language/manage.html.heex:8
 #: lib/vutuv_web/templates/language/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:676
+#: lib/vutuv_web/templates/user/show.html.heex:677
 #, elixir-autogen, elixir-format
 msgid "Add a language"
 msgstr ""
@@ -9320,7 +9321,7 @@ msgstr ""
 #: lib/vutuv_web/templates/language/manage.html.heex:4
 #: lib/vutuv_web/templates/language/new.html.heex:4
 #: lib/vutuv_web/templates/language/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:673
+#: lib/vutuv_web/templates/user/show.html.heex:674
 #, elixir-autogen, elixir-format
 msgid "Languages"
 msgstr ""
@@ -9600,7 +9601,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/templates/qualification/manage.html.heex:8
-#: lib/vutuv_web/templates/user/show.html.heex:716
+#: lib/vutuv_web/templates/user/show.html.heex:717
 #, elixir-autogen, elixir-format
 msgid "Add a certificate or license"
 msgstr ""
@@ -9648,7 +9649,7 @@ msgstr ""
 #: lib/vutuv_web/templates/qualification/manage.html.heex:4
 #: lib/vutuv_web/templates/qualification/new.html.heex:4
 #: lib/vutuv_web/templates/qualification/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:713
+#: lib/vutuv_web/templates/user/show.html.heex:714
 #, elixir-autogen, elixir-format
 msgid "Certificates & licenses"
 msgstr ""
@@ -9765,8 +9766,8 @@ msgstr ""
 msgid "Preferred contact language"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:1111
 #: lib/vutuv_web/templates/user/show.html.heex:1112
+#: lib/vutuv_web/templates/user/show.html.heex:1113
 #, elixir-autogen, elixir-format
 msgid "+%{code} is the calling code of %{region}"
 msgstr ""
@@ -9950,7 +9951,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:131
 #: lib/vutuv_web/templates/totp/new.html.heex:58
-#: lib/vutuv_web/templates/user/show.html.heex:912
+#: lib/vutuv_web/templates/user/show.html.heex:913
 #: lib/vutuv_web/templates/username/new.html.heex:27
 #: lib/vutuv_web/templates/username/new.html.heex:114
 #, elixir-autogen, elixir-format
@@ -9961,8 +9962,8 @@ msgstr ""
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:134
 #: lib/vutuv_web/templates/totp/new.html.heex:57
 #: lib/vutuv_web/templates/totp/new.html.heex:61
-#: lib/vutuv_web/templates/user/show.html.heex:911
-#: lib/vutuv_web/templates/user/show.html.heex:915
+#: lib/vutuv_web/templates/user/show.html.heex:912
+#: lib/vutuv_web/templates/user/show.html.heex:916
 #: lib/vutuv_web/templates/username/new.html.heex:26
 #: lib/vutuv_web/templates/username/new.html.heex:30
 #: lib/vutuv_web/templates/username/new.html.heex:113
@@ -10422,7 +10423,7 @@ msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:62
 #: lib/vutuv_web/agent_docs/text.ex:59
-#: lib/vutuv_web/templates/user/show.html.heex:1257
+#: lib/vutuv_web/templates/user/show.html.heex:1258
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -11981,17 +11982,17 @@ msgstr ""
 msgid "No organizations found for %{term}."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:600
+#: lib/vutuv_web/live/post_live/saved.ex:677
 #, elixir-autogen, elixir-format
 msgid "No saved organizations match your search."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:597
+#: lib/vutuv_web/live/post_live/saved.ex:674
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Organizations you bookmark show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:594
+#: lib/vutuv_web/live/post_live/saved.ex:671
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Organizations you like show up here."
 msgstr ""
@@ -12050,7 +12051,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:165
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
-#: lib/vutuv_web/live/post_live/saved.ex:455
+#: lib/vutuv_web/live/post_live/saved.ex:497
 #: lib/vutuv_web/live/shell_live.ex:566
 #: lib/vutuv_web/templates/layout/app.html.heex:83
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
@@ -12378,7 +12379,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:56
 #: lib/vutuv_web/live/job_board_live.ex:45
 #: lib/vutuv_web/live/job_board_live.ex:211
-#: lib/vutuv_web/live/post_live/saved.ex:458
+#: lib/vutuv_web/live/post_live/saved.ex:500
 #: lib/vutuv_web/live/shell_live.ex:457
 #: lib/vutuv_web/templates/layout/app.html.heex:81
 #: lib/vutuv_web/templates/qualification/show.html.heex:38
@@ -12453,17 +12454,17 @@ msgstr ""
 msgid "Nice to have"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:607
+#: lib/vutuv_web/live/post_live/saved.ex:684
 #, elixir-autogen, elixir-format
 msgid "No saved jobs match your search."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:605
+#: lib/vutuv_web/live/post_live/saved.ex:682
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Jobs you bookmark show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/saved.ex:602
+#: lib/vutuv_web/live/post_live/saved.ex:679
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Jobs you like show up here."
 msgstr ""
@@ -13279,7 +13280,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1807
+#: lib/vutuv_web/components/post_components.ex:1904
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -13717,14 +13718,14 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3474
 #: lib/vutuv_web/controllers/settings_controller.ex:447
-#: lib/vutuv_web/live/post_live/feed.ex:1199
+#: lib/vutuv_web/live/post_live/feed.ex:1168
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:1
 #: lib/vutuv_web/templates/settings/followed_tags.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Tags you follow"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1214
+#: lib/vutuv_web/live/post_live/feed.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Unfollow #%{tag}"
 msgstr ""
@@ -13766,7 +13767,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/messenger/manage.html.heex:8
 #: lib/vutuv_web/templates/messenger/new.html.heex:5
-#: lib/vutuv_web/templates/user/show.html.heex:1223
+#: lib/vutuv_web/templates/user/show.html.heex:1224
 #, elixir-autogen, elixir-format
 msgid "Add a messenger"
 msgstr ""
@@ -13803,7 +13804,7 @@ msgstr ""
 #: lib/vutuv_web/templates/messenger/manage.html.heex:4
 #: lib/vutuv_web/templates/messenger/new.html.heex:4
 #: lib/vutuv_web/templates/messenger/show.html.heex:6
-#: lib/vutuv_web/templates/user/show.html.heex:1221
+#: lib/vutuv_web/templates/user/show.html.heex:1222
 #, elixir-autogen, elixir-format
 msgid "Messengers"
 msgstr ""
@@ -13880,50 +13881,50 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3799
+#: lib/vutuv_web/components/post_components.ex:3896
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3756
+#: lib/vutuv_web/components/post_components.ex:3853
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3800
+#: lib/vutuv_web/components/post_components.ex:3897
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3802
+#: lib/vutuv_web/components/post_components.ex:3899
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3798
+#: lib/vutuv_web/components/post_components.ex:3895
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3755
+#: lib/vutuv_web/components/post_components.ex:3852
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:448
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:338
+#: lib/vutuv_web/live/fediverse_account_live.ex:405
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3797
+#: lib/vutuv_web/components/post_components.ex:3894
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3801
+#: lib/vutuv_web/components/post_components.ex:3898
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13943,34 +13944,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3838
+#: lib/vutuv_web/components/post_components.ex:3935
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3868
+#: lib/vutuv_web/components/post_components.ex:3965
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3869
+#: lib/vutuv_web/components/post_components.ex:3966
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3867
+#: lib/vutuv_web/components/post_components.ex:3964
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3827
+#: lib/vutuv_web/components/post_components.ex:3924
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3874
+#: lib/vutuv_web/components/post_components.ex:3971
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14000,7 +14001,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3641
+#: lib/vutuv_web/components/post_components.ex:3738
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14048,7 +14049,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3632
+#: lib/vutuv_web/components/post_components.ex:3729
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14402,7 +14403,7 @@ msgstr ""
 msgid "No accounts are currently frozen."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:426
+#: lib/vutuv_web/live/post_live/thread.ex:367
 #, elixir-autogen, elixir-format
 msgid "Read it from the start"
 msgstr ""
@@ -14422,14 +14423,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2063
+#: lib/vutuv_web/components/post_components.ex:2160
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2085
+#: lib/vutuv_web/components/post_components.ex:2182
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14441,7 +14442,7 @@ msgstr[1] ""
 msgid "This page is no longer available."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:418
+#: lib/vutuv_web/live/post_live/thread.ex:359
 #, elixir-autogen, elixir-format
 msgid "This post is part of a conversation with %{formatted} posts."
 msgstr ""
@@ -14456,7 +14457,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4251
+#: lib/vutuv_web/components/post_components.ex:4348
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14921,7 +14922,7 @@ msgstr ""
 msgid "Nobody yet. Post your handle where people can see it, and the first follows will show up here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:413
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:369
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Related"
@@ -15189,27 +15190,27 @@ msgstr ""
 msgid "Book an ad"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:880
+#: lib/vutuv_web/templates/user/show.html.heex:881
 #, elixir-autogen, elixir-format
 msgid "%{name} moved this Fediverse account. Follow the new address instead:"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:896
+#: lib/vutuv_web/templates/user/show.html.heex:897
 #, elixir-autogen, elixir-format
 msgid "Are you on Mastodon or another Fediverse app? Follow %{name} from there and new public posts arrive in your timeline. No vutuv account needed."
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:933
+#: lib/vutuv_web/templates/user/show.html.heex:934
 #, elixir-autogen, elixir-format
 msgid "Follow from your own server"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:944
+#: lib/vutuv_web/templates/user/show.html.heex:945
 #, elixir-autogen, elixir-format
 msgid "@you@example.social"
 msgstr ""
 
-#: lib/vutuv_web/templates/user/show.html.heex:952
+#: lib/vutuv_web/templates/user/show.html.heex:953
 #, elixir-autogen, elixir-format
 msgid "Your address is used once, to send you to your own server's follow dialog. It is never stored here."
 msgstr ""
@@ -15628,21 +15629,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4210
+#: lib/vutuv_web/components/post_components.ex:4307
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4214
+#: lib/vutuv_web/components/post_components.ex:4311
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4218
+#: lib/vutuv_web/components/post_components.ex:4315
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15650,7 +15651,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:951
-#: lib/vutuv_web/components/post_components.ex:4169
+#: lib/vutuv_web/components/post_components.ex:4266
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15666,14 +15667,14 @@ msgstr ""
 msgid "Content warning"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1124
-#: lib/vutuv_web/components/post_components.ex:1350
-#: lib/vutuv_web/live/fediverse_account_live.ex:321
+#: lib/vutuv_web/components/post_components.ex:1096
+#: lib/vutuv_web/components/post_components.ex:1509
+#: lib/vutuv_web/live/fediverse_account_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "From another network"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:980
+#: lib/vutuv_web/components/post_components.ex:983
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this reply from your post?"
 msgstr ""
@@ -15695,12 +15696,12 @@ msgstr ""
 msgid "Reply from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:148
+#: lib/vutuv_web/live/post_live/thread.ex:141
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reply removed."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:989
+#: lib/vutuv_web/components/post_components.ex:992
 #, elixir-autogen, elixir-format
 msgid "Report this reply as not appropriate? It is deleted right away."
 msgstr ""
@@ -15710,7 +15711,7 @@ msgstr ""
 msgid "Reported as not appropriate"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1003
+#: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/notification_live/index.ex:534
 #, elixir-autogen, elixir-format
 msgid "Sent to you only, visible to nobody else"
@@ -15731,19 +15732,19 @@ msgstr ""
 msgid "Taken down"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:157
+#: lib/vutuv_web/live/post_live/thread.ex:150
 #, elixir-autogen, elixir-format
 msgid "Thank you. The reply was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/thread.ex:328
+#: lib/vutuv_web/live/post_live/thread.ex:269
 #, elixir-autogen, elixir-format
 msgid "That reply is not yours to remove."
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1112
-#: lib/vutuv_web/components/post_components.ex:1055
-#: lib/vutuv_web/components/post_components.ex:1764
+#: lib/vutuv_web/components/post_components.ex:1027
+#: lib/vutuv_web/components/post_components.ex:1861
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15754,10 +15755,10 @@ msgstr ""
 msgid "What"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:168
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:139
+#: lib/vutuv_web/live/fediverse_account_live.ex:167
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:118
 #: lib/vutuv_web/live/post_live/feed.ex:426
-#: lib/vutuv_web/live/post_live/thread.ex:324
+#: lib/vutuv_web/live/post_live/thread.ex:265
 #: lib/vutuv_web/live/tag_live/timeline.ex:138
 #, elixir-autogen, elixir-format
 msgid "You have reported a lot today. Please try again tomorrow."
@@ -16183,7 +16184,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:198
 #: lib/vutuv_web/live/admin/activity_live.ex:237
 #: lib/vutuv_web/live/fediverse_following_live.ex:313
-#: lib/vutuv_web/live/tag_live/timeline.ex:397
+#: lib/vutuv_web/live/tag_live/timeline.ex:398
 #, elixir-autogen, elixir-format
 msgid "Nothing matches that. Try a shorter search, or clear the filters."
 msgstr ""
@@ -16403,22 +16404,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2300
+#: lib/vutuv_web/components/post_components.ex:2397
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2407
+#: lib/vutuv_web/components/post_components.ex:2504
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2415
+#: lib/vutuv_web/components/post_components.ex:2512
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2401
+#: lib/vutuv_web/components/post_components.ex:2498
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16504,7 +16505,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1040
 #: lib/vutuv_web/agent_docs/text.ex:654
-#: lib/vutuv_web/components/post_components.ex:2872
+#: lib/vutuv_web/components/post_components.ex:2969
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16534,7 +16535,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2871
+#: lib/vutuv_web/components/post_components.ex:2968
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16544,29 +16545,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3250
+#: lib/vutuv_web/components/post_components.ex:3347
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1860
+#: lib/vutuv_web/components/post_components.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3253
+#: lib/vutuv_web/components/post_components.ex:3350
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3078
+#: lib/vutuv_web/components/post_components.ex:3175
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2616
+#: lib/vutuv_web/components/post_components.ex:2713
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16579,12 +16580,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1073
 #: lib/vutuv_web/agent_docs/text.ex:641
-#: lib/vutuv_web/components/post_components.ex:3287
+#: lib/vutuv_web/components/post_components.ex:3384
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2870
+#: lib/vutuv_web/components/post_components.ex:2967
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
@@ -16605,7 +16606,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1913
+#: lib/vutuv_web/components/post_components.ex:2010
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16625,7 +16626,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1904
+#: lib/vutuv_web/components/post_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16635,12 +16636,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1922
+#: lib/vutuv_web/components/post_components.ex:2019
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1856
+#: lib/vutuv_web/components/post_components.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16655,7 +16656,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1917
+#: lib/vutuv_web/components/post_components.ex:2014
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16665,7 +16666,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1870
+#: lib/vutuv_web/components/post_components.ex:1967
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16686,8 +16687,8 @@ msgstr ""
 msgid "Licence"
 msgstr ""
 
-#: lib/vutuv_web/live/post_live/feed.ex:1024
-#: lib/vutuv_web/live/post_live/feed.ex:1025
+#: lib/vutuv_web/live/post_live/feed.ex:982
+#: lib/vutuv_web/live/post_live/feed.ex:983
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Post photos"
 msgstr ""
@@ -16752,13 +16753,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:969
-#: lib/vutuv_web/components/post_components.ex:4207
+#: lib/vutuv_web/components/post_components.ex:4304
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:967
-#: lib/vutuv_web/components/post_components.ex:4204
+#: lib/vutuv_web/components/post_components.ex:4301
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16768,7 +16769,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4096
+#: lib/vutuv_web/components/post_components.ex:4193
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16859,11 +16860,11 @@ msgstr ""
 msgid "Photo details"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:454
+#: lib/vutuv_web/live/fediverse_account_live.ex:411
 #: lib/vutuv_web/live/fediverse_following_live.ex:52
 #: lib/vutuv_web/live/fediverse_following_live.ex:236
 #: lib/vutuv_web/live/fediverse_following_live.ex:249
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:422
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:378
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Accounts you follow elsewhere"
@@ -16889,9 +16890,9 @@ msgstr ""
 msgid "Follow accounts on Mastodon, and be followed from there"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:112
+#: lib/vutuv_web/live/fediverse_account_live.ex:111
 #: lib/vutuv_web/live/fediverse_following_live.ex:192
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:158
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Follow request sent to %{account}."
 msgstr ""
@@ -16982,7 +16983,7 @@ msgid "That server answered, but it has no account at that address to follow."
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:272
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:260
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "That server did not answer. Check the address, and that the server is online."
 msgstr ""
@@ -17017,7 +17018,7 @@ msgstr ""
 msgid "To follow an account out there you need a Fediverse identity of your own: the request is signed in your name, so the other server knows who is asking."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:128
+#: lib/vutuv_web/live/fediverse_account_live.ex:127
 #: lib/vutuv_web/live/fediverse_following_live.ex:154
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unfollowed."
@@ -17105,20 +17106,20 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1646
+#: lib/vutuv_web/components/post_components.ex:1807
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:160
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:131
+#: lib/vutuv_web/live/fediverse_account_live.ex:159
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:110
 #: lib/vutuv_web/live/post_live/feed.ex:418
 #: lib/vutuv_web/live/tag_live/timeline.ex:130
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1763
+#: lib/vutuv_web/components/post_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -17138,23 +17139,23 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1282
+#: lib/vutuv_web/components/post_components.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1663
+#: lib/vutuv_web/components/post_components.ex:1824
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1625
+#: lib/vutuv_web/components/post_components.ex:1786
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mute %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:264
-#: lib/vutuv_web/live/post_live/feed.ex:476
+#: lib/vutuv_web/live/fediverse_account_live.ex:221
+#: lib/vutuv_web/live/post_live/feed.ex:448
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
 msgstr ""
@@ -17164,7 +17165,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1632
+#: lib/vutuv_web/components/post_components.ex:1793
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17184,57 +17185,57 @@ msgstr ""
 msgid "%{name} (another network)"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:304
+#: lib/vutuv_web/live/fediverse_account_live.ex:261
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account on another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:438
+#: lib/vutuv_web/live/fediverse_account_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "Look up another account"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:369
+#: lib/vutuv_web/live/fediverse_account_live.ex:326
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Muted"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:279
+#: lib/vutuv_web/live/fediverse_account_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Nothing cached yet. Their posts appear here as they publish them."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:274
+#: lib/vutuv_web/live/fediverse_account_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Nothing here. vutuv only keeps an account's posts while somebody here follows it, and this page never fetches any."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:440
+#: lib/vutuv_web/live/fediverse_account_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Paste an address from Mastodon and friends to open its page here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:336
+#: lib/vutuv_web/live/fediverse_account_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Show the whole description"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:423
+#: lib/vutuv_web/live/fediverse_account_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "The most recent %{count} are shown. The rest are on their own server."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:266
+#: lib/vutuv_web/live/fediverse_account_live.ex:223
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unmuted. Their posts are back in your feed."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:433
+#: lib/vutuv_web/live/fediverse_account_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "View their full profile on %{host}"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:283
+#: lib/vutuv_web/live/fediverse_account_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Waiting for that server to accept your follow. Posts they addressed to their followers appear once it does."
 msgstr ""
@@ -17245,7 +17246,7 @@ msgid "You redirected your Fediverse followers to another account, so this one n
 msgstr ""
 
 #: lib/vutuv_web/components/fediverse_components.ex:183
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:240
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Your account move"
 msgstr ""
@@ -17386,27 +17387,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1453
+#: lib/vutuv_web/components/post_components.ex:1612
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1482
+#: lib/vutuv_web/components/post_components.ex:1641
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1477
+#: lib/vutuv_web/components/post_components.ex:1636
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1789
+#: lib/vutuv_web/components/post_components.ex:1886
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1795
+#: lib/vutuv_web/components/post_components.ex:1892
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17416,7 +17417,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1908
+#: lib/vutuv_web/components/post_components.ex:2005
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17426,9 +17427,7 @@ msgstr ""
 msgid "This post was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_account_live.ex:193
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:110
-#: lib/vutuv_web/live/post_live/feed.ex:454
+#: lib/vutuv_web/live/post_live/remote_actions_component.ex:93
 #, elixir-autogen, elixir-format
 msgid "Reposted. Your followers see it now."
 msgstr ""
@@ -17695,22 +17694,22 @@ msgstr ""
 msgid "Travel & places"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:320
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:277
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Address of the post"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:237
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:194
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:221
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "Fetching a post asks its server for it in your name, signed with your own key, so there is no such thing as an anonymous lookup here."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:267
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Its author published this post to their followers alone, so vutuv does not keep a copy of it."
 msgstr ""
@@ -17722,17 +17721,17 @@ msgid "Look up a post by its address"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:54
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:284
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Look up a post from another network"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:416
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Looking for an account rather than a single post?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:287
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "Paste the address of a post on Mastodon and friends. vutuv fetches it, shows it here, and you can answer, like or repost it as if it had arrived on its own."
 msgstr ""
@@ -17742,42 +17741,42 @@ msgstr ""
 msgid "Read something out there that you want to answer from here?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:252
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "That does not look like a link to a post. Copy the address of the post itself, for example https://server/@name/12345."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:257
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "That is a link on this vutuv, not on another network."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:408
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Their account page here"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:263
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "There is no post to show at that address."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:216
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "This account no longer acts out there"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:233
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:190
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This vutuv does not exchange anything with other networks. That is an operator setting, not yours."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:217
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "This vutuv stays to itself"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:215
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Turn on Fediverse participation to look up"
 msgstr ""
@@ -17787,22 +17786,22 @@ msgstr ""
 msgid "Want to answer one particular post rather than follow its author?"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:373
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Who wrote this"
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:272
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:229
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You have looked a lot of posts up in the last hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:227
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:184
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You redirected your Fediverse followers to another account, so nothing is fetched or sent from this one any more."
 msgstr ""
 
-#: lib/vutuv_web/live/fediverse_lookup_live.ex:426
+#: lib/vutuv_web/live/fediverse_lookup_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "vutuv keeps a copy of a post you look up for the same six months every other post from another network gets, and its author's server is asked nothing else."
 msgstr ""
@@ -18169,22 +18168,22 @@ msgid_plural "%{formatted} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:381
+#: lib/vutuv_web/live/tag_live/timeline.ex:382
 #, elixir-autogen, elixir-format
 msgid "Most liked"
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:405
+#: lib/vutuv_web/live/tag_live/timeline.ex:406
 #, elixir-autogen, elixir-format
 msgid "No posts carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:403
+#: lib/vutuv_web/live/tag_live/timeline.ex:404
 #, elixir-autogen, elixir-format
 msgid "No posts from other networks carry this tag yet."
 msgstr ""
 
-#: lib/vutuv_web/live/tag_live/timeline.ex:400
+#: lib/vutuv_web/live/tag_live/timeline.ex:401
 #, elixir-autogen, elixir-format
 msgid "No posts on vutuv carry this tag yet."
 msgstr ""
@@ -18199,7 +18198,22 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1792
+#: lib/vutuv_web/components/post_components.ex:1889
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/saved.ex:452
+#, elixir-autogen, elixir-format
+msgid "Nothing saved from other networks matches that."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/saved.ex:456
+#, elixir-autogen, elixir-format
+msgid "Nothing saved from other networks yet. The bookmark on a post or reply from another network keeps it here."
+msgstr ""
+
+#: lib/vutuv_web/live/post_live/saved.ex:511
+#, elixir-autogen, elixir-format
+msgid "Other networks"
 msgstr ""

--- a/priv/repo/migrations/20260731181100_create_fediverse_note_reposts.exs
+++ b/priv/repo/migrations/20260731181100_create_fediverse_note_reposts.exs
@@ -1,0 +1,37 @@
+defmodule Vutuv.Repo.Migrations.CreateFediverseNoteReposts do
+  use Ecto.Migration
+
+  @moduledoc """
+  A member here passed a **reply** from another network on to their own
+  followers (issue #1275) — the sibling of `fediverse_post_reposts`, one table
+  further down the conversation, exactly as `fediverse_note_likes` is of
+  `fediverse_post_likes`.
+
+  Unlike the like marker beside it this row is **read**, not only written: it is
+  a feed source (`Vutuv.Fediverse.feed_remote_reply_reposts/3`), which is how
+  somebody who follows nobody out there meets the reply at all — through
+  somebody here vouching for it. Hence the second index: the feed asks "what
+  have the people I follow reshared, newest first", which is a scan by user and
+  time, not by note.
+
+  It cascades away with the cached reply, which is correct rather than lossy:
+  our copy is a six-month cache and the `Announce` on the resharer's followers'
+  servers is not ours to keep alive.
+  """
+
+  def change do
+    create table(:fediverse_note_reposts) do
+      add(:user_id, references(:users, on_delete: :delete_all), null: false)
+      add(:note_id, references(:fediverse_notes, on_delete: :delete_all), null: false)
+
+      timestamps(updated_at: false)
+    end
+
+    # The pair is the identity: resharing twice is the same reshare.
+    create(unique_index(:fediverse_note_reposts, [:user_id, :note_id]))
+    # The cascade's own index, so a note delete does not scan this table.
+    create(index(:fediverse_note_reposts, [:note_id]))
+    # The feed's own read: "the reshares of the people I follow, newest first".
+    create(index(:fediverse_note_reposts, [:user_id, :inserted_at]))
+  end
+end

--- a/priv/repo/migrations/20260731181959_create_fediverse_bookmarks.exs
+++ b/priv/repo/migrations/20260731181959_create_fediverse_bookmarks.exs
@@ -1,0 +1,59 @@
+defmodule Vutuv.Repo.Migrations.CreateFediverseBookmarks do
+  use Ecto.Migration
+
+  @moduledoc """
+  "Keep this for me" for anything that came from another network (issue #1276):
+  a cached post by a followed account, or a reply that arrived under a vutuv
+  post.
+
+  **One table for both**, unlike the like and reshare markers beside it, which
+  have one per subject. Those two had to be split: each is read by queries that
+  join its own subject and its own audience rules, and the reshare is a feed
+  source. A bookmark is none of that — it federates nothing, is addressed to
+  nobody, carries no audience question, and is only ever read as "what did this
+  member save", which wants the two kinds interleaved rather than apart. So it
+  follows the `post_screenshots` pattern already in this schema: two nullable
+  owner columns and a check constraint saying exactly one is set.
+
+  Nothing here is public and nothing here is a count: a bookmark is private to
+  the member who made it. The row cascades with our copy of what it points at
+  (six-month retention), which is the honest behaviour — we cannot keep a
+  pointer to something we no longer hold.
+  """
+
+  def change do
+    create table(:fediverse_bookmarks) do
+      add(:user_id, references(:users, on_delete: :delete_all), null: false)
+      add(:remote_post_id, references(:fediverse_posts, on_delete: :delete_all))
+      add(:note_id, references(:fediverse_notes, on_delete: :delete_all))
+
+      timestamps(updated_at: false)
+    end
+
+    create(
+      constraint(:fediverse_bookmarks, :fediverse_bookmarks_one_subject,
+        check: "(remote_post_id IS NOT NULL)::int + (note_id IS NOT NULL)::int = 1"
+      )
+    )
+
+    # One bookmark per member and subject. Two **partial** unique indexes rather
+    # than one over both columns: a NULL is not equal to anything in a btree, so
+    # a plain unique index on the pair would let the same post be saved twice.
+    create(
+      unique_index(:fediverse_bookmarks, [:user_id, :remote_post_id],
+        where: "remote_post_id IS NOT NULL"
+      )
+    )
+
+    create(
+      unique_index(:fediverse_bookmarks, [:user_id, :note_id], where: "note_id IS NOT NULL")
+    )
+
+    # The cascades' own indexes, so deleting a cached post or an expired reply
+    # does not scan this table — both delete in bulk.
+    create(index(:fediverse_bookmarks, [:remote_post_id]))
+    create(index(:fediverse_bookmarks, [:note_id]))
+    # The saved page's own read: "what I saved, newest first".
+    create(index(:fediverse_bookmarks, [:user_id, :inserted_at]))
+  end
+end

--- a/priv/repo/migrations/20260731181959_create_fediverse_bookmarks.exs
+++ b/priv/repo/migrations/20260731181959_create_fediverse_bookmarks.exs
@@ -36,18 +36,19 @@ defmodule Vutuv.Repo.Migrations.CreateFediverseBookmarks do
       )
     )
 
-    # One bookmark per member and subject. Two **partial** unique indexes rather
-    # than one over both columns: a NULL is not equal to anything in a btree, so
-    # a plain unique index on the pair would let the same post be saved twice.
-    create(
-      unique_index(:fediverse_bookmarks, [:user_id, :remote_post_id],
-        where: "remote_post_id IS NOT NULL"
-      )
-    )
-
-    create(
-      unique_index(:fediverse_bookmarks, [:user_id, :note_id], where: "note_id IS NOT NULL")
-    )
+    # One bookmark per member and subject: one index per owner column, and
+    # deliberately **not** partial (`where: "... IS NOT NULL"`). A partial unique
+    # index cannot be inferred by `ON CONFLICT (user_id, note_id)` — Postgres
+    # answers 42P10, "no unique or exclusion constraint matching the ON CONFLICT
+    # specification" — and the whole marker fabric is built on that inference.
+    #
+    # Plain indexes are correct here anyway. A NULL is not equal to anything in
+    # a btree, so the `note_id` index constrains nothing for a saved *post*
+    # (whose `note_id` is NULL) — and it does not need to, because the
+    # `remote_post_id` index constrains exactly those rows, and the check
+    # constraint above guarantees every row has one owner or the other.
+    create(unique_index(:fediverse_bookmarks, [:user_id, :remote_post_id]))
+    create(unique_index(:fediverse_bookmarks, [:user_id, :note_id]))
 
     # The cascades' own indexes, so deleting a cached post or an expired reply
     # does not scan this table — both delete in bulk.

--- a/test/vutuv/fediverse_remote_engagement_test.exs
+++ b/test/vutuv/fediverse_remote_engagement_test.exs
@@ -1,0 +1,281 @@
+defmodule Vutuv.FediverseRemoteEngagementTest do
+  @moduledoc """
+  Resharing a reply from another network (issue #1275) and saving either kind of
+  thing from one (issue #1276).
+
+  The point of this file is the **pairing**: a cached post and a reply are the
+  same object to a reader, so a claim that holds for one and not the other is
+  drift. Each describe block therefore asks the same question of both.
+
+  `async: false` — the outbound budget lives in the shared `Vutuv.RateLimiter`
+  ETS table, which the SQL sandbox does not roll back.
+  """
+  use Vutuv.DataCase, async: false
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.Bookmark
+  alias Vutuv.Fediverse.Delivery
+  alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.NoteRepost
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+
+  @actor "https://social.example/users/them"
+  @inbox "https://social.example/users/them/inbox"
+
+  setup do
+    Vutuv.RateLimiter.reset()
+    :ok
+  end
+
+  defp federating_member do
+    user = insert(:activated_user, fediverse_followers?: true)
+    {:ok, _actor} = Fediverse.ensure_actor(user)
+    Repo.reload!(user)
+  end
+
+  defp note(attrs \\ []) do
+    now = DateTime.utc_now(:second)
+    post = insert(:post, user: attrs[:author] || insert(:activated_user))
+
+    Repo.insert!(%Note{
+      post_id: post.id,
+      object_uri: "https://social.example/n/#{System.unique_integer([:positive])}",
+      actor_uri: @actor,
+      origin_url: "https://social.example/@them/1",
+      handle: "them",
+      display_name: "Thea Remote",
+      content_text: attrs[:content_text] || "Etwas Lesenswertes.",
+      audience: attrs[:audience] || "public",
+      inbox_uri: @inbox,
+      received_at: now,
+      checked_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+  end
+
+  defp cached_post(audience \\ "public") do
+    now = DateTime.utc_now(:second)
+
+    account =
+      Repo.insert!(%RemoteAccount{
+        actor_uri: @actor,
+        host: "social.example",
+        handle: "them",
+        inbox_uri: @inbox
+      })
+
+    Repo.insert!(%RemotePost{
+      remote_account_id: account.id,
+      object_uri: "https://social.example/p/#{System.unique_integer([:positive])}",
+      content_text: "Etwas Lesenswertes.",
+      audience: audience,
+      kind: "note",
+      published_at: now,
+      received_at: now,
+      expires_at: DateTime.add(now, 86_400)
+    })
+    |> Repo.preload(:remote_account)
+  end
+
+  defp queued do
+    from(d in Delivery, order_by: [asc: d.id])
+    |> Repo.all()
+    |> Enum.map(&Jason.decode!(&1.activity_json))
+  end
+
+  describe "resharing a reply" do
+    test "writes the row and queues a signed Announce to the reader's own followers" do
+      user = federating_member()
+      note = note()
+
+      assert {:ok, :reposted} = Fediverse.repost_note(user, note)
+
+      assert Repo.aggregate(NoteRepost, :count) == 1
+      assert [%{"type" => "Announce", "object" => object}] = queued()
+      assert object == note.object_uri
+    end
+
+    test "resharing twice is one row and one activity" do
+      user = federating_member()
+      note = note()
+
+      assert {:ok, :reposted} = Fediverse.repost_note(user, note)
+      assert {:ok, :already} = Fediverse.repost_note(user, note)
+
+      assert Repo.aggregate(NoteRepost, :count) == 1
+      assert length(queued()) == 1
+    end
+
+    test "taking it back drops the row and queues the matching Undo" do
+      user = federating_member()
+      note = note()
+      {:ok, :reposted} = Fediverse.repost_note(user, note)
+
+      assert {:ok, :unreposted} = Fediverse.unrepost_note(user, note)
+
+      assert Repo.aggregate(NoteRepost, :count) == 0
+      assert [%{"type" => "Announce", "id" => id}, %{"type" => "Undo"} = undo] = queued()
+      assert undo["object"]["id"] == id
+    end
+
+    test "a reply its author sent to one person cannot be passed on" do
+      user = federating_member()
+      note = note(audience: "direct", author: user)
+
+      # The reader may *like* it — that is addressed to its author alone — but a
+      # reshare hands it to everybody, and the audience its author chose is not
+      # ours to widen.
+      assert :ok = Fediverse.check_note_like(user, note)
+      assert {:error, :note_not_public} = Fediverse.check_note_repost(user, note)
+      assert {:error, :note_not_public} = Fediverse.repost_note(user, note)
+      assert queued() == []
+    end
+
+    test "a member who does not federate is told so, and nothing goes out" do
+      user = insert(:activated_user)
+
+      assert {:error, :not_federating} = Fediverse.repost_note(user, note())
+      assert queued() == []
+    end
+
+    test "leaving the Fediverse withdraws it" do
+      user = federating_member()
+      {:ok, :reposted} = Fediverse.repost_note(user, note())
+
+      Fediverse.drop_remote_follows(user)
+
+      assert Repo.aggregate(NoteRepost, :count) == 0
+      assert Enum.any?(queued(), &(&1["type"] == "Undo"))
+    end
+
+    test "it reaches the feed of somebody who follows the resharer here" do
+      resharer = federating_member()
+      reader = insert(:activated_user)
+      {:ok, _} = Vutuv.Social.follow(reader, resharer.id)
+      note = note()
+
+      {:ok, :reposted} = Fediverse.repost_note(resharer, note)
+
+      assert [entry] = Fediverse.feed_remote_reply_reposts(reader, 10, nil)
+      assert entry.note.id == note.id
+      assert entry.reposted_by.id == resharer.id
+      # What is new is the sharing, so the row is stamped with it.
+      assert entry.post == nil
+      assert Vutuv.Posts.remote_reply_entry?(entry)
+      assert Vutuv.Posts.remote_feed_entry?(entry)
+    end
+
+    test "it does not reach somebody who follows nobody involved" do
+      resharer = federating_member()
+      stranger = insert(:activated_user)
+      {:ok, :reposted} = Fediverse.repost_note(resharer, note())
+
+      assert Fediverse.feed_remote_reply_reposts(stranger, 10, nil) == []
+    end
+  end
+
+  describe "saving either kind of thing" do
+    test "a reply and a cached post both land in one list, newest saved first" do
+      user = federating_member()
+      note = note()
+      post = cached_post()
+
+      assert {:ok, :bookmarked} = Fediverse.bookmark_note(user, note)
+      assert {:ok, :bookmarked} = Fediverse.bookmark_remote_post(user, post)
+
+      assert [first, second] = Fediverse.saved_from_networks(user)
+      assert first.remote_post.id == post.id
+      assert second.note.id == note.id
+      assert Repo.aggregate(Bookmark, :count) == 2
+    end
+
+    test "nothing is sent for either — a bookmark stays here" do
+      user = federating_member()
+
+      {:ok, :bookmarked} = Fediverse.bookmark_note(user, note())
+      {:ok, :bookmarked} = Fediverse.bookmark_remote_post(user, cached_post())
+
+      assert queued() == []
+    end
+
+    test "a member who does not federate at all may still save" do
+      # The one act on these cards that asks nothing of a member's standing: no
+      # actor is needed because nothing is signed.
+      user = insert(:activated_user)
+
+      assert {:ok, :bookmarked} = Fediverse.bookmark_note(user, note())
+      assert {:ok, :bookmarked} = Fediverse.bookmark_remote_post(user, cached_post())
+    end
+
+    test "saving twice is one row, and taking it back drops it" do
+      user = federating_member()
+      note = note()
+
+      assert {:ok, :bookmarked} = Fediverse.bookmark_note(user, note)
+      assert {:ok, :already} = Fediverse.bookmark_note(user, note)
+      assert Repo.aggregate(Bookmark, :count) == 1
+
+      assert {:ok, :unbookmarked} = Fediverse.unbookmark_note(user, note)
+      assert {:ok, :already} = Fediverse.unbookmark_note(user, note)
+      assert Repo.aggregate(Bookmark, :count) == 0
+    end
+
+    test "what a member may not read, they may not save" do
+      user = federating_member()
+
+      assert {:error, :not_visible} = Fediverse.bookmark_note(user, note(audience: "direct"))
+
+      assert {:error, :not_visible} =
+               Fediverse.bookmark_remote_post(user, cached_post("followers"))
+
+      assert Repo.aggregate(Bookmark, :count) == 0
+    end
+
+    test "the list can be searched by what was said and by who said it" do
+      user = federating_member()
+      {:ok, :bookmarked} = Fediverse.bookmark_note(user, note(content_text: "Über Fahrräder."))
+      {:ok, :bookmarked} = Fediverse.bookmark_remote_post(user, cached_post())
+
+      assert [entry] = Fediverse.saved_from_networks(user, q: "Fahrräder")
+      assert entry.note.content_text == "Über Fahrräder."
+
+      assert length(Fediverse.saved_from_networks(user, q: "them")) == 2
+      assert Fediverse.saved_from_networks(user, q: "nothing like this") == []
+    end
+
+    test "it goes with the thing it points at" do
+      user = federating_member()
+      note = note()
+      {:ok, :bookmarked} = Fediverse.bookmark_note(user, note)
+
+      Repo.delete!(note)
+
+      # Our copy is a six-month cache; a pointer to something we no longer hold
+      # is not something to keep.
+      assert Repo.aggregate(Bookmark, :count) == 0
+    end
+  end
+
+  describe "the marks a page batches" do
+    test "one lookup answers all three for a mixed page" do
+      user = federating_member()
+      note = note()
+      post = cached_post()
+
+      {:ok, :liked} = Fediverse.like_note(user, note)
+      {:ok, :bookmarked} = Fediverse.bookmark_remote_post(user, post)
+
+      marks = Fediverse.mark_lookup([note, post], user)
+
+      assert marks.(note) == %{liked?: true, reposted?: false, bookmarked?: false}
+      assert marks.(post) == %{liked?: false, reposted?: false, bookmarked?: true}
+    end
+
+    test "a logged-out reader has done none of it, and asking does not blow up" do
+      marks = Fediverse.mark_lookup([note(), cached_post()], nil)
+
+      assert marks.(note()) == %{liked?: false, reposted?: false, bookmarked?: false}
+    end
+  end
+end

--- a/test/vutuv_web/live/fediverse_account_live_test.exs
+++ b/test/vutuv_web/live/fediverse_account_live_test.exs
@@ -244,10 +244,10 @@ defmodule VutuvWeb.FediverseAccountLiveTest do
       # This page shows public posts of accounts the reader does NOT follow, so
       # liking what it shows has to work — which is why the gate asks whether
       # the post is readable, not whether there is a follow.
-      view |> element("[phx-click='like-remote-post']") |> render_click()
+      view |> element("[data-remote-act='like']") |> render_click()
       assert has_element?(view, "[data-remote-act='like'][data-on='on']")
 
-      view |> element("[phx-click='unlike-remote-post']") |> render_click()
+      view |> element("[data-remote-act='like']") |> render_click()
       refute has_element?(view, "[data-remote-act='like'][data-on='on']")
     end
   end

--- a/test/vutuv_web/live/fediverse_account_live_test.exs
+++ b/test/vutuv_web/live/fediverse_account_live_test.exs
@@ -245,10 +245,10 @@ defmodule VutuvWeb.FediverseAccountLiveTest do
       # liking what it shows has to work — which is why the gate asks whether
       # the post is readable, not whether there is a follow.
       view |> element("[phx-click='like-remote-post']") |> render_click()
-      assert has_element?(view, "[data-remote-like='on']")
+      assert has_element?(view, "[data-remote-act='like'][data-on='on']")
 
       view |> element("[phx-click='unlike-remote-post']") |> render_click()
-      refute has_element?(view, "[data-remote-like='on']")
+      refute has_element?(view, "[data-remote-act='like'][data-on='on']")
     end
   end
 

--- a/test/vutuv_web/live/fediverse_lookup_live_test.exs
+++ b/test/vutuv_web/live/fediverse_lookup_live_test.exs
@@ -119,7 +119,7 @@ defmodule VutuvWeb.FediverseLookupLiveTest do
     # delivered here.
     assert has_element?(view, "button[phx-click='like-remote-post']")
     assert has_element?(view, "button[phx-click='repost-remote-post']")
-    assert has_element?(view, "[data-remote-post-reply-link='#{post.id}']")
+    assert has_element?(view, "[data-remote-reply-link='#{post.id}']")
   end
 
   test "the author can be followed from the result", %{conn: conn} do

--- a/test/vutuv_web/live/fediverse_lookup_live_test.exs
+++ b/test/vutuv_web/live/fediverse_lookup_live_test.exs
@@ -117,8 +117,8 @@ defmodule VutuvWeb.FediverseLookupLiveTest do
     assert has_element?(view, "[data-remote-post='#{post.id}']")
     # The three acts the card carries, all reaching a post that was never
     # delivered here.
-    assert has_element?(view, "button[phx-click='like-remote-post']")
-    assert has_element?(view, "button[phx-click='repost-remote-post']")
+    assert has_element?(view, "[data-remote-act='like']")
+    assert has_element?(view, "[data-remote-act='repost']")
     assert has_element?(view, "[data-remote-reply-link='#{post.id}']")
   end
 
@@ -156,11 +156,11 @@ defmodule VutuvWeb.FediverseLookupLiveTest do
     {:ok, view, _html} = live(conn, ~p"/system/fediverse/lookup")
     view |> element("#lookup-form") |> render_submit(%{"url" => @display})
 
-    view |> element("button[phx-click='like-remote-post']") |> render_click()
+    view |> element("[data-remote-act='like']") |> render_click()
 
     post = Repo.get_by!(RemotePost, object_uri: @object)
     assert MapSet.member?(Fediverse.liked_remote_post_ids(user, [post.id]), post.id)
-    assert has_element?(view, "button[phx-click='unlike-remote-post']")
+    assert has_element?(view, "button[data-remote-act='like']")
   end
 
   test "a refused URL says why and shows no card", %{conn: conn} do

--- a/test/vutuv_web/live/feed_remote_posts_test.exs
+++ b/test/vutuv_web/live/feed_remote_posts_test.exs
@@ -112,15 +112,15 @@ defmodule VutuvWeb.FeedRemotePostsTest do
 
       # Nothing about how many others liked it: the real number is on their
       # server, and one assembled from what passed through here would be a lie.
-      assert has_element?(view, "[phx-click='like-remote-post']")
+      assert has_element?(view, "[data-remote-act='like']")
       refute html =~ "data-on=\"on\""
 
-      view |> element("[phx-click='like-remote-post']") |> render_click()
+      view |> element("[data-remote-act='like']") |> render_click()
 
       assert has_element?(view, "[data-remote-act='like'][data-on='on']")
-      assert has_element?(view, "[phx-click='unlike-remote-post']")
+      assert has_element?(view, "[data-remote-act='like']")
 
-      view |> element("[phx-click='unlike-remote-post']") |> render_click()
+      view |> element("[data-remote-act='like']") |> render_click()
 
       refute has_element?(view, "[data-remote-act='like'][data-on='on']")
     end
@@ -128,14 +128,14 @@ defmodule VutuvWeb.FeedRemotePostsTest do
     test "resharing paints the state and says so, and takes it back", ctx do
       {:ok, view, _html} = live(ctx.conn, ~p"/feed")
 
-      html = view |> element("[phx-click='repost-remote-post']") |> render_click()
+      html = view |> element("[data-remote-act='repost']") |> render_click()
 
       assert has_element?(view, "[data-remote-act='repost'][data-on='on']")
       # Publishing, unlike the heart: the reader's own feed does not show their
       # reshare back to them, so a silent button would leave them unsure.
       assert html =~ "Repostet" or html =~ "Reposted"
 
-      view |> element("[phx-click='unrepost-remote-post']") |> render_click()
+      view |> element("[data-remote-act='repost']") |> render_click()
 
       refute has_element?(view, "[data-remote-act='repost'][data-on='on']")
     end
@@ -186,9 +186,9 @@ defmodule VutuvWeb.FeedRemotePostsTest do
       # No control rather than one that refuses: passing on an audience its
       # author narrowed is not ours to do.
       assert has_element?(view, "[data-remote-post='#{ctx.post.id}']")
-      refute has_element?(view, "[phx-click='repost-remote-post']")
+      refute has_element?(view, "[data-remote-act='repost']")
       # The heart stays: liking is private and reaches nobody new.
-      assert has_element?(view, "[phx-click='like-remote-post']")
+      assert has_element?(view, "[data-remote-act='like']")
     end
 
     test "a member who does not federate is told where the switch is", ctx do
@@ -198,7 +198,7 @@ defmodule VutuvWeb.FeedRemotePostsTest do
 
       # The heart is shown anyway: hiding it would leave them no way to find
       # out that this exists and is one setting away.
-      html = view |> element("[phx-click='like-remote-post']") |> render_click()
+      html = view |> element("[data-remote-act='like']") |> render_click()
 
       # The wording is the one every other Fediverse refusal uses, and it must
       # not claim the switch is off — `federated?/1` is also false for an

--- a/test/vutuv_web/live/feed_remote_posts_test.exs
+++ b/test/vutuv_web/live/feed_remote_posts_test.exs
@@ -113,16 +113,16 @@ defmodule VutuvWeb.FeedRemotePostsTest do
       # Nothing about how many others liked it: the real number is on their
       # server, and one assembled from what passed through here would be a lie.
       assert has_element?(view, "[phx-click='like-remote-post']")
-      refute html =~ "data-remote-like=\"on\""
+      refute html =~ "data-on=\"on\""
 
       view |> element("[phx-click='like-remote-post']") |> render_click()
 
-      assert has_element?(view, "[data-remote-like='on']")
+      assert has_element?(view, "[data-remote-act='like'][data-on='on']")
       assert has_element?(view, "[phx-click='unlike-remote-post']")
 
       view |> element("[phx-click='unlike-remote-post']") |> render_click()
 
-      refute has_element?(view, "[data-remote-like='on']")
+      refute has_element?(view, "[data-remote-act='like'][data-on='on']")
     end
 
     test "resharing paints the state and says so, and takes it back", ctx do
@@ -130,14 +130,14 @@ defmodule VutuvWeb.FeedRemotePostsTest do
 
       html = view |> element("[phx-click='repost-remote-post']") |> render_click()
 
-      assert has_element?(view, "[data-remote-repost='on']")
+      assert has_element?(view, "[data-remote-act='repost'][data-on='on']")
       # Publishing, unlike the heart: the reader's own feed does not show their
       # reshare back to them, so a silent button would leave them unsure.
       assert html =~ "Repostet" or html =~ "Reposted"
 
       view |> element("[phx-click='unrepost-remote-post']") |> render_click()
 
-      refute has_element?(view, "[data-remote-repost='on']")
+      refute has_element?(view, "[data-remote-act='repost'][data-on='on']")
     end
 
     test "a post reaching the reader twice renders one card", ctx do
@@ -204,7 +204,7 @@ defmodule VutuvWeb.FeedRemotePostsTest do
       # not claim the switch is off — `federated?/1` is also false for an
       # unconfirmed address or a frozen account, whose switch is already on.
       assert html =~ VutuvWeb.FediverseComponents.refusal_message(:not_federating)
-      refute has_element?(view, "[data-remote-like='on']")
+      refute has_element?(view, "[data-remote-act='like'][data-on='on']")
       # And no marker is written for a like that never left.
       assert Repo.aggregate(Vutuv.Fediverse.PostLike, :count) == 0
     end

--- a/test/vutuv_web/live/post_thread_remote_replies_test.exs
+++ b/test/vutuv_web/live/post_thread_remote_replies_test.exs
@@ -315,7 +315,8 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
 
       {:ok, _view, html} = thread_view(post, owner)
 
-      assert html =~ ~s(data-remote-reply-like="#{note.id}")
+      assert html =~ ~s(phx-click="like-remote-reply")
+      assert html =~ ~s(data-remote-id="#{note.id}")
       assert html =~ ~s(data-remote-reply-link="#{note.id}")
       # Both are real controls under the body, not words in the provenance
       # footer, which is what made the card read as having no actions at all.
@@ -327,7 +328,7 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
 
       {:ok, _view, html} = thread_view(post)
 
-      refute html =~ "data-remote-reply-like"
+      refute html =~ "like-remote-reply"
       refute html =~ "data-remote-reply-link"
     end
 
@@ -344,7 +345,7 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
         |> element(~s([phx-click="like-remote-reply"][phx-value-id="#{note.id}"]))
         |> render_click()
 
-      assert html =~ ~s(data-liked="on")
+      assert html =~ ~s(data-on="on")
       assert MapSet.member?(Fediverse.liked_note_ids(user, [note.id]), note.id)
 
       html =
@@ -352,7 +353,7 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
         |> element(~s([phx-click="unlike-remote-reply"][phx-value-id="#{note.id}"]))
         |> render_click()
 
-      refute html =~ ~s(data-liked="on")
+      refute html =~ ~s(data-on="on")
       refute MapSet.member?(Fediverse.liked_note_ids(user, [note.id]), note.id)
     end
 
@@ -363,7 +364,7 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
 
       # A Like for it could never leave the building, and a heart that paints
       # itself over nothing is worse than no heart. Answering still stands.
-      refute html =~ "data-remote-reply-like"
+      refute html =~ "like-remote-reply"
       assert html =~ ~s(data-remote-reply-link="#{note.id}")
     end
 
@@ -382,7 +383,7 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
         |> render_click()
 
       assert html =~ "thread-notice"
-      refute html =~ ~s(data-liked="on")
+      refute html =~ ~s(data-on="on")
       assert Repo.aggregate(Vutuv.Fediverse.NoteLike, :count) == 0
     end
 

--- a/test/vutuv_web/live/post_thread_remote_replies_test.exs
+++ b/test/vutuv_web/live/post_thread_remote_replies_test.exs
@@ -315,12 +315,12 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
 
       {:ok, _view, html} = thread_view(post, owner)
 
-      assert html =~ ~s(phx-click="like-remote-reply")
+      assert html =~ ~s(data-remote-act="like")
       assert html =~ ~s(data-remote-id="#{note.id}")
       assert html =~ ~s(data-remote-reply-link="#{note.id}")
       # Both are real controls under the body, not words in the provenance
       # footer, which is what made the card read as having no actions at all.
-      assert html =~ ~s(phx-click="like-remote-reply")
+      assert html =~ ~s(data-remote-act="like")
     end
 
     test "a logged-out visitor gets neither", %{post: post} do
@@ -328,7 +328,7 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
 
       {:ok, _view, html} = thread_view(post)
 
-      refute html =~ "like-remote-reply"
+      refute html =~ "data-remote-act=\"like\""
       refute html =~ "data-remote-reply-link"
     end
 
@@ -342,7 +342,7 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
 
       html =
         view
-        |> element(~s([phx-click="like-remote-reply"][phx-value-id="#{note.id}"]))
+        |> element(~s([data-remote-act="like"][data-remote-id="#{note.id}"]))
         |> render_click()
 
       assert html =~ ~s(data-on="on")
@@ -350,7 +350,7 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
 
       html =
         view
-        |> element(~s([phx-click="unlike-remote-reply"][phx-value-id="#{note.id}"]))
+        |> element(~s([data-remote-act='like'][data-remote-id='#{note.id}']))
         |> render_click()
 
       refute html =~ ~s(data-on="on")
@@ -364,7 +364,7 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
 
       # A Like for it could never leave the building, and a heart that paints
       # itself over nothing is worse than no heart. Answering still stands.
-      refute html =~ "like-remote-reply"
+      refute html =~ "data-remote-act=\"like\""
       assert html =~ ~s(data-remote-reply-link="#{note.id}")
     end
 
@@ -379,10 +379,10 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
       # explain itself.
       html =
         view
-        |> element(~s([phx-click="like-remote-reply"][phx-value-id="#{note.id}"]))
+        |> element(~s([data-remote-act="like"][data-remote-id="#{note.id}"]))
         |> render_click()
 
-      assert html =~ "thread-notice"
+      assert html =~ "data-remote-notice"
       refute html =~ ~s(data-on="on")
       assert Repo.aggregate(Vutuv.Fediverse.NoteLike, :count) == 0
     end
@@ -410,7 +410,7 @@ defmodule VutuvWeb.PostThreadRemoteRepliesTest do
 
       refusal =
         view
-        |> element(~s([phx-click="like-remote-reply"][phx-value-id="#{note.id}"]))
+        |> element(~s([data-remote-act="like"][data-remote-id="#{note.id}"]))
         |> render_click()
 
       assert refusal =~ "Diese Antwort gibt es hier nicht mehr."

--- a/test/vutuv_web/live/remote_post_reply_test.exs
+++ b/test/vutuv_web/live/remote_post_reply_test.exs
@@ -77,7 +77,7 @@ defmodule VutuvWeb.RemotePostReplyTest do
 
       {:ok, view, _html} = live(conn, ~p"/feed")
 
-      assert has_element?(view, "[data-remote-post-reply-link='#{post.id}']")
+      assert has_element?(view, "[data-remote-reply-link='#{post.id}']")
     end
 
     test "a followers-only post offers none", %{conn: conn} do
@@ -91,7 +91,7 @@ defmodule VutuvWeb.RemotePostReplyTest do
       # No control rather than one that refuses: the answer would be a public
       # vutuv post quoting a restricted context.
       assert has_element?(view, "[data-remote-post='#{post.id}']")
-      refute has_element?(view, "[data-remote-post-reply-link='#{post.id}']")
+      refute has_element?(view, "[data-remote-reply-link='#{post.id}']")
     end
   end
 


### PR DESCRIPTION
Closes #1275. Closes #1276.

Finishes what #1270 started, and answers the two things you said while it was in flight: that a fediverse card was missing actions a vutuv post has, and that the actions it did have looked nothing like a vutuv post's. Both had the same root — a reply and a cached post from another network were built as two parallel stacks — so most of this is removing the parallel.

### The bar

One `remote_actions/1`, wearing `post_actions/1`'s geometry to the pixel: icon-only, spread across the column by `justify-between`, same rounded hover target, same state colours, same order (like, reply, repost, bookmark). It carries no counts, which is the one deliberate difference — vutuv cannot know a remote tally, so it leaves the number out rather than inventing one.

It is a **LiveComponent** (`VutuvWeb.PostLive.RemoteActionsComponent`) for the reason the local card's `ActionsComponent` is one. Seven hosts render these cards, and every act used to mean another copy of the same handler in each: that is why the two cards drifted to two acts and three, why the answering pages rendered buttons that would have crashed them, and why a dead controller page rendered buttons that silently did nothing. Four hosts lose their handlers and their per-act plumbing entirely.

### The context

- All six outbound acts run through one `outbound_act/3` — reload, gate, marker, budget, activity, roll back if the budget refuses — over one marker fabric parameterized by the column that names the subject. Each act is a map naming only what is its own. The public functions keep their names and return shapes; the existing suites are the proof.
- `Vutuv.Fediverse.mark_lookup/2` replaces the three near-identical batching blocks the hosts each kept.

### Resharing a reply (#1275)

`repost_note/2` is `repost_remote_post/2` one table over: marker, signed `Announce` of the reply's own id to the resharer's followers with its author in `cc`, matching `Undo`, shared hourly boost budget, withdrawal on leaving. Public replies only, and that question is asked **first** — no setting of the member's own could make a private reply shareable, so pointing them at one would be a lie.

Unlike the like beside it the row is also **read**: it is the feed's seventh source, so a reply somebody here vouched for reaches readers who never opened that conversation, wearing the same "Reposted by" line a reshared post wears. That second remote row shape is why `Posts.remote_reply_entry?/1` exists and why every reader of `entry.remote_post` now asks it first.

### Saving one (#1276)

Did not exist for anything from another network. One table for both kinds — two nullable owner columns plus a check constraint, the `post_screenshots` pattern — because a bookmark has no audience question, no activity and no per-kind read. It is the one act here that asks nothing of the member's Fediverse standing: nothing is signed, so somebody who does not federate at all can still keep what they read.

They surface under `/bookmarks` on an **"Other networks"** tab. That is a deliberate deviation from the one-stream option we discussed: the list has no vutuv author for the "by name" sort and pages a different table, so merging it into the saved posts would need a union pager to stay honest about `more?`. Happy to do the merge as a follow-up if you'd rather have it.

### Two things the tests caught

- `ON CONFLICT` cannot infer a **partial** unique index (Postgres answers 42P10), and the whole marker fabric is built on that inference. The bookmark indexes are plain; the check constraint is what makes that correct.
- An edited migration does not re-apply, so a test database keeps the old schema — and `mix ecto.drop` without `MIX_ENV=test` drops the *dev* database instead. The pre-push hook caught the second half of that on the unpartitioned test DB after the partitioned one was already green.

`mix precommit` green (6405 tests). All three migrations are plain additions, so N-1 compatible.

https://claude.ai/code/session_01CFunanSAvyACTQDNTm9D6A

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
