### PR TITLE
The push gate checks the worktree the push actually comes from (v7.222.1)

### DIFF
--- a/.claude/hooks/precommit-before-push.sh
+++ b/.claude/hooks/precommit-before-push.sh
@@ -1,29 +1,196 @@
 #!/usr/bin/env bash
 # PreToolUse(Bash) gate: before any `git push`, run the project's full precommit
-# (`mix precommit` = compile --warnings-as-errors, credo --strict, format check,
-# mix test) and BLOCK the push if it fails. CI runs the same gate, and a push to
-# `main` auto-deploys to production, so a failing precommit must never be pushed.
+# (`mix precommit` = compile --warnings-as-errors, deps.unlock --unused, format
+# check, credo --strict, mix test) and BLOCK the push if it fails. CI runs the
+# same gate and a push to `main` auto-deploys to production, so a failing
+# precommit must never be pushed.
 #
-# The tool call arrives as JSON on stdin; we act only on `git push` commands and
-# let every other Bash command through. Exit 2 blocks the tool call and feeds the
-# precommit output back to Claude.
+# The tool call arrives as JSON on stdin. Exit 2 blocks the call and feeds the
+# reason back to Claude; exit 0 lets it through.
+#
+# Two rules this script exists to honour, both learned the hard way (2026-08-02):
+#
+#   1. CHECK THE TREE THE PUSH COMES FROM. This used to `cd $CLAUDE_PROJECT_DIR`,
+#      which names the *session's* project directory, not the worktree the push
+#      runs in. Several worktrees share this repo, so the gate would run
+#      `mix precommit` in one checkout and wave through a push from another —
+#      reporting green for code it had never compiled. The push's own directory
+#      is resolved below, and when it cannot be resolved the push is BLOCKED.
+#      Every degraded path here fails closed: silence must never mean "allow".
+#
+#   2. RECOGNISE A PUSH BY ITS SHAPE, NOT BY A SUBSTRING. This used to match
+#      `*"git push"*` anywhere in the command line, which over-matched (a plain
+#      `grep "git push"` was blocked) and, far worse, under-matched: the common
+#      `git -C <dir> push` does not contain the string "git push" and sailed
+#      straight past the gate. Each segment of the command line is now tokenised
+#      and a git invocation's subcommand is read properly.
+#
+# LIMITS — read this as a backstop, not a sandbox. It sees `git` invoked
+# directly in a segment of one Bash tool call. It cannot see a push made through
+# a wrapper it does not know (`bash -c '…'`, `xargs git`, a shell function, a
+# script, a Makefile target, an editor's VCS integration), and quoting is
+# approximated rather than parsed. It is the last automatic reminder before
+# production, not a guarantee that nothing else can push.
+#
+# Run `bash precommit-before-push.sh --explain < payload.json` to print the
+# decision (ALLOW / PUSH <toplevel> / BLOCK <reason>) without running precommit.
+# `test/vutuv/precommit_hook_test.exs` drives that mode, so CI covers this file.
 set -uo pipefail
 
-command=$(jq -r '.tool_input.command // ""' 2>/dev/null)
+explain=0
+[ "${1:-}" = "--explain" ] && explain=1
 
-case "$command" in
-  *"git push"*) : ;;  # a push — fall through to the gate
-  *) exit 0 ;;        # anything else — allow untouched
-esac
+block() {
+  if [ "$explain" -eq 1 ]; then
+    echo "BLOCK $1"
+    exit 0
+  fi
+  echo "" 1>&2
+  echo "BLOCKED: $1" 1>&2
+  echo "CI runs the same gate, and pushing to main auto-deploys to production." 1>&2
+  exit 2
+}
 
-cd "${CLAUDE_PROJECT_DIR:-$PWD}" 2>/dev/null || true
+allow() {
+  [ "$explain" -eq 1 ] && echo "ALLOW"
+  exit 0
+}
 
