### PR TITLE
Die Vorschläge-Karte rechnet einmal für alle statt dreimal pro Leser (v7.231.3)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -436,8 +436,10 @@ config :vutuv, :reconcile_member_count, true
 # slow timer. Tests turn this off (sandbox ownership); every call then falls
 # back to the direct ranking query, so tests always see fresh data.
 config :vutuv, :refresh_popular_users, true
-# Same deal for the "who to follow" recent-poster pool (Vutuv.Posts.TopPosters).
+# Same deal for the "who to follow" recent-poster pool (Vutuv.Posts.TopPosters)
+# and the feed rail's suggested-posts pool (Vutuv.Posts.PopularPosts).
 config :vutuv, :refresh_top_posters, true
+config :vutuv, :refresh_popular_posts, true
 
 # The inline social posts on profiles (Vutuv.SocialFeed), one flag per
 # provider. Tests turn them off: every profile LiveView test performs a

--- a/config/test.exs
+++ b/config/test.exs
@@ -115,6 +115,7 @@ config :vutuv, :async_email, false
 config :vutuv, :reconcile_member_count, false
 config :vutuv, :refresh_popular_users, false
 config :vutuv, :refresh_top_posters, false
+config :vutuv, :refresh_popular_posts, false
 # Every profile LiveView test performs a connected mount; the inline social
 # feeds must never fetch a remote network from there. The feed tests flip
 # these on per-test and stub HTTP via :mastodon_req_options /

--- a/docs/architecture/posts-and-feed.md
+++ b/docs/architecture/posts-and-feed.md
@@ -359,6 +359,36 @@ render — the accepted cost of the immediate desktop paint. The periodic
 reshuffle timer is armed at connect; the refresh paths
 (`:refresh_suggestions`, `{:tag_follows_changed, _}`) redraw unconditionally.
 
