### PR TITLE
Deploy-Nachlauf darf den Deploy nicht mehr abbrechen (v7.233.2)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.233.1",
+      version: "7.233.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -142,12 +142,29 @@ else
   sudo systemctl disable "$OLD_UNIT" 2>/dev/null || true
 fi
 
+# Everything from here on is MAINTENANCE, not deploy: traffic already runs on
+# the new slot, so the deploy has succeeded. Such a step must therefore never
+# be allowed to abort the script, because the one thing still outstanding —
+# stopping the old slot — matters far more than any of it. `set -e` used to
+# make a failure here fatal, and on 2026-08-09 that left both slots running
+# for 40 minutes: two pools against a 100-connection Postgres (which was what
+# had failed the maintenance step in the first place), and every periodic
+# sweeper running twice, including the one that emails members about unread
+# messages. Each step logs its own failure and the script carries on.
+maintenance() {
+  local what=$1
+  shift
+  if ! "$@"; then
+    log "WARNING: $what failed; continuing so the old slot still gets stopped"
+  fi
+}
+
 # UUID cutover only: rename the image directories from their old integer id to
 # the new UUID (avatars/covers/screenshots + their originals/ mirrors), using
 # the legacy_id_map the convert_ids_to_uuid_v7 migration leaves behind. Must run
 # before regenerate_images so the originals are found at their new UUID paths.
 # Idempotent and a no-op once the map is cleaned up after the cutover.
-"$dest/bin/$RELEASE" eval "Vutuv.Release.relabel_image_dirs()"
+maintenance "relabel_image_dirs" "$dest/bin/$RELEASE" eval "Vutuv.Release.relabel_image_dirs()"
 
 # Re-derive any image whose served versions predate the current
 # Vutuv.Uploads.Spec (format/resolution/quality), relocating legacy public
@@ -155,7 +172,7 @@ fi
 # there is nothing to do; runs after the traffic switch so new uploads are
 # already on the current spec (a not-yet-converted file keeps serving through
 # the transitional legacy fallback in the meantime).
-"$dest/bin/$RELEASE" eval "Vutuv.Release.regenerate_images()"
+maintenance "regenerate_images" "$dest/bin/$RELEASE" eval "Vutuv.Release.regenerate_images()"
 
 # Drain, then stop the old instance. The drain lets in-flight requests and
 # LiveView websockets finish; it stays short because the app's periodic

