### PR TITLE
A post from another network shows a short handle, and its time opens our copy (v7.215.0)

### DIFF
--- a/lib/vutuv/fediverse/handle.ex
+++ b/lib/vutuv/fediverse/handle.ex
@@ -41,6 +41,29 @@ defmodule Vutuv.Fediverse.Handle do
     end
   end
 
+  @doc """
+  The handle without its server: `"@tagesschau@ard.social"` → `"@tagesschau"`.
+
+  What a card header shows once the server is already on the card in its own
+  right — the globe chip beside the name says `ard.social`, so spelling it out a
+  second time in the handle only pushed the timestamp off the line. The full
+  form stays the link's `title`, so it is one hover away and still copyable from
+  the account page, where it is the address somebody pastes into their own
+  server.
+
+  A handle we could only derive as `@host` (no username anywhere in the actor
+  document or its URI) has nothing to cut and is returned unchanged: the host is
+  the name there.
+  """
+  def short("@" <> rest = handle) do
+    case String.split(rest, "@", parts: 2) do
+      [name, host] when name != "" and host != "" -> "@" <> name
+      _ -> handle
+    end
+  end
+
+  def short(handle), do: handle
+
   @doc "The server an account URI names, or nil."
   def host(uri) when is_binary(uri) do
     case URI.parse(uri) do

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -1117,6 +1117,12 @@ defmodule VutuvWeb.PostComponents do
     doc: "the stored account row, when we know it: the handle then links to its page here"
   )
 
+  attr(:permalink, :any,
+    default: nil,
+    doc:
+      "our own page for this content, which the stamp then links to like a member post's does; nil leaves the stamp plain text"
+  )
+
   slot(:menu)
 
   # `break-words` on the author and the handle is not cosmetic: both come
@@ -1125,6 +1131,12 @@ defmodule VutuvWeb.PostComponents do
   # min-content, and on a phone that scrolls the whole page sideways and pushes
   # the ⋯ menu off the viewport — taking Report with it, on exactly the post
   # most likely to need it.
+  #
+  # The handle is shown **without its server** (`Handle.short/1`): the globe chip
+  # at the end of this very row already names the server, so `@tagesschau@ard.social`
+  # said it twice and ate the width the stamp needed. The full address stays as
+  # the link's `title`, which is also what a member wants to read before they
+  # paste it somewhere.
   defp remote_header(assigns) do
     ~H"""
     <div class="flex items-start gap-2">
@@ -1134,9 +1146,24 @@ defmodule VutuvWeb.PostComponents do
           <.link
             {remote_actor_destination(@account_id, @actor_uri)}
             data-remote-account={@account_id}
+            data-remote-handle={@handle}
+            title={@handle}
             class="break-all hover:text-brand-700 dark:hover:text-brand-300 sm:break-normal"
-          >{@handle}</.link>
-          · <.post_time at={@at} />
+          >{Handle.short(@handle)}</.link>
+          ·
+          <%!-- The stamp is the way to this post's own page here, exactly as on a
+          member's card. Only where we have such a page: a reply from another
+          network has none, and a reader who is not signed in cannot open the one
+          a cached post has. --%>
+          <.link
+            :if={@permalink}
+            navigate={@permalink}
+            data-remote-permalink
+            class="hover:text-brand-700 dark:hover:text-brand-300"
+          >
+            <.post_time at={@at} />
+          </.link>
+          <.post_time :if={!@permalink} at={@at} />
         </span>
         <%!-- Where this came from, up here where the eye lands, not only in the
         footer under the text. A reply card can leave it to the footer because
@@ -1691,8 +1718,13 @@ defmodule VutuvWeb.PostComponents do
       happened to pass through this installation would read as the real one
       while being a fraction of it. Replying and resharing are still their own
       issues (#1165, #1166); an absent control beats a dead one.
-    * **no permalink of ours.** The post lives on its own server; "View the
-      original" is where it is read in full.
+    * **a page for our copy, but not a published one.** The stamp in the header
+      links to `/system/fediverse/post/:id` (`VutuvWeb.FediversePostLive`), the
+      same place a member post's stamp leads — that is where the card came from
+      when somebody links it to you, and where a photo-heavy post is readable
+      without the feed around it. It is signed-in only and `noindex`, so the
+      link is rendered only when there is a viewer; the post itself still lives
+      on its own server, and "View the original" is where it is read in full.
 
   A content warning (or the author's `sensitive` flag) renders as a closed lid
   and reveals the text on a click, which is the one thing that author asked for.
@@ -1742,6 +1774,7 @@ defmodule VutuvWeb.PostComponents do
       |> assign(:account, account)
       |> assign(:initials, name_initials(account.name || account.handle))
       |> assign(:link_screenshot, remote_link_screenshot(post, assigns.images))
+      |> assign(:permalink, remote_post_permalink(post, assigns.viewer))
 
     ~H"""
     <article data-remote-post={@remote_post.id} data-audience={@remote_post.audience}>
@@ -1772,6 +1805,7 @@ defmodule VutuvWeb.PostComponents do
             at={@remote_post.published_at}
             network={@account.host}
             account_id={@account.id}
+            permalink={@permalink}
           >
             <:menu>
               <.card_menu :if={@viewer} id={"remote-post-menu-#{@remote_post.id}"}>
@@ -1860,6 +1894,17 @@ defmodule VutuvWeb.PostComponents do
       do: gettext("Vote on the original"),
       else: gettext("View the original")
   end
+
+  # Our copy's own page (`VutuvWeb.FediversePostLive`), for the stamp in the
+  # header. Signed-in readers only, because that page is: it is assembled from
+  # what somebody else wrote on somebody else's server, so it is a members' page
+  # like every other `/system/fediverse/*` one — and a link an anonymous reader
+  # of the tag timeline could only follow into a login wall is worse than the
+  # plain stamp they have today.
+  defp remote_post_permalink(%RemotePost{id: id}, %User{}),
+    do: ~p"/system/fediverse/post/#{id}"
+
+  defp remote_post_permalink(_post, _viewer), do: nil
 
   @doc """
   The sentence for one `{:error, reason}` refusing the heart above (issue

--- a/lib/vutuv_web/live/fediverse_post_live.ex
+++ b/lib/vutuv_web/live/fediverse_post_live.ex
@@ -1,0 +1,150 @@
+defmodule VutuvWeb.FediversePostLive do
+  @moduledoc """
+  vutuv's copy of one post from another network (`/system/fediverse/post/:id`).
+
+  Every card in the feed carries a timestamp, and on a member's post that stamp
+  is the way to the post's own page. On a cached remote post it was plain text,
+  so the one card in the timeline that a reader could not open, link, or come
+  back to was the one from somewhere else. This is that page: the same card the
+  feed draws, alone, with its action bar and its way on to the account.
+
+  It is **our copy, not a republication**, and the difference is what the page is
+  shaped by:
+
+    * **Signed-in only and `noindex`**, like the account page and the lookup box
+      next to it, and for the same reason — the content is somebody else's words
+      from somebody else's server. So it has no agent-format siblings either,
+      and `PostComponents` renders the stamp as a link only when the card has a
+      viewer (an anonymous reader of a public tag timeline keeps the plain
+      stamp instead of a link into a login wall).
+    * **Readable, not merely present.** `Fediverse.remote_post_readable?/2` is
+      the one gate every read-side surface shares, so a post its author
+      addressed to their followers opens here for a member whose own follow was
+      accepted and is a 404 for everybody else. Nothing about the row leaks
+      through the refusal.
+    * **Nothing is fetched on view.** Opening this URL makes no request to
+      anybody: it renders the row we already hold, or it does not exist. The
+      cached copy is also not ours to keep forever — the sweep drops it once
+      nobody here follows the author, and a reported copy is deleted at once, so
+      this page can go away while its link lives on. "View the original" on the
+      card is the address that does not expire.
+
+  The two card controls a host has to answer for are handled here as everywhere:
+  the ⋯ menu's Report (which deletes the copy, so the page has nothing left to
+  show and the reader is sent back to the feed) and Mute. The action bar owns
+  its own events (`VutuvWeb.PostLive.RemoteActionsComponent`) and is handed no
+  batched marks — one card, so its own three lookups are cheaper than a batch.
+  """
+
+  use VutuvWeb, :live_view
+
+  import VutuvWeb.PostComponents
+
+  on_mount({VutuvWeb.Live.InitAssigns, :require_login})
+
+  alias Vutuv.Fediverse
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias VutuvWeb.Live.InitAssigns
+
+  @impl true
+  def mount(%{"id" => id}, _session, socket) do
+    viewer = socket.assigns.current_user
+    post = Fediverse.get_remote_post(id)
+
+    if post && Fediverse.remote_post_readable?(post, viewer) do
+      {:ok, assign_post(socket, post, viewer)}
+    else
+      {:ok, InitAssigns.not_found(socket, ~p"/feed")}
+    end
+  end
+
+  defp assign_post(socket, %RemotePost{} = post, viewer) do
+    account = post.remote_account
+
+    socket
+    # Named for what it is, because the tab, the bookmark and the history entry
+    # all outlive the page: a bare name there reads as a vutuv member's post.
+    |> assign(
+      :page_title,
+      gettext("A post by %{name} (another network)", name: RemoteAccount.label(account))
+    )
+    |> assign(:remote_post, post)
+    |> assign(:images, Map.get(Fediverse.list_remote_images([post.id]), post.id, []))
+    # Whether the ⋯ menu offers Mute at all. This page is reachable for a public
+    # post whose author the reader does not follow (it is cached because
+    # somebody else does), and muting a follow that does not exist is a control
+    # that does nothing behind a flash saying otherwise.
+    |> assign(:follows?, not is_nil(Fediverse.remote_follow_for(viewer, account)))
+  end
+
+  # ── Events ────────────────────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("report-remote-post", _params, socket) do
+    case Fediverse.report_remote_post(socket.assigns.remote_post.id, socket.assigns.current_user) do
+      :ok ->
+        # The copy this page is about is gone, so there is no page left to stay
+        # on. The feed is where the card was met.
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("Thank you. Our copy was deleted right away."))
+         |> push_navigate(to: ~p"/feed")}
+
+      {:error, :rate_limited} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("You have reported a lot today. Please try again tomorrow.")
+         )}
+
+      {:error, :not_found} ->
+        {:noreply, push_navigate(socket, to: ~p"/feed")}
+    end
+  end
+
+  def handle_event("mute-remote-account", %{"id" => account_id}, socket) do
+    :ok = Fediverse.set_remote_follow_mute(socket.assigns.current_user, account_id, true)
+
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("Muted. You still follow them; their posts leave your feed."))
+     |> assign(:follows?, false)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="fediverse-post" class="mx-auto max-w-2xl space-y-6 py-6">
+      <.card>
+        <.section_title>{gettext("A post from another network")}</.section_title>
+        <%!-- Said once, at the top: what a reader has in front of them is the
+        copy this installation received, not the post itself. It is why the
+        pictures, the counts and the "View the original" link below behave the
+        way they do. --%>
+        <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+          {gettext(
+            "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author.",
+            host: @remote_post.remote_account.host
+          )}
+        </p>
+
+        <div class="mt-4">
+          <.remote_post_card
+            live?
+            remote_post={@remote_post}
+            images={@images}
+            viewer={@current_user}
+            mute?={@follows?}
+          />
+        </div>
+
+        <.card_footer_link href={~p"/system/fediverse/account/#{@remote_post.remote_account_id}"}>
+          {gettext("More from %{name}", name: RemoteAccount.label(@remote_post.remote_account))}
+        </.card_footer_link>
+      </.card>
+    </div>
+    """
+  end
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -516,6 +516,7 @@ defmodule VutuvWeb.Router do
         live("/reply/:id", PostLive.RemoteReply, :new)
         live("/reply/post/:id", PostLive.RemotePostReply, :new)
         live("/account/:id", FediverseAccountLive, :show)
