### PR TITLE
Lesezeichen und Like sitzen jetzt unter dem Profil, nicht im Menü (v7.222.0)

### DIFF
--- a/lib/vutuv_web/live/user_profile_live.ex
+++ b/lib/vutuv_web/live/user_profile_live.ex
@@ -240,18 +240,25 @@ defmodule VutuvWeb.UserProfileLive do
   end
 
   # Private, silent saves of this member (bookmark / like): no follow, no
-  # notification, no public count. The menu label flips on re-render.
+  # notification, no public count. The header card's two glyph toggles flip on
+  # the re-render, which is the whole confirmation — no toast. They used to
+  # flash one, because back when they were ⋯-menu items the label flipped out
+  # of sight behind a closing menu and nothing else moved; a filled bookmark
+  # sitting right under the cursor says it better, and a toast repeating it
+  # trains members to stop reading toasts. The classic CSRF route
+  # (UserSaveController, the no-JS path) keeps its flash: there the page
+  # reloads and the flash is the only thing that reports what happened.
   def handle_event("bookmark_user", _params, socket),
-    do: {:noreply, save_member(socket, &Social.bookmark_user/2, gettext("Bookmarked."))}
+    do: {:noreply, save_member(socket, &Social.bookmark_user/2)}
 
   def handle_event("unbookmark_user", _params, socket),
-    do: {:noreply, save_member(socket, &Social.unbookmark_user/2, gettext("Bookmark removed."))}
+    do: {:noreply, save_member(socket, &Social.unbookmark_user/2)}
 
   def handle_event("like_user", _params, socket),
-    do: {:noreply, save_member(socket, &Social.like_user/2, gettext("Liked."))}
+    do: {:noreply, save_member(socket, &Social.like_user/2)}
 
   def handle_event("unlike_user", _params, socket),
-    do: {:noreply, save_member(socket, &Social.unlike_user/2, gettext("Like removed."))}
+    do: {:noreply, save_member(socket, &Social.unlike_user/2)}
 
   # Block / unblock this member. Both reshape the page (follows severed, the
   # control swaps to Unblock and back, counts change), so reload the whole
@@ -480,23 +487,16 @@ defmodule VutuvWeb.UserProfileLive do
   end
 
   # Run a private-save toggle (bookmark/like a member) for a logged-in
-  # non-owner, then re-read the saved flags so the menu item label flips, and
-  # confirm with the same copy the controller used.
-  defp save_member(socket, fun, ok_msg) do
+  # non-owner, then re-read the saved flags so the glyph fills (or empties) and
+  # its label flips on the re-render.
+  defp save_member(socket, fun) do
     me = socket.assigns.current_user
     user = socket.assigns.user
 
     cond do
-      is_nil(me) or me.id == user.id ->
-        socket
-
-      fun.(me, user) == :ok ->
-        socket
-        |> assign(:user_saved, Social.user_saved_flags(me, user))
-        |> put_flash(:info, ok_msg)
-
-      true ->
-        socket
+      is_nil(me) or me.id == user.id -> socket
+      fun.(me, user) == :ok -> assign(socket, :user_saved, Social.user_saved_flags(me, user))
+      true -> socket
     end
   end
 

--- a/lib/vutuv_web/templates/user/show.html.heex
+++ b/lib/vutuv_web/templates/user/show.html.heex
@@ -184,13 +184,11 @@ the resulting ~200px rail width. --%>
               <:item :if={is_binary(@header_follow_id)} click="toggle_mute" value={@header_follow_id}>
                 {if @header_follow_muted?, do: gettext("Unmute"), else: gettext("Mute")}
               </:item>
-              <%!-- Private, silent saves (no follow, no notification); live toggles. --%>
-              <:item :if={saved_present?} click={if(bookmarked?, do: "unbookmark_user", else: "bookmark_user")}>
-                {if bookmarked?, do: gettext("Remove bookmark"), else: gettext("Bookmark")}
-              </:item>
-              <:item :if={saved_present?} click={if(liked?, do: "unlike_user", else: "like_user")}>
-                {if liked?, do: gettext("Unlike"), else: gettext("Like")}
-              </:item>
+              <%!-- Bookmark and Like are NOT in here any more: they are the two
+              one-click glyph toggles in the footer row below, where they read
+              like the bookmark and heart under a post. What stays in the menu
+              is what has no glyph vocabulary of its own (Message, Report) or
+              what should not be one tap away (Block). --%>
               <:item id="report-profile" href={report_path}>{gettext("Report")}</:item>
               <:item id="block-user" click="block_user" confirm={block_confirm} danger>
                 {gettext("Block")}
@@ -292,22 +290,35 @@ the resulting ~200px rail width. --%>
           </.link>
         </div>
 
