### PR TITLE
robots.txt says it once, and Safari can read both discovery files (v7.221.3)

### DIFF
--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -110,8 +110,28 @@ defmodule VutuvWeb.PageController do
   """
   def robots(conn, _params) do
     conn
+    |> discovery_cache_headers()
     |> put_resp_content_type("text/plain")
     |> send_resp(200, VutuvWeb.RobotsTxt.render(VutuvWeb.ContentPolicy.policy()))
+  end
+
+  # robots.txt and llms.txt answer every visitor with the same bytes and carry
+  # nothing personal, so they are `public` cacheable like /sitemap.xml and
+  # /.well-known/security.txt beside them in the router (an hour, short enough
+  # that flipping :ai_crawler_policy reaches crawlers promptly; Googlebot keeps
+  # its own robots.txt copy for up to 24h regardless).
+  #
+  # Setting this is also what un-breaks the two files in Safari. Without an
+  # explicit header Plug falls back to `max-age=0, private, must-revalidate`,
+  # and Safari 26 on macOS renders such a top-level text/plain document as a
+  # blank page: the response arrives complete (nginx logs a 200 with the full
+  # body, the body decodes fine), but WebKit ends up with
+  # `<html><head></head><body></body></html>`, no `<pre>` in it, and leaves
+  # the progress bar spinning. Chrome shows the same response without complaint.
+  # These two were the only text/plain URLs in the app without an explicit
+  # cache-control, and the only ones that came up blank (2026-08-02).
+  defp discovery_cache_headers(conn) do
+    put_resp_header(conn, "cache-control", "public, max-age=3600")
   end
 
   def impressum(conn, _params) do
@@ -356,6 +376,7 @@ defmodule VutuvWeb.PageController do
   @doc "Serves /llms.txt: the agent-format discovery file (llms.txt convention)."
   def llms(conn, _params) do
     conn
+    |> discovery_cache_headers()
     |> put_resp_content_type("text/plain")
     |> send_resp(200, llms_txt())
   end

--- a/lib/vutuv_web/robots_txt.ex
+++ b/lib/vutuv_web/robots_txt.ex
@@ -6,53 +6,57 @@ defmodule VutuvWeb.RobotsTxt do
   `ContentPolicy.policy/0`.
 
   robots.txt groups do not inherit from `User-agent: *`, so every allowed
-  group carries its own copy of the sensitive-path rules. `Content-Signal`
-  is the (draft) IETF/Cloudflare vocabulary — `search`, `ai-input`,
-  `ai-train` — declared per group.
+  group carries its own copy of the path rules. Only the *rules* repeat:
+  the reasoning behind them used to sit in the same string and was
+  therefore printed once per group, which is what made the file 3.4 KB of
+  the same paragraphs over and over. The prose lives in `preamble/0` now
+  and is written once, so a group is its User-agent lines plus two rules.
+  `Content-Signal` is the (draft) IETF/Cloudflare vocabulary (`search`,
+  `ai-input`, `ai-train`), declared per group.
   """
 
   alias VutuvWeb.ContentPolicy
 
   # Built at call time so the comment names the installation's own host.