+        live("/post/:id", FediversePostLive, :show)
         live("/lookup", FediverseLookupLive, :index)
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.214.0",
+      version: "7.215.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -156,7 +156,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:2520
+#: lib/vutuv_web/components/post_components.ex:2565
 #: lib/vutuv_web/components/ui.ex:3140
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -205,7 +205,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:2485
+#: lib/vutuv_web/components/post_components.ex:2530
 #: lib/vutuv_web/components/ui.ex:3131
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -455,8 +455,8 @@ msgstr "Einloggen"
 msgid "Log Out"
 msgstr "Ausloggen"
 
-#: lib/vutuv_web/live/shell_live.ex:672
-#: lib/vutuv_web/live/shell_live.ex:709
+#: lib/vutuv_web/live/shell_live.ex:679
+#: lib/vutuv_web/live/shell_live.ex:716
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -652,8 +652,8 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:37
 #: lib/vutuv_web/live/search_live.ex:378
-#: lib/vutuv_web/live/shell_live.ex:536
-#: lib/vutuv_web/live/shell_live.ex:692
+#: lib/vutuv_web/live/shell_live.ex:543
+#: lib/vutuv_web/live/shell_live.ex:699
 #: lib/vutuv_web/live/tag_live/timeline.ex:278
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -663,7 +663,7 @@ msgstr "Speichern"
 msgid "Search"
 msgstr "Suche"
 
-#: lib/vutuv_web/components/post_components.ex:1251
+#: lib/vutuv_web/components/post_components.ex:1278
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1235,7 +1235,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:644
+#: lib/vutuv_web/live/shell_live.ex:651
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1679,7 +1679,7 @@ msgstr "Adressen von %{name}"
 msgid "Admin control panel"
 msgstr "Admin-Bereich"
 
-#: lib/vutuv_web/live/shell_live.ex:695
+#: lib/vutuv_web/live/shell_live.ex:702
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr "Mitteilungen"
@@ -1698,7 +1698,7 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/post_components.ex:2966
+#: lib/vutuv_web/components/post_components.ex:3011
 #: lib/vutuv_web/components/ui.ex:244
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1792,7 +1792,7 @@ msgstr ""
 " von jemandem, den Sie kennen oder interessant finden, und klicken Sie auf "
 "Folgen!"
 
-#: lib/vutuv_web/live/shell_live.ex:663
+#: lib/vutuv_web/live/shell_live.ex:670
 #: lib/vutuv_web/views/settings_html.ex:229
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1820,8 +1820,8 @@ msgstr "Nachricht"
 
 #: lib/vutuv_web/live/message_live/index.ex:45
 #: lib/vutuv_web/live/message_live/index.ex:512
-#: lib/vutuv_web/live/shell_live.ex:552
-#: lib/vutuv_web/live/shell_live.ex:694
+#: lib/vutuv_web/live/shell_live.ex:559
+#: lib/vutuv_web/live/shell_live.ex:701
 #: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1848,7 +1848,7 @@ msgstr "Noch nichts Neues."
 #: lib/vutuv_web/components/ui.ex:3466
 #: lib/vutuv_web/live/notification_live/index.ex:105
 #: lib/vutuv_web/live/notification_live/index.ex:329
-#: lib/vutuv_web/live/shell_live.ex:563
+#: lib/vutuv_web/live/shell_live.ex:570
 #: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2189,7 +2189,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:2517
+#: lib/vutuv_web/components/post_components.ex:2562
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2204,7 +2204,7 @@ msgstr "Beitrag bearbeiten"
 #: lib/vutuv_web/live/post_live/feed.ex:154
 #: lib/vutuv_web/live/post_live/feed.ex:948
 #: lib/vutuv_web/live/shell_live.ex:461
-#: lib/vutuv_web/live/shell_live.ex:690
+#: lib/vutuv_web/live/shell_live.ex:697
 #: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2230,8 +2230,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:2471
-#: lib/vutuv_web/components/post_components.ex:2473
+#: lib/vutuv_web/components/post_components.ex:2516
+#: lib/vutuv_web/components/post_components.ex:2518
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2298,13 +2298,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:2902
-#: lib/vutuv_web/components/post_components.ex:2906
+#: lib/vutuv_web/components/post_components.ex:2947
+#: lib/vutuv_web/components/post_components.ex:2951
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:2903
+#: lib/vutuv_web/components/post_components.ex:2948
 #: lib/vutuv_web/live/fediverse_account_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2377,7 +2377,7 @@ msgid "Upload failed."
 msgstr "Upload fehlgeschlagen."
 
 #: lib/vutuv_web/components/ui.ex:3718
-#: lib/vutuv_web/live/shell_live.ex:606
+#: lib/vutuv_web/live/shell_live.ex:613
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:176
@@ -2395,27 +2395,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:2468
+#: lib/vutuv_web/components/post_components.ex:2513
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:4033
+#: lib/vutuv_web/components/post_components.ex:4078
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:4037
+#: lib/vutuv_web/components/post_components.ex:4082
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:4035
+#: lib/vutuv_web/components/post_components.ex:4080
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:4036
+#: lib/vutuv_web/components/post_components.ex:4081
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2456,8 +2456,8 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1415
-#: lib/vutuv_web/components/post_components.ex:4117
+#: lib/vutuv_web/components/post_components.ex:1442
+#: lib/vutuv_web/components/post_components.ex:4162
 #: lib/vutuv_web/components/ui.ex:2665
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2467,15 +2467,15 @@ msgstr "Lesezeichen setzen"
 #: lib/vutuv_web/agent_docs/markdown.ex:933
 #: lib/vutuv_web/live/post_live/saved.ex:171
 #: lib/vutuv_web/live/post_live/saved.ex:484
-#: lib/vutuv_web/live/shell_live.ex:545
-#: lib/vutuv_web/live/shell_live.ex:611
+#: lib/vutuv_web/live/shell_live.ex:552
+#: lib/vutuv_web/live/shell_live.ex:618
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1381
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:1408
+#: lib/vutuv_web/components/post_components.ex:4385
 #: lib/vutuv_web/components/ui.ex:2651
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #: lib/vutuv_web/templates/user/show.html.heex:192
@@ -2484,11 +2484,11 @@ msgid "Like"
 msgstr "Gefällt mir"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:932
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4394
 #: lib/vutuv_web/live/notification_live/index.ex:940
 #: lib/vutuv_web/live/post_live/saved.ex:170
 #: lib/vutuv_web/live/post_live/saved.ex:481
-#: lib/vutuv_web/live/shell_live.ex:614
+#: lib/vutuv_web/live/shell_live.ex:621
 #: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Likes"
@@ -2504,39 +2504,39 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:4106
+#: lib/vutuv_web/components/post_components.ex:4151
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1415
-#: lib/vutuv_web/components/post_components.ex:4117
+#: lib/vutuv_web/components/post_components.ex:1442
+#: lib/vutuv_web/components/post_components.ex:4162
 #: lib/vutuv_web/live/post_live/saved.ex:771
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1404
-#: lib/vutuv_web/components/post_components.ex:4103
+#: lib/vutuv_web/components/post_components.ex:1431
+#: lib/vutuv_web/components/post_components.ex:4148
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1567
-#: lib/vutuv_web/components/post_components.ex:3480
+#: lib/vutuv_web/components/post_components.ex:1594
+#: lib/vutuv_web/components/post_components.ex:3525
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1404
-#: lib/vutuv_web/components/post_components.ex:4103
+#: lib/vutuv_web/components/post_components.ex:1431
+#: lib/vutuv_web/components/post_components.ex:4148
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:4385
 #: lib/vutuv_web/live/post_live/saved.ex:770
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
@@ -2558,7 +2558,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:4393
+#: lib/vutuv_web/components/post_components.ex:4438
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2569,16 +2569,16 @@ msgstr "Nur öffentliche Beiträge können beantwortet werden."
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1391
-#: lib/vutuv_web/components/post_components.ex:4376
-#: lib/vutuv_web/components/post_components.ex:4377
+#: lib/vutuv_web/components/post_components.ex:1418
+#: lib/vutuv_web/components/post_components.ex:4421
+#: lib/vutuv_web/components/post_components.ex:4422
 #: lib/vutuv_web/live/notification_live/index.ex:1000
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2439
+#: lib/vutuv_web/components/post_components.ex:2484
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2599,7 +2599,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:1945
+#: lib/vutuv_web/components/post_components.ex:1990
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2607,14 +2607,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2415
+#: lib/vutuv_web/components/post_components.ex:2460
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:2409
-#: lib/vutuv_web/components/post_components.ex:2431
-#: lib/vutuv_web/components/post_components.ex:2434
+#: lib/vutuv_web/components/post_components.ex:2454
+#: lib/vutuv_web/components/post_components.ex:2476
+#: lib/vutuv_web/components/post_components.ex:2479
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2920,7 +2920,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:4034
+#: lib/vutuv_web/components/post_components.ex:4079
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -3199,7 +3199,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:2385
+#: lib/vutuv_web/components/post_components.ex:2430
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3254,7 +3254,7 @@ msgstr "Private Nachricht"
 
 #: lib/vutuv_web/components/ui.ex:3399
 #: lib/vutuv_web/live/shell_live.ex:474
