### PR TITLE
Die gender-Spalte fällt weg (v7.229.1)

### DIFF
--- a/docs/architecture/settings-and-account.md
+++ b/docs/architecture/settings-and-account.md
@@ -181,9 +181,14 @@ preselected: an inviter naming how they address someone they know.
 the spelled-out params and in the positional `i=` token alike, because links
 already sitting in inboxes outlive any deploy.
 
-**Open follow-up (expand/contract):** the migration added `salutation` and left
-`gender` in place so the previous release kept working during the blue/green
-switch. Nothing reads `gender` any more, so a later deploy should drop it.
+**Expand/contract, both halves shipped:** the first migration added
+`salutation` and left `gender` in place so the previous release kept working
+during the blue/green switch; a second one dropped the column once v7.229.0 was
+serving. Two references to the old word survive on purpose and are not leftovers:
+`AccountEventText.field_label("gender")`, because the account-activity log is
+append-only and its old rows still name that field, and the legacy `gender`
+parameter in `Invitations.prefill_from_params/1`, because invitation links live
+in inboxes far longer than a deploy.
 
 ## New-member onboarding
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.229.0",
+      version: "7.229.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260804132928_drop_gender_from_users.exs
+++ b/priv/repo/migrations/20260804132928_drop_gender_from_users.exs
@@ -1,0 +1,31 @@
+defmodule Vutuv.Repo.Migrations.DropGenderFromUsers do
+  @moduledoc """
+  Contract half of the expand/contract pair started in
+  `20260804082102_add_salutation_to_users`.
+
+  That migration added `salutation`, copied the two addressable values over and
+  deliberately left `gender` in place so the release serving traffic during the
+  blue/green switch kept working. v7.229.0 is deployed and reads `salutation`
+  only — nothing in the tree touches this column any more, and the schema has no
+  such field — so the column can go.
+
+  `up` is irreversible in the sense that matters: the values it drops were
+  already copied, and `down` puts the column back empty rather than pretending
+  otherwise. Anything that needed the old classification is gone with it by
+  design, which is the point of the change (see
+  `docs/architecture/settings-and-account.md`).
+  """
+  use Ecto.Migration
+
+  def up do
+    alter table(:users) do
+      remove(:gender)
+    end
+  end
+
+  def down do
+    alter table(:users) do
+      add(:gender, :string)
+    end
+  end
+end


### PR DESCRIPTION
**TL;DR** Zweiter und letzter Schritt des Expand/Contract-Paars aus v7.229.0: die Spalte `users.gender` fällt weg.

**Where:** `priv/repo/migrations/20260804132928_drop_gender_from_users.exs`

**Warum jetzt und nicht vorher:** Die erste Migration legte `salutation` an, kopierte die beiden anschreibbaren Werte hinüber und ließ `gender` absichtlich stehen — während der Blau/Grün-Umschaltung bediente das vorige Release noch Anfragen und las diese Spalte. v7.229.0 ist ausgeliefert und liest ausschließlich `salutation`, das Schema kennt das Feld nicht mehr. Damit ist die Spalte für das laufende Release unsichtbar und der Drop N-1-sicher.

**Zwei Vorkommen des Worts bleiben, mit Absicht:**

- `AccountEventText.field_label("gender")` — das Konto-Aktivitätsprotokoll wird anhängend geführt, seine alten Zeilen benennen dieses Feld weiterhin und müssen lesbar bleiben.
- der `gender`-Parameter in `Invitations.prefill_from_params/1` — Einladungslinks liegen länger in Postfächern, als ein Deploy dauert.

Beide lesen einen String beziehungsweise einen Query-Parameter, nicht die Spalte.

**`down/0`** legt die Spalte leer wieder an, statt so zu tun, als ließe sich der Inhalt zurückholen.

Gegen die Dev-Datenbank ausgeführt: die Spalte ist weg, `salutation` steht unverändert.

`mix precommit` grün, 6975 Tests.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*
