### PR TITLE
On a phone, a post from another network wears its server beside the name (v7.215.1)

### DIFF
--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -1133,15 +1133,45 @@ defmodule VutuvWeb.PostComponents do
   # most likely to need it.
   #
   # The handle is shown **without its server** (`Handle.short/1`): the globe chip
-  # at the end of this very row already names the server, so `@tagesschau@ard.social`
+  # in this very row already names the server, so `@tagesschau@ard.social`
   # said it twice and ate the width the stamp needed. The full address stays as
   # the link's `title`, which is also what a member wants to read before they
   # paste it somewhere.
+  #
+  # Three things wrap in that row — the name, the server chip and the muted
+  # `@handle · stamp` line — and on a phone they do not all fit. So the order is
+  # **name, chip, meta**, and the row has a `gap-y`. Both are load-bearing.
+  # Trailing the row, the chip was the item a narrow column pushed out first: it
+  # landed alone on a third line under the handle, touching it, because `gap-x-2`
+  # sets no vertical gap at all. Beside the name it shares the first line (a
+  # display name and a hostname are both short, where the handle *plus* the
+  # stamp are not), so the phone reads as two lines — who and where, then the
+  # address and the time — and a desktop still puts all three on one. Keep the
+  # chip next to the name; `feed_remote_posts_test.exs` fails the build if it
+  # drifts back to the end of the row or the row loses its `gap-y`.
   defp remote_header(assigns) do
     ~H"""
     <div class="flex items-start gap-2">
-      <div class="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2">
-        <span class="break-words font-semibold text-slate-900 dark:text-white">{@author}</span>
+      <div
+        data-remote-header
+        class="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2 gap-y-1"
+      >
+        <span data-remote-author class="break-words font-semibold text-slate-900 dark:text-white">
+          {@author}
+        </span>
+        <%!-- Where this came from, up here where the eye lands, not only in the
+        footer under the text. A reply card can leave it to the footer because
+        it is visibly indented under a member's post; in a flat feed that
+        context is gone, and a reader must not have to finish the post before
+        learning it is not a member's. --%>
+        <span
+          :if={@network}
+          data-remote-network={@network}
+          class="inline-flex max-w-full items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+        >
+          <span aria-hidden="true">🌐</span>
+          <span class="truncate">{@network}</span>
+        </span>
         <span class="min-w-0 text-xs text-slate-600 dark:text-slate-400">
           <.link
             {remote_actor_destination(@account_id, @actor_uri)}
@@ -1164,19 +1194,6 @@ defmodule VutuvWeb.PostComponents do
             <.post_time at={@at} />
           </.link>
           <.post_time :if={!@permalink} at={@at} />
-        </span>
-        <%!-- Where this came from, up here where the eye lands, not only in the
-        footer under the text. A reply card can leave it to the footer because
-        it is visibly indented under a member's post; in a flat feed that
-        context is gone, and a reader must not have to finish the post before
-        learning it is not a member's. --%>
-        <span
-          :if={@network}
-          data-remote-network={@network}
-          class="inline-flex max-w-full items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
-        >
-          <span aria-hidden="true">🌐</span>
-          <span class="truncate">{@network}</span>
         </span>
       </div>
       {render_slot(@menu)}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.215.0",
+      version: "7.215.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/feed_remote_posts_test.exs
+++ b/test/vutuv_web/live/feed_remote_posts_test.exs
@@ -297,6 +297,26 @@ defmodule VutuvWeb.FeedRemotePostsTest do
     assert has_element?(view, "[data-remote-network='social.example']")
   end
 
+  test "the header wraps on a phone as name + chip over the meta line", %{conn: conn} do
+    {conn, user} = create_and_login_user(conn)
+    cached_post(user)
+
+    {:ok, view, _html} = live(conn, ~p"/feed")
+
+    # The chip is the NAME's neighbour, not the row's last item. Trailing the
+    # whole header it was the first thing a narrow column pushed onto a line of
+    # its own, under the handle and the stamp — a stray pill hanging below the
+    # header with nothing beside it. Bound to the name it shares the first line
+    # (both are short) and the phone gets two clean lines instead of three.
+    assert has_element?(view, "[data-remote-author] + [data-remote-network]")
+
+    # And whenever it does wrap, the lines are set apart. `gap-x-2` alone left
+    # a wrapped row with literally zero vertical gap.
+    header = view |> element("[data-remote-header]") |> render()
+    assert [opening_tag] = Regex.run(~r/^<div[^>]*>/, header)
+    assert opening_tag =~ "gap-y-"
+  end
+
   test "muting the account takes its posts out of the feed and keeps the follow", %{conn: conn} do
     {conn, user} = create_and_login_user(conn)
     post = cached_post(user)


### PR DESCRIPTION
**TL;DR** The globe chip on a fediverse card was the last item in a wrapping header row, so on a phone it dropped onto a line of its own under the handle, with zero vertical gap. It now sits beside the display name and the row has a `gap-y`.

**Where:** `remote_header/1` in `lib/vutuv_web/components/post_components.ex` (the shared header of `remote_post_card/1` and `remote_reply_card/1`)

**Now:** the row lays out name, `@handle · stamp`, chip in that order with `gap-x-2` and no vertical gap. A narrow column pushes the chip out first, so it lands alone on a third line, touching the line above it.

**Want:** name and chip together on the first line, the muted meta line below it, and a gap wherever the row wraps.

Measured on `/feed` with the card clamped to a 390px phone's width, the ard.social card that was reported:

```
before                          after
tagesschau                      tagesschau  [🌐 ard.social]
@tagesschau · 20:37 Uhr         @tagesschau · 20:37 Uhr
[🌐 ard.social]

3 lines, 61px, gaps 0/0         2 lines, 45px, gap 4
```

A display name and a hostname are both short where the handle plus the stamp are not, which is why binding the chip to the name is what fits. Every ordinary card in the dev feed comes out two lines; an unusually long display name still wraps to three, but with the lines set apart. A desktop is unchanged, all three sit on one line where there is room.

`feed_remote_posts_test.exs` gains a test that fails the build if the chip drifts back to the end of the row or the row loses its `gap-y`.

An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.

https://claude.ai/code/session_015BYRMpwJahNQQeSFVUKrK6