-#: lib/vutuv_web/live/shell_live.ex:699
+#: lib/vutuv_web/live/shell_live.ex:706
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3279,8 +3279,8 @@ msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
 #: lib/vutuv_web/components/post_components.ex:995
-#: lib/vutuv_web/components/post_components.ex:1798
-#: lib/vutuv_web/components/post_components.ex:2541
+#: lib/vutuv_web/components/post_components.ex:1832
+#: lib/vutuv_web/components/post_components.ex:2586
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -5557,7 +5557,7 @@ msgstr "Sie können auf diesen Beitrag nicht mehr antworten."
 msgid "Content under review"
 msgstr "Inhalte in Prüfung"
 
-#: lib/vutuv_web/live/shell_live.ex:593
+#: lib/vutuv_web/live/shell_live.ex:600
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr "Kontomenü"
@@ -5579,7 +5579,7 @@ msgstr "Menüs und Dialoge schließen"
 msgid "General"
 msgstr "Allgemeines"
 
-#: lib/vutuv_web/live/shell_live.ex:654
+#: lib/vutuv_web/live/shell_live.ex:661
 #: lib/vutuv_web/templates/layout/app.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5598,7 +5598,7 @@ msgstr "Navigation"
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:108
 #: lib/vutuv_web/live/fediverse_following_live.ex:238
-#: lib/vutuv_web/live/shell_live.ex:634
+#: lib/vutuv_web/live/shell_live.ex:641
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
@@ -5650,7 +5650,7 @@ msgid "Previous post in the feed"
 msgstr "Vorheriger Beitrag im Feed"
 
 #: lib/vutuv_web/live/shell_live.ex:454
-#: lib/vutuv_web/live/shell_live.ex:683
+#: lib/vutuv_web/live/shell_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr "Hauptnavigation"
@@ -5660,9 +5660,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:2604
-#: lib/vutuv_web/components/post_components.ex:2656
-#: lib/vutuv_web/components/post_components.ex:3046
+#: lib/vutuv_web/components/post_components.ex:2649
+#: lib/vutuv_web/components/post_components.ex:2701
+#: lib/vutuv_web/components/post_components.ex:3091
 #: lib/vutuv_web/live/notification_live/index.ex:680
 #: lib/vutuv_web/live/post_live/feed.ex:1255
 #: lib/vutuv_web/views/user_html.ex:111
@@ -6963,7 +6963,7 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:2538
+#: lib/vutuv_web/components/post_components.ex:2583
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6973,7 +6973,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:2537
+#: lib/vutuv_web/components/post_components.ex:2582
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7680,7 +7680,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
-#: lib/vutuv_web/components/post_components.ex:4262
+#: lib/vutuv_web/components/post_components.ex:4307
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -9299,7 +9299,7 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:3483
+#: lib/vutuv_web/components/post_components.ex:3528
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -10339,7 +10339,7 @@ msgid "First name"
 msgstr "Vorname"
 
 #: lib/vutuv_web/controllers/invitation_controller.ex:54
-#: lib/vutuv_web/live/shell_live.ex:625
+#: lib/vutuv_web/live/shell_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Invite a friend"
 msgstr "Freunde einladen"
@@ -12731,7 +12731,7 @@ msgstr "Organisation wieder freigegeben."
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:497
-#: lib/vutuv_web/live/shell_live.ex:621
+#: lib/vutuv_web/live/shell_live.ex:628
 #: lib/vutuv_web/templates/layout/app.html.heex:83
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
@@ -13978,7 +13978,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:1904
+#: lib/vutuv_web/components/post_components.ex:1949
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -14594,34 +14594,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:3896
+#: lib/vutuv_web/components/post_components.ex:3941
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3853
+#: lib/vutuv_web/components/post_components.ex:3898
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:3897
+#: lib/vutuv_web/components/post_components.ex:3942
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:3899
+#: lib/vutuv_web/components/post_components.ex:3944
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:3895
+#: lib/vutuv_web/components/post_components.ex:3940
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3852
+#: lib/vutuv_web/components/post_components.ex:3897
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14632,12 +14632,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:3894
+#: lib/vutuv_web/components/post_components.ex:3939
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:3898
+#: lib/vutuv_web/components/post_components.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14657,34 +14657,34 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:3935
+#: lib/vutuv_web/components/post_components.ex:3980
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:3965
+#: lib/vutuv_web/components/post_components.ex:4010
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:3966
+#: lib/vutuv_web/components/post_components.ex:4011
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:3964
+#: lib/vutuv_web/components/post_components.ex:4009
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:3924
+#: lib/vutuv_web/components/post_components.ex:3969
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:3971
+#: lib/vutuv_web/components/post_components.ex:4016
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14714,7 +14714,7 @@ msgstr "Mit Qualifikation:"
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3738
+#: lib/vutuv_web/components/post_components.ex:3783
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14762,7 +14762,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:3729
+#: lib/vutuv_web/components/post_components.ex:3774
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -15160,14 +15160,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2160
+#: lib/vutuv_web/components/post_components.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2182
+#: lib/vutuv_web/components/post_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -15194,7 +15194,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:4348
+#: lib/vutuv_web/components/post_components.ex:4393
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -16382,21 +16382,21 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:4307
+#: lib/vutuv_web/components/post_components.ex:4352
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4311
+#: lib/vutuv_web/components/post_components.ex:4356
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:4315
+#: lib/vutuv_web/components/post_components.ex:4360
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -16404,7 +16404,7 @@ msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:951
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4311
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16421,7 +16421,7 @@ msgid "Content warning"
 msgstr "Inhaltswarnung"
 
 #: lib/vutuv_web/components/post_components.ex:1096
-#: lib/vutuv_web/components/post_components.ex:1509
+#: lib/vutuv_web/components/post_components.ex:1536
 #: lib/vutuv_web/live/fediverse_account_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "From another network"
@@ -16497,7 +16497,7 @@ msgstr "Diese Antwort können Sie nicht entfernen."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1112
 #: lib/vutuv_web/components/post_components.ex:1027
-#: lib/vutuv_web/components/post_components.ex:1861
+#: lib/vutuv_web/components/post_components.ex:1895
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16510,6 +16510,7 @@ msgstr "Was"
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:167
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:118
+#: lib/vutuv_web/live/fediverse_post_live.ex:99
 #: lib/vutuv_web/live/post_live/feed.ex:426
 #: lib/vutuv_web/live/post_live/thread.ex:265
 #: lib/vutuv_web/live/tag_live/timeline.ex:138
@@ -17161,22 +17162,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:2397
+#: lib/vutuv_web/components/post_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2504
+#: lib/vutuv_web/components/post_components.ex:2549
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:2512
+#: lib/vutuv_web/components/post_components.ex:2557
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:2498
+#: lib/vutuv_web/components/post_components.ex:2543
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -17268,7 +17269,7 @@ msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1040
 #: lib/vutuv_web/agent_docs/text.ex:654
-#: lib/vutuv_web/components/post_components.ex:2969
+#: lib/vutuv_web/components/post_components.ex:3014
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
@@ -17298,7 +17299,7 @@ msgstr "Volle Auflösung, direkt aus dem Beitrag."
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/components/post_components.ex:2968
+#: lib/vutuv_web/components/post_components.ex:3013
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
@@ -17308,29 +17309,29 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3347
+#: lib/vutuv_web/components/post_components.ex:3392
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr "Bisher sehen nur Sie diesen Beitrag."
 
-#: lib/vutuv_web/components/post_components.ex:1957
+#: lib/vutuv_web/components/post_components.ex:2002
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:3350
+#: lib/vutuv_web/components/post_components.ex:3395
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] "Unsere KI prüft das Foto. Sobald es durch ist, geht der Beitrag von selbst online."
 msgstr[1] "Unsere KI prüft die Fotos, %{done} von %{total} sind durch. Sobald das letzte durch ist, geht der Beitrag von selbst online."
 
-#: lib/vutuv_web/components/post_components.ex:3175
+#: lib/vutuv_web/components/post_components.ex:3220
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:2713
+#: lib/vutuv_web/components/post_components.ex:2758
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17343,12 +17344,12 @@ msgstr "Foto-Einstellungen"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1073
 #: lib/vutuv_web/agent_docs/text.ex:641
-#: lib/vutuv_web/components/post_components.ex:3384
+#: lib/vutuv_web/components/post_components.ex:3429
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/post_components.ex:2967
+#: lib/vutuv_web/components/post_components.ex:3012
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
@@ -17369,7 +17370,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2010
+#: lib/vutuv_web/components/post_components.ex:2055
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -17389,7 +17390,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:2001
+#: lib/vutuv_web/components/post_components.ex:2046
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -17399,12 +17400,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:2019
+#: lib/vutuv_web/components/post_components.ex:2064
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:1953
+#: lib/vutuv_web/components/post_components.ex:1998
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -17419,7 +17420,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2014
+#: lib/vutuv_web/components/post_components.ex:2059
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -17429,7 +17430,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:1967
+#: lib/vutuv_web/components/post_components.ex:2012
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17516,13 +17517,13 @@ msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exak
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
 #: lib/vutuv_web/agent_docs/markdown.ex:969
