### PR TITLE
Ein Tag kann Zweitnamen tragen (v7.234.0)

### DIFF
--- a/lib/vutuv/newsletters.ex
+++ b/lib/vutuv/newsletters.ex
@@ -277,9 +277,15 @@ defmodule Vutuv.Newsletters do
         nil
 
       trimmed ->
-        Repo.one(
-          from(t in Tag, where: fragment("lower(?) = lower(?)", t.name, ^trimmed), limit: 1)
-        )
+        # An audience named by an alternative name is the topic's audience
+        # (issue #1338): the members are on the canonical tag, so a group built
+        # on "ROR" must resolve to Ruby on Rails or it would mail nobody.
+        from(t in Tag, where: fragment("lower(?) = lower(?)", t.name, ^trimmed), limit: 1)
+        |> Repo.one()
+        |> case do
+          nil -> nil
+          tag -> Tag.canonical(tag)
+        end
     end
   end
 

--- a/lib/vutuv/search.ex
+++ b/lib/vutuv/search.ex
@@ -23,6 +23,7 @@ defmodule Vutuv.Search do
   alias Vutuv.Search.SearchQuery
   alias Vutuv.Search.SearchQueryRequester
   alias Vutuv.Search.SearchQueryResult
+  alias Vutuv.Tags.Tag
 
   @min_chars 3
   @min_field_chars 2
@@ -527,15 +528,39 @@ defmodule Vutuv.Search do
     end
   end
 
+  # Tags match on their alternative names too (issue #1338) — searching "ROR"
+  # has to find the Ruby on Rails page — but the row that comes back is always
+  # the topic, never the alias, so one subject appears once. `alias_matches/1`
+  # is the id set of canonicals whose aliases match; the outer query keeps only
+  # unmerged rows.
   defp visible_tags(needle, true) do
