### PR TITLE
GSC-Erkenntnisse vom 10.08. in der SEO-Doku (v7.233.3)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -25,7 +25,7 @@ installing and operating vutuv in [Running your own vutuv](../ADMINS.md).
 | [authentication.md](authentication.md) | passwordless PIN login, passkeys, server-side sessions |
 | [account-activity.md](account-activity.md) | the append-only account-activity log: what changed on an account, when, from where and how it was confirmed; the member's page, the admin's page, retention |
 | [moderation.md](moderation.md) | reports, freezes, the strike ladder, reporter trust, evidence screenshots |
-| [agents-and-seo.md](agents-and-seo.md) | agent formats (`.md`/`.txt`/`.json`/`.xml`/`.vcf`), the member directory, sitemap/RSS/JSON-LD, Open Graph |
+| [agents-and-seo.md](agents-and-seo.md) | agent formats (`.md`/`.txt`/`.json`/`.xml`/`.vcf`), the member directory, sitemap/RSS/JSON-LD, Open Graph, how to read the Search Console reports |
 | [email.md](email.md) | the Emailer chokepoint, multipart bodies, opt-outs, bounces & deliverability |
 | [images.md](images.md) | the AVIF pipeline, kept originals, fingerprinted filenames, URL screenshots, AI image moderation (Ollama) |
 | [admin.md](admin.md) | the admin panel: live dashboard, member browser, account deletion, newsletter & audiences, daily report |

--- a/docs/architecture/agents-and-seo.md
+++ b/docs/architecture/agents-and-seo.md
@@ -161,6 +161,49 @@ near-duplicates of the profile's own cards; internal links and unique titles
 are the right treatment), and locale stays Accept-Language-negotiated on one
 URL (no hreflang variants).
 
+## Reading Search Console
+
+Google's index reports lag the site by weeks, so a red bucket here is normally
+Google catching up with a fix that already shipped, not a defect. What each one
+means for this installation, re-checked against production on 2026-08-10:
+
+- **"Indexed, though blocked by robots.txt"** holds legacy `/users/…` URLs
+  only, every one last crawled before the robots.txt fixes above. Nothing on
+  the site can add to it: robots.txt fences `/admin/` and nothing else,
+  `/users/:slug` 301s to the canonical `/:slug`, and `/login` answers 200 with
+  `X-Robots-Tag: noindex`. The important part is how validation behaves: a
+  "validate fix" pass **fails on the first URL whose last crawl still saw the
+  old state**, so it can go red long after the cause is gone. The July pass
+  failed on `/login` alone, crawled three days before v7.185.1 freed it.
+  Restarted 2026-08-10; Google takes weeks over such a run.
+- **"Crawled - currently not indexed"** is dominated by the profiles'
+  `.md`/`.txt`/`.json`/`.xml` siblings, and for them this bucket is the
+  *correct* end state, not a backlog: each answers with
+  `Link: <…>; rel="canonical"; type="text/html"`, so Google fetches the
+  document, learns the content belongs to the HTML page and files it here.
+  Leave it alone, and in particular never put `noindex` on those URLs: a
+  canonical says "index the other one", a noindex says "index neither", and a
+  page carrying both gives Google contradictory instructions. (The ~10K thin
+  tag pages that used to fill this bucket are a separate, solved story: the
+  indexability bar above.)
+- **The 404 and 403 buckets are intended** (agent-export opt-out, moderation
+  withholding), as documented above.
+- **The "Profile page" rich-result report can read 0 valid items with nothing
+  broken.** It counts freshly crawled pages, so at this crawl volume it drops
+  to zero on its own. Live, every indexable profile serves the full JSON-LD
+  (verified 2026-08-10: ProfilePage, Person, Organization, BreadcrumbList).
+  Check a real 200 profile before believing a regression, and mind the trap
+  that makes the check itself lie: a *guessed* handle 404s with a
+  fully-styled error page whose head carries a self-canonical, which reads
+  like a profile page with its structured data stripped out.
+- **Sitemap, HTTPS and breadcrumbs are green.** Core Web Vitals reports no
+  data, which is what too few CrUX samples look like at the current traffic,
+  not a measurement failure.
+
+The standing rule behind all of it: verify the live response before treating a
+Search Console bucket as a bug (`curl -sI`, the JSON-LD in the rendered page),
+because every report here describes the site as it was at the last crawl.
+
 ## Member directory (`/system/members`)
 
 The crawlable A-Z index of every member whose profile is open to search engines

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.233.2",
+      version: "7.233.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Behebt #1341.

Der Search-Console-Rundgang vom 10.08.2026 hat ergeben, dass alle rot gemeldeten Indexierungsprobleme Google-Nachlauf auf bereits gefixte Zustände sind. Die Doku beschrieb bisher die robots.txt-Strategie, aber nicht, wie die Berichte danach zu lesen sind, also musste jeder, der die Console öffnet, die komplette Verifikation neu machen.

**Neu:** Abschnitt "Reading Search Console" in `docs/architecture/agents-and-seo.md`, direkt hinter der Profil-SEO, weil er beide Voraussetzungen braucht (robots.txt-Strategie und das JSON-LD des Profils).

Er hält fest:

- **"Indexiert, obwohl durch robots.txt blockiert"**: nur Legacy-`/users/`-URLs von vor den Fixes. Wichtig ist das Verhalten der Validierung: sie scheitert an der ersten URL, deren letzter Crawl noch den alten Zustand sah, kann also lange nach der Ursache rot werden. Die Juli-Validierung fiel allein über `/login`, gecrawlt drei Tage vor v7.185.1.
- **"Gecrawlt, zurzeit nicht indexiert"**: für die `.md`/`.txt`/`.json`/`.xml`-Siblings der korrekte Endzustand, weil sie `Link: rel="canonical"` auf die HTML-Seite senden. Nicht "fixen", vor allem kein noindex (canonical und noindex geben Google widersprüchliche Anweisungen).
- **404-/403-Buckets bleiben gewollt** (Agent-Export-Opt-out, Moderation).
- **Der Strukturdaten-Bericht kann 0 gültige Elemente zeigen, ohne dass etwas kaputt ist**: er zählt nur frisch gecrawlte Seiten. Dazu die Stolperfalle, die die Gegenprüfung selbst verfälscht: ein geratener Handle 404t mit einer vollwertig aussehenden Fehlerseite samt Self-Canonical im head.
- **Sitemap, HTTPS, Breadcrumbs grün**; CWV ohne Daten ist zu wenig CrUX-Traffic, kein Messfehler.

Jede Aussage vor dem Aufschreiben gegen die Produktion geprüft: robots.txt sperrt nur `/admin/`, `/users/:slug` 301t auf `/:slug`, `/login` liefert 200 + `X-Robots-Tag: noindex`, `/wintermeyer.md` sendet `Link: <https://vutuv.de/wintermeyer>; rel="canonical"; type="text/html"`, das Profil liefert ProfilePage/Person/Organization/BreadcrumbList, und ein geratener Handle 404t mit Self-Canonical.

Kein Code-Fehler gefunden, also keine Code-Änderung. `mix precommit` grün (7021 Tests).

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*