### PR TITLE
Die Like-Zahlen fremder Posts bleiben nicht mehr bei null stehen (v7.228.1)

### DIFF
--- a/docs/architecture/fediverse.md
+++ b/docs/architecture/fediverse.md
@@ -1266,6 +1266,30 @@ a `totalItems`. The figures are knowable; they have to be asked for.
 - **Public and unlisted objects only, and only signed.** A followers-only or
   direct object answers `403` anyway, and asking would tell its origin that we
   hold their member's private post and how often we look at it.
+- **Whoever we sign as has a reason to be asking**, and for a boosted post that
+  reason is one step further out than it looks: nobody here follows the author,
+  so the signer is a member who follows the account that *re-shared* it — the
+  same follower `fetch_and_store_announced/2` signed as to store the post in the
+  first place.
+- **An object nobody can ask about is still stamped.** `counts_checked_at` is
+  the ladder's clock, not a claim that we asked, and a skip that leaves it alone
+  is due again two minutes later — for good, since nothing about the object
+  changes in that time — while the queue is served least-recently-asked first
+  and therefore hands it the front of every batch from now on.
+
+That last point is the one that bit. Until v7.228.1 the signer for a cached post
+was only ever a follower of its **author**, so every post boosted into a feed by
+a followed account was unaskable — and a skip wrote nothing. On production those
+objects took the front of the queue permanently, and because the per-host cap is
+applied to an already-sorted list they also spent their host's whole quota: a
+60-object batch resolved to 37 objects, *all* of them unaskable, twice a minute,
+for hours. Nothing else was ever reached, `ard.social` (the largest single
+source cached here) did not appear in a batch at all, and the day's posts — each
+stamped on arrival and so last in the queue — kept the `0` their `Create` had
+carried. Both halves are fixed: the boost fallback makes almost all of them
+askable, and a genuine skip now stamps (no strike: the origin did nothing wrong
+and a signer appears the moment somebody here follows the account) so the object
+rejoins the ladder and ages off it like everything else.
 
 The columns are nullable on both `fediverse_posts` and `fediverse_notes`
 (`likes_count`, `shares_count`, `counts_checked_at`, `counts_etag`,

--- a/lib/vutuv/fediverse.ex
+++ b/lib/vutuv/fediverse.ex
@@ -4290,14 +4290,35 @@ defmodule Vutuv.Fediverse do
       belongs to the retention paths (`refresh_note/1`,
       `refresh_reposted_post/1`), which are built to weigh a `403` properly.
       A counter refresh must never become a deletion path by accident.
+
+  A `:skip` still stamps `counts_checked_at`, and that is the one thing here
+  worth spelling out. It is not a claim that we asked: it is the ladder's clock,
+  and leaving it alone means the object is due again on the next run — for good,
+  since nothing about it changes in two minutes — while `due_for_counts/1`
+  serves the least recently asked first and therefore puts it at the head of
+  every queue from now on. A handful of such objects then spend the whole batch
+  cap on questions nobody can ask, and the posts a member is reading right now,
+  stamped on arrival and so last in the queue, are never reached at all. That
+  ran on production: every object boosted into the feed by a followed account
+  was unsignable (fixed in `counts_signer/1` below), 50 of them held the front
+  of a 60-object batch, and the day's posts kept the `0` their `Create` had
+  carried. Stamped, the object simply rejoins the ladder, is reconsidered at
+  its tier's pace, and ages off it like everything else — no strike, because
+  the origin did nothing wrong and a signer can appear the moment somebody here
+  follows the account.
   """
   def refresh_counts(subject) do
-    with true <- enabled?(),
-         true <- counts_askable?(subject),
+    if enabled?(), do: ask_counts(subject), else: :skip
+  end
+
+  defp ask_counts(subject) do
+    with true <- counts_askable?(subject),
          signer when not is_nil(signer) <- counts_signer(subject) do
       apply_counts(subject, fetch_object(subject.object_uri, signer, subject.counts_etag))
     else
-      _ -> :skip
+      _ ->
+        stamp_counts(subject, [])
+        :skip
     end
   end
 
@@ -4308,20 +4329,16 @@ defmodule Vutuv.Fediverse do
   # Somebody here with a keypair who has a reason to be asking: for a cached
   # post any member who follows the account, for a reply the member whose post
   # it answers.
-  defp counts_signer(%RemotePost{remote_account_id: account_id}) do
-    Repo.one(
-      from(f in Follow,
-        join: u in User,
-        on: u.id == f.user_id,
-        join: a in Actor,
-        on: a.user_id == u.id,
-        where: f.remote_account_id == ^account_id,
-        order_by: [asc: f.id],
-        limit: 1,
-        select: u
-      )
-    )
-    |> case do
+  #
+  # A boosted post has neither, and it is not a rare case — a large share of
+  # what any account contributes is boosts, and their authors live on servers
+  # nobody here follows. The reason to ask is one step further out: a member
+  # follows the account that re-shared it, which is why the post is in their
+  # feed and why its card carries these figures at all. That is also exactly
+  # who `fetch_and_store_announced/2` signed as to store the post in the first
+  # place, so the fallback claims nothing new about us.
+  defp counts_signer(%RemotePost{} = post) do
+    case account_follower(post.remote_account_id) || boost_follower(post) do
       %User{} = follower -> signer(follower)
       nil -> nil
     end
@@ -4334,6 +4351,44 @@ defmodule Vutuv.Fediverse do
     else
       _ -> nil
     end
+  end
+
+  # A member who follows the account and holds a keypair. `nil` in rather than
+  # a query on it: `where: f.remote_account_id == ^nil` raises, it is not a
+  # silent no-op.
+  defp account_follower(nil), do: nil
+
+  defp account_follower(account_id) do
+    Repo.one(
+      from(f in Follow,
+        join: u in User,
+        on: u.id == f.user_id,
+        join: a in Actor,
+        on: a.user_id == u.id,
+        where: f.remote_account_id == ^account_id,
+        order_by: [asc: f.id],
+        limit: 1,
+        select: u
+      )
+    )
+  end
+
+  # The same, for whoever re-shared the post into somebody's feed.
+  defp boost_follower(%RemotePost{id: post_id}) do
+    Repo.one(
+      from(b in PostBoost,
+        join: f in Follow,
+        on: f.remote_account_id == b.remote_account_id,
+        join: u in User,
+        on: u.id == f.user_id,
+        join: a in Actor,
+        on: a.user_id == u.id,
+        where: b.remote_post_id == ^post_id,
+        order_by: [asc: f.id],
+        limit: 1,
+        select: u
+      )
+    )
   end
 
   defp apply_counts(subject, {:ok, doc, etag}) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.228.0",
+      version: "7.228.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/fediverse_counts_test.exs
+++ b/test/vutuv/fediverse_counts_test.exs
@@ -14,6 +14,7 @@ defmodule Vutuv.FediverseCountsTest do
   alias Vutuv.Fediverse.Actor
   alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.Note
+  alias Vutuv.Fediverse.PostBoost
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
 
@@ -47,6 +48,15 @@ defmodule Vutuv.FediverseCountsTest do
       remote_account_id: acc.id,
       state: "accepted",
       follow_activity_id: "https://vutuv.test/#{user.id}/actor#f/#{acc.id}"
+    })
+  end
+
+  defp boost(booster, post) do
+    Repo.insert!(%PostBoost{
+      remote_account_id: booster.id,
+      remote_post_id: post.id,
+      activity_id: "#{booster.actor_uri}/statuses/#{System.unique_integer([:positive])}/activity",
+      announced_at: DateTime.utc_now(:second)
     })
   end
 
@@ -213,12 +223,29 @@ defmodule Vutuv.FediverseCountsTest do
       assert stored.content_text == "Lesenswert."
     end
 
-    test "a post nobody follows the author of is not asked about at all" do
+    test "a post nobody follows the author or the booster of is not asked about" do
       post = cached_post(account())
       serve(object(post))
 
       assert :skip = Fediverse.refresh_counts(post)
-      assert is_nil(Repo.get!(RemotePost, post.id).counts_checked_at)
+      assert Repo.get!(RemotePost, post.id).likes_count == nil
+    end
+
+    # Nobody here follows the author — the post is in the feed because somebody
+    # they do follow re-shared it, and that follower is who we sign as. The
+    # dereference that stored the post in the first place already works this
+    # way; only the figures on its card did not.
+    test "a boosted post is asked about, signed as a follower of the booster" do
+      booster = account()
+      user = federating_member()
+      follow(user, booster)
+
+      post = cached_post(account())
+      boost(booster, post)
+      serve(object(post))
+
+      assert :updated = Fediverse.refresh_counts(post)
+      assert Repo.get!(RemotePost, post.id).likes_count == 12
     end
 
     test "a followers-only post is never asked about" do
@@ -226,7 +253,40 @@ defmodule Vutuv.FediverseCountsTest do
       serve(object(post))
 
       assert :skip = Fediverse.refresh_counts(post)
-      assert is_nil(Repo.get!(RemotePost, post.id).counts_checked_at)
+      assert Repo.get!(RemotePost, post.id).likes_count == nil
+    end
+
+    # The starvation this pair guards against ran on production for days: the
+    # skipped objects hold the front of the queue for good, the batch cap is
+    # spent on them, and the posts somebody is reading right now — stamped on
+    # arrival, so last in the queue — are never reached.
+    test "a skipped object rejoins the ladder instead of standing at the head of the queue" do
+      post = cached_post(account())
+      serve(object(post))
+
+      assert :skip = Fediverse.refresh_counts(post)
+
+      stored = Repo.get!(RemotePost, post.id)
+      assert stored.counts_checked_at
+      # No strike: the origin did nothing wrong, and a signer can appear the
+      # moment somebody here follows the account.
+      assert stored.counts_failures == 0
+      refute stored.id in Enum.map(Fediverse.due_for_counts(10), & &1.id)
+    end
+
+    test "an object that can never be asked about does not fill the batch forever" do
+      unaskable =
+        for _ <- 1..3 do
+          post = cached_post(account(), %{published_at: minutes_ago(45)})
+          assert :skip = Fediverse.refresh_counts(post)
+          post.id
+        end
+
+      {fresh, _user} = followed_post(%{counts_checked_at: minutes_ago(6)})
+
+      due = Enum.map(Fediverse.due_for_counts(2), & &1.id)
+      assert fresh.id in due
+      assert due -- unaskable == due
     end
   end
 


### PR DESCRIPTION
**TL;DR** Der Zaehler-Refresher hat sich selbst blockiert: geboostete Posts waren nie signierbar, ein `:skip` schrieb nichts, und die unbeantwortbaren Objekte hielten damit dauerhaft den Kopf der Warteschlange samt Per-Host-Kontingent. Ergebnis in der Produktion: seit Stunden keine einzige echte Abfrage, und jeder Post des Tages blieb bei `0`.

## Befund aus der Produktion

Jeder Post von heute trug `likes_count = 0`, `shares_count = 0`, `counts_failures = 0` und ein `counts_checked_at` von wenigen Sekunden nach `published_at` -- also den Wert, den das ausgelieferte `Create` mitgebracht hat, und nie eine Nachfrage danach. Die letzte erfolgreiche Nachfrage lag knapp zwei Stunden zurueck, waehrend 307 Objekte faellig waren.

Der reale 60er-Stapel in dem Moment:

```
host                     im Stapel   nicht signierbar
social.heise.de                 33                 10   <- 10 verbrauchen das Host-Kontingent,
bizzfed.de                       8                  8      die 23 signierbaren fallen raus
infosec.exchange                 4                  4
15 weitere Hosts             je  1              je  1
                                --                 --
nach Per-Host-Deckel:           37                 37   <- kein einziges beantwortbar
```

`ard.social` -- mit 102 Posts die groesste hier zwischengespeicherte Quelle und ohne ein einziges unsignierbares Objekt -- kam im Stapel gar nicht mehr vor.

## Ursache

**Where:** `Vutuv.Fediverse.refresh_counts/1` + `counts_signer/1` (`lib/vutuv/fediverse.ex`)

1. **Kein Signierender fuer geboostete Posts.** `counts_signer/1` suchte fuer einen zwischengespeicherten Post nur ein Mitglied, das dem **Autor** folgt. Bei einem Boost sitzt der Autor auf einem dritten Server, dem hier niemand folgt -- der Post ist im Feed, weil ein *gefolgtes* Konto ihn geteilt hat. 54 der 327 Posts waren so dauerhaft unbeantwortbar, alle 54 kamen ueber einen Boost herein.
2. **Ein `:skip` schrieb nichts.** Weder `counts_checked_at` noch `counts_failures`. Das Objekt war zwei Minuten spaeter wieder faellig -- fuer immer -- und weil `due_for_counts/1` nach "am laengsten nicht gefragt" sortiert, stand es ab dann ganz vorn. Der Per-Host-Deckel wird auf die bereits sortierte Liste angewendet und wurde deshalb mit verbraucht.

Die 27 Zeilen mit `counts_checked_at IS NULL` waren dabei das dauerhafte Gift: null ist bewusst *immer* faellig, unabhaengig vom Alter, damit der einmalige Backfill greift -- ohne Stempel gibt es aus diesem Zustand kein Entkommen.

## Fix

- `counts_signer/1` faellt auf ein Mitglied zurueck, das dem **teilenden** Konto folgt. Das ist dieselbe Person, in deren Namen `fetch_and_store_announced/2` den Post ueberhaupt erst geholt hat, die Zuordnung behauptet also nichts Neues ueber uns.
- Ein echter `:skip` stempelt `counts_checked_at`, ohne einen Fehlversuch zu zaehlen -- der Ursprungsserver hat nichts falsch gemacht, und ein Signierender kann auftauchen, sobald jemand hier dem Konto folgt. Das Objekt kehrt auf die Leiter zurueck und faellt nach einer Woche wie alles andere von ihr herunter. Bei abgeschaltetem Fediverse bleibt der `:skip` folgenlos wie bisher.

Auf den aktuellen Produktionsdaten sinkt der unbeantwortbare Anteil des Stapels damit von 37 auf 6, und diese 6 verlassen die Warteschlange beim ersten Lauf. Keine Migration noetig, der Rueckstand loest sich selbst auf.

## Tests

Neu in `test/vutuv/fediverse_counts_test.exs`:

- ein geboosteter Post wird abgefragt, signiert als Folgender des Teilenden
- ein uebersprungenes Objekt kehrt auf die Leiter zurueck, statt am Kopf der Warteschlange zu stehen (ohne Fehlversuch)
- drei unbeantwortbare Objekte fuellen den Stapel nicht mehr dauerhaft, ein faelliger Post kommt an sie heran

Die beiden bestehenden Skip-Tests pruefen jetzt, dass keine Zahl erfunden wird (`likes_count` bleibt `nil`), statt auf dem Fehlen des Stempels zu bestehen.

`mix precommit` gruen (6927 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprueft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*