-#: lib/vutuv_web/components/post_components.ex:4304
+#: lib/vutuv_web/components/post_components.ex:4349
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:967
-#: lib/vutuv_web/components/post_components.ex:4301
+#: lib/vutuv_web/components/post_components.ex:4346
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17532,7 +17533,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:4193
+#: lib/vutuv_web/components/post_components.ex:4238
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17878,20 +17879,21 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1807
+#: lib/vutuv_web/components/post_components.ex:1841
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:159
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:110
+#: lib/vutuv_web/live/fediverse_post_live.ex:91
 #: lib/vutuv_web/live/post_live/feed.ex:418
 #: lib/vutuv_web/live/tag_live/timeline.ex:130
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:1860
+#: lib/vutuv_web/components/post_components.ex:1894
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17911,22 +17913,23 @@ msgstr "Zwischengespeicherter Beitrag gemeldet, hier für alle entfernt"
 msgid "Content from other networks taken down by members"
 msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 
-#: lib/vutuv_web/components/post_components.ex:1254
+#: lib/vutuv_web/components/post_components.ex:1281
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:1858
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
 
-#: lib/vutuv_web/components/post_components.ex:1786
+#: lib/vutuv_web/components/post_components.ex:1820
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr "%{handle} stummschalten"
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:221
+#: lib/vutuv_web/live/fediverse_post_live.ex:112
 #: lib/vutuv_web/live/post_live/feed.ex:448
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -17937,7 +17940,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:1793
+#: lib/vutuv_web/components/post_components.ex:1827
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -18159,27 +18162,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:1612
+#: lib/vutuv_web/components/post_components.ex:1639
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr "Ein Bild ist unterwegs."
 
-#: lib/vutuv_web/components/post_components.ex:1641
+#: lib/vutuv_web/components/post_components.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:1636
+#: lib/vutuv_web/components/post_components.ex:1663
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:1886
+#: lib/vutuv_web/components/post_components.ex:1931
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:1892
+#: lib/vutuv_web/components/post_components.ex:1937
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -18189,7 +18192,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:2005
+#: lib/vutuv_web/components/post_components.ex:2050
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18992,7 +18995,7 @@ msgstr "Zu Beiträgen aus anderen Netzwerken kennen wir hier keine öffentliche 
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:1889
+#: lib/vutuv_web/components/post_components.ex:1934
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -19018,3 +19021,23 @@ msgid "%{formatted} member"
 msgid_plural "%{formatted} members"
 msgstr[0] "%{formatted} Mitglied"
 msgstr[1] "%{formatted} Mitglieder"
+
+#: lib/vutuv_web/live/fediverse_post_live.ex:70
+#, elixir-autogen, elixir-format
+msgid "A post by %{name} (another network)"
+msgstr "Ein Beitrag von %{name} (anderes Netzwerk)"
+
+#: lib/vutuv_web/live/fediverse_post_live.ex:121
+#, elixir-autogen, elixir-format
+msgid "A post from another network"
+msgstr "Ein Beitrag aus einem anderen Netzwerk"
+
+#: lib/vutuv_web/live/fediverse_post_live.ex:144
+#, elixir-autogen, elixir-format
+msgid "More from %{name}"
+msgstr "Mehr von %{name}"
+
+#: lib/vutuv_web/live/fediverse_post_live.ex:127
+#, elixir-autogen, elixir-format
+msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
+msgstr "Das ist die Kopie, die vutuv von einem auf %{host} veröffentlichten Beitrag hat. Sie bleibt erhalten, solange hier jemand diesem Konto folgt."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -156,7 +156,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2520
+#: lib/vutuv_web/components/post_components.ex:2565
 #: lib/vutuv_web/components/ui.ex:3140
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -205,7 +205,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2485
+#: lib/vutuv_web/components/post_components.ex:2530
 #: lib/vutuv_web/components/ui.ex:3131
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -455,8 +455,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:672
-#: lib/vutuv_web/live/shell_live.ex:709
+#: lib/vutuv_web/live/shell_live.ex:679
+#: lib/vutuv_web/live/shell_live.ex:716
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -652,8 +652,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:37
 #: lib/vutuv_web/live/search_live.ex:378
-#: lib/vutuv_web/live/shell_live.ex:536
-#: lib/vutuv_web/live/shell_live.ex:692
+#: lib/vutuv_web/live/shell_live.ex:543
+#: lib/vutuv_web/live/shell_live.ex:699
 #: lib/vutuv_web/live/tag_live/timeline.ex:278
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -663,7 +663,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1251
+#: lib/vutuv_web/components/post_components.ex:1278
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1209,7 +1209,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:644
+#: lib/vutuv_web/live/shell_live.ex:651
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:695
+#: lib/vutuv_web/live/shell_live.ex:702
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2966
+#: lib/vutuv_web/components/post_components.ex:3011
 #: lib/vutuv_web/components/ui.ex:244
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1755,7 +1755,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:663
+#: lib/vutuv_web/live/shell_live.ex:670
 #: lib/vutuv_web/views/settings_html.ex:229
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1783,8 +1783,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:45
 #: lib/vutuv_web/live/message_live/index.ex:512
-#: lib/vutuv_web/live/shell_live.ex:552
-#: lib/vutuv_web/live/shell_live.ex:694
+#: lib/vutuv_web/live/shell_live.ex:559
+#: lib/vutuv_web/live/shell_live.ex:701
 #: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1811,7 +1811,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3466
 #: lib/vutuv_web/live/notification_live/index.ex:105
 #: lib/vutuv_web/live/notification_live/index.ex:329
-#: lib/vutuv_web/live/shell_live.ex:563
+#: lib/vutuv_web/live/shell_live.ex:570
 #: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2144,7 +2144,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2517
+#: lib/vutuv_web/components/post_components.ex:2562
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2159,7 +2159,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:154
 #: lib/vutuv_web/live/post_live/feed.ex:948
 #: lib/vutuv_web/live/shell_live.ex:461
-#: lib/vutuv_web/live/shell_live.ex:690
+#: lib/vutuv_web/live/shell_live.ex:697
 #: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2185,8 +2185,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2471
-#: lib/vutuv_web/components/post_components.ex:2473
+#: lib/vutuv_web/components/post_components.ex:2516
+#: lib/vutuv_web/components/post_components.ex:2518
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2251,13 +2251,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2902
-#: lib/vutuv_web/components/post_components.ex:2906
+#: lib/vutuv_web/components/post_components.ex:2947
+#: lib/vutuv_web/components/post_components.ex:2951
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2903
+#: lib/vutuv_web/components/post_components.ex:2948
 #: lib/vutuv_web/live/fediverse_account_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2328,7 +2328,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3718
-#: lib/vutuv_web/live/shell_live.ex:606
+#: lib/vutuv_web/live/shell_live.ex:613
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:176
@@ -2346,27 +2346,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2468
+#: lib/vutuv_web/components/post_components.ex:2513
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4033
+#: lib/vutuv_web/components/post_components.ex:4078
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4037
+#: lib/vutuv_web/components/post_components.ex:4082
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4035
+#: lib/vutuv_web/components/post_components.ex:4080
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4036
+#: lib/vutuv_web/components/post_components.ex:4081
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2407,8 +2407,8 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1415
-#: lib/vutuv_web/components/post_components.ex:4117
+#: lib/vutuv_web/components/post_components.ex:1442
+#: lib/vutuv_web/components/post_components.ex:4162
 #: lib/vutuv_web/components/ui.ex:2665
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2418,15 +2418,15 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:933
 #: lib/vutuv_web/live/post_live/saved.ex:171
 #: lib/vutuv_web/live/post_live/saved.ex:484
-#: lib/vutuv_web/live/shell_live.ex:545
-#: lib/vutuv_web/live/shell_live.ex:611
+#: lib/vutuv_web/live/shell_live.ex:552
+#: lib/vutuv_web/live/shell_live.ex:618
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1381
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:1408
+#: lib/vutuv_web/components/post_components.ex:4385
 #: lib/vutuv_web/components/ui.ex:2651
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #: lib/vutuv_web/templates/user/show.html.heex:192
@@ -2435,11 +2435,11 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:932
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4394
 #: lib/vutuv_web/live/notification_live/index.ex:940
 #: lib/vutuv_web/live/post_live/saved.ex:170
 #: lib/vutuv_web/live/post_live/saved.ex:481
-#: lib/vutuv_web/live/shell_live.ex:614
+#: lib/vutuv_web/live/shell_live.ex:621
 #: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Likes"
@@ -2455,39 +2455,39 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4106
+#: lib/vutuv_web/components/post_components.ex:4151
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1415
-#: lib/vutuv_web/components/post_components.ex:4117
+#: lib/vutuv_web/components/post_components.ex:1442
+#: lib/vutuv_web/components/post_components.ex:4162
 #: lib/vutuv_web/live/post_live/saved.ex:771
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1404
-#: lib/vutuv_web/components/post_components.ex:4103
+#: lib/vutuv_web/components/post_components.ex:1431
+#: lib/vutuv_web/components/post_components.ex:4148
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1567
-#: lib/vutuv_web/components/post_components.ex:3480
+#: lib/vutuv_web/components/post_components.ex:1594
+#: lib/vutuv_web/components/post_components.ex:3525
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1404
-#: lib/vutuv_web/components/post_components.ex:4103
+#: lib/vutuv_web/components/post_components.ex:1431
+#: lib/vutuv_web/components/post_components.ex:4148
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:4385
 #: lib/vutuv_web/live/post_live/saved.ex:770
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
@@ -2509,7 +2509,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4393
+#: lib/vutuv_web/components/post_components.ex:4438
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2520,16 +2520,16 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1391
-#: lib/vutuv_web/components/post_components.ex:4376
-#: lib/vutuv_web/components/post_components.ex:4377
+#: lib/vutuv_web/components/post_components.ex:1418
+#: lib/vutuv_web/components/post_components.ex:4421
+#: lib/vutuv_web/components/post_components.ex:4422
 #: lib/vutuv_web/live/notification_live/index.ex:1000
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2439
+#: lib/vutuv_web/components/post_components.ex:2484
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2550,7 +2550,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1945
+#: lib/vutuv_web/components/post_components.ex:1990
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2558,14 +2558,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2415
+#: lib/vutuv_web/components/post_components.ex:2460
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2409
-#: lib/vutuv_web/components/post_components.ex:2431
-#: lib/vutuv_web/components/post_components.ex:2434
+#: lib/vutuv_web/components/post_components.ex:2454
+#: lib/vutuv_web/components/post_components.ex:2476
+#: lib/vutuv_web/components/post_components.ex:2479
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2867,7 +2867,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4034
+#: lib/vutuv_web/components/post_components.ex:4079
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3128,7 +3128,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2385
+#: lib/vutuv_web/components/post_components.ex:2430
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3179,7 +3179,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3399
 #: lib/vutuv_web/live/shell_live.ex:474
