### PR TITLE
llms.txt nennt die Anzeigenseite nur, wenn es sie gibt (v7.221.1)

### DIFF
--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -310,8 +310,7 @@ defmodule VutuvWeb.PageController do
   - `/organizations` — the verified organization directory; one organization at `/organizations/<slug>`
   - `/jobs` — the public job board: open positions, filterable, newest first
   - `/jobs/<slug>` — a job posting: role, location, pay range, tags and how to apply
-  - `/ads` — the daily text ad: price, conditions, next available day
-    (booking happens online and requires a login)
+  {{ads}}
 
   List pages paginate with `?page=N`.
 
@@ -358,7 +357,24 @@ defmodule VutuvWeb.PageController do
   def llms(conn, _params) do
     conn
     |> put_resp_content_type("text/plain")
-    |> send_resp(200, @llms_txt)
+    |> send_resp(200, llms_txt())
+  end
+
+  # The document is a compile-time constant with one hole in it, because one of
+  # the pages it lists is optional. `:ads_enabled` ships **off** (config.exs),
+  # and the ad page 404s while it is — so listing `/ads` unconditionally pointed
+  # every installation's agents at a dead URL, vutuv.de included. A discovery
+  # file that names a page which is not there is worse than one that stays quiet
+  # about a feature.
+  defp llms_txt, do: String.replace(@llms_txt, "{{ads}}\n", ads_entry())
+
+  defp ads_entry do
+    if Vutuv.Ads.enabled?() do
+      "- `/ads` — the daily text ad: price, conditions, next available day\n" <>
+        "  (booking happens online and requires a login)\n"
+    else
+      ""
+    end
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.221.0",
+      version: "7.221.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/landing_configuration_test.exs
+++ b/test/vutuv_web/landing_configuration_test.exs
@@ -35,6 +35,34 @@ defmodule VutuvWeb.LandingConfigurationTest do
 
   defp example(url), do: put_config(:landing_example_profile_url, url)
 
+  # /llms.txt is the agent-discovery file, and it used to list `/ads`
+  # unconditionally. Ads ship switched OFF, and the ad page 404s while they are,
+  # so every installation was pointing agents at a dead URL.
+  describe "/llms.txt lists only pages this installation actually serves" do
+    test "names the ad page when ads are on", %{conn: conn} do
+      put_config(:ads_enabled, true)
+
+      body = conn |> get(~p"/llms.txt") |> response(200)
+
+      assert body =~ "`/ads`"
+      refute body =~ "{{ads}}"
+      assert body =~ "(booking happens online and requires a login)\n\nList pages"
+    end
+
+    test "leaves it out when they are off, so it names no 404", %{conn: conn} do
+      put_config(:ads_enabled, false)
+
+      body = conn |> get(~p"/llms.txt") |> response(200)
+
+      refute body =~ "`/ads`"
+      refute body =~ "{{ads}}"
+      # The rest of the document is untouched, blank line and indentation
+      # included — the placeholder must not eat the paragraph break.
+      assert body =~ "`/jobs`"
+      assert body =~ "how to apply\n\nList pages paginate with `?page=N`."
+    end
+  end
+
   describe "the landing page's installation switches" do
     # "Readable without an account" is a claim, and this is the one-click check
     # that goes with it. The label drops the scheme, the href keeps it.


### PR DESCRIPTION
Beim Nachgehen der Meldung, der `/llms.txt`-Link auf der Startseite funktioniere nicht, kam heraus: der Link selbst ist in Ordnung (200, `text/plain`, auch über `www.` und mit Browser-Headern, zehn von zehn Anfragen). Kaputt war eine URL **im** Dokument.

## Das Problem

`/llms.txt` listete `/ads` bedingungslos. Anzeigen sind aber per Auslieferungszustand abgeschaltet (`:ads_enabled` in `config.exs`), und solange sie das sind, antwortet `/ads` mit 404. Jede Installation hat damit Agenten und Crawler auf eine tote URL geschickt, vutuv.de eingeschlossen. Ein Verzeichnis, das eine nicht vorhandene Seite nennt, ist schlechter als eines, das über ein Feature schweigt.

## Die Lösung

Das Dokument bleibt eine Compile-Zeit-Konstante mit einem Platzhalter an der einen Stelle, die von der Installation abhängt; die Zeile wird beim Ausliefern eingesetzt oder weggelassen.

Zwei Tests decken beide Zustände ab — und prüfen ausdrücklich Absatzumbruch und Einrückung mit, weil der Platzhalter beim ersten Versuch die Leerzeile vor "List pages paginate" verschluckt hatte.

Die übrigen 20 in `llms.txt` genannten Pfade habe ich gegen die Produktion geprüft; alle antworten mit 200 (bis auf `/api/2.0`, das erwartungsgemäß 401 ohne Token liefert).

## Deploy

**Hot deploy.** Keine Migrationen, keine Supervision- oder Config-Änderungen.

Version **7.221.1** (patch).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*