### PR TITLE
Fremde Inhalte auf indexierbaren Seiten: data-nosnippet und ugc nofollow (v7.218.1)

### DIFF
--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -1320,6 +1320,15 @@ defmodule VutuvWeb.PostComponents do
   # post from over there wears its tags the way a member's post does. A warned
   # post keeps its chips **inside** the lid: the tags of a post its author put
   # behind a content warning are part of what they covered up.
+  #
+  # `data-nosnippet` on the wrapper because this card also shows up on pages a
+  # crawler reads: a public tag timeline lists cached remote posts, and a member
+  # who reshares one puts it on their profile. The page stays indexable — it is
+  # ours, and the remote card is one entry on it — but the passage a search
+  # result quotes under our URL must come from our own content, not from a
+  # sentence somebody wrote on another server. Google honors the attribute on a
+  # `div`/`span`/`section` and covers its descendants, so the one wrapper takes
+  # the warning, the body and the chips with it.
   defp remote_body(assigns) do
     {text, hashtags} = Markdown.split_trailing_hashtags(assigns.text)
 
@@ -1330,7 +1339,7 @@ defmodule VutuvWeb.PostComponents do
       |> assign(:tags, remote_tag_chips(hashtags))
 
     ~H"""
-    <div :if={@warning || @body? || @tags != []} class="mt-1.5">
+    <div :if={@warning || @body? || @tags != []} data-nosnippet class="mt-1.5">
       <%= if @warning do %>
         <details data-remote-warning class="group">
           <summary class="flex min-h-10 cursor-pointer list-none items-center gap-1 text-sm font-medium text-slate-700 dark:text-slate-300">

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -139,7 +139,9 @@ defmodule VutuvWeb.Markdown do
       account (it unambiguously names one), the same as in a member post;
     * bare `@mentions` deliberately stay plain text — a Mastodon `@name` names
       an account in the fediverse, not the vutuv member who happens to share
-      the handle, so linking it would point at the wrong person.
+      the handle, so linking it would point at the wrong person;
+    * every link that leaves the site is marked `ugc nofollow` — see
+      `mark_foreign_links/1`.
 
   Returns an HTML **string** (not `safe`): the caller renders it with
   `raw/1`; it is sanitized exactly like member-post HTML.
@@ -149,9 +151,36 @@ defmodule VutuvWeb.Markdown do
     |> render_pipeline()
     |> open_links_in_new_tab()
     |> linkify_entities(:hashtags_only)
+    |> mark_foreign_links()
   end
 
   def render_remote(_), do: ""
+
+  @doc """
+  Marks every outbound link in rendered **remote** content `ugc nofollow`.
+
+  A cached post is somebody else's text sitting on our domain, and the links in
+  it are their editorial choice, not ours. `ugc` is the value search engines
+  define for exactly that (user-generated content we host but did not write) and
+  `nofollow` says we are not vouching for the destination — without them a
+  spammer's post, boosted into one reader's feed, would hand its link our
+  ranking signal from every public page that shows the card (a tag timeline, a
+  member's reshare on their profile).
+
+  It rewrites the `rel` the two link builders above have already written
+  (`open_links_in_new_tab/1` for URLs in the body, `linkify_entities/2` for a
+  `@user@host` handle), so the marker cannot be forgotten on one of them. Links
+  to **our own** pages carry no `rel` at all — a `#hashtag` resolves to
+  `/tags/:slug` — so they are left alone: nofollowing our own tag pages would
+  throw away the internal linking they exist for.
+  """
+  def mark_foreign_links(html) when is_binary(html) do
+    String.replace(
+      html,
+      ~s(rel="noopener noreferrer"),
+      ~s(rel="ugc nofollow noopener noreferrer")
+    )
+  end
 
   @doc """
   Split remote plain text into `{body, hashtags}`, lifting the closing

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.218.0",
+      version: "7.218.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/markdown_remote_test.exs
+++ b/test/vutuv_web/markdown_remote_test.exs
@@ -15,8 +15,10 @@ defmodule VutuvWeb.MarkdownRemoteTest do
     test "autolinks bare URLs with truncated display, opening in a new tab" do
       html = Markdown.render_remote("Anleitung: https://drnik.org/tausendfusser.html")
 
+      # `rel` also carries the ugc/nofollow marking every outbound link in
+      # somebody else's post gets (see VutuvWeb.RemoteContentSeoTest).
       assert html =~
-               ~s(<a target="_blank" rel="noopener noreferrer" href="https://drnik.org/tausendfusser.html">)
+               ~s(<a target="_blank" rel="ugc nofollow noopener noreferrer" href="https://drnik.org/tausendfusser.html">)
 
       assert html =~ "drnik.org/tausendfusser.html</a>"
     end

--- a/test/vutuv_web/remote_content_seo_test.exs
+++ b/test/vutuv_web/remote_content_seo_test.exs
@@ -1,0 +1,125 @@
+defmodule VutuvWeb.RemoteContentSeoTest do
+  @moduledoc """
+  What a search engine may do with somebody else's post on our domain.
+
+  Our own copy of a remote post lives on a members' page (`/system/fediverse/*`
+  is login-gated and `noindex`, see `VutuvWeb.Plug.NoIndex`), but the card
+  itself also appears on two pages a crawler reads: a public tag timeline, and
+  a member's profile once they reshare one. Two rules follow from that, and
+  neither of them is "hide the card":
+
+    * the passage a search result quotes under a vutuv URL must be ours, so the
+      foreign text carries `data-nosnippet`;
+    * the links inside that text are the remote author's editorial choice, not
+      our recommendation, so they are marked `ugc nofollow`.
+  """
+  use VutuvWeb.ConnCase, async: true
+
+  alias Vutuv.Fediverse.Hashtags
+  alias Vutuv.Fediverse.RemoteAccount
+  alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.PostsHelpers
+  alias Vutuv.Tags.Tag
+  alias VutuvWeb.Markdown
+
+  defp tag_with_post(body) do
+    name = unique_tag_name("Seo")
+    PostsHelpers.create_post!(insert(:activated_user), %{body: body, tags: name})
+
+    Repo.get_by!(Tag, name: name)
+  end
+
+  defp remote_post(tag, text) do
+    account =
+      Repo.insert!(%RemoteAccount{
+        actor_uri: "https://social.example/users/them-#{System.unique_integer([:positive])}",
+        host: "social.example",
+        handle: "them",
+        name: "Them Themself",
+        inbox_uri: "https://social.example/inbox"
+      })
+
+    now = DateTime.utc_now(:second)
+
+    post =
+      Repo.insert!(%RemotePost{
+        remote_account_id: account.id,
+        object_uri: "https://social.example/posts/#{System.unique_integer([:positive])}",
+        origin_url: "https://social.example/@them/1",
+        content_text: text,
+        audience: "public",
+        kind: "note",
+        published_at: now,
+        received_at: now,
+        expires_at: DateTime.add(now, 86_400)
+      })
+
+    Hashtags.sync(post, %{"tag" => [%{"type" => "Hashtag", "name" => "#" <> tag.name}]})
+    post
+  end
+
+  describe "links inside a cached remote post" do
+    test "an autolinked URL is marked ugc nofollow" do
+      html = Markdown.render_remote("Mehr dazu: https://drnik.org/tausendfusser.html")
+
+      assert html =~ ~s(rel="ugc nofollow noopener noreferrer")
+      refute html =~ ~s(rel="noopener noreferrer")
+    end
+
+    test "so is a @user@host handle, which also leaves the site" do
+      html = Markdown.render_remote("Siehe @hostsharing@geno.social")
+
+      assert html =~ ~s(href="https://geno.social/@hostsharing")
+      assert html =~ ~s(rel="ugc nofollow noopener noreferrer")
+    end
+
+    test "a #hashtag pointing at our own tag page keeps its ranking signal" do
+      # Name and slug have to agree here (and stay inside the hashtag charset),
+      # so this one is built by hand rather than from the factory sequence.
+      n = System.unique_integer([:positive])
+      tag = insert(:tag, name: "Crochet#{n}", slug: "crochet#{n}")
+      insert(:user_tag, user: insert_activated_user(), tag: tag)
+
+      html = Markdown.render_remote("Kleine Kritzelei ##{tag.name}")
+
+      assert html =~ ~s(<a href="/tags/#{tag.slug}" class="hashtag">)
+      refute html =~ ~s(href="/tags/#{tag.slug}" class="hashtag" rel=)
+      refute html =~ "nofollow"
+    end
+
+    test "a member's own post is not marked — those links are ours to vouch for" do
+      html =
+        "Mehr dazu: https://drnik.org/tausendfusser.html"
+        |> Markdown.render_post([])
+        |> Phoenix.HTML.safe_to_string()
+
+      assert html =~ ~s(rel="noopener noreferrer")
+      refute html =~ "nofollow"
+    end
+  end
+
+  describe "the public tag page a crawler reads" do
+    test "shows the remote post and keeps its text out of the snippet", %{conn: conn} do
+      tag = tag_with_post("Ein Beitrag von hier")
+      remote_post(tag, "Ein Beitrag von woanders")
+
+      body = conn |> get(~p"/tags/#{tag}") |> html_response(200)
+
+      # The card really is in the crawled HTML — this is not a page where the
+      # foreign text only appears after a socket connects.
+      assert body =~ "Ein Beitrag von woanders"
+      assert body =~ "data-nosnippet"
+    end
+
+    test "our own post carries no such marker", %{conn: conn} do
+      tag = tag_with_post("Ein Beitrag von hier")
+      remote_post(tag, "Ein Beitrag von woanders")
+
+      body = conn |> get(~p"/tags/#{tag}") |> html_response(200)
+
+      assert body =~ "Ein Beitrag von hier"
+      # One card is foreign, one is ours, so exactly one marker.
+      assert length(Regex.scan(~r/data-nosnippet/, body)) == 1
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** Fremder Fediverse-Text steht auf zwei crawlbaren Seiten (Tag-Timeline, Profil-Repost). Er bekommt `data-nosnippet`, seine Links `ugc nofollow`.

Ausgangsfrage war, was wir SEO-seitig mit `/system/fediverse/post/:id` und `/system/fediverse/account/:id` machen. Antwort: nichts, das ist erledigt und in Produktion nachgeprüft (302 auf `/login`, `x-robots-tag: noindex, noai, noimageai`, keine Agent-Formate, nicht in der Sitemap, für anonyme Leser gar nicht verlinkt).

Die Suche danach hat aber die Stelle gefunden, an der fremder Text wirklich in den Index kann:

**Wo:** `VutuvWeb.PostComponents.remote_body/1` (die fremde Karte) und `VutuvWeb.Markdown.render_remote/1` (ihr Text)
**Now:** `/tags/:slug` liefert gecachte Fediverse-Posts schon im reinen HTML aus (an `vutuv.de/tags/berlin` geprüft), ein Repost stellt so eine Karte auf ein öffentliches Profil, und die Links darin waren `rel="noopener noreferrer"`, also gefolgt.
**Want:** Seite bleibt indexierbar, das Snippet zitiert aber nur uns, und wir vouchen nicht für die Ziele fremder Links.

Zwei Änderungen:

- `data-nosnippet` auf dem fremden Textblock. Deckt Warnung, Body und Chips ab, weil Google das Attribut auf einem `div` samt Nachfahren auswertet. Die Karte bleibt sichtbar und indexierbar.
- `ugc nofollow` vor dem bestehenden `noopener noreferrer` bei jedem Link, der aus fremdem Text hinausführt (Body-URLs **und** `@user@host`-Handles, eine Stelle statt zwei). Links auf unsere eigenen Tag-Seiten bleiben unmarkiert, die tragen kein `rel` und sollen die interne Verlinkung behalten.

Nicht angefasst: der Mastodon/Bluesky-Feed auf dem Profil. Der lädt erst nach dem Socket-Connect, steht also nie im gecrawlten HTML, und seine Links tragen `nofollow ugc` schon.

Tests: `test/vutuv_web/remote_content_seo_test.exs` (neu) prüft beide Richtungen der Link-Markierung und dass auf einer Tag-Seite mit einem eigenen und einem fremden Post genau ein `data-nosnippet` steht. `mix precommit` grün (6512 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*