-#: lib/vutuv_web/live/shell_live.ex:699
+#: lib/vutuv_web/live/shell_live.ex:706
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3204,8 +3204,8 @@ msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:995
-#: lib/vutuv_web/components/post_components.ex:1798
-#: lib/vutuv_web/components/post_components.ex:2541
+#: lib/vutuv_web/components/post_components.ex:1832
+#: lib/vutuv_web/components/post_components.ex:2586
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:593
+#: lib/vutuv_web/live/shell_live.ex:600
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5352,7 +5352,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:654
+#: lib/vutuv_web/live/shell_live.ex:661
 #: lib/vutuv_web/templates/layout/app.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5371,7 +5371,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:108
 #: lib/vutuv_web/live/fediverse_following_live.ex:238
-#: lib/vutuv_web/live/shell_live.ex:634
+#: lib/vutuv_web/live/shell_live.ex:641
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
@@ -5423,7 +5423,7 @@ msgid "Previous post in the feed"
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:454
-#: lib/vutuv_web/live/shell_live.ex:683
+#: lib/vutuv_web/live/shell_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5433,9 +5433,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2604
-#: lib/vutuv_web/components/post_components.ex:2656
-#: lib/vutuv_web/components/post_components.ex:3046
+#: lib/vutuv_web/components/post_components.ex:2649
+#: lib/vutuv_web/components/post_components.ex:2701
+#: lib/vutuv_web/components/post_components.ex:3091
 #: lib/vutuv_web/live/notification_live/index.ex:680
 #: lib/vutuv_web/live/post_live/feed.ex:1255
 #: lib/vutuv_web/views/user_html.ex:111
@@ -6678,7 +6678,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2538
+#: lib/vutuv_web/components/post_components.ex:2583
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6688,7 +6688,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2537
+#: lib/vutuv_web/components/post_components.ex:2582
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7371,7 +7371,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4262
+#: lib/vutuv_web/components/post_components.ex:4307
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8846,7 +8846,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3483
+#: lib/vutuv_web/components/post_components.ex:3528
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9838,7 +9838,7 @@ msgid "First name"
 msgstr ""
 
 #: lib/vutuv_web/controllers/invitation_controller.ex:54
-#: lib/vutuv_web/live/shell_live.ex:625
+#: lib/vutuv_web/live/shell_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Invite a friend"
 msgstr ""
@@ -12054,7 +12054,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:497
-#: lib/vutuv_web/live/shell_live.ex:621
+#: lib/vutuv_web/live/shell_live.ex:628
 #: lib/vutuv_web/templates/layout/app.html.heex:83
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
@@ -13282,7 +13282,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1904
+#: lib/vutuv_web/components/post_components.ex:1949
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -13883,34 +13883,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3896
+#: lib/vutuv_web/components/post_components.ex:3941
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3853
+#: lib/vutuv_web/components/post_components.ex:3898
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3897
+#: lib/vutuv_web/components/post_components.ex:3942
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3899
+#: lib/vutuv_web/components/post_components.ex:3944
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3895
+#: lib/vutuv_web/components/post_components.ex:3940
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3852
+#: lib/vutuv_web/components/post_components.ex:3897
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13921,12 +13921,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3894
+#: lib/vutuv_web/components/post_components.ex:3939
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3898
+#: lib/vutuv_web/components/post_components.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13946,34 +13946,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3935
+#: lib/vutuv_web/components/post_components.ex:3980
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3965
+#: lib/vutuv_web/components/post_components.ex:4010
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3966
+#: lib/vutuv_web/components/post_components.ex:4011
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3964
+#: lib/vutuv_web/components/post_components.ex:4009
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3924
+#: lib/vutuv_web/components/post_components.ex:3969
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3971
+#: lib/vutuv_web/components/post_components.ex:4016
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14003,7 +14003,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3738
+#: lib/vutuv_web/components/post_components.ex:3783
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14051,7 +14051,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3729
+#: lib/vutuv_web/components/post_components.ex:3774
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14425,14 +14425,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2160
+#: lib/vutuv_web/components/post_components.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2182
+#: lib/vutuv_web/components/post_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14459,7 +14459,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4348
+#: lib/vutuv_web/components/post_components.ex:4393
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15631,21 +15631,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4307
+#: lib/vutuv_web/components/post_components.ex:4352
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4311
+#: lib/vutuv_web/components/post_components.ex:4356
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4315
+#: lib/vutuv_web/components/post_components.ex:4360
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15653,7 +15653,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:951
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4311
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15670,7 +15670,7 @@ msgid "Content warning"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1096
-#: lib/vutuv_web/components/post_components.ex:1509
+#: lib/vutuv_web/components/post_components.ex:1536
 #: lib/vutuv_web/live/fediverse_account_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "From another network"
@@ -15746,7 +15746,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1112
 #: lib/vutuv_web/components/post_components.ex:1027
-#: lib/vutuv_web/components/post_components.ex:1861
+#: lib/vutuv_web/components/post_components.ex:1895
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15759,6 +15759,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:167
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:118
+#: lib/vutuv_web/live/fediverse_post_live.ex:99
 #: lib/vutuv_web/live/post_live/feed.ex:426
 #: lib/vutuv_web/live/post_live/thread.ex:265
 #: lib/vutuv_web/live/tag_live/timeline.ex:138
@@ -16406,22 +16407,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2397
+#: lib/vutuv_web/components/post_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2504
+#: lib/vutuv_web/components/post_components.ex:2549
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2512
+#: lib/vutuv_web/components/post_components.ex:2557
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2498
+#: lib/vutuv_web/components/post_components.ex:2543
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16507,7 +16508,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1040
 #: lib/vutuv_web/agent_docs/text.ex:654
-#: lib/vutuv_web/components/post_components.ex:2969
+#: lib/vutuv_web/components/post_components.ex:3014
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16537,7 +16538,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2968
+#: lib/vutuv_web/components/post_components.ex:3013
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16547,29 +16548,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3347
+#: lib/vutuv_web/components/post_components.ex:3392
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1957
+#: lib/vutuv_web/components/post_components.ex:2002
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3350
+#: lib/vutuv_web/components/post_components.ex:3395
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3175
+#: lib/vutuv_web/components/post_components.ex:3220
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2713
+#: lib/vutuv_web/components/post_components.ex:2758
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16582,12 +16583,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1073
 #: lib/vutuv_web/agent_docs/text.ex:641
-#: lib/vutuv_web/components/post_components.ex:3384
+#: lib/vutuv_web/components/post_components.ex:3429
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2967
+#: lib/vutuv_web/components/post_components.ex:3012
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
@@ -16608,7 +16609,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2010
+#: lib/vutuv_web/components/post_components.ex:2055
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16628,7 +16629,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2001
+#: lib/vutuv_web/components/post_components.ex:2046
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16638,12 +16639,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2019
+#: lib/vutuv_web/components/post_components.ex:2064
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1953
+#: lib/vutuv_web/components/post_components.ex:1998
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16658,7 +16659,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2014
+#: lib/vutuv_web/components/post_components.ex:2059
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16668,7 +16669,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1967
+#: lib/vutuv_web/components/post_components.ex:2012
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16755,13 +16756,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:969
-#: lib/vutuv_web/components/post_components.ex:4304
+#: lib/vutuv_web/components/post_components.ex:4349
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:967
-#: lib/vutuv_web/components/post_components.ex:4301
+#: lib/vutuv_web/components/post_components.ex:4346
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16771,7 +16772,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4193
+#: lib/vutuv_web/components/post_components.ex:4238
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -17108,20 +17109,21 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1807
+#: lib/vutuv_web/components/post_components.ex:1841
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:159
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:110
+#: lib/vutuv_web/live/fediverse_post_live.ex:91
 #: lib/vutuv_web/live/post_live/feed.ex:418
 #: lib/vutuv_web/live/tag_live/timeline.ex:130
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1860
+#: lib/vutuv_web/components/post_components.ex:1894
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -17141,22 +17143,23 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1254
+#: lib/vutuv_web/components/post_components.ex:1281
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:1858
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1786
+#: lib/vutuv_web/components/post_components.ex:1820
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:221
+#: lib/vutuv_web/live/fediverse_post_live.ex:112
 #: lib/vutuv_web/live/post_live/feed.ex:448
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -17167,7 +17170,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1793
+#: lib/vutuv_web/components/post_components.ex:1827
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17389,27 +17392,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1612
+#: lib/vutuv_web/components/post_components.ex:1639
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1641
+#: lib/vutuv_web/components/post_components.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1636
+#: lib/vutuv_web/components/post_components.ex:1663
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1886
+#: lib/vutuv_web/components/post_components.ex:1931
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1892
+#: lib/vutuv_web/components/post_components.ex:1937
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17419,7 +17422,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2005
+#: lib/vutuv_web/components/post_components.ex:2050
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18200,7 +18203,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1889
+#: lib/vutuv_web/components/post_components.ex:1934
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18226,3 +18229,23 @@ msgid "%{formatted} member"
 msgid_plural "%{formatted} members"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/vutuv_web/live/fediverse_post_live.ex:70