-    from(t in Vutuv.Tags.Tag,
-      where: fragment("lower(?)", t.name) == ^needle or t.slug == ^needle
+    aliases =
+      from(a in Tag,
+        where: not is_nil(a.merged_into_id),
+        where: fragment("lower(?)", a.name) == ^needle or a.slug == ^needle,
+        select: a.merged_into_id
+      )
+
+    from(t in Tag.not_merged(),
+      where:
+        fragment("lower(?)", t.name) == ^needle or t.slug == ^needle or
+          t.id in subquery(aliases)
     )
   end
 
   defp visible_tags(needle, false) do
     infix = contains(needle)
-    from(t in Vutuv.Tags.Tag, where: ilike(t.name, ^infix) or ilike(t.slug, ^infix))
+
+    aliases =
+      from(a in Tag,
+        where: not is_nil(a.merged_into_id),
+        where: ilike(a.name, ^infix) or ilike(a.slug, ^infix),
+        select: a.merged_into_id
+      )
+
+    from(t in Tag.not_merged(),
+      where: ilike(t.name, ^infix) or ilike(t.slug, ^infix) or t.id in subquery(aliases)
+    )
   end
 
   # How many members carry each found tag - the number that makes a tag chip

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -105,10 +105,15 @@ defmodule Vutuv.Tags do
       names ->
         downcased = Enum.map(names, &String.downcase/1)
 
+        # The displayed name is the topic's, not the typed spelling's: someone
+        # typing an alternative name (issue #1338) gets the chip they will
+        # actually end up with, the same way a case variant already resolves to
+        # the stored casing.
         display_by_key =
           from(t in Tag,
+            left_join: c in assoc(t, :merged_into),
             where: fragment("lower(?)", t.name) in ^downcased or t.slug in ^downcased,
-            select: {fragment("lower(?)", t.name), t.slug, t.name}
+            select: {fragment("lower(?)", t.name), t.slug, coalesce(c.name, t.name)}
           )
           |> Repo.all()
           |> Enum.flat_map(fn {lower_name, slug, name} -> [{lower_name, name}, {slug, name}] end)
@@ -263,7 +268,7 @@ defmodule Vutuv.Tags do
   "Honor tags" overview (`/admin/honor_tags`). Returns `[{%Tag{}, count}]`.
   """
   def honor_tags do
-    from(t in Tag,
+    from(t in Tag.not_merged(),
       where: t.honor?,
       left_join: ut in assoc(t, :user_tags),
       group_by: t.id,
@@ -275,7 +280,7 @@ defmodule Vutuv.Tags do
 
   @doc "How many honor tags exist (the dashboard tile's count)."
   def honor_tags_count do
-    Repo.aggregate(from(t in Tag, where: t.honor?), :count)
+    Repo.aggregate(from(t in Tag.not_merged(), where: t.honor?), :count)
   end
 
   @doc """
@@ -368,7 +373,11 @@ defmodule Vutuv.Tags do
 
     posted = from([post_tag: pt] in Posts.visible_tagged_posts_query(), select: pt.tag_id)
 
-    from(t in Tag,
+    # `not_merged/1`: an alternative name is not a page of its own, so it never
+    # enters the sitemap and its own URL is noindexed (issue #1338). It holds no
+    # rows after a merge anyway, but an alias added by hand to a busy topic
+    # would otherwise inherit the topic's numbers through the id it points at.
+    from(t in Tag.not_merged(),
       where: t.id in subquery(endorsed_enough) or t.id in subquery(posted)
     )
   end
@@ -379,13 +388,20 @@ defmodule Vutuv.Tags do
   end
 
   @doc """
-  Given candidate tag slugs (the `#hashtags` in a Markdown body), returns the
-  `MapSet` of those whose `/tags/:slug` page actually shows something — a real
-  tag with **at least one visible member** (a confirmed, non-hidden user carries
-  it, the same gate the tag page lists by) **or at least one publicly visible
-  post** filed under it (`Posts.visible_tagged_posts_query/0`, the tag page's own
-  posts gate). Powers the hashtag links `VutuvWeb.Markdown` writes; an unknown or
-  empty tag is absent from the set, so it stays plain text.
+  Given candidate tag slugs (the `#hashtags` in a Markdown body), returns a map
+  from each written slug to the slug its link should point at — for those whose
+  `/tags/:slug` page actually shows something: a real tag with **at least one
+  visible member** (a confirmed, non-hidden user carries it, the same gate the
+  tag page lists by) **or at least one publicly visible post** filed under it
+  (`Posts.visible_tagged_posts_query/0`, the tag page's own posts gate). Powers
+  the hashtag links `VutuvWeb.Markdown` writes; an unknown or empty tag is
+  absent from the map, so it stays plain text.
+
+  The two slugs differ exactly when the written one names an **alternative name**
+  for a topic (issue #1338): `#rubyonrails` links straight to `/tags/ruby_on_rails`
+  rather than to a URL that redirects there, and the gate is applied to the
+  canonical tag, which is where the members and posts of an absorbed tag now sit.
+  That is also why the answer is a map and not a set.
 
   The post arm is what keeps the link and the listing honest in both directions:
   a post is filed under the tag its own `#hashtag` names, so a tag nobody has on
@@ -403,29 +419,35 @@ defmodule Vutuv.Tags do
 
     case slugs |> Enum.map(&String.downcase/1) |> Enum.uniq() do
       [] ->
-        MapSet.new()
+        %{}
 
       normalized ->
         held =
           from(t in Tag,
-            join: ut in assoc(t, :user_tags),
+            left_join: c in assoc(t, :merged_into),
+            join: ut in UserTag,
+            on: ut.tag_id == coalesce(c.id, t.id),
             join: u in assoc(ut, :user),
             where: t.slug in ^normalized,
             where: account_confirmed_row(u) and not account_hidden_row(u),
-            select: %{slug: t.slug}
+            select: %{slug: t.slug, target: coalesce(c.slug, t.slug)}
           )
 
         posted =
           from([post_tag: pt] in Posts.visible_tagged_posts_query(),
             join: t in Tag,
-            on: t.id == pt.tag_id,
+            on: pt.tag_id == coalesce(t.merged_into_id, t.id),
+            left_join: c in assoc(t, :merged_into),
             where: t.slug in ^normalized,
-            select: %{slug: t.slug}
+            select: %{slug: t.slug, target: coalesce(c.slug, t.slug)}
           )
 
-        from(row in subquery(union_all(held, ^posted)), distinct: true, select: row.slug)
+        from(row in subquery(union_all(held, ^posted)),
+          distinct: true,
+          select: {row.slug, row.target}
+        )
         |> Repo.all()
-        |> MapSet.new()
+        |> Map.new()
     end
   end
 
@@ -459,8 +481,14 @@ defmodule Vutuv.Tags do
 
     Repo.all(
       from(t in Tag,
+        # A body that writes an alternative name files the post under the topic
+        # (issue #1338), so `#rubyonrails` and `#RubyOnRails` land in the same
+        # timeline. `distinct` because two written spellings can now resolve to
+        # one tag, and `post_tags` has a unique index on (post_id, tag_id).
+        left_join: c in assoc(t, :merged_into),
         where: fragment("lower(?)", t.name) in ^names or t.slug in ^names,
-        select: t.id
+        distinct: true,
+        select: coalesce(c.id, t.id)
       )
     )
   end

--- a/lib/vutuv/tags/tag.ex
+++ b/lib/vutuv/tags/tag.ex
@@ -30,6 +30,12 @@ defmodule Vutuv.Tags.Tag do
   # actually use and search for, unlike a run of question marks.
   @content_char ~r/[^\p{P}\p{Z}\p{C}]/u
 
+  # The three things an alternative name for a topic can be (issue #1338).
+  # There is deliberately no `misspelling`: a typo is unbounded, a near-miss
+  # pair is exactly where a wrong merge does the most damage, and catching one
+  # buys almost nothing — so a misspelled tag stays its own tag.
+  @alias_kinds ~w(alias abbreviation former)
+
   schema "tags" do
     field(:slug, :string)
     field(:name, :string)
@@ -39,10 +45,21 @@ defmodule Vutuv.Tags.Tag do
     # form / the generic changeset head — never the member "value" head below.
     field(:honor?, :boolean, default: false)
 
+    # Set when this tag is an alternative name for another one (issue #1338):
+    # `rails`, `ROR` and `rubyonrails` all point at `Ruby on Rails`. Such a row
+    # is never a topic of its own — it keeps its slug so old links resolve, and
+    # every listing leaves it out (`not_merged/1`).
+    belongs_to(:merged_into, __MODULE__)
+    field(:alias_kind, :string)
+
     has_many(:user_tags, Vutuv.Tags.UserTag)
+    has_many(:aliases, __MODULE__, foreign_key: :merged_into_id)
 
     timestamps()
   end
+
+  @doc "The kinds an alternative name can have: #{inspect(@alias_kinds)}."
+  def alias_kinds, do: @alias_kinds
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -219,12 +236,69 @@ defmodule Vutuv.Tags.Tag do
   def find_by_value(value) when is_binary(value) do
     down = String.downcase(value)
 
-    Repo.one(
-      from(t in __MODULE__,
-        where: fragment("lower(?)", t.name) == ^down or t.slug == ^down,
-        limit: 1
-      )
+    from(t in __MODULE__,
+      where: fragment("lower(?)", t.name) == ^down or t.slug == ^down,
+      limit: 1
     )
+    |> Repo.one()
+    |> follow_alias()
+  end
+
+  # An alias is a tag row pointing at its canonical (issue #1338), so a value
+  # naming one resolves to the topic rather than to the alias. One hop is the
+  # whole rule — an alias may never point at another alias, which
+  # `Vutuv.Tags.Merge` refuses — so nothing here recurses. A canonical tag
+  # costs one query as before; only an alias costs the second.
+  defp follow_alias(nil), do: nil
+  defp follow_alias(%__MODULE__{merged_into_id: nil} = tag), do: tag
+  defp follow_alias(%__MODULE__{merged_into_id: id} = tag), do: Repo.get(__MODULE__, id) || tag
+
+  @doc """
+  The topic a tag stands for: itself, or the tag it is an alternative name for.
+
+  Takes a loaded `%Tag{}` and answers without a query when the association is
+  already loaded, which is the common case on a page that has just listed a
+  tag's aliases.
+  """
+  def canonical(%__MODULE__{merged_into_id: nil} = tag), do: tag
+  def canonical(%__MODULE__{merged_into: %__MODULE__{} = canonical}), do: canonical
+  def canonical(%__MODULE__{merged_into_id: id}), do: Repo.get(__MODULE__, id)
+
+  @doc """
+  Whether this tag is an alternative name for another one, rather than a topic
+  of its own.
+  """
+  def merged?(%__MODULE__{merged_into_id: id}), do: not is_nil(id)
+
+  @doc """
+  Narrows a tag query to real topics, leaving out every alternative name.
+
+  **Every listing, search and count owes this call.** A tag query that forgets
+  it puts the second page for one topic back in front of a reader, which is the
+  bug issue #1338 exists to remove and which nothing else would report.
+  `test/vutuv/tags/merged_tags_hidden_test.exs` walks the surfaces one by one.
+  """
+  def not_merged(query \\ __MODULE__), do: from(t in query, where: is_nil(t.merged_into_id))
+
+  @doc """
+  The alternative names filed under `tag`, oldest first.
+  """
+  def aliases_of(%__MODULE__{id: id}) do
+    Repo.all(from(t in __MODULE__, where: t.merged_into_id == ^id, order_by: t.id))
+  end
+
+  @doc """
+  Points `tag` at `canonical` as an alternative name of the given kind.
+
+  The kind is validated here rather than in `changeset/2` because it only means
+  anything alongside the pointer: a canonical tag carries neither.
+  """
+  def alias_changeset(%__MODULE__{} = tag, %__MODULE__{} = canonical, kind) do
+    tag
+    |> cast(%{alias_kind: kind}, [:alias_kind])
+    |> put_change(:merged_into_id, canonical.id)
+    |> validate_required([:alias_kind])
+    |> validate_inclusion(:alias_kind, @alias_kinds)
   end
 
   defp link_or_build_tag(changeset, value, params) do

--- a/lib/vutuv_web/agent_docs/list_docs.ex
+++ b/lib/vutuv_web/agent_docs/list_docs.ex
@@ -22,6 +22,7 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
   alias VutuvWeb.UI
   alias VutuvWeb.UserHelpers
 
+  alias Vutuv.Tags.Tag
   alias Vutuv.Tags.UserTag
 
   # The noindexed per-user people lists; the renderers derive their dispatch
@@ -81,6 +82,10 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
   it reads one in the feed or an author's archive, and a fediverse entry carries
   the `network` / `account` facts that say where it came from. `post_count` is
   the total across all pages.
+
+  `also_known_as` are the topic's alternative names (issue #1338), the same line
+  the HTML page shows: an agent that met `ROR` elsewhere can tell it is reading
+  the page for it.
   """
   def build_tag(
         tag,
@@ -96,6 +101,7 @@ defmodule VutuvWeb.AgentDocs.ListDocs do
       description: tag.description,
       name: tag.name,
       slug: tag.slug,
+      also_known_as: tag |> Tag.aliases_of() |> Enum.map(& &1.name),
       most_endorsed_users: Enum.map(recommended_users, &person_entry(&1, work_info_by_id)),
       post_count: post_count,
       posts: Enum.map(entries, &PostDoc.timeline_entry/1),

--- a/lib/vutuv_web/agent_docs/markdown.ex
+++ b/lib/vutuv_web/agent_docs/markdown.ex
@@ -184,6 +184,9 @@ defmodule VutuvWeb.AgentDocs.Markdown do
       frontmatter(doc),
       "# #{doc.name}",
       doc.description,
+      # The other names this topic answers to (issue #1338), so an agent that
+      # met one of them elsewhere can tell this is the page for it.
+      also_known_as(doc),
       section(
         gettext("Most endorsed members"),
         Enum.map(doc.most_endorsed_users, &person_line/1)

--- a/lib/vutuv_web/agent_docs/text.ex
+++ b/lib/vutuv_web/agent_docs/text.ex
@@ -172,6 +172,9 @@ defmodule VutuvWeb.AgentDocs.Text do
     [
       heading(doc.name),
       doc.description,
+      # The other names this topic answers to (issue #1338); see the Markdown
+      # sibling, which states the same fact.
+      also_known_as(doc),
       section(
         gettext("Most endorsed members"),
         Enum.map(doc.most_endorsed_users, &person_line/1)

--- a/lib/vutuv_web/components/post_components.ex
+++ b/lib/vutuv_web/components/post_components.ex
@@ -1426,8 +1426,10 @@ defmodule VutuvWeb.PostComponents do
     linkable = Tags.linkable_slugs(hashtags)
 
     Enum.map(hashtags, fn hashtag ->
-      slug = String.downcase(hashtag)
-      %{name: hashtag, path: if(MapSet.member?(linkable, slug), do: ~p"/tags/#{slug}")}
+      # The slug we link is the one the gate hands back, which is the canonical
+      # tag's when the remote server wrote an alternative name (issue #1338).
+      slug = Map.get(linkable, String.downcase(hashtag))
+      %{name: hashtag, path: slug && ~p"/tags/#{slug}"}
     end)
   end
 

--- a/lib/vutuv_web/controllers/tag_controller.ex
+++ b/lib/vutuv_web/controllers/tag_controller.ex
@@ -10,22 +10,56 @@ defmodule VutuvWeb.TagController do
   alias VutuvWeb.AgentDocs.ListDocs
   alias VutuvWeb.ContentPolicy
 
-  plug(VutuvWeb.Plug.ResolveSlug,
-    slug: "slug",
-    model: Vutuv.Tags.Tag,
-    assign: :tag,
-    field: :slug
-  )
+  # Not the shared `ResolveSlug` plug: an alternative name for a topic keeps its
+  # own slug (issue #1338), and that URL must lead to the topic rather than 404
+  # or render a second page for it. So the resolution has three answers, not
+  # two — see `resolve_tag/2`.
+  plug(:resolve_tag)
 
   def index(conn, _params) do
-    tags_count = Repo.aggregate(Tag, :count)
+    listable = Tag.not_merged()
+    tags_count = Repo.aggregate(listable, :count)
 
     tags =
-      from(t in Tag, order_by: fragment("lower(coalesce(?, ?))", t.name, t.slug))
+      from(t in listable, order_by: fragment("lower(coalesce(?, ?))", t.name, t.slug))
       |> Pages.paginate(conn.params, tags_count)
       |> Repo.all()
 
     render(conn, "index.html", tags: tags, tags_count: tags_count)
+  end
+
+  # Resolves the `:slug` param: a topic is assigned and rendered; an alternative
+  # name **redirects permanently** to the topic it names; anything else is a
+  # clean 404. Actions without the param (`:index`) pass through.
+  #
+  # 301 and not 302, because the absorbed page's ranking signal should pass to
+  # the page that survived. The requested agent format rides along on its own:
+  # `VutuvWeb.Plug.AgentFormat` re-appends the extension to any in-app redirect,
+  # so `/tags/rubyonrails.md` lands on `/tags/ruby_on_rails.md` and never falls
+  # back to HTML. The query string is carried here, since the redirect is what
+  # loses it otherwise (`?source=fediverse` selects the timeline's half).
+  defp resolve_tag(%{params: %{"slug" => slug}} = conn, _opts) do
+    case Repo.get_by(Tag, slug: slug) do
+      nil ->
+        VutuvWeb.ControllerHelpers.render_error(conn, 404)
+
+      %Tag{merged_into_id: nil} = tag ->
+        assign(conn, :tag, tag)
+
+      %Tag{} = tag_alias ->
+        conn
+        |> put_status(:moved_permanently)
+        |> redirect(to: canonical_path(tag_alias, conn.query_string))
+        |> halt()
+    end
+  end
+
+  defp resolve_tag(conn, _opts), do: conn
+
+  defp canonical_path(tag_alias, query_string) do
+    path = ~p"/tags/#{Tag.canonical(tag_alias)}"
+
+    if query_string == "", do: path, else: path <> "?" <> query_string
   end
 
   # Also served as Markdown / text / JSON via VutuvWeb.AgentDocs.ListDocs

--- a/lib/vutuv_web/markdown.ex
+++ b/lib/vutuv_web/markdown.ex
@@ -1026,9 +1026,15 @@ defmodule VutuvWeb.Markdown do
     end
   end
 
+  # The written hashtag keeps its casing in the text; the href is the slug
+  # `Tags.linkable_slugs/1` hands back, which is the canonical one when the
+  # author wrote an alternative name for a topic (issue #1338) — so the reader
+  # lands on the page rather than on a redirect to it.
   defp hashtag_link(whole, hashtag, tags) do
-    slug = String.downcase(hashtag)
-    if MapSet.member?(tags, slug), do: hashtag_anchor(slug, hashtag), else: whole
+    case Map.get(tags, String.downcase(hashtag)) do
+      nil -> whole
+      slug -> hashtag_anchor(slug, hashtag)
+    end
   end
 
   # The display text is the handle the author typed (case preserved); the href

--- a/lib/vutuv_web/templates/tag/single_card.html.heex
+++ b/lib/vutuv_web/templates/tag/single_card.html.heex
@@ -7,6 +7,12 @@
   <% else %>
   <p><%= gettext("This tag doesn't have a description yet.") %></p>
 	<% end %>
+  <%!-- The other names this topic answers to (issue #1338), so a reader who
+  arrived by one of them knows where they ended up. --%>
+  <div :if={@tag_aliases != []} data-tag-aliases>
+    <h2 class="card__label">{gettext("Also known as")}</h2>
+    <p>{alias_names(@tag_aliases)}</p>
+  </div>
 	<%= if Enum.count(@related_users) > 0 do %>
 		<h2 class="card__label"><%= gettext("People you may know with this tag") %></h2>
 		{VutuvWeb.UserHTML.card_list(Map.put(assigns, :users, @related_users))}

--- a/lib/vutuv_web/views/tag_html.ex
+++ b/lib/vutuv_web/views/tag_html.ex
@@ -17,10 +17,21 @@ defmodule VutuvWeb.TagHTML do
     assigns
     |> Map.put(:related_users, related_users)
     |> Map.put(:recommended_users, recommended_users)
+    |> Map.put(:tag_aliases, Tag.aliases_of(assigns[:tag]))
     |> Map.put(:work_string_length, 45)
     |> Map.put(:work_info_by_id, work_information_map(users, 45))
     |> Map.put(:following_by_id, following_map(assigns[:current_user], users))
   end
+
+  @doc """
+  The other names this topic answers to, as one comma-separated line.
+
+  A reader who typed `ROR` and landed on Ruby on Rails has to be able to see
+  why, so the page says so plainly (issue #1338) rather than leaving the
+  redirect unexplained. The names are the alias rows' own, in the casing their
+  first writer used.
+  """
+  def alias_names(aliases), do: Enum.map_join(aliases, ", ", & &1.name)
 
   embed_templates("../templates/tag/*")
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.233.3",
+      version: "7.234.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -25,9 +25,9 @@ msgstr "Impressum"
 msgid "Add"
 msgstr "Eintrag hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:219
+#: lib/vutuv_web/agent_docs/markdown.ex:222
 #: lib/vutuv_web/agent_docs/section_docs.ex:127
-#: lib/vutuv_web/agent_docs/text.ex:207
+#: lib/vutuv_web/agent_docs/text.ex:210
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
@@ -95,10 +95,10 @@ msgstr "Avatar"
 msgid "Birthdate"
 msgstr "Geburtstag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:486
-#: lib/vutuv_web/agent_docs/markdown.ex:487
-#: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/agent_docs/text.ex:457
+#: lib/vutuv_web/agent_docs/markdown.ex:489
+#: lib/vutuv_web/agent_docs/markdown.ex:490
+#: lib/vutuv_web/agent_docs/text.ex:459
+#: lib/vutuv_web/agent_docs/text.ex:460
 #: lib/vutuv_web/templates/user/show.html.heex:1103
 #, elixir-autogen
 msgid "Birthday"
@@ -157,7 +157,7 @@ msgstr "Kontakt"
 msgid "Couldn't follow back to %{name}."
 msgstr "%{name} konnte nicht zurückgefolgt werden."
 
-#: lib/vutuv_web/components/post_components.ex:2726
+#: lib/vutuv_web/components/post_components.ex:2728
 #: lib/vutuv_web/components/ui.ex:3326
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -206,7 +206,7 @@ msgstr "Inaktivieren"
 msgid "Download"
 msgstr "Download"
 
-#: lib/vutuv_web/components/post_components.ex:2691
+#: lib/vutuv_web/components/post_components.ex:2693
 #: lib/vutuv_web/components/ui.ex:3317
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -301,14 +301,14 @@ msgstr "Lebenslauf"
 msgid "Fax"
 msgstr "Fax"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:472
+#: lib/vutuv_web/agent_docs/markdown.ex:475
 #: lib/vutuv_web/templates/user/edit.html.heex:125
 #, elixir-autogen
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:507
-#: lib/vutuv_web/agent_docs/text.ex:477
+#: lib/vutuv_web/agent_docs/markdown.ex:510
+#: lib/vutuv_web/agent_docs/text.ex:480
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/live/notification_live/index.ex:954
@@ -319,8 +319,8 @@ msgstr "Vorname"
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:508
-#: lib/vutuv_web/agent_docs/text.ex:478
+#: lib/vutuv_web/agent_docs/markdown.ex:511
+#: lib/vutuv_web/agent_docs/text.ex:481
 #: lib/vutuv_web/components/fediverse_components.ex:223
 #: lib/vutuv_web/components/ui.ex:1976
 #: lib/vutuv_web/components/ui.ex:2001
@@ -378,7 +378,7 @@ msgstr "Stellenbezeichnung"
 msgid "Language"
 msgstr "Sprache"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:474
+#: lib/vutuv_web/agent_docs/markdown.ex:477
 #: lib/vutuv_web/templates/user/edit.html.heex:130
 #, elixir-autogen
 msgid "Last Name"
@@ -445,7 +445,7 @@ msgstr "Ausloggen"
 msgid "Log in"
 msgstr "Einloggen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:473
+#: lib/vutuv_web/agent_docs/markdown.ex:476
 #: lib/vutuv_web/templates/user/edit.html.heex:135
 #, elixir-autogen
 msgid "Middle Name"
@@ -483,7 +483,7 @@ msgstr "Neu"
 msgid "New message from @%{slug} on vutuv"
 msgstr "Neue Nachricht von @%{slug} auf vutuv"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:476
+#: lib/vutuv_web/agent_docs/markdown.ex:479
 #: lib/vutuv_web/templates/user/edit.html.heex:140
 #, elixir-autogen
 msgid "Nickname"
@@ -564,7 +564,7 @@ msgstr "Telefonnummer wurde gelöscht."
 msgid "Phone number updated successfully."
 msgstr "Telefonnummer wurde geändert."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:471
+#: lib/vutuv_web/agent_docs/markdown.ex:474
 #: lib/vutuv_web/templates/user/edit.html.heex:145
 #, elixir-autogen
 msgid "Prefix"
@@ -746,7 +746,7 @@ msgstr "Etwas ist schiefgelaufen"
 msgid "Submit a bugreport or a feature request."
 msgstr "Fehler auf der Seite melden."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:475
+#: lib/vutuv_web/agent_docs/markdown.ex:478
 #: lib/vutuv_web/templates/user/edit.html.heex:150
 #, elixir-autogen
 msgid "Suffix"
@@ -1103,7 +1103,7 @@ msgstr "User mit den meisten Followern"
 msgid "The 1,000 Users with the most Followers"
 msgstr "Die 1.000 User mit den meisten Followern"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:147
+#: lib/vutuv_web/agent_docs/list_docs.ex:153
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
 msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
@@ -1391,11 +1391,11 @@ msgid "Tag urls"
 msgstr "Tag-URLs"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
-#: lib/vutuv_web/agent_docs/markdown.ex:379
-#: lib/vutuv_web/agent_docs/markdown.ex:920
+#: lib/vutuv_web/agent_docs/markdown.ex:382
+#: lib/vutuv_web/agent_docs/markdown.ex:923
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:404
-#: lib/vutuv_web/agent_docs/text.ex:623
+#: lib/vutuv_web/agent_docs/text.ex:407
+#: lib/vutuv_web/agent_docs/text.ex:626
 #: lib/vutuv_web/components/ui.ex:3616
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1503,7 +1503,7 @@ msgstr "Eltern-Tag"
 msgid "Parent slug"
 msgstr "Eltern-Slug"
 
-#: lib/vutuv_web/templates/tag/single_card.html.heex:11
+#: lib/vutuv_web/templates/tag/single_card.html.heex:17
 #, elixir-autogen
 msgid "People you may know with this tag"
 msgstr "Personen mit diesem Tag"
@@ -1540,7 +1540,7 @@ msgstr "Tag-Beziehungen"
 msgid "Tag name"
 msgstr "Tag-Name"
 
-#: lib/vutuv_web/templates/tag/single_card.html.heex:15
+#: lib/vutuv_web/templates/tag/single_card.html.heex:21
 #, elixir-autogen
 msgid "The most endorsed users with this tag"
 msgstr "Die am häufigsten empfohlenen Mitglieder mit diesem Tag"
@@ -1640,7 +1640,7 @@ msgstr "Zur Startseite"
 msgid "Check your inbox"
 msgstr "Schauen Sie in Ihr Postfach"
 
-#: lib/vutuv_web/components/post_components.ex:3174
+#: lib/vutuv_web/components/post_components.ex:3176
 #: lib/vutuv_web/components/ui.ex:280
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -2126,7 +2126,7 @@ msgstr "Upload abbrechen"
 msgid "Delete post"
 msgstr "Beitrag löschen"
 
-#: lib/vutuv_web/components/post_components.ex:2723
+#: lib/vutuv_web/components/post_components.ex:2725
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2167,8 +2167,8 @@ msgstr "Vor einer bestimmten Person verbergen…"
 msgid "Hide this post from…"
 msgstr "Diesen Beitrag verbergen vor…"
 
-#: lib/vutuv_web/components/post_components.ex:2677
 #: lib/vutuv_web/components/post_components.ex:2679
+#: lib/vutuv_web/components/post_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr "Eingeschränkte Sichtbarkeit"
@@ -2235,13 +2235,13 @@ msgstr "Beitrag erfolgreich gelöscht."
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:3110
-#: lib/vutuv_web/components/post_components.ex:3114
+#: lib/vutuv_web/components/post_components.ex:3112
+#: lib/vutuv_web/components/post_components.ex:3116
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr "Weiterlesen"
 
-#: lib/vutuv_web/components/post_components.ex:3111
+#: lib/vutuv_web/components/post_components.ex:3113
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2332,27 +2332,27 @@ msgstr "Was gibt's Neues?"
 msgid "What's new? Markdown is supported."
 msgstr "Was gibt's Neues? Markdown wird unterstützt."
 
-#: lib/vutuv_web/components/post_components.ex:2674
+#: lib/vutuv_web/components/post_components.ex:2676
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr "bearbeitet"
 
-#: lib/vutuv_web/components/post_components.ex:4318
+#: lib/vutuv_web/components/post_components.ex:4320
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr "alle anderen"
 
-#: lib/vutuv_web/components/post_components.ex:4322
+#: lib/vutuv_web/components/post_components.ex:4324
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr "nicht eingeloggte Besucher"
 
-#: lib/vutuv_web/components/post_components.ex:4320
+#: lib/vutuv_web/components/post_components.ex:4322
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr "Personen, die Ihnen nicht folgen"
 
-#: lib/vutuv_web/components/post_components.ex:4321
+#: lib/vutuv_web/components/post_components.ex:4323
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr "Personen, denen Sie nicht folgen"
@@ -2393,15 +2393,15 @@ msgstr "Alle %{count} Beiträge ansehen"
 msgid "All posts"
 msgstr "Alle Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1551
-#: lib/vutuv_web/components/post_components.ex:4402
+#: lib/vutuv_web/components/post_components.ex:1553
+#: lib/vutuv_web/components/post_components.ex:4404
 #: lib/vutuv_web/components/ui.ex:2851
 #: lib/vutuv_web/views/user_html.ex:333
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:958
+#: lib/vutuv_web/agent_docs/markdown.ex:961
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
 #: lib/vutuv_web/live/shell_live.ex:595
@@ -2412,8 +2412,8 @@ msgstr "Lesezeichen setzen"
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/vutuv_web/components/post_components.ex:1515
-#: lib/vutuv_web/components/post_components.ex:4625
+#: lib/vutuv_web/components/post_components.ex:1517
+#: lib/vutuv_web/components/post_components.ex:4627
 #: lib/vutuv_web/components/ui.ex:2837
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #: lib/vutuv_web/views/user_html.ex:343
@@ -2421,8 +2421,8 @@ msgstr "Lesezeichen"
 msgid "Like"
 msgstr "Gefällt mir"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:957
-#: lib/vutuv_web/components/post_components.ex:4634
+#: lib/vutuv_web/agent_docs/markdown.ex:960
+#: lib/vutuv_web/components/post_components.ex:4636
 #: lib/vutuv_web/live/notification_live/index.ex:956
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2444,39 +2444,39 @@ msgstr "Hier ist noch nichts. Beiträge mit Lesezeichen erscheinen hier."
 msgid "Nothing here yet. Posts you like show up here."
 msgstr "Hier ist noch nichts. Beiträge, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/components/post_components.ex:4391
+#: lib/vutuv_web/components/post_components.ex:4393
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr "Nur öffentliche Beiträge können repostet werden."
 
-#: lib/vutuv_web/components/post_components.ex:1551
-#: lib/vutuv_web/components/post_components.ex:4402
+#: lib/vutuv_web/components/post_components.ex:1553
+#: lib/vutuv_web/components/post_components.ex:4404
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:333
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr "Lesezeichen entfernen"
 
-#: lib/vutuv_web/components/post_components.ex:1539
-#: lib/vutuv_web/components/post_components.ex:4388
+#: lib/vutuv_web/components/post_components.ex:1541
+#: lib/vutuv_web/components/post_components.ex:4390
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr "Reposten"
 
-#: lib/vutuv_web/components/post_components.ex:1729
-#: lib/vutuv_web/components/post_components.ex:3690
+#: lib/vutuv_web/components/post_components.ex:1731
+#: lib/vutuv_web/components/post_components.ex:3692
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr "Repostet von %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:1539
-#: lib/vutuv_web/components/post_components.ex:4388
+#: lib/vutuv_web/components/post_components.ex:1541
+#: lib/vutuv_web/components/post_components.ex:4390
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr "Repost zurücknehmen"
 
-#: lib/vutuv_web/components/post_components.ex:4625
+#: lib/vutuv_web/components/post_components.ex:4627
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:343
 #, elixir-autogen, elixir-format
@@ -2498,7 +2498,7 @@ msgstr "Entfolgen"
 msgid "Welcome to vutuv!"
 msgstr "Willkommen bei vutuv!"
 
-#: lib/vutuv_web/components/post_components.ex:4678
+#: lib/vutuv_web/components/post_components.ex:4680
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr "Nur öffentliche Beiträge können beantwortet werden."
@@ -2509,16 +2509,16 @@ msgstr "Nur öffentliche Beiträge können beantwortet werden."
 msgid "Replies"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:1526
-#: lib/vutuv_web/components/post_components.ex:4661
-#: lib/vutuv_web/components/post_components.ex:4662
+#: lib/vutuv_web/components/post_components.ex:1528
+#: lib/vutuv_web/components/post_components.ex:4663
+#: lib/vutuv_web/components/post_components.ex:4664
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2645
+#: lib/vutuv_web/components/post_components.ex:2647
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr "Antwort auf einen gelöschten Beitrag"
@@ -2539,7 +2539,7 @@ msgstr "Dieser Beitrag wurde geteilt oder beantwortet. Solange es geteilte Beitr
 msgid "replied to your post."
 msgstr "hat auf Ihren Beitrag geantwortet."
 
-#: lib/vutuv_web/components/post_components.ex:2139
+#: lib/vutuv_web/components/post_components.ex:2141
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2547,14 +2547,14 @@ msgstr "hat auf Ihren Beitrag geantwortet."
 msgid "Reply to %{handle}"
 msgstr "Auf %{handle} antworten"
 
-#: lib/vutuv_web/components/post_components.ex:2621
+#: lib/vutuv_web/components/post_components.ex:2623
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr "Antwort auf einen inzwischen gelöschten Beitrag von %{handle}"
 
-#: lib/vutuv_web/components/post_components.ex:2615
-#: lib/vutuv_web/components/post_components.ex:2637
-#: lib/vutuv_web/components/post_components.ex:2640
+#: lib/vutuv_web/components/post_components.ex:2617
+#: lib/vutuv_web/components/post_components.ex:2639
+#: lib/vutuv_web/components/post_components.ex:2642
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr "Antwort an %{handle}"
@@ -2812,8 +2812,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] "+1 weiteres Tag"
 msgstr[1] "+%{formatted} weitere Tags"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:509
-#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/markdown.ex:512
+#: lib/vutuv_web/agent_docs/text.ex:482
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/live/notification_live/index.ex:955
 #: lib/vutuv_web/templates/connection/index.html.heex:5
@@ -2859,7 +2859,7 @@ msgid_plural "connections"
 msgstr[0] "Vernetzung"
 msgstr[1] "Vernetzungen"
 
-#: lib/vutuv_web/components/post_components.ex:4319
+#: lib/vutuv_web/components/post_components.ex:4321
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr "Personen, mit denen Sie nicht vernetzt sind"
@@ -2964,8 +2964,8 @@ msgstr "Gibt es etwas, das unsere Admins wissen sollten? (optional)"
 msgid "Bullying or harassment"
 msgstr "Mobbing oder Belästigung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:298
-#: lib/vutuv_web/agent_docs/text.ex:282
+#: lib/vutuv_web/agent_docs/markdown.ex:301
+#: lib/vutuv_web/agent_docs/text.ex:285
 #: lib/vutuv_web/controllers/page_controller.ex:83
 #: lib/vutuv_web/templates/layout/app.html.heex:91
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3138,7 +3138,7 @@ msgstr "Nacktheit, Gewalt oder andere Inhalte, die nicht auf vutuv gehören."
 msgid "Only visible to you"
 msgstr "Nur für Sie sichtbar"
 
-#: lib/vutuv_web/components/post_components.ex:2591
+#: lib/vutuv_web/components/post_components.ex:2593
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr "Solange eine Meldung zu diesem Beitrag bearbeitet wird, sehen nur Sie ihn."
@@ -3218,8 +3218,8 @@ msgid "Remove it. That settles the report, no questions asked."
 msgstr "Entfernen. Damit ist die Meldung erledigt, ohne weitere Fragen."
 
 #: lib/vutuv_web/components/post_components.ex:1016
-#: lib/vutuv_web/components/post_components.ex:1990
-#: lib/vutuv_web/components/post_components.ex:2747
+#: lib/vutuv_web/components/post_components.ex:1992
+#: lib/vutuv_web/components/post_components.ex:2749
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
@@ -3924,12 +3924,12 @@ msgstr "gemeldete Nachricht"
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr "Im Rahmen scrollen oder klicken, um das ganze Bild zu öffnen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:601
+#: lib/vutuv_web/agent_docs/markdown.ex:604
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr "%{count} Empfehlungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1079
+#: lib/vutuv_web/agent_docs/markdown.ex:1082
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr "%{count} auf dieser Seite, weitere mit ?page=N"
@@ -3943,16 +3943,16 @@ msgstr "%{count} Beiträge von %{name}"
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:162
 #: lib/vutuv_web/agent_docs/markdown.ex:175
-#: lib/vutuv_web/agent_docs/markdown.ex:920
+#: lib/vutuv_web/agent_docs/markdown.ex:923
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:150
 #: lib/vutuv_web/agent_docs/text.ex:163
-#: lib/vutuv_web/agent_docs/text.ex:623
+#: lib/vutuv_web/agent_docs/text.ex:626
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr "%{count} insgesamt"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:47
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr "Follower von %{name}"
@@ -3964,44 +3964,44 @@ msgstr "Follower von %{name}"
 msgid "Images"
 msgstr "Bilder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:938
-#: lib/vutuv_web/agent_docs/text.ex:634
+#: lib/vutuv_web/agent_docs/markdown.ex:941
+#: lib/vutuv_web/agent_docs/text.ex:637
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr "Antwort auf einen gelöschten Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:935
-#: lib/vutuv_web/agent_docs/text.ex:631
+#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/text.ex:634
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr "Antwort auf einen gelöschten Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:942
-#: lib/vutuv_web/agent_docs/markdown.ex:1156
-#: lib/vutuv_web/agent_docs/text.ex:637
-#: lib/vutuv_web/agent_docs/text.ex:681
+#: lib/vutuv_web/agent_docs/markdown.ex:945
+#: lib/vutuv_web/agent_docs/markdown.ex:1159
+#: lib/vutuv_web/agent_docs/text.ex:640
+#: lib/vutuv_web/agent_docs/text.ex:684
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr "Antwort auf einen Beitrag von %{name}."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:444
-#: lib/vutuv_web/agent_docs/text.ex:442
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/text.ex:445
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Mitglied seit"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:188
-#: lib/vutuv_web/agent_docs/text.ex:176
+#: lib/vutuv_web/agent_docs/markdown.ex:191
+#: lib/vutuv_web/agent_docs/text.ex:179
 #, elixir-autogen, elixir-format
 msgid "Most endorsed members"
 msgstr "Am häufigsten empfohlene Mitglieder"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:145
+#: lib/vutuv_web/agent_docs/list_docs.ex:151
 #, elixir-autogen, elixir-format
 msgid "Most followed members"
 msgstr "Mitglieder mit den meisten Followern"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:48
+#: lib/vutuv_web/agent_docs/list_docs.ex:49
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr "Wem %{name} folgt"
@@ -4026,23 +4026,23 @@ msgstr "Beitrag von %{name}"
 msgid "Posts (%{count} total)"
 msgstr "Beiträge (insgesamt %{count})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:438
-#: lib/vutuv_web/agent_docs/text.ex:436
+#: lib/vutuv_web/agent_docs/markdown.ex:441
+#: lib/vutuv_web/agent_docs/text.ex:439
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr "Verifiziertes Profil: ja"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:889
+#: lib/vutuv_web/agent_docs/markdown.ex:892
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr "repostet von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:789
+#: lib/vutuv_web/agent_docs/markdown.ex:792
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr "heute"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:790
+#: lib/vutuv_web/agent_docs/markdown.ex:793
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr "bis %{date}"
@@ -4052,7 +4052,7 @@ msgstr "bis %{date}"
 msgid "This page in %{language}: %{url}"
 msgstr "Diese Seite auf %{language}: %{url}"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:49
+#: lib/vutuv_web/agent_docs/list_docs.ex:50
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr "Vernetzungen von %{name}"
@@ -4119,8 +4119,8 @@ msgstr ""
 msgid "Billing name"
 msgstr "Name für die Rechnung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:312
-#: lib/vutuv_web/agent_docs/text.ex:290
+#: lib/vutuv_web/agent_docs/markdown.ex:315
+#: lib/vutuv_web/agent_docs/text.ex:293
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr "Online buchen (Login erforderlich): %{url}"
@@ -4173,8 +4173,8 @@ msgstr "Tag"
 msgid "Markdown is supported. At most %{max} characters."
 msgstr "Markdown wird unterstützt. Höchstens %{max} Zeichen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:302
-#: lib/vutuv_web/agent_docs/text.ex:286
+#: lib/vutuv_web/agent_docs/markdown.ex:305
+#: lib/vutuv_web/agent_docs/text.ex:289
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4190,8 +4190,8 @@ msgstr "Ein Tag. Eine Anzeige. Alle Besucher."
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr "Eine reine Textanzeige pro Kalendertag, gesehen von allen Besuchern."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:299
-#: lib/vutuv_web/agent_docs/text.ex:283
+#: lib/vutuv_web/agent_docs/markdown.ex:302
+#: lib/vutuv_web/agent_docs/text.ex:286
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4425,14 +4425,14 @@ msgstr "gebucht am"
 msgid "deleted account"
 msgstr "gelöschtes Konto"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:304
-#: lib/vutuv_web/agent_docs/text.ex:288
+#: lib/vutuv_web/agent_docs/markdown.ex:307
+#: lib/vutuv_web/agent_docs/text.ex:291
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr "Bereits gebucht"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:300
-#: lib/vutuv_web/agent_docs/text.ex:284
+#: lib/vutuv_web/agent_docs/markdown.ex:303
+#: lib/vutuv_web/agent_docs/text.ex:287
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr "Buchungszeitraum"
@@ -4731,8 +4731,8 @@ msgstr "Keine Ergebnisse für \"%{query}\""
 msgid "Not an exact match, but sounds like your search."
 msgstr "Kein exakter Treffer, klingt aber ähnlich wie Ihre Suche."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:327
-#: lib/vutuv_web/agent_docs/text.ex:352
+#: lib/vutuv_web/agent_docs/markdown.ex:330
+#: lib/vutuv_web/agent_docs/text.ex:355
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:877
@@ -4861,8 +4861,8 @@ msgstr "Entwickler"
 msgid "Edit your profile and its sections"
 msgstr "Ihr Profil und seine Bereiche bearbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:241
-#: lib/vutuv_web/agent_docs/text.ex:228
+#: lib/vutuv_web/agent_docs/markdown.ex:244
+#: lib/vutuv_web/agent_docs/text.ex:231
 #: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
@@ -5603,9 +5603,9 @@ msgstr "Hauptnavigation"
 msgid "Footer navigation"
 msgstr "Fußzeilen-Navigation"
 
-#: lib/vutuv_web/components/post_components.ex:2810
-#: lib/vutuv_web/components/post_components.ex:2862
-#: lib/vutuv_web/components/post_components.ex:3254
+#: lib/vutuv_web/components/post_components.ex:2812
+#: lib/vutuv_web/components/post_components.ex:2864
+#: lib/vutuv_web/components/post_components.ex:3256
 #: lib/vutuv_web/live/notification_live/index.ex:680
 #: lib/vutuv_web/live/post_live/feed.ex:1259
 #: lib/vutuv_web/views/user_html.ex:111
@@ -6347,8 +6347,8 @@ msgid_plural "%{count} years old"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:488
-#: lib/vutuv_web/agent_docs/text.ex:458
+#: lib/vutuv_web/agent_docs/markdown.ex:491
+#: lib/vutuv_web/agent_docs/text.ex:461
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr "Alter"
@@ -6422,7 +6422,7 @@ msgstr "Tagesbericht öffnen"
 msgid "Previous day"
 msgstr "Vorheriger Tag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:957
+#: lib/vutuv_web/agent_docs/markdown.ex:960
 #: lib/vutuv_web/components/post_components.ex:348
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6513,7 +6513,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr "Empfohlen am"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:118
+#: lib/vutuv_web/agent_docs/list_docs.ex:124
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -6533,7 +6533,7 @@ msgstr "Noch keine Empfehlungen."
 msgid "and %{count} more"
 msgstr "und %{count} weitere"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:933
+#: lib/vutuv_web/agent_docs/markdown.ex:936
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr "empfohlen am %{date}"
@@ -6891,7 +6891,7 @@ msgstr "Folgen Sie einander, um mit %{name} vernetzt zu sein und ihn zu lesen."
 msgid "Go to profile to follow"
 msgstr "Zum Profil, um zu folgen"
 
-#: lib/vutuv_web/components/post_components.ex:2744
+#: lib/vutuv_web/components/post_components.ex:2746
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr "@%{handle} stummschalten"
@@ -6901,7 +6901,7 @@ msgstr "@%{handle} stummschalten"
 msgid "Professional"
 msgstr "Beruflich"
 
-#: lib/vutuv_web/components/post_components.ex:2743
+#: lib/vutuv_web/components/post_components.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr "@%{handle} nicht mehr stummschalten"
@@ -7106,8 +7106,8 @@ msgstr "Filtern"
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:215
-#: lib/vutuv_web/agent_docs/text.ex:203
+#: lib/vutuv_web/agent_docs/markdown.ex:218
+#: lib/vutuv_web/agent_docs/text.ex:206
 #: lib/vutuv_web/live/account_activity_live.ex:167
 #: lib/vutuv_web/live/admin/activity_live.ex:211
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
@@ -7607,7 +7607,7 @@ msgstr "Alle abwählen"
 msgid "applies to the whole list, not just this page"
 msgstr "betrifft die ganze Liste, nicht nur diese Seite"
 
-#: lib/vutuv_web/components/post_components.ex:4547
+#: lib/vutuv_web/components/post_components.ex:4549
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7796,17 +7796,17 @@ msgstr "Feed von %{name}"
 msgid "The vutuv newsfeed of %{name}"
 msgstr "Der vutuv-Newsfeed von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1084
+#: lib/vutuv_web/agent_docs/markdown.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr "Ihr Feed ist leer."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1087
+#: lib/vutuv_web/agent_docs/markdown.ex:1090
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr "%{count} Beiträge auf dieser Seite"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1094
+#: lib/vutuv_web/agent_docs/markdown.ex:1097
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr "weitere Beiträge verfügbar, ?cursor=%{cursor} anhängen"
@@ -8889,14 +8889,14 @@ msgstr ""
 "Alle %{count} Mitglieder, deren Profile für Suchmaschinen freigegeben sind, "
 "alphabetisch nach Nachnamen sortiert."
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:181
+#: lib/vutuv_web/agent_docs/list_docs.ex:187
 #, elixir-autogen, elixir-format
 msgid "All members who allow search engines to index their profile, grouped by the first letter of their last name."
 msgstr ""
 "Alle Mitglieder, die die Indexierung ihres Profils durch Suchmaschinen "
 "erlauben, gruppiert nach dem Anfangsbuchstaben des Nachnamens."
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:166
+#: lib/vutuv_web/agent_docs/list_docs.ex:172
 #: lib/vutuv_web/controllers/directory_controller.ex:35
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8912,7 +8912,7 @@ msgstr "Mitgliederverzeichnis"
 msgid "Members by initial"
 msgstr "Mitglieder nach Anfangsbuchstaben"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:198
+#: lib/vutuv_web/agent_docs/list_docs.ex:204
 #: lib/vutuv_web/controllers/directory_controller.ex:62
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8931,7 +8931,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] "Ein Mitglied"
 msgstr[1] "%{formatted} Mitglieder"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:204
+#: lib/vutuv_web/agent_docs/list_docs.ex:210
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -9040,10 +9040,10 @@ msgstr "Die Seite wurde veröffentlicht."
 msgid "Write it under Admin › Legal pages"
 msgstr "Unter Admin › Rechtstexte verfassen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:498
-#: lib/vutuv_web/agent_docs/markdown.ex:502
-#: lib/vutuv_web/agent_docs/text.ex:468
-#: lib/vutuv_web/agent_docs/text.ex:472
+#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:505
+#: lib/vutuv_web/agent_docs/text.ex:471
+#: lib/vutuv_web/agent_docs/text.ex:475
 #: lib/vutuv_web/components/ui.ex:3688
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:322
@@ -9123,7 +9123,7 @@ msgid "Employment"
 msgstr "Anstellung"
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:661
+#: lib/vutuv_web/agent_docs/markdown.ex:664
 #: lib/vutuv_web/views/work_experience_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -9146,7 +9146,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr "Berufserfahrung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:662
+#: lib/vutuv_web/agent_docs/markdown.ex:665
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -9177,13 +9177,13 @@ msgstr "Ihr Profil als Lebenslauf"
 msgid "Higher Education"
 msgstr "Studium"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:699
+#: lib/vutuv_web/agent_docs/markdown.ex:702
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr "Schulbildung"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:698
+#: lib/vutuv_web/agent_docs/markdown.ex:701
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -9212,14 +9212,14 @@ msgstr ""
 msgid "CV download"
 msgstr "Lebenslauf-Download"
 
-#: lib/vutuv_web/components/post_components.ex:3693
+#: lib/vutuv_web/components/post_components.ex:3695
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] "Repostet von %{name} und %{formatted} weiteren"
 msgstr[1] "Repostet von %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:892
+#: lib/vutuv_web/agent_docs/markdown.ex:895
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr "repostet von %{name} und %{count} weiteren"
@@ -9312,14 +9312,14 @@ msgstr ""
 "Der Lebenslauf von %{name} auf vutuv: Berufserfahrung, Ausbildung und "
 "Kenntnisse zum Ansehen und Herunterladen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:660
+#: lib/vutuv_web/agent_docs/markdown.ex:663
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #: lib/vutuv_web/views/work_experience_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr "Freiberuflich / Selbstständig"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:663
+#: lib/vutuv_web/agent_docs/markdown.ex:666
 #: lib/vutuv_web/views/work_experience_html.ex:32
 #: lib/vutuv_web/views/work_experience_html.ex:39
 #, elixir-autogen, elixir-format
@@ -9473,8 +9473,8 @@ msgstr "Ehren-Tag"
 msgid "Honor tag (only site admins can assign it)"
 msgstr "Ehren-Tag (nur Admins können es vergeben)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:518
-#: lib/vutuv_web/agent_docs/text.ex:486
+#: lib/vutuv_web/agent_docs/markdown.ex:521
+#: lib/vutuv_web/agent_docs/text.ex:489
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr "Ehren-Tag"
@@ -9896,8 +9896,8 @@ msgstr "Walisisch"
 msgid "Yoruba"
 msgstr "Yoruba"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:440
-#: lib/vutuv_web/agent_docs/text.ex:438
+#: lib/vutuv_web/agent_docs/markdown.ex:443
+#: lib/vutuv_web/agent_docs/text.ex:441
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr "Beschäftigungsstatus"
@@ -10011,7 +10011,7 @@ msgstr[1] "%{count} Zertifikate oder Lizenzen"
 msgid "Add a certificate or license"
 msgstr "Zertifikat oder Lizenz hinzufügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:783
+#: lib/vutuv_web/agent_docs/markdown.ex:786
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -10089,7 +10089,7 @@ msgstr "Läuft nicht ab"
 msgid "Expired"
 msgstr "Abgelaufen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:761
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr "ID: %{id}"
@@ -10106,7 +10106,7 @@ msgstr "Ausgestellt"
 msgid "Issuer"
 msgstr "Aussteller"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:782
+#: lib/vutuv_web/agent_docs/markdown.ex:785
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -10136,7 +10136,7 @@ msgstr "Nachweis"
 msgid "Verification link"
 msgstr "Nachweislink"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:756
+#: lib/vutuv_web/agent_docs/markdown.ex:759
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr "ausgestellt %{date}"
@@ -10151,7 +10151,7 @@ msgstr "z. B. AWS Solutions Architect – Associate"
 msgid "e.g. Amazon Web Services"
 msgstr "z. B. Amazon Web Services"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:757
+#: lib/vutuv_web/agent_docs/markdown.ex:760
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -10170,7 +10170,7 @@ msgstr ""
 msgid "Preferred"
 msgstr "Bevorzugt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/markdown.ex:621
 #: lib/vutuv_web/live/section_reorder_live.ex:280
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -10720,21 +10720,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr "auf diesem Gerät einrichten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:581
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] "%{count} Follower"
 msgstr[1] "%{count} Follower"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:576
+#: lib/vutuv_web/agent_docs/markdown.ex:579
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] "%{count} Repository"
 msgstr[1] "%{count} Repositories"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:574
+#: lib/vutuv_web/agent_docs/markdown.ex:577
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10794,12 +10794,12 @@ msgstr ""
 "Wenn deaktiviert, zeigt die Social-Media-Karte Ihre Konten nur als einfache "
 "Links."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:595
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr "zuletzt aktiv %{date}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:579
+#: lib/vutuv_web/agent_docs/markdown.ex:582
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr "seit %{date}"
@@ -10958,7 +10958,7 @@ msgstr ""
 "Verwalten Sie Ihr vutuv-Konto: Profil, Privatsphäre, Benachrichtigungen und "
 "Anmeldung."
 
-#: lib/vutuv_web/controllers/tag_controller.ex:74
+#: lib/vutuv_web/controllers/tag_controller.ex:108
 #, elixir-autogen, elixir-format
 msgid "Members on vutuv tagged %{tag}."
 msgstr "Mitglieder auf vutuv mit dem Tag %{tag}."
@@ -11747,8 +11747,8 @@ msgstr "Verifizierungsmethode"
 msgid "Verified domains"
 msgstr "Verifizierte Domains"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:216
-#: lib/vutuv_web/agent_docs/text.ex:204
+#: lib/vutuv_web/agent_docs/markdown.ex:219
+#: lib/vutuv_web/agent_docs/text.ex:207
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr "Verifiziert über"
@@ -11777,8 +11777,8 @@ msgstr ""
 "Wir konnten den Eintrag oder die Datei noch nicht finden. Die Verbreitung "
 "kann etwas dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/text.ex:206
+#: lib/vutuv_web/agent_docs/markdown.ex:221
+#: lib/vutuv_web/agent_docs/text.ex:209
 #: lib/vutuv_web/live/organization_live/edit.ex:287
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -11864,10 +11864,11 @@ msgstr "Alias hinzugefügt."
 msgid "Alias removed."
 msgstr "Alias entfernt."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:319
-#: lib/vutuv_web/agent_docs/text.ex:345
+#: lib/vutuv_web/agent_docs/markdown.ex:322
+#: lib/vutuv_web/agent_docs/text.ex:348
 #: lib/vutuv_web/live/organization_live/edit.ex:353
 #: lib/vutuv_web/live/organization_live/show.ex:360
+#: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr "Auch bekannt als"
@@ -12109,8 +12110,8 @@ msgstr "ausstehend"
 msgid "primary"
 msgstr "primär"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:340
-#: lib/vutuv_web/agent_docs/text.ex:365
+#: lib/vutuv_web/agent_docs/markdown.ex:343
+#: lib/vutuv_web/agent_docs/text.ex:368
 #: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -12251,8 +12252,8 @@ msgstr ""
 "Wir konnten den Nachweis noch nicht finden. Die Verbreitung kann etwas "
 "dauern. Bitte versuchen Sie es erneut."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:803
-#: lib/vutuv_web/agent_docs/text.ex:596
+#: lib/vutuv_web/agent_docs/markdown.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:599
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr "verifizierte Webseite"
@@ -12288,8 +12289,8 @@ msgstr "Verknüpft mit {name}"
 msgid "Remove link"
 msgstr "Verknüpfung entfernen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:331
-#: lib/vutuv_web/agent_docs/text.ex:356
+#: lib/vutuv_web/agent_docs/markdown.ex:334
+#: lib/vutuv_web/agent_docs/text.ex:359
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr "ehemalig"
@@ -12770,10 +12771,10 @@ msgstr "Entwürfe"
 msgid "Edit posting"
 msgstr "Anzeige bearbeiten"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:235
-#: lib/vutuv_web/agent_docs/markdown.ex:364
-#: lib/vutuv_web/agent_docs/text.ex:222
-#: lib/vutuv_web/agent_docs/text.ex:389
+#: lib/vutuv_web/agent_docs/markdown.ex:238
+#: lib/vutuv_web/agent_docs/markdown.ex:367
+#: lib/vutuv_web/agent_docs/text.ex:225
+#: lib/vutuv_web/agent_docs/text.ex:392
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:188
@@ -12786,10 +12787,10 @@ msgstr "Arbeitgeber"
 msgid "Employer name (optional)"
 msgstr "Name des Arbeitgebers (optional)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:236
-#: lib/vutuv_web/agent_docs/markdown.ex:365
-#: lib/vutuv_web/agent_docs/text.ex:223
-#: lib/vutuv_web/agent_docs/text.ex:390
+#: lib/vutuv_web/agent_docs/markdown.ex:239
+#: lib/vutuv_web/agent_docs/markdown.ex:368
+#: lib/vutuv_web/agent_docs/text.ex:226
+#: lib/vutuv_web/agent_docs/text.ex:393
 #: lib/vutuv_web/live/job_board_live.ex:367
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
@@ -12867,12 +12868,12 @@ msgstr "Jobs"
 msgid "Let search engines index this posting."
 msgstr "Suchmaschinen dürfen diese Anzeige indexieren."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:346
-#: lib/vutuv_web/agent_docs/markdown.ex:350
-#: lib/vutuv_web/agent_docs/markdown.ex:352
-#: lib/vutuv_web/agent_docs/text.ex:371
-#: lib/vutuv_web/agent_docs/text.ex:375
-#: lib/vutuv_web/agent_docs/text.ex:377
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/markdown.ex:353
+#: lib/vutuv_web/agent_docs/markdown.ex:355
+#: lib/vutuv_web/agent_docs/text.ex:374
+#: lib/vutuv_web/agent_docs/text.ex:378
+#: lib/vutuv_web/agent_docs/text.ex:380
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12921,8 +12922,8 @@ msgstr "Neue Konten können nach einigen Tagen veröffentlichen."
 msgid "New posting"
 msgstr "Neue Anzeige"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:247
-#: lib/vutuv_web/agent_docs/text.ex:233
+#: lib/vutuv_web/agent_docs/markdown.ex:250
+#: lib/vutuv_web/agent_docs/text.ex:236
 #: lib/vutuv_web/live/job_posting_live/form.ex:525
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
@@ -13006,10 +13007,10 @@ msgstr "Veröffentlichen als"
 msgid "Postal code"
 msgstr "Postleitzahl"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:240
-#: lib/vutuv_web/agent_docs/markdown.ex:369
-#: lib/vutuv_web/agent_docs/text.ex:227
-#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/agent_docs/markdown.ex:243
+#: lib/vutuv_web/agent_docs/markdown.ex:372
+#: lib/vutuv_web/agent_docs/text.ex:230
+#: lib/vutuv_web/agent_docs/text.ex:397
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -13034,10 +13035,10 @@ msgstr "Veröffentlichen"
 #: lib/vutuv/accounts/user.ex:1085
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:497
-#: lib/vutuv_web/agent_docs/markdown.ex:350
-#: lib/vutuv_web/agent_docs/markdown.ex:352
-#: lib/vutuv_web/agent_docs/text.ex:375
-#: lib/vutuv_web/agent_docs/text.ex:377
+#: lib/vutuv_web/agent_docs/markdown.ex:353
+#: lib/vutuv_web/agent_docs/markdown.ex:355
+#: lib/vutuv_web/agent_docs/text.ex:378
+#: lib/vutuv_web/agent_docs/text.ex:380
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format
@@ -13049,18 +13050,18 @@ msgstr "Remote"
 msgid "Report this posting"
 msgstr "Diese Anzeige melden"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:246
-#: lib/vutuv_web/agent_docs/text.ex:232
+#: lib/vutuv_web/agent_docs/markdown.ex:249
+#: lib/vutuv_web/agent_docs/text.ex:235
 #: lib/vutuv_web/live/job_posting_live/form.ex:515
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Erforderlich"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:239
-#: lib/vutuv_web/agent_docs/markdown.ex:368
-#: lib/vutuv_web/agent_docs/text.ex:226
-#: lib/vutuv_web/agent_docs/text.ex:393
+#: lib/vutuv_web/agent_docs/markdown.ex:242
+#: lib/vutuv_web/agent_docs/markdown.ex:371
+#: lib/vutuv_web/agent_docs/text.ex:229
+#: lib/vutuv_web/agent_docs/text.ex:396
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr "Gehalt"
@@ -13154,10 +13155,10 @@ msgstr "Wer kann sie sehen"
 msgid "Working student"
 msgstr "Werkstudent:in"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:237
-#: lib/vutuv_web/agent_docs/markdown.ex:366
-#: lib/vutuv_web/agent_docs/text.ex:224
-#: lib/vutuv_web/agent_docs/text.ex:391
+#: lib/vutuv_web/agent_docs/markdown.ex:240
+#: lib/vutuv_web/agent_docs/markdown.ex:369
+#: lib/vutuv_web/agent_docs/text.ex:227
+#: lib/vutuv_web/agent_docs/text.ex:394
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -13360,13 +13361,13 @@ msgstr "%{km} km"
 msgid "All countries"
 msgstr "Alle Länder"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:387
+#: lib/vutuv_web/agent_docs/markdown.ex:390
 #: lib/vutuv_web/templates/tag/show.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr "Alle Stellen mit diesem Tag"
 
-#: lib/vutuv_web/agent_docs/text.ex:411
+#: lib/vutuv_web/agent_docs/text.ex:414
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr "Alle Stellen mit diesem Tag: %{url}"
@@ -13412,12 +13413,12 @@ msgstr "Mindestgehalt pro Jahr"
 msgid "More jobs"
 msgstr "Weitere Stellen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:259
+#: lib/vutuv_web/agent_docs/markdown.ex:262
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr "Nächste Seite"
 
-#: lib/vutuv_web/agent_docs/text.ex:245
+#: lib/vutuv_web/agent_docs/text.ex:248
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr "Nächste Seite: %{url}"
@@ -13432,10 +13433,10 @@ msgstr "Noch keine Stellenanzeigen."
 msgid "No matching positions. Try adjusting the filters."
 msgstr "Keine passenden Stellen. Passen Sie die Filter an."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:385
-#: lib/vutuv_web/agent_docs/markdown.ex:397
-#: lib/vutuv_web/agent_docs/text.ex:409
-#: lib/vutuv_web/agent_docs/text.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:388
+#: lib/vutuv_web/agent_docs/markdown.ex:400
+#: lib/vutuv_web/agent_docs/text.ex:412
+#: lib/vutuv_web/agent_docs/text.ex:424
 #: lib/vutuv_web/live/organization_live/show.ex:329
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
@@ -13761,7 +13762,7 @@ msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 "E-Mail-Benachrichtigungen für Ihre gespeicherte Suche „%{label}“ stoppen?"
 
-#: lib/vutuv_web/components/post_components.ex:2098
+#: lib/vutuv_web/components/post_components.ex:2100
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
@@ -14153,8 +14154,8 @@ msgstr "Bild einfügen"
 msgid "Insert into text"
 msgstr "In den Text einfügen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:191
-#: lib/vutuv_web/agent_docs/text.ex:179
+#: lib/vutuv_web/agent_docs/markdown.ex:194
+#: lib/vutuv_web/agent_docs/text.ex:182
 #: lib/vutuv_web/live/tag_live/timeline.ex:255
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
@@ -14377,34 +14378,34 @@ msgstr "Wenn aus, erscheint diese Art von Benachrichtigung nie, von wem auch imm
 msgid "added %{count} new entries to their CV:"
 msgstr "hat %{count} neue Einträge im Lebenslauf:"
 
-#: lib/vutuv_web/components/post_components.ex:4181
+#: lib/vutuv_web/components/post_components.ex:4183
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr "Hörbuch"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1046
-#: lib/vutuv_web/components/post_components.ex:4138
+#: lib/vutuv_web/agent_docs/markdown.ex:1049
+#: lib/vutuv_web/components/post_components.ex:4140
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr "Buchbesprechung"
 
-#: lib/vutuv_web/components/post_components.ex:4182
+#: lib/vutuv_web/components/post_components.ex:4184
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr "Kino"
 
-#: lib/vutuv_web/components/post_components.ex:4184
+#: lib/vutuv_web/components/post_components.ex:4186
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr "DVD/Blu-ray"
 
-#: lib/vutuv_web/components/post_components.ex:4180
+#: lib/vutuv_web/components/post_components.ex:4182
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr "E-Book"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1046
-#: lib/vutuv_web/components/post_components.ex:4137
+#: lib/vutuv_web/agent_docs/markdown.ex:1049
+#: lib/vutuv_web/components/post_components.ex:4139
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr "Filmbesprechung"
@@ -14415,12 +14416,12 @@ msgstr "Filmbesprechung"
 msgid "Look up"
 msgstr "Nachschlagen"
 
-#: lib/vutuv_web/components/post_components.ex:4179
+#: lib/vutuv_web/components/post_components.ex:4181
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr "Gedrucktes Buch"
 
-#: lib/vutuv_web/components/post_components.ex:4183
+#: lib/vutuv_web/components/post_components.ex:4185
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr "Streaming"
@@ -14440,7 +14441,7 @@ msgstr "Streaming"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/vutuv_web/components/post_components.ex:4220
+#: lib/vutuv_web/components/post_components.ex:4222
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -14448,27 +14449,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] "%{formatted} Seite"
 msgstr[1] "%{formatted} Seiten"
 
-#: lib/vutuv_web/components/post_components.ex:4250
+#: lib/vutuv_web/components/post_components.ex:4252
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr "%{hours} Std."
 
-#: lib/vutuv_web/components/post_components.ex:4251
+#: lib/vutuv_web/components/post_components.ex:4253
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr "%{hours} Std. %{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4249
+#: lib/vutuv_web/components/post_components.ex:4251
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr "%{minutes} Min."
 
-#: lib/vutuv_web/components/post_components.ex:4209
+#: lib/vutuv_web/components/post_components.ex:4211
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr "(Druckausgabe)"
 
-#: lib/vutuv_web/components/post_components.ex:4256
+#: lib/vutuv_web/components/post_components.ex:4258
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr "ca. %{duration}"
@@ -14493,12 +14494,12 @@ msgstr "Qualifikation"
 msgid "With qualification:"
 msgstr "Mit Qualifikation:"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:647
+#: lib/vutuv_web/agent_docs/markdown.ex:650
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr "Mit Qualifikation: %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:4023
+#: lib/vutuv_web/components/post_components.ex:4025
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr "Verlag:"
@@ -14546,7 +14547,7 @@ msgstr "folgen Ihnen jetzt."
 msgid "endorsed you for %{tags}."
 msgstr "hat Sie für %{tags} empfohlen."
 
-#: lib/vutuv_web/components/post_components.ex:4014
+#: lib/vutuv_web/components/post_components.ex:4016
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr "von:"
@@ -14589,19 +14590,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] "Für %{formatted} Job genutzt"
 msgstr[1] "Für %{formatted} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:772