+**Both suggestion cards read a snapshot, and neither trusts it.** "Who to
+follow" takes its pool from `Vutuv.Social.PopularUsers`, "Vorschläge" from
+`Vutuv.Posts.PopularPosts`: one GenServer each, re-ranking every ten minutes
+into a `read_concurrency` ETS table, with `:miss` falling back to the live
+query so boot and tests behave exactly as before. The reason is the same for
+both, and it is not the page load — it is that timer above. Every open feed tab
+redraws the rail every five minutes, so the old per-viewer ranking scaled with
+tabs left open rather than with people reading, while the expensive half of the
+question ("which posts in this language were well received, one per author,
+best first") has the same answer for every reader on the installation.
+
+What stays per request is the half that is actually personal, and for
+`discover_posts/2` that is where the old three-tier ladder went: the tiers were
+always one ordering over one candidate set (a stranger's post ahead of a
+followed author's, whose post must also be from this fortnight), so they are a
+`CASE` in the draw's `ORDER BY` now instead of three ranking scans, and the
+draw shuffles *inside* each tier — shuffling across the whole set silently
+throws the preference away. The ladder itself is still the code that runs on a
+`:miss`.
+
+The rule the design rests on: **the pool proposes, the database disposes.** A
+snapshot is minutes old and moderation is not, so the draw re-applies the full
+anonymous visibility gate plus the viewer's blocks and mutes to the candidates
+it picked. That check is affordable exactly because it is bounded to a few
+hundred known ids. Staleness can therefore cost a reader a slightly out-of-date
+*suggestion*, never a post they were not allowed to see — `popular_posts_test.exs`
+holds one case per way the world can move after a snapshot (post frozen, author
+frozen / suspended / deactivated / unreachable, post restricted, author blocked
+or muted since).
+
 The composer's body field is the shared **Milkdown WYSIWYG Markdown editor**
 (`VutuvWeb.UI.markdown_editor/1` + the `MarkdownEditor` hook, also used by the
 message composer). It edits Markdown *source* in place — the field stays a

--- a/lib/vutuv/application.ex
+++ b/lib/vutuv/application.ex
@@ -51,6 +51,9 @@ defmodule Vutuv.Application do
         # Snapshots the "who to follow" recent-poster pool the profile rail
         # draws from — same deal as PopularUsers. Starts after the Repo.
         Vutuv.Posts.TopPosters,
+        # Snapshots the candidate pool the feed's "Vorschläge" rail draws from,
+        # per locale — same deal again. Starts after the Repo.
+        Vutuv.Posts.PopularPosts,
         # Fans a :day_changed broadcast out at Berlin midnight so open pages
         # re-render "today"/"Gestern" post timestamps. Needs PubSub only.
         Vutuv.DayClock,

--- a/lib/vutuv/posts.ex
+++ b/lib/vutuv/posts.ex
@@ -65,6 +65,7 @@ defmodule Vutuv.Posts do
   alias Vutuv.Pages
   alias Vutuv.PostImageStore
   alias Vutuv.Posts.PhotoLicense
+  alias Vutuv.Posts.PopularPosts
   alias Vutuv.Posts.Post
   alias Vutuv.Posts.PostBookmark
   alias Vutuv.Posts.PostDenial
@@ -2570,6 +2571,106 @@ defmodule Vutuv.Posts do
   """
   def discover_posts(%User{} = viewer, opts \\ []) do
     limit = Keyword.get(opts, :limit, @discover_limit)
+    table = Keyword.get(opts, :pool_table, PopularPosts.default_table())
+
+    case PopularPosts.top(locale_or_english(viewer.locale), table) do
+      {:ok, candidates} -> discover_from_pool(viewer, candidates, limit)
+      :miss -> discover_by_ladder(viewer, limit)
+    end
+  end
+
+  # The cheap path: the shared ranking already happened (see
+  # `Vutuv.Posts.PopularPosts`), so all that is left is to ask the database
+  # which of those candidates this reader may see, and to pick a handful.
+  #
+  # The ladder's three tiers become one ordering over one candidate set, which
+  # is what they always were. It also fixes which way round they run: tiers 1
+  # and 2 exclude everyone the viewer follows, so a well-connected member used
+  # to pay for two draws that could not fill the card before the third one did
+  # the work.
+  defp discover_from_pool(%User{} = viewer, candidates, limit) do
+    rank = candidates |> Enum.map(& &1.id) |> Enum.with_index() |> Map.new()
+
+    drawn =
+      rank
+      |> Map.keys()
+      |> discover_eligible(viewer)
+      |> Enum.group_by(& &1.tier)
+      |> Enum.sort_by(fn {tier, _rows} -> tier end)
+      # Each tier keeps its own draw — the best-liked @discover_pool of it, in
+      # random order — and a lower tier only fills what the ones above left
+      # over. The shuffle has to happen inside the tier, not across the whole
+      # set: shuffling the lot would throw away the preference the tiers exist
+      # to express and suggest someone the reader already follows while a
+      # stranger was available.
+      |> Enum.flat_map(fn {_tier, rows} ->
+        rows
+        |> Enum.sort_by(&Map.fetch!(rank, &1.id))
+        |> Enum.take(@discover_pool)
+        |> Enum.shuffle()
+      end)
+      |> Enum.uniq_by(& &1.user_id)
+      |> Enum.take(limit)
+
+    # Nothing drawn is not the same as nothing to show, and it happens two
+    # ways: a brand-new installation where nobody has liked anything yet (so
+    # the pool is legitimately empty), or a reader who filtered away every
+    # candidate in it. Both land on the same last resort the ladder has always
+    # had — the newest eligible posts — so the rail is never permanently blank.
+    if drawn == [] do
+      discover_recent_draw(discover_candidates(viewer, :strangers), limit)
+      |> Enum.map(& &1.id)
+      |> load_discover_posts()
+    else
+      drawn |> Enum.map(& &1.id) |> load_discover_posts()
+    end
+  end
+
+  # Which of `ids` this viewer may be shown, and in which tier each one lands.
+  # Bounded to the pool's ids, so every gate in here is a primary-key lookup
+  # rather than a scan — that is what makes re-checking visibility on a
+  # minutes-old snapshot affordable.
+  defp discover_eligible([], _viewer), do: []
+
+  defp discover_eligible(ids, %User{id: viewer_id}) do
+    window = discover_window_start()
+
+    from(p in Post,
+      as: :post,
+      join: u in assoc(p, :user),
+      as: :author,
+      left_join: f in Follow,
+      on: f.follower_id == ^viewer_id and f.followee_id == p.user_id,
+      as: :edge,
+      where: p.id in ^ids,
+      where: p.user_id != ^viewer_id,
+      # Muting means "keep this person's posts away from me", in every tier.
+      where: is_nil(f.id) or f.muted == false,
+      # A post by someone the viewer already reads is only a discovery while
+      # it is this fortnight's news; a stranger's may be any age.
+      where: is_nil(f.id) or p.inserted_at >= ^window,
+      where: p.user_id not in subquery(blocked_either_way(viewer_id)),
+      where: account_confirmed_row(u),
+      select: %{
+        id: p.id,
+        user_id: p.user_id,
+        tier:
+          fragment(
+            "CASE WHEN ? IS NULL AND ? >= ? THEN 0 WHEN ? IS NULL THEN 1 ELSE 2 END",
+            f.id,
+            p.inserted_at,
+            ^window,
+            f.id
+          )
+      }
+    )
+    |> scope_visible(nil)
+    |> Repo.all()
+  end
+
+  # The uncached path, unchanged: three tiers, each its own ranking scan. Still
+  # the answer at boot, for a locale the snapshot does not carry, and in tests.
+  defp discover_by_ladder(%User{} = viewer, limit) do
     window = discover_window_start()
 
     rows =
@@ -2622,6 +2723,40 @@ defmodule Vutuv.Posts do
       where: p.body != ""
     )
     |> scope_visible(nil)
+  end
+
+  @doc false
+  # The viewer-independent half of the rail, ranked once for the whole
+  # installation by `Vutuv.Posts.PopularPosts` (which is the only caller):
+  # this locale's best-liked eligible posts, one per author, best first.
+  #
+  # Deliberately no viewer in it. Every gate that depends on who is reading —
+  # own posts, follows, mutes, blocks — belongs to the draw, and so does the
+  # visibility gate, which is re-applied there because this list ages.
+  def compute_discover_pool(locale, pool_size) do
+    from(p in Post,
+      as: :post,
+      join: u in assoc(p, :user),
+      as: :author,
+      left_join: r in assoc(p, :reply_ref),
+      join: lc in subquery(discover_like_counts()),
+      on: lc.post_id == p.id,
+      as: :like_count,
+      where: is_nil(r.id),
+      where: fragment("COALESCE(NULLIF(?, ''), 'en')", u.locale) == ^locale,
+      where: account_confirmed_row(u),
+      where: p.body != "",
+      where: lc.likes >= @discover_min_likes,
+      distinct: p.user_id,
+      order_by: [asc: p.user_id, desc: lc.likes, desc: p.id],
+      select: %{id: p.id, user_id: p.user_id, likes: lc.likes, inserted_at: p.inserted_at}
+    )
+    |> scope_visible(nil)
+    |> subquery()
+    |> order_by([s], desc: s.likes, desc: s.id)
+    |> limit(^pool_size)
+    |> select([s], %{id: s.id, user_id: s.user_id, inserted_at: s.inserted_at})
+    |> Repo.all()
   end
 
   # The like counts the rail ranks on, rolled up once for the whole table

--- a/lib/vutuv/posts/popular_posts.ex
+++ b/lib/vutuv/posts/popular_posts.ex
@@ -1,0 +1,132 @@
+defmodule Vutuv.Posts.PopularPosts do
+  @moduledoc """
+  Periodically cached candidate pool for the feed's "Vorschläge" rail.
+
+  `Posts.discover_posts/2` used to answer the whole question per viewer, and
+  it answered it up to three times: a ladder of tiers (recent strangers →
+  strangers of any age → anyone recent), each one a fresh scan over posts
+  joined to a like rollup, ranked one-per-author. But the expensive half of
+  that question — *which public posts in this language were well received, one
+  per author, best first* — has the same answer for every reader on the
+  installation. Only the last mile is personal: not my own posts, nobody I
+  muted or blocked, and people I do not follow ahead of people I do.
+
+  So one GenServer owns the shared half, exactly the `Vutuv.Social.PopularUsers`
+  and `Vutuv.Posts.TopPosters` deal: every few minutes it ranks each configured
+  locale's pool into a `read_concurrency` ETS table, and a draw takes its
+  candidates from the snapshot with no ranking scan at all. That matters more
+  than a page-load figure suggests, because the rail is not only drawn on
+  arrival: every open feed tab redraws it on a timer, so the old cost scaled
+  with tabs left open, not with people reading.
+
+  **The pool proposes; the database disposes.** A snapshot is minutes old, and
+  in those minutes a post can be frozen, restricted, or its author suspended,
+  deactivated or blocked by this very viewer. So the snapshot holds *candidate*
+  ids only, and the draw re-applies the full anonymous visibility gate
+  (`Posts.scope_visible/2`) plus the viewer's own exclusions to the handful it
+  picked. That check is affordable precisely because it is bounded to a few
+  hundred known ids instead of the posts table — which is the trade the whole
+  design rests on. Staleness may therefore cost a reader a slightly out-of-date
+  *suggestion*, never a post they were not allowed to see.
+
+  When the snapshot cannot answer (application boot, an unconfigured locale,
+  or tests — the refresh timer is off under
+  `config :vutuv, :refresh_popular_posts, false`), `top/2` returns `:miss` and
+  `discover_posts/2` transparently falls back to the live tier ladder, so
+  behaviour is unchanged, only cheaper.
+  """
+  use GenServer
+
+  @table __MODULE__
+  # Deeper than the handful a card shows, and deeper than the 100 the draw
+  # ranks: the per-viewer filter removes everyone the reader already follows,
+  # and a member who follows every active author is exactly the case the
+  # ladder's last tier exists for. A shallow pool would leave them an empty
+  # rail — the one thing the tiers were built to prevent.
+  @pool_size 500
+  @refresh_interval :timer.minutes(10)
+
+  @doc "How many posts per locale the snapshot ranks."
+  def pool_size, do: @pool_size
+
+  @doc "The ETS table the application-wide snapshot lives in."
+  def default_table, do: @table
+
+  @doc """
+  The cached candidates for `locale`, best-liked first, as `{:ok, rows}` —
+  each row a `%{id:, user_id:, inserted_at:}` — or `:miss` when the snapshot
+  cannot answer (not seeded yet, table absent, or a locale it does not carry).
+  """
+  def top(locale, table \\ @table) do
+    case :ets.lookup(table, {:pool, locale}) do
+      [{{:pool, ^locale}, rows}] -> {:ok, rows}
+      [] -> :miss
+    end
+  rescue
+    ArgumentError -> :miss
+  end
+
+  @doc "Recompute the snapshot now (synchronous; used by tests)."
+  def refresh(server \\ __MODULE__), do: GenServer.call(server, :refresh)
+
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    # `name: nil` (isolated test instances) starts the process unregistered.
+    gen_opts = if name, do: [name: name], else: []
+    GenServer.start_link(__MODULE__, opts, gen_opts)
+  end
+
+  @impl true
+  def init(opts) do
+    table =
+      :ets.new(Keyword.get(opts, :table, @table), [
+        :named_table,
+        :protected,
+        read_concurrency: true
+      ])
+
+    interval = Keyword.get(opts, :refresh_interval, @refresh_interval)
+
+    # The seed is a 0ms refresh rather than an inline query: the ranking scan
+    # must not block the supervisor at boot. Until it lands, readers miss and
+    # fall back to the tier ladder — exactly the pre-cache behaviour.
+    if Keyword.get(opts, :refresh?, enabled?()), do: schedule(0)
+
+    {:ok, %{table: table, interval: interval}}
+  end
+
+  @impl true
+  def handle_call(:refresh, _from, state) do
+    snapshot(state.table)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_info(:refresh, state) do
+    snapshot(state.table)
+    schedule(state.interval)
+    {:noreply, state}
+  end
+
+  def handle_info(_other, state), do: {:noreply, state}
+
+  # One ranking query per configured locale, for the whole installation,
+  # however many people are reading.
+  defp snapshot(table) do
+    for locale <- locales() do
+      :ets.insert(table, {{:pool, locale}, Vutuv.Posts.compute_discover_pool(locale, @pool_size)})
+    end
+  end
+
+  # The installation's configured locales, the same list the locale plug reads
+  # (it lives under the Endpoint's config, not at the top level).
+  defp locales do
+    :vutuv
+    |> Application.get_env(VutuvWeb.Endpoint, [])
+    |> Keyword.get(:locales, ["en"])
+  end
+
+  defp schedule(interval), do: Process.send_after(self(), :refresh, interval)
+
+  defp enabled?, do: Application.get_env(:vutuv, :refresh_popular_posts, true)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.231.2",
+      version: "7.231.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/vutuv/posts/popular_posts_test.exs
+++ b/test/vutuv/posts/popular_posts_test.exs
@@ -1,0 +1,338 @@
+defmodule Vutuv.Posts.PopularPostsTest do
+  @moduledoc """
+  The snapshot behind the feed's "Vorschläge" rail, and the draw that reads it.
+
+  Two halves, and the second one is the important one: the snapshot may be up
+  to ten minutes old, so every test that matters here asks what happens when
+  the world moved on after it was taken. The pool decides *candidacy*; the
+  database still decides *visibility*, on every single draw.
+  """
+  use Vutuv.DataCase
+
+  import Vutuv.QueryCounter
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Vutuv.Accounts.User
+  alias Vutuv.Posts
+  alias Vutuv.Posts.PopularPosts
+  alias Vutuv.Posts.Post
+
+  # An isolated cache instance on its own table, so these tests never race the
+  # application singleton (whose refresh timer is off in tests anyway).
+  defp start_pool! do
+    table = :"popular_posts_test_#{System.unique_integer([:positive])}"
+    pid = start_supervised!({PopularPosts, name: nil, table: table, refresh?: false})
+    Sandbox.allow(Vutuv.Repo, self(), pid)
+    :ok = PopularPosts.refresh(pid)
+    table
+  end
+
+  defp user(attrs \\ []), do: insert(:activated_user, attrs)
+
+  defp liked_post!(author, body, likers \\ 2) do
+    post = Vutuv.PostsHelpers.create_post!(author, %{body: body})
+    for _ <- 1..likers//1, do: :ok = Posts.like_post(user(), post)
+    post
+  end
+
+  defp backdate_post!(post, seconds) do
+    at = NaiveDateTime.add(NaiveDateTime.utc_now(:second), -seconds)
+    Repo.update_all(from(p in Post, where: p.id == ^post.id), set: [inserted_at: at])
+    %{post | inserted_at: at}
+  end
+
+  defp set_user!(user, fields) do
+    Repo.update_all(from(u in User, where: u.id == ^user.id), set: fields)
+    Repo.get!(User, user.id)
+  end
+
+  describe "the snapshot" do
+    test "serves the locale's pool without a database round trip" do
+      author = user(locale: "de")
+      post = liked_post!(author, "entdecke mich")
+      table = start_pool!()
+
+      {result, queries} = count_queries(fn -> PopularPosts.top("de", table) end)
+
+      assert {:ok, [%{id: id, user_id: user_id}]} = result
+      assert id == post.id
+      assert user_id == author.id
+      assert queries == 0
+    end
+
+    test "keeps the locales apart" do
+      german = liked_post!(user(locale: "de"), "auf deutsch")
+      english = liked_post!(user(locale: "en"), "in english")
+      table = start_pool!()
+
+      assert {:ok, [%{id: id}]} = PopularPosts.top("de", table)
+      assert id == german.id
+      assert {:ok, [%{id: id}]} = PopularPosts.top("en", table)
+      assert id == english.id
+    end
+
+    test "holds one post per author, their best-liked one" do
+      prolific = user(locale: "de")
+      best = liked_post!(prolific, "die gute", 4)
+      liked_post!(prolific, "die schwächere", 2)
+
+      table = start_pool!()
+
+      assert {:ok, [%{id: id}]} = PopularPosts.top("de", table)
+      assert id == best.id
+    end
+
+    test "ranks by likes, best first" do
+      middling = liked_post!(user(locale: "de"), "ganz nett", 2)
+      loved = liked_post!(user(locale: "de"), "grossartig", 5)
+
+      table = start_pool!()
+
+      assert {:ok, rows} = PopularPosts.top("de", table)
+      assert Enum.map(rows, & &1.id) == [loved.id, middling.id]
+    end
+
+    test "holds only posts that cleared the like bar" do
+      Vutuv.PostsHelpers.create_post!(user(locale: "de"), %{body: "niemand mag mich"})
+      liked = liked_post!(user(locale: "de"), "beliebt")
+
+      table = start_pool!()
+
+      assert {:ok, [%{id: id}]} = PopularPosts.top("de", table)
+      assert id == liked.id
+    end
+
+    test "misses on an unseeded table, an unknown table and an unknown locale" do
+      table = :"popular_posts_test_#{System.unique_integer([:positive])}"
+      pid = start_supervised!({PopularPosts, name: nil, table: table, refresh?: false})
+      Sandbox.allow(Vutuv.Repo, self(), pid)
+
+      # A miss, never a lie: the caller falls back to the live ladder.
+      assert PopularPosts.top("de", table) == :miss
+      assert PopularPosts.top("de", :no_such_table) == :miss
+
+      :ok = PopularPosts.refresh(pid)
+      assert PopularPosts.top("kl", table) == :miss
+    end
+  end
+
+  describe "the draw that reads it" do
+    test "suggests a stranger's well-liked post, author preloaded" do
+      author = user(locale: "de")
+      post = liked_post!(author, "entdecke mich")
+      viewer = user(locale: "de")
+      table = start_pool!()
+
+      assert [found] = Posts.discover_posts(viewer, pool_table: table)
+      assert found.id == post.id
+      assert found.user.id == author.id
+    end
+
+    test "runs no ranking scan at all — that is the whole point" do
+      liked_post!(user(locale: "de"), "entdecke mich")
+      viewer = user(locale: "de")
+      table = start_pool!()
+
+      # The like rollup (post_likes UNION ALL fediverse_reactions) is the
+      # expensive half of the ladder. On the cached path it must not run.
+      {found, scans} =
+        count_queries(fn -> Posts.discover_posts(viewer, pool_table: table) end,
+          matching: "fediverse_reactions"
+        )
+
+      assert length(found) == 1
+      assert scans == 0
+    end
+
+    test "prefers a stranger over someone the viewer already follows" do
+      followed = user(locale: "de")
+      stranger = user(locale: "de")
+      liked_post!(followed, "von jemandem, dem ich folge")
+      strangers_post = liked_post!(stranger, "von einer neuen Stimme")
+
+      viewer = user(locale: "de")
+      {:ok, _} = Vutuv.Social.follow(viewer, followed.id)
+      table = start_pool!()
+
+      assert Enum.map(Posts.discover_posts(viewer, limit: 1, pool_table: table), & &1.id) ==
+               [strangers_post.id]
+    end
+
+    test "suggests a followed author only to fill the card, and only from the window" do
+      followed = user(locale: "de")
+      recent = liked_post!(followed, "aus dieser Woche")
+      old = liked_post!(user(locale: "de"), "der Klassiker")
+      old = backdate_post!(old, 20 * 24 * 60 * 60)
+
+      viewer = user(locale: "de")
+      {:ok, _} = Vutuv.Social.follow(viewer, followed.id)
+      table = start_pool!()
+
+      ids = Posts.discover_posts(viewer, pool_table: table) |> Enum.map(& &1.id)
+
+      # The stranger's old favourite still qualifies (tier 2), the followed
+      # author's post only because it is inside the fortnight (tier 3).
+      assert Enum.sort(ids) == Enum.sort([recent.id, old.id])
+
+      # Backdate the followed author's post out of the window and it goes:
+      # an old post from someone you already read is not a discovery.
+      backdate_post!(recent, 20 * 24 * 60 * 60)
+      assert Enum.map(Posts.discover_posts(viewer, pool_table: table), & &1.id) == [old.id]
+    end
+
+    test "never suggests a muted followee, the viewer themselves, or a blocked member" do
+      muted = user(locale: "de")
+      blocked = user(locale: "de")
+      viewer = user(locale: "de")
+
+      liked_post!(muted, "still gestellt")
+      liked_post!(blocked, "blockiert")
+      liked_post!(viewer, "mein eigener")
+
+      {:ok, _} = Vutuv.Social.follow(viewer, muted.id)
+      Vutuv.Social.toggle_follow_mute!(viewer.id, Vutuv.Social.follow_id(viewer.id, muted.id))
+      {:ok, _} = Vutuv.Social.block_user(viewer, blocked)
+
+      table = start_pool!()
+
+      assert Posts.discover_posts(viewer, pool_table: table) == []
+    end
+
+    test "matches the viewer's language" do
+      german = liked_post!(user(locale: "de"), "auf deutsch")
+      liked_post!(user(locale: "en"), "in english")
+      table = start_pool!()
+
+      assert Enum.map(Posts.discover_posts(user(locale: "de"), pool_table: table), & &1.id) ==
+               [german.id]
+    end
+
+    test "fills the card and still varies between draws" do
+      for n <- 1..8, do: liked_post!(user(locale: "de"), "Stimme #{n}")
+      viewer = user(locale: "de")
+      table = start_pool!()
+
+      assert length(Posts.discover_posts(viewer, limit: 5, pool_table: table)) == 5
+
+      # The shuffle lives inside the tier now (an earlier cut shuffled across
+      # the whole set and silently lost the tier preference), so this asserts
+      # the half that survived: within one tier the draw is still random.
+      slates =
+        Enum.reduce(1..20, MapSet.new(), fn _, seen ->
+          Posts.discover_posts(viewer, limit: 5, pool_table: table)
+          |> Enum.map(& &1.user_id)
+          |> MapSet.new()
+          |> MapSet.union(seen)
+        end)
+
+      assert MapSet.size(slates) > 5
+    end
+
+    test "falls back to recent posts when the pool is empty, as the ladder does" do
+      # A brand-new installation: nothing has been liked, so nothing clears the
+      # bar and the snapshot is legitimately empty — an answer, not a miss. The
+      # rail must still not be permanently blank, which is the whole reason the
+      # like-less fallback exists.
+      post = Vutuv.PostsHelpers.create_post!(user(locale: "de"), %{body: "ganz frisch hier"})
+      viewer = user(locale: "de")
+      table = start_pool!()
+
+      assert {:ok, []} = PopularPosts.top("de", table)
+      assert Enum.map(Posts.discover_posts(viewer, pool_table: table), & &1.id) == [post.id]
+    end
+
+    test "falls back to recent posts when the viewer filtered the whole pool away" do
+      # The pool is not empty, this reader's view of it is: they follow the one
+      # author in it and the post is older than the fortnight, so no tier can
+      # take it. Same rule, same fallback.
+      author = user(locale: "de")
+      old = liked_post!(author, "der Klassiker")
+      backdate_post!(old, 20 * 24 * 60 * 60)
+
+      viewer = user(locale: "de")
+      {:ok, _} = Vutuv.Social.follow(viewer, author.id)
+      fresh = Vutuv.PostsHelpers.create_post!(user(locale: "de"), %{body: "ungeliebt, aber neu"})
+
+      table = start_pool!()
+      assert {:ok, [_]} = PopularPosts.top("de", table)
+
+      assert Enum.map(Posts.discover_posts(viewer, pool_table: table), & &1.id) == [fresh.id]
+    end
+
+    test "falls back to the live ladder when the snapshot cannot answer" do
+      post = liked_post!(user(locale: "de"), "entdecke mich")
+      viewer = user(locale: "de")
+
+      # No snapshot: behaviour is unchanged, only uncached.
+      assert Enum.map(Posts.discover_posts(viewer, pool_table: :no_such_table), & &1.id) ==
+               [post.id]
+    end
+  end
+
+  # The reason the pool may only ever propose a candidate: it is a snapshot,
+  # and moderation is not. Each of these makes the world move after the
+  # snapshot was taken and asserts the draw still refuses the post.
+  describe "a stale pool never leaks a hidden post" do
+    setup do
+      author = user(locale: "de")
+      post = liked_post!(author, "entdecke mich")
+      viewer = user(locale: "de")
+      table = start_pool!()
+
+      # Sanity: it is in the pool and it is being suggested.
+      assert {:ok, [_]} = PopularPosts.top("de", table)
+      assert [_] = Posts.discover_posts(viewer, pool_table: table)
+
+      %{author: author, post: post, viewer: viewer, table: table}
+    end
+
+    test "the post was frozen since", %{post: post, viewer: viewer, table: table} do
+      Repo.update_all(from(p in Post, where: p.id == ^post.id),
+        set: [frozen_at: NaiveDateTime.utc_now(:second)]
+      )
+
+      assert Posts.discover_posts(viewer, pool_table: table) == []
+    end
+
+    test "the author was frozen since", %{author: author, viewer: viewer, table: table} do
+      set_user!(author, frozen_at: NaiveDateTime.utc_now(:second))
+      assert Posts.discover_posts(viewer, pool_table: table) == []
+    end
+
+    test "the author was suspended since", %{author: author, viewer: viewer, table: table} do
+      set_user!(author, suspended_until: NaiveDateTime.add(NaiveDateTime.utc_now(:second), 3600))
+      assert Posts.discover_posts(viewer, pool_table: table) == []
+    end
+
+    test "the author deactivated since", %{author: author, viewer: viewer, table: table} do
+      set_user!(author, deactivated_at: NaiveDateTime.utc_now(:second))
+      assert Posts.discover_posts(viewer, pool_table: table) == []
+    end
+
+    test "the author became unreachable since", %{author: author, viewer: viewer, table: table} do
+      set_user!(author, unreachable_at: NaiveDateTime.utc_now(:second))
+      assert Posts.discover_posts(viewer, pool_table: table) == []
+    end
+
+    test "the post was restricted since", %{post: post, viewer: viewer, table: table} do
+      Repo.insert!(%Vutuv.Posts.PostDenial{post_id: post.id, wildcard: "everyone"})
+      assert Posts.discover_posts(viewer, pool_table: table) == []
+    end
+
+    test "the viewer blocked the author since", %{author: author, viewer: viewer, table: table} do
+      {:ok, _} = Vutuv.Social.block_user(viewer, author)
+      assert Posts.discover_posts(viewer, pool_table: table) == []
+    end
+
+    test "the viewer followed and muted the author since", %{
+      author: author,
+      viewer: viewer,
+      table: table
+    } do
+      {:ok, _} = Vutuv.Social.follow(viewer, author.id)
+      Vutuv.Social.toggle_follow_mute!(viewer.id, Vutuv.Social.follow_id(viewer.id, author.id))
+
+      assert Posts.discover_posts(viewer, pool_table: table) == []
+    end
+  end
+end


### PR DESCRIPTION
Die "Vorschläge"-Karte im Feed hat ihre Kandidaten bisher pro Leser neu ermittelt, und zwar bis zu dreimal: eine Leiter aus drei Stufen (fremde Autoren aus den letzten 14 Tagen → fremde Autoren jeden Alters → alle außer mir selbst, wieder aus 14 Tagen), jede Stufe ein eigener Scan über `posts` plus Like-Rollup, gruppiert auf einen Post pro Autor.

Der teure Teil dieser Frage ist aber für jeden Leser derselbe: *welche öffentlichen Posts dieser Sprache kamen gut an, einer pro Autor, bester zuerst.* Persönlich ist nur die letzte Meile — nicht meine eigenen Posts, niemand, den ich stumm gestellt oder blockiert habe, und Leute, denen ich noch nicht folge, vor denen, denen ich schon folge.

## Was sich ändert

**Der geteilte Teil wandert in einen Snapshot.** `Vutuv.Posts.PopularPosts` ist ein GenServer nach genau demselben Muster wie `Vutuv.Social.PopularUsers` (die Schwesterkarte "Wem folgen?" im selben Rail) und `Vutuv.Posts.TopPosters`: alle zehn Minuten eine Rangliste pro konfigurierter Sprache in eine `read_concurrency`-ETS-Tabelle, `:miss` fällt auf die bisherige Abfrage zurück. Eine Ranglisten-Abfrage pro Sprache für die ganze Installation, egal wie viele Leute gerade lesen.

Das lohnt sich mehr, als eine Zahl pro Seitenaufruf vermuten lässt: `feed.ex` zeichnet das Rail alle fünf Minuten neu (`@suggestions_refresh`), also skalierte die alte Rechnung mit **offenen Tabs**, nicht mit Lesern.

**Die drei Stufen werden eine Sortierung.** Sie waren immer eine Rangfolge über eine Kandidatenmenge, keine drei Suchen. Jetzt sind sie ein `CASE` im `ORDER BY` der Ziehung. Nebenbei behebt das die Richtung: Stufe 1 und 2 schließen alle aus, denen der Leser folgt, also bezahlten gut vernetzte Mitglieder bisher zwei Ziehungen, die die Karte gar nicht füllen konnten, bevor die dritte die Arbeit machte.

**Der Pool schlägt vor, die Datenbank entscheidet.** Ein Snapshot ist Minuten alt, Moderation ist es nicht. Deshalb enthält er nur Kandidaten-IDs, und die Ziehung legt das volle anonyme Sichtbarkeits-Gate plus Blocks und Mutes des Lesers erneut an. Bezahlbar ist das genau deshalb, weil es auf ein paar hundert bekannte IDs begrenzt ist statt auf die posts-Tabelle. Veralteter Pool kann also einen leicht veralteten *Vorschlag* kosten, nie einen Post, den jemand nicht sehen darf.

## Gemessen (Kopie der Produktionsdaten)

| | Ziehung | Abfragen | DB-Zeit |
|---|---|---|---|
| Leiter (bisher) | 4,35 ms | 13 | 8,59 ms |
| Snapshot (neu) | 1,13 ms | 11 | 2,03 ms |

Dazu 3,2 ms alle zehn Minuten für alle Sprachen zusammen, einmal für die ganze Installation. Die Abfragezahl sinkt nur um zwei, weil der Rest Preloads sind; die drei Ranglisten-Scans sind durch eine ID-gebundene Abfrage ersetzt, und deren Kosten hängen nicht mehr an der Größe der posts-Tabelle.

## Tests

`test/vutuv/posts/popular_posts_test.exs`, 24 Fälle. Der wichtigste Block heißt "a stale pool never leaks a hidden post" und hat einen Fall pro Art, wie sich die Welt nach dem Snapshot bewegen kann: Post eingefroren, Autor eingefroren / gesperrt / deaktiviert / unerreichbar, Post nachträglich beschränkt, Autor seither blockiert oder stumm gestellt. Dazu die Rückfälle (leerer Pool auf einer frischen Installation, Leser filtert den ganzen Pool weg, Snapshot antwortet nicht) und eine Zusicherung, dass auf dem Cache-Pfad **kein** Ranking-Scan mehr läuft.

Ein Fehler, den die Tests gefangen haben und der es wert ist, erwähnt zu werden: die erste Fassung mischte die Kandidaten über die ganze Menge statt innerhalb einer Stufe und warf damit still die Bevorzugung fremder Autoren weg. Jetzt wird pro Stufe gemischt, mit eigenem Test dafür.

Die bestehende `discover_posts/2`-Suite (25 Fälle) prüft weiter die Leiter: in Tests ist der Refresh-Timer aus, also läuft dort der `:miss`-Pfad. Beide Wege sind damit abgedeckt.

**Deploy:** hot, keine Migration. Neuer Prozess im Supervision-Tree und ein neuer Schalter `:refresh_popular_posts` (in Tests aus, wie bei den beiden Schwester-Caches).
**Version:** 7.231.3 (Patch: das Rail verhält sich gleich, es ist ein Refactor)
**`mix precommit`:** grün (6961 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*
