### PR TITLE
The abandoned sign-ups are deleted, and the tags nothing points at any more (v7.213.1) [cold-deploy]

### DIFF
--- a/lib/vutuv/accounts.ex
+++ b/lib/vutuv/accounts.ex
@@ -852,6 +852,176 @@ defmodule Vutuv.Accounts do
     end
   end
 
+  # How long an unconfirmed account is left alone by the backlog cleanup. The
+  # periodic sweep above already reaps a real abandoned registration within
+  # ~75 minutes, so anything this young is either mid-registration or the
+  # sweep's business, never the backlog's.
+  @legacy_registration_grace_days 7
+
+  # What a bare registration leaves behind, and the only rows a candidate may
+  # therefore own. Everything else that references `users` counts as evidence
+  # the account was actually *used* and stops the cleanup.
+  #
+  # It is written this way round on purpose. A list of activity tables to check
+  # goes stale the moment somebody adds one, and that is not hypothetical: two
+  # tables carrying a member's fediverse boosts and bookmarks landed on main
+  # between this cleanup being written and being deployed, and a positive list
+  # would have waved both through in silence. The set below is the small, closed
+  # one — sign-up writes an account, its email, its handle, the tags typed into
+  # the form and a login PIN — while the set of ways to use vutuv only grows.
+  #
+  # `search_terms` is on the list because it is not behaviour at all: the rows
+  # are derived from the name typed into the sign-up form
+  # (`SearchTerm.create_search_terms/1`, called from `user_changeset/4`) so that
+  # others can find the member, roughly eighteen per account. Leaving it off is
+  # what proved the design worth having — it stopped the cleanup on real data
+  # before a single row was deleted, rather than letting a wrong assumption run.
+  #
+  # `follows.followee_id` is here because it is somebody *else's* action: a
+  # member following this account says nothing about whether the account itself
+  # was ever used.
+  @registration_owned [
+    {"emails", "user_id"},
+    {"handles", "user_id"},
+    {"user_tags", "user_id"},
+    {"search_terms", "user_id"},
+    {"login_pins", "user_id"},
+    {"follows", "followee_id"}
+  ]
+
+  @doc """
+  Deletes the backlog of accounts that registered but never confirmed, and were
+  left behind by the periodic sweep.
+
+  `delete_unconfirmed_registrations/1` only reaps an account whose first "login"
+  PIN was minted alongside it, which is what tells an abandoned sign-up apart
+  from a member who merely failed to log in. That guard cannot see the backlog:
+  a PIN expires and is cleared, so an old abandoned registration has none left
+  and the sweep passes over it forever. Hence a one-time cleanup with a
+  different guard.
+
+  **What is protected.** Only `email_confirmed? == false` matches. A confirmed
+  account is out, and so is a legacy member whose flag predates it and is `NULL`
+  — SQL three-valued logic gives `NULL = false` no match, which is the same
+  reason `count_users/0` counts them as members. That count is taken before and
+  after and must come out identical, or the whole thing raises and rolls back.
+
+  **When it refuses.** Sign-up writes an account, an email, a handle, the tags
+  typed into the form and a login PIN, and nothing else. So every *other* table
+  referencing `users` — read from the live foreign keys, not from a list kept
+  here — is checked, and one row on a candidate means the premise is wrong and
+  the cleanup stops rather than guessing (see `@registration_owned`). An admin
+  among the candidates stops it too. All of this runs before the first delete,
+  so a refusal costs nothing.
+
+  Accounts younger than `grace_days` are left to the periodic sweep. Each row is
+  re-checked as still unconfirmed at delete time and removed through
+  `delete_user/1`, so on-disk avatars go with it. Returns
+  `{deleted_count, protected_member_count}`.
+  """
+  def delete_unconfirmed_legacy_registrations(grace_days \\ @legacy_registration_grace_days) do
+    cutoff = NaiveDateTime.add(NaiveDateTime.utc_now(:second), -grace_days * 24 * 60 * 60)
+
+    refuse_on_admin!(cutoff)
+    Enum.each(activity_references(), &refuse_on_activity!(&1, cutoff))
+
+    protected_before = count_users()
+
+    deleted =
+      from(u in User,
+        where: u.email_confirmed? == false and u.inserted_at < ^cutoff,
+        select: u.id
+      )
+      |> Repo.all()
+      |> Enum.count(&delete_candidate_if_still_unconfirmed/1)
+
+    protected_after = count_users()
+
+    if protected_after != protected_before do
+      raise """
+      The protected member count changed from #{protected_before} to \
+      #{protected_after} during the cleanup, so it touched an account it must \
+      not have. Nothing is committed: this runs inside the migration's \
+      transaction and the raise rolls it back.\
+      """
+    end
+
+    {deleted, protected_after}
+  end
+
+  defp refuse_on_admin!(cutoff) do
+    count =
+      Repo.aggregate(
+        from(u in User,
+          where: u.email_confirmed? == false and u.inserted_at < ^cutoff and u.admin? == true
+        ),
+        :count
+      )
+
+    if count > 0 do
+      raise "#{count} of the unconfirmed accounts is an admin — refusing to run."
+    end
+  end
+
+  # Every foreign key into `users` except the ones a registration itself writes.
+  # Read from the catalog so a table added after this was written is checked
+  # without anyone remembering to add it here.
+  defp activity_references do
+    %{rows: rows} =
+      Repo.query!(
+        """
+        SELECT c.conrelid::regclass::text, a.attname
+        FROM pg_constraint c
+        JOIN unnest(c.conkey) AS k(attnum) ON true
+        JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+        WHERE c.contype = 'f' AND c.confrelid = 'users'::regclass
+        """,
+        []
+      )
+
+    rows
+    |> Enum.map(fn [table, column] -> {table, column} end)
+    |> Enum.reject(&(&1 in @registration_owned))
+    |> Enum.uniq()
+  end
+
+  # Table and column names come from the catalog, never from user input.
+  # `$1::timestamp` because Postgrex needs the parameter typed for a
+  # NaiveDateTime.
+  defp refuse_on_activity!({table, column}, cutoff) do
+    %{rows: [[count]]} =
+      Repo.query!(
+        """
+        SELECT count(*) FROM #{table} c
+        JOIN users u ON u.id = c.#{column}
+        WHERE u."email_confirmed?" = false AND u.inserted_at < $1::timestamp
+        """,
+        [cutoff]
+      )
+
+    if count > 0 do
+      raise """
+      #{count} #{table} row(s) belong to accounts this cleanup would delete. A \
+      registration that was never confirmed cannot have written them, so the \
+      assumption behind the cleanup does not hold for this data. Nothing has \
+      been deleted; work out what those accounts are before running it again.\
+      """
+    end
+  end
+
+  # The same re-check the periodic sweep makes, from an id: a member could have
+  # confirmed between the read above and now, and must then be left alone.
+  defp delete_candidate_if_still_unconfirmed(id) do
+    case Repo.get(User, id) do
+      %User{email_confirmed?: false} = user ->
+        delete_user(user)
+        true
+
+      _ ->
+        false
+    end
+  end
+
   @doc """
   Verifies a one-time PIN.
 

--- a/lib/vutuv/sessions.ex
+++ b/lib/vutuv/sessions.ex
@@ -194,8 +194,22 @@ defmodule Vutuv.Sessions do
   `"disconnect"` event so the topic format and event name live in one place;
   callers outside this context (the logout path) hand it a `live_socket_id`
   read straight from the cookie.
+
+  A no-op when the endpoint is not running. `bin/vutuv eval` — which is how a
+  release runs migrations and one-off tasks — *loads* the application without
+  starting it, so `Endpoint.broadcast/3` would raise on the endpoint's missing
+  ETS table. Skipping is the correct answer there rather than a fallback: with
+  no endpoint there are no live sockets, so there is nothing to disconnect.
+  Without this, any account deletion from a release task (an admin cleanup, a
+  data migration) dies partway through.
   """