-  defp header do
+  defp preamble do
     """
     # robots.txt for #{VutuvWeb.Endpoint.host()}
     #
     # vutuv is the friendly social/business network.
     # Humans and robots are welcome and overly enthusiastic crawlers
     # are politely asked to read the house rules.
+    #
+    # The rules are short on purpose: help yourself to the public stuff
+    # (profiles, tags, listings), but the admin area is backstage, no
+    # autographs, no peeking. Every welcome group below repeats those two
+    # lines, because robots.txt groups do not inherit from `User-agent: *`.
+    #
+    # Everything else that must stay out of search is DELIBERATELY not
+    # disallowed, though several paths look like candidates. A Disallow only
+    # stops the fetch: a URL linked from elsewhere still gets indexed as a
+    # bare link, can never be crawled to learn it should drop out, and a
+    # redirect on it can never consolidate. So instead:
+    #
+    # 1. Redirects stay crawlable so their 301 can do its job: the old
+    #    /users/... URLs (-> /<slug>), /sessions/new (-> /login) and the
+    #    legacy /api/1.0/users/<slug>/vcard URLs (-> /<slug>.vcf).
+    #
+    # 2. Pages that must never surface in results carry a page-level
+    #    `X-Robots-Tag: noindex` and stay crawlable precisely so that header
+    #    is seen: the personal profile detail sub-pages (/<slug>/emails,
+    #    /tags, /work_experiences, /followers, ...; VutuvWeb.Plug.NoIndex),
+    #    the RSS feeds, /login and /search. Keeping /login fetchable also
+    #    lets the sign-in redirect behind every login-only URL a crawler
+    #    stumbles into (/posts/<id>/reply, /messages, ...) resolve cleanly
+    #    instead of stranding those URLs as "blocked by robots.txt".
+    #
+    # 3. /api/ is linked nowhere and answers every crawler itself: 404/301
+    #    for the legacy 1.0 paths, 401 for the token-only 2.0 endpoints.
     """
   end
 
-  @path_rules """
-  # Help yourself to the public stuff: profiles, tags, listings.
-  Allow: /
-
-  # ...but the admin area is backstage. No autographs, no peeking.
-  Disallow: /admin/
-
-  # Everything else that must stay out of search is DELIBERATELY not
-  # disallowed, though several paths look like candidates. A Disallow only
-  # stops the fetch: a URL linked from elsewhere still gets indexed as a
-  # bare link, can never be crawled to learn it should drop out, and a
-  # redirect on it can never consolidate. So instead:
-  #
-  # 1. Redirects stay crawlable so their 301 can do its job: the old
-  #    /users/... URLs (-> /<slug>), /sessions/new (-> /login) and the
-  #    legacy /api/1.0/users/<slug>/vcard URLs (-> /<slug>.vcf).
-  #
-  # 2. Pages that must never surface in results carry a page-level
-  #    `X-Robots-Tag: noindex` and stay crawlable precisely so that header
-  #    is seen: the personal profile detail sub-pages (/<slug>/emails,
-  #    /tags, /work_experiences, /followers, ...; VutuvWeb.Plug.NoIndex),
-  #    the RSS feeds, /login and /search. Keeping /login fetchable also
-  #    lets the sign-in redirect behind every login-only URL a crawler
-  #    stumbles into (/posts/<id>/reply, /messages, ...) resolve cleanly
-  #    instead of stranding those URLs as "blocked by robots.txt".
-  #
-  # 3. /api/ is linked nowhere and answers every crawler itself: 404/301
-  #    for the legacy 1.0 paths, 401 for the token-only 2.0 endpoints.
-  """
+  @path_rules "Allow: /\nDisallow: /admin/\n"
+  @blocked_rules "Disallow: /\n"
 
   # The AI crawlers named explicitly (the spec's list): training collects
   # for model training, retrieval fetches for live search/answers. Under
@@ -63,10 +67,14 @@ defmodule VutuvWeb.RobotsTxt do
 
   def render(:permissive) do
     [
-      header(),
+      preamble(),
       group("everyone", ["*"], @path_rules, ContentPolicy.render_signals(true, true, true)),
-      "\n# AI crawlers are welcome too — same house rules, said explicitly.\n",
-      group(nil, @training_bots ++ @retrieval_bots, @path_rules, allowed_signals(:permissive)),
+      group(
+        "AI crawlers, same house rules said explicitly",
+        @training_bots ++ @retrieval_bots,
+        @path_rules,
+        allowed_signals(:permissive)
+      ),
       sitemap_line()
     ]
     |> IO.iodata_to_binary()