+#: lib/vutuv_web/agent_docs/markdown.ex:775
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr "aktuell genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:774
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] "für %{count} Job genutzt"
 msgstr[1] "für %{count} Jobs genutzt"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:777
+#: lib/vutuv_web/agent_docs/markdown.ex:780
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -14681,8 +14682,8 @@ msgstr "Hochgeladener Nachweis für %{name}"
 msgid "View the uploaded proof (%{label})"
 msgstr "Hochgeladenen Nachweis ansehen (%{label})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:740
-#: lib/vutuv_web/agent_docs/text.ex:588
+#: lib/vutuv_web/agent_docs/markdown.ex:743
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr "Nachweis"
@@ -14777,8 +14778,8 @@ msgstr "Speichern und weiter"
 msgid "Skip for now"
 msgstr "Erstmal überspringen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:442
-#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:445
+#: lib/vutuv_web/agent_docs/text.ex:443
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr "Bevorzugte Arbeitsform"
@@ -14938,14 +14939,14 @@ msgstr "Konto zum Einfrieren suchen"
 msgid "See all frozen accounts"
 msgstr "Alle eingefrorenen Konten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2362
+#: lib/vutuv_web/components/post_components.ex:2364
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] "%{formatted} früheren Beitrag anzeigen"
 msgstr[1] "%{formatted} frühere Beiträge anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2384
+#: lib/vutuv_web/components/post_components.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14972,7 +14973,7 @@ msgstr "Dieses Profil ist zurzeit nicht verfügbar."
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr "Geben Sie einen Namen, ein @Handle oder eine E-Mail-Adresse ein, um das Konto zu finden, das eingefroren werden soll."
 
-#: lib/vutuv_web/components/post_components.ex:4633
+#: lib/vutuv_web/components/post_components.ex:4635
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr "Der eigene Beitrag lässt sich nicht mit „Gefällt mir“ markieren."
@@ -15378,7 +15379,7 @@ msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
 msgid "none yet"
 msgstr "noch keiner"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:993
+#: lib/vutuv_web/agent_docs/markdown.ex:996
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr "Reaktionen aus anderen Netzwerken"
@@ -15761,8 +15762,8 @@ msgstr "%{server} hat nicht geantwortet. Kopieren Sie stattdessen die Adresse ob
 msgid "Your server"
 msgstr "Ihr Server"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:499
-#: lib/vutuv_web/agent_docs/text.ex:469
+#: lib/vutuv_web/agent_docs/markdown.ex:502
+#: lib/vutuv_web/agent_docs/text.ex:472
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr "umgezogen nach %{address}"
@@ -16159,29 +16160,29 @@ msgstr ""
 "wohin sie weiterwandert. Ein Bearbeiten oder Löschen auf vutuv ist für diese "
 "Server nur eine Bitte, und nicht jeder Server befolgt sie."
 
-#: lib/vutuv_web/components/post_components.ex:4592
+#: lib/vutuv_web/components/post_components.ex:4594
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] "%{formatted} Antwort"
 msgstr[1] "%{formatted} Antworten"
 
-#: lib/vutuv_web/components/post_components.ex:4596
+#: lib/vutuv_web/components/post_components.ex:4598
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] "%{formatted} Like"
 msgstr[1] "%{formatted} Likes"
 
-#: lib/vutuv_web/components/post_components.ex:4600
+#: lib/vutuv_web/components/post_components.ex:4602
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
 msgstr[0] "%{formatted} Repost"
 msgstr[1] "%{formatted} Reposts"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:995
-#: lib/vutuv_web/components/post_components.ex:4551
+#: lib/vutuv_web/agent_docs/markdown.ex:998
+#: lib/vutuv_web/components/post_components.ex:4553
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr "Bereits in den Zahlen oben enthalten."
@@ -16191,14 +16192,14 @@ msgstr "Bereits in den Zahlen oben enthalten."
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr "Antworten, die dort draußen geschrieben werden, erscheinen unter Ihrem Beitrag, gekennzeichnet als aus einem anderen Netzwerk. Wir speichern eine Kopie für bis zu sechs Monate und prüfen ab und zu, ob sie dort noch veröffentlicht ist; löscht sie die Autorin oder der Autor, verschwindet auch unsere. Sie können jede einzelne Antwort entfernen, und wenn Sie das hier ausschalten, werden alle gelöscht."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1177
-#: lib/vutuv_web/agent_docs/text.ex:695
+#: lib/vutuv_web/agent_docs/markdown.ex:1180
+#: lib/vutuv_web/agent_docs/text.ex:698
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
 #: lib/vutuv_web/components/post_components.ex:1117
-#: lib/vutuv_web/components/post_components.ex:1671
+#: lib/vutuv_web/components/post_components.ex:1673
 #: lib/vutuv_web/live/fediverse_account_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "From another network"
@@ -16215,7 +16216,7 @@ msgid "Removed by the member"
 msgstr "Vom Mitglied entfernt"
 
 #: lib/vutuv_web/agent_docs/markdown.ex:125
-#: lib/vutuv_web/agent_docs/markdown.ex:994
+#: lib/vutuv_web/agent_docs/markdown.ex:997
 #: lib/vutuv_web/agent_docs/text.ex:116
 #, elixir-autogen, elixir-format
 msgid "Replies from other networks"
@@ -16272,10 +16273,10 @@ msgstr "Danke. Die Antwort wurde sofort gelöscht."
 msgid "That reply is not yours to remove."
 msgstr "Diese Antwort können Sie nicht entfernen."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1179
+#: lib/vutuv_web/agent_docs/markdown.ex:1182
 #: lib/vutuv_web/components/post_components.ex:1048
 #: lib/vutuv_web/components/post_components.ex:1248
-#: lib/vutuv_web/components/post_components.ex:2044
+#: lib/vutuv_web/components/post_components.ex:2046
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr "Original ansehen"
@@ -16940,22 +16941,22 @@ msgstr "Was sich an welchem Konto geändert hat, wann, von welchem Gerät und wi
 msgid "device or detail"
 msgstr "Gerät oder Detail"
 
-#: lib/vutuv_web/components/post_components.ex:2603
+#: lib/vutuv_web/components/post_components.ex:2605
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr "Angehefteter Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2710
+#: lib/vutuv_web/components/post_components.ex:2712
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr "An Profil anheften"
 
-#: lib/vutuv_web/components/post_components.ex:2718
+#: lib/vutuv_web/components/post_components.ex:2720
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr "Vom Profil lösen"
 
-#: lib/vutuv_web/components/post_components.ex:2704
+#: lib/vutuv_web/components/post_components.ex:2706
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr "Es lässt sich nur ein Beitrag an Ihr Profil anheften. Diesen anheften und den anderen lösen?"
@@ -16977,13 +16978,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr "Nicht mehr angeheftet. Der Beitrag ist wieder ein normaler Beitrag."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:875
+#: lib/vutuv_web/agent_docs/markdown.ex:878
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr "angehefteter Beitrag"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:436
-#: lib/vutuv_web/agent_docs/text.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:439
+#: lib/vutuv_web/agent_docs/text.ex:434
 #: lib/vutuv_web/templates/user/edit.html.heex:180
 #: lib/vutuv_web/templates/user/show.html.heex:217
 #: lib/vutuv_web/views/account_event_text.ex:176
@@ -17045,9 +17046,9 @@ msgstr "Titelbild"
 msgid "Describe the photo for people who can't see it"
 msgstr "Beschreiben Sie das Foto für Menschen, die es nicht sehen können"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/agent_docs/text.ex:662
-#: lib/vutuv_web/components/post_components.ex:3177
+#: lib/vutuv_web/agent_docs/markdown.ex:1110
+#: lib/vutuv_web/agent_docs/text.ex:665
+#: lib/vutuv_web/components/post_components.ex:3179
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr "Original herunterladen"
@@ -17077,7 +17078,7 @@ msgstr "Volle Auflösung, direkt aus dem Beitrag."
 msgid "Just the picture"
 msgstr "Nur das Bild"
 
-#: lib/vutuv_web/components/post_components.ex:3176
+#: lib/vutuv_web/components/post_components.ex:3178
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr "Nächstes Foto"
@@ -17087,29 +17088,29 @@ msgstr "Nächstes Foto"
 msgid "No image description yet"
 msgstr "Noch keine Bildbeschreibung"
 
-#: lib/vutuv_web/components/post_components.ex:3557
+#: lib/vutuv_web/components/post_components.ex:3559
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr "Bisher sehen nur Sie diesen Beitrag."
 
-#: lib/vutuv_web/components/post_components.ex:2151
+#: lib/vutuv_web/components/post_components.ex:2153
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr "Fediverse-Einstellungen öffnen"
 
-#: lib/vutuv_web/components/post_components.ex:3560
+#: lib/vutuv_web/components/post_components.ex:3562
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] "Unsere KI prüft das Foto. Sobald es durch ist, geht der Beitrag von selbst online."
 msgstr[1] "Unsere KI prüft die Fotos, %{done} von %{total} sind durch. Sobald das letzte durch ist, geht der Beitrag von selbst online."
 
-#: lib/vutuv_web/components/post_components.ex:3383
+#: lib/vutuv_web/components/post_components.ex:3385
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr "Foto %{n} von %{total}"
 
-#: lib/vutuv_web/components/post_components.ex:2919
+#: lib/vutuv_web/components/post_components.ex:2921
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr "Foto wird geprüft"
@@ -17120,14 +17121,14 @@ msgstr "Foto wird geprüft"
 msgid "Photo options"
 msgstr "Foto-Einstellungen"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1140
