### PR TITLE
The follower list from other networks keeps itself current too (v7.220.0)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -917,18 +917,26 @@ deletes the row (there is nothing left to show, nothing to retry, and keeping a
 stranger's refusal on file earns nobody anything). Both are scoped to the actor
 that answered, so one server can never settle a follow addressed to another.
 
-**The following browser updates itself.** Every change on that page except the
-member's own follow and unfollow is decided on another server and arrives in the
-inbox at a time nobody here picks — an `Accept` seconds or days behind the
-request, a `Reject`, a `Move`, an account `Delete`, an operator blocking the
-instance. So each of those write paths broadcasts a bare `:remote_follows_changed`
-on the affected members' `"user:<id>"` topic (`Vutuv.Activity`), and
-`VutuvWeb.FediverseFollowingLive` reloads its current view: the rows and their
-state badges, the headline count, the server filter and the pager, keeping the
-page the member is on. Without it "Requested" stays on screen long after the
-other side said yes, and only a manual reload tells the truth. The signal
-carries no payload on purpose — the page's view is filtered, sorted and paged,
-and none of that is knowable from the context.
+**Both relationship browsers update themselves.** Every change on those pages
+except the member's own follow and unfollow is decided on another server and
+arrives in the inbox at a time nobody here picks — an `Accept` seconds or days
+behind the request, a `Reject`, a `Move`, an account `Delete`, an operator
+blocking the instance; and on the follower side a `Follow`, an `Undo`, an actor
+`Update` that renames somebody, or the pruner dropping an account that is gone.
+So each of those write paths broadcasts on the affected members' `"user:<id>"`
+topic (`Vutuv.Activity`): `:remote_follows_changed` for the accounts a member
+follows, `:remote_followers_changed` for the people who follow them. The two
+signals are named for the two tables and are never interchangeable — *follows*
+is what the member does, *followers* is what is done to them.
+
+Each page then reloads its current view — rows, headline count, server filter,
+pager — keeping the page number the member is on, and marks the rows that
+actually moved so they light up (`BrowseTable.mark_changed_rows/4`, the
+`tr[data-row-changed]` sweep). Without it "Angefragt" stays on screen long after
+the other side said yes, and the follower page's own promise that a renamed
+account updates by itself is only true across a reload. The signals carry no
+payload on purpose — a page's view is filtered, sorted and paged, and none of
+that is knowable from the context.
 
 ### The gates
 

--- a/docs/architecture/realtime.md
+++ b/docs/architecture/realtime.md
@@ -33,13 +33,16 @@ browser** (`/settings/fediverse/followers`,
 changes nothing, it *finds* something — search-as-you-type, a server filter,
 sortable columns and paging over a follower list that can run to five figures,
 with the whole view in the URL via `push_patch` (see
-[fediverse.md](fediverse.md)). Its mirror image, the **following browser**
-(`/settings/fediverse/following`, `VutuvWeb.FediverseFollowingLive`), is the one
-settings page that has to keep itself current: what a follow's state *is* is
-decided on another server and reaches us in the inbox, so an `Accept`, a
-`Reject`, a `Move`, an account `Delete` or an instance block reloads the open
-page over `:remote_follows_changed` instead of waiting for somebody to hit
-reload.
+[fediverse.md](fediverse.md)). It and its mirror image, the **following
+browser** (`/settings/fediverse/following`,
+`VutuvWeb.FediverseFollowingLive`), are the settings pages that have to keep
+themselves current: what they show is decided on other servers and reaches us
+through the inbox, so an `Accept`, a `Reject`, a `Move`, an inbound `Follow` or
+`Undo`, a rename, a prune or an instance block reloads the open page
+(`:remote_follows_changed` / `:remote_followers_changed`) instead of waiting for
+somebody to hit reload. A row that moved sweeps once through a brand tint
+(`tr[data-row-changed]`), because a table that silently rewrites itself under
+the reader looks like a misread.
 
 **Every state-changing control fires a LiveView event, so the page never
 reloads**: the follow pill, the ⋯-menu mute/bookmark/like/block (and unblock),

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -221,13 +221,17 @@ defmodule Vutuv.Fediverse do
   with `{:error, :inbound_capped}`.
   """
   def add_follower(%User{} = user, attrs) do
-    with :ok <- check_inbound_cap(attrs[:actor_uri] || attrs["actor_uri"]) do
-      %Follower{user_id: user.id}
-      |> Follower.changeset(attrs)
-      |> Repo.insert(
-        on_conflict: {:replace, [:inbox_uri, :shared_inbox_uri, :handle, :name, :updated_at]},
-        conflict_target: [:user_id, :actor_uri]
-      )
+    with :ok <- check_inbound_cap(attrs[:actor_uri] || attrs["actor_uri"]),
+         {:ok, follower} <-
+           %Follower{user_id: user.id}
+           |> Follower.changeset(attrs)
+           |> Repo.insert(
+             on_conflict:
+               {:replace, [:inbox_uri, :shared_inbox_uri, :handle, :name, :updated_at]},
+             conflict_target: [:user_id, :actor_uri]
+           ) do
+      broadcast_remote_followers_changed([user.id])
+      {:ok, follower}
     end
   end
 
@@ -239,17 +243,25 @@ defmodule Vutuv.Fediverse do
   document must not crash the inbox.
   """
   def refresh_follower(%User{id: user_id}, %{actor_uri: actor_uri} = attrs) do
-    if follower = Repo.get_by(Follower, user_id: user_id, actor_uri: actor_uri) do
-      follower |> Follower.changeset(attrs) |> Repo.update()
+    with %Follower{} = follower <- Repo.get_by(Follower, user_id: user_id, actor_uri: actor_uri),
+         {:ok, _updated} <- follower |> Follower.changeset(attrs) |> Repo.update() do
+      # The name and handle are what the follower table shows, so a rename is a
+      # change to that page even though no row came or went.
+      broadcast_remote_followers_changed([user_id])
     end
 
     :ok
   end
 
   def remove_follower(%User{id: user_id}, actor_uri) do
-    Repo.delete_all(
-      from(f in Follower, where: f.user_id == ^user_id and f.actor_uri == ^actor_uri)
-    )
+    {count, _} =
+      Repo.delete_all(
+        from(f in Follower, where: f.user_id == ^user_id and f.actor_uri == ^actor_uri)
+      )
+
+    # Only when a row really went: an `Undo` for a follow we never stored is
+    # ordinary inbox traffic, and waking every open page for it would be noise.
+    if count > 0, do: broadcast_remote_followers_changed([user_id])
 
     :ok
   end
@@ -959,6 +971,19 @@ defmodule Vutuv.Fediverse do
     user_ids
     |> Enum.uniq()
     |> Enum.each(&Activity.broadcast(&1, :remote_follows_changed))
+  end
+
+  # The same thing for the **other** direction: who follows the member from out
+  # there (`/settings/fediverse/followers`, `Vutuv.Fediverse.Follower`), which
+  # moves when a `Follow` arrives, an `Undo` withdraws one, an actor `Update`
+  # renames somebody, the pruner drops an account that is gone, or an operator
+  # blocks its server. The two signals are named for the two tables and are
+  # never interchangeable — `follows` is what the member does, `followers` is
+  # what is done to them.
+  defp broadcast_remote_followers_changed(user_ids) when is_list(user_ids) do
+    user_ids
+    |> Enum.uniq()
+    |> Enum.each(&Activity.broadcast(&1, :remote_followers_changed))
   end
 
   # The members here who follow one of these remote accounts. Read **before** a
@@ -2632,6 +2657,7 @@ defmodule Vutuv.Fediverse do
 
   defp prune_follower(%Follower{} = follower, status) do
     Repo.delete(follower)
+    broadcast_remote_followers_changed([follower.user_id])
 
     # The host is always parseable here (an unparseable actor URI never gets as
     # far as an HTTP status), but fall back rather than lose the ledger row: a
@@ -2784,8 +2810,20 @@ defmodule Vutuv.Fediverse do
   post_deliveries: n}`.
   """
   def purge_instance(host) when is_binary(host) do
+    # Whose follower tables are about to lose rows, asked while they still exist.
+    followed_members =
+      Repo.all(
+        from(f in Follower,
+          where: uri_host(f.actor_uri) == ^host,
+          distinct: true,
+          select: f.user_id
+        )
+      )
+
     {followers, _} =
       Repo.delete_all(from(f in Follower, where: uri_host(f.actor_uri) == ^host))
+
+    broadcast_remote_followers_changed(followed_members)
 
     # A block cuts both directions (issue #1160): the accounts our members
     # follow over there go with the ones that follow us, and the follow rows

--- a/lib/vutuv_web/components/browse_table.ex
+++ b/lib/vutuv_web/components/browse_table.ex
@@ -181,6 +181,81 @@ defmodule VutuvWeb.BrowseTable do
     push_patch(socket, [to: path_fun.(query)] ++ opts)
   end
 
+  ## Rows that change while somebody is looking at them
+
+  # How long a changed row keeps its marker. Longer than the CSS sweep
+  # (`tr[data-row-changed]` in `components.css`, 1.4s): taking the marker off
+  # mid-animation would cut the fade short.
+  @row_mark_ms 1_800
+
+  @doc """
+  Sets up the row-marking assigns. Call it in `mount/3` of a browse page whose
+  rows can change without the member touching anything.
+
+  Nothing is marked on arrival, on purpose: the animation is for a change the
+  member watched happen, and a table that lights up on every page load would
+  say "something moved" when nothing did.
+  """
+  def init_row_marks(socket) do
+    socket |> assign(:changed_ids, MapSet.new()) |> assign(:change_seq, 0)
+  end
+
+  @doc """
+  Marks the rows a reload actually moved, so only those light up.
+
+  `signature` is what "unchanged" means for this page's row — the state of a
+  follow, the display name and handle of a follower — read from the rows shown
+  before and the rows shown now. A row whose signature moved is marked, and so
+  is one that was not there before. A row that is simply *gone* gets nothing:
+  there is no longer anything to mark, and animating a removal would mean
+  holding on to a row the member no longer has.
+
+  "Not there before" is read against this **page** of the table, not the whole
+  list, so a row that a deletion further up pulled onto the page counts as one.
+  That is the honest reading anyway: from where the member is looking, it did
+  just turn up.
+
+  The marker is taken off again on a timer, because a CSS animation restarts
+  only when the element begins matching the rule afresh: left on, the same row
+  changing a second time would stay silent. The timer's message carries a
+  sequence number so an older one cannot cut a newer change's animation short —
+  route it to `clear_row_marks/2`.
+  """
+  def mark_changed_rows(socket, shown_before, shown_now, signature) do
+    before = Map.new(shown_before, &{&1.id, signature.(&1)})
+
+    changed =
+      for row <- shown_now,
+          Map.get(before, row.id) != signature.(row),
+          into: MapSet.new(),
+          do: row.id
+
+    if Enum.empty?(changed) do
+      socket
+    else
+      seq = socket.assigns.change_seq + 1
+      Process.send_after(self(), {:clear_changed_rows, seq}, @row_mark_ms)
+
+      socket |> assign(:changed_ids, changed) |> assign(:change_seq, seq)
+    end
+  end
+
+  @doc """
+  The marker timer come round (see `mark_changed_rows/4`). Ignored when a newer
+  change has since marked its own rows.
+  """
+  def clear_row_marks(socket, seq) do
+    if seq == socket.assigns.change_seq,
+      do: assign(socket, :changed_ids, MapSet.new()),
+      else: socket
+  end
+
+  @doc """
+  Whether this row is one the last reload moved — the `data-row-changed`
+  attribute value, which HEEx drops entirely when it is false.
+  """
+  def row_changed?(changed_ids, id), do: MapSet.member?(changed_ids, id)
+
   @doc """
   The utilities that fold a column away on a phone.
 

--- a/lib/vutuv_web/live/fediverse_followers_live.ex
+++ b/lib/vutuv_web/live/fediverse_followers_live.ex
@@ -12,13 +12,20 @@ defmodule VutuvWeb.FediverseFollowersLive do
   (Account / Server / Following since) and numbered paging.
 
   Filter, sort and page live in the **URL** (`push_patch`), so a particular view
-  is shareable and the back button restores it; `handle_params/3` is the single
-  loader, the table itself — query string, sortable headers, filter form,
-  account and server cells, range line and pager — is `VutuvWeb.BrowseTable`
-  (shared with the mirror-image following browser) and the query work stays in
-  `Vutuv.Fediverse` (`browse_filters/1`, `count_followers/2`,
-  `list_followers_page/4`, `follower_hosts/2`). What is left here is what
-  genuinely differs: the rows, the columns, and the wording.
+  is shareable and the back button restores it; the table itself — query string,
+  sortable headers, filter form, account and server cells, range line and pager
+  — is `VutuvWeb.BrowseTable` (shared with the mirror-image following browser)
+  and the query work stays in `Vutuv.Fediverse` (`browse_filters/1`,
+  `count_followers/2`, `list_followers_page/4`, `follower_hosts/2`). What is
+  left here is what genuinely differs: the rows, the columns, and the wording.
+
+  It **keeps itself current**. Nothing on this page is ever the member's own
+  doing — a follower arrives, withdraws, renames itself or is pruned on another
+  server's time — so `handle_params/3` is not the only loader: the page
+  subscribes to the owner's topic and reloads on `:remote_followers_changed`,
+  marking the rows that moved so they light up (`BrowseTable.mark_changed_rows/4`).
+  Without it the card below the table would be promising something untrue when
+  it says a renamed account updates here on its own.
 
   Owner-only by construction: it lives in the `/settings` scope, reads only
   `current_user`'s rows, and a member who does not federate is sent back to
@@ -31,6 +38,7 @@ defmodule VutuvWeb.FediverseFollowersLive do
 
   on_mount({VutuvWeb.Live.InitAssigns, :require_login})
 
+  alias Vutuv.Activity
   alias Vutuv.Fediverse
   alias Vutuv.Fediverse.Follower
   alias Vutuv.Pages
@@ -40,12 +48,19 @@ defmodule VutuvWeb.FediverseFollowersLive do
     user = socket.assigns.current_user
 
     if Fediverse.federated?(user) do
+      # Nothing on this page is ever the member's own doing: a follower arrives,
+      # withdraws, renames itself or is pruned entirely on other servers' time.
+      # The owner topic is the only way the list can be right without a reload
+      # (see `Vutuv.Fediverse`'s `:remote_followers_changed`). Connected only:
+      # the disconnected render is thrown away.
+      if connected?(socket), do: Activity.subscribe(user.id)
+
       {:ok,
        socket
        |> assign(:page_title, gettext("Followers from other networks"))
        |> assign(:user, user)
-       |> assign(:total_followers, Fediverse.follower_count(user))
-       |> assign(:hosts, Fediverse.follower_hosts(user))}
+       |> init_row_marks()
+       |> assign_totals()}
     else
       {:ok, push_navigate(socket, to: ~p"/settings/fediverse")}
     end
@@ -53,8 +68,30 @@ defmodule VutuvWeb.FediverseFollowersLive do
 
   @impl true
   def handle_params(params, _uri, socket) do
+    {:noreply, socket |> assign(:filters, Fediverse.browse_filters(params)) |> load_page(params)}
+  end
+
+  # The headline count and the server dropdown: what the whole list looks like,
+  # whatever the current view filters out of it. Only something that adds or
+  # removes a follower can move them, so they refresh with the page rather than
+  # per keystroke.
+  defp assign_totals(socket) do
     user = socket.assigns.user
-    filters = Fediverse.browse_filters(params)
+
+    socket
+    |> assign(:total_followers, Fediverse.follower_count(user))
+    |> assign(:hosts, Fediverse.follower_hosts(user))
+  end
+
+  # Reloads the view the member is looking at. The page number comes from the
+  # socket rather than starting over at 1, so a follower arriving while they
+  # read page three does not throw them back to the top of the list
+  # (`Pages.effective_page/3` still catches a page that just ran out of rows).
+  defp load_page(socket), do: load_page(socket, %{"page" => socket.assigns.page})
+
+  defp load_page(socket, params) do
+    user = socket.assigns.user
+    filters = socket.assigns.filters
     per_page = Fediverse.browse_per_page()
     total = Fediverse.count_followers(user, filters)
     page = Pages.effective_page(params, total, per_page)
@@ -65,14 +102,37 @@ defmodule VutuvWeb.FediverseFollowersLive do
         per_page: per_page
       )
 
-    {:noreply,
-     socket
-     |> assign(:filters, filters)
-     |> assign(:total, total)
-     |> assign(:page, page)
-     |> assign(:per_page, per_page)
-     |> assign(:followers, followers)}
+    socket
+    |> assign(:total, total)
+    |> assign(:page, page)
+    |> assign(:per_page, per_page)
+    |> assign(:followers, followers)
   end
+
+  # ── Live updates from elsewhere ───────────────────────────────────────────
+
+  # A `Follow` arrived, an `Undo` withdrew one, an actor `Update` renamed
+  # somebody, the pruner dropped an account that is gone, or an operator blocked
+  # its server — broadcast by `Vutuv.Fediverse` on the owner's topic.
+  #
+  # What "unchanged" means for a row here is the display pair the Account column
+  # shows: a rename moves the row without anything coming or going, and the card
+  # below this table promises exactly that ("a renamed account updates here on
+  # its own too").
+  @impl true
+  def handle_info(:remote_followers_changed, socket) do
+    shown = socket.assigns.followers
+    socket = socket |> assign_totals() |> load_page()
+
+    {:noreply, mark_changed_rows(socket, shown, socket.assigns.followers, &{&1.name, &1.handle})}
+  end
+
+  def handle_info({:clear_changed_rows, seq}, socket),
+    do: {:noreply, clear_row_marks(socket, seq)}
+
+  # The owner topic carries every other in-app event (message and notification
+  # badges, follows made here); this page has nothing to do with them.
+  def handle_info(_other, socket), do: {:noreply, socket}
 
   # ── Events (every one just rewrites the URL; handle_params reloads) ──
 
@@ -153,7 +213,11 @@ defmodule VutuvWeb.FediverseFollowersLive do
                   </tr>
                 </thead>
                 <tbody id="followers">
-                  <tr :for={follower <- @followers} id={"follower-#{follower.id}"}>
+                  <tr
+                    :for={follower <- @followers}
+                    id={"follower-#{follower.id}"}
+                    data-row-changed={row_changed?(@changed_ids, follower.id)}
+                  >
                     <td>
                       <.account_link
                         uri={follower.actor_uri}

--- a/lib/vutuv_web/live/fediverse_following_live.ex
+++ b/lib/vutuv_web/live/fediverse_following_live.ex
@@ -44,11 +44,6 @@ defmodule VutuvWeb.FediverseFollowingLive do
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Pages
 
-  # How long a changed row keeps its marker. Longer than the CSS sweep
-  # (`tr[data-row-changed]`, 1.4s): taking the marker off mid-animation would
-  # cut the fade short.
-  @row_mark_ms 1_800
-
   @impl true
   def mount(_params, _session, socket) do
     user = socket.assigns.current_user
@@ -68,11 +63,7 @@ defmodule VutuvWeb.FediverseFollowingLive do
      |> assign(:blocked_reason, Fediverse.follow_refusal(user))
      |> assign(:address, "")
      |> assign(:error, nil)
-     # Nothing is marked on arrival: the animation is for a change the member
-     # watched happen, and a table that lights up on every page load would say
-     # "something moved" when nothing did.
-     |> assign(:changed_ids, MapSet.new())
-     |> assign(:change_seq, 0)
+     |> init_row_marks()
      |> assign_totals()}
   end
 
@@ -213,62 +204,23 @@ defmodule VutuvWeb.FediverseFollowingLive do
   # moves the headline count and can move the server filter and the pager, and
   # a page is at most 50 rows, so re-asking costs the same four queries the
   # member's own unfollow already pays.
+  # What "unchanged" means for a row here: the state of the follow. That is the
+  # only thing on the row another server can move (the account's own name and
+  # handle are the following browser's mirror page's business).
   @impl true
   def handle_info(:remote_follows_changed, socket) do
     shown = socket.assigns.follows
+    socket = socket |> assign_totals() |> load_page()
 
-    {:noreply,
-     socket
-     |> assign_totals()
-     |> load_page()
-     |> mark_changed_rows(shown)}
+    {:noreply, mark_changed_rows(socket, shown, socket.assigns.follows, & &1.state)}
   end
 
-  # The marker's own timer, come round: see `mark_changed_rows/2`. Ignored when
-  # a newer change has since marked its own rows, or this one would cut that
-  # animation short.
-  def handle_info({:clear_changed_rows, seq}, socket) do
-    if seq == socket.assigns.change_seq,
-      do: {:noreply, assign(socket, :changed_ids, MapSet.new())},
-      else: {:noreply, socket}
-  end
+  def handle_info({:clear_changed_rows, seq}, socket),
+    do: {:noreply, clear_row_marks(socket, seq)}
 
   # The owner topic carries every other in-app event (message and notification
   # badges, follows made here); this page has nothing to do with them.
   def handle_info(_other, socket), do: {:noreply, socket}
-
-  # Which rows the reload actually moved, so only those light up: a follow whose
-  # state changed under the member's eyes, and one that has appeared (an account
-  # that moved servers arrives as a fresh request beside its old row). A row that
-  # is simply *gone* gets nothing — there is no longer anything to mark, and
-  # animating a removal would mean holding a row the member no longer follows.
-  #
-  # "Appeared" is read against this page of the table, not the whole list, so a
-  # row that a deletion further up pulled onto the page counts as one. That is
-  # the honest reading anyway: from where the member is looking, it did just
-  # turn up.
-  #
-  # The marker is taken off again on a timer, because a CSS animation restarts
-  # only when the element begins matching the rule afresh: left on, the same row
-  # changing a second time would stay silent.
-  defp mark_changed_rows(socket, shown_before) do
-    before = Map.new(shown_before, &{&1.id, &1.state})
-
-    changed =
-      for follow <- socket.assigns.follows,
-          Map.get(before, follow.id) != follow.state,
-          into: MapSet.new(),
-          do: follow.id
-
-    if Enum.empty?(changed) do
-      socket
-    else
-      seq = socket.assigns.change_seq + 1
-      Process.send_after(self(), {:clear_changed_rows, seq}, @row_mark_ms)
-
-      socket |> assign(:changed_ids, changed) |> assign(:change_seq, seq)
-    end
-  end
 
   # ── Wording ───────────────────────────────────────────────────────────────
 
@@ -426,7 +378,7 @@ defmodule VutuvWeb.FediverseFollowingLive do
                   <tr
                     :for={follow <- @follows}
                     id={"follow-#{follow.id}"}
-                    data-row-changed={MapSet.member?(@changed_ids, follow.id)}
+                    data-row-changed={row_changed?(@changed_ids, follow.id)}
                   >
                     <td>
                       <.account_link

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.219.0",
+      version: "7.220.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/fediverse_followers_live_test.exs
+++ b/test/vutuv_web/live/fediverse_followers_live_test.exs
@@ -210,6 +210,76 @@ defmodule VutuvWeb.FediverseFollowersLiveTest do
     end
   end
 
+  describe "the list keeps itself current" do
+    setup %{conn: conn} do
+      {conn, user} = federating(conn)
+      {:ok, live, _html} = live(conn, ~p"/settings/fediverse/followers")
+      %{conn: conn, live: live, user: user}
+    end
+
+    test "a follow that arrives in the inbox lands on the open page", %{live: live, user: user} do
+      assert has_element?(live, "#no-followers")
+
+      # A follower arrives through the inbox, at a time nobody here picks —
+      # never through this page.
+      {:ok, follower} =
+        Fediverse.add_follower(user, %{
+          actor_uri: "https://mastodon.example/users/newcomer",
+          inbox_uri: "https://mastodon.example/users/newcomer/inbox",
+          handle: "newcomer",
+          name: "Newcomer"
+        })
+
+      refute has_element?(live, "#no-followers")
+      assert has_element?(live, "#follower-#{follower.id}")
+      assert render(live) =~ "@newcomer@mastodon.example"
+      # And the row says it is the one that moved.
+      assert has_element?(live, "#follower-#{follower.id}[data-row-changed]")
+
+      # The marker comes off again by itself (its timer's own message, fired
+      # here rather than waited out — first change, so its sequence is 1), or a
+      # second change to the same row would arrive on a row already marked and
+      # the CSS animation would not restart.
+      send(live.pid, {:clear_changed_rows, 1})
+      refute has_element?(live, "tr[data-row-changed]")
+    end
+
+    test "an Undo takes the follower off the open page", %{live: live, user: user} do
+      one = follower(user, handle: "one")
+
+      {:ok, _} =
+        Fediverse.add_follower(user, %{
+          actor_uri: "https://x.example/users/two",
+          inbox_uri: "https://x.example/users/two/inbox",
+          handle: "two"
+        })
+
+      Fediverse.remove_follower(user, one.actor_uri)
+
+      refute has_element?(live, "#follower-#{one.id}")
+      assert render(live) =~ "@two@x.example"
+      # The headline count went with it, not just the row.
+      assert has_element?(live, "#follower-total", "1")
+    end
+
+    test "a rename reaches the open page and marks the row", %{live: live, user: user} do
+      one = follower(user, handle: "one", name: "Old Name")
+      # A rename arrives as an actor Update, not as anything this member did.
+      :ok =
+        Fediverse.refresh_follower(user, %{
+          actor_uri: one.actor_uri,
+          inbox_uri: one.inbox_uri,
+          handle: "one",
+          name: "New Name"
+        })
+
+      html = render(live)
+      assert html =~ "New Name"
+      refute html =~ "Old Name"
+      assert has_element?(live, "#follower-#{one.id}[data-row-changed]")
+    end
+  end
+
   # vutuv is a German site, so a page whose new strings have no German msgstr
   # renders as an English island for real visitors while every English check
   # stays green.


### PR DESCRIPTION
The mirror of what [#1294](https://github.com/wintermeyer/vutuv/pull/1294) gave `/settings/fediverse/following`, for the page where the member is on the receiving end.

Nothing on the follower table is ever their own doing: a `Follow` arrives, an `Undo` withdraws one, an actor `Update` renames somebody, the pruner drops an account that is gone, an operator blocks its server. All of it happens on another server's clock, so the list was only as true as the last reload — while the card directly under the table promised that accounts which no longer exist "drop off this list by themselves" and that "a renamed account updates here on its own too". Both sentences are true now.

## What changed

`Vutuv.Fediverse` broadcasts `:remote_followers_changed` on the owner's `"user:<id>"` topic from those five write paths, beside the `:remote_follows_changed` of the other direction. **The two signals are named for the two tables and are never interchangeable** — *follows* is what the member does, *followers* is what is done to them.

`VutuvWeb.FediverseFollowersLive` subscribes on connect and reloads its current view (rows, headline count, server filter, pager), keeping the member on their page rather than dropping them back to page 1, and marks the rows that moved so they sweep once through the brand tint.

**The row-marking machinery moved into `VutuvWeb.BrowseTable`**, which these two pages already share for their query string, sortable headers, filter form and pager. A second copy here is exactly what the `.notif-clamp` / `.teaser-clamp` twins cost us once already: one bug, found and fixed twice. What stays per page is the one thing that genuinely differs — what "unchanged" means for its rows: the state of a follow on one side, the display name and handle on the other, since a rename moves a follower row without anything coming or going.

## Notes

* **Hot deploy** — no migrations, no supervision tree, no config, no deps.
* Three new tests on the followers page (a follow arriving, an `Undo`, a rename), each asserting the row *and* the marker; the following page's existing tests cover the extraction.
* `mix precommit` green: credo --strict clean, whole suite passing.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*