### PR TITLE
The list of accounts followed elsewhere keeps itself current (v7.219.0)

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -45,7 +45,20 @@ LiveView can sit on either style.
    arrows are the reorder path on phones), `.card__tablewrap` (every in-card `<table>`
    sits in this overflow-x scroller so a wide table scrolls instead of being
    clipped by the card's `overflow:hidden` — `card_table_scroll_test.exs`
-   enforces it), `.breakwrap` (break a long unbroken string and cap the line at a
+   enforces it), `tr[data-row-changed]` (the **live-row marker**: a table row that
+   changed while the member was only looking at the page sweeps once through a
+   brand tint and back to transparent, 1.4s — for a table whose rows can move
+   without anybody here touching them, like `/settings/fediverse/following`,
+   where the answer to a follow comes from another server. The tint is the
+   custom property `--row-changed-tint`, which is why light/dark share one set
+   of keyframes and why the `prefers-reduced-motion` rule can paint the very
+   colour it would otherwise have faded — under reduced motion the row is still
+   pointed out, it just stands still. **The marker must be put on by the server
+   on exactly the rows that moved and taken off again** after the sweep, or the
+   table lights up on every page load and a row that changes twice lights up
+   once: a CSS animation restarts only when the element begins matching the rule
+   afresh),
+   `.breakwrap` (break a long unbroken string and cap the line at a
    readable measure — use it instead of an inline `word-wrap`/`max-width` style),
    `.card__empty` empty-state line, `.card__label` (the small uppercase muted
    caption for field/section labels inside a legacy card — e.g. the detail show

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -882,6 +882,37 @@ td.text-right {
   white-space: nowrap;
 }
 
+/* A row that changed while the member was only looking at the page — today
+   `/settings/fediverse/following`, where a follow's state is answered on
+   ANOTHER server, so "Angefragt" can turn into "Folge ich" with nothing on
+   this end touched. One calm sweep of brand tint fading back out tells an eye
+   that was elsewhere which row moved; a table that silently rewrites itself
+   otherwise looks like a misread.
+   The marker is put on by the server, on exactly the rows that moved, and
+   taken off again a moment later (`VutuvWeb.FediverseFollowingLive`): a CSS
+   animation only restarts when the element starts matching the rule afresh, so
+   a marker left on forever would light a row up once and never again.
+   The tint is a custom property rather than a literal, because a keyframe
+   resolves `var()` against the animated element — which is what lets light and
+   dark share one set of keyframes AND lets the reduced-motion rule below paint
+   the same colour it would have faded. Under `prefers-reduced-motion` the tint
+   simply stands still for that moment: the row is still pointed out, nothing
+   moves or fades. */
+@keyframes row-changed {
+  from { background-color: var(--row-changed-tint); }
+  to { background-color: transparent; }
+}
+tr[data-row-changed] > td {
+  --row-changed-tint: var(--color-brand-100);
+  animation: row-changed 1.4s ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  tr[data-row-changed] > td {
+    animation: none;
+    background-color: var(--row-changed-tint);
+  }
+}
+
 /* ---------- Lists / tags / badges ---------- */
 .tags,
 .badges {
@@ -2600,6 +2631,9 @@ html.lightbox-open { overflow: hidden; }
   .reorder__btn:hover:not(:disabled) { background: #334155; }
   .pure-table th { background: #1e293b; color: #cbd5e1; }
   .pure-table th, .pure-table td { border-color: #1e293b; }
+  /* Only the tint: the keyframes read it off the element, so the animation and
+     the reduced-motion fallback both follow without a dark copy of either. */
+  tr[data-row-changed] > td { --row-changed-tint: var(--color-brand-900); }
   /* Bare tables (legacy sets `th{color:#444;border:#ddd}` / `td{border:#eee}`). */
   th { color: #cbd5e1; border-color: #1e293b; }
   td { border-color: #1e293b; }

--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -917,6 +917,19 @@ deletes the row (there is nothing left to show, nothing to retry, and keeping a
 stranger's refusal on file earns nobody anything). Both are scoped to the actor
 that answered, so one server can never settle a follow addressed to another.
 
+**The following browser updates itself.** Every change on that page except the
+member's own follow and unfollow is decided on another server and arrives in the
+inbox at a time nobody here picks — an `Accept` seconds or days behind the
+request, a `Reject`, a `Move`, an account `Delete`, an operator blocking the
+instance. So each of those write paths broadcasts a bare `:remote_follows_changed`
+on the affected members' `"user:<id>"` topic (`Vutuv.Activity`), and
+`VutuvWeb.FediverseFollowingLive` reloads its current view: the rows and their
+state badges, the headline count, the server filter and the pager, keeping the
+page the member is on. Without it "Requested" stays on screen long after the
+other side said yes, and only a manual reload tells the truth. The signal
+carries no payload on purpose — the page's view is filtered, sorted and paged,
+and none of that is knowable from the context.
+
 ### The gates
 
 In the order they cost, because the cheap ones must run before the network is

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -33,7 +33,13 @@ browser** (`/settings/fediverse/followers`,
 changes nothing, it *finds* something — search-as-you-type, a server filter,
 sortable columns and paging over a follower list that can run to five figures,
 with the whole view in the URL via `push_patch` (see
-[fediverse.md](fediverse.md)).
+[fediverse.md](fediverse.md)). Its mirror image, the **following browser**
+(`/settings/fediverse/following`, `VutuvWeb.FediverseFollowingLive`), is the one
+settings page that has to keep itself current: what a follow's state *is* is
+decided on another server and reaches us in the inbox, so an `Accept`, a
+`Reject`, a `Move`, an account `Delete` or an instance block reloads the open
+page over `:remote_follows_changed` instead of waiting for somebody to hit
+reload.
 
 **Every state-changing control fires a LiveView event, so the page never
 reloads**: the follow pill, the ⋯-menu mute/bookmark/like/block (and unblock),

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -914,6 +914,8 @@ defmodule Vutuv.Fediverse do
       # #1168). A move the successor never answers keeps the record of what the
       # member had.
       settle_moved_follows(user, actor_uri)
+
+      broadcast_remote_follows_changed([user.id])
     end
 
     :ok
@@ -928,9 +930,49 @@ defmodule Vutuv.Fediverse do
   list, which is what "they did not accept" looks like.
   """
   def reject_remote_follow(%User{} = user, activity, actor_uri) do
-    if follow = find_answered_follow(user, activity, actor_uri), do: Repo.delete(follow)
+    if follow = find_answered_follow(user, activity, actor_uri) do
+      Repo.delete(follow)
+      broadcast_remote_follows_changed([user.id])
+    end
 
     :ok
+  end
+
+  # Tells these members' open following browsers
+  # (`/settings/fediverse/following`) that their list of accounts elsewhere
+  # changed underneath them.
+  #
+  # Every change on that page except the member's own follow and unfollow
+  # arrives from **another server**, at a time nobody here picks: an `Accept`
+  # may be seconds or days behind the request, a `Reject` or a `Delete` comes
+  # with no warning at all. So the one page that shows a follow's *state* is
+  # also the one page in /settings that cannot be a snapshot — left to a
+  # reload, "Requested" reads as the current answer long after the other side
+  # said yes.
+  #
+  # A bare signal, not a payload: the page reloads its own view (which is
+  # filtered, sorted and paged, and none of that is knowable from here) rather
+  # than patching a row. `VutuvWeb.FediverseFollowingLive` listens; every other
+  # subscriber of the owner topic ignores it through its catch-all
+  # `handle_info/2`.
+  defp broadcast_remote_follows_changed(user_ids) when is_list(user_ids) do
+    user_ids
+    |> Enum.uniq()
+    |> Enum.each(&Activity.broadcast(&1, :remote_follows_changed))
+  end
+
+  # The members here who follow one of these remote accounts. Read **before** a
+  # delete of those accounts: their follows cascade away with them, so asked
+  # afterwards the answer is always "nobody" and the page never hears about it.
+  defp remote_follow_user_ids(accounts) do
+    Repo.all(
+      from(f in Follow,
+        join: a in subquery(accounts),
+        on: a.id == f.remote_account_id,
+        distinct: true,
+        select: f.user_id
+      )
+    )
   end
 
   @doc """
@@ -1132,6 +1174,7 @@ defmodule Vutuv.Fediverse do
   def remove_remote_account(actor_uri) when is_binary(actor_uri) do
     accounts = from(a in RemoteAccount, where: a.actor_uri == ^actor_uri)
     log_account_gone(actor_uri, accounts)
+    follow_owners = remote_follow_user_ids(from(a in accounts, select: %{id: a.id}))
 
     # The rows cascade, the files do not: the account's own picture and every
     # picture on the posts we cached for it have to be swept before the delete
@@ -1142,6 +1185,7 @@ defmodule Vutuv.Fediverse do
 
     wipe_avatars(accounts)
     Repo.delete_all(accounts)
+    broadcast_remote_follows_changed(follow_owners)
     :ok
   end
 
@@ -2763,8 +2807,19 @@ defmodule Vutuv.Fediverse do
 
     wipe_avatars(from(a in RemoteAccount, where: a.host == ^host))
 
+    # Which members are about to lose follows, asked while the rows still
+    # exist. Named for the members it holds, not `followers` — that is already
+    # this function's count of the rows pointing the *other* way, and the
+    # returned tally would silently become a list of member ids.
+    follow_owners =
+      remote_follow_user_ids(
+        from(a in RemoteAccount, where: a.host == ^host, select: %{id: a.id})
+      )
+
     {remote_accounts, _} =
       Repo.delete_all(from(a in RemoteAccount, where: a.host == ^host))
+
+    broadcast_remote_follows_changed(follow_owners)
 
     # A block is also a takedown: text that server's members wrote under our
     # members' posts goes with it (issue #1069), not just the follow rows.
@@ -5831,6 +5886,7 @@ defmodule Vutuv.Fediverse do
          {:ok, successor} <- upsert_remote_account(remote) do
       Repo.update(Ecto.Changeset.change(old, moved_to: successor.actor_uri))
       Enum.each(follows, &repoint_follow(&1, successor))
+      broadcast_remote_follows_changed(Enum.map(follows, & &1.user_id))
       :ok
     else
       _ -> :skip

--- a/lib/vutuv_web/live/fediverse_following_live.ex
+++ b/lib/vutuv_web/live/fediverse_following_live.ex
@@ -38,14 +38,27 @@ defmodule VutuvWeb.FediverseFollowingLive do
 
   on_mount({VutuvWeb.Live.InitAssigns, :require_login})
 
+  alias Vutuv.Activity
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Pages
 
+  # How long a changed row keeps its marker. Longer than the CSS sweep
+  # (`tr[data-row-changed]`, 1.4s): taking the marker off mid-animation would
+  # cut the fade short.
+  @row_mark_ms 1_800
+
   @impl true
   def mount(_params, _session, socket) do
     user = socket.assigns.current_user
+
+    # Everything this page shows that the member did not do themselves is
+    # decided on another server and arrives in the inbox, so the owner topic is
+    # the only way the page can be right without a reload (see
+    # `Vutuv.Fediverse`'s `:remote_follows_changed`). Connected only, like every
+    # other subscriber here: the disconnected render is thrown away.
+    if connected?(socket), do: Activity.subscribe(user.id)
 
     {:ok,
      socket
@@ -55,6 +68,11 @@ defmodule VutuvWeb.FediverseFollowingLive do
      |> assign(:blocked_reason, Fediverse.follow_refusal(user))
      |> assign(:address, "")
      |> assign(:error, nil)
+     # Nothing is marked on arrival: the animation is for a change the member
+     # watched happen, and a table that lights up on every page load would say
+     # "something moved" when nothing did.
+     |> assign(:changed_ids, MapSet.new())
+     |> assign(:change_seq, 0)
      |> assign_totals()}
   end
 
@@ -78,7 +96,8 @@ defmodule VutuvWeb.FediverseFollowingLive do
   # the headline count and the server dropdown. Deliberately not in the page
   # loader — neither depends on the filters, the sort or the page, so recomputing
   # them per keystroke would be two extra queries for an unchanged answer. Only
-  # a follow or an unfollow can move them, so only those refresh.
+  # something that adds or removes a follow can move them: the member's own
+  # follow and unfollow, and the answers that arrive from other servers.
   defp assign_totals(socket) do
     user = socket.assigns.user
 
@@ -87,7 +106,14 @@ defmodule VutuvWeb.FediverseFollowingLive do
     |> assign(:hosts, Fediverse.remote_follow_hosts(user))
   end
 
-  defp load_page(socket, params \\ %{}) do
+  # Reloads the view the member is looking at. The page number comes from the
+  # socket rather than starting over at 1, so an answer arriving from another
+  # server while they read page three does not throw them back to the top of
+  # the list (`Pages.effective_page/3` still catches a page that just ran out
+  # of rows).
+  defp load_page(socket), do: load_page(socket, %{"page" => socket.assigns.page})
+
+  defp load_page(socket, params) do
     user = socket.assigns.user
     filters = socket.assigns.filters
     per_page = Fediverse.browse_per_page()
@@ -174,6 +200,75 @@ defmodule VutuvWeb.FediverseFollowingLive do
   # `Fediverse.follow_remote/2` — so no lookup rides along with the refusal any
   # more; the template's one extra affordance is the search hand-off.
   defp assign_error(socket, reason), do: assign(socket, :error, reason)
+
+  # ── Live updates from elsewhere ───────────────────────────────────────────
+
+  # The other side answered (`Accept` / `Reject`), a followed account moved to
+  # another server, deleted itself, or an operator blocked its instance —
+  # broadcast by `Vutuv.Fediverse` on the owner's topic. None of it passes
+  # through this page, so without this a follow reads "Requested" until the
+  # member reloads by hand.
+  #
+  # The whole view is reloaded rather than one row patched: a state change also
+  # moves the headline count and can move the server filter and the pager, and
+  # a page is at most 50 rows, so re-asking costs the same four queries the
+  # member's own unfollow already pays.
+  @impl true
+  def handle_info(:remote_follows_changed, socket) do
+    shown = socket.assigns.follows
+
+    {:noreply,
+     socket
+     |> assign_totals()
+     |> load_page()
+     |> mark_changed_rows(shown)}
+  end
+
+  # The marker's own timer, come round: see `mark_changed_rows/2`. Ignored when
+  # a newer change has since marked its own rows, or this one would cut that
+  # animation short.
+  def handle_info({:clear_changed_rows, seq}, socket) do
+    if seq == socket.assigns.change_seq,
+      do: {:noreply, assign(socket, :changed_ids, MapSet.new())},
+      else: {:noreply, socket}
+  end
+
+  # The owner topic carries every other in-app event (message and notification
+  # badges, follows made here); this page has nothing to do with them.
+  def handle_info(_other, socket), do: {:noreply, socket}
+
+  # Which rows the reload actually moved, so only those light up: a follow whose
+  # state changed under the member's eyes, and one that has appeared (an account
+  # that moved servers arrives as a fresh request beside its old row). A row that
+  # is simply *gone* gets nothing — there is no longer anything to mark, and
+  # animating a removal would mean holding a row the member no longer follows.
+  #
+  # "Appeared" is read against this page of the table, not the whole list, so a
+  # row that a deletion further up pulled onto the page counts as one. That is
+  # the honest reading anyway: from where the member is looking, it did just
+  # turn up.
+  #
+  # The marker is taken off again on a timer, because a CSS animation restarts
+  # only when the element begins matching the rule afresh: left on, the same row
+  # changing a second time would stay silent.
+  defp mark_changed_rows(socket, shown_before) do
+    before = Map.new(shown_before, &{&1.id, &1.state})
+
+    changed =
+      for follow <- socket.assigns.follows,
+          Map.get(before, follow.id) != follow.state,
+          into: MapSet.new(),
+          do: follow.id
+
+    if Enum.empty?(changed) do
+      socket
+    else
+      seq = socket.assigns.change_seq + 1
+      Process.send_after(self(), {:clear_changed_rows, seq}, @row_mark_ms)
+
+      socket |> assign(:changed_ids, changed) |> assign(:change_seq, seq)
+    end
+  end
 
   # ── Wording ───────────────────────────────────────────────────────────────
 
@@ -328,7 +423,11 @@ defmodule VutuvWeb.FediverseFollowingLive do
                   </tr>
                 </thead>
                 <tbody id="following">
-                  <tr :for={follow <- @follows} id={"follow-#{follow.id}"}>
+                  <tr
+                    :for={follow <- @follows}
+                    id={"follow-#{follow.id}"}
+                    data-row-changed={MapSet.member?(@changed_ids, follow.id)}
+                  >
                     <td>
                       <.account_link
                         uri={follow.remote_account.actor_uri}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.218.1",
+      version: "7.219.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/fediverse_following_live_test.exs
+++ b/test/vutuv_web/live/fediverse_following_live_test.exs
@@ -132,12 +132,19 @@ defmodule VutuvWeb.FediverseFollowingLiveTest do
       refute has_element?(view, "#no-following")
     end
 
-    test "an accepted follow reads differently", %{conn: conn, user: user} do
+    test "an Accept flips the state on the open page, no reload", %{conn: conn, user: user} do
       {:ok, view, _html} = live(conn, ~p"/settings/fediverse/following")
       view |> element("#follow-form") |> render_submit(%{"address" => "@them@social.example"})
 
       [follow] = Repo.all(from(f in Follow, where: f.user_id == ^user.id))
+      assert has_element?(view, "[data-follow-state=requested]")
+      # Nothing is marked until something moves, or every page load would claim
+      # a change.
+      refute has_element?(view, "tr[data-row-changed]")
 
+      # The answer arrives in the inbox minutes or days later and never in this
+      # member's browser, so the page they left open has to follow along by
+      # itself — otherwise "Requested" is a lie until somebody hits reload.
       :ok =
         Fediverse.accept_remote_follow(
           user,
@@ -145,8 +152,36 @@ defmodule VutuvWeb.FediverseFollowingLiveTest do
           @actor_uri
         )
 
-      {:ok, view, _html} = live(conn, ~p"/settings/fediverse/following")
       assert has_element?(view, "[data-follow-state=accepted]")
+      refute has_element?(view, "[data-follow-state=requested]")
+      # And the row says which one moved, so the eye can find it.
+      assert has_element?(view, "#follow-#{follow.id}[data-row-changed]")
+
+      # The marker comes off again by itself (its timer's own message, fired
+      # here rather than waited out — this is the first change, so the sequence
+      # number it carries is 1). Without that a second change to the same row
+      # would arrive on a row already marked, and a CSS animation does not
+      # restart on an element that never stopped matching.
+      send(view.pid, {:clear_changed_rows, 1})
+      refute has_element?(view, "tr[data-row-changed]")
+    end
+
+    test "a Reject takes the row off the open page", %{conn: conn, user: user} do
+      {:ok, view, _html} = live(conn, ~p"/settings/fediverse/following")
+      view |> element("#follow-form") |> render_submit(%{"address" => "@them@social.example"})
+
+      [follow] = Repo.all(from(f in Follow, where: f.user_id == ^user.id))
+
+      :ok =
+        Fediverse.reject_remote_follow(
+          user,
+          %{"type" => "Reject", "object" => follow.follow_activity_id},
+          @actor_uri
+        )
+
+      refute has_element?(view, "#follow-#{follow.id}")
+      # And the headline count went with it, not just the row.
+      assert has_element?(view, "#no-following")
     end
 
     test "a refusal is explained next to the box", %{conn: conn} do


### PR DESCRIPTION
A follow of an account on another network is a request, and the answer comes from **that** server: an `Accept` may be seconds or days behind it, a `Reject`, a `Move` or an account `Delete` arrive with no warning at all. None of it passes through `/settings/fediverse/following`, so a page left open kept reading "Angefragt" long after the other side had said yes, and the only way to the truth was a manual reload.

## What changed

**It updates itself.** Every write path that moves a member's remote follows broadcasts a bare `:remote_follows_changed` on the owner's `"user:<id>"` topic — `Accept`, `Reject`, `Move`, an account deleting itself, an operator blocking its instance — and `VutuvWeb.FediverseFollowingLive` reloads the view it is showing: rows and state badges, the headline count, the server filter, the pager. The signal deliberately carries no payload: the page's view is filtered, sorted and paged, and none of that is knowable from the context.

The reload keeps the member on their current page instead of starting over at page 1, which also stops their own unfollow from throwing them back to the top of a long list.

**A row that moved says so.** `tr[data-row-changed]` sweeps once through a brand tint and back to transparent (1.4s), because a table that silently rewrites itself under the reader looks like a misread. Two things about it are load-bearing:

* the marker is set **by the server**, on exactly the rows that changed. Set at render time it would make every page load claim a change.
* it is **taken off again** after the sweep. A CSS animation restarts only when the element begins matching the rule afresh, so a marker left on would light a row up once and never again.

The tint is the custom property `--row-changed-tint`, which a keyframe resolves against the animated element — that is why light and dark share one set of keyframes and why the `prefers-reduced-motion` rule can paint the very colour it would otherwise have faded. Under reduced motion the row is still pointed out, it just stands still.

## Notes

* **Hot deploy** — no migrations, no supervision tree, no config, no deps.
* Caught on the way: naming the new "who is about to lose follows" list `followers` inside `purge_instance/1` shadowed that function's own count of the rows pointing the other way, so the admin block page would have reported a list of member ids as the follower tally. Renamed.
* Not touched: the mirror page `/settings/fediverse/followers` has the same staleness (a new remote follower appears only after a reload). The mechanism is now there for it.
* `mix precommit` green: 6495 tests, credo --strict clean.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*