-#: lib/vutuv_web/agent_docs/text.ex:649
-#: lib/vutuv_web/components/post_components.ex:3594
+#: lib/vutuv_web/agent_docs/markdown.ex:1143
+#: lib/vutuv_web/agent_docs/text.ex:652
+#: lib/vutuv_web/components/post_components.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr "Fotos:"
 
-#: lib/vutuv_web/components/post_components.ex:3175
+#: lib/vutuv_web/components/post_components.ex:3177
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr "Vorheriges Foto"
@@ -17148,7 +17149,7 @@ msgstr "Dieselben Bildpunkte, sonst nichts: Ort und Seriennummern entfernt, Qual
 msgid "Show camera settings"
 msgstr "Kameradaten anzeigen"
 
-#: lib/vutuv_web/components/post_components.ex:2204
+#: lib/vutuv_web/components/post_components.ex:2206
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr "Dieser Server ist auf dieser Seite gesperrt, deshalb kann keine Antwort dorthin gesendet werden."
@@ -17168,7 +17169,7 @@ msgstr "Dieses Dateiformat lässt sich nur unverändert weitergeben. Entfernen S
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr "Dieses Foto enthält den Ort, an dem es aufgenommen wurde. Wer die exakte Datei herunterlädt, kann ihn auslesen."
 
-#: lib/vutuv_web/components/post_components.ex:2195
+#: lib/vutuv_web/components/post_components.ex:2197
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht öffentlich beantworten."
@@ -17178,12 +17179,12 @@ msgstr "Diese Antwort wurde nur an Sie geschickt und lässt sich deshalb nicht �
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr "Diese Antwort wurde in einem anderen Netzwerk geschrieben. Sie zu beantworten heißt, Ihre Worte in dieses Netzwerk zu senden, und das tut vutuv nur für Mitglieder, die die Fediverse-Teilnahme eingeschaltet haben."
 
-#: lib/vutuv_web/components/post_components.ex:2213
+#: lib/vutuv_web/components/post_components.ex:2215
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr "Diese Seite nimmt nicht am Fediverse teil."
 
-#: lib/vutuv_web/components/post_components.ex:2147
+#: lib/vutuv_web/components/post_components.ex:2149
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr "Fediverse-Teilnahme einschalten, um zu antworten"
@@ -17198,7 +17199,7 @@ msgstr "Wer diese Fotos weiterverwenden darf"
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr "Sie haben in der letzten Stunde viele Antworten in andere Netzwerke geschickt. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2208
+#: lib/vutuv_web/components/post_components.ex:2210
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshalb werden von hier aus keine Antworten mehr gesendet."
@@ -17208,7 +17209,7 @@ msgstr "Sie haben Ihr Fediverse-Konto auf einen anderen Server umgezogen, deshal
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr "Ihre Fediverse-Einstellungen erlauben es derzeit nicht, eine Antwort zu senden."
 
-#: lib/vutuv_web/components/post_components.ex:2161
+#: lib/vutuv_web/components/post_components.ex:2163
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr "Ihre Antwort geht an %{handle} auf dem eigenen Server und an Ihre Fediverse-Follower. Auf vutuv ist sie ebenfalls ein öffentlicher Beitrag."
@@ -17294,14 +17295,14 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] "Dieses Foto trägt den Ort, an dem es aufgenommen wurde, und die exakte Datei gibt ihn weiter."
 msgstr[1] "Einige dieser Fotos tragen den Ort, an dem sie aufgenommen wurden, und die exakte Datei gibt ihn weiter."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1013
-#: lib/vutuv_web/components/post_components.ex:4589
+#: lib/vutuv_web/agent_docs/markdown.ex:1016
+#: lib/vutuv_web/components/post_components.ex:4591
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr "%{handle} gefällt das"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1011
-#: lib/vutuv_web/components/post_components.ex:4586
+#: lib/vutuv_web/agent_docs/markdown.ex:1014
+#: lib/vutuv_web/components/post_components.ex:4588
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr "%{handle} hat das geteilt"
@@ -17311,7 +17312,7 @@ msgstr "%{handle} hat das geteilt"
 msgid "Fediverse reactions"
 msgstr "Fediverse-Reaktionen"
 
-#: lib/vutuv_web/components/post_components.ex:4478
+#: lib/vutuv_web/components/post_components.ex:4480
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr "Aus anderen Netzwerken"
@@ -17657,7 +17658,7 @@ msgstr "Von hier aus wird %{follows} Konten in anderen Netzwerken gefolgt, davon
 msgid "Cached posts"
 msgstr "Zwischengespeicherte Beiträge"
 
-#: lib/vutuv_web/components/post_components.ex:1999
+#: lib/vutuv_web/components/post_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr "Nur für die Follower dieses Kontos"
@@ -17671,7 +17672,7 @@ msgstr "Nur für die Follower dieses Kontos"
 msgid "Thank you. Our copy was deleted right away."
 msgstr "Danke. Unsere Kopie wurde sofort gelöscht."
 
-#: lib/vutuv_web/components/post_components.ex:2043
+#: lib/vutuv_web/components/post_components.ex:2045
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr "Beim Original abstimmen"
@@ -17696,12 +17697,12 @@ msgstr "Von Mitgliedern entfernte Inhalte aus anderen Netzwerken"
 msgid "Hide"
 msgstr "Verbergen"
 
-#: lib/vutuv_web/components/post_components.ex:2016
+#: lib/vutuv_web/components/post_components.ex:2018
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr "Von der verfassenden Person als sensibel markiert"
 
-#: lib/vutuv_web/components/post_components.ex:1978
+#: lib/vutuv_web/components/post_components.ex:1980
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr "%{handle} stummschalten"
@@ -17718,7 +17719,7 @@ msgstr "Stummgeschaltet. Sie folgen dem Konto weiterhin; die Beiträge verschwin
 msgid "Nobody has removed or reported anything yet."
 msgstr "Bisher hat niemand etwas entfernt oder gemeldet."
 
-#: lib/vutuv_web/components/post_components.ex:1985
+#: lib/vutuv_web/components/post_components.ex:1987
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr "Diesen Beitrag als unangemessen melden? Unsere Kopie wird sofort für alle auf diesem vutuv gelöscht."
@@ -17933,34 +17934,34 @@ msgstr "Variante"
 msgid "What is being measured"
 msgstr "Was gemessen wird"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:870
+#: lib/vutuv_web/agent_docs/markdown.ex:873
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
 msgstr[0] "(ein Bild)"
 msgstr[1] "(%{count} Bilder)"
 
-#: lib/vutuv_web/components/post_components.ex:1774
+#: lib/vutuv_web/components/post_components.ex:1776
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr "Ein Bild ist unterwegs."
 
-#: lib/vutuv_web/components/post_components.ex:1803
+#: lib/vutuv_web/components/post_components.ex:1805
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr "Wieder verdecken"
 
-#: lib/vutuv_web/components/post_components.ex:1798
+#: lib/vutuv_web/components/post_components.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr "Heikles Motiv. Bild anzeigen."
 
-#: lib/vutuv_web/components/post_components.ex:2080
+#: lib/vutuv_web/components/post_components.ex:2082
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr "Das sind viele Likes in einer Stunde. Bitte versuchen Sie es später noch einmal."
 
-#: lib/vutuv_web/components/post_components.ex:2086
+#: lib/vutuv_web/components/post_components.ex:2088
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr "Diesen Beitrag gibt es hier nicht mehr."
@@ -17970,7 +17971,7 @@ msgstr "Diesen Beitrag gibt es hier nicht mehr."
 msgid "Back to the feed"
 msgstr "Zurück zum Feed"
 
-#: lib/vutuv_web/components/post_components.ex:2199
+#: lib/vutuv_web/components/post_components.ex:2201
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -18117,8 +18118,8 @@ msgstr "Wir haben den Link in Ihrer Profilbeschreibung noch nicht gefunden. Bitt
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr "Wir konnten das Netzwerk gerade nicht erreichen. Bitte versuchen Sie es gleich noch einmal."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:817
-#: lib/vutuv_web/agent_docs/text.ex:515
+#: lib/vutuv_web/agent_docs/markdown.ex:820
+#: lib/vutuv_web/agent_docs/text.ex:518
 #, elixir-autogen, elixir-format, fuzzy
 msgid "verified profile"
 msgstr "verifiziertes Profil"
@@ -18752,7 +18753,7 @@ msgstr "Auf vutuv gibt es zu diesem Tag noch keine Beiträge."
 msgid "word in a post"
 msgstr "Wort in einem Beitrag"
 
-#: lib/vutuv_web/components/post_components.ex:2083
+#: lib/vutuv_web/components/post_components.ex:2085
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr "Diese Antwort gibt es hier nicht mehr."
@@ -19063,24 +19064,24 @@ msgstr "Höchstens %{max} Tags. Entfernen Sie eines, um ein anderes hinzuzufüge
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr "Auf der Seite eines Beitrags stehen direkt unter der Zahl die Mitglieder, denen er gefällt. Hier legen Sie fest, ob Sie zu diesen Gesichtern gehören."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:981
+#: lib/vutuv_web/agent_docs/markdown.ex:984
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr "Gefällt diesen Mitgliedern"
 
-#: lib/vutuv_web/components/post_components.ex:3760
+#: lib/vutuv_web/components/post_components.ex:3762
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr "Gefällt %{name}"
 
-#: lib/vutuv_web/components/post_components.ex:3762
+#: lib/vutuv_web/components/post_components.ex:3764
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] "Gefällt %{name} und %{formatted} weiteren"
 msgstr[1] "Gefällt %{name} und %{formatted} weiteren"
 
-#: lib/vutuv_web/components/post_components.ex:3773
+#: lib/vutuv_web/components/post_components.ex:3775
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr "Nur Sie sehen hier alle: Einige dieser Mitglieder werden anderen Lesern nicht genannt."
@@ -19105,12 +19106,12 @@ msgstr "Wenn aus, sehen andere Mitglieder Sie nicht mehr bei den Likes eines Bei
 msgid "Your likes follow the site default again."
 msgstr "Ihre Likes folgen wieder dem Standardwert der Website."
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1036
+#: lib/vutuv_web/agent_docs/markdown.ex:1039
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr "%{address} (nur diese Seite)"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1036
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr "%{address} (ganze Website)"
@@ -19120,14 +19121,14 @@ msgstr "%{address} (ganze Website)"
 msgid "Verified webpage of the author (%{address})"
 msgstr "Verifizierte Webseite der Autorin oder des Autors (%{address})"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1025
+#: lib/vutuv_web/agent_docs/markdown.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
 "Verifizierte Webseiten der Autorin oder des Autors, hier verlinkt: "
 "%{addresses}"
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:185
+#: lib/vutuv_web/agent_docs/list_docs.ex:191
 #, elixir-autogen, elixir-format
 msgid "%{listed} of %{total} members are listed here; the others do not open their profile to search engines."
 msgstr ""
@@ -19481,7 +19482,7 @@ msgstr "Weder den Prompt noch das Modell haben wir geschrieben."
 msgid "Employment references of %{name}"
 msgstr "Arbeitszeugnisse von %{name}"
 
-#: lib/vutuv_web/agent_docs/markdown.ex:723
+#: lib/vutuv_web/agent_docs/markdown.ex:726
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr "Dokument"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -27,9 +27,9 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:219
+#: lib/vutuv_web/agent_docs/markdown.ex:222
 #: lib/vutuv_web/agent_docs/section_docs.ex:127
-#: lib/vutuv_web/agent_docs/text.ex:207
+#: lib/vutuv_web/agent_docs/text.ex:210
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
@@ -97,10 +97,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:486
-#: lib/vutuv_web/agent_docs/markdown.ex:487
-#: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/agent_docs/text.ex:457
+#: lib/vutuv_web/agent_docs/markdown.ex:489
+#: lib/vutuv_web/agent_docs/markdown.ex:490
+#: lib/vutuv_web/agent_docs/text.ex:459
+#: lib/vutuv_web/agent_docs/text.ex:460
 #: lib/vutuv_web/templates/user/show.html.heex:1103
 #, elixir-autogen
 msgid "Birthday"
@@ -157,7 +157,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2726
+#: lib/vutuv_web/components/post_components.ex:2728
 #: lib/vutuv_web/components/ui.ex:3326
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2691
+#: lib/vutuv_web/components/post_components.ex:2693
 #: lib/vutuv_web/components/ui.ex:3317
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -301,14 +301,14 @@ msgstr ""
 msgid "Fax"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:472
+#: lib/vutuv_web/agent_docs/markdown.ex:475
 #: lib/vutuv_web/templates/user/edit.html.heex:125
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:507
-#: lib/vutuv_web/agent_docs/text.ex:477
+#: lib/vutuv_web/agent_docs/markdown.ex:510
+#: lib/vutuv_web/agent_docs/text.ex:480
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/live/notification_live/index.ex:954
@@ -319,8 +319,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:508
-#: lib/vutuv_web/agent_docs/text.ex:478
+#: lib/vutuv_web/agent_docs/markdown.ex:511
+#: lib/vutuv_web/agent_docs/text.ex:481
 #: lib/vutuv_web/components/fediverse_components.ex:223
 #: lib/vutuv_web/components/ui.ex:1976
 #: lib/vutuv_web/components/ui.ex:2001
@@ -378,7 +378,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:474
+#: lib/vutuv_web/agent_docs/markdown.ex:477
 #: lib/vutuv_web/templates/user/edit.html.heex:130
 #, elixir-autogen
 msgid "Last Name"
@@ -445,7 +445,7 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:473
+#: lib/vutuv_web/agent_docs/markdown.ex:476
 #: lib/vutuv_web/templates/user/edit.html.heex:135
 #, elixir-autogen
 msgid "Middle Name"
@@ -483,7 +483,7 @@ msgstr ""
 msgid "New message from @%{slug} on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:476
+#: lib/vutuv_web/agent_docs/markdown.ex:479
 #: lib/vutuv_web/templates/user/edit.html.heex:140
 #, elixir-autogen
 msgid "Nickname"
@@ -564,7 +564,7 @@ msgstr ""
 msgid "Phone number updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:471
+#: lib/vutuv_web/agent_docs/markdown.ex:474
 #: lib/vutuv_web/templates/user/edit.html.heex:145
 #, elixir-autogen
 msgid "Prefix"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Submit a bugreport or a feature request."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:475
+#: lib/vutuv_web/agent_docs/markdown.ex:478
 #: lib/vutuv_web/templates/user/edit.html.heex:150
 #, elixir-autogen
 msgid "Suffix"
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "The 1,000 Users with the most Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:147
+#: lib/vutuv_web/agent_docs/list_docs.ex:153
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
 msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
@@ -1364,11 +1364,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
-#: lib/vutuv_web/agent_docs/markdown.ex:379
-#: lib/vutuv_web/agent_docs/markdown.ex:920
+#: lib/vutuv_web/agent_docs/markdown.ex:382
+#: lib/vutuv_web/agent_docs/markdown.ex:923
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:404
-#: lib/vutuv_web/agent_docs/text.ex:623
+#: lib/vutuv_web/agent_docs/text.ex:407
+#: lib/vutuv_web/agent_docs/text.ex:626
 #: lib/vutuv_web/components/ui.ex:3616
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Parent slug"
 msgstr ""
 
-#: lib/vutuv_web/templates/tag/single_card.html.heex:11
+#: lib/vutuv_web/templates/tag/single_card.html.heex:17
 #, elixir-autogen
 msgid "People you may know with this tag"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "Tag name"
 msgstr ""
 
-#: lib/vutuv_web/templates/tag/single_card.html.heex:15
+#: lib/vutuv_web/templates/tag/single_card.html.heex:21
 #, elixir-autogen
 msgid "The most endorsed users with this tag"
 msgstr ""
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3174
+#: lib/vutuv_web/components/post_components.ex:3176
 #: lib/vutuv_web/components/ui.ex:280
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -2083,7 +2083,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2723
+#: lib/vutuv_web/components/post_components.ex:2725
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2124,8 +2124,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2677
 #: lib/vutuv_web/components/post_components.ex:2679
+#: lib/vutuv_web/components/post_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2190,13 +2190,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3110
-#: lib/vutuv_web/components/post_components.ex:3114
+#: lib/vutuv_web/components/post_components.ex:3112
+#: lib/vutuv_web/components/post_components.ex:3116
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3111
+#: lib/vutuv_web/components/post_components.ex:3113
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2285,27 +2285,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2674
+#: lib/vutuv_web/components/post_components.ex:2676
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4318
+#: lib/vutuv_web/components/post_components.ex:4320
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4322
+#: lib/vutuv_web/components/post_components.ex:4324
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4320
+#: lib/vutuv_web/components/post_components.ex:4322
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4321
+#: lib/vutuv_web/components/post_components.ex:4323
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2346,15 +2346,15 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1551
-#: lib/vutuv_web/components/post_components.ex:4402
+#: lib/vutuv_web/components/post_components.ex:1553
+#: lib/vutuv_web/components/post_components.ex:4404
 #: lib/vutuv_web/components/ui.ex:2851
 #: lib/vutuv_web/views/user_html.ex:333
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:958
+#: lib/vutuv_web/agent_docs/markdown.ex:961
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
 #: lib/vutuv_web/live/shell_live.ex:595
@@ -2365,8 +2365,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1515
-#: lib/vutuv_web/components/post_components.ex:4625
+#: lib/vutuv_web/components/post_components.ex:1517
+#: lib/vutuv_web/components/post_components.ex:4627
 #: lib/vutuv_web/components/ui.ex:2837
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #: lib/vutuv_web/views/user_html.ex:343
@@ -2374,8 +2374,8 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:957
-#: lib/vutuv_web/components/post_components.ex:4634
+#: lib/vutuv_web/agent_docs/markdown.ex:960
+#: lib/vutuv_web/components/post_components.ex:4636
 #: lib/vutuv_web/live/notification_live/index.ex:956
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2397,39 +2397,39 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4391
+#: lib/vutuv_web/components/post_components.ex:4393
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1551
-#: lib/vutuv_web/components/post_components.ex:4402
+#: lib/vutuv_web/components/post_components.ex:1553
+#: lib/vutuv_web/components/post_components.ex:4404
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:333
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1539
-#: lib/vutuv_web/components/post_components.ex:4388
+#: lib/vutuv_web/components/post_components.ex:1541
+#: lib/vutuv_web/components/post_components.ex:4390
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1729
-#: lib/vutuv_web/components/post_components.ex:3690
+#: lib/vutuv_web/components/post_components.ex:1731
+#: lib/vutuv_web/components/post_components.ex:3692
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1539
-#: lib/vutuv_web/components/post_components.ex:4388
+#: lib/vutuv_web/components/post_components.ex:1541
+#: lib/vutuv_web/components/post_components.ex:4390
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4625
+#: lib/vutuv_web/components/post_components.ex:4627
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:343
 #, elixir-autogen, elixir-format
@@ -2451,7 +2451,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4678
+#: lib/vutuv_web/components/post_components.ex:4680
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2462,16 +2462,16 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1526
-#: lib/vutuv_web/components/post_components.ex:4661
-#: lib/vutuv_web/components/post_components.ex:4662
+#: lib/vutuv_web/components/post_components.ex:1528
+#: lib/vutuv_web/components/post_components.ex:4663
+#: lib/vutuv_web/components/post_components.ex:4664
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2645
+#: lib/vutuv_web/components/post_components.ex:2647
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2492,7 +2492,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2139
+#: lib/vutuv_web/components/post_components.ex:2141
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2500,14 +2500,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2621
+#: lib/vutuv_web/components/post_components.ex:2623
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2615
-#: lib/vutuv_web/components/post_components.ex:2637
-#: lib/vutuv_web/components/post_components.ex:2640
+#: lib/vutuv_web/components/post_components.ex:2617
+#: lib/vutuv_web/components/post_components.ex:2639
+#: lib/vutuv_web/components/post_components.ex:2642
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2761,8 +2761,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:509
-#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/markdown.ex:512
+#: lib/vutuv_web/agent_docs/text.ex:482
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/live/notification_live/index.ex:955
 #: lib/vutuv_web/templates/connection/index.html.heex:5
@@ -2808,7 +2808,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4319
+#: lib/vutuv_web/components/post_components.ex:4321
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2913,8 +2913,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:298
-#: lib/vutuv_web/agent_docs/text.ex:282
+#: lib/vutuv_web/agent_docs/markdown.ex:301
+#: lib/vutuv_web/agent_docs/text.ex:285
 #: lib/vutuv_web/controllers/page_controller.ex:83
 #: lib/vutuv_web/templates/layout/app.html.heex:91
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3069,7 +3069,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2591
+#: lib/vutuv_web/components/post_components.ex:2593
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3145,8 +3145,8 @@ msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1016
-#: lib/vutuv_web/components/post_components.ex:1990
-#: lib/vutuv_web/components/post_components.ex:2747
+#: lib/vutuv_web/components/post_components.ex:1992
+#: lib/vutuv_web/components/post_components.ex:2749
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
@@ -3796,12 +3796,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:601
+#: lib/vutuv_web/agent_docs/markdown.ex:604
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1079
+#: lib/vutuv_web/agent_docs/markdown.ex:1082
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3815,16 +3815,16 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:162
 #: lib/vutuv_web/agent_docs/markdown.ex:175
-#: lib/vutuv_web/agent_docs/markdown.ex:920
+#: lib/vutuv_web/agent_docs/markdown.ex:923
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:150
 #: lib/vutuv_web/agent_docs/text.ex:163
-#: lib/vutuv_web/agent_docs/text.ex:623
+#: lib/vutuv_web/agent_docs/text.ex:626
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:47
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr ""
@@ -3836,44 +3836,44 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:938
-#: lib/vutuv_web/agent_docs/text.ex:634
+#: lib/vutuv_web/agent_docs/markdown.ex:941
+#: lib/vutuv_web/agent_docs/text.ex:637
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:935
-#: lib/vutuv_web/agent_docs/text.ex:631
+#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/text.ex:634
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:942
-#: lib/vutuv_web/agent_docs/markdown.ex:1156
-#: lib/vutuv_web/agent_docs/text.ex:637
-#: lib/vutuv_web/agent_docs/text.ex:681
+#: lib/vutuv_web/agent_docs/markdown.ex:945
+#: lib/vutuv_web/agent_docs/markdown.ex:1159
+#: lib/vutuv_web/agent_docs/text.ex:640
+#: lib/vutuv_web/agent_docs/text.ex:684
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:444
-#: lib/vutuv_web/agent_docs/text.ex:442
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/text.ex:445
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:188
-#: lib/vutuv_web/agent_docs/text.ex:176
+#: lib/vutuv_web/agent_docs/markdown.ex:191
+#: lib/vutuv_web/agent_docs/text.ex:179
 #, elixir-autogen, elixir-format
 msgid "Most endorsed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:145
+#: lib/vutuv_web/agent_docs/list_docs.ex:151
 #, elixir-autogen, elixir-format
 msgid "Most followed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:48
+#: lib/vutuv_web/agent_docs/list_docs.ex:49
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr ""
@@ -3898,23 +3898,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:438
-#: lib/vutuv_web/agent_docs/text.ex:436
+#: lib/vutuv_web/agent_docs/markdown.ex:441
+#: lib/vutuv_web/agent_docs/text.ex:439
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:889
+#: lib/vutuv_web/agent_docs/markdown.ex:892
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:789
+#: lib/vutuv_web/agent_docs/markdown.ex:792
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:790
+#: lib/vutuv_web/agent_docs/markdown.ex:793
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -3924,7 +3924,7 @@ msgstr ""
 msgid "This page in %{language}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:49
+#: lib/vutuv_web/agent_docs/list_docs.ex:50
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr ""
@@ -3989,8 +3989,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:312
-#: lib/vutuv_web/agent_docs/text.ex:290
+#: lib/vutuv_web/agent_docs/markdown.ex:315
+#: lib/vutuv_web/agent_docs/text.ex:293
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4043,8 +4043,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:302
-#: lib/vutuv_web/agent_docs/text.ex:286
+#: lib/vutuv_web/agent_docs/markdown.ex:305
+#: lib/vutuv_web/agent_docs/text.ex:289
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4060,8 +4060,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:299
-#: lib/vutuv_web/agent_docs/text.ex:283
+#: lib/vutuv_web/agent_docs/markdown.ex:302
+#: lib/vutuv_web/agent_docs/text.ex:286
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4275,14 +4275,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:304
-#: lib/vutuv_web/agent_docs/text.ex:288
+#: lib/vutuv_web/agent_docs/markdown.ex:307
+#: lib/vutuv_web/agent_docs/text.ex:291
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:300
-#: lib/vutuv_web/agent_docs/text.ex:284
+#: lib/vutuv_web/agent_docs/markdown.ex:303
+#: lib/vutuv_web/agent_docs/text.ex:287
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4558,8 +4558,8 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:327
-#: lib/vutuv_web/agent_docs/text.ex:352
+#: lib/vutuv_web/agent_docs/markdown.ex:330
+#: lib/vutuv_web/agent_docs/text.ex:355
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:877
@@ -4684,8 +4684,8 @@ msgstr ""
 msgid "Edit your profile and its sections"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:241
-#: lib/vutuv_web/agent_docs/text.ex:228
+#: lib/vutuv_web/agent_docs/markdown.ex:244
+#: lib/vutuv_web/agent_docs/text.ex:231
 #: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
@@ -5378,9 +5378,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2810
-#: lib/vutuv_web/components/post_components.ex:2862
-#: lib/vutuv_web/components/post_components.ex:3254
+#: lib/vutuv_web/components/post_components.ex:2812
+#: lib/vutuv_web/components/post_components.ex:2864
+#: lib/vutuv_web/components/post_components.ex:3256
 #: lib/vutuv_web/live/notification_live/index.ex:680
 #: lib/vutuv_web/live/post_live/feed.ex:1259
 #: lib/vutuv_web/views/user_html.ex:111