+#, elixir-autogen, elixir-format
+msgid "A post by %{name} (another network)"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_post_live.ex:121
+#, elixir-autogen, elixir-format
+msgid "A post from another network"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_post_live.ex:144
+#, elixir-autogen, elixir-format
+msgid "More from %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_post_live.ex:127
+#, elixir-autogen, elixir-format
+msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2520
+#: lib/vutuv_web/components/post_components.ex:2565
 #: lib/vutuv_web/components/ui.ex:3140
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2485
+#: lib/vutuv_web/components/post_components.ex:2530
 #: lib/vutuv_web/components/ui.ex:3131
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -453,8 +453,8 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:672
-#: lib/vutuv_web/live/shell_live.ex:709
+#: lib/vutuv_web/live/shell_live.ex:679
+#: lib/vutuv_web/live/shell_live.ex:716
 #: lib/vutuv_web/templates/post/teaser.html.heex:34
 #: lib/vutuv_web/templates/session/new.html.heex:38
 #, elixir-autogen
@@ -650,8 +650,8 @@ msgstr ""
 #: lib/vutuv_web/live/job_board_live.ex:418
 #: lib/vutuv_web/live/search_live.ex:37
 #: lib/vutuv_web/live/search_live.ex:378
-#: lib/vutuv_web/live/shell_live.ex:536
-#: lib/vutuv_web/live/shell_live.ex:692
+#: lib/vutuv_web/live/shell_live.ex:543
+#: lib/vutuv_web/live/shell_live.ex:699
 #: lib/vutuv_web/live/tag_live/timeline.ex:278
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
@@ -661,7 +661,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1251
+#: lib/vutuv_web/components/post_components.ex:1278
 #: lib/vutuv_web/templates/admin/report/index.html.heex:45
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:6
 #: lib/vutuv_web/templates/tag/show.html.heex:23
@@ -1207,7 +1207,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
-#: lib/vutuv_web/live/shell_live.ex:644
+#: lib/vutuv_web/live/shell_live.ex:651
 #: lib/vutuv_web/templates/admin/account/frozen.html.heex:3
 #: lib/vutuv_web/templates/admin/account/index.html.heex:3
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:4
@@ -1643,7 +1643,7 @@ msgstr ""
 msgid "Admin control panel"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:695
+#: lib/vutuv_web/live/shell_live.ex:702
 #, elixir-autogen, elixir-format
 msgid "Alerts"
 msgstr ""
@@ -1662,7 +1662,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2966
+#: lib/vutuv_web/components/post_components.ex:3011
 #: lib/vutuv_web/components/ui.ex:244
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -1753,7 +1753,7 @@ msgstr ""
 msgid "It doesn't look like you're following anyone yet. Open the profile of someone you know or find interesting and click the follow button!"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:663
+#: lib/vutuv_web/live/shell_live.ex:670
 #: lib/vutuv_web/views/settings_html.ex:229
 #, elixir-autogen, elixir-format
 msgid "Log out"
@@ -1781,8 +1781,8 @@ msgstr ""
 
 #: lib/vutuv_web/live/message_live/index.ex:45
 #: lib/vutuv_web/live/message_live/index.ex:512
-#: lib/vutuv_web/live/shell_live.ex:552
-#: lib/vutuv_web/live/shell_live.ex:694
+#: lib/vutuv_web/live/shell_live.ex:559
+#: lib/vutuv_web/live/shell_live.ex:701
 #: lib/vutuv_web/templates/layout/app.html.heex:123
 #, elixir-autogen, elixir-format
 msgid "Messages"
@@ -1809,7 +1809,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3466
 #: lib/vutuv_web/live/notification_live/index.ex:105
 #: lib/vutuv_web/live/notification_live/index.ex:329
-#: lib/vutuv_web/live/shell_live.ex:563
+#: lib/vutuv_web/live/shell_live.ex:570
 #: lib/vutuv_web/templates/layout/app.html.heex:124
 #: lib/vutuv_web/templates/settings/notifications.html.heex:8
 #, elixir-autogen, elixir-format
@@ -2142,7 +2142,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2517
+#: lib/vutuv_web/components/post_components.ex:2562
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2157,7 +2157,7 @@ msgstr ""
 #: lib/vutuv_web/live/post_live/feed.ex:154
 #: lib/vutuv_web/live/post_live/feed.ex:948
 #: lib/vutuv_web/live/shell_live.ex:461
-#: lib/vutuv_web/live/shell_live.ex:690
+#: lib/vutuv_web/live/shell_live.ex:697
 #: lib/vutuv_web/templates/layout/app.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Feed"
@@ -2183,8 +2183,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2471
-#: lib/vutuv_web/components/post_components.ex:2473
+#: lib/vutuv_web/components/post_components.ex:2516
+#: lib/vutuv_web/components/post_components.ex:2518
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2249,13 +2249,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2902
-#: lib/vutuv_web/components/post_components.ex:2906
+#: lib/vutuv_web/components/post_components.ex:2947
+#: lib/vutuv_web/components/post_components.ex:2951
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2903
+#: lib/vutuv_web/components/post_components.ex:2948
 #: lib/vutuv_web/live/fediverse_account_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2326,7 +2326,7 @@ msgid "Upload failed."
 msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3718
-#: lib/vutuv_web/live/shell_live.ex:606
+#: lib/vutuv_web/live/shell_live.ex:613
 #: lib/vutuv_web/templates/post/index.html.heex:13
 #: lib/vutuv_web/templates/post/teaser.html.heex:55
 #: lib/vutuv_web/views/settings_html.ex:176
@@ -2344,27 +2344,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2468
+#: lib/vutuv_web/components/post_components.ex:2513
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4033
+#: lib/vutuv_web/components/post_components.ex:4078
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4037
+#: lib/vutuv_web/components/post_components.ex:4082
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4035
+#: lib/vutuv_web/components/post_components.ex:4080
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4036
+#: lib/vutuv_web/components/post_components.ex:4081
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2405,8 +2405,8 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1415
-#: lib/vutuv_web/components/post_components.ex:4117
+#: lib/vutuv_web/components/post_components.ex:1442
+#: lib/vutuv_web/components/post_components.ex:4162
 #: lib/vutuv_web/components/ui.ex:2665
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
@@ -2416,15 +2416,15 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:933
 #: lib/vutuv_web/live/post_live/saved.ex:171
 #: lib/vutuv_web/live/post_live/saved.ex:484
-#: lib/vutuv_web/live/shell_live.ex:545
-#: lib/vutuv_web/live/shell_live.ex:611
+#: lib/vutuv_web/live/shell_live.ex:552
+#: lib/vutuv_web/live/shell_live.ex:618
 #: lib/vutuv_web/views/admin/report_html.ex:38
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1381
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:1408
+#: lib/vutuv_web/components/post_components.ex:4385
 #: lib/vutuv_web/components/ui.ex:2651
 #: lib/vutuv_web/live/notification_live/index.ex:1003
 #: lib/vutuv_web/templates/user/show.html.heex:192
@@ -2433,11 +2433,11 @@ msgid "Like"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:932
-#: lib/vutuv_web/components/post_components.ex:4349
+#: lib/vutuv_web/components/post_components.ex:4394
 #: lib/vutuv_web/live/notification_live/index.ex:940
 #: lib/vutuv_web/live/post_live/saved.ex:170
 #: lib/vutuv_web/live/post_live/saved.ex:481
-#: lib/vutuv_web/live/shell_live.ex:614
+#: lib/vutuv_web/live/shell_live.ex:621
 #: lib/vutuv_web/views/admin/report_html.ex:37
 #, elixir-autogen, elixir-format
 msgid "Likes"
@@ -2453,39 +2453,39 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4106
+#: lib/vutuv_web/components/post_components.ex:4151
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1415
-#: lib/vutuv_web/components/post_components.ex:4117
+#: lib/vutuv_web/components/post_components.ex:1442
+#: lib/vutuv_web/components/post_components.ex:4162
 #: lib/vutuv_web/live/post_live/saved.ex:771
 #: lib/vutuv_web/templates/user/show.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1404
-#: lib/vutuv_web/components/post_components.ex:4103
+#: lib/vutuv_web/components/post_components.ex:1431
+#: lib/vutuv_web/components/post_components.ex:4148
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1567
-#: lib/vutuv_web/components/post_components.ex:3480
+#: lib/vutuv_web/components/post_components.ex:1594
+#: lib/vutuv_web/components/post_components.ex:3525
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1404
-#: lib/vutuv_web/components/post_components.ex:4103
+#: lib/vutuv_web/components/post_components.ex:1431
+#: lib/vutuv_web/components/post_components.ex:4148
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4340
+#: lib/vutuv_web/components/post_components.ex:4385
 #: lib/vutuv_web/live/post_live/saved.ex:770
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4393
+#: lib/vutuv_web/components/post_components.ex:4438
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2518,16 +2518,16 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1391
-#: lib/vutuv_web/components/post_components.ex:4376
-#: lib/vutuv_web/components/post_components.ex:4377
+#: lib/vutuv_web/components/post_components.ex:1418
+#: lib/vutuv_web/components/post_components.ex:4421
+#: lib/vutuv_web/components/post_components.ex:4422
 #: lib/vutuv_web/live/notification_live/index.ex:1000
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2439
+#: lib/vutuv_web/components/post_components.ex:2484
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2548,7 +2548,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1945
+#: lib/vutuv_web/components/post_components.ex:1990
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2556,14 +2556,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2415
+#: lib/vutuv_web/components/post_components.ex:2460
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2409
-#: lib/vutuv_web/components/post_components.ex:2431
-#: lib/vutuv_web/components/post_components.ex:2434
+#: lib/vutuv_web/components/post_components.ex:2454
+#: lib/vutuv_web/components/post_components.ex:2476
+#: lib/vutuv_web/components/post_components.ex:2479
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2865,7 +2865,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4034
+#: lib/vutuv_web/components/post_components.ex:4079
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -3126,7 +3126,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2385
+#: lib/vutuv_web/components/post_components.ex:2430
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3177,7 +3177,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:3399
 #: lib/vutuv_web/live/shell_live.ex:474
-#: lib/vutuv_web/live/shell_live.ex:699
+#: lib/vutuv_web/live/shell_live.ex:706
 #: lib/vutuv_web/templates/import/new.html.heex:15
 #: lib/vutuv_web/templates/import/preview.html.heex:55
 #: lib/vutuv_web/views/admin/moderation_html.ex:28