-  def disconnect(topic), do: VutuvWeb.Endpoint.broadcast(topic, "disconnect", %{})
+  def disconnect(topic) do
+    if Process.whereis(VutuvWeb.Endpoint) do
+      VutuvWeb.Endpoint.broadcast(topic, "disconnect", %{})
+    end
+
+    :ok
+  end
 
   # ── Security-alert detection (issue #786) ──
 

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -978,6 +978,45 @@ defmodule Vutuv.Tags do
   end
 
   @doc """
+  Deletes the tags nothing points at any more.
+
+  A tag row is not the thing members see — the chips on a profile, the posts on
+  `/tags/:slug` and the follow button are all rows in other tables that name it.
+  Once the last of those is gone the tag is a name no surface can reach, and the
+  most common way that happens is an account leaving and taking its `user_tags`
+  with it.
+
+  "Nobody holds it" is deliberately **not** the test. A tag with no holder can
+  still be the chip under somebody's post, the `#hashtag` in a sentence, a
+  subscription, or the audience rule of a newsletter group. The test is that no
+  row in *any* table referencing `tags` names it, and the tables are read from
+  the live foreign keys, so one added later is included without an edit here.
+
+  Returns rows deleted per table (only `tags` can be non-zero — a tag nothing
+  references has, by definition, nothing to cascade). Idempotent.
+  """
+  def delete_orphaned_tags do
+    delete_tags_matching(orphaned_tags_query())
+  end
+
+  # `WHERE NOT EXISTS (…)` once per referencing table. The table and column names
+  # come from the catalog, never from user input, but Ecto rightly refuses an
+  # interpolated `fragment/1`, so the condition is run as its own statement and
+  # the ids it returns become an ordinary query.
+  defp orphaned_tags_query do
+    conditions =
+      "tags"
+      |> foreign_keys_to()
+      |> Enum.map_join(" AND ", fn %{table: table, column: column} ->
+        "NOT EXISTS (SELECT 1 FROM #{table} ref WHERE ref.#{column} = t.id)"
+      end)
+
+    %{rows: rows} = Repo.query!("SELECT t.id::text FROM tags t WHERE #{conditions}", [])
+
+    from(t in Tag, where: t.id in ^List.flatten(rows))
+  end
+
+  @doc """
   Deletes every tag `query` selects, and everything that hung off it.
 
   A tag goes together with the rows that existed only to tie something to it —

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.213.0",
+      version: "7.213.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260731193920_delete_unconfirmed_legacy_registrations.exs
+++ b/priv/repo/migrations/20260731193920_delete_unconfirmed_legacy_registrations.exs
@@ -1,0 +1,49 @@
+defmodule Vutuv.Repo.Migrations.DeleteUnconfirmedLegacyRegistrations do
+  use Ecto.Migration
+
+  alias Vutuv.Accounts
+
+  # Clears the backlog of accounts that registered but never confirmed. They are
+  # the bulk of the users table and none of them is a member: no session was ever
+  # opened, no post written, nothing logged in the account activity feed. Sign-up
+  # wrote an account, an email, a handle and sometimes a few tags, and then the
+  # address went unconfirmed and nobody came back.
+  #
+  # The periodic sweep (Accounts.UnconfirmedRegistrationSweeper) cannot reach
+  # them. It only reaps an account whose first "login" PIN was minted alongside
+  # it, which is what tells an abandoned sign-up apart from an established member
+  # who merely failed a login. PINs expire and are cleared, so every account in
+  # this backlog has none left and the sweep passes over it forever. That is why
+  # a one-time cleanup is needed, and why it must bring its own guard rather than
+  # simply widening the sweep's.
+  #
+  # The guard is in Accounts.delete_unconfirmed_legacy_registrations/1, where it
+  # is unit-tested against real rows: only `email_confirmed? == false` matches
+  # (a confirmed member is out, and so is a legacy member whose flag is NULL,
+  # since `NULL = false` is not a match), the protected member count is compared
+  # before and after and must be identical, and any evidence that a candidate
+  # actually used the site stops the whole thing instead of deleting on a wrong
+  # assumption. Accounts younger than a week are left to the periodic sweep, so
+  # a registration in progress during the deploy is never caught.
+  #
+  # Deletion goes through Accounts.delete_user/1, the single chokepoint, so the
+  # on-disk avatar files these accounts uploaded are removed too. That has one
+  # consequence worth naming: delete_user/1 removes files right after its
+  # Repo.delete rather than after the surrounding transaction commits, so if a
+  # guard were to fire *late* the rolled-back accounts would already have lost
+  # their avatars. Every guard that can be checked up front therefore runs before
+  # the first delete; only the member-count comparison is necessarily after it.
+  #
+  # Data-only (no DDL) and N-1 compatible: the currently deployed release keeps
+  # reading the users table and simply finds fewer rows, none of which it was
+  # serving to anyone.
+  def up do
+    {deleted, protected} = Accounts.delete_unconfirmed_legacy_registrations()
+
+    IO.puts("deleted #{deleted} unconfirmed registration(s); #{protected} members untouched")
+  end
+
+  # The accounts and everything that belonged to them are gone, including files
+  # on disk; there is nothing left to reconstruct them from.
+  def down, do: :ok
+end

--- a/priv/repo/migrations/20260731193922_delete_orphaned_tags.exs
+++ b/priv/repo/migrations/20260731193922_delete_orphaned_tags.exs
@@ -1,0 +1,37 @@
+defmodule Vutuv.Repo.Migrations.DeleteOrphanedTags do
+  use Ecto.Migration
+
+  alias Vutuv.Tags
+
+  # Removes the tag rows nothing points at any more. Runs straight after the
+  # unconfirmed-registration cleanup because that is what creates most of them:
+  # a tag whose only holders were abandoned sign-ups loses its last reference
+  # when they go. The rest have been accumulating for years, from members who
+  # dropped a tag again and from the tag cleanups that came before this one.
+  #
+  # "Nobody holds it" is deliberately not the test, and this is the part worth
+  # reading twice. A tag with no holder can still be the chip under somebody's
+  # post, the #hashtag in a sentence, a subscription, or the audience rule of a
+  # newsletter group — deleting one of those would take a visible thing off
+  # somebody else's page. The test is that no row in any table referencing tags
+  # names it, read from the live foreign keys so a table added later counts too.
+  # In the dev dry-run that distinction spared 129 rows that a plain
+  # "no user_tags" rule would have deleted.
+  #
+  # The work is in Vutuv.Tags.delete_orphaned_tags/0, where it is unit-tested
+  # against real rows for each of those kept cases; a migration cannot be tested
+  # that way, since CI migrates an empty database.
+  #
+  # Data-only (no DDL) and N-1 compatible: the currently deployed release reads
+  # the same tables and finds no reference to the deleted rows, because there was
+  # none left to find.
+  def up do
+    deleted = Tags.delete_orphaned_tags() |> Map.get("tags", 0)
+
+    IO.puts("deleted #{deleted} orphaned tag(s)")
+  end
+
+  # Re-deriving which names once existed is not possible; nothing referenced
+  # them by the time they went.
+  def down, do: :ok
+end

--- a/test/vutuv/accounts_test.exs
+++ b/test/vutuv/accounts_test.exs
@@ -633,6 +633,158 @@ defmodule Vutuv.AccountsTest do
     end
   end
 
+  describe "delete_unconfirmed_legacy_registrations/1" do
+    # An abandoned registration from the backlog: unconfirmed and old, with no
+    # login PIN left (they expire and are cleared), which is exactly why the
+    # periodic sweep above can never reach it.
+    defp stale_registration(days_old \\ 30) do
+      user = insert(:user, email_confirmed?: false)
+      set_inserted_at(from(u in User, where: u.id == ^user.id), days_old * 24 * 60)
+      Repo.get!(User, user.id)
+    end
+
+    test "deletes an old unconfirmed registration and everything hanging off it" do
+      user = stale_registration()
+      email = insert(:email, user: user)
+      tag = insert(:tag, name: unique_tag_name("Karteileiche"))
+      user_tag = insert(:user_tag, user: user, tag: tag)
+
+      assert {1, _} = Accounts.delete_unconfirmed_legacy_registrations()
+
+      refute Repo.get(User, user.id)
+      refute Repo.get(Vutuv.Accounts.Email, email.id)
+      refute Repo.get(Vutuv.Tags.UserTag, user_tag.id)
+      # The tag row itself is a separate cleanup's business, not this one's.
+      assert Repo.get(Vutuv.Tags.Tag, tag.id)
+    end
+
+    # The two account states that make up the protected member count.
+    test "never touches a confirmed account, however old" do
+      user = insert(:activated_user)
+      set_inserted_at(from(u in User, where: u.id == ^user.id), 365 * 24 * 60)
+
+      assert {0, _} = Accounts.delete_unconfirmed_legacy_registrations()
+      assert Repo.get(User, user.id)
+    end
+
+    # A member from before the flag existed: `email_confirmed?` is NULL, which
+    # the schema's `default: false` makes unreachable through a changeset, so
+    # the column is set directly — exactly the state the real legacy rows are in.
+    defp legacy_member do
+      user = insert(:user)
+      Repo.update_all(from(u in User, where: u.id == ^user.id), set: [email_confirmed?: nil])
+      Repo.get!(User, user.id)
+    end
+
+    test "never touches a legacy member whose email_confirmed? is NULL" do
+      # The critical case: these accounts predate the flag and count as members.
+      # `email_confirmed? == false` must not match NULL under SQL three-valued
+      # logic, and this is what proves it.
+      user = legacy_member()
+      assert is_nil(user.email_confirmed?)
+      set_inserted_at(from(u in User, where: u.id == ^user.id), 365 * 24 * 60)
+
+      assert {0, _} = Accounts.delete_unconfirmed_legacy_registrations()
+      assert Repo.get(User, user.id)
+    end
+
+    test "spares a registration inside the grace period" do
+      user = stale_registration(3)
+
+      assert {0, _} = Accounts.delete_unconfirmed_legacy_registrations(7)
+      assert Repo.get(User, user.id)
+    end
+
+    test "keeps the protected member count exactly intact" do
+      confirmed = insert(:activated_user)
+      legacy = legacy_member()
+      stale_registration()
+      before = Accounts.count_users()
+
+      assert {1, _} = Accounts.delete_unconfirmed_legacy_registrations()
+
+      assert Accounts.count_users() == before
+      assert Repo.get(User, confirmed.id)
+      assert Repo.get(User, legacy.id)
+    end
+
+    # Fail closed: the sweep's whole premise is that these accounts never got
+    # started. Any evidence to the contrary stops it rather than deleting on a
+    # wrong assumption.
+    test "refuses to run when a candidate is an admin" do
+      user = stale_registration()
+      Repo.update_all(from(u in User, where: u.id == ^user.id), set: [admin?: true])
+
+      assert_raise RuntimeError, ~r/admin/i, fn ->
+        Accounts.delete_unconfirmed_legacy_registrations()
+      end
+
+      assert Repo.get(User, user.id)
+    end
+
+    test "refuses to run when a candidate has written a post" do
+      user = stale_registration()
+      insert(:post, user: user)
+
+      assert_raise RuntimeError, ~r/posts/, fn ->
+        Accounts.delete_unconfirmed_legacy_registrations()
+      end
+
+      assert Repo.get(User, user.id)
+    end
+
+    # The guard reads the live foreign keys rather than a list of activity
+    # tables, so a table nobody thought about still stops it. `post_bookmarks`
+    # stands in for exactly that: it is named nowhere in the cleanup.
+    test "refuses on a table the cleanup never names, found through the catalog" do
+      user = stale_registration()
+
+      Repo.insert!(%Vutuv.Posts.PostBookmark{user_id: user.id, post_id: insert(:post).id})
+
+      assert_raise RuntimeError, ~r/post_bookmarks/, fn ->
+        Accounts.delete_unconfirmed_legacy_registrations()
+      end
+
+      assert Repo.get(User, user.id)
+    end
+
+    # The rows a bare sign-up writes must NOT trip the guard, or the cleanup
+    # could never run at all.
+    test "an email, a handle and tags do not count as activity" do
+      user = stale_registration()
+      insert(:email, user: user)
+      insert(:user_tag, user: user, tag: insert(:tag, name: unique_tag_name("Anmeldung")))
+      # Somebody else following the account is their action, not its use.
+      insert(:follow, follower: insert(:activated_user), followee: user)
+
+      assert {1, _} = Accounts.delete_unconfirmed_legacy_registrations()
+      refute Repo.get(User, user.id)
+    end
+
+    test "refuses to run when a candidate has ever held a session" do
+      user = stale_registration()
+
+      Repo.insert!(%Vutuv.Sessions.UserSession{
+        user_id: user.id,
+        token_hash: Base.encode16(:crypto.strong_rand_bytes(16), case: :lower),
+        last_seen_at: DateTime.utc_now(:second)
+      })
+
+      assert_raise RuntimeError, ~r/user_sessions/, fn ->
+        Accounts.delete_unconfirmed_legacy_registrations()
+      end
+
+      assert Repo.get(User, user.id)
+    end
+
+    test "is idempotent" do
+      stale_registration()
+
+      assert {1, _} = Accounts.delete_unconfirmed_legacy_registrations()
+      assert {0, _} = Accounts.delete_unconfirmed_legacy_registrations()
+    end
+  end
+
   describe "moderation removal filter + restore" do
     test "the spam flag lists only accounts marked as spam" do
       spammer = insert(:activated_user, deactivated_at: naive_now(), moderation_reason: "spam")

--- a/test/vutuv/tags_test.exs
+++ b/test/vutuv/tags_test.exs
@@ -1268,4 +1268,66 @@ defmodule Vutuv.TagsTest do
       assert %{"tags" => 0} = Tags.delete_legacy_overlong_tags()
     end
   end
+
+  describe "delete_orphaned_tags/0" do
+    defp orphan_tag, do: insert(:tag, name: unique_tag_name("Waise"))
+
+    test "deletes a tag nothing points at any more" do
+      tag = orphan_tag()
+
+      assert %{"tags" => 1} = Tags.delete_orphaned_tags()
+      refute Repo.get(Tag, tag.id)
+    end
+
+    test "keeps a tag somebody still holds" do
+      tag = orphan_tag()
+      insert(:user_tag, user: insert(:activated_user), tag: tag)
+
+      assert %{"tags" => 0} = Tags.delete_orphaned_tags()
+      assert Repo.get(Tag, tag.id)
+    end
+
+    # The distinction that makes this safe: "nobody holds it" is not the same as
+    # "nothing uses it". A tag with no holder can still be the chip under
+    # somebody's post, and deleting it would take that chip with it.
+    test "keeps a holderless tag that is still a post's tag" do
+      tag = orphan_tag()
+      post_tag = Repo.insert!(%PostTag{post_id: insert(:post).id, tag_id: tag.id})
+
+      assert %{"tags" => 0} = Tags.delete_orphaned_tags()
+      assert Repo.get(Tag, tag.id)
+      assert Repo.get(PostTag, post_tag.id)
+    end
+
+    test "keeps a holderless tag a post names as a #hashtag" do
+      tag = orphan_tag()
+      Repo.insert!(%PostHashtag{post_id: insert(:post).id, tag_id: tag.id})
+
+      assert %{"tags" => 0} = Tags.delete_orphaned_tags()
+      assert Repo.get(Tag, tag.id)
+    end
+
+    test "keeps a holderless tag somebody follows" do
+      tag = orphan_tag()
+      insert(:tag_follow, user: insert(:activated_user), tag: tag)
+
+      assert %{"tags" => 0} = Tags.delete_orphaned_tags()
+      assert Repo.get(Tag, tag.id)
+    end
+
+    test "keeps a holderless tag a newsletter group is built on" do
+      tag = orphan_tag()
+      Repo.insert!(%NewsletterGroup{name: "Zielgruppe", tag_id: tag.id})
+
+      assert %{"tags" => 0} = Tags.delete_orphaned_tags()
+      assert Repo.get(Tag, tag.id)
+    end
+
+    test "is idempotent" do
+      orphan_tag()
+
+      assert %{"tags" => 1} = Tags.delete_orphaned_tags()
+      assert %{"tags" => 0} = Tags.delete_orphaned_tags()
+    end
+  end
 end


### PR DESCRIPTION
Deletes the accounts that registered but never confirmed, and afterwards the tag rows nothing points at any more.

**Version:** v7.213.1 · **Deploy:** cold (two new Ecto migrations)

## Why

Nine out of ten rows in `users` were never a member: registered, address never confirmed, nobody came back. No session was ever opened, no post written, nothing in the account activity log. What remains is the **5,867** accounts the member count has always meant.

The periodic sweep cannot reach them. It only reaps an account whose first `"login"` PIN was minted alongside it — that is what tells an abandoned sign-up apart from an established member who merely failed a login. PINs expire and are cleared, so this backlog has none left and the sweep passes over it forever.

## The guard is inverted on purpose

Rather than list the tables that would prove an account was used, it lists the five things a bare registration writes — an email, a handle, the tags typed into the form, the name-derived search terms, a login PIN — then reads **every other foreign key into `users` from the catalog** and stops if one has a row.

A positive list goes stale the moment somebody adds a table, and that is not hypothetical: two tables carrying fediverse boosts and bookmarks landed on `main` while this was being written, and the positive list waved both through in silence. The inverted one caught them without being told.

It earned its keep twice more:

- Against real data it **stopped on 984,348 `search_terms` rows** — which turned out to be a name-derived search index rather than behaviour. A wrong assumption, caught before a single row was deleted instead of after.
- The **member count is compared before and after**; if the cleanup ever touched a protected account, the migration raises and rolls back.

Only `email_confirmed? == false` matches. A confirmed member is out, and so is a legacy member whose flag is `NULL` (SQL three-valued logic gives `NULL = false` no match — the same reason `count_users/0` counts them). Accounts younger than 7 days are left to the periodic sweep. Every check runs before the first delete, so a refusal costs nothing.

## A bug this surfaced

Deletion goes through `Accounts.delete_user/1`, the chokepoint, so the uploaded avatars go with the accounts. But `delete_user/1` broadcasts a socket disconnect, and a release runs migrations with `bin/vutuv eval`, which **loads** the application without starting it — so the endpoint is absent and the broadcast raised. That would have killed this migration partway through a production deploy, with accounts and files already gone.

`Sessions.disconnect/1` now skips when the endpoint is not running. That is the correct answer rather than a workaround: with no endpoint there are no live sockets to disconnect. Any account deletion from a release task was broken before this.

## The tag cleanup

Removes the tag rows nothing references, most of which the first migration creates. "Nobody holds it" is deliberately **not** the test — a tag with no holder can still be the chip under somebody's post, a `#hashtag`, a subscription or a newsletter audience. That distinction spared **129 rows** a simpler rule would have taken off other people's pages.

## Verified against a copy of the production database, three times

| | before | after |
|---|---|---|
| **members (`count_users/0`)** | **5,867** | **5,867** |
| confirmed / legacy `NULL` / admin | 5,833 / 34 / 1 | 5,833 / 34 / 1 |
| users total | 60,553 | 5,867 |
| emails / handles | 60,686 / 60,554 | 6,000 / 5,868 |
| search_terms | 1,095,918 | 111,570 |
| tags / user_tags | 10,210 / 21,772 | 7,904 / 19,849 |
| **posts / post_tags / hashtags / endorsements** | 368 / 364 / 19 / 4,325 | **unchanged** |

54,686 accounts deleted in ~78s. Orphan hunt across the whole graph: zero. Repeat run: `{0, 5867}` and 0 tags. The app then boots against the migrated data and the landing page reports 5,867.

Both migrations are data-only with no DDL, so they are N-1 compatible: the currently deployed release reads the same tables and finds fewer rows.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