@@ -6101,8 +6101,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:488
-#: lib/vutuv_web/agent_docs/text.ex:458
+#: lib/vutuv_web/agent_docs/markdown.ex:491
+#: lib/vutuv_web/agent_docs/text.ex:461
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6174,7 +6174,7 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:957
+#: lib/vutuv_web/agent_docs/markdown.ex:960
 #: lib/vutuv_web/components/post_components.ex:348
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6259,7 +6259,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:118
+#: lib/vutuv_web/agent_docs/list_docs.ex:124
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -6279,7 +6279,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:933
+#: lib/vutuv_web/agent_docs/markdown.ex:936
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6611,7 +6611,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2744
+#: lib/vutuv_web/components/post_components.ex:2746
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6621,7 +6621,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2743
+#: lib/vutuv_web/components/post_components.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -6816,8 +6816,8 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:215
-#: lib/vutuv_web/agent_docs/text.ex:203
+#: lib/vutuv_web/agent_docs/markdown.ex:218
+#: lib/vutuv_web/agent_docs/text.ex:206
 #: lib/vutuv_web/live/account_activity_live.ex:167
 #: lib/vutuv_web/live/admin/activity_live.ex:211
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
@@ -7303,7 +7303,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4547
+#: lib/vutuv_web/components/post_components.ex:4549
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7478,17 +7478,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1084
+#: lib/vutuv_web/agent_docs/markdown.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1087
+#: lib/vutuv_web/agent_docs/markdown.ex:1090
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1094
+#: lib/vutuv_web/agent_docs/markdown.ex:1097
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8473,12 +8473,12 @@ msgstr ""
 msgid "All %{count} members whose profiles are open to search engines, filed alphabetically by last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:181
+#: lib/vutuv_web/agent_docs/list_docs.ex:187
 #, elixir-autogen, elixir-format
 msgid "All members who allow search engines to index their profile, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:166
+#: lib/vutuv_web/agent_docs/list_docs.ex:172
 #: lib/vutuv_web/controllers/directory_controller.ex:35
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8494,7 +8494,7 @@ msgstr ""
 msgid "Members by initial"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:198
+#: lib/vutuv_web/agent_docs/list_docs.ex:204
 #: lib/vutuv_web/controllers/directory_controller.ex:62
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8513,7 +8513,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:204
+#: lib/vutuv_web/agent_docs/list_docs.ex:210
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -8609,10 +8609,10 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:498
-#: lib/vutuv_web/agent_docs/markdown.ex:502
-#: lib/vutuv_web/agent_docs/text.ex:468
-#: lib/vutuv_web/agent_docs/text.ex:472
+#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:505
+#: lib/vutuv_web/agent_docs/text.ex:471
+#: lib/vutuv_web/agent_docs/text.ex:475
 #: lib/vutuv_web/components/ui.ex:3688
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:322
@@ -8685,7 +8685,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:661
+#: lib/vutuv_web/agent_docs/markdown.ex:664
 #: lib/vutuv_web/views/work_experience_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8706,7 +8706,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:662
+#: lib/vutuv_web/agent_docs/markdown.ex:665
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -8737,13 +8737,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:699
+#: lib/vutuv_web/agent_docs/markdown.ex:702
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:698
+#: lib/vutuv_web/agent_docs/markdown.ex:701
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8769,14 +8769,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3693
+#: lib/vutuv_web/components/post_components.ex:3695
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:892
+#: lib/vutuv_web/agent_docs/markdown.ex:895
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8854,14 +8854,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:660
+#: lib/vutuv_web/agent_docs/markdown.ex:663
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #: lib/vutuv_web/views/work_experience_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:663
+#: lib/vutuv_web/agent_docs/markdown.ex:666
 #: lib/vutuv_web/views/work_experience_html.ex:32
 #: lib/vutuv_web/views/work_experience_html.ex:39
 #, elixir-autogen, elixir-format
@@ -9003,8 +9003,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:518
-#: lib/vutuv_web/agent_docs/text.ex:486
+#: lib/vutuv_web/agent_docs/markdown.ex:521
+#: lib/vutuv_web/agent_docs/text.ex:489
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9426,8 +9426,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:440
-#: lib/vutuv_web/agent_docs/text.ex:438
+#: lib/vutuv_web/agent_docs/markdown.ex:443
+#: lib/vutuv_web/agent_docs/text.ex:441
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
@@ -9530,7 +9530,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:783
+#: lib/vutuv_web/agent_docs/markdown.ex:786
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9608,7 +9608,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:761
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9625,7 +9625,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:782
+#: lib/vutuv_web/agent_docs/markdown.ex:785
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9652,7 +9652,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:756
+#: lib/vutuv_web/agent_docs/markdown.ex:759
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9667,7 +9667,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:757
+#: lib/vutuv_web/agent_docs/markdown.ex:760
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -9684,7 +9684,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/markdown.ex:621
 #: lib/vutuv_web/live/section_reorder_live.ex:280
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -10187,21 +10187,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:581
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:576
+#: lib/vutuv_web/agent_docs/markdown.ex:579
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:574
+#: lib/vutuv_web/agent_docs/markdown.ex:577
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10256,12 +10256,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:595
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:579
+#: lib/vutuv_web/agent_docs/markdown.ex:582
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10406,7 +10406,7 @@ msgstr ""
 msgid "Manage your vutuv account: profile, privacy, notifications and sign-in."
 msgstr ""
 
-#: lib/vutuv_web/controllers/tag_controller.ex:74
+#: lib/vutuv_web/controllers/tag_controller.ex:108
 #, elixir-autogen, elixir-format
 msgid "Members on vutuv tagged %{tag}."
 msgstr ""
@@ -11135,8 +11135,8 @@ msgstr ""
 msgid "Verified domains"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:216
-#: lib/vutuv_web/agent_docs/text.ex:204
+#: lib/vutuv_web/agent_docs/markdown.ex:219
+#: lib/vutuv_web/agent_docs/text.ex:207
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr ""
@@ -11163,8 +11163,8 @@ msgstr ""
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/text.ex:206
+#: lib/vutuv_web/agent_docs/markdown.ex:221
+#: lib/vutuv_web/agent_docs/text.ex:209
 #: lib/vutuv_web/live/organization_live/edit.ex:287
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -11248,10 +11248,11 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:319
-#: lib/vutuv_web/agent_docs/text.ex:345
+#: lib/vutuv_web/agent_docs/markdown.ex:322
+#: lib/vutuv_web/agent_docs/text.ex:348
 #: lib/vutuv_web/live/organization_live/edit.ex:353
 #: lib/vutuv_web/live/organization_live/show.ex:360
+#: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr ""
@@ -11484,8 +11485,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:340
-#: lib/vutuv_web/agent_docs/text.ex:365
+#: lib/vutuv_web/agent_docs/markdown.ex:343
+#: lib/vutuv_web/agent_docs/text.ex:368
 #: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11618,8 +11619,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:803
-#: lib/vutuv_web/agent_docs/text.ex:596
+#: lib/vutuv_web/agent_docs/markdown.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:599
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11655,8 +11656,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:331
-#: lib/vutuv_web/agent_docs/text.ex:356
+#: lib/vutuv_web/agent_docs/markdown.ex:334
+#: lib/vutuv_web/agent_docs/text.ex:359
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -12101,10 +12102,10 @@ msgstr ""
 msgid "Edit posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:235
-#: lib/vutuv_web/agent_docs/markdown.ex:364
-#: lib/vutuv_web/agent_docs/text.ex:222
-#: lib/vutuv_web/agent_docs/text.ex:389
+#: lib/vutuv_web/agent_docs/markdown.ex:238
+#: lib/vutuv_web/agent_docs/markdown.ex:367
+#: lib/vutuv_web/agent_docs/text.ex:225
+#: lib/vutuv_web/agent_docs/text.ex:392
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:188
@@ -12117,10 +12118,10 @@ msgstr ""
 msgid "Employer name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:236
-#: lib/vutuv_web/agent_docs/markdown.ex:365
-#: lib/vutuv_web/agent_docs/text.ex:223
-#: lib/vutuv_web/agent_docs/text.ex:390
+#: lib/vutuv_web/agent_docs/markdown.ex:239
+#: lib/vutuv_web/agent_docs/markdown.ex:368
+#: lib/vutuv_web/agent_docs/text.ex:226
+#: lib/vutuv_web/agent_docs/text.ex:393
 #: lib/vutuv_web/live/job_board_live.ex:367
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
@@ -12198,12 +12199,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:346
-#: lib/vutuv_web/agent_docs/markdown.ex:350
-#: lib/vutuv_web/agent_docs/markdown.ex:352
-#: lib/vutuv_web/agent_docs/text.ex:371
-#: lib/vutuv_web/agent_docs/text.ex:375
-#: lib/vutuv_web/agent_docs/text.ex:377
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/markdown.ex:353
+#: lib/vutuv_web/agent_docs/markdown.ex:355
+#: lib/vutuv_web/agent_docs/text.ex:374
+#: lib/vutuv_web/agent_docs/text.ex:378
+#: lib/vutuv_web/agent_docs/text.ex:380
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12252,8 +12253,8 @@ msgstr ""
 msgid "New posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:247
-#: lib/vutuv_web/agent_docs/text.ex:233
+#: lib/vutuv_web/agent_docs/markdown.ex:250
+#: lib/vutuv_web/agent_docs/text.ex:236
 #: lib/vutuv_web/live/job_posting_live/form.ex:525
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
@@ -12337,10 +12338,10 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:240
-#: lib/vutuv_web/agent_docs/markdown.ex:369
-#: lib/vutuv_web/agent_docs/text.ex:227
-#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/agent_docs/markdown.ex:243
+#: lib/vutuv_web/agent_docs/markdown.ex:372
+#: lib/vutuv_web/agent_docs/text.ex:230
+#: lib/vutuv_web/agent_docs/text.ex:397
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12365,10 +12366,10 @@ msgstr ""
 #: lib/vutuv/accounts/user.ex:1085
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:497
-#: lib/vutuv_web/agent_docs/markdown.ex:350
-#: lib/vutuv_web/agent_docs/markdown.ex:352
-#: lib/vutuv_web/agent_docs/text.ex:375
-#: lib/vutuv_web/agent_docs/text.ex:377
+#: lib/vutuv_web/agent_docs/markdown.ex:353
+#: lib/vutuv_web/agent_docs/markdown.ex:355
+#: lib/vutuv_web/agent_docs/text.ex:378
+#: lib/vutuv_web/agent_docs/text.ex:380
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format
@@ -12380,18 +12381,18 @@ msgstr ""
 msgid "Report this posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:246
-#: lib/vutuv_web/agent_docs/text.ex:232
+#: lib/vutuv_web/agent_docs/markdown.ex:249
+#: lib/vutuv_web/agent_docs/text.ex:235
 #: lib/vutuv_web/live/job_posting_live/form.ex:515
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:239
-#: lib/vutuv_web/agent_docs/markdown.ex:368
-#: lib/vutuv_web/agent_docs/text.ex:226
-#: lib/vutuv_web/agent_docs/text.ex:393
+#: lib/vutuv_web/agent_docs/markdown.ex:242
+#: lib/vutuv_web/agent_docs/markdown.ex:371
+#: lib/vutuv_web/agent_docs/text.ex:229
+#: lib/vutuv_web/agent_docs/text.ex:396
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12485,10 +12486,10 @@ msgstr ""
 msgid "Working student"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:237
-#: lib/vutuv_web/agent_docs/markdown.ex:366
-#: lib/vutuv_web/agent_docs/text.ex:224
-#: lib/vutuv_web/agent_docs/text.ex:391
+#: lib/vutuv_web/agent_docs/markdown.ex:240
+#: lib/vutuv_web/agent_docs/markdown.ex:369
+#: lib/vutuv_web/agent_docs/text.ex:227
+#: lib/vutuv_web/agent_docs/text.ex:394
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -12691,13 +12692,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:387
+#: lib/vutuv_web/agent_docs/markdown.ex:390
 #: lib/vutuv_web/templates/tag/show.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:411
+#: lib/vutuv_web/agent_docs/text.ex:414
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12743,12 +12744,12 @@ msgstr ""
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:259
+#: lib/vutuv_web/agent_docs/markdown.ex:262
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:245
+#: lib/vutuv_web/agent_docs/text.ex:248
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
@@ -12763,10 +12764,10 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:385
-#: lib/vutuv_web/agent_docs/markdown.ex:397
-#: lib/vutuv_web/agent_docs/text.ex:409
-#: lib/vutuv_web/agent_docs/text.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:388
+#: lib/vutuv_web/agent_docs/markdown.ex:400
+#: lib/vutuv_web/agent_docs/text.ex:412
+#: lib/vutuv_web/agent_docs/text.ex:424
 #: lib/vutuv_web/live/organization_live/show.ex:329
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
@@ -13086,7 +13087,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2098
+#: lib/vutuv_web/components/post_components.ex:2100
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
@@ -13470,8 +13471,8 @@ msgstr ""
 msgid "Insert into text"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:191
-#: lib/vutuv_web/agent_docs/text.ex:179
+#: lib/vutuv_web/agent_docs/markdown.ex:194
+#: lib/vutuv_web/agent_docs/text.ex:182
 #: lib/vutuv_web/live/tag_live/timeline.ex:255
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
@@ -13687,34 +13688,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4181
+#: lib/vutuv_web/components/post_components.ex:4183
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1046
-#: lib/vutuv_web/components/post_components.ex:4138
+#: lib/vutuv_web/agent_docs/markdown.ex:1049
+#: lib/vutuv_web/components/post_components.ex:4140
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4182
+#: lib/vutuv_web/components/post_components.ex:4184
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4184
+#: lib/vutuv_web/components/post_components.ex:4186
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4180
+#: lib/vutuv_web/components/post_components.ex:4182
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1046
-#: lib/vutuv_web/components/post_components.ex:4137
+#: lib/vutuv_web/agent_docs/markdown.ex:1049
+#: lib/vutuv_web/components/post_components.ex:4139
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13725,12 +13726,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4179
+#: lib/vutuv_web/components/post_components.ex:4181
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4183
+#: lib/vutuv_web/components/post_components.ex:4185
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13750,7 +13751,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4220
+#: lib/vutuv_web/components/post_components.ex:4222
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13758,27 +13759,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4250
+#: lib/vutuv_web/components/post_components.ex:4252
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4251
+#: lib/vutuv_web/components/post_components.ex:4253
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4249
+#: lib/vutuv_web/components/post_components.ex:4251
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4209
+#: lib/vutuv_web/components/post_components.ex:4211
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4256
+#: lib/vutuv_web/components/post_components.ex:4258
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13803,12 +13804,12 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:647
+#: lib/vutuv_web/agent_docs/markdown.ex:650
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4023
+#: lib/vutuv_web/components/post_components.ex:4025
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13856,7 +13857,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4014
+#: lib/vutuv_web/components/post_components.ex:4016
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13899,19 +13900,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:772
+#: lib/vutuv_web/agent_docs/markdown.ex:775
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:774
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:777
+#: lib/vutuv_web/agent_docs/markdown.ex:780
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -13991,8 +13992,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:740
-#: lib/vutuv_web/agent_docs/text.ex:588
+#: lib/vutuv_web/agent_docs/markdown.ex:743
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14075,8 +14076,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:442
-#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:445
+#: lib/vutuv_web/agent_docs/text.ex:443
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14226,14 +14227,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2362
+#: lib/vutuv_web/components/post_components.ex:2364
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2384
+#: lib/vutuv_web/components/post_components.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14260,7 +14261,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4633
+#: lib/vutuv_web/components/post_components.ex:4635
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14664,7 +14665,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:993
+#: lib/vutuv_web/agent_docs/markdown.ex:996
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -15047,8 +15048,8 @@ msgstr ""
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:499
-#: lib/vutuv_web/agent_docs/text.ex:469
+#: lib/vutuv_web/agent_docs/markdown.ex:502
+#: lib/vutuv_web/agent_docs/text.ex:472
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
@@ -15431,29 +15432,29 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4592
+#: lib/vutuv_web/components/post_components.ex:4594
 #, elixir-autogen, elixir-format
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4596
+#: lib/vutuv_web/components/post_components.ex:4598
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4600
+#: lib/vutuv_web/components/post_components.ex:4602
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:995
-#: lib/vutuv_web/components/post_components.ex:4551
+#: lib/vutuv_web/agent_docs/markdown.ex:998
+#: lib/vutuv_web/components/post_components.ex:4553
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15463,14 +15464,14 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1177
-#: lib/vutuv_web/agent_docs/text.ex:695
+#: lib/vutuv_web/agent_docs/markdown.ex:1180
+#: lib/vutuv_web/agent_docs/text.ex:698
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1117
-#: lib/vutuv_web/components/post_components.ex:1671
+#: lib/vutuv_web/components/post_components.ex:1673
 #: lib/vutuv_web/live/fediverse_account_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "From another network"
@@ -15487,7 +15488,7 @@ msgid "Removed by the member"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:125
-#: lib/vutuv_web/agent_docs/markdown.ex:994
+#: lib/vutuv_web/agent_docs/markdown.ex:997
 #: lib/vutuv_web/agent_docs/text.ex:116
 #, elixir-autogen, elixir-format
 msgid "Replies from other networks"
@@ -15544,10 +15545,10 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1179
+#: lib/vutuv_web/agent_docs/markdown.ex:1182
 #: lib/vutuv_web/components/post_components.ex:1048
 #: lib/vutuv_web/components/post_components.ex:1248
-#: lib/vutuv_web/components/post_components.ex:2044
+#: lib/vutuv_web/components/post_components.ex:2046
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16208,22 +16209,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2603
+#: lib/vutuv_web/components/post_components.ex:2605
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2710
+#: lib/vutuv_web/components/post_components.ex:2712
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2718
+#: lib/vutuv_web/components/post_components.ex:2720
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2704
+#: lib/vutuv_web/components/post_components.ex:2706
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16243,13 +16244,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:875
+#: lib/vutuv_web/agent_docs/markdown.ex:878
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:436
-#: lib/vutuv_web/agent_docs/text.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:439
+#: lib/vutuv_web/agent_docs/text.ex:434
 #: lib/vutuv_web/templates/user/edit.html.heex:180
 #: lib/vutuv_web/templates/user/show.html.heex:217
 #: lib/vutuv_web/views/account_event_text.ex:176
@@ -16307,9 +16308,9 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/agent_docs/text.ex:662
-#: lib/vutuv_web/components/post_components.ex:3177
+#: lib/vutuv_web/agent_docs/markdown.ex:1110
+#: lib/vutuv_web/agent_docs/text.ex:665
+#: lib/vutuv_web/components/post_components.ex:3179
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16339,7 +16340,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3176
+#: lib/vutuv_web/components/post_components.ex:3178
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16349,29 +16350,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3557
+#: lib/vutuv_web/components/post_components.ex:3559
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2151
+#: lib/vutuv_web/components/post_components.ex:2153
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3560
+#: lib/vutuv_web/components/post_components.ex:3562
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3383
+#: lib/vutuv_web/components/post_components.ex:3385
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2919
+#: lib/vutuv_web/components/post_components.ex:2921
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16382,14 +16383,14 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1140
-#: lib/vutuv_web/agent_docs/text.ex:649
-#: lib/vutuv_web/components/post_components.ex:3594
+#: lib/vutuv_web/agent_docs/markdown.ex:1143
+#: lib/vutuv_web/agent_docs/text.ex:652
+#: lib/vutuv_web/components/post_components.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3175
+#: lib/vutuv_web/components/post_components.ex:3177
 #, elixir-autogen, elixir-format
 msgid "Previous photo"
 msgstr ""
@@ -16410,7 +16411,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2204
+#: lib/vutuv_web/components/post_components.ex:2206
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16430,7 +16431,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2195
+#: lib/vutuv_web/components/post_components.ex:2197
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16440,12 +16441,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2213
+#: lib/vutuv_web/components/post_components.ex:2215
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2147
+#: lib/vutuv_web/components/post_components.ex:2149
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16460,7 +16461,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2208
+#: lib/vutuv_web/components/post_components.ex:2210
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16470,7 +16471,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2161
+#: lib/vutuv_web/components/post_components.ex:2163
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16556,14 +16557,14 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1013
-#: lib/vutuv_web/components/post_components.ex:4589
+#: lib/vutuv_web/agent_docs/markdown.ex:1016
+#: lib/vutuv_web/components/post_components.ex:4591
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1011
-#: lib/vutuv_web/components/post_components.ex:4586
+#: lib/vutuv_web/agent_docs/markdown.ex:1014
+#: lib/vutuv_web/components/post_components.ex:4588
 #, elixir-autogen, elixir-format
 msgid "%{handle} shared this"
 msgstr ""
@@ -16573,7 +16574,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4478
+#: lib/vutuv_web/components/post_components.ex:4480
 #, elixir-autogen, elixir-format
 msgid "From other networks"
 msgstr ""
@@ -16910,7 +16911,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1999
+#: lib/vutuv_web/components/post_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16924,7 +16925,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2043
+#: lib/vutuv_web/components/post_components.ex:2045
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16949,12 +16950,12 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2016
+#: lib/vutuv_web/components/post_components.ex:2018
 #, elixir-autogen, elixir-format
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1978
+#: lib/vutuv_web/components/post_components.ex:1980
 #, elixir-autogen, elixir-format
 msgid "Mute %{handle}"
 msgstr ""
@@ -16971,7 +16972,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1985
+#: lib/vutuv_web/components/post_components.ex:1987
 #, elixir-autogen, elixir-format
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17186,34 +17187,34 @@ msgstr ""
 msgid "What is being measured"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:870
+#: lib/vutuv_web/agent_docs/markdown.ex:873
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1774
+#: lib/vutuv_web/components/post_components.ex:1776
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1803
+#: lib/vutuv_web/components/post_components.ex:1805
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1798
+#: lib/vutuv_web/components/post_components.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2080
+#: lib/vutuv_web/components/post_components.ex:2082
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2086
+#: lib/vutuv_web/components/post_components.ex:2088
 #, elixir-autogen, elixir-format
 msgid "That post is not here any more."
 msgstr ""
@@ -17223,7 +17224,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2199
+#: lib/vutuv_web/components/post_components.ex:2201
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17357,8 +17358,8 @@ msgstr ""
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:817
-#: lib/vutuv_web/agent_docs/text.ex:515
+#: lib/vutuv_web/agent_docs/markdown.ex:820
+#: lib/vutuv_web/agent_docs/text.ex:518
 #, elixir-autogen, elixir-format
 msgid "verified profile"
 msgstr ""
@@ -17989,7 +17990,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2083
+#: lib/vutuv_web/components/post_components.ex:2085
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18300,24 +18301,24 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:981
+#: lib/vutuv_web/agent_docs/markdown.ex:984
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3760
+#: lib/vutuv_web/components/post_components.ex:3762
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3762
+#: lib/vutuv_web/components/post_components.ex:3764
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3773
+#: lib/vutuv_web/components/post_components.ex:3775
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18342,12 +18343,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1036
+#: lib/vutuv_web/agent_docs/markdown.ex:1039
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1036
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18357,12 +18358,12 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1025
+#: lib/vutuv_web/agent_docs/markdown.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:185
+#: lib/vutuv_web/agent_docs/list_docs.ex:191
 #, elixir-autogen, elixir-format
 msgid "%{listed} of %{total} members are listed here; the others do not open their profile to search engines."
 msgstr ""
@@ -18712,7 +18713,7 @@ msgstr ""
 msgid "Employment references of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:723
+#: lib/vutuv_web/agent_docs/markdown.ex:726
 #, elixir-autogen, elixir-format
 msgid "document"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -25,9 +25,9 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:219
+#: lib/vutuv_web/agent_docs/markdown.ex:222
 #: lib/vutuv_web/agent_docs/section_docs.ex:127
-#: lib/vutuv_web/agent_docs/text.ex:207
+#: lib/vutuv_web/agent_docs/text.ex:210
 #: lib/vutuv_web/live/admin/deliverability_live.ex:170
 #: lib/vutuv_web/live/admin/deliverability_live.ex:251
 #: lib/vutuv_web/live/cv_live.ex:151
@@ -95,10 +95,10 @@ msgstr ""
 msgid "Birthdate"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:486
-#: lib/vutuv_web/agent_docs/markdown.ex:487
-#: lib/vutuv_web/agent_docs/text.ex:456
-#: lib/vutuv_web/agent_docs/text.ex:457
+#: lib/vutuv_web/agent_docs/markdown.ex:489
+#: lib/vutuv_web/agent_docs/markdown.ex:490
+#: lib/vutuv_web/agent_docs/text.ex:459
+#: lib/vutuv_web/agent_docs/text.ex:460
 #: lib/vutuv_web/templates/user/show.html.heex:1103
 #, elixir-autogen
 msgid "Birthday"
@@ -155,7 +155,7 @@ msgstr ""
 msgid "Couldn't follow back to %{name}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2726
+#: lib/vutuv_web/components/post_components.ex:2728
 #: lib/vutuv_web/components/ui.ex:3326
 #: lib/vutuv_web/live/admin/job_live.ex:493
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:622
@@ -204,7 +204,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2691
+#: lib/vutuv_web/components/post_components.ex:2693
 #: lib/vutuv_web/components/ui.ex:3317
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:613
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:653
@@ -299,14 +299,14 @@ msgstr ""
 msgid "Fax"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:472
+#: lib/vutuv_web/agent_docs/markdown.ex:475
 #: lib/vutuv_web/templates/user/edit.html.heex:125
 #, elixir-autogen
 msgid "First Name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:507
-#: lib/vutuv_web/agent_docs/text.ex:477
+#: lib/vutuv_web/agent_docs/markdown.ex:510
+#: lib/vutuv_web/agent_docs/text.ex:480
 #: lib/vutuv_web/controllers/follower_controller.ex:23
 #: lib/vutuv_web/live/fediverse_followers_live.ex:170
 #: lib/vutuv_web/live/notification_live/index.ex:954
@@ -317,8 +317,8 @@ msgstr ""
 msgid "Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:508
-#: lib/vutuv_web/agent_docs/text.ex:478
+#: lib/vutuv_web/agent_docs/markdown.ex:511
+#: lib/vutuv_web/agent_docs/text.ex:481
 #: lib/vutuv_web/components/fediverse_components.ex:223
 #: lib/vutuv_web/components/ui.ex:1976
 #: lib/vutuv_web/components/ui.ex:2001
@@ -376,7 +376,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:474
+#: lib/vutuv_web/agent_docs/markdown.ex:477
 #: lib/vutuv_web/templates/user/edit.html.heex:130
 #, elixir-autogen
 msgid "Last Name"
@@ -443,7 +443,7 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:473
+#: lib/vutuv_web/agent_docs/markdown.ex:476
 #: lib/vutuv_web/templates/user/edit.html.heex:135
 #, elixir-autogen
 msgid "Middle Name"
@@ -481,7 +481,7 @@ msgstr ""
 msgid "New message from @%{slug} on vutuv"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:476