-# Stream precommit output to stderr so a failure is surfaced back to Claude.
+payload=$(cat)
+
+# Without `jq` the command line cannot be read at all, and an unreadable command
+# must not be mistaken for a harmless one. Blocking every Bash call would brick
+# the session, so narrow it to the dangerous case: if the raw payload so much as
+# mentions git and push, refuse; otherwise let it through.
+if ! command -v jq >/dev/null 2>&1; then
+  case "$payload" in
+    *git*push*)
+      block "\`jq\` is not installed, so this push cannot be vetted. Install jq (\`brew install jq\`) or run \`mix precommit\` yourself before pushing."
+      ;;
+    *) allow ;;
+  esac
+fi
+
+command=$(printf '%s' "$payload" | jq -r '.tool_input.command // ""' 2>/dev/null)
+payload_cwd=$(printf '%s' "$payload" | jq -r '.cwd // ""' 2>/dev/null)
+
+# One layer of surrounding quotes, removed. Full shell quoting is not parsed —
+# see LIMITS above.
+strip_quotes() {
+  local t=$1
+  t=${t#\"}
+  t=${t%\"}
+  t=${t#\'}
+  t=${t%\'}
+  printf '%s' "$t"
+}
+
+# The command line, split into segments on the operators that separate one
+# command from the next. Splitting inside a quoted string only produces extra
+# segments that start with no command at all, which are ignored.
+segments=$(printf '%s' "$command" | awk '{gsub(/&&|\|\||;|\||&/, "\n"); print}')
+
+found_push=0
+push_dir=""
+# A `cd` in an earlier segment governs a push in a later one
+# (`cd /tree && git push`), so the walk carries the last target along.
+chain_dir=""
+
+while IFS= read -r segment; do
+  # Word-split on whitespace. Quoted arguments holding spaces are split too;
+  # that can only cost us the *directory*, never the push detection.
+  read -ra words <<<"$segment"
+  [ "${#words[@]}" -eq 0 ] && continue
+
+  # Skip leading `VAR=value` environment assignments.
+  idx=0
+  while [ "$idx" -lt "${#words[@]}" ]; do
+    case "${words[$idx]}" in
+      [A-Za-z_]*=*) idx=$((idx + 1)) ;;
+      *) break ;;
+    esac
+  done
+  [ "$idx" -lt "${#words[@]}" ] || continue
+
+  argv0=$(strip_quotes "${words[$idx]}")
+  case "${argv0##*/}" in
+    cd)
+      next=$((idx + 1))
+      [ "$next" -lt "${#words[@]}" ] && chain_dir=$(strip_quotes "${words[$next]}")
+      continue
+      ;;
+    git) ;;
+    *) continue ;;
+  esac
+
+  # Walk git's own global options to find the subcommand. `-C <dir>` names the
+  # tree the push runs in and is the whole reason this parse exists.
+  dir_opt=""
+  subcommand=""
+  j=$((idx + 1))
+  while [ "$j" -lt "${#words[@]}" ]; do
+    w=$(strip_quotes "${words[$j]}")
+    case "$w" in
+      -C)
+        j=$((j + 1))
+        [ "$j" -lt "${#words[@]}" ] && dir_opt=$(strip_quotes "${words[$j]}")
+        ;;
+      -C?*) dir_opt=${w#-C} ;;
+      # Global options that swallow the following word.
+      -c | --git-dir | --work-tree | --namespace | --exec-path | --config-env)
+        j=$((j + 1))
+        ;;
+      -*) : ;; # any other global option (including the `--opt=value` forms)
+      *)
+        subcommand=$w
+        break
+        ;;
+    esac
+    j=$((j + 1))
+  done
+
+  if [ "$subcommand" = "push" ]; then
+    found_push=1
+  elif [ -z "$subcommand" ]; then
+    # No subcommand identified — an option this script does not know swallowed
+    # it. Under-matching is the dangerous direction, so fall back to a bare
+    # scan: a `push` token anywhere in a git invocation counts as a push.
+    for w in "${words[@]}"; do
+      [ "$(strip_quotes "$w")" = "push" ] && found_push=1 && break
+    done
+  fi
+
+  if [ "$found_push" -eq 1 ]; then
+    push_dir=${dir_opt:-$chain_dir}
+    break
+  fi
+done <<<"$segments"
+
+[ "$found_push" -eq 1 ] || allow
+
+# Resolve the worktree the push actually runs in: an explicit `git -C <dir>`
+# first, then a `cd` from the same command line, then the directory the tool
+# call was made in. Anything unresolvable blocks.
+dir=${push_dir:-$payload_cwd}
+dir=${dir:-$PWD}
+
+toplevel=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
+[ -n "$toplevel" ] ||
+  block "cannot tell which git worktree this push comes from (looked in: ${dir:-<empty>}). Refusing to guess."
+
+[ -f "$toplevel/mix.exs" ] ||
+  block "$toplevel is not the vutuv project root (no mix.exs), so the precommit gate cannot vouch for this push."
+
+if [ "$explain" -eq 1 ]; then
+  echo "PUSH $toplevel"
+  exit 0
+fi
+
+cd "$toplevel" || block "cannot enter $toplevel."
+
+echo "Running mix precommit in $toplevel …" 1>&2
 if mise exec -- mix precommit 1>&2; then
   exit 0
 fi
 