--- a/test/vutuv/deploy_script_test.exs
+++ b/test/vutuv/deploy_script_test.exs
@@ -1,0 +1,96 @@
+defmodule Vutuv.DeployScriptTest do
+  @moduledoc """
+  `scripts/deploy.sh` runs on the self-hosted runner and is what puts a release
+  into production, so its failure modes are production incidents rather than
+  test failures.
+
+  This covers one of them, seen on 2026-08-09. The script runs `set -euo
+  pipefail`, and after the traffic switch it called two image-maintenance
+  tasks directly. One of them could not open a database connection, `set -e`
+  took the whole script down, and the lines below it never ran — including the
+  one that stops the previous slot. Both releases then kept running for forty
+  minutes: two connection pools against a Postgres already at its
+  100-connection ceiling (which is what had failed the maintenance step to
+  begin with), and every periodic sweeper firing twice, among them the one
+  that emails members about unread messages.
+
+  The property to hold on to: **once traffic has been switched, the deploy has
+  succeeded**, so nothing after that point may abort the script before the old
+  slot is stopped. Both the wrapper's behaviour and the ordering it protects
+  are asserted here, because either one alone can regress silently.
+  """
+  use ExUnit.Case, async: true
+
+  @script "scripts/deploy.sh"
+
+  setup do
+    {:ok, source: File.read!(@script)}
+  end
+
+  describe "the maintenance wrapper" do
+    test "runs the failing command, says so, and lets the script continue", %{source: source} do
+      # Exercise the definition the script actually ships, not a copy of it.
+      [definition] = Regex.run(~r/^maintenance\(\) \{.*?^\}$/ms, source)
+
+      harness = """
+      set -euo pipefail
+      log() { echo "LOG: $*"; }
+      #{definition}
+      maintenance "a step that fails" false
+      maintenance "a step that works" true
+      echo "REACHED-THE-STOP-STEP"
+      """
+
+      {output, status} = System.cmd("bash", ["-c", harness], stderr_to_stdout: true)
+
+      assert status == 0
+      assert output =~ "REACHED-THE-STOP-STEP"
+      assert output =~ "WARNING: a step that fails failed"
+      refute output =~ "WARNING: a step that works"
+    end
+  end
+
+  describe "the post-switch section" do
+    test "wraps every release task after the traffic switch", %{source: source} do
+      after_switch = post_switch_section(source)
+
+      for line <- String.split(after_switch, "\n"),
+          String.contains?(line, ~s|eval "Vutuv.Release|),
+          not String.starts_with?(String.trim(line), "#") do
+        assert String.contains?(line, "maintenance "),
+               """
+               An unwrapped release task after the traffic switch can abort the \
+               deploy before the old slot is stopped:
+
+                   #{String.trim(line)}
+               """
+      end
+    end
+
+    test "stops the old slot after the maintenance tasks, not before", %{source: source} do
+      after_switch = post_switch_section(source)
+
+      assert [_ | _] = Regex.scan(~r/^maintenance /m, after_switch)
+
+      last_maintenance =
+        after_switch
+        |> String.split("\n")
+        |> Enum.find_index(&String.starts_with?(&1, "maintenance "))
+
+      stop_line =
+        after_switch
+        |> String.split("\n")
+        |> Enum.find_index(&String.contains?(&1, ~s|systemctl stop "$OLD_UNIT"|))
+
+      assert stop_line, "the deploy must stop the old slot"
+      assert stop_line > last_maintenance
+    end
+  end
+
+  # Everything from the nginx reload onwards: at that point users are already
+  # being served by the new release.
+  defp post_switch_section(source) do
+    [_, after_switch] = String.split(source, "Traffic switched to", parts: 2)
+    after_switch
+  end
+end


### PR DESCRIPTION
**TL;DR** A maintenance step after the traffic switch took the whole deploy down with `set -e`, so the old slot never got stopped and both releases ran side by side for 40 minutes. Post-switch steps are now non-fatal.

## What happened on the v7.233.1 deploy

`relabel_image_dirs` could not open a database connection — Postgres stood at 103 of 100 connections. The script runs `set -euo pipefail`, so it died there, and every line below it never ran:

```
  ✓ migrations
  ✓ health check passed
  ✓ traffic switched to blue
  ✗ relabel_image_dirs      <- DBConnection.ConnectionError, script exits
  – regenerate_images       never ran
  – drain + stop old slot   NEVER RAN
```

The site itself was fine throughout: the switch had already happened and v7.233.1 served normally. What was not fine is what the missing lines were for. Both slots kept running, which means two connection pools against the very database whose exhaustion caused the failure, and every periodic sweeper firing twice — including the one that emails members about unread messages. The script's own comment says exactly that: *"it stays short because the app's periodic sweepers (e.g. unread-message emails) must not run twice for long."*

## The fix

The mistake is one of classification. **Once traffic has been switched, the deploy has succeeded**; everything after that is maintenance, and maintenance must never prevent the cleanup that matters far more. Both image tasks now run through a small `maintenance` wrapper that logs a failure and carries on.

## What this does *not* fix

The connection exhaustion itself. During the switch window two releases each hold a pool by design, and a `bin/vutuv eval` opens a third. Whether the ceiling should rise or the pools should shrink is a separate decision, not one to make inside an incident fix.

Worth noting separately: `relabel_image_dirs` is a leftover from the June UUID cutover. It is idempotent and returns `{:error, :no_mapping}` once the map is cleaned up, so it may well be doing nothing on every deploy and could be dropped from the script — but proving that needs a look at production's `legacy_id_map`, so it is not in here.

## Tests

Three, and they run the shipped `maintenance` function rather than a copy of it, so the two cannot drift:

- the wrapper runs the failing command, logs it, and lets the script reach the stop step;
- every `Vutuv.Release` task after the traffic switch is wrapped;
- the old slot is stopped *after* the maintenance tasks.

Both halves are asserted because either can regress on its own: wrapping without the ordering, or the ordering without the wrapping. Removing the wrapper from one line makes the second test fail with the offending line quoted (verified by mutation).

*An AI agent wrote this text in my name, unreviewed by me. The work behind it is mine; I only delegated the writing.*