+#: lib/vutuv_web/agent_docs/markdown.ex:479
 #: lib/vutuv_web/templates/user/edit.html.heex:140
 #, elixir-autogen
 msgid "Nickname"
@@ -562,7 +562,7 @@ msgstr ""
 msgid "Phone number updated successfully."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:471
+#: lib/vutuv_web/agent_docs/markdown.ex:474
 #: lib/vutuv_web/templates/user/edit.html.heex:145
 #, elixir-autogen
 msgid "Prefix"
@@ -742,7 +742,7 @@ msgstr ""
 msgid "Submit a bugreport or a feature request."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:475
+#: lib/vutuv_web/agent_docs/markdown.ex:478
 #: lib/vutuv_web/templates/user/edit.html.heex:150
 #, elixir-autogen
 msgid "Suffix"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "The 1,000 Users with the most Followers"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:147
+#: lib/vutuv_web/agent_docs/list_docs.ex:153
 #: lib/vutuv_web/templates/page/most_followed_users.html.heex:12
 #, elixir-autogen
 msgid "We haven't yet figured out the best way to help everyone discover other interesting vutuv users. So for now, this page simply lists the 1,000 users with the most followers."
@@ -1362,11 +1362,11 @@ msgid "Tag urls"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:33
-#: lib/vutuv_web/agent_docs/markdown.ex:379
-#: lib/vutuv_web/agent_docs/markdown.ex:920
+#: lib/vutuv_web/agent_docs/markdown.ex:382
+#: lib/vutuv_web/agent_docs/markdown.ex:923
 #: lib/vutuv_web/agent_docs/text.ex:30
-#: lib/vutuv_web/agent_docs/text.ex:404
-#: lib/vutuv_web/agent_docs/text.ex:623
+#: lib/vutuv_web/agent_docs/text.ex:407
+#: lib/vutuv_web/agent_docs/text.ex:626
 #: lib/vutuv_web/components/ui.ex:3616
 #: lib/vutuv_web/controllers/user_tag_controller.ex:43
 #: lib/vutuv_web/controllers/user_tag_controller.ex:60
@@ -1471,7 +1471,7 @@ msgstr ""
 msgid "Parent slug"
 msgstr ""
 
-#: lib/vutuv_web/templates/tag/single_card.html.heex:11
+#: lib/vutuv_web/templates/tag/single_card.html.heex:17
 #, elixir-autogen
 msgid "People you may know with this tag"
 msgstr ""
@@ -1508,7 +1508,7 @@ msgstr ""
 msgid "Tag name"
 msgstr ""
 
-#: lib/vutuv_web/templates/tag/single_card.html.heex:15
+#: lib/vutuv_web/templates/tag/single_card.html.heex:21
 #, elixir-autogen
 msgid "The most endorsed users with this tag"
 msgstr ""
@@ -1606,7 +1606,7 @@ msgstr ""
 msgid "Check your inbox"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3174
+#: lib/vutuv_web/components/post_components.ex:3176
 #: lib/vutuv_web/components/ui.ex:280
 #: lib/vutuv_web/live/admin/job_live.ex:325
 #: lib/vutuv_web/live/admin/job_live.ex:484
@@ -2081,7 +2081,7 @@ msgstr ""
 msgid "Delete post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2723
+#: lib/vutuv_web/components/post_components.ex:2725
 #: lib/vutuv_web/live/post_live/edit.ex:151
 #, elixir-autogen, elixir-format
 msgid "Delete this post permanently?"
@@ -2122,8 +2122,8 @@ msgstr ""
 msgid "Hide this post from…"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2677
 #: lib/vutuv_web/components/post_components.ex:2679
+#: lib/vutuv_web/components/post_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "Limited audience"
 msgstr ""
@@ -2188,13 +2188,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3110
-#: lib/vutuv_web/components/post_components.ex:3114
+#: lib/vutuv_web/components/post_components.ex:3112
+#: lib/vutuv_web/components/post_components.ex:3116
 #, elixir-autogen, elixir-format
 msgid "Read more"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3111
+#: lib/vutuv_web/components/post_components.ex:3113
 #: lib/vutuv_web/live/fediverse_account_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Show less"
@@ -2283,27 +2283,27 @@ msgstr ""
 msgid "What's new? Markdown is supported."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2674
+#: lib/vutuv_web/components/post_components.ex:2676
 #, elixir-autogen, elixir-format
 msgid "edited"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4318
+#: lib/vutuv_web/components/post_components.ex:4320
 #, elixir-autogen, elixir-format
 msgid "everyone else"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4322
+#: lib/vutuv_web/components/post_components.ex:4324
 #, elixir-autogen, elixir-format
 msgid "logged-out visitors"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4320
+#: lib/vutuv_web/components/post_components.ex:4322
 #, elixir-autogen, elixir-format
 msgid "people who don't follow you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4321
+#: lib/vutuv_web/components/post_components.ex:4323
 #, elixir-autogen, elixir-format
 msgid "people you don't follow"
 msgstr ""
@@ -2344,15 +2344,15 @@ msgstr ""
 msgid "All posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1551
-#: lib/vutuv_web/components/post_components.ex:4402
+#: lib/vutuv_web/components/post_components.ex:1553
+#: lib/vutuv_web/components/post_components.ex:4404
 #: lib/vutuv_web/components/ui.ex:2851
 #: lib/vutuv_web/views/user_html.ex:333
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:958
+#: lib/vutuv_web/agent_docs/markdown.ex:961
 #: lib/vutuv_web/live/post_live/saved.ex:175
 #: lib/vutuv_web/live/post_live/saved.ex:488
 #: lib/vutuv_web/live/shell_live.ex:595
@@ -2363,8 +2363,8 @@ msgstr ""
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1515
-#: lib/vutuv_web/components/post_components.ex:4625
+#: lib/vutuv_web/components/post_components.ex:1517
+#: lib/vutuv_web/components/post_components.ex:4627
 #: lib/vutuv_web/components/ui.ex:2837
 #: lib/vutuv_web/live/notification_live/index.ex:1023
 #: lib/vutuv_web/views/user_html.ex:343
@@ -2372,8 +2372,8 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:957
-#: lib/vutuv_web/components/post_components.ex:4634
+#: lib/vutuv_web/agent_docs/markdown.ex:960
+#: lib/vutuv_web/components/post_components.ex:4636
 #: lib/vutuv_web/live/notification_live/index.ex:956
 #: lib/vutuv_web/live/post_live/saved.ex:174
 #: lib/vutuv_web/live/post_live/saved.ex:485
@@ -2395,39 +2395,39 @@ msgstr ""
 msgid "Nothing here yet. Posts you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4391
+#: lib/vutuv_web/components/post_components.ex:4393
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be reposted."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1551
-#: lib/vutuv_web/components/post_components.ex:4402
+#: lib/vutuv_web/components/post_components.ex:1553
+#: lib/vutuv_web/components/post_components.ex:4404
 #: lib/vutuv_web/live/post_live/saved.ex:775
 #: lib/vutuv_web/views/user_html.ex:333
 #, elixir-autogen, elixir-format
 msgid "Remove bookmark"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1539
-#: lib/vutuv_web/components/post_components.ex:4388
+#: lib/vutuv_web/components/post_components.ex:1541
+#: lib/vutuv_web/components/post_components.ex:4390
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:169
 #, elixir-autogen, elixir-format
 msgid "Repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1729
-#: lib/vutuv_web/components/post_components.ex:3690
+#: lib/vutuv_web/components/post_components.ex:1731
+#: lib/vutuv_web/components/post_components.ex:3692
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1539
-#: lib/vutuv_web/components/post_components.ex:4388
+#: lib/vutuv_web/components/post_components.ex:1541
+#: lib/vutuv_web/components/post_components.ex:4390
 #, elixir-autogen, elixir-format
 msgid "Undo repost"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4625
+#: lib/vutuv_web/components/post_components.ex:4627
 #: lib/vutuv_web/live/post_live/saved.ex:774
 #: lib/vutuv_web/views/user_html.ex:343
 #, elixir-autogen, elixir-format
@@ -2449,7 +2449,7 @@ msgstr ""
 msgid "Welcome to vutuv!"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4678
+#: lib/vutuv_web/components/post_components.ex:4680
 #, elixir-autogen, elixir-format
 msgid "Only public posts can be answered."
 msgstr ""
@@ -2460,16 +2460,16 @@ msgstr ""
 msgid "Replies"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1526
-#: lib/vutuv_web/components/post_components.ex:4661
-#: lib/vutuv_web/components/post_components.ex:4662
+#: lib/vutuv_web/components/post_components.ex:1528
+#: lib/vutuv_web/components/post_components.ex:4663
+#: lib/vutuv_web/components/post_components.ex:4664
 #: lib/vutuv_web/live/notification_live/index.ex:1020
 #: lib/vutuv_web/live/post_live/reply.ex:36
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2645
+#: lib/vutuv_web/components/post_components.ex:2647
 #, elixir-autogen, elixir-format
 msgid "Reply to a deleted post"
 msgstr ""
@@ -2490,7 +2490,7 @@ msgstr ""
 msgid "replied to your post."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2139
+#: lib/vutuv_web/components/post_components.ex:2141
 #: lib/vutuv_web/live/post_live/remote_post_reply.ex:59
 #: lib/vutuv_web/live/post_live/remote_reply.ex:58
 #: lib/vutuv_web/live/post_live/reply.ex:50
@@ -2498,14 +2498,14 @@ msgstr ""
 msgid "Reply to %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2621
+#: lib/vutuv_web/components/post_components.ex:2623
 #, elixir-autogen, elixir-format
 msgid "Reply to a now-deleted post by %{handle}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2615
-#: lib/vutuv_web/components/post_components.ex:2637
-#: lib/vutuv_web/components/post_components.ex:2640
+#: lib/vutuv_web/components/post_components.ex:2617
+#: lib/vutuv_web/components/post_components.ex:2639
+#: lib/vutuv_web/components/post_components.ex:2642
 #, elixir-autogen, elixir-format
 msgid "Replying to %{handle}"
 msgstr ""
@@ -2759,8 +2759,8 @@ msgid_plural "+%{formatted} more tags"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:509
-#: lib/vutuv_web/agent_docs/text.ex:479
+#: lib/vutuv_web/agent_docs/markdown.ex:512
+#: lib/vutuv_web/agent_docs/text.ex:482
 #: lib/vutuv_web/controllers/connection_controller.ex:37
 #: lib/vutuv_web/live/notification_live/index.ex:955
 #: lib/vutuv_web/templates/connection/index.html.heex:5
@@ -2806,7 +2806,7 @@ msgid_plural "connections"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4319
+#: lib/vutuv_web/components/post_components.ex:4321
 #, elixir-autogen, elixir-format
 msgid "people who aren't your connections"
 msgstr ""
@@ -2911,8 +2911,8 @@ msgstr ""
 msgid "Bullying or harassment"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:298
-#: lib/vutuv_web/agent_docs/text.ex:282
+#: lib/vutuv_web/agent_docs/markdown.ex:301
+#: lib/vutuv_web/agent_docs/text.ex:285
 #: lib/vutuv_web/controllers/page_controller.ex:83
 #: lib/vutuv_web/templates/layout/app.html.heex:91
 #: lib/vutuv_web/templates/page/community.html.heex:4
@@ -3067,7 +3067,7 @@ msgstr ""
 msgid "Only visible to you"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2591
+#: lib/vutuv_web/components/post_components.ex:2593
 #, elixir-autogen, elixir-format
 msgid "Only you can see this post while a report about it is handled."
 msgstr ""
@@ -3143,8 +3143,8 @@ msgid "Remove it. That settles the report, no questions asked."
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1016
-#: lib/vutuv_web/components/post_components.ex:1990
-#: lib/vutuv_web/components/post_components.ex:2747
+#: lib/vutuv_web/components/post_components.ex:1992
+#: lib/vutuv_web/components/post_components.ex:2749
 #: lib/vutuv_web/live/organization_live/show.ex:284
 #: lib/vutuv_web/templates/user/show.html.heex:192
 #, elixir-autogen, elixir-format
@@ -3794,12 +3794,12 @@ msgstr ""
 msgid "Scroll inside the frame, or click to open the full image."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:601
+#: lib/vutuv_web/agent_docs/markdown.ex:604
 #, elixir-autogen, elixir-format
 msgid "%{count} endorsements"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1079
+#: lib/vutuv_web/agent_docs/markdown.ex:1082
 #, elixir-autogen, elixir-format
 msgid "%{count} on this page, use ?page=N"
 msgstr ""
@@ -3813,16 +3813,16 @@ msgstr ""
 #: lib/vutuv_web/agent_docs/markdown.ex:82
 #: lib/vutuv_web/agent_docs/markdown.ex:162
 #: lib/vutuv_web/agent_docs/markdown.ex:175
-#: lib/vutuv_web/agent_docs/markdown.ex:920
+#: lib/vutuv_web/agent_docs/markdown.ex:923
 #: lib/vutuv_web/agent_docs/text.ex:79
 #: lib/vutuv_web/agent_docs/text.ex:150
 #: lib/vutuv_web/agent_docs/text.ex:163
-#: lib/vutuv_web/agent_docs/text.ex:623
+#: lib/vutuv_web/agent_docs/text.ex:626
 #, elixir-autogen, elixir-format
 msgid "%{count} total"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:47
+#: lib/vutuv_web/agent_docs/list_docs.ex:48
 #, elixir-autogen, elixir-format
 msgid "Followers of %{name}"
 msgstr ""
@@ -3834,44 +3834,44 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:938
-#: lib/vutuv_web/agent_docs/text.ex:634
+#: lib/vutuv_web/agent_docs/markdown.ex:941
+#: lib/vutuv_web/agent_docs/text.ex:637
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:935
-#: lib/vutuv_web/agent_docs/text.ex:631
+#: lib/vutuv_web/agent_docs/markdown.ex:938
+#: lib/vutuv_web/agent_docs/text.ex:634
 #, elixir-autogen, elixir-format
 msgid "In reply to a deleted post."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:942
-#: lib/vutuv_web/agent_docs/markdown.ex:1156
-#: lib/vutuv_web/agent_docs/text.ex:637
-#: lib/vutuv_web/agent_docs/text.ex:681
+#: lib/vutuv_web/agent_docs/markdown.ex:945
+#: lib/vutuv_web/agent_docs/markdown.ex:1159
+#: lib/vutuv_web/agent_docs/text.ex:640
+#: lib/vutuv_web/agent_docs/text.ex:684
 #, elixir-autogen, elixir-format
 msgid "In reply to a post by %{name}."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:444
-#: lib/vutuv_web/agent_docs/text.ex:442
+#: lib/vutuv_web/agent_docs/markdown.ex:447
+#: lib/vutuv_web/agent_docs/text.ex:445
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:188
-#: lib/vutuv_web/agent_docs/text.ex:176
+#: lib/vutuv_web/agent_docs/markdown.ex:191
+#: lib/vutuv_web/agent_docs/text.ex:179
 #, elixir-autogen, elixir-format
 msgid "Most endorsed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:145
+#: lib/vutuv_web/agent_docs/list_docs.ex:151
 #, elixir-autogen, elixir-format
 msgid "Most followed members"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:48
+#: lib/vutuv_web/agent_docs/list_docs.ex:49
 #, elixir-autogen, elixir-format
 msgid "People %{name} follows"
 msgstr ""
@@ -3896,23 +3896,23 @@ msgstr ""
 msgid "Posts (%{count} total)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:438
-#: lib/vutuv_web/agent_docs/text.ex:436
+#: lib/vutuv_web/agent_docs/markdown.ex:441
+#: lib/vutuv_web/agent_docs/text.ex:439
 #, elixir-autogen, elixir-format
 msgid "Verified profile: yes"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:889
+#: lib/vutuv_web/agent_docs/markdown.ex:892
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:789
+#: lib/vutuv_web/agent_docs/markdown.ex:792
 #, elixir-autogen, elixir-format
 msgid "today"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:790
+#: lib/vutuv_web/agent_docs/markdown.ex:793
 #, elixir-autogen, elixir-format
 msgid "until %{date}"
 msgstr ""
@@ -3922,7 +3922,7 @@ msgstr ""
 msgid "This page in %{language}: %{url}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:49
+#: lib/vutuv_web/agent_docs/list_docs.ex:50
 #, elixir-autogen, elixir-format
 msgid "Connections of %{name}"
 msgstr ""
@@ -3987,8 +3987,8 @@ msgstr ""
 msgid "Billing name"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:312
-#: lib/vutuv_web/agent_docs/text.ex:290
+#: lib/vutuv_web/agent_docs/markdown.ex:315
+#: lib/vutuv_web/agent_docs/text.ex:293
 #, elixir-autogen, elixir-format
 msgid "Book online (login required): %{url}"
 msgstr ""
@@ -4041,8 +4041,8 @@ msgstr ""
 msgid "Markdown is supported. At most %{max} characters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:302
-#: lib/vutuv_web/agent_docs/text.ex:286
+#: lib/vutuv_web/agent_docs/markdown.ex:305
+#: lib/vutuv_web/agent_docs/text.ex:289
 #: lib/vutuv_web/templates/ad/index.html.heex:43
 #, elixir-autogen, elixir-format
 msgid "Next available day"
@@ -4058,8 +4058,8 @@ msgstr ""
 msgid "One text-only ad per calendar day, seen by every visitor."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:299
-#: lib/vutuv_web/agent_docs/text.ex:283
+#: lib/vutuv_web/agent_docs/markdown.ex:302
+#: lib/vutuv_web/agent_docs/text.ex:286
 #: lib/vutuv_web/templates/ad/index.html.heex:35
 #: lib/vutuv_web/templates/ad/preview.html.heex:32
 #: lib/vutuv_web/views/admin/ad_html.ex:59
@@ -4273,14 +4273,14 @@ msgstr ""
 msgid "deleted account"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:304
-#: lib/vutuv_web/agent_docs/text.ex:288
+#: lib/vutuv_web/agent_docs/markdown.ex:307
+#: lib/vutuv_web/agent_docs/text.ex:291
 #, elixir-autogen, elixir-format
 msgid "Already booked"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:300
-#: lib/vutuv_web/agent_docs/text.ex:284
+#: lib/vutuv_web/agent_docs/markdown.ex:303
+#: lib/vutuv_web/agent_docs/text.ex:287
 #, elixir-autogen, elixir-format
 msgid "Booking window"
 msgstr ""
@@ -4556,8 +4556,8 @@ msgstr ""
 msgid "Not an exact match, but sounds like your search."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:327
-#: lib/vutuv_web/agent_docs/text.ex:352
+#: lib/vutuv_web/agent_docs/markdown.ex:330
+#: lib/vutuv_web/agent_docs/text.ex:355
 #: lib/vutuv_web/components/saved_search_components.ex:57
 #: lib/vutuv_web/components/ui.ex:516
 #: lib/vutuv_web/live/notification_live/index.ex:877
@@ -4682,8 +4682,8 @@ msgstr ""
 msgid "Edit your profile and its sections"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:241
-#: lib/vutuv_web/agent_docs/text.ex:228
+#: lib/vutuv_web/agent_docs/markdown.ex:244
+#: lib/vutuv_web/agent_docs/text.ex:231
 #: lib/vutuv_web/live/admin/job_live.ex:393
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:142
 #: lib/vutuv_web/live/job_posting_live/show.ex:136
@@ -5376,9 +5376,9 @@ msgstr ""
 msgid "Footer navigation"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2810
-#: lib/vutuv_web/components/post_components.ex:2862
-#: lib/vutuv_web/components/post_components.ex:3254
+#: lib/vutuv_web/components/post_components.ex:2812
+#: lib/vutuv_web/components/post_components.ex:2864
+#: lib/vutuv_web/components/post_components.ex:3256
 #: lib/vutuv_web/live/notification_live/index.ex:680
 #: lib/vutuv_web/live/post_live/feed.ex:1259
 #: lib/vutuv_web/views/user_html.ex:111
@@ -6099,8 +6099,8 @@ msgid_plural "%{count} years old"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:488
-#: lib/vutuv_web/agent_docs/text.ex:458
+#: lib/vutuv_web/agent_docs/markdown.ex:491
+#: lib/vutuv_web/agent_docs/text.ex:461
 #, elixir-autogen, elixir-format
 msgid "Age"
 msgstr ""
@@ -6172,7 +6172,7 @@ msgstr ""
 msgid "Previous day"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:957
+#: lib/vutuv_web/agent_docs/markdown.ex:960
 #: lib/vutuv_web/components/post_components.ex:348
 #: lib/vutuv_web/templates/settings/auto_post_deletion.html.heex:185
 #: lib/vutuv_web/views/admin/report_html.ex:36
@@ -6257,7 +6257,7 @@ msgstr ""
 msgid "Endorsed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:118
+#: lib/vutuv_web/agent_docs/list_docs.ex:124
 #: lib/vutuv_web/templates/user_tag/endorsers.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Members who endorsed %{name} for %{tag}"
@@ -6277,7 +6277,7 @@ msgstr ""
 msgid "and %{count} more"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:933
+#: lib/vutuv_web/agent_docs/markdown.ex:936
 #, elixir-autogen, elixir-format
 msgid "endorsed %{date}"
 msgstr ""
@@ -6609,7 +6609,7 @@ msgstr ""
 msgid "Go to profile to follow"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2744
+#: lib/vutuv_web/components/post_components.ex:2746
 #, elixir-autogen, elixir-format
 msgid "Mute @%{handle}"
 msgstr ""
@@ -6619,7 +6619,7 @@ msgstr ""
 msgid "Professional"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2743
+#: lib/vutuv_web/components/post_components.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Unmute @%{handle}"
 msgstr ""
@@ -6814,8 +6814,8 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:215
-#: lib/vutuv_web/agent_docs/text.ex:203
+#: lib/vutuv_web/agent_docs/markdown.ex:218
+#: lib/vutuv_web/agent_docs/text.ex:206
 #: lib/vutuv_web/live/account_activity_live.ex:167
 #: lib/vutuv_web/live/admin/activity_live.ex:211
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:254
@@ -7301,7 +7301,7 @@ msgstr ""
 msgid "applies to the whole list, not just this page"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4547
+#: lib/vutuv_web/components/post_components.ex:4549
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "+%{count} more"
@@ -7476,17 +7476,17 @@ msgstr ""
 msgid "The vutuv newsfeed of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1084
+#: lib/vutuv_web/agent_docs/markdown.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Your feed is empty."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1087
+#: lib/vutuv_web/agent_docs/markdown.ex:1090
 #, elixir-autogen, elixir-format
 msgid "%{count} posts on this page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1094
+#: lib/vutuv_web/agent_docs/markdown.ex:1097
 #, elixir-autogen, elixir-format
 msgid "more posts available, append ?cursor=%{cursor}"
 msgstr ""
@@ -8471,12 +8471,12 @@ msgstr ""
 msgid "All %{count} members whose profiles are open to search engines, filed alphabetically by last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:181
+#: lib/vutuv_web/agent_docs/list_docs.ex:187
 #, elixir-autogen, elixir-format
 msgid "All members who allow search engines to index their profile, grouped by the first letter of their last name."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:166
+#: lib/vutuv_web/agent_docs/list_docs.ex:172
 #: lib/vutuv_web/controllers/directory_controller.ex:35
 #: lib/vutuv_web/templates/directory/index.html.heex:2
 #: lib/vutuv_web/templates/directory/index.html.heex:3
@@ -8492,7 +8492,7 @@ msgstr ""
 msgid "Members by initial"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:198
+#: lib/vutuv_web/agent_docs/list_docs.ex:204
 #: lib/vutuv_web/controllers/directory_controller.ex:62
 #: lib/vutuv_web/templates/directory/show.html.heex:2
 #, elixir-autogen, elixir-format
@@ -8511,7 +8511,7 @@ msgid_plural "%{formatted} members"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:204
+#: lib/vutuv_web/agent_docs/list_docs.ex:210
 #, elixir-autogen, elixir-format
 msgid "The member directory's %{letter} page, sorted by last name."
 msgstr ""
@@ -8607,10 +8607,10 @@ msgstr ""
 msgid "Write it under Admin › Legal pages"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:498
-#: lib/vutuv_web/agent_docs/markdown.ex:502
-#: lib/vutuv_web/agent_docs/text.ex:468
-#: lib/vutuv_web/agent_docs/text.ex:472
+#: lib/vutuv_web/agent_docs/markdown.ex:501
+#: lib/vutuv_web/agent_docs/markdown.ex:505
+#: lib/vutuv_web/agent_docs/text.ex:471
+#: lib/vutuv_web/agent_docs/text.ex:475
 #: lib/vutuv_web/components/ui.ex:3688
 #: lib/vutuv_web/controllers/admin/fediverse_controller.ex:38
 #: lib/vutuv_web/controllers/settings_controller.ex:322
@@ -8683,7 +8683,7 @@ msgid "Employment"
 msgstr ""
 
 #: lib/vutuv/jobs/job_posting.ex:153
-#: lib/vutuv_web/agent_docs/markdown.ex:661
+#: lib/vutuv_web/agent_docs/markdown.ex:664
 #: lib/vutuv_web/views/work_experience_html.ex:27
 #, elixir-autogen, elixir-format
 msgid "Internship"
@@ -8704,7 +8704,7 @@ msgstr ""
 msgid "Professional Experience"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:662
+#: lib/vutuv_web/agent_docs/markdown.ex:665
 #: lib/vutuv_web/views/work_experience_html.ex:31
 #: lib/vutuv_web/views/work_experience_html.ex:38
 #, elixir-autogen, elixir-format
@@ -8735,13 +8735,13 @@ msgstr ""
 msgid "Higher Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:699
+#: lib/vutuv_web/agent_docs/markdown.ex:702
 #: lib/vutuv_web/views/education_html.ex:23
 #, elixir-autogen, elixir-format
 msgid "School Education"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:698
+#: lib/vutuv_web/agent_docs/markdown.ex:701
 #: lib/vutuv_web/views/education_html.ex:22
 #, elixir-autogen, elixir-format
 msgid "Vocational Training"
@@ -8767,14 +8767,14 @@ msgstr ""
 msgid "CV download"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3693
+#: lib/vutuv_web/components/post_components.ex:3695
 #, elixir-autogen, elixir-format
 msgid "Reposted by %{name} and %{formatted} other"
 msgid_plural "Reposted by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:892