@@ -3202,8 +3202,8 @@ msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:995
-#: lib/vutuv_web/components/post_components.ex:1798
-#: lib/vutuv_web/components/post_components.ex:2541
+#: lib/vutuv_web/components/post_components.ex:1832
+#: lib/vutuv_web/components/post_components.ex:2586
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:194
 #, elixir-autogen, elixir-format
@@ -5328,7 +5328,7 @@ msgstr ""
 msgid "Content under review"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:593
+#: lib/vutuv_web/live/shell_live.ex:600
 #, elixir-autogen, elixir-format
 msgid "Account menu"
 msgstr ""
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/vutuv_web/live/shell_live.ex:654
+#: lib/vutuv_web/live/shell_live.ex:661
 #: lib/vutuv_web/templates/layout/app.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
@@ -5369,7 +5369,7 @@ msgstr ""
 #: lib/vutuv_web/live/account_activity_live.ex:115
 #: lib/vutuv_web/live/fediverse_followers_live.ex:108
 #: lib/vutuv_web/live/fediverse_following_live.ex:238
-#: lib/vutuv_web/live/shell_live.ex:634
+#: lib/vutuv_web/live/shell_live.ex:641
 #: lib/vutuv_web/templates/email/confirm.html.heex:7
 #: lib/vutuv_web/templates/export/index.html.heex:11
 #: lib/vutuv_web/templates/login_code/index.html.heex:4
@@ -5421,7 +5421,7 @@ msgid "Previous post in the feed"
 msgstr ""
 
 #: lib/vutuv_web/live/shell_live.ex:454
-#: lib/vutuv_web/live/shell_live.ex:683
+#: lib/vutuv_web/live/shell_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
@@ -5431,9 +5431,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2604
-#: lib/vutuv_web/components/post_components.ex:2656
-#: lib/vutuv_web/components/post_components.ex:3046
+#: lib/vutuv_web/components/post_components.ex:2649
+#: lib/vutuv_web/components/post_components.ex:2701
+#: lib/vutuv_web/components/post_components.ex:3091
 #: lib/vutuv_web/live/notification_live/index.ex:680
 #: lib/vutuv_web/live/post_live/feed.ex:1255
 #: lib/vutuv_web/views/user_html.ex:111
@@ -6676,7 +6676,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2538
+#: lib/vutuv_web/components/post_components.ex:2583
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6686,7 +6686,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2537
+#: lib/vutuv_web/components/post_components.ex:2582
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -7369,7 +7369,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4262
+#: lib/vutuv_web/components/post_components.ex:4307
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -8844,7 +8844,7 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3483
+#: lib/vutuv_web/components/post_components.ex:3528
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
@@ -9836,7 +9836,7 @@ msgid "First name"
 msgstr ""
 
 #: lib/vutuv_web/controllers/invitation_controller.ex:54
-#: lib/vutuv_web/live/shell_live.ex:625
+#: lib/vutuv_web/live/shell_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Invite a friend"
 msgstr ""
@@ -12052,7 +12052,7 @@ msgstr ""
 #: lib/vutuv_web/live/organization_live/index.ex:30
 #: lib/vutuv_web/live/organization_live/index.ex:61
 #: lib/vutuv_web/live/post_live/saved.ex:497
-#: lib/vutuv_web/live/shell_live.ex:621
+#: lib/vutuv_web/live/shell_live.ex:628
 #: lib/vutuv_web/templates/layout/app.html.heex:83
 #: lib/vutuv_web/templates/settings/organizations.html.heex:6
 #, elixir-autogen, elixir-format
@@ -13280,7 +13280,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1904
+#: lib/vutuv_web/components/post_components.ex:1949
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:528
 #: lib/vutuv_web/controllers/settings_controller.ex:546
@@ -13881,34 +13881,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3896
+#: lib/vutuv_web/components/post_components.ex:3941
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3853
+#: lib/vutuv_web/components/post_components.ex:3898
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3897
+#: lib/vutuv_web/components/post_components.ex:3942
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3899
+#: lib/vutuv_web/components/post_components.ex:3944
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3895
+#: lib/vutuv_web/components/post_components.ex:3940
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:979
-#: lib/vutuv_web/components/post_components.ex:3852
+#: lib/vutuv_web/components/post_components.ex:3897
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13919,12 +13919,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3894
+#: lib/vutuv_web/components/post_components.ex:3939
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3898
+#: lib/vutuv_web/components/post_components.ex:3943
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13944,34 +13944,34 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3935
+#: lib/vutuv_web/components/post_components.ex:3980
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
 msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3965
+#: lib/vutuv_web/components/post_components.ex:4010
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3966
+#: lib/vutuv_web/components/post_components.ex:4011
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3964
+#: lib/vutuv_web/components/post_components.ex:4009
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3924
+#: lib/vutuv_web/components/post_components.ex:3969
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3971
+#: lib/vutuv_web/components/post_components.ex:4016
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -14001,7 +14001,7 @@ msgstr ""
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3738
+#: lib/vutuv_web/components/post_components.ex:3783
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -14049,7 +14049,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3729
+#: lib/vutuv_web/components/post_components.ex:3774
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -14423,14 +14423,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2160
+#: lib/vutuv_web/components/post_components.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2182
+#: lib/vutuv_web/components/post_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14457,7 +14457,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4348
+#: lib/vutuv_web/components/post_components.ex:4393
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -15629,21 +15629,21 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4307
+#: lib/vutuv_web/components/post_components.ex:4352
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4311
+#: lib/vutuv_web/components/post_components.ex:4356
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4315
+#: lib/vutuv_web/components/post_components.ex:4360
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
@@ -15651,7 +15651,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:951
-#: lib/vutuv_web/components/post_components.ex:4266
+#: lib/vutuv_web/components/post_components.ex:4311
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15668,7 +15668,7 @@ msgid "Content warning"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1096
-#: lib/vutuv_web/components/post_components.ex:1509
+#: lib/vutuv_web/components/post_components.ex:1536
 #: lib/vutuv_web/live/fediverse_account_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "From another network"
@@ -15744,7 +15744,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1112
 #: lib/vutuv_web/components/post_components.ex:1027
-#: lib/vutuv_web/components/post_components.ex:1861
+#: lib/vutuv_web/components/post_components.ex:1895
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -15757,6 +15757,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:167
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:118
+#: lib/vutuv_web/live/fediverse_post_live.ex:99
 #: lib/vutuv_web/live/post_live/feed.ex:426
 #: lib/vutuv_web/live/post_live/thread.ex:265
 #: lib/vutuv_web/live/tag_live/timeline.ex:138
@@ -16404,22 +16405,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2397
+#: lib/vutuv_web/components/post_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2504
+#: lib/vutuv_web/components/post_components.ex:2549
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2512
+#: lib/vutuv_web/components/post_components.ex:2557
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2498
+#: lib/vutuv_web/components/post_components.ex:2543
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16505,7 +16506,7 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1040
 #: lib/vutuv_web/agent_docs/text.ex:654
-#: lib/vutuv_web/components/post_components.ex:2969
+#: lib/vutuv_web/components/post_components.ex:3014
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16535,7 +16536,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2968
+#: lib/vutuv_web/components/post_components.ex:3013
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16545,29 +16546,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3347
+#: lib/vutuv_web/components/post_components.ex:3392
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1957
+#: lib/vutuv_web/components/post_components.ex:2002
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3350
+#: lib/vutuv_web/components/post_components.ex:3395
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3175
+#: lib/vutuv_web/components/post_components.ex:3220
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2713
+#: lib/vutuv_web/components/post_components.ex:2758
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16580,12 +16581,12 @@ msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:1073
 #: lib/vutuv_web/agent_docs/text.ex:641
-#: lib/vutuv_web/components/post_components.ex:3384
+#: lib/vutuv_web/components/post_components.ex:3429
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2967
+#: lib/vutuv_web/components/post_components.ex:3012
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
@@ -16606,7 +16607,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2010
+#: lib/vutuv_web/components/post_components.ex:2055
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16626,7 +16627,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2001
+#: lib/vutuv_web/components/post_components.ex:2046
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16636,12 +16637,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2019
+#: lib/vutuv_web/components/post_components.ex:2064
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1953
+#: lib/vutuv_web/components/post_components.ex:1998
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16656,7 +16657,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2014
+#: lib/vutuv_web/components/post_components.ex:2059
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16666,7 +16667,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1967
+#: lib/vutuv_web/components/post_components.ex:2012
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16753,13 +16754,13 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:969
-#: lib/vutuv_web/components/post_components.ex:4304
+#: lib/vutuv_web/components/post_components.ex:4349
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:967
-#: lib/vutuv_web/components/post_components.ex:4301
+#: lib/vutuv_web/components/post_components.ex:4346
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16769,7 +16770,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4193
+#: lib/vutuv_web/components/post_components.ex:4238
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -17106,20 +17107,21 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1807
+#: lib/vutuv_web/components/post_components.ex:1841
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:159
 #: lib/vutuv_web/live/fediverse_lookup_live.ex:110
+#: lib/vutuv_web/live/fediverse_post_live.ex:91
 #: lib/vutuv_web/live/post_live/feed.ex:418
 #: lib/vutuv_web/live/tag_live/timeline.ex:130
 #, elixir-autogen, elixir-format
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1860
+#: lib/vutuv_web/components/post_components.ex:1894
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -17139,22 +17141,23 @@ msgstr ""
 msgid "Content from other networks taken down by members"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1254
+#: lib/vutuv_web/components/post_components.ex:1281
 #, elixir-autogen, elixir-format
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1824
+#: lib/vutuv_web/components/post_components.ex:1858
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1786
+#: lib/vutuv_web/components/post_components.ex:1820
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mute %{handle}"
 msgstr ""
 
 #: lib/vutuv_web/live/fediverse_account_live.ex:221
+#: lib/vutuv_web/live/fediverse_post_live.ex:112
 #: lib/vutuv_web/live/post_live/feed.ex:448
 #, elixir-autogen, elixir-format
 msgid "Muted. You still follow them; their posts leave your feed."
