### PR TITLE
The machine-facing documents say nosniff, so Safari can read them (v7.221.4)

### DIFF
--- a/lib/vutuv_web/controllers/page_controller.ex
+++ b/lib/vutuv_web/controllers/page_controller.ex
@@ -121,15 +121,9 @@ defmodule VutuvWeb.PageController do
   # that flipping :ai_crawler_policy reaches crawlers promptly; Googlebot keeps
   # its own robots.txt copy for up to 24h regardless).
   #
-  # Setting this is also what un-breaks the two files in Safari. Without an
-  # explicit header Plug falls back to `max-age=0, private, must-revalidate`,
-  # and Safari 26 on macOS renders such a top-level text/plain document as a
-  # blank page: the response arrives complete (nginx logs a 200 with the full
-  # body, the body decodes fine), but WebKit ends up with
-  # `<html><head></head><body></body></html>`, no `<pre>` in it, and leaves
-  # the progress bar spinning. Chrome shows the same response without complaint.
-  # These two were the only text/plain URLs in the app without an explicit
-  # cache-control, and the only ones that came up blank (2026-08-02).
+  # This is NOT what makes them readable in Safari, though it was the first
+  # suspect: the `nosniff` header is, and it comes from the :machine_docs
+  # pipeline in the router, which explains the whole trap.
   defp discovery_cache_headers(conn) do
     put_resp_header(conn, "cache-control", "public, max-age=3600")
   end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -43,6 +43,31 @@ defmodule VutuvWeb.Router do
     plug(Plugs.NoIndex)
   end
 
+  # The machine-facing documents (robots.txt, llms.txt, the sitemaps, the RSS
+  # feeds, the .well-known files, the ActivityPub endpoints) run without the
+  # :browser pipeline on purpose, so `accepts ["html"]` cannot turn away a
+  # crawler that asks for text/plain. They lost `put_secure_browser_headers`
+  # along with it, and one of its headers turns out not to be optional here.
+  #
+  # Every one of these declares an exact Content-Type, so nosniff is simply
+  # true. Without it Safari sniffs, and it sniffs the body it was handed, which
+  # for anything past ~512 bytes is still zstd-compressed (Bandit compresses on
+  # the way out). Compressed bytes look like binary, so Safari concludes a
+  # `text/plain` document is not text and renders NOTHING: no `<pre>`, an empty
+  # `<body>`, and a progress bar that never finishes. That is why /robots.txt
+  # and /llms.txt were blank in Safari while Chrome showed them, and why
+  # /.well-known/security.txt was fine (144 bytes, under the sniff window) and
+  # /<slug>.txt was fine too (it rides :browser and had the header all along).
+  # Measured 2026-08-02: 511 encoded bytes renders, 623 does not, and the same
+  # 1185-byte body renders as soon as this header is on it.
+  pipeline :machine_docs do
+    plug(:put_nosniff)
+  end
+
+  defp put_nosniff(conn, _opts) do
+    Plug.Conn.put_resp_header(conn, "x-content-type-options", "nosniff")
+  end
+
   pipeline :user_pipe do
     # Keep the per-user detail pages (phone numbers, emails, addresses, …) out
     # of search indexes. Runs first so the header is present even when a later
@@ -105,9 +130,12 @@ defmodule VutuvWeb.Router do
   end
 
   # Served from the app (not priv/static, which is gitignored) and with no
-  # pipeline so crawlers that send "Accept: text/plain" are not turned away
-  # by the browser pipeline's `accepts ["html"]`.
+  # browser pipeline, so crawlers that send "Accept: text/plain" are not turned
+  # away by its `accepts ["html"]`. :machine_docs adds back the one secure
+  # header these documents cannot do without (see the pipeline).
   scope "/", VutuvWeb do
+    pipe_through(:machine_docs)
+
     get("/robots.txt", PageController, :robots)
     # The agent-format discovery file (llms.txt convention): documents the
     # .md/.txt/.json/.vcf URL scheme; see VutuvWeb.AgentDocs.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.221.3",
+      version: "7.221.4",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/controllers/page_controller_test.exs
+++ b/test/vutuv_web/controllers/page_controller_test.exs
@@ -79,15 +79,7 @@ defmodule VutuvWeb.PageControllerTest do
 
   # Both discovery files answer every visitor with the same bytes, so they are
   # `public` cacheable like /sitemap.xml and /.well-known/security.txt beside
-  # them. Without an explicit header Plug falls back to
-  # `max-age=0, private, must-revalidate`, and Safari 26 on macOS then renders
-  # such a top-level text/plain document as an EMPTY page: the response arrives
-  # complete (nginx logs a 200 with the full body), but WebKit builds
-  # `<html><head></head><body></body></html>` with no `<pre>` in it and leaves
-  # the progress bar hanging. Chrome shows the same response fine. Every other
-  # text/plain URL in this app sets `public` and renders in Safari, and these
-  # two were the only ones that did not, which is what made them look broken
-  # (2026-08-02).
+  # them in the router.
   describe "the discovery files' cache headers" do
     test "robots.txt and llms.txt are never marked private" do
       for path <- ["/robots.txt", "/llms.txt"] do
@@ -95,6 +87,40 @@ defmodule VutuvWeb.PageControllerTest do
 
         assert header =~ "public", "#{path} should be publicly cacheable, got: #{header}"
         refute header =~ "private", "#{path} must not be private, got: #{header}"
+      end
+    end
+  end
+
+  # The header that decides whether a human can read these files at all.
+  #
+  # These routes deliberately skip the :browser pipeline (so a crawler sending
+  # `Accept: text/plain` is not turned away by `accepts ["html"]`), which also
+  # dropped `put_secure_browser_headers` and with it `nosniff`. Safari 26 on
+  # macOS then sniffs the body it was handed, and past ~512 bytes that body is
+  # still zstd-compressed (Bandit compresses on the way out). Compressed bytes
+  # look binary, so Safari decides a `text/plain` document is not text and
+  # renders NOTHING: empty `<body>`, no `<pre>`, progress bar spinning forever.
+  # Chrome shows the same response fine, which is what made this look like a
+  # vutuv-only mystery.
+  #
+  # Measured against production on 2026-08-02: a 511-byte encoded body renders,
+  # 623 does not, and the same 1185-byte body renders the moment this header is
+  # on it. /.well-known/security.txt escaped it only by being 144 bytes, and
+  # /<slug>.txt only by riding :browser. `mix test` sees no compression at all,
+  # so nothing here can reproduce the blank page: this asserts the header, and
+  # the header is the fix.
+  describe "the machine-facing documents' nosniff header" do
+    test "every no-pipeline document declares nosniff" do
+      for path <- [
+            "/robots.txt",
+            "/llms.txt",
+            "/sitemap.xml",
+            "/.well-known/security.txt",
+            "/.well-known/agent-skills/index.json"
+          ] do
+        assert ["nosniff"] =
+                 build_conn() |> get(path) |> get_resp_header("x-content-type-options"),
+               "#{path} must send nosniff or Safari renders it blank once it grows past ~512 encoded bytes"
       end
     end
   end


### PR DESCRIPTION
Follow-up to #1300, which blamed the wrong header. The `public` cache-control was right on its own merits and stays, but it fixed nothing: both files were still blank in Safari after that deploy.

## The real cause

These routes deliberately skip the `:browser` pipeline, so a crawler sending `Accept: text/plain` is not turned away by its `accepts ["html"]`. That also drops `put_secure_browser_headers`, and with it `X-Content-Type-Options: nosniff`.

Safari 26 then sniffs the body it was handed — and the body it was handed is **still compressed**, because Bandit gzips or zstds anything past ~512 bytes on the way out. Compressed bytes look like binary, so Safari concludes a `text/plain` document is not text and renders nothing: an empty `<body>` with no `<pre>` in it and a progress bar that never finishes. Chrome sniffs differently and shows the same response fine, which is what made this look like a vutuv-only mystery.

## Measured, not guessed

Serving the identical body from a local server, varying one thing at a time:

| encoded body | `nosniff` | Safari |
|---|---|---|
| 1185 bytes | no | **blank** |
| 1185 bytes | **yes** | renders |
| 511 bytes | no | renders |
| 623 bytes | no | **blank** |

Uncompressed, the same text always rendered; `fetch()` decoded every variant correctly, so the network layer was never at fault — only the document path.

That threshold is also why production looked so arbitrary. `/.well-known/security.txt` escaped it by being 144 bytes and `/<slug>.txt` escaped it by riding `:browser`, so the two files that broke looked special when they were only the ones that were both big *and* pipeline-less.

## The fix

A `:machine_docs` pipeline that puts the header back on that whole scope, rather than on the two files that happened to get reported. Every route in there declares an exact content type, so `nosniff` is simply true for all of them — and the sitemaps (7 KB and 40 KB encoded), the RSS feeds and `SKILL.md` were all sitting the same distance past the threshold.

It is also plain security hardening: this scope has been serving without `nosniff` all along.

## Tests

`page_controller_test.exs` asserts the header across the scope, with the threshold and the mechanism written down. Note the suite cannot reproduce the blank page — `mix test` sees no compression at all — so the test asserts the header, and the header is the fix.

`mix precommit` green (6579 tests). Verified in Safari against a local server **before** this went near production.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*

https://claude.ai/code/session_01J4MXkd6t4yUoZJhmCjGgAW