### PR TITLE
Der Newsfeed liest eine Seite statt der ganzen posts-Tabelle (v7.231.2)

### DIFF
--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -283,6 +283,22 @@ out there (#1161), what people you follow *here* reshared from another network
 (#1166), and what those accounts boosted (#1167) — see
 [fediverse.md](fediverse.md).
 
+**What keeps that first source cheap.** The local posts source ("mine plus the
+people I follow", newest first) has to stay a *page*-sized read as the posts
+table grows, and two things make it one. `posts_recency_index` covers its sort
+key `(inserted_at DESC, id DESC)` — without it Postgres reads every post ever
+written and top-N sorts, because the `my own OR my followees'` disjunction rules
+out the per-author indexes. And the query names its author join `as: :author`,
+which makes `scope_visible/2` spell the moderation gate as
+`Moderation.Query.account_hidden_row/1` (reading the joined row) instead of the
+correlated `account_hidden/1`, whose de-correlated form scans all of `users` per
+post query. Any post query may opt in the same way: naming the binding is the
+only signal, and it changes how the question is asked, never the answer. For the
+queries that legitimately cannot join the author, `users_hidden_index` (partial,
+on the four columns that hide an account) keeps the EXISTS off a full scan.
+Measured on a copy of production seeded to 200,000 posts, the two indexes took
+that source from 76.7 ms to 0.53 ms.
+
 **Source tabs: All / vutuv / Fediverse.** Above the timeline sits the same
 segmented control the profile's post-type tabs use
 (`PostComponents.post_filter_tabs/1`, here with `feed_filter_options/0` and the

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -924,10 +924,7 @@ defmodule Vutuv.Posts do
   # condition itself is owned by Vutuv.Moderation.Query.
   defp scope_unfrozen(query, viewer) do
     passes =
-      dynamic(
-        [p],
-        is_nil(p.frozen_at) and p.images_pending? == false and not account_hidden(p.user_id)
-      )
+      dynamic([p], is_nil(p.frozen_at) and p.images_pending? == false) |> and_author_shown(query)
 
     filter =
       case viewer do
@@ -936,6 +933,30 @@ defmodule Vutuv.Posts do
       end
 
     where(query, ^filter)
+  end
+
+  # "…and the author's account is not hidden", in whichever of the two spellings
+  # the query can afford.
+  #
+  # `account_hidden/1` re-fetches the author row by id in a correlated EXISTS,
+  # which composes into any query but costs a pass over `users` — Postgres
+  # de-correlates it into a hashed subplan and scans the whole table to collect
+  # the few hundred hidden ids, once per post query (five times on one /feed).
+  # A query that already joins the author has those columns in hand, so it uses
+  # the row form instead and reads them; `Vutuv.Moderation.Query` documents the
+  # pair, and the two say exactly the same thing about the same row.
+  #
+  # The named binding is the signal: a post query that joins its author as
+  # `as: :author` gets the cheaper gate automatically, one that does not keeps
+  # the EXISTS. Nothing here decides *whether* a post is shown — only how the
+  # question is put to Postgres — so a caller may add or drop the binding
+  # freely.
+  defp and_author_shown(passes, query) do
+    if has_named_binding?(query, :author) do
+      dynamic([author: a], ^passes and not account_hidden_row(a))
+    else
+      dynamic([p], ^passes and not account_hidden(p.user_id))
+    end
   end
 
   @doc """
@@ -1620,7 +1641,12 @@ defmodule Vutuv.Posts do
     # (no denials, unfrozen, non-hidden author); only the search-specific
     # filters stay here. Search keeps the stricter `email_confirmed? == true`
     # (not the confirmed-or-legacy-NULL gate) deliberately.
-    from(p in Post, as: :post, join: u in assoc(p, :user), where: u.email_confirmed? == true)
+    from(p in Post,
+      as: :post,
+      join: u in assoc(p, :user),
+      as: :author,
+      where: u.email_confirmed? == true
+    )
     |> filter_body_search(value)
     |> filter_posts_by_tag(tag, Keyword.get(opts, :exact, false))
     |> order_public_search(value)
@@ -1709,6 +1735,7 @@ defmodule Vutuv.Posts do
 
     from(p in Post,
       join: u in assoc(p, :user),
+      as: :author,
       join: pt in subquery(filings),
       as: :post_tag,
       on: pt.post_id == p.id,
@@ -1965,6 +1992,7 @@ defmodule Vutuv.Posts do
   defp feed_post_items(%User{id: viewer_id} = viewer, fetch_n, cursor) do
     from(p in Post,
       join: u in assoc(p, :user),
+      as: :author,
       where: p.user_id == ^viewer_id or p.user_id in subquery(followees_of(viewer_id)),
       where: p.user_id == ^viewer_id or account_confirmed_row(u),
       order_by: [desc: p.inserted_at, desc: p.id],
@@ -1988,6 +2016,7 @@ defmodule Vutuv.Posts do
       join: reposter in User,
       on: reposter.id == r.user_id,
       join: u in assoc(p, :user),
+      as: :author,
       where: r.user_id == ^viewer_id or r.user_id in subquery(followees_of(viewer_id)),
       where: r.user_id == ^viewer_id or account_confirmed_row(reposter),
       where: p.user_id == ^viewer_id or account_confirmed_row(u),
@@ -2030,6 +2059,7 @@ defmodule Vutuv.Posts do
         from(p in Post,
           as: :post,
           join: u in assoc(p, :user),
+          as: :author,
           where: p.user_id != ^viewer_id,
           where: p.user_id not in subquery(all_followees_of(viewer_id)),
           where: p.user_id not in subquery(blocked_either_way(viewer_id)),
@@ -2481,7 +2511,7 @@ defmodule Vutuv.Posts do
 
   def recent_public_posts(:all, opts) do
     Post
-    |> join(:inner, [p], u in assoc(p, :user))
+    |> join(:inner, [p], u in assoc(p, :user), as: :author)
     |> where([p, u], u.email_confirmed? and not u.noindex? and not u.noai?)
     |> recent_public(opts)
   end
@@ -2581,6 +2611,7 @@ defmodule Vutuv.Posts do
     from(p in Post,
       as: :post,
       join: u in assoc(p, :user),
+      as: :author,
       left_join: r in assoc(p, :reply_ref),
       where: is_nil(r.id),
       where: fragment("COALESCE(NULLIF(?, ''), 'en')", u.locale) == ^locale,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.231.1",
+      version: "7.231.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260806142105_add_feed_recency_and_hidden_account_indexes.exs
+++ b/priv/repo/migrations/20260806142105_add_feed_recency_and_hidden_account_indexes.exs
@@ -1,0 +1,38 @@
+defmodule Vutuv.Repo.Migrations.AddFeedRecencyAndHiddenAccountIndexes do
+  use Ecto.Migration
+
+  # Two indexes for the newsfeed's main query ("posts of me and the people I
+  # follow", newest first). Measured on a copy of production seeded to 200,000
+  # posts: 76.7 ms -> 0.53 ms. Both are plain additions, so the release still
+  # serving traffic during the blue/green switch is unaffected (N-1).
+  #
+  # 1. posts_recency_index — the feed, the tag timeline and the discovery rail
+  #    all sort by (inserted_at DESC, id DESC), and nothing indexed that. Only
+  #    (user_id, inserted_at) and (user_id, published_on) existed, and the
+  #    feed's "my own posts OR posts of my followees" disjunction makes those
+  #    unusable, so Postgres read the whole posts table and top-N sorted it on
+  #    every single feed load.
+  #
+  # 2. users_hidden_index — Vutuv.Moderation.Query.account_hidden/1 asks for the
+  #    accounts that are frozen, deactivated, unreachable or currently
+  #    suspended, i.e. the *complement* of what users_visible_covering_index
+  #    holds, so that index cannot serve it and Postgres scanned all of users
+  #    to collect a few hundred ids — five times on one /feed.
+  #
+  #    The predicate says `suspended_until IS NOT NULL` rather than `> now()`:
+  #    an index predicate has to be immutable and now() is not. The comparison
+  #    then runs on the rows this index returns instead of on the whole table,
+  #    which is the entire point.
+  def change do
+    create(index(:posts, ["inserted_at DESC", "id DESC"], name: :posts_recency_index))
+
+    create(
+      index(:users, [:id],
+        name: :users_hidden_index,
+        where:
+          "frozen_at IS NOT NULL OR deactivated_at IS NOT NULL " <>
+            "OR unreachable_at IS NOT NULL OR suspended_until IS NOT NULL"
+      )
+    )
+  end
+end

--- a/test/vutuv/moderation_enforcement_test.exs
+++ b/test/vutuv/moderation_enforcement_test.exs
@@ -106,6 +106,26 @@ defmodule Vutuv.ModerationEnforcementTest do
       set_user!(author, deactivated_at: NaiveDateTime.utc_now(:second))
       refute post.id in feed_post_ids(follower)
     end
+
+    # The fourth arm of `Vutuv.Moderation.Query.account_hidden/1`, and the one
+    # that had no feed test: an account whose every address bounced
+    # (`Vutuv.Deliverability`) is a zombie nobody can reach, so it leaves the
+    # public network like the other three. Worth its own test because the gate
+    # is spelled twice — as a correlated EXISTS and, where the author row is
+    # already joined, as `account_hidden_row/1` — and the two must agree.
+    test "an unreachable account's posts vanish", %{
+      follower: follower,
+      author: author,
+      post: post
+    } do
+      assert post.id in feed_post_ids(follower)
+
+      set_user!(author, unreachable_at: NaiveDateTime.utc_now(:second))
+
+      refute post.id in feed_post_ids(follower)
+      refute Posts.visible_to?(Repo.get!(Posts.Post, post.id), follower)
+      assert post.id in feed_post_ids(author)
+    end
   end
 
   describe "frozen messages" do

--- a/test/vutuv/repo/feed_indexes_test.exs
+++ b/test/vutuv/repo/feed_indexes_test.exs
@@ -1,0 +1,69 @@
+defmodule Vutuv.Repo.FeedIndexesTest do
+  @moduledoc """
+  The two indexes the newsfeed's main query needs, pinned so a later migration
+  cannot quietly drop them.
+
+  Neither changes a result, so nothing else in the suite would go red if they
+  disappeared — the page would simply get slower and slower as the tables grow,
+  which is the kind of regression nobody notices for months.
+
+  Measured on a copy of production seeded to 200,000 posts, the feed's
+  "posts of me and the people I follow" query went from **76.7 ms to 0.53 ms**
+  with these two in place. Without them Postgres reads the whole posts table
+  and top-N sorts it on every feed load (at 200k rows: 84,513 candidates
+  matched, 115,487 discarded), and re-derives the set of moderation-hidden
+  accounts by scanning all of `users` once per post query — five times on one
+  `/feed`.
+  """
+  use Vutuv.DataCase, async: true
+
+  describe "posts_recency_index" do
+    test "covers the feed's sort key" do
+      assert index_definition("posts", "posts_recency_index") =~ "inserted_at DESC"
+      assert index_definition("posts", "posts_recency_index") =~ "id DESC"
+    end
+  end
+
+  describe "users_hidden_index" do
+    test "covers exactly the four columns that hide an account" do
+      definition = index_definition("users", "users_hidden_index")
+
+      for column <- ~w(frozen_at deactivated_at unreachable_at suspended_until) do
+        assert definition =~ column,
+               "#{column} hides an account (Vutuv.Moderation.Query.account_hidden/1) " <>
+                 "but is missing from the partial index that finds them"
+      end
+    end
+
+    test "is a partial index, not a full one" do
+      # The point is its size: a few hundred hidden accounts instead of every
+      # member. A full index on the same columns would be no cheaper to scan
+      # than the table.
+      assert index_definition("users", "users_hidden_index") =~ "WHERE"
+    end
+
+    test "keeps its predicate immutable, so Postgres may use it" do
+      # `suspended_until > now()` cannot live in an index predicate (now() is
+      # not immutable) — the index has to say IS NOT NULL and leave the
+      # comparison to the query, on the handful of rows it returns.
+      definition = index_definition("users", "users_hidden_index")
+
+      refute definition =~ "now()",
+             "an index predicate with now() in it is not immutable and Postgres will refuse it"
+    end
+  end
+
+  defp index_definition(table, name) do
+    %{rows: rows} =
+      Repo.query!(
+        "SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' " <>
+          "AND tablename = $1 AND indexname = $2",
+        [table, name]
+      )
+
+    case rows do
+      [[definition]] -> definition
+      [] -> flunk("#{table} has no index named #{name}")
+    end
+  end
+end


### PR DESCRIPTION
Die Hauptabfrage des Feeds ("meine Posts plus die der Leute, denen ich folge", neueste zuerst) hat bisher bei jedem Aufruf die **komplette posts-Tabelle** gelesen und per Top-N-Sort auf 21 Zeilen eingedampft.

Gemessen auf einer Kopie der Produktionsdaten, aufgefüllt auf 200.000 Posts:

| posts-Tabelle | vorher | nachher |
|---|---|---|
| 370 (heute) | 5,2 ms | 0,44 ms |
| 200.000 | **76,7 ms** | **0,53 ms** |

Wichtiger als der Faktor ist die Form: vorher wuchs die Abfrage linear mit jedem jemals geschriebenen Post (bei 200k: 84.513 Treffer geprüft, 115.487 verworfen), jetzt liest sie 60 Zeilen und hört auf.

## Die beiden Indizes (rein additiv, N-1-sicher)

1. **`posts_recency_index`** auf `(inserted_at DESC, id DESC)`, den Sortierschlüssel von Feed, Tag-Timeline und Entdecken-Leiste. Bisher gab es dafür keinen Index: vorhanden waren nur `(user_id, inserted_at)` und `(user_id, published_on)`, und die ODER-Verknüpfung "eigene Posts oder die meiner Followees" macht die unbrauchbar.

2. **`users_hidden_index`**, partiell auf die vier Spalten, die einen Account verstecken. `Moderation.Query.account_hidden/1` fragt nach den *versteckten* Accounts, `users_visible_covering_index` deckt genau die Gegenmenge ab und kann dafür nichts tun, also hat Postgres für ein paar hundert IDs die ganze users-Tabelle gescannt — einmal pro Post-Abfrage, fünfmal auf einem einzigen `/feed`. Das Prädikat sagt bewusst `suspended_until IS NOT NULL` statt `> now()`, weil ein Index-Prädikat immutable sein muss.

## Dieselbe Frage, billiger gestellt

`Vutuv.Moderation.Query` hält seit jeher beide Schreibweisen des Gates bereit, und `scope_visible/2` hat immer die teure genommen, obwohl die Feed-Abfrage die Autorenzeile ohnehin schon joint. Jetzt entscheidet das benannte Binding: wer seinen Autoren-Join `as: :author` nennt, bekommt `account_hidden_row/1` auf die bereits gelesene Zeile, alle anderen behalten das EXISTS. Welche Posts sichtbar sind, ändert das nicht — nur wie die Frage gestellt wird. Auf `/feed` und in der Entdecken-Leiste verschwindet der users-Scan damit komplett (5 → 0 pro Seitenaufbau).

## Tests

- Der `unreachable`-Arm des Gates hatte als einziger der vier keinen Feed-Test; er kam dazu, weil er genau den neuen Pfad absichert.
- Die Indizes haben einen eigenen Regressionstest (`test/vutuv/repo/feed_indexes_test.exs`): sie ändern kein Ergebnis, ihr Verlust würde also in keinem anderen Test auffallen — die Seite würde nur mit den Jahren immer langsamer.

**Deploy:** enthält eine Migration, aber rein additiv (zwei neue Indizes) und damit N-1-sicher. `scripts/deploy.sh` migriert im Blue/Green-Ablauf ohnehin vor dem Slot-Wechsel, eine Sonderbehandlung braucht es nicht.
**Version:** 7.231.2
**`mix precommit`:** grün (6937 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*