@@ -74,15 +82,18 @@ defmodule VutuvWeb.RobotsTxt do
 
   def render(:block_training) do
     [
-      header(),
+      preamble(),
       group("everyone", ["*"], @path_rules, allowed_signals(:block_training)),
-      "\n# Retrieval and AI search may read; model training may not.\n",
-      group(nil, @retrieval_bots, @path_rules, allowed_signals(:block_training)),
-      "\n# Training crawlers sit this one out.\n",
       group(
-        nil,
+        "retrieval and AI search, which may read",
+        @retrieval_bots,
+        @path_rules,
+        allowed_signals(:block_training)
+      ),
+      group(
+        "training crawlers, which sit this one out",
         @training_bots,
-        "Disallow: /\n",
+        @blocked_rules,
         ContentPolicy.render_signals(false, false, false)
       ),
       sitemap_line()
@@ -95,7 +106,7 @@ defmodule VutuvWeb.RobotsTxt do
 
   defp group(comment, agents, rules, signals) do
     [
-      if(comment, do: "\n# Rules for #{comment}:\n", else: "\n"),
+      "\n# Rules for #{comment}:\n",
       Enum.map(agents, &"User-agent: #{&1}\n"),
       rules,
       "Content-Signal: #{signals}\n"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.221.2",
+      version: "7.221.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/page_controller_test.exs
+++ b/test/vutuv_web/controllers/page_controller_test.exs
@@ -71,6 +71,32 @@ defmodule VutuvWeb.PageControllerTest do
       assert body =~ "Content-Signal: ai-train=yes, search=yes, ai-input=yes"
       assert body =~ "Sitemap: http://localhost:4001/sitemap.xml"
     end
+
+    test "is publicly cacheable" do
+      assert cache_control("/robots.txt") =~ "public"
+    end
+  end
+
+  # Both discovery files answer every visitor with the same bytes, so they are
+  # `public` cacheable like /sitemap.xml and /.well-known/security.txt beside
+  # them. Without an explicit header Plug falls back to
+  # `max-age=0, private, must-revalidate`, and Safari 26 on macOS then renders
+  # such a top-level text/plain document as an EMPTY page: the response arrives
+  # complete (nginx logs a 200 with the full body), but WebKit builds
+  # `<html><head></head><body></body></html>` with no `<pre>` in it and leaves
+  # the progress bar hanging. Chrome shows the same response fine. Every other
+  # text/plain URL in this app sets `public` and renders in Safari, and these
+  # two were the only ones that did not, which is what made them look broken
+  # (2026-08-02).
+  describe "the discovery files' cache headers" do
+    test "robots.txt and llms.txt are never marked private" do
+      for path <- ["/robots.txt", "/llms.txt"] do
+        header = cache_control(path)
+
+        assert header =~ "public", "#{path} should be publicly cacheable, got: #{header}"
+        refute header =~ "private", "#{path} must not be private, got: #{header}"
+      end
+    end
   end
 
   describe "GET /llms.txt" do
@@ -725,5 +751,10 @@ defmodule VutuvWeb.PageControllerTest do
       |> File.read!()
 
     {:ok, _page} = Vutuv.Legal.upsert_page(slug, %{body: body})
+  end
+
+  defp cache_control(path) do
+    assert [header] = build_conn() |> get(path) |> get_resp_header("cache-control")
+    header
   end
 end

--- a/test/vutuv_web/robots_txt_test.exs
+++ b/test/vutuv_web/robots_txt_test.exs
@@ -36,8 +36,32 @@ defmodule VutuvWeb.RobotsTxtTest do
       body = RobotsTxt.render(:permissive)
 
       # Each group carries its own copy of the sensitive-path rules.
-      occurrences = body |> String.split("Disallow: /admin/") |> length()
-      assert occurrences == 3, "expected the path rules in both groups"
+      assert count(body, "Disallow: /admin/") == 2, "expected the path rules in both groups"
+      assert count(body, "Allow: /\n") == 2
+    end
+
+    # The *rules* have to repeat per group, the *reasoning* does not. It used to
+    # ride along in the same string, so the whole 29-line essay about why
+    # nothing else is disallowed was printed once per group and the file was
+    # 3.4 KB of mostly the same paragraphs. The prose now lives in the preamble
+    # and is written once; a group is its User-agent lines plus two rules.
+    test "explains itself once, not once per group" do
+      for policy <- [:permissive, :block_training] do
+        body = RobotsTxt.render(policy)
+
+        for sentence <- ["A Disallow only", "Redirects stay crawlable", "linked nowhere"] do
+          assert count(body, sentence) == 1,
+                 "#{policy}: #{inspect(sentence)} should appear once, not per group"
+        end
+      end
+    end
+
+    test "stays small: the prose is written once, the rules are two lines a group" do
+      # A guard on the shape, not the wording. The duplicated version was 3.4 KB
+      # because each group dragged the whole explanation along; deduplicated it
+      # is ~2.2 KB, nearly all of it the one-time preamble. If this trips again,
+      # someone re-attached prose to a per-group block.
+      assert byte_size(RobotsTxt.render(:permissive)) < 2_500
     end
 
     test "advertises the sitemap with an absolute URL" do
@@ -155,4 +179,6 @@ defmodule VutuvWeb.RobotsTxtTest do
       assert ContentPolicy.robots_directives(true, true) == "noindex, noai, noimageai"
     end
   end
+
+  defp count(body, needle), do: length(String.split(body, needle)) - 1
 end


### PR DESCRIPTION
Two things, both about `/robots.txt` and `/llms.txt`.

## The duplication

`VutuvWeb.RobotsTxt` kept the path rules and the reasoning behind them in one string, and robots.txt groups do not inherit from `User-agent: *`, so every group had to repeat that whole string. The two rules that actually matter (`Allow: /`, `Disallow: /admin/`) legitimately repeat; the 29-line essay about why nothing else is disallowed did not, and printing it once per group is most of why the file was 3.4 KB.

The prose moved into the preamble, where it is written once. A group is now its `User-agent` lines plus its two rules:

```
# Rules for everyone:
User-agent: *
Allow: /
Disallow: /admin/
Content-Signal: ai-train=yes, search=yes, ai-input=yes

# Rules for AI crawlers, same house rules said explicitly:
User-agent: GPTBot
...
User-agent: PerplexityBot
Allow: /
Disallow: /admin/
Content-Signal: ai-train=yes, search=yes, ai-input=yes
```

Same directives, 3463 -> 2238 bytes, and the whole rule set fits on one screen. Both stances (`:permissive`, `:block_training`) render correctly.

## Why Safari showed a blank page

The response was never at fault. nginx logs a complete `200`, the body decodes, `curl` prints it in full. What differs is one header.

Neither controller set `cache-control`, so Plug fell back to its default `max-age=0, private, must-revalidate`. Safari 26 on macOS renders such a top-level `text/plain` document as an **empty document** (`<html><head></head><body></body></html>`, no `<pre>`) and leaves the progress bar spinning. Chrome shows the same response without complaint.

The evidence is a clean single-variable A/B on production:

| URL | `cache-control` | Safari |
|---|---|---|
| `/.well-known/security.txt` | `public, max-age=86400` | renders |
| `/sitemap.xml` | `public, max-age=3600` | renders |
| `/<slug>.txt` | `public, max-age=300` | renders |
| `/robots.txt` | *(Plug default)* | **blank** |
| `/llms.txt` | *(Plug default)* | **blank** |

`security.txt` is the tightest comparison: it sits in the **same router scope**, is built with the same `put_resp_content_type("text/plain") |> send_resp/3`, and differs only in that header. Ruled out along the way: the zstd content-encoding (Bandit compresses these; the frames are valid, Safari decodes zstd fine, and `/<slug>.txt` is zstd too and renders), the browser cache (`?cachebust=` and a hard reload are equally blank) and the UTF-8 content.

Both files are `public, max-age=3600` now, which is what they should have been anyway: they answer every visitor with the same bytes and carry nothing personal. An hour keeps an `:ai_crawler_policy` change reaching crawlers promptly (Googlebot caches robots.txt for up to 24h on its own regardless).

## Tests

* `robots_txt_test.exs` asserts the rules still repeat per group, that each explanatory sentence appears exactly **once** across both stances, and a size guard so nobody re-attaches prose to a per-group block.
* `page_controller_test.exs` asserts both files are `public` and never `private`, with the Safari symptom written down as the reason.

`mix precommit` green (6578 tests).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01J4MXkd6t4yUoZJhmCjGgAW