-        <%!-- Footer: member-since anchors the left, the vCard download the right.
-        Report / Block moved into the #profile-actions ⋯ menu, so the footer is
-        just the universal member-since + vCard (shown to everyone, owner too). --%>
+        <%!-- Footer, ordered by how often a viewer reaches for each thing rather
+        than by kind: the two save toggles are the frequent act and own the
+        right-hand end of the row, where a thumb rests and where the same two
+        glyphs sit under every post; the rare vCard download follows the
+        member-since line on the left. Bookmark and Like live here and not in
+        the ⋯ menu, so saving a member costs the one tap it already costs on a
+        post; the menu keeps what has no such glyph vocabulary. Member-since and
+        vCard stay universal (owner and logged-out visitor included); the
+        toggles need a logged-in non-owner who has not blocked this member,
+        which is exactly what the ⋯ menu above is guarded by. The two glyphs
+        are held a good gap apart (rather than tucked together as one cluster)
+        so a thumb can tell them apart on a phone. --%>
         <div class="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-slate-100 pt-3 dark:border-slate-800">
           <.member_since_line :if={member_since} value={member_since} class="my-0" />
           <.link
             id="download-vcard"
             href={vcard_path}
             title={gettext("Download")}
-            class="ml-auto inline-flex items-center gap-1.5 text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+            class="inline-flex items-center gap-1.5 text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
           >
             <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
             </svg>
             {gettext("vCard")}
           </.link>
+          <div :if={saved_present? && !@viewer_block} class="ml-auto flex items-center gap-3">
+            <.profile_save_toggle kind={:bookmark} active?={bookmarked?} />
+            <.profile_save_toggle kind={:like} active?={liked?} />
+          </div>
         </div>
       </div>
     </section>