-echo "" 1>&2
-echo "BLOCKED: \`mix precommit\` failed — fix it before pushing." 1>&2
-echo "CI runs the same gate, and pushing to main auto-deploys to production." 1>&2
-exit 2
+block "\`mix precommit\` failed in $toplevel — fix it before pushing."

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.222.1",
+      version: "7.222.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/precommit_hook_test.exs
+++ b/test/vutuv/precommit_hook_test.exs
@@ -1,0 +1,173 @@
+defmodule Vutuv.PrecommitHookTest do
+  @moduledoc """
+  `.claude/hooks/precommit-before-push.sh` is the last automatic gate before a
+  push, and a push to `main` auto-deploys to production. It shipped with two
+  defects that this covers (both found 2026-08-02):
+
+    * it ran `mix precommit` in `$CLAUDE_PROJECT_DIR` rather than in the
+      worktree the push came from, so with several worktrees on one repository
+      it could report green for code it had never compiled;
+    * it recognised a push by the substring `"git push"`, which blocked a plain
+      `grep "git push"` and, far worse, missed `git -C <dir> push` entirely.
+
+  The three shapes asserted here are the ones a guard like this fails in:
+  the exemption belonging to a *different* unit of the command line, the
+  forbidden effect spelled a way the rule does not literally name, and a
+  degraded path (missing dependency, unresolvable directory) that must fail
+  closed rather than wave the push through.
+
+  The hook's `--explain` mode prints its decision without running precommit;
+  that mode exists for this test, and the settings.json invocation passes no
+  arguments so it can never be reached in normal use.
+  """
+  use ExUnit.Case, async: true
+
+  @hook ".claude/hooks/precommit-before-push.sh"
+
+  setup do
+    root = File.cwd!()
+    {:ok, root: root, hook: Path.join(root, @hook)}
+  end
+
+  describe "commands that are not a push" do
+    test "an ordinary command is allowed", ctx do
+      assert decide(ctx, "echo hello") == "ALLOW"
+    end
+
+    test "a command that merely mentions the words is allowed", ctx do
+      # The exemption belongs to a different unit: `git push` appears as grep's
+      # argument, not as the command being run. The substring match blocked this.
+      assert decide(ctx, ~s{grep -rn "git push" .claude/}) == "ALLOW"
+      assert decide(ctx, ~s{echo "run git push when done"}) == "ALLOW"
+    end
+
+    test "other git subcommands are allowed", ctx do
+      assert decide(ctx, "git status") == "ALLOW"
+      assert decide(ctx, "git log --oneline") == "ALLOW"
+      assert decide(ctx, "git log --grep push") == "ALLOW"
+    end
+  end
+
+  describe "pushes, however they are spelled" do
+    test "a plain push resolves to the tool call's own directory", ctx do
+      assert decide(ctx, "git push") == "PUSH #{ctx.root}"
+      assert decide(ctx, "git push origin main") == "PUSH #{ctx.root}"
+    end
+
+    test "`git -C <dir> push` is a push and names its own tree", ctx do
+      # The spelling the old substring rule could not see at all.
+      assert decide(ctx, "git -C #{ctx.root} push") == "PUSH #{ctx.root}"
+      assert decide(ctx, "git -C#{ctx.root} push origin HEAD") == "PUSH #{ctx.root}"
+    end
+
+    test "a push behind a chain operator is still a push", ctx do
+      assert decide(ctx, "mix test && git push") == "PUSH #{ctx.root}"
+      assert decide(ctx, "echo one; git push") == "PUSH #{ctx.root}"
+    end
+
+    test "a leading cd governs the push that follows it", ctx do
+      assert decide(ctx, "cd #{ctx.root} && git push") == "PUSH #{ctx.root}"
+    end
+
+    test "environment assignments before git do not hide the push", ctx do
+      assert decide(ctx, "GIT_TRACE=1 git push") == "PUSH #{ctx.root}"
+    end
+
+    test "global options that swallow a word do not hide the push", ctx do
+      assert decide(ctx, "git -c user.name=x push") == "PUSH #{ctx.root}"
+    end
+  end
+
+  describe "degraded paths fail closed" do
+    test "an unresolvable working directory blocks instead of allowing", ctx do
+      decision = decide(ctx, "git push", cwd: "/nonexistent/worktree")
+
+      assert decision =~ "BLOCK",
+             "a push whose tree cannot be resolved must be blocked, got: #{decision}"
+
+      assert decision =~ "cannot tell which git worktree"
+    end
+
+    test "a push from a tree that is not the project blocks", ctx do
+      # Resolvable as a git repo is not enough — it must be the vutuv checkout,
+      # or precommit would vouch for the wrong thing.
+      tmp =
+        System.tmp_dir!()
+        |> Path.join("precommit-hook-test-#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp)
+      on_exit(fn -> File.rm_rf!(tmp) end)
+      {_, 0} = System.cmd("git", ["init", "--quiet", tmp])
+
+      decision = decide(ctx, "git -C #{tmp} push")
+
+      assert decision =~ "BLOCK", "expected a block, got: #{decision}"
+      assert decision =~ "not the vutuv project root"
+    end
+
+    test "without jq a push is refused rather than waved through", ctx do
+      # The dependency this hook reads its input with, removed. Silence must
+      # mean "block", never "allow".
+      path = path_without_jq()
+
+      assert decide(ctx, "git push", path: path) =~ "BLOCK"
+      assert decide(ctx, "git push", path: path) =~ "jq"
+      # A harmless command still gets through, so a missing jq does not brick
+      # every Bash call in the session.
+      assert decide(ctx, "echo hello", path: path) == "ALLOW"
+    end
+  end
+
+  # Runs the hook in `--explain` mode against a payload and returns its verdict.
+  # `System.cmd/3` cannot feed stdin, so the payload goes in through a file
+  # redirect run by `sh`.
+  defp decide(ctx, command, opts \\ []) do
+    cwd = Keyword.get(opts, :cwd, ctx.root)
+    payload = Jason.encode!(%{"cwd" => cwd, "tool_input" => %{"command" => command}})
+
+    payload_file =
+      Path.join(
+        System.tmp_dir!(),
+        "precommit-hook-payload-#{System.unique_integer([:positive])}.json"
+      )
+
+    File.write!(payload_file, payload)
+    on_exit(fn -> File.rm(payload_file) end)
+
+    env =
+      case Keyword.fetch(opts, :path) do
+        {:ok, path} -> [{"PATH", path}]
+        :error -> []
+      end
+
+    script = "bash #{shell_quote(ctx.hook)} --explain < #{shell_quote(payload_file)}"
+
+    {out, _status} =
+      System.cmd("sh", ["-c", script], cd: ctx.root, env: env, stderr_to_stdout: true)
+
+    String.trim(out)
+  end
+
+  defp shell_quote(value), do: "'" <> String.replace(value, "'", ~S('\'')) <> "'"
+
+  # A PATH holding every binary the hook needs except `jq`.
+  defp path_without_jq do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "precommit-hook-nojq-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    for tool <- ~w(bash sh awk git cat sed grep env) do
+      case System.find_executable(tool) do
+        nil -> :ok
+        path -> File.ln_s!(path, Path.join(dir, tool))
+      end
+    end
+
+    dir
+  end
+end


### PR DESCRIPTION
**TL;DR** The pre-push gate ran `mix precommit` in the wrong worktree and recognised a push by a substring, so it blocked harmless commands, missed `git -C <dir> push` entirely, and could report green for code it had never compiled.

**Where:** `.claude/hooks/precommit-before-push.sh` (wired as the `PreToolUse(Bash)` hook in `.claude/settings.json`)

**Now:**
* `cd "${CLAUDE_PROJECT_DIR:-$PWD}"` — the *session's* project directory, not the tree the push runs in. Several worktrees share this repository, so the gate could compile checkout A and wave through a push from checkout B.
* `case "$command" in *"git push"*)` — a substring. `grep "git push"` was blocked; `git -C <dir> push` does not contain the string and sailed straight past.
* No `jq` installed meant the command line read as empty, which read as "not a push", which read as "allow".

**Want:** the gate checks the tree the push comes from, recognises a push by its shape, and fails closed on every degraded path.

```
                     old                              new
git push  ─────► cd $CLAUDE_PROJECT_DIR   git push  ─────► resolve from the call:
   from            (some other worktree)     from            -C <dir> › cd › cwd
worktree B            precommit ✓         worktree B       precommit in worktree B
                         ▲                                          │
                    never saw B's code                   unresolvable → BLOCK
```

**Repro:** in a second worktree, `git push` on a branch with a deliberately broken test. The gate ran precommit in the main checkout and reported green. In this session it surfaced as the mirror-image symptom: the worktree had no `deps/`, so the gate blocked *every* push regardless of the branch, and the agent working #1237 got past it only because `git -C <path> push` did not match the substring.

**How a push is recognised now:** each segment of the command line (split on `&&`, `||`, `;`, `|`, `&`) is tokenised, leading `VAR=value` assignments are skipped, and a git invocation's global options are walked to find the real subcommand. `-C <dir>` and a preceding `cd` name the tree. When an unknown global option swallows the subcommand, a bare `push` token still counts: under-matching is the dangerous direction, over-matching only costs a precommit run.

**What it still cannot see,** stated in the script's own header so it is read as a backstop rather than a sandbox: a push through a wrapper it does not know (`bash -c '…'`, `xargs git`, a shell function, a script, a Makefile target, an editor's VCS integration). Shell quoting is approximated, not parsed.

**Tests:** `test/vutuv/precommit_hook_test.exs` drives the script's new `--explain` mode, which prints its verdict without running precommit (the `settings.json` invocation passes no arguments, so that mode is unreachable in normal use). Twelve cases across the three shapes a guard like this fails in: the words appearing as another command's argument, the spellings the substring rule could not see, and each degraded path — unresolvable directory, a git repo that is not this project, and `jq` removed from `PATH` — blocking rather than allowing. All three failed against the old script.

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*