@@ -17165,7 +17168,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1793
+#: lib/vutuv_web/components/post_components.ex:1827
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17387,27 +17390,27 @@ msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1612
+#: lib/vutuv_web/components/post_components.ex:1639
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1641
+#: lib/vutuv_web/components/post_components.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1636
+#: lib/vutuv_web/components/post_components.ex:1663
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1886
+#: lib/vutuv_web/components/post_components.ex:1931
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1892
+#: lib/vutuv_web/components/post_components.ex:1937
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17417,7 +17420,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2005
+#: lib/vutuv_web/components/post_components.ex:2050
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18198,7 +18201,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1889
+#: lib/vutuv_web/components/post_components.ex:1934
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18224,3 +18227,23 @@ msgid "%{formatted} member"
 msgid_plural "%{formatted} members"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/vutuv_web/live/fediverse_post_live.ex:70
+#, elixir-autogen, elixir-format
+msgid "A post by %{name} (another network)"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_post_live.ex:121
+#, elixir-autogen, elixir-format
+msgid "A post from another network"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_post_live.ex:144
+#, elixir-autogen, elixir-format
+msgid "More from %{name}"
+msgstr ""
+
+#: lib/vutuv_web/live/fediverse_post_live.ex:127
+#, elixir-autogen, elixir-format
+msgid "This is vutuv's copy of a post published on %{host}. It is kept while somebody here follows its author."
+msgstr ""

--- a/test/vutuv/fediverse_handle_test.exs
+++ b/test/vutuv/fediverse_handle_test.exs
@@ -45,6 +45,21 @@ defmodule Vutuv.FediverseHandleTest do
     end
   end
 
+  describe "short/1" do
+    test "drops the server, which the card's globe chip already names" do
+      assert Handle.short("@tagesschau@ard.social") == "@tagesschau"
+      assert Handle.short("@alice@social.example") == "@alice"
+    end
+
+    test "leaves a handle that is only a server alone" do
+      # `display/2`'s last fallback: no username anywhere, so the host IS the
+      # name and there is nothing to cut.
+      assert Handle.short("@social.example") == "@social.example"
+      assert Handle.short("@alice") == "@alice"
+      assert Handle.short(nil) == nil
+    end
+  end
+
   describe "host/1" do
     test "is the URI's host, or nil" do
       assert Handle.host("https://social.example/users/alice") == "social.example"

--- a/test/vutuv_web/live/fediverse_post_live_test.exs
+++ b/test/vutuv_web/live/fediverse_post_live_test.exs
@@ -1,0 +1,171 @@
+defmodule VutuvWeb.FediversePostLiveTest do
+  @moduledoc """
+  The page for vutuv's copy of one post from another network
+  (`/system/fediverse/post/:id`): who may open it, that the card's stamp leads
+  here, and that the handle beside it no longer repeats the server the chip
+  already names.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Fediverse.Follow
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+
+  @actor "https://ard.social/users/tagesschau"
+
+  defp account do
+    Repo.insert!(%RemoteAccount{
+      actor_uri: @actor,
+      host: "ard.social",
+      handle: "tagesschau",
+      name: "tagesschau",
+      inbox_uri: @actor <> "/inbox"
+    })
+  end
+
+  defp follow(user, account, state \\ "accepted") do
+    Repo.insert!(%Follow{
+      user_id: user.id,
+      remote_account_id: account.id,
+      state: state,
+      follow_activity_id: "https://vutuv.test/#{user.id}/actor#follows/#{account.id}"
+    })
+  end
+
+  defp cached_post(account, attrs \\ %{}) do
+    now = DateTime.utc_now(:second)
+
+    Repo.insert!(
+      struct(
+        %RemotePost{
+          remote_account_id: account.id,
+          object_uri: "https://ard.social/posts/#{System.unique_integer([:positive])}",
+          content_text: "Die Nachrichten von heute.",
+          audience: "public",
+          kind: "note",
+          published_at: now,
+          received_at: now,
+          expires_at: DateTime.add(now, 86_400)
+        },
+        attrs
+      )
+    )
+  end
+
+  test "an anonymous visitor is sent to the login", %{conn: conn} do
+    post = cached_post(account())
+
+    conn = get(conn, ~p"/system/fediverse/post/#{post.id}")
+    assert redirected_to(conn) == ~p"/login"
+  end
+
+  test "robots are told not to index it", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+    post = cached_post(account())
+
+    conn = get(conn, ~p"/system/fediverse/post/#{post.id}")
+
+    # Somebody else's words on somebody else's server: our copy is a members'
+    # page, not something this installation publishes.
+    assert [robots] = Plug.Conn.get_resp_header(conn, "x-robots-tag")
+    assert robots =~ "noindex"
+  end
+
+  test "an unknown id lands on the feed instead of crashing", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+
+    assert {:error, {:redirect, %{to: "/feed"}}} =
+             live(conn, ~p"/system/fediverse/post/019fa2ba-b301-771a-8bbf-efd42278fd8a")
+  end
+
+  test "it shows the post, the network it came from and the way to the account",
+       %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+    acc = account()
+    post = cached_post(acc)
+
+    {:ok, view, html} = live(conn, ~p"/system/fediverse/post/#{post.id}")
+
+    assert html =~ "Die Nachrichten von heute."
+    assert html =~ "ard.social"
+    assert has_element?(view, ~s{a[href="/system/fediverse/account/#{acc.id}"]})
+    # The address that does not expire, since our copy can be swept away.
+    assert has_element?(view, ~s{[data-remote-origin][href="#{post.object_uri}"]})
+  end
+
+  test "a followers-only post opens for an accepted follower and 404s for anyone else",
+       %{conn: conn} do
+    acc = account()
+    post = cached_post(acc, %{audience: "followers"})
+
+    {follower_conn, follower} = create_and_login_user(conn)
+    follow(follower, acc)
+
+    assert {:ok, _view, html} = live(follower_conn, ~p"/system/fediverse/post/#{post.id}")
+    assert html =~ "Die Nachrichten von heute."
+
+    {stranger_conn, stranger} =
+      create_and_login_user(Plug.Test.init_test_session(build_conn(), %{}))
+
+    # A request nobody answered is not a relationship.
+    follow(stranger, acc, "requested")
+
+    assert {:error, {:redirect, %{to: "/feed"}}} =
+             live(stranger_conn, ~p"/system/fediverse/post/#{post.id}")
+  end
+
+  test "it reads properly in German", %{conn: conn} do
+    {conn, _user} = create_and_login_user(conn)
+    post = cached_post(account())
+    conn = conn |> recycle() |> put_req_header("accept-language", "de-DE,de;q=0.9")
+
+    {:ok, _view, html} = live(conn, ~p"/system/fediverse/post/#{post.id}")
+
+    # Named by hand, because `gettext.extract --merge` fuzzy-filled this page's
+    # heading with "Reaktion aus einem anderen Netzwerk" — a reaction, which is
+    # a different thing entirely, and nothing fails a build over it.
+    assert html =~ "Ein Beitrag aus einem anderen Netzwerk"
+    assert html =~ "Das ist die Kopie, die vutuv"
+    assert html =~ "Mehr von tagesschau"
+  end
+
+  describe "the card header" do
+    test "the stamp links here and the handle drops the server the chip names",
+         %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      acc = account()
+      follow(user, acc)
+      post = cached_post(acc)
+
+      {:ok, view, html} = live(conn, ~p"/feed")
+
+      # The stamp is the way to our copy's own page, exactly as on a member's
+      # post.
+      assert has_element?(
+               view,
+               ~s{a[data-remote-permalink][href="/system/fediverse/post/#{post.id}"]}
+             )
+
+      # Shortened, because the globe chip at the end of the same row already
+      # says "ard.social" — with the full address one hover away.
+      assert has_element?(view, ~s{a[title="@tagesschau@ard.social"]})
+      refute html =~ ">@tagesschau@ard.social<"
+    end
+
+    test "an anonymous reader keeps a plain stamp rather than a link into a login wall" do
+      acc = account()
+      post = cached_post(acc)
+
+      html =
+        render_component(&VutuvWeb.PostComponents.remote_post_card/1,
+          remote_post: %{post | remote_account: acc},
+          viewer: nil
+        )
+
+      refute html =~ "data-remote-permalink"
+      assert html =~ "@tagesschau"
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** A fediverse card's handle drops the server the globe chip already names, and its timestamp now leads to `/system/fediverse/post/:id` — vutuv's own page for the cached copy.

Both reported from the tagesschau card in the feed.

### The handle said the server twice

`@tagesschau@ard.social` sat right next to a chip reading `ard.social`, so a third of the header row was one fact stated twice and the timestamp was pushed to the end. It reads `@tagesschau` now (`Vutuv.Fediverse.Handle.short/1`), with the full address as the link's `title` — one hover away, and still spelled out in full on the account page, which is where somebody copies it from. A handle we could only derive as a bare host has nothing to cut and is returned unchanged.

### The timestamp was plain text

On a member's post the stamp is the way to the post's own page. On a cached remote post it led nowhere, so the one card in the timeline nobody could open, link, or come back to was the one from somewhere else. It now opens **`/system/fediverse/post/:id`** (`VutuvWeb.FediversePostLive`): the same card the feed draws, alone, with its action bar and a way on to the account.

That page is our **copy**, not a republication, and is shaped by it:

- **Signed-in only and `noindex`**, like the account page and the lookup box beside it — so no agent-format siblings either, and the stamp is rendered as a link **only when the card has a viewer**. An anonymous reader of a public tag timeline keeps the plain stamp rather than a link into a login wall.
- **Readable, not merely present**: the gate is the shared `Fediverse.remote_post_readable?/2`, so a followers-only post opens for a member whose own follow was accepted and 404s for everyone else.
- **Nothing is fetched on view** — it renders the row we already hold, or it does not exist. A reported copy is deleted at once and the reader goes back to the feed.

### Notes

- German for the new page was written by hand: `gettext.extract --merge` fuzzy-filled "A post from another network" with *"Reaktion aus einem anderen Netzwerk"* (a reaction, a different thing). A German-render test now names the strings.
- `mix precommit` green: 6443 tests.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01N6e43RiXnsJjvwJjPJnKfy