+#: lib/vutuv_web/agent_docs/markdown.ex:895
 #, elixir-autogen, elixir-format
 msgid "reposted by %{name} and %{count} more"
 msgstr ""
@@ -8852,14 +8852,14 @@ msgstr ""
 msgid "The CV of %{name} on vutuv: work experience, education and skills to view and download."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:660
+#: lib/vutuv_web/agent_docs/markdown.ex:663
 #: lib/vutuv_web/views/work_experience_html.ex:26
 #: lib/vutuv_web/views/work_experience_html.ex:36
 #, elixir-autogen, elixir-format
 msgid "Freelance / Self-employed"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:663
+#: lib/vutuv_web/agent_docs/markdown.ex:666
 #: lib/vutuv_web/views/work_experience_html.ex:32
 #: lib/vutuv_web/views/work_experience_html.ex:39
 #, elixir-autogen, elixir-format
@@ -9001,8 +9001,8 @@ msgstr ""
 msgid "Honor tag (only site admins can assign it)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:518
-#: lib/vutuv_web/agent_docs/text.ex:486
+#: lib/vutuv_web/agent_docs/markdown.ex:521
+#: lib/vutuv_web/agent_docs/text.ex:489
 #, elixir-autogen, elixir-format
 msgid "honor tag"
 msgstr ""
@@ -9424,8 +9424,8 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:440
-#: lib/vutuv_web/agent_docs/text.ex:438
+#: lib/vutuv_web/agent_docs/markdown.ex:443
+#: lib/vutuv_web/agent_docs/text.ex:441
 #, elixir-autogen, elixir-format
 msgid "Employment status"
 msgstr ""
@@ -9528,7 +9528,7 @@ msgstr[1] ""
 msgid "Add a certificate or license"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:783
+#: lib/vutuv_web/agent_docs/markdown.ex:786
 #: lib/vutuv_web/views/qualification_html.ex:11
 #, elixir-autogen, elixir-format
 msgid "Certificate"
@@ -9606,7 +9606,7 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:758
+#: lib/vutuv_web/agent_docs/markdown.ex:761
 #, elixir-autogen, elixir-format
 msgid "ID: %{id}"
 msgstr ""
@@ -9623,7 +9623,7 @@ msgstr ""
 msgid "Issuer"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:782
+#: lib/vutuv_web/agent_docs/markdown.ex:785
 #: lib/vutuv_web/views/qualification_html.ex:12
 #, elixir-autogen, elixir-format
 msgid "License"
@@ -9650,7 +9650,7 @@ msgstr ""
 msgid "Verification link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:756
+#: lib/vutuv_web/agent_docs/markdown.ex:759
 #, elixir-autogen, elixir-format
 msgid "awarded %{date}"
 msgstr ""
@@ -9665,7 +9665,7 @@ msgstr ""
 msgid "e.g. Amazon Web Services"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:757
+#: lib/vutuv_web/agent_docs/markdown.ex:760
 #: lib/vutuv_web/views/qualification_html.ex:77
 #: lib/vutuv_web/views/qualification_html.ex:80
 #, elixir-autogen, elixir-format
@@ -9682,7 +9682,7 @@ msgstr ""
 msgid "Preferred"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:618
+#: lib/vutuv_web/agent_docs/markdown.ex:621
 #: lib/vutuv_web/live/section_reorder_live.ex:280
 #: lib/vutuv_web/views/language_html.ex:79
 #, elixir-autogen, elixir-format
@@ -10185,21 +10185,21 @@ msgstr ""
 msgid "set it up on this device"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:578
+#: lib/vutuv_web/agent_docs/markdown.ex:581
 #, elixir-autogen, elixir-format
 msgid "%{count} follower"
 msgid_plural "%{count} followers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:576
+#: lib/vutuv_web/agent_docs/markdown.ex:579
 #, elixir-autogen, elixir-format
 msgid "%{count} repository"
 msgid_plural "%{count} repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:574
+#: lib/vutuv_web/agent_docs/markdown.ex:577
 #, elixir-autogen, elixir-format
 msgid "%{count} star"
 msgid_plural "%{count} stars"
@@ -10254,12 +10254,12 @@ msgstr ""
 msgid "When off, the Social Media card lists your accounts as plain links only."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:592
+#: lib/vutuv_web/agent_docs/markdown.ex:595
 #, elixir-autogen, elixir-format
 msgid "last active %{date}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:579
+#: lib/vutuv_web/agent_docs/markdown.ex:582
 #, elixir-autogen, elixir-format
 msgid "since %{date}"
 msgstr ""
@@ -10404,7 +10404,7 @@ msgstr ""
 msgid "Manage your vutuv account: profile, privacy, notifications and sign-in."
 msgstr ""
 
-#: lib/vutuv_web/controllers/tag_controller.ex:74
+#: lib/vutuv_web/controllers/tag_controller.ex:108
 #, elixir-autogen, elixir-format
 msgid "Members on vutuv tagged %{tag}."
 msgstr ""
@@ -11133,8 +11133,8 @@ msgstr ""
 msgid "Verified domains"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:216
-#: lib/vutuv_web/agent_docs/text.ex:204
+#: lib/vutuv_web/agent_docs/markdown.ex:219
+#: lib/vutuv_web/agent_docs/text.ex:207
 #, elixir-autogen, elixir-format
 msgid "Verified via"
 msgstr ""
@@ -11161,8 +11161,8 @@ msgstr ""
 msgid "We could not find the record or file yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:218
-#: lib/vutuv_web/agent_docs/text.ex:206
+#: lib/vutuv_web/agent_docs/markdown.ex:221
+#: lib/vutuv_web/agent_docs/text.ex:209
 #: lib/vutuv_web/live/organization_live/edit.ex:287
 #: lib/vutuv_web/live/organization_live/new.ex:115
 #, elixir-autogen, elixir-format
@@ -11246,10 +11246,11 @@ msgstr ""
 msgid "Alias removed."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:319
-#: lib/vutuv_web/agent_docs/text.ex:345
+#: lib/vutuv_web/agent_docs/markdown.ex:322
+#: lib/vutuv_web/agent_docs/text.ex:348
 #: lib/vutuv_web/live/organization_live/edit.ex:353
 #: lib/vutuv_web/live/organization_live/show.ex:360
+#: lib/vutuv_web/templates/tag/single_card.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "Also known as"
 msgstr ""
@@ -11482,8 +11483,8 @@ msgstr ""
 msgid "primary"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:340
-#: lib/vutuv_web/agent_docs/text.ex:365
+#: lib/vutuv_web/agent_docs/markdown.ex:343
+#: lib/vutuv_web/agent_docs/text.ex:368
 #: lib/vutuv_web/live/admin/organization_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "verified"
@@ -11616,8 +11617,8 @@ msgstr ""
 msgid "We could not find the proof yet. It can take a while to propagate. Please try again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:803
-#: lib/vutuv_web/agent_docs/text.ex:596
+#: lib/vutuv_web/agent_docs/markdown.ex:806
+#: lib/vutuv_web/agent_docs/text.ex:599
 #, elixir-autogen, elixir-format
 msgid "verified webpage"
 msgstr ""
@@ -11653,8 +11654,8 @@ msgstr ""
 msgid "Remove link"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:331
-#: lib/vutuv_web/agent_docs/text.ex:356
+#: lib/vutuv_web/agent_docs/markdown.ex:334
+#: lib/vutuv_web/agent_docs/text.ex:359
 #, elixir-autogen, elixir-format
 msgid "former"
 msgstr ""
@@ -12099,10 +12100,10 @@ msgstr ""
 msgid "Edit posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:235
-#: lib/vutuv_web/agent_docs/markdown.ex:364
-#: lib/vutuv_web/agent_docs/text.ex:222
-#: lib/vutuv_web/agent_docs/text.ex:389
+#: lib/vutuv_web/agent_docs/markdown.ex:238
+#: lib/vutuv_web/agent_docs/markdown.ex:367
+#: lib/vutuv_web/agent_docs/text.ex:225
+#: lib/vutuv_web/agent_docs/text.ex:392
 #: lib/vutuv_web/live/admin/job_live.ex:344
 #: lib/vutuv_web/templates/job_reference/form_content.html.heex:17
 #: lib/vutuv_web/views/account_event_text.ex:188
@@ -12115,10 +12116,10 @@ msgstr ""
 msgid "Employer name (optional)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:236
-#: lib/vutuv_web/agent_docs/markdown.ex:365
-#: lib/vutuv_web/agent_docs/text.ex:223
-#: lib/vutuv_web/agent_docs/text.ex:390
+#: lib/vutuv_web/agent_docs/markdown.ex:239
+#: lib/vutuv_web/agent_docs/markdown.ex:368
+#: lib/vutuv_web/agent_docs/text.ex:226
+#: lib/vutuv_web/agent_docs/text.ex:393
 #: lib/vutuv_web/live/job_board_live.ex:367
 #: lib/vutuv_web/live/job_posting_live/form.ex:345
 #, elixir-autogen, elixir-format
@@ -12196,12 +12197,12 @@ msgstr ""
 msgid "Let search engines index this posting."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:346
-#: lib/vutuv_web/agent_docs/markdown.ex:350
-#: lib/vutuv_web/agent_docs/markdown.ex:352
-#: lib/vutuv_web/agent_docs/text.ex:371
-#: lib/vutuv_web/agent_docs/text.ex:375
-#: lib/vutuv_web/agent_docs/text.ex:377
+#: lib/vutuv_web/agent_docs/markdown.ex:349
+#: lib/vutuv_web/agent_docs/markdown.ex:353
+#: lib/vutuv_web/agent_docs/markdown.ex:355
+#: lib/vutuv_web/agent_docs/text.ex:374
+#: lib/vutuv_web/agent_docs/text.ex:378
+#: lib/vutuv_web/agent_docs/text.ex:380
 #: lib/vutuv_web/live/job_posting_live/form.ex:386
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -12250,8 +12251,8 @@ msgstr ""
 msgid "New posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:247
-#: lib/vutuv_web/agent_docs/text.ex:233
+#: lib/vutuv_web/agent_docs/markdown.ex:250
+#: lib/vutuv_web/agent_docs/text.ex:236
 #: lib/vutuv_web/live/job_posting_live/form.ex:525
 #: lib/vutuv_web/live/job_posting_live/show.ex:154
 #, elixir-autogen, elixir-format
@@ -12335,10 +12336,10 @@ msgstr ""
 msgid "Postal code"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:240
-#: lib/vutuv_web/agent_docs/markdown.ex:369
-#: lib/vutuv_web/agent_docs/text.ex:227
-#: lib/vutuv_web/agent_docs/text.ex:394
+#: lib/vutuv_web/agent_docs/markdown.ex:243
+#: lib/vutuv_web/agent_docs/markdown.ex:372
+#: lib/vutuv_web/agent_docs/text.ex:230
+#: lib/vutuv_web/agent_docs/text.ex:397
 #: lib/vutuv_web/live/job_posting_live/show.ex:133
 #, elixir-autogen, elixir-format
 msgid "Posted"
@@ -12363,10 +12364,10 @@ msgstr ""
 #: lib/vutuv/accounts/user.ex:1085
 #: lib/vutuv/jobs/job_posting.ex:164
 #: lib/vutuv/notifications/emailer.ex:497
-#: lib/vutuv_web/agent_docs/markdown.ex:350
-#: lib/vutuv_web/agent_docs/markdown.ex:352
-#: lib/vutuv_web/agent_docs/text.ex:375
-#: lib/vutuv_web/agent_docs/text.ex:377
+#: lib/vutuv_web/agent_docs/markdown.ex:353
+#: lib/vutuv_web/agent_docs/markdown.ex:355
+#: lib/vutuv_web/agent_docs/text.ex:378
+#: lib/vutuv_web/agent_docs/text.ex:380
 #: lib/vutuv_web/components/job_components.ex:132
 #: lib/vutuv_web/components/job_components.ex:133
 #, elixir-autogen, elixir-format
@@ -12378,18 +12379,18 @@ msgstr ""
 msgid "Report this posting"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:246
-#: lib/vutuv_web/agent_docs/text.ex:232
+#: lib/vutuv_web/agent_docs/markdown.ex:249
+#: lib/vutuv_web/agent_docs/text.ex:235
 #: lib/vutuv_web/live/job_posting_live/form.ex:515
 #: lib/vutuv_web/live/job_posting_live/show.ex:149
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:239
-#: lib/vutuv_web/agent_docs/markdown.ex:368
-#: lib/vutuv_web/agent_docs/text.ex:226
-#: lib/vutuv_web/agent_docs/text.ex:393
+#: lib/vutuv_web/agent_docs/markdown.ex:242
+#: lib/vutuv_web/agent_docs/markdown.ex:371
+#: lib/vutuv_web/agent_docs/text.ex:229
+#: lib/vutuv_web/agent_docs/text.ex:396
 #, elixir-autogen, elixir-format
 msgid "Salary"
 msgstr ""
@@ -12483,10 +12484,10 @@ msgstr ""
 msgid "Working student"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:237
-#: lib/vutuv_web/agent_docs/markdown.ex:366
-#: lib/vutuv_web/agent_docs/text.ex:224
-#: lib/vutuv_web/agent_docs/text.ex:391
+#: lib/vutuv_web/agent_docs/markdown.ex:240
+#: lib/vutuv_web/agent_docs/markdown.ex:369
+#: lib/vutuv_web/agent_docs/text.ex:227
+#: lib/vutuv_web/agent_docs/text.ex:394
 #: lib/vutuv_web/live/job_posting_live/form.ex:360
 #, elixir-autogen, elixir-format
 msgid "Workplace"
@@ -12689,13 +12690,13 @@ msgstr ""
 msgid "All countries"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:387
+#: lib/vutuv_web/agent_docs/markdown.ex:390
 #: lib/vutuv_web/templates/tag/show.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:411
+#: lib/vutuv_web/agent_docs/text.ex:414
 #, elixir-autogen, elixir-format
 msgid "All jobs with this tag: %{url}"
 msgstr ""
@@ -12741,12 +12742,12 @@ msgstr ""
 msgid "More jobs"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:259
+#: lib/vutuv_web/agent_docs/markdown.ex:262
 #, elixir-autogen, elixir-format
 msgid "Next page"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/text.ex:245
+#: lib/vutuv_web/agent_docs/text.ex:248
 #, elixir-autogen, elixir-format
 msgid "Next page: %{url}"
 msgstr ""
@@ -12761,10 +12762,10 @@ msgstr ""
 msgid "No matching positions. Try adjusting the filters."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:385
-#: lib/vutuv_web/agent_docs/markdown.ex:397
-#: lib/vutuv_web/agent_docs/text.ex:409
-#: lib/vutuv_web/agent_docs/text.ex:421
+#: lib/vutuv_web/agent_docs/markdown.ex:388
+#: lib/vutuv_web/agent_docs/markdown.ex:400
+#: lib/vutuv_web/agent_docs/text.ex:412
+#: lib/vutuv_web/agent_docs/text.ex:424
 #: lib/vutuv_web/live/organization_live/show.ex:329
 #: lib/vutuv_web/templates/tag/show.html.heex:45
 #, elixir-autogen, elixir-format
@@ -13084,7 +13085,7 @@ msgstr ""
 msgid "Stop e-mail alerts for your saved search \"%{label}\"?"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2098
+#: lib/vutuv_web/components/post_components.ex:2100
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
@@ -13468,8 +13469,8 @@ msgstr ""
 msgid "Insert into text"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:191
-#: lib/vutuv_web/agent_docs/text.ex:179
+#: lib/vutuv_web/agent_docs/markdown.ex:194
+#: lib/vutuv_web/agent_docs/text.ex:182
 #: lib/vutuv_web/live/tag_live/timeline.ex:255
 #, elixir-autogen, elixir-format
 msgid "Posts with this tag"
@@ -13685,34 +13686,34 @@ msgstr ""
 msgid "added %{count} new entries to their CV:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4181
+#: lib/vutuv_web/components/post_components.ex:4183
 #, elixir-autogen, elixir-format
 msgid "Audiobook"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1046
-#: lib/vutuv_web/components/post_components.ex:4138
+#: lib/vutuv_web/agent_docs/markdown.ex:1049
+#: lib/vutuv_web/components/post_components.ex:4140
 #, elixir-autogen, elixir-format
 msgid "Book review"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4182
+#: lib/vutuv_web/components/post_components.ex:4184
 #, elixir-autogen, elixir-format
 msgid "Cinema"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4184
+#: lib/vutuv_web/components/post_components.ex:4186
 #, elixir-autogen, elixir-format
 msgid "DVD/Blu-ray"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4180
+#: lib/vutuv_web/components/post_components.ex:4182
 #, elixir-autogen, elixir-format
 msgid "E-book"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1046
-#: lib/vutuv_web/components/post_components.ex:4137
+#: lib/vutuv_web/agent_docs/markdown.ex:1049
+#: lib/vutuv_web/components/post_components.ex:4139
 #, elixir-autogen, elixir-format
 msgid "Film review"
 msgstr ""
@@ -13723,12 +13724,12 @@ msgstr ""
 msgid "Look up"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4179
+#: lib/vutuv_web/components/post_components.ex:4181
 #, elixir-autogen, elixir-format
 msgid "Printed book"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4183
+#: lib/vutuv_web/components/post_components.ex:4185
 #, elixir-autogen, elixir-format
 msgid "Streaming"
 msgstr ""
@@ -13748,7 +13749,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4220
+#: lib/vutuv_web/components/post_components.ex:4222
 #: lib/vutuv_web/views/job_reference_html.ex:180
 #, elixir-autogen, elixir-format
 msgid "%{formatted} page"
@@ -13756,27 +13757,27 @@ msgid_plural "%{formatted} pages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4250
+#: lib/vutuv_web/components/post_components.ex:4252
 #, elixir-autogen, elixir-format
 msgid "%{hours} h"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4251
+#: lib/vutuv_web/components/post_components.ex:4253
 #, elixir-autogen, elixir-format
 msgid "%{hours} h %{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4249
+#: lib/vutuv_web/components/post_components.ex:4251
 #, elixir-autogen, elixir-format
 msgid "%{minutes} min"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4209
+#: lib/vutuv_web/components/post_components.ex:4211
 #, elixir-autogen, elixir-format
 msgid "(print edition)"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4256
+#: lib/vutuv_web/components/post_components.ex:4258
 #, elixir-autogen, elixir-format
 msgid "approx. %{duration}"
 msgstr ""
@@ -13801,12 +13802,12 @@ msgstr ""
 msgid "With qualification:"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:647
+#: lib/vutuv_web/agent_docs/markdown.ex:650
 #, elixir-autogen, elixir-format
 msgid "With qualification: %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4023
+#: lib/vutuv_web/components/post_components.ex:4025
 #, elixir-autogen, elixir-format
 msgid "Publisher:"
 msgstr ""
@@ -13854,7 +13855,7 @@ msgstr ""
 msgid "endorsed you for %{tags}."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4014
+#: lib/vutuv_web/components/post_components.ex:4016
 #, elixir-autogen, elixir-format
 msgid "by:"
 msgstr ""
@@ -13897,19 +13898,19 @@ msgid_plural "Used for %{formatted} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:772
+#: lib/vutuv_web/agent_docs/markdown.ex:775
 #, elixir-autogen, elixir-format
 msgid "currently in use"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:771
+#: lib/vutuv_web/agent_docs/markdown.ex:774
 #, elixir-autogen, elixir-format
 msgid "used for %{count} job"
 msgid_plural "used for %{count} jobs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:777
+#: lib/vutuv_web/agent_docs/markdown.ex:780
 #, elixir-autogen, elixir-format
 msgctxt "qualification job usage"
 msgid "last used %{date}"
@@ -13989,8 +13990,8 @@ msgstr ""
 msgid "View the uploaded proof (%{label})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:740
-#: lib/vutuv_web/agent_docs/text.ex:588
+#: lib/vutuv_web/agent_docs/markdown.ex:743
+#: lib/vutuv_web/agent_docs/text.ex:591
 #, elixir-autogen, elixir-format
 msgid "proof document"
 msgstr ""
@@ -14073,8 +14074,8 @@ msgstr ""
 msgid "Skip for now"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:442
-#: lib/vutuv_web/agent_docs/text.ex:440
+#: lib/vutuv_web/agent_docs/markdown.ex:445
+#: lib/vutuv_web/agent_docs/text.ex:443
 #, elixir-autogen, elixir-format
 msgid "Preferred workplace"
 msgstr ""
@@ -14224,14 +14225,14 @@ msgstr ""
 msgid "See all frozen accounts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2362
+#: lib/vutuv_web/components/post_components.ex:2364
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} earlier post"
 msgid_plural "Show %{formatted} earlier posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:2384
+#: lib/vutuv_web/components/post_components.ex:2386
 #, elixir-autogen, elixir-format
 msgid "Show %{formatted} more reply"
 msgid_plural "Show %{formatted} more replies"
@@ -14258,7 +14259,7 @@ msgstr ""
 msgid "Type a name, @handle or email to find an account to freeze."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4633
+#: lib/vutuv_web/components/post_components.ex:4635
 #, elixir-autogen, elixir-format
 msgid "You can't like your own post."
 msgstr ""
@@ -14662,7 +14663,7 @@ msgstr ""
 msgid "none yet"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:993
+#: lib/vutuv_web/agent_docs/markdown.ex:996
 #, elixir-autogen, elixir-format
 msgid "Reactions from other networks"
 msgstr ""
@@ -15045,8 +15046,8 @@ msgstr ""
 msgid "Your server"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:499
-#: lib/vutuv_web/agent_docs/text.ex:469
+#: lib/vutuv_web/agent_docs/markdown.ex:502
+#: lib/vutuv_web/agent_docs/text.ex:472
 #, elixir-autogen, elixir-format
 msgid "moved to %{address}"
 msgstr ""
@@ -15429,29 +15430,29 @@ msgstr ""
 msgid "Your public posts are copied to other servers. Once a copy is there we cannot delete it, we cannot change it, and we cannot see where it travels next. Editing or deleting a post on vutuv is only a request to those servers, and not every server honours it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4592
+#: lib/vutuv_web/components/post_components.ex:4594
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{formatted} reply"
 msgid_plural "%{formatted} replies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4596
+#: lib/vutuv_web/components/post_components.ex:4598
 #, elixir-autogen, elixir-format
 msgid "%{formatted} like"
 msgid_plural "%{formatted} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:4600
+#: lib/vutuv_web/components/post_components.ex:4602
 #, elixir-autogen, elixir-format
 msgid "%{formatted} repost"
 msgid_plural "%{formatted} reposts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:995
-#: lib/vutuv_web/components/post_components.ex:4551
+#: lib/vutuv_web/agent_docs/markdown.ex:998
+#: lib/vutuv_web/components/post_components.ex:4553
 #, elixir-autogen, elixir-format
 msgid "Already counted in the numbers above."
 msgstr ""
@@ -15461,14 +15462,14 @@ msgstr ""
 msgid "Answers people write out there appear under your post, marked as coming from another network. We keep a copy for up to six months and check now and then whether it is still published; if the author deletes it, ours goes too. You can remove any single reply, and switching this off deletes all of them."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1177
-#: lib/vutuv_web/agent_docs/text.ex:695
+#: lib/vutuv_web/agent_docs/markdown.ex:1180
+#: lib/vutuv_web/agent_docs/text.ex:698
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Content warning"
 msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:1117
-#: lib/vutuv_web/components/post_components.ex:1671
+#: lib/vutuv_web/components/post_components.ex:1673
 #: lib/vutuv_web/live/fediverse_account_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "From another network"
@@ -15485,7 +15486,7 @@ msgid "Removed by the member"
 msgstr ""
 
 #: lib/vutuv_web/agent_docs/markdown.ex:125
-#: lib/vutuv_web/agent_docs/markdown.ex:994
+#: lib/vutuv_web/agent_docs/markdown.ex:997
 #: lib/vutuv_web/agent_docs/text.ex:116
 #, elixir-autogen, elixir-format
 msgid "Replies from other networks"
@@ -15542,10 +15543,10 @@ msgstr ""
 msgid "That reply is not yours to remove."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1179
+#: lib/vutuv_web/agent_docs/markdown.ex:1182
 #: lib/vutuv_web/components/post_components.ex:1048
 #: lib/vutuv_web/components/post_components.ex:1248
-#: lib/vutuv_web/components/post_components.ex:2044
+#: lib/vutuv_web/components/post_components.ex:2046
 #, elixir-autogen, elixir-format
 msgid "View the original"
 msgstr ""
@@ -16206,22 +16207,22 @@ msgstr ""
 msgid "device or detail"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2603
+#: lib/vutuv_web/components/post_components.ex:2605
 #, elixir-autogen, elixir-format
 msgid "Pinned post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2710
+#: lib/vutuv_web/components/post_components.ex:2712
 #, elixir-autogen, elixir-format
 msgid "Pin to profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2718
+#: lib/vutuv_web/components/post_components.ex:2720
 #, elixir-autogen, elixir-format
 msgid "Unpin from profile"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2704
+#: lib/vutuv_web/components/post_components.ex:2706
 #, elixir-autogen, elixir-format
 msgid "Only one post can be pinned to your profile. Pin this one and release the other?"
 msgstr ""
@@ -16241,13 +16242,13 @@ msgstr ""
 msgid "Unpinned. The post is a normal post again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:875
+#: lib/vutuv_web/agent_docs/markdown.ex:878
 #, elixir-autogen, elixir-format
 msgid "pinned post"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:436
-#: lib/vutuv_web/agent_docs/text.ex:431
+#: lib/vutuv_web/agent_docs/markdown.ex:439
+#: lib/vutuv_web/agent_docs/text.ex:434
 #: lib/vutuv_web/templates/user/edit.html.heex:180
 #: lib/vutuv_web/templates/user/show.html.heex:217
 #: lib/vutuv_web/views/account_event_text.ex:176
@@ -16305,9 +16306,9 @@ msgstr ""
 msgid "Describe the photo for people who can't see it"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1107
-#: lib/vutuv_web/agent_docs/text.ex:662
-#: lib/vutuv_web/components/post_components.ex:3177
+#: lib/vutuv_web/agent_docs/markdown.ex:1110
+#: lib/vutuv_web/agent_docs/text.ex:665
+#: lib/vutuv_web/components/post_components.ex:3179
 #, elixir-autogen, elixir-format
 msgid "Download the original"
 msgstr ""
@@ -16337,7 +16338,7 @@ msgstr ""
 msgid "Just the picture"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3176
