### PR TITLE
The backfill of remote like counts is served newest first (v7.216.1)

### DIFF
--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -4160,13 +4160,23 @@ defmodule Vutuv.Fediverse do
     |> Enum.take(limit)
   end
 
-  # Least recently asked first, never-asked ahead of everything — the two
-  # tables' own orders merged into one. **Not** the `DateTime` struct itself:
-  # Erlang's term order compares maps field by field in key order, so it would
-  # put `day` before `month` and `year` and sort the queue by nothing anybody
-  # means.
-  defp counts_order(%{counts_checked_at: nil} = subject), do: {-1, subject.id}
-  defp counts_order(subject), do: {DateTime.to_unix(subject.counts_checked_at), subject.id}
+  # The two tables' own orders merged into one, and it has to agree with the
+  # `order_by` each of them was fetched under or the merge would undo it.
+  #
+  # **Not** the `DateTime` struct itself: Erlang's term order compares maps field
+  # by field in key order, so it would weigh `day` before `month` and `year` and
+  # sort the queue by nothing anybody means.
+  defp counts_order(%{counts_checked_at: nil} = subject),
+    do: {0, -DateTime.to_unix(counts_age(subject)), subject.id}
+
+  defp counts_order(subject),
+    do: {1, DateTime.to_unix(subject.counts_checked_at), subject.id}
+
+  # How old the thing itself is — the clock the ladder runs on. A cached post
+  # was published somewhere; a reply was delivered here, which is the closest
+  # thing it has to the same fact.
+  defp counts_age(%RemotePost{published_at: at}), do: at
+  defp counts_age(%Note{received_at: at}), do: at
 
   @doc """
   Asks one object's origin for its figures and stores the answer.
@@ -4355,10 +4365,21 @@ defmodule Vutuv.Fediverse do
   # failed ask, so a server having a bad day is asked less and less rather than
   # every quarter of an hour. An object with `@counts_max_strikes` strikes has
   # left the ladder for good.
+  # Least recently asked first — and, among the never-asked, **newest first**.
+  # That tiebreaker is load-bearing rather than tidy: every row an installation
+  # already holds when this ships has a null here, so the queue starts as one
+  # long backfill, and ordering it by id (creation order, since the ids are v7)
+  # would serve the six-month-old cache first and leave today's posts — the ones
+  # somebody is actually reading — until last. Newest first means a post reaches
+  # its figures within a run of arriving, and the old cache fills in behind it.
   defp due_counts_query(schema, age_field, now, ladder, limit) do
     from(r in schema,
       where: r.counts_failures < @counts_max_strikes,
-      order_by: [asc_nulls_first: r.counts_checked_at, asc: r.id],
+      order_by: [
+        asc_nulls_first: r.counts_checked_at,
+        desc: field(r, ^age_field),
+        asc: r.id
+      ],
       limit: ^limit
     )
     |> where(^ladder_conditions(age_field, now, ladder))

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.216.0",
+      version: "7.216.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_counts_test.exs
+++ b/test/vutuv/fediverse_counts_test.exs
@@ -295,6 +295,20 @@ defmodule Vutuv.FediverseCountsTest do
       assert old.id in Enum.map(Fediverse.due_for_counts(10), & &1.id)
     end
 
+    test "the never-asked queue is served newest first" do
+      # Everything an installation already holds when this ships has a null
+      # here, so the queue starts as one long backfill. Served in creation order
+      # it would work through the six-month-old cache first and leave today's
+      # posts — the ones somebody is reading — until last.
+      {stale, _user} = followed_post(%{published_at: minutes_ago(60 * 24 * 60)})
+      {recent, _user} = followed_post(%{published_at: minutes_ago(30)})
+
+      due = Enum.map(Fediverse.due_for_counts(10), & &1.id)
+
+      assert Enum.find_index(due, &(&1 == recent.id)) <
+               Enum.find_index(due, &(&1 == stale.id))
+    end
+
     test "failures push the next ask out, and enough of them end it" do
       {post, _user} = followed_post(%{counts_checked_at: minutes_ago(20), counts_failures: 1})
 


### PR DESCRIPTION
**TL;DR** v7.216.0's refresher drained its never-asked backlog in id order (= creation order), so the oldest cache got its figures first and today's posts came last. Order the never-asked by the object's own age, newest first.

**Where:** `Vutuv.Fediverse.due_counts_query/5` + `counts_order/1`
**Now:** every row starts with a null `counts_checked_at`, so the whole cache is one queue ordered by `id` — v7 ids sort by creation, so a six-month-old post is served before this morning's. Watching v7.216.0 land on production, the post that prompted the feature sat near the back of months of cached posts.
**Want:** a post reaches its figures within a run of arriving; the old cache fills in behind it.

The Elixir merge of the two tables' queues had to learn the same order, or it would have undone the one the queries were fetched under. One new test asserts a recent post is served ahead of a two-month-old one.

Follow-up to #1285 / issue #1283.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*