--- a/lib/vutuv_web/views/user_html.ex
+++ b/lib/vutuv_web/views/user_html.ex
@@ -275,6 +275,77 @@ defmodule VutuvWeb.UserHTML do
   end
 
   @doc """
+  The profile's private-save toggle — bookmark or like *this member* — as the
+  twin of the post card's bookmark and heart: the same glyph, the same fill-on-
+  active language, one click, in the footer row of the header card. It used to
+  be an item in the header's ⋯ menu, where saving a profile cost two taps and
+  looked nothing like the act everyone already knows from a post.
+
+  The save is silent and private (no follow, no notification, no public count),
+  so unlike the post bar there is no counter beside the glyph and its own state
+  is the whole confirmation: the glyph fills, `aria-pressed` flips, and the
+  label swaps between "Bookmark" and "Remove bookmark". Icon-only, so that
+  label rides `title` + `aria-label`; it is a full 40px touch target because it
+  stands alone in a footer row rather than in the post bar's dense cluster.
+
+  `kind` picks the pair of events the profile LiveView handles
+  (`bookmark_user` / `unbookmark_user`, `like_user` / `unlike_user`); keep the
+  logged-in, non-owner, non-blocker guard on the `:if` at the call site.
+  """
+  attr(:kind, :atom, required: true, values: [:bookmark, :like])
+  attr(:active?, :boolean, required: true)
+
+  def profile_save_toggle(assigns) do
+    assigns = assign(assigns, :spec, save_toggle_spec(assigns.kind, assigns.active?))
+
+    ~H"""
+    <button
+      type="button"
+      id={@spec.id}
+      phx-click={@spec.event}
+      aria-pressed={to_string(@active?)}
+      aria-label={@spec.label}
+      title={@spec.label}
+      data-profile-save={@spec.token}
+      class={[
+        "inline-flex h-10 w-10 items-center justify-center rounded-lg",
+        "hover:bg-slate-100 dark:hover:bg-slate-800",
+        # components.css colors a bare `button` brand-600, which would beat the
+        # row's inherited slate — so the state color sits on the button itself.
+        if(@active?, do: @spec.active_class, else: "text-slate-600 dark:text-slate-400")
+      ]}
+    >
+      <.icon_bookmark :if={@kind == :bookmark} filled?={@active?} />
+      <.icon_heart :if={@kind == :like} filled?={@active?} />
+    </button>
+    """
+  end
+
+  # Everything that differs between the two toggles, in one place: the ids the
+  # tests key on, the event pair, the label (which names the act, not the
+  # state), and the active tint — brand for a bookmark, the coral accent for a
+  # like, exactly as the post action bar colors the same two glyphs.
+  defp save_toggle_spec(:bookmark, active?) do
+    %{
+      id: "profile-bookmark",
+      token: "bookmark",
+      event: if(active?, do: "unbookmark_user", else: "bookmark_user"),
+      label: if(active?, do: gettext("Remove bookmark"), else: gettext("Bookmark")),
+      active_class: "text-brand-600 dark:text-brand-300"
+    }
+  end
+
+  defp save_toggle_spec(:like, active?) do
+    %{
+      id: "profile-like",
+      token: "like",
+      event: if(active?, do: "unlike_user", else: "like_user"),
+      label: if(active?, do: gettext("Unlike"), else: gettext("Like")),
+      active_class: "text-accent"
+    }
+  end
+
+  @doc """
   A single-path brand glyph for a social-media provider (Simple Icons, CC0),
   drawn in `currentColor` so it inherits the surrounding text colour and can
   shift on hover. Unknown providers fall back to a generic link glyph. Used by

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.221.5",
+      version: "7.222.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/user_profile_live_test.exs
+++ b/test/vutuv_web/live/user_profile_live_test.exs
@@ -175,21 +175,6 @@ defmodule VutuvWeb.UserProfileLiveTest do
       assert view |> element(~s(button[phx-click="toggle_mute"])) |> render_click() =~ "Mute"
     end
 
-    test "bookmark / like toggle the menu item between save and remove", %{conn: conn} do
-      {conn, _viewer} = create_and_login_user(conn)
-      owner = insert_activated_user()
-
-      {:ok, view, _html} = live(conn, ~p"/#{owner}")
-
-      assert has_element?(view, ~s(button[phx-click="bookmark_user"]))
-      view |> element(~s(button[phx-click="bookmark_user"])) |> render_click()
-      assert has_element?(view, ~s(button[phx-click="unbookmark_user"]))
-
-      assert has_element?(view, ~s(button[phx-click="like_user"]))
-      view |> element(~s(button[phx-click="like_user"])) |> render_click()
-      assert has_element?(view, ~s(button[phx-click="unlike_user"]))
-    end
-
     test "blocking swaps the controls to Unblock, and unblocking restores them", %{conn: conn} do
       {conn, _viewer} = create_and_login_user(conn)
       owner = insert_activated_user()
@@ -206,6 +191,117 @@ defmodule VutuvWeb.UserProfileLiveTest do
       refute has_element?(view, "#unblock-user")
       # The follow pill is back once the block is gone.
       assert has_element?(view, ~s(button[phx-click="follow"][phx-value-followee="#{owner.id}"]))
+    end
+  end
+
+  describe "bookmark / like straight from the header card" do
+    test "each toggle flips its own state without a reload", %{conn: conn} do
+      {conn, _viewer} = create_and_login_user(conn)
+      owner = insert_activated_user()
+
+      {:ok, view, _html} = live(conn, ~p"/#{owner}")
+
+      bookmark = "#profile-bookmark"
+      like = "#profile-like"
+
+      assert has_element?(view, ~s(#{bookmark}[phx-click="bookmark_user"][aria-pressed="false"]))
+      view |> element(bookmark) |> render_click()
+      assert has_element?(view, ~s(#{bookmark}[phx-click="unbookmark_user"][aria-pressed="true"]))
+      view |> element(bookmark) |> render_click()
+      assert has_element?(view, ~s(#{bookmark}[phx-click="bookmark_user"][aria-pressed="false"]))
+
+      assert has_element?(view, ~s(#{like}[phx-click="like_user"][aria-pressed="false"]))
+      view |> element(like) |> render_click()
+      assert has_element?(view, ~s(#{like}[phx-click="unlike_user"][aria-pressed="true"]))
+      view |> element(like) |> render_click()
+      assert has_element?(view, ~s(#{like}[phx-click="like_user"][aria-pressed="false"]))
+    end
+
+    test "a toggle raises no toast — the glyph itself is the confirmation", %{conn: conn} do
+      {conn, _viewer} = create_and_login_user(conn)
+      owner = insert_activated_user()
+
+      {:ok, view, _html} = live(conn, ~p"/#{owner}")
+
+      # The tray already holds the login's "Welcome back" toast, so the claim is
+      # that a toggle leaves it exactly as it was — a put_flash would replace
+      # that text with its own confirmation.
+      tray = fn ->
+        view
+        |> render()
+        |> LazyHTML.from_document()
+        |> LazyHTML.query("#toast-tray")
+        |> LazyHTML.text()
+      end
+
+      before = tray.()
+
+      view |> element("#profile-bookmark") |> render_click()
+      assert has_element?(view, ~s(#profile-bookmark[aria-pressed="true"]))
+      assert tray.() == before
+
+      view |> element("#profile-like") |> render_click()
+      assert has_element?(view, ~s(#profile-like[aria-pressed="true"]))
+      assert tray.() == before
+    end
+
+    test "the frequent act sits last in the row, the rare vCard download first", %{conn: conn} do
+      {conn, _viewer} = create_and_login_user(conn)
+      owner = insert_activated_user()
+
+      {:ok, _view, html} = live(conn, ~p"/#{owner}")
+
+      {vcard_at, _} = :binary.match(html, ~s(id="download-vcard"))
+      {bookmark_at, _} = :binary.match(html, ~s(id="profile-bookmark"))
+      {like_at, _} = :binary.match(html, ~s(id="profile-like"))
+      assert vcard_at < bookmark_at and bookmark_at < like_at
+    end
+
+    test "the ⋯ menu no longer carries either of them", %{conn: conn} do
+      {conn, _viewer} = create_and_login_user(conn)
+      owner = insert_activated_user()
+
+      {:ok, view, _html} = live(conn, ~p"/#{owner}")
+
+      menu = "#profile-actions-menu"
+      refute has_element?(view, ~s(#{menu} button[phx-click="bookmark_user"]))
+      refute has_element?(view, ~s(#{menu} button[phx-click="like_user"]))
+      # What the menu keeps: navigation and the heavier moderation actions.
+      assert has_element?(view, "#{menu} #message-user")
+      assert has_element?(view, "#{menu} #report-profile")
+      assert has_element?(view, "#{menu} #block-user")
+    end
+
+    test "a signed-out visitor gets no toggles", %{conn: conn} do
+      owner = insert_activated_user()
+
+      {:ok, view, _html} = live(conn, ~p"/#{owner}")
+
+      refute has_element?(view, "#profile-bookmark")
+      refute has_element?(view, "#profile-like")
+      # The row itself still carries the vCard download for everyone.
+      assert has_element?(view, "#download-vcard")
+    end
+
+    test "the owner cannot bookmark or like themselves", %{conn: conn} do
+      {conn, viewer} = create_and_login_user(conn)
+
+      {:ok, view, _html} = live(conn, ~p"/#{viewer}")
+
+      refute has_element?(view, "#profile-bookmark")
+      refute has_element?(view, "#profile-like")
+    end
+
+    test "a member the viewer blocked shows Unblock alone, no toggles", %{conn: conn} do
+      {conn, viewer} = create_and_login_user(conn)
+      owner = insert_activated_user()
+      {:ok, _} = Social.block_user(viewer, owner)
+
+      {:ok, view, _html} = live(conn, ~p"/#{owner}")
+
+      assert has_element?(view, "#unblock-user")
+      refute has_element?(view, "#profile-bookmark")
+      refute has_element?(view, "#profile-like")
     end
   end
 


### PR DESCRIPTION
**TL;DR** Ein Profil mit Lesezeichen zu versehen (oder zu liken) kostete zwei Taps im ⋯-Menü. Beides sind jetzt Ein-Klick-Glyphen in der Fußzeile der Header-Card, mit denselben Symbolen wie unter einem Post.

**Warum:** Unter einem Post ist das Lesezeichen immer an derselben Stelle und einen Klick entfernt. Auf dem Profil lag derselbe Akt in einem Menü, das sich beim Klick schließt, sodass man die Wirkung gar nicht sah.

**Was sich ändert**

- **Zwei Toggles in der Fußzeile** der Header-Card, `<.icon_bookmark>` / `<.icon_heart>` wie am Post: gefüllt heißt gesetzt, brandblau fürs Lesezeichen, Koralle fürs Herz. 40 x 40 px Touch-Ziele, Label über `title` + `aria-label`, Zustand über `aria-pressed`. Sichtbar für eingeloggte Nicht-Eigentümer, die das Mitglied nicht blockiert haben.
- **Reihenfolge nach Häufigkeit:** der seltene vCard-Download folgt links auf die Mitglied-seit-Zeile, die häufigen Toggles halten das rechte Ende. Zwischen den Glyphen liegt ein spürbarer Abstand, damit sie auf einem Telefon nicht als ein Block gelesen werden.
- **Beide Einträge sind aus dem ⋯-Menü raus.** Dort bleibt Nachricht, Stummschalten, Melden, Blockieren.
- **Keine Toasts mehr** beim Umschalten: das gefüllte Symbol ist die Bestätigung. Der klassische CSRF-Weg (`UserSaveController`, ohne JavaScript) behält seine Meldung, dort lädt die Seite neu.

**Tests:** sieben neue in `user_profile_live_test.exs` (Umschalten hin und zurück ohne Reload, Menü führt beide nicht mehr, kein Toast, Reihenfolge in der Zeile, und die drei Fälle ohne Toggles: ausgeloggt, eigenes Profil, blockiert). `mix precommit` grün.

**Im Browser geprüft:** beide Zustände, Zustand übersteht einen Reload, Zeile bricht auf schmaler Breite sauber um, Abstand nachgemessen.

**Deploy:** hot (keine Migrationen, keine Änderungen an Supervision, `runtime.exs` oder Dependencies).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*