+#: lib/vutuv_web/components/post_components.ex:3178
 #, elixir-autogen, elixir-format
 msgid "Next photo"
 msgstr ""
@@ -16347,29 +16348,29 @@ msgstr ""
 msgid "No image description yet"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3557
+#: lib/vutuv_web/components/post_components.ex:3559
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Only you can see this post so far."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2151
+#: lib/vutuv_web/components/post_components.ex:2153
 #, elixir-autogen, elixir-format
 msgid "Open Fediverse settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3560
+#: lib/vutuv_web/components/post_components.ex:3562
 #, elixir-autogen, elixir-format
 msgid "Our AI is checking the photo. As soon as it is through, the post goes live by itself."
 msgid_plural "Our AI is checking the photos, %{done} of %{total} done. As soon as the last one is through, the post goes live by itself."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3383
+#: lib/vutuv_web/components/post_components.ex:3385
 #, elixir-autogen, elixir-format
 msgid "Photo %{n} of %{total}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2919
+#: lib/vutuv_web/components/post_components.ex:2921
 #, elixir-autogen, elixir-format
 msgid "Photo is being checked"
 msgstr ""
@@ -16380,14 +16381,14 @@ msgstr ""
 msgid "Photo options"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1140
-#: lib/vutuv_web/agent_docs/text.ex:649
-#: lib/vutuv_web/components/post_components.ex:3594
+#: lib/vutuv_web/agent_docs/markdown.ex:1143
+#: lib/vutuv_web/agent_docs/text.ex:652
+#: lib/vutuv_web/components/post_components.ex:3596
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photos:"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3175
+#: lib/vutuv_web/components/post_components.ex:3177
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Previous photo"
 msgstr ""
@@ -16408,7 +16409,7 @@ msgstr ""
 msgid "Show camera settings"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2204
+#: lib/vutuv_web/components/post_components.ex:2206
 #, elixir-autogen, elixir-format
 msgid "That server is blocked on this site, so no answer can be sent to it."
 msgstr ""
@@ -16428,7 +16429,7 @@ msgstr ""
 msgid "This photo carries the location it was taken at. Anyone who downloads the exact file can read it."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2195
+#: lib/vutuv_web/components/post_components.ex:2197
 #, elixir-autogen, elixir-format
 msgid "This reply was sent to you alone, so it cannot be answered publicly."
 msgstr ""
@@ -16438,12 +16439,12 @@ msgstr ""
 msgid "This reply was written on another network. Answering it means sending your words to that network, which vutuv only does for members who have switched Fediverse participation on."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2213
+#: lib/vutuv_web/components/post_components.ex:2215
 #, elixir-autogen, elixir-format
 msgid "This site does not take part in the Fediverse."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2147
+#: lib/vutuv_web/components/post_components.ex:2149
 #, elixir-autogen, elixir-format
 msgid "Turn on Fediverse participation to answer"
 msgstr ""
@@ -16458,7 +16459,7 @@ msgstr ""
 msgid "You have sent a lot of answers to other networks in the past hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2208
+#: lib/vutuv_web/components/post_components.ex:2210
 #, elixir-autogen, elixir-format
 msgid "You moved your Fediverse account to another server, so answers are no longer sent from here."
 msgstr ""
@@ -16468,7 +16469,7 @@ msgstr ""
 msgid "Your Fediverse settings do not allow sending an answer right now."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2161
+#: lib/vutuv_web/components/post_components.ex:2163
 #, elixir-autogen, elixir-format
 msgid "Your answer goes to %{handle} on their own server and to your Fediverse followers. It is a public post on vutuv as well."
 msgstr ""
@@ -16554,14 +16555,14 @@ msgid_plural "Some of these photos carry the location they were taken at, and th
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1013
-#: lib/vutuv_web/components/post_components.ex:4589
+#: lib/vutuv_web/agent_docs/markdown.ex:1016
+#: lib/vutuv_web/components/post_components.ex:4591
 #, elixir-autogen, elixir-format
 msgid "%{handle} liked this"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1011
-#: lib/vutuv_web/components/post_components.ex:4586
+#: lib/vutuv_web/agent_docs/markdown.ex:1014
+#: lib/vutuv_web/components/post_components.ex:4588
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{handle} shared this"
 msgstr ""
@@ -16571,7 +16572,7 @@ msgstr ""
 msgid "Fediverse reactions"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:4478
+#: lib/vutuv_web/components/post_components.ex:4480
 #, elixir-autogen, elixir-format, fuzzy
 msgid "From other networks"
 msgstr ""
@@ -16908,7 +16909,7 @@ msgstr ""
 msgid "Cached posts"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1999
+#: lib/vutuv_web/components/post_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Only for this account's followers"
 msgstr ""
@@ -16922,7 +16923,7 @@ msgstr ""
 msgid "Thank you. Our copy was deleted right away."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2043
+#: lib/vutuv_web/components/post_components.ex:2045
 #, elixir-autogen, elixir-format
 msgid "Vote on the original"
 msgstr ""
@@ -16947,12 +16948,12 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2016
+#: lib/vutuv_web/components/post_components.ex:2018
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marked as sensitive by its author"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1978
+#: lib/vutuv_web/components/post_components.ex:1980
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mute %{handle}"
 msgstr ""
@@ -16969,7 +16970,7 @@ msgstr ""
 msgid "Nobody has removed or reported anything yet."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1985
+#: lib/vutuv_web/components/post_components.ex:1987
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report this post as not appropriate? Our copy is deleted for everyone on this vutuv right away."
 msgstr ""
@@ -17184,34 +17185,34 @@ msgstr ""
 msgid "What is being measured"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:870
+#: lib/vutuv_web/agent_docs/markdown.ex:873
 #, elixir-autogen, elixir-format
 msgid "(a picture)"
 msgid_plural "(%{count} pictures)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:1774
+#: lib/vutuv_web/components/post_components.ex:1776
 #, elixir-autogen, elixir-format
 msgid "A picture is on its way."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1803
+#: lib/vutuv_web/components/post_components.ex:1805
 #, elixir-autogen, elixir-format
 msgid "Cover it again"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:1798
+#: lib/vutuv_web/components/post_components.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Sensitive. Show the picture."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2080
+#: lib/vutuv_web/components/post_components.ex:2082
 #, elixir-autogen, elixir-format
 msgid "That is a lot of likes in one hour. Please try again later."
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2086
+#: lib/vutuv_web/components/post_components.ex:2088
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is not here any more."
 msgstr ""
@@ -17221,7 +17222,7 @@ msgstr ""
 msgid "Back to the feed"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2199
+#: lib/vutuv_web/components/post_components.ex:2201
 #, elixir-autogen, elixir-format
 msgid "This post was published to that account's followers only, so it cannot be answered with a public post here."
 msgstr ""
@@ -17355,8 +17356,8 @@ msgstr ""
 msgid "We could not reach the network just now. Please try again in a moment."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:817
-#: lib/vutuv_web/agent_docs/text.ex:515
+#: lib/vutuv_web/agent_docs/markdown.ex:820
+#: lib/vutuv_web/agent_docs/text.ex:518
 #, elixir-autogen, elixir-format, fuzzy
 msgid "verified profile"
 msgstr ""
@@ -17987,7 +17988,7 @@ msgstr ""
 msgid "word in a post"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:2083
+#: lib/vutuv_web/components/post_components.ex:2085
 #, elixir-autogen, elixir-format
 msgid "That reply is not here any more."
 msgstr ""
@@ -18298,24 +18299,24 @@ msgstr ""
 msgid "A post's page shows the members who liked it, right under the count. This is whether you are one of the faces."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:981
+#: lib/vutuv_web/agent_docs/markdown.ex:984
 #, elixir-autogen, elixir-format
 msgid "Liked by"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3760
+#: lib/vutuv_web/components/post_components.ex:3762
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name}"
 msgstr ""
 
-#: lib/vutuv_web/components/post_components.ex:3762
+#: lib/vutuv_web/components/post_components.ex:3764
 #, elixir-autogen, elixir-format
 msgid "Liked by %{name} and %{formatted} other"
 msgid_plural "Liked by %{name} and %{formatted} others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/components/post_components.ex:3773
+#: lib/vutuv_web/components/post_components.ex:3775
 #, elixir-autogen, elixir-format
 msgid "Only you see everyone here: some of these members are not named to other readers."
 msgstr ""
@@ -18340,12 +18341,12 @@ msgstr ""
 msgid "Your likes follow the site default again."
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1036
+#: lib/vutuv_web/agent_docs/markdown.ex:1039
 #, elixir-autogen, elixir-format
 msgid "%{address} (this page only)"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1033
+#: lib/vutuv_web/agent_docs/markdown.ex:1036
 #, elixir-autogen, elixir-format
 msgid "%{address} (whole website)"
 msgstr ""
@@ -18355,12 +18356,12 @@ msgstr ""
 msgid "Verified webpage of the author (%{address})"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:1025
+#: lib/vutuv_web/agent_docs/markdown.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Verified webpages of the author linked here: %{addresses}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/list_docs.ex:185
+#: lib/vutuv_web/agent_docs/list_docs.ex:191
 #, elixir-autogen, elixir-format
 msgid "%{listed} of %{total} members are listed here; the others do not open their profile to search engines."
 msgstr ""
@@ -18710,7 +18711,7 @@ msgstr ""
 msgid "Employment references of %{name}"
 msgstr ""
 
-#: lib/vutuv_web/agent_docs/markdown.ex:723
+#: lib/vutuv_web/agent_docs/markdown.ex:726
 #, elixir-autogen, elixir-format, fuzzy
 msgid "document"
 msgstr ""

--- a/priv/repo/migrations/20260810104048_add_tag_aliases.exs
+++ b/priv/repo/migrations/20260810104048_add_tag_aliases.exs
@@ -1,0 +1,27 @@
+defmodule Vutuv.Repo.Migrations.AddTagAliases do
+  use Ecto.Migration
+
+  # Issue #1338: a topic spread over several tags that share no letters
+  # (`Ruby on Rails` / `rails` / `ROR` / `rubyonrails`) becomes one canonical
+  # tag carrying the others as alternative names.
+  #
+  # An alias is a tag row pointing at its canonical rather than a row in a
+  # separate names table, which buys three things at once: the absorbed slug
+  # keeps resolving because the row that owns it is still there (this is the
+  # slug history #1332 planned), the absorbed id survives so a merge can be
+  # reverted exactly, and an alias cannot collide with a real tag because both
+  # live under the same unique index on `slug`.
+  #
+  # Additive only, so the currently deployed release keeps working: it does not
+  # know the columns and simply goes on treating every tag as canonical.
+  def change do
+    alter table(:tags) do
+      add(:merged_into_id, references(:tags, type: :binary_id, on_delete: :nilify_all))
+      add(:alias_kind, :string)
+    end
+
+    # Every tag listing filters on this column, and the canonical page looks up
+    # its own aliases by it.
+    create(index(:tags, [:merged_into_id]))
+  end
+end

--- a/test/vutuv/tags/merged_tags_hidden_test.exs
+++ b/test/vutuv/tags/merged_tags_hidden_test.exs
@@ -1,0 +1,114 @@
+defmodule Vutuv.Tags.MergedTagsHiddenTest do
+  use Vutuv.DataCase, async: true
+
+  # Issue #1338 stores an alias as a tag row pointing at its canonical
+  # (`merged_into_id`), which buys the retired slug, the stable id and an exact
+  # revert — at the price of one rule every tag query has to obey: **a merged
+  # tag is never a topic of its own**. A query that forgets it shows the second
+  # page for a topic, which is the very bug this issue exists to remove, and it
+  # shows it quietly.
+  #
+  # So this file walks the surfaces one by one rather than trusting a shared
+  # scope. Add a surface that lists tags, add it here.
+
+  alias Vutuv.Newsletters
+  alias Vutuv.Search
+  alias Vutuv.Tags
+  alias Vutuv.Tags.Tag
+
+  setup do
+    canonical_name = unique_tag_name("Ruby on Rails")
+    canonical = insert(:tag, name: canonical_name, slug: slugify(canonical_name))
+
+    absorbed_name = unique_tag_name("rubyonrails")
+
+    absorbed =
+      insert(:tag,
+        name: absorbed_name,
+        slug: slugify(absorbed_name),
+        merged_into_id: canonical.id,
+        alias_kind: "former"
+      )
+
+    %{canonical: canonical, absorbed: absorbed}
+  end
+
+  defp slugify(name), do: Vutuv.SlugHelpers.gen_slug_unique(name, Tag, :slug)
+
+  defp with_two_visible_members(tag) do
+    for _ <- 1..2, do: insert(:user_tag, user: insert(:activated_user), tag: tag)
+    tag
+  end
+
+  describe "the tag directory and the search-engine bar" do
+    test "the sitemap/indexability set leaves a merged tag out", ctx do
+      with_two_visible_members(ctx.canonical)
+      with_two_visible_members(ctx.absorbed)
+
+      ids = Tags.indexable_tags_query() |> Repo.all() |> Enum.map(& &1.id)
+
+      assert ctx.canonical.id in ids
+      refute ctx.absorbed.id in ids
+    end
+
+    test "indexable_tag?/1 is false for a merged tag whatever its numbers", ctx do
+      with_two_visible_members(ctx.absorbed)
+
+      refute Tags.indexable_tag?(ctx.absorbed)
+    end
+  end
+
+  describe "hashtag links in a post body" do
+    test "a merged tag's slug links to the canonical page, not to itself", ctx do
+      with_two_visible_members(ctx.canonical)
+
+      linkable = Tags.linkable_slugs([ctx.absorbed.slug])
+
+      # The reader should land on the topic, not take a redirect hop: the
+      # written slug maps to the canonical one.
+      assert linkable == %{ctx.absorbed.slug => ctx.canonical.slug}
+    end
+
+    test "a post's #hashtag files it under the canonical tag", ctx do
+      assert Tags.tag_ids_for_hashtags([ctx.absorbed.slug]) == [ctx.canonical.id]
+    end
+  end
+
+  describe "typing a tag" do
+    test "the add-tag preview shows the canonical spelling", ctx do
+      assert Tags.preview_tag_names(ctx.absorbed.name) == [ctx.canonical.name]
+    end
+  end
+
+  describe "search" do
+    test "searching the merged name finds the canonical tag once", ctx do
+      with_two_visible_members(ctx.canonical)
+
+      %{tags: tags} = Search.instant(ctx.absorbed.name)
+
+      assert Enum.map(tags, & &1.id) == [ctx.canonical.id]
+    end
+
+    test "searching the canonical name never turns up its aliases", ctx do
+      with_two_visible_members(ctx.canonical)
+
+      %{tags: tags} = Search.instant(ctx.canonical.name)
+
+      refute ctx.absorbed.id in Enum.map(tags, & &1.id)
+    end
+  end
+
+  describe "honor tags" do
+    test "a merged tag is not listed among the badges", ctx do
+      ctx.absorbed |> Ecto.Changeset.change(honor?: true) |> Repo.update!()
+
+      refute ctx.absorbed.id in Enum.map(Tags.honor_tags(), fn {tag, _count} -> tag.id end)
+    end
+  end
+
+  describe "the newsletter audience builder" do
+    test "targeting a merged name targets the canonical tag", ctx do
+      assert Newsletters.find_tag(ctx.absorbed.name).id == ctx.canonical.id
+    end
+  end
+end

--- a/test/vutuv/tags/tag_alias_test.exs
+++ b/test/vutuv/tags/tag_alias_test.exs
@@ -1,0 +1,121 @@
+defmodule Vutuv.Tags.TagAliasTest do
+  use Vutuv.DataCase, async: true
+
+  # Issue #1338: one topic spread over several tags that share no letters
+  # (`Ruby on Rails` / `rails` / `ROR` / `rubyonrails`). A tag may now carry
+  # alternative names, and an alias is itself a tag row pointing at its
+  # canonical through `merged_into_id` — so the alias keeps its own slug (old
+  # links survive), its own id (a merge stays revertible) and cannot collide
+  # with a real tag, since it lives under the same unique index.
+  #
+  # What this file guards is the *resolution*: typing any alias must attach the
+  # canonical tag rather than mint a new one, which is what stops the sprawl
+  # from regrowing.
+
+  import Ecto.Changeset
+
+  alias Vutuv.Tags.Tag
+  alias Vutuv.Tags.UserTag
+
+  defp canonical_with_alias(kind \\ "alias") do
+    name = unique_tag_name("Ruby on Rails")
+
+    canonical =
+      insert(:tag, name: name, slug: Vutuv.SlugHelpers.gen_slug_unique(name, Tag, :slug))
+
+    alias_name = unique_tag_name("ROR")
+
+    tag_alias =
+      insert(:tag,
+        name: alias_name,
+        slug: Vutuv.SlugHelpers.gen_slug_unique(alias_name, Tag, :slug),
+        merged_into_id: canonical.id,
+        alias_kind: kind
+      )
+
+    {canonical, tag_alias}
+  end
+
+  describe "find_by_value/1" do
+    test "an alias name resolves to its canonical tag" do
+      {canonical, tag_alias} = canonical_with_alias()
+
+      assert Tag.find_by_value(tag_alias.name).id == canonical.id
+    end
+
+    test "an alias slug resolves to its canonical tag" do
+      {canonical, tag_alias} = canonical_with_alias()
+
+      assert Tag.find_by_value(tag_alias.slug).id == canonical.id
+    end
+
+    test "an alias resolves case-insensitively, like every other tag value" do
+      {canonical, tag_alias} = canonical_with_alias()
+
+      assert Tag.find_by_value(String.upcase(tag_alias.name)).id == canonical.id
+      assert Tag.find_by_value(String.downcase(tag_alias.name)).id == canonical.id
+    end
+
+    test "a canonical tag still resolves to itself" do
+      {canonical, _} = canonical_with_alias()
+
+      assert Tag.find_by_value(canonical.name).id == canonical.id
+    end
+  end
+
+  describe "create_or_link_tag/2" do
+    test "typing an alias links the canonical tag instead of minting a duplicate" do
+      {canonical, tag_alias} = canonical_with_alias()
+      before = Repo.aggregate(Tag, :count)
+
+      changeset =
+        %UserTag{}
+        |> change(%{})
+        |> Tag.create_or_link_tag(%{"value" => tag_alias.name})
+
+      assert get_change(changeset, :tag_id) == canonical.id
+      assert Repo.aggregate(Tag, :count) == before
+    end
+  end
+
+  describe "canonical/1" do
+    test "follows the pointer once and stops" do
+      {canonical, tag_alias} = canonical_with_alias()
+
+      assert Tag.canonical(tag_alias).id == canonical.id
+      assert Tag.canonical(canonical).id == canonical.id
+    end
+  end
+
+  describe "the alias_kind vocabulary" do
+    test "a merged tag must carry a known kind" do
+      {canonical, _} = canonical_with_alias()
+      name = unique_tag_name("rails")
+
+      changeset =
+        Tag.alias_changeset(%Tag{name: name, slug: name}, canonical, "misspelling")
+
+      # Typos are deliberately out of scope (#1338), so there is no
+      # `misspelling` kind to file one under.
+      refute changeset.valid?
+      assert %{alias_kind: [_ | _]} = errors_on(changeset)
+    end
+
+    test "alias, abbreviation and former are the whole vocabulary" do
+      assert Enum.sort(Tag.alias_kinds()) == ~w(abbreviation alias former)
+    end
+  end
+
+  describe "aliases_of/1" do
+    test "names every tag pointing at this one, in one query" do
+      {canonical, tag_alias} = canonical_with_alias()
+
+      assert [found] = Tag.aliases_of(canonical)
+      assert found.id == tag_alias.id
+    end
+
+    test "an unaliased tag has none" do
+      assert Tag.aliases_of(insert(:tag)) == []
+    end
+  end
+end

--- a/test/vutuv_web/controllers/tag_controller_test.exs
+++ b/test/vutuv_web/controllers/tag_controller_test.exs
@@ -114,6 +114,87 @@ defmodule VutuvWeb.TagControllerTest do
     end
   end
 
+  # Issue #1338: one page per topic. An absorbed tag keeps its own row and slug
+  # (that row IS the history), so its URL never dies — it leads to the topic.
+  describe "a merged tag's slug" do
+    setup do
+      canonical = insert(:tag, name: "Ruby on Rails", slug: "ruby_on_rails")
+
+      absorbed =
+        insert(:tag,
+          name: "rubyonrails",
+          slug: "rubyonrails",
+          merged_into_id: canonical.id,
+          alias_kind: "former"
+        )
+
+      %{canonical: canonical, absorbed: absorbed}
+    end
+
+    test "redirects permanently to the canonical page", ctx do
+      conn = get(ctx.conn, ~p"/tags/rubyonrails")
+
+      # 301, never 302: permanent is what passes the ranking signal on to the
+      # page that survived.
+      assert conn.status == 301
+      assert redirected_to(conn, 301) == ~p"/tags/ruby_on_rails"
+    end
+
+    test "carries the query string across", ctx do
+      conn = get(ctx.conn, ~p"/tags/rubyonrails?source=fediverse&page=2")
+
+      assert redirected_to(conn, 301) == ~p"/tags/ruby_on_rails?source=fediverse&page=2"
+    end
+
+    test "an agent format lands on the canonical page in the same format", ctx do
+      # The `.md` sibling must not fall back to HTML, and must not 404: the
+      # endpoint plug re-appends the extension to an in-app redirect, so the
+      # controller only has to name the canonical path.
+      conn = get(ctx.conn, "/tags/rubyonrails.md")
+
+      assert conn.status == 301
+      assert redirected_to(conn, 301) == "/tags/ruby_on_rails.md"
+    end
+
+    test "the canonical page names its aliases", ctx do
+      html = ctx.conn |> get(~p"/tags/#{ctx.canonical}") |> html_response(200)
+
+      # A reader who arrived via the other spelling has to be able to see where
+      # they ended up.
+      assert html =~ "rubyonrails"
+      assert html =~ ~s(data-tag-aliases)
+    end
+
+    test "the German page says it in German", ctx do
+      # vutuv is a German site, and an English-only check would not have caught
+      # a missing or fuzzy-filled translation of this label.
+      html =
+        ctx.conn
+        |> put_req_header("accept-language", "de-DE,de")
+        |> get(~p"/tags/#{ctx.canonical}")
+        |> html_response(200)
+
+      assert html =~ "Auch bekannt als"
+    end
+
+    test "the agent siblings carry the alternative names too", ctx do
+      md = ctx.conn |> get("/tags/ruby_on_rails.md") |> response(200)
+      txt = ctx.conn |> get("/tags/ruby_on_rails.txt") |> response(200)
+      json = ctx.conn |> get("/tags/ruby_on_rails.json") |> response(200) |> Jason.decode!()
+
+      assert md =~ "rubyonrails"
+      assert txt =~ "rubyonrails"
+      assert json["also_known_as"] == ["rubyonrails"]
+    end
+
+    test "the tag directory lists the topic once", ctx do
+      html = ctx.conn |> get(~p"/tags") |> html_response(200)
+
+      assert html =~ "Ruby on Rails"
+      refute html =~ ~s(href="/tags/rubyonrails")
+    end
+  end
+
   # Issue #877: the "Add this tag" button was removed from the public tag page.
   # "Add this tag" was ambiguous ("create/define this tag" vs "add it to my
   # profile" — it misled the #844 reporter into a 404), redundant with the


### PR DESCRIPTION
**TL;DR** Ein Thema, mehrere Tags (`Ruby on Rails` / `rails` / `ROR` / `rubyonrails`): ein Tag kann jetzt Zweitnamen tragen, jede Schreibweise löst auf das Thema auf, und die URL eines Zweitnamens leitet dauerhaft dorthin. Erster von drei Schritten zu #1338.

**Warum so:** ein Zweitname ist eine Tag-Zeile mit `merged_into_id` auf ihr Thema, keine Zeile in einer eigenen Namenstabelle (wie im Issue skizziert). Damit löst der aufgegebene Slug weiter auf, weil die Zeile stehen bleibt (zugleich die Slug-Historie aus #1332), die id überlebt, so dass die Zusammenlegung in Schritt 2 exakt rückgängig zu machen ist, und ein Zweitname kann mit keinem echten Tag kollidieren, weil beide unter demselben Unique-Index liegen.

**Was drin ist**

- `tags.merged_into_id` + `tags.alias_kind` (`alias` / `abbreviation` / `former`), rein additiv, N-1-verträglich.
- `Tag.find_by_value/1` folgt dem Zeiger: jede Schreibweise hängt das kanonische Tag an, statt ein neues anzulegen. Das hindert den Wildwuchs am Nachwachsen.
- Ein Zweitname ist nie ein eigenes Thema: Verzeichnis, Suche, Sitemap-Schwelle, Hashtag-Links, Tag-Vorschau, Ehren-Tags und der Newsletter-Zielgruppenbau lassen ihn aus bzw. lösen auf das Thema auf. `merged_tags_hidden_test.exs` geht die Oberflächen einzeln durch, weil eine vergessene Abfrage genau den Fehler zurückbringt, um den es hier geht, und zwar lautlos.
- `/tags/<zweitname>` → **301** auf das Thema, mit Query-String und Agent-Format (`/tags/rubyonrails.md?source=fediverse` landet auf `/tags/ruby_on_rails.md?source=fediverse`).
- Die Themenseite nennt ihre Zweitnamen; die `.md`/`.txt`/`.json`/`.xml`-Geschwister tragen `also_known_as` – dieselbe Zeile, die Organisationen seit #930 haben, samt vorhandener Übersetzung.
- Hashtag-Links zeigen direkt auf die kanonische Seite statt auf eine Weiterleitung, deshalb liefert `Tags.linkable_slugs/1` jetzt eine Map statt eines MapSets.

**Nicht dabei: Tippfehler.** Die sind unbegrenzt, ein Fast-Treffer-Paar ist genau die Stelle, an der eine falsche Zusammenlegung am meisten anrichtet, und einen einzufangen bringt kaum etwas. Es gibt daher keine Sorte `misspelling` und keine Editierdistanz.

**Als Nächstes:** Schritt 2 die umkehrbare Zusammenlegung samt Admin-Oberfläche, Schritt 3 der einmalige assistierte Durchlauf, der Vorschläge zur Freigabe erzeugt.

**Geprüft:** `mix precommit` grün (7046 Tests), Migration gegen `vutuv1_dev` gelaufen, deutsche Ausgabe mit echtem `Accept-Language: de-DE,de` getestet.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*