### PR TITLE
Tag-Chips unter Fediverse-Posts mit demselben Abstand wie bei vutuv-Posts (v7.231.1)

### DIFF
--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -1394,11 +1394,18 @@ defmodule VutuvWeb.PostComponents do
   # row a member's post gets for its tags — the whole point of lifting them out
   # of the text (`Markdown.split_trailing_hashtags/1`): one tag vocabulary,
   # rendered one way, wherever a post came from.
+  #
+  # Down to the gap above the row, which is `<.post_tags>`'s `mt-3` and not a
+  # tighter one of its own: the two cards sit one under the other in the same
+  # feed column, so a row 4px closer to the last line does not read as "this
+  # one came from elsewhere", it reads as a card that got its spacing wrong.
+  # It showed most where a post ends on a link, which is where the eye already
+  # sits low in the line.
   attr(:tags, :list, required: true)
 
   defp remote_tags(assigns) do
     ~H"""
-    <div :if={@tags != []} data-remote-tags class="mt-2 flex flex-wrap gap-2">
+    <div :if={@tags != []} data-remote-tags class="mt-3 flex flex-wrap gap-2">
       <.chip :for={tag <- @tags} navigate={tag.path} data-remote-tag={tag.name}>{tag.name}</.chip>
     </div>
     """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.231.0",
+      version: "7.231.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv_web/live/feed_remote_posts_test.exs
+++ b/test/vutuv_web/live/feed_remote_posts_test.exs
@@ -12,6 +12,7 @@ defmodule VutuvWeb.FeedRemotePostsTest do
   alias Vutuv.Fediverse.Follow
   alias Vutuv.Fediverse.RemoteAccount
   alias Vutuv.Fediverse.RemotePost
+  alias Vutuv.Posts
 
   @actor "https://social.example/users/them"
 
@@ -483,6 +484,35 @@ defmodule VutuvWeb.FeedRemotePostsTest do
 
       assert has_element?(view, "#{card} [data-remote-tag='Anschlag']")
       refute has_element?(view, "#{card} .markdown")
+    end
+
+    test "sits as far below the text as a member post's tag row", %{conn: conn} do
+      {conn, user} = create_and_login_user(conn)
+      # Two different tags, so the chip looked up below can only be the member
+      # card's — a remote chip links to the very same tag page.
+      theirs = linkable_tag()
+      mine = linkable_tag()
+
+      cached_post(user, %{content_text: "Von drüben.\n\n##{theirs.name}"})
+      {:ok, _post} = Posts.create_post(user, %{body: "Von hier.", tags: mine.name})
+
+      {:ok, _view, html} = live(conn, ~p"/feed")
+      doc = LazyHTML.from_document(html)
+
+      # Compare the two rows' classes rather than assert a literal margin: the
+      # member row is the reference, so whatever it changes to, the remote row
+      # has to follow. The last line of a post is very often a link, and a link
+      # that ends a paragraph sits closer to the chips than a plain sentence
+      # does, which made the 4px the remote row was short (mt-2 against mt-3)
+      # read as a different card rather than a different origin.
+      [remote_row_class] =
+        doc |> LazyHTML.query("[data-remote-tags]") |> LazyHTML.attribute("class")
+
+      member_chip =
+        LazyHTML.query(doc, ~s|div[class="#{remote_row_class}"] a[href="/tags/#{mine.slug}"]|)
+
+      refute Enum.empty?(member_chip),
+             "the member card's tag row does not carry the remote row's spacing (#{remote_row_class})"
     end
   end
 end


### PR DESCRIPTION
Die Hashtag-Chips einer gecachten Fediverse-Karte saßen 4px näher am Text als die Tag-Chips eines vutuv-Posts (`mt-2` statt `mt-3`). Beide Karten stehen in derselben Feed-Spalte untereinander, deshalb liest sich der kleinere Abstand nicht als "kommt von woanders", sondern als eine Karte mit falschem Abstand. Am deutlichsten fällt es auf, wenn ein Post mit einem Link endet, weil eine Linkzeile ohnehin dicht und tief im Zeilenkasten sitzt. Genau so ist es aufgefallen.

Beide Bodies setzen den unteren Abstand des letzten Absatzes auf 0 (`.markdown > *:last-child`), der sichtbare Abstand der Chip-Reihe ist also komplett ihr eigener `margin-top`, jetzt in beiden Fällen 12px. Die Aktionsleiste darunter war schon vorher auf beiden Karten identisch (`-mx-2 mt-3`).

**Test:** rendert eine Fediverse- und eine vutuv-Karte im selben Feed und vergleicht die Klassen der beiden Chip-Reihen miteinander statt gegen ein Literal. Die Reihe des Mitglieder-Posts bleibt die Referenz: ändert sich dort der Abstand, zieht das die Fediverse-Reihe mit. Der Test ist gegen den alten Stand rot.

**Deploy:** hot (nur Komponente und Test, keine Migration, kein Config-, Deps- oder Supervision-Tree-Change).
**Version:** 7.231.1
**`mix precommit`:** grün (6932 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*