### PR TITLE
Tags zusammenlegen, umkehrbar (v7.235.0)

### DIFF
--- a/docs/architecture/admin.md
+++ b/docs/architecture/admin.md
@@ -113,7 +113,21 @@ before the DB lookup, like the sibling preferences page).
 `/admin/tags` is the classic CRUD over the shared global tag catalog
 (`Vutuv.Tags.Tag`: slug, name, description) — create, rename and delete the tags
 members share. Deleting a tag removes it from every member who holds it
-(cascading FK).
+(cascading FK). It is also the one listing that shows a tag's **alternative
+names** (issue #1338), marked and linked to the topic they belong to, so a tag
+looked up under an absorbed name is still findable here.
+
+**`/admin/tag_merges`** (`VutuvWeb.Admin.TagMergeLive`) folds several tags for one
+topic into one page. Pick the tag to absorb and the one that stays, and the
+screen says what would move **before** anything happens: how many profiles,
+posts, follows and job postings change hands, and how many rows would be dropped
+because their owner already carries both spellings. Every merge is listed below
+the form with a "Revert" that puts all of it back. The same screen files a name
+as an alternative *before* anyone types it (so `ROR` never becomes a page of its
+own) and marks a pair as deliberately distinct, which refuses the merge for good.
+The mechanics, the four refusals and why an alternative name is a tag row rather
+than a separate table are in
+[social-graph.md](social-graph.md#one-topic-one-tag-alternative-names-and-merges-issue-1338).
 
 A tag can be flagged an **honor tag** (`tags.honor?`, edited on the tag's page).
 That reserves the tag name site-wide as an **admin-granted badge** — think

--- a/docs/architecture/social-graph.md
+++ b/docs/architecture/social-graph.md
@@ -121,6 +121,66 @@ controller passes `?source=`, `?sort=`, `?q=`, `?from=` and `?until=` into the
 mount session, so a shared link opens on exactly that view, and the agent
 formats honour the same params.
 
+## One topic, one tag: alternative names and merges (issue #1338)
+
+A topic used to spread over several tags that share no letters — `Ruby on
+Rails`, `rails`, `ROR`, `rubyonrails` — each with its own page, its own members
+and its own half of the timeline. A tag can now carry **alternative names**, and
+an alternative name is **a tag row pointing at its topic**
+(`tags.merged_into_id` + `tags.alias_kind`, one of `alias` / `abbreviation` /
+`former`), not a row in a separate names table.
+
+That shape buys three things at once:
+
+- the absorbed **slug keeps resolving**, because the row that owns it is still
+  there — `VutuvWeb.TagController`'s `resolve_tag` plug answers `/tags/<alias>`
+  with a **301** to the topic, carrying the query string, and the endpoint's
+  `AgentFormat` plug re-appends the extension so `.md` lands on `.md`;
+- the absorbed **id survives**, so a merge is exactly revertible;
+- an alternative name **cannot collide** with a real tag, since both live under
+  the same unique index on `slug`.
+
+`Tag.find_by_value/1` follows the pointer, so typing any spelling attaches the
+topic instead of minting a duplicate — that is what stops the sprawl regrowing.
+The price is one rule every tag query owes: **an alternative name is never a
+topic of its own** (`Tag.not_merged/1`). Forgetting it puts a second page for one
+topic back in front of a reader, silently, so
+`test/vutuv/tags/merged_tags_hidden_test.exs` walks the surfaces one at a time —
+directory, search, the indexability bar and sitemap, hashtag links, the add-tag
+preview, honor tags, the newsletter audience builder. The admin catalog
+(`/admin/tags`) is the deliberate exception: it lists them, marked, linked to
+their topic.
+
+**Merging** is `Vutuv.Tags.Merge`, driven from `/admin/tag_merges`
+(`VutuvWeb.Admin.TagMergeLive`; its own path segment because the earlier
+`resources("/tags", …)` in the router would read `merge` as a slug). It moves
+every row filed under the absorbed tag — profile tags and the endorsements under
+them, post tags and body hashtags, tag follows, job postings, cached remote
+posts, newsletter audiences — and only deletes a row whose owner already holds
+the surviving tag, because of the `(owner, tag)` unique index. A member carrying
+both spellings ends up carrying the topic once, and their endorsers' vouches move
+onto the row that survives.
+
+Every merge is written to `tag_merges` with an `undo` payload — the ids it moved
+and the **whole content** of the rows it had to drop — and `revert/1` puts all of
+it back, re-inserting dropped rows verbatim through `jsonb_populate_record` so
+they keep their ids and anything pointing at them still does. The row-moving is
+SQL rather than Ecto for exactly that reason: a revert restores a *row*, not a
+schema's idea of one.
+
+Four refusals are rules rather than judgement calls: an **honor tag** never
+merges (it is granted, not spelled), an **alternative name** never merges again,
+a pair recorded in `tag_distinctions` as **different topics** stays refused
+whichever way round it is named, and a pair whose names differ **only in
+characters the slugifier deletes** is refused outright — that is the `c` / `c++`
+/ `c#` / `µc` bucket from issue #1337, four languages one normalization would
+fold into one. A separator is not such a character: `open source` and
+`OpenSource` are the ordinary mechanical variant a merge is *for*.
+
+Typos are deliberately out of scope. There is no `misspelling` kind: a typo is
+unbounded, a near-miss pair is exactly where a wrong merge does the most damage,
+and catching one buys almost nothing.
+
 ## Blocking
 
 Reachable wherever you decide to block someone — a quiet "Block" next to the

--- a/lib/vutuv/tags.ex
+++ b/lib/vutuv/tags.ex
@@ -14,6 +14,7 @@ defmodule Vutuv.Tags do
   alias Vutuv.Accounts.User
   alias Vutuv.Posts
   alias Vutuv.Repo
+  alias Vutuv.SearchText
   alias Vutuv.Tags.Tag
   alias Vutuv.Tags.TagFollow
   alias Vutuv.Tags.UserTag
@@ -121,6 +122,37 @@ defmodule Vutuv.Tags do
 
         Enum.map(names, &Map.get(display_by_key, String.downcase(&1), &1))
     end
+  end
+
+  @doc """
+  Tags whose name or slug contains `query`, for the admin screens.
+
+  One definition for the tag catalog and the merge screen, so an admin who found
+  a tag in one finds it in the other. `:merged` says what to do with alternative
+  names: `:include` (the catalog, which marks them and links their topic) or
+  `:exclude` (the merge screen, where only a real topic can be picked). A blank
+  query answers with every tag, which is what the catalog's unfiltered listing
+  is; pass a `:limit` where that would be too much.
+  """
+  def admin_search(query, opts \\ []) do
+    base = if opts[:merged] == :include, do: Tag, else: Tag.not_merged()
+
+    base
+    |> admin_search_filter(String.trim(to_string(query)))
+    |> admin_search_limit(opts[:limit])
+  end
+
+  defp admin_search_filter(base, ""), do: from(t in base)
+
+  defp admin_search_filter(base, query) do
+    infix = SearchText.contains(query)
+    from(t in base, where: ilike(t.name, ^infix) or ilike(t.slug, ^infix))
+  end
+
+  defp admin_search_limit(query, nil), do: query
+
+  defp admin_search_limit(query, limit) do
+    from(t in query, order_by: [asc: t.name], limit: ^limit)
   end
 
   @doc "The most tags one profile may carry (see `@max_user_tags`)."

--- a/lib/vutuv/tags/merge.ex
+++ b/lib/vutuv/tags/merge.ex
@@ -1,0 +1,514 @@
+defmodule Vutuv.Tags.Merge do
+  @moduledoc """
+  Folding one topic's several tags into one page (issue #1338).
+
+  `Ruby on Rails`, `rails`, `ROR` and `rubyonrails` are four pages for one
+  subject. Absorbing one into another moves every row filed under it — the tag
+  on a member's profile and the vouches under it, the posts, the follows, the
+  job postings, a cached post from another network, a newsletter audience — and
+  then files the absorbed tag as an **alternative name** rather than deleting
+  it. Keeping that row is what lets its slug go on resolving and what makes the
+  whole act reversible.
+
+  Three things are deliberate:
+
+    * **Nothing is deleted that can be moved.** Only a row whose owner already
+      holds the surviving tag has to go, because of the `(owner, tag)` unique
+      index — a member carrying both spellings ends up carrying the topic once.
+      Their endorsements move onto the surviving row first, so a vouch somebody
+      gave is not collateral damage.
+    * **Every merge can be taken back.** `merge/3` writes what it did into
+      `Vutuv.Tags.TagMerge`: the ids it moved and the full content of the rows
+      it had to drop. `revert/1` moves the ids back and re-inserts the dropped
+      rows verbatim — same ids, so anything that pointed at them still does.
+    * **The dangerous cases are refused by rule, not by judgement.** An honor
+      tag never merges, an alias never merges again, a pair a human called
+      distinct stays distinct, and a pair whose names differ only in characters
+      the slugifier deletes is refused outright — that is the `c` / `c++` /
+      `c#` / `µc` bucket from #1337, four languages one normalization would
+      happily fold into one.
+
+  The row-moving is written in SQL rather than in Ecto because a revert has to
+  restore a **row**, not a schema's idea of one: `to_jsonb(t)` captures it whole
+  and `jsonb_populate_record` puts it back, with no per-column knowledge here
+  that could fall out of step with a future migration. Table and column names
+  come from the compile-time list `@movable`, never from anything a caller
+  supplies. Ids are passed as text and cast (`$1::text::uuid`), the form
+  Postgrex can encode.
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias Vutuv.Repo
+  alias Vutuv.Tags.Tag
+  alias Vutuv.Tags.TagDistinction
+  alias Vutuv.Tags.TagMerge
+
+  # Every table with a `tag_id`, and the column that makes a row's owner unique
+  # under it (`nil` where a tag can be filed twice, so nothing ever collides).
+  # A new table pointing at `tags` belongs here, or a merge would leave its rows
+  # behind on a tag that is no longer a topic.
+  @movable [
+    {"user_tags", "user_id"},
+    {"post_tags", "post_id"},
+    {"post_hashtags", "post_id"},
+    {"tag_follows", "user_id"},
+    {"job_posting_tags", "job_posting_id"},
+    {"fediverse_post_tags", "remote_post_id"},
+    {"newsletter_groups", nil}
+  ]
+
+  @doc """
+  What a merge would do, without doing any of it: `%{moved: %{table => count},
+  dropped: %{table => count}}`, or `{:error, reason}` when the merge is refused.
+
+  The split matters to whoever confirms it — a moved row keeps a member's
+  profile as it was, a dropped one means somebody carried both spellings.
+  """
+  def preview(%Tag{} = absorbed, %Tag{} = canonical) do
+    with :ok <- check(absorbed, canonical) do
+      counts =
+        Enum.reduce(@movable, %{moved: %{}, dropped: %{}}, fn {table, owner}, acc ->
+          moved = count_rows(movable_ids_sql(table, owner), params(owner, absorbed, canonical))
+
+          total =
+            count_rows("select 1 from #{table} where tag_id = $1::text::uuid", [absorbed.id])
+
+          acc
+          |> put_count(:moved, table, moved)
+          |> put_count(:dropped, table, total - moved)
+        end)
+
+      Map.merge(counts, %{absorbed: absorbed, canonical: canonical})
+    end
+  end
+
+  @doc """
+  Absorbs `absorbed` into `canonical` in one transaction and records it.
+
+  `opts` takes `:actor` (the admin) and `:kind` (the alias kind the absorbed
+  name is filed under, `"former"` by default — it *was* the tag's own name).
+  Returns `{:ok, %TagMerge{}}` or `{:error, reason}`.
+  """
+  def merge(%Tag{} = absorbed, %Tag{} = canonical, opts \\ []) do
+    kind = Keyword.get(opts, :kind, "former")
+    actor = Keyword.get(opts, :actor)
+
+    with :ok <- check(absorbed, canonical) do
+      Multi.new()
+      |> Multi.run(:rows, fn repo, _ -> {:ok, move_rows(repo, absorbed, canonical)} end)
+      |> Multi.update(:alias, Tag.alias_changeset(absorbed, canonical, kind))
+      |> Multi.insert(:merge, fn %{rows: rows} ->
+        TagMerge.changeset(%TagMerge{}, %{
+          canonical_tag_id: canonical.id,
+          absorbed_tag_id: absorbed.id,
+          admin_user_id: actor && actor.id,
+          moved_counts: rows.counts,
+          undo: %{"moves" => rows.moves, "deletes" => rows.deletes}
+        })
+      end)
+      |> Repo.transaction()
+      |> case do
+        {:ok, %{merge: merge}} -> {:ok, merge}
+        {:error, _step, reason, _changes} -> {:error, reason}
+      end
+    end
+  end
+
+  @doc """
+  Takes a merge back: every moved row returns to the absorbed tag, every dropped
+  row is re-inserted as it was, and the absorbed tag stops being an alias.
+
+  A merge is reverted once; a second attempt answers `{:error, :already_reverted}`.
+  """
+  def revert(%TagMerge{reverted_at: %NaiveDateTime{}}), do: {:error, :already_reverted}
+
+  def revert(%TagMerge{} = merge) do
+    absorbed = Repo.get!(Tag, merge.absorbed_tag_id)
+
+    Multi.new()
+    |> Multi.run(:restore, fn repo, _ -> {:ok, restore(repo, merge.undo)} end)
+    |> Multi.update(:alias, Ecto.Changeset.change(absorbed, merged_into_id: nil, alias_kind: nil))
+    |> Multi.update(:merge, Ecto.Changeset.change(merge, reverted_at: now()))
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{merge: merge}} -> {:ok, merge}
+      {:error, _step, reason, _changes} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Records that these two tags are different topics, so no assisted pass proposes
+  the pair again and no merge of it goes through by hand either.
+
+  Saying it twice is not an error: the second call answers with the row already
+  there.
+  """
+  def mark_distinct(%Tag{} = a, %Tag{} = b, opts \\ []) do
+    {tag_a_id, tag_b_id} = TagDistinction.ordered(a, b)
+    actor = Keyword.get(opts, :actor)
+
+    %TagDistinction{}
+    |> TagDistinction.changeset(%{
+      tag_a_id: tag_a_id,
+      tag_b_id: tag_b_id,
+      admin_user_id: actor && actor.id
+    })
+    |> Repo.insert(on_conflict: :nothing, conflict_target: [:tag_a_id, :tag_b_id])
+    |> case do
+      {:ok, %TagDistinction{id: nil}} -> {:ok, get_distinction(tag_a_id, tag_b_id)}
+      other -> other
+    end
+  end
+
+  @doc "Whether this pair has been called two different topics."
+  def distinct?(%Tag{} = a, %Tag{} = b) do
+    {tag_a_id, tag_b_id} = TagDistinction.ordered(a, b)
+    not is_nil(get_distinction(tag_a_id, tag_b_id))
+  end
+
+  @doc """
+  Files `name` as an alternative name for `canonical` without there ever having
+  been a tag by that name — an admin adding `ROR` before anyone types it, so the
+  duplicate is never minted in the first place.
+
+  A name that **is** already a tag is refused with `{:error, :name_taken}`: that
+  is a merge, and a merge has rows to move and a preview to show first.
+  """
+  def add_alias(%Tag{} = canonical, name, opts \\ []) do
+    kind = Keyword.get(opts, :kind, "alias")
+    name = Tag.normalize_value(to_string(name))
+
+    cond do
+      canonical.honor? ->
+        {:error, :honor_tag}
+
+      not is_nil(canonical.merged_into_id) ->
+        {:error, :target_is_alias}
+
+      not is_nil(Tag.find_by_value(name)) ->
+        {:error, :name_taken}
+
+      true ->
+        %Tag{}
+        |> Tag.changeset(%{"value" => name})
+        |> Ecto.Changeset.put_change(:merged_into_id, canonical.id)
+        |> Ecto.Changeset.put_change(:alias_kind, kind)
+        |> Ecto.Changeset.validate_inclusion(:alias_kind, Tag.alias_kinds())
+        |> Repo.insert()
+    end
+  end
+
+  @doc """
+  Drops an alternative name again.
+
+  Only one that never carried anything: an alias left behind by a merge is
+  undone by reverting that merge, not by deleting the row its slug lives on.
+  """
+  def remove_alias(%Tag{merged_into_id: nil}), do: {:error, :not_an_alias}
+
+  def remove_alias(%Tag{} = tag_alias) do
+    if merged?(tag_alias), do: {:error, :from_merge}, else: Repo.delete(tag_alias)
+  end
+
+  # An alias that came out of a merge is named by a ledger row; a hand-added one
+  # is not, and only the latter is a plain mistake to take back.
+  defp merged?(%Tag{id: id}) do
+    Repo.exists?(from(m in TagMerge, where: m.absorbed_tag_id == ^id and is_nil(m.reverted_at)))
+  end
+
+  @doc """
+  Whether two names differ **only** in characters the slugifier deletes.
+
+  `c` and `c++` do, and they are two languages (#1337): a merge of such a pair
+  is refused as a rule rather than left to judgement, because every
+  normalization that could propose it has already thrown away the one thing
+  telling them apart. A pair differing in a separator (`open source` /
+  `OpenSource`) does not — the slugifier folds those, it does not drop them, and
+  that pair is the ordinary mechanical variant a merge is *for*.
+  """
+  def punctuation_only_difference?(a, b) when is_binary(a) and is_binary(b) do
+    keep(a) != keep(b) and strip(a) == strip(b)
+  end
+
+  @doc """
+  The merges recorded so far, newest first, with both tags and the admin loaded.
+  """
+  def history(limit \\ 50) do
+    Repo.all(
+      from(m in TagMerge,
+        order_by: [desc: m.id],
+        limit: ^limit,
+        preload: [:canonical_tag, :absorbed_tag, :admin_user]
+      )
+    )
+  end
+
+  @doc "One recorded merge, with everything the admin screen shows."
+  def get_merge(id) do
+    Vutuv.UUIDv7.with_cast(id, fn uuid ->
+      Repo.one(
+        from(m in TagMerge,
+          where: m.id == ^uuid,
+          preload: [:canonical_tag, :absorbed_tag, :admin_user]
+        )
+      )
+    end)
+  end
+
+  # --- refusals -------------------------------------------------------------
+
+  defp check(%Tag{id: same}, %Tag{id: same}), do: {:error, :same_tag}
+  defp check(%Tag{honor?: true}, _), do: {:error, :honor_tag}
+  defp check(_, %Tag{honor?: true}), do: {:error, :honor_tag}
+  defp check(%Tag{merged_into_id: id}, _) when not is_nil(id), do: {:error, :already_merged}
+  defp check(_, %Tag{merged_into_id: id}) when not is_nil(id), do: {:error, :target_is_alias}
+
+  defp check(%Tag{} = absorbed, %Tag{} = canonical) do
+    cond do
+      distinct?(absorbed, canonical) ->
+        {:error, :marked_distinct}
+
+      punctuation_only_difference?(absorbed.name, canonical.name) ->
+        {:error, :punctuation_only_difference}
+
+      true ->
+        :ok
+    end
+  end
+
+  # What the slugifier keeps of a name: case folded and separators removed, so
+  # only the characters that survive slugification are compared.
+  defp keep(name) do
+    name |> String.downcase() |> String.replace(~r/[\s_-]+/u, "")
+  end
+
+  # The same, minus everything `SlugHelpers.slugify_downcase/1`'s character
+  # filter deletes — `+`, `#`, `/`, `.`, and every other non-word symbol. Two
+  # names that agree here but not in `keep/1` are told apart by exactly those
+  # deleted characters.
+  defp strip(name), do: name |> keep() |> String.replace(~r/[^\w]/u, "")
+
+  # --- moving rows ----------------------------------------------------------
+
+  defp move_rows(repo, absorbed, canonical) do
+    Enum.reduce(@movable, %{counts: %{}, moves: [], deletes: []}, fn {table, owner}, acc ->
+      move_table(repo, table, owner, absorbed, canonical, acc)
+    end)
+  end
+
+  defp move_table(repo, table, owner, absorbed, canonical, acc) do
+    moved_ids =
+      query_column(repo, movable_ids_sql(table, owner), params(owner, absorbed, canonical))
+
+    # The rows are re-filed, not edited: `updated_at` stays as it was, so a
+    # revert really does restore the state rather than something like it.
+    if moved_ids != [] do
+      repo.query!(
+        "update #{table} set tag_id = $1::text::uuid where id = any($2::text[]::uuid[])",
+        [canonical.id, moved_ids]
+      )
+    end
+
+    acc =
+      acc
+      |> put_in([:counts, table], length(moved_ids))
+      |> add_move(table, "tag_id", absorbed.id, moved_ids)
+
+    drop_leftovers(repo, table, owner, absorbed, canonical, acc)
+  end
+
+  # Whatever is still filed under the absorbed tag now belongs to an owner who
+  # already holds the canonical one, so it cannot come along. Captured whole
+  # first, then deleted.
+  defp drop_leftovers(_repo, _table, nil, _absorbed, _canonical, acc), do: acc
+
+  defp drop_leftovers(repo, table, _owner, absorbed, canonical, acc) do
+    acc =
+      if table == "user_tags", do: rescue_endorsements(repo, absorbed, canonical, acc), else: acc
+
+    rows =
+      repo
+      |> query_column("select to_jsonb(t) from #{table} t where t.tag_id = $1::text::uuid", [
+        absorbed.id
+      ])
+
+    if rows == [] do
+      acc
+    else
+      repo.query!("delete from #{table} where tag_id = $1::text::uuid", [absorbed.id])
+      add_delete(acc, table, rows)
+    end
+  end
+
+  # A member who carried both spellings loses one `user_tags` row, and deleting
+  # it would cascade the endorsements under it. The vouches are what somebody
+  # else said about this person, so they move onto the row that survives —
+  # except where that endorser already vouched for the surviving row, which the
+  # `(user_id, user_tag_id)` unique index forbids and which is the same vouch
+  # anyway. Those few are captured for the revert and go with the row.
+  defp rescue_endorsements(repo, absorbed, canonical, acc) do
+    %{rows: rows} =
+      repo.query!(
+        """
+        with doomed as (
+          select a.id as doomed_id, b.id as survivor_id
+          from user_tags a
+          join user_tags b on b.user_id = a.user_id and b.tag_id = $2::text::uuid
+          where a.tag_id = $1::text::uuid
+        )
+        select e.id::text, d.doomed_id::text, d.survivor_id::text
+        from user_tag_endorsements e
+        join doomed d on d.doomed_id = e.user_tag_id
+        where not exists (
+          select 1 from user_tag_endorsements x
+          where x.user_tag_id = d.survivor_id and x.user_id = e.user_id
+        )
+        """,
+        [absorbed.id, canonical.id]
+      )
+
+    # Captured before the move, because a doomed row's remaining endorsements
+    # are about to be cascade-deleted with it.
+    doomed_endorsements =
+      query_column(
+        repo,
+        """
+        select to_jsonb(e)
+        from user_tag_endorsements e
+        join user_tags a on a.id = e.user_tag_id
+        join user_tags b on b.user_id = a.user_id and b.tag_id = $2::text::uuid
+        where a.tag_id = $1::text::uuid
+        """,
+        [absorbed.id, canonical.id]
+      )
+
+    acc =
+      rows
+      |> Enum.group_by(fn [_id, doomed_id, _survivor] -> doomed_id end, fn [id, _, survivor] ->
+        {id, survivor}
+      end)
+      |> Enum.reduce(acc, fn {doomed_id, pairs}, acc ->
+        ids = Enum.map(pairs, &elem(&1, 0))
+        [{_, survivor_id} | _] = pairs
+
+        repo.query!(
+          "update user_tag_endorsements set user_tag_id = $1::text::uuid " <>
+            "where id = any($2::text[]::uuid[])",
+          [survivor_id, ids]
+        )
+
+        add_move(acc, "user_tag_endorsements", "user_tag_id", doomed_id, ids)
+      end)
+
+    moved_ids = Enum.map(rows, fn [id, _, _] -> id end)
+
+    case Enum.reject(doomed_endorsements, &(&1["id"] in moved_ids)) do
+      [] -> acc
+      leftovers -> add_delete(acc, "user_tag_endorsements", leftovers)
+    end
+  end
+
+  # --- reverting ------------------------------------------------------------
+
+  defp restore(repo, undo) do
+    # Parents before children: a re-inserted endorsement points at a `user_tags`
+    # row that has to exist again first.
+    undo
+    |> Map.get("deletes", [])
+    |> Enum.sort_by(&(&1["table"] == "user_tag_endorsements"))
+    |> Enum.each(fn %{"table" => table, "rows" => rows} ->
+      Enum.each(rows, fn row ->
+        repo.query!(
+          "insert into #{safe_table(table)} select * from jsonb_populate_record(null::#{safe_table(table)}, $1::jsonb)",
+          [row]
+        )
+      end)
+    end)
+
+    undo
+    |> Map.get("moves", [])
+    |> Enum.each(fn %{"table" => table, "column" => column, "to" => to, "ids" => ids} ->
+      if ids != [] do
+        repo.query!(
+          "update #{safe_table(table)} set #{safe_column(table, column)} = $1::text::uuid " <>
+            "where id = any($2::text[]::uuid[])",
+          [to, ids]
+        )
+      end
+    end)
+
+    :ok
+  end
+
+  # The undo payload is ours, but it round-trips through the database as JSON,
+  # so the table and column names it names are checked against the compile-time
+  # list before they reach a query rather than trusted for having been written
+  # by us once.
+  @tables ["user_tag_endorsements" | Enum.map(@movable, &elem(&1, 0))]
+  @columns %{"user_tag_endorsements" => "user_tag_id"}
+
+  # Fail closed: an unknown name raises rather than being skipped, so a payload
+  # that does not match this list stops the revert instead of half-applying it.
+  defp safe_table(table) when table in @tables, do: table
+
+  defp safe_column(table, column) do
+    expected = Map.get(@columns, safe_table(table), "tag_id")
+    if expected == column, do: column, else: raise(ArgumentError, "unknown column #{column}")
+  end
+
+  # --- plumbing -------------------------------------------------------------
+
+  defp movable_ids_sql(table, nil) do
+    "select id::text from #{table} where tag_id = $1::text::uuid"
+  end
+
+  defp movable_ids_sql(table, owner) do
+    """
+    select a.id::text from #{table} a
+    where a.tag_id = $1::text::uuid
+      and not exists (
+        select 1 from #{table} b
+        where b.tag_id = $2::text::uuid and b.#{owner} = a.#{owner}
+      )
+    """
+  end
+
+  # A table with no owner column cannot collide, so its query names one tag and
+  # takes one parameter; passing a second would be a bind error, not a no-op.
+  defp params(nil, absorbed, _canonical), do: [absorbed.id]
+  defp params(_owner, absorbed, canonical), do: [absorbed.id, canonical.id]
+
+  defp count_rows(sql, params) do
+    %{num_rows: count} = Repo.query!(sql, params)
+    count
+  end
+
+  defp query_column(repo, sql, params) do
+    %{rows: rows} = repo.query!(sql, params)
+    Enum.map(rows, fn [value] -> value end)
+  end
+
+  defp put_count(acc, _key, _table, 0), do: acc
+  defp put_count(acc, key, table, count), do: put_in(acc, [key, table], count)
+
+  defp add_move(acc, _table, _column, _to, []), do: acc
+
+  defp add_move(acc, table, column, to, ids) do
+    move = %{"table" => table, "column" => column, "to" => to, "ids" => ids}
+    Map.update!(acc, :moves, &(&1 ++ [move]))
+  end
+
+  defp add_delete(acc, table, rows) do
+    Map.update!(acc, :deletes, &(&1 ++ [%{"table" => table, "rows" => rows}]))
+  end
+
+  defp get_distinction(tag_a_id, tag_b_id) do
+    Repo.one(
+      from(d in TagDistinction, where: d.tag_a_id == ^tag_a_id and d.tag_b_id == ^tag_b_id)
+    )
+  end
+
+  defp now, do: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+end

--- a/lib/vutuv/tags/tag_distinction.ex
+++ b/lib/vutuv/tags/tag_distinction.ex
@@ -1,0 +1,41 @@
+defmodule Vutuv.Tags.TagDistinction do
+  @moduledoc """
+  Two tags a human has looked at and called different topics (issue #1338).
+
+  `Ruby` and `Ruby on Rails` share a word, an assisted pass will keep noticing
+  that, and a reviewer should have to say so only once. The pair is stored with
+  the smaller id first, so the fact is one row whichever way round it is named,
+  and the unique index is what makes saying it twice harmless.
+
+  It refuses a merge as well as a proposal: a rejected pair is not merely
+  unproposed, it is a decision.
+  """
+
+  use VutuvWeb, :model
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Tags.Tag
+
+  schema "tag_distinctions" do
+    belongs_to(:tag_a, Tag)
+    belongs_to(:tag_b, Tag)
+    belongs_to(:admin_user, User)
+
+    timestamps()
+  end
+
+  def changeset(tag_distinction, attrs) do
+    tag_distinction
+    |> cast(attrs, [:tag_a_id, :tag_b_id, :admin_user_id])
+    |> validate_required([:tag_a_id, :tag_b_id])
+    |> unique_constraint([:tag_a_id, :tag_b_id])
+  end
+
+  @doc """
+  The two ids in their stored order (smaller first), so a lookup and a write
+  agree about which is which.
+  """
+  def ordered(%Tag{id: a}, %Tag{id: b}), do: ordered(a, b)
+  def ordered(a, b) when a <= b, do: {a, b}
+  def ordered(a, b), do: {b, a}
+end

--- a/lib/vutuv/tags/tag_merge.ex
+++ b/lib/vutuv/tags/tag_merge.ex
@@ -1,0 +1,45 @@
+defmodule Vutuv.Tags.TagMerge do
+  @moduledoc """
+  One absorbed tag, written down (issue #1338).
+
+  A merge moves rows people put somewhere on purpose, so it is recorded rather
+  than just done: what moved, how much of it, and everything a revert needs.
+  `Vutuv.Tags.Merge` is the only writer; the admin screen reads this table as
+  the merge history and reverts from it.
+  """
+
+  use VutuvWeb, :model
+
+  alias Vutuv.Accounts.User
+  alias Vutuv.Tags.Tag
+
+  schema "tag_merges" do
+    belongs_to(:canonical_tag, Tag)
+    belongs_to(:absorbed_tag, Tag)
+    belongs_to(:admin_user, User)
+
+    # Per table, how many rows moved — what the admin screen reports back.
+    field(:moved_counts, :map, default: %{})
+
+    # What a revert needs: `"moves"` (ids grouped per table and destination)
+    # and `"deletes"` (whole rows, restored verbatim). See `Vutuv.Tags.Merge`.
+    field(:undo, :map, default: %{})
+
+    field(:reverted_at, :naive_datetime)
+
+    timestamps()
+  end
+
+  def changeset(tag_merge, attrs) do
+    tag_merge
+    |> cast(attrs, [
+      :canonical_tag_id,
+      :absorbed_tag_id,
+      :admin_user_id,
+      :moved_counts,
+      :undo,
+      :reverted_at
+    ])
+    |> validate_required([:canonical_tag_id, :absorbed_tag_id])
+  end
+end

--- a/lib/vutuv_web/controllers/admin/tag_controller.ex
+++ b/lib/vutuv_web/controllers/admin/tag_controller.ex
@@ -9,7 +9,6 @@ defmodule VutuvWeb.Admin.TagController do
   )
 
   alias Vutuv.Pages
-  alias Vutuv.SearchText
   alias Vutuv.Tags
   alias Vutuv.Tags.Tag
   alias VutuvWeb.ControllerHelpers
@@ -22,11 +21,14 @@ defmodule VutuvWeb.Admin.TagController do
         _ -> ""
       end
 
-    base = search_tags(query)
+    # The catalog is the one screen that shows alternative names too (issue
+    # #1338), marked and linked to the topic they belong to — an admin looking
+    # for a tag by a name that was absorbed must still find it here.
+    base = Tags.admin_search(query, merged: :include)
     tags_count = Repo.aggregate(base, :count)
 
     tags =
-      from(t in base, order_by: t.slug)
+      from(t in base, order_by: t.slug, preload: [:merged_into])
       |> Pages.paginate(params, tags_count)
       |> Repo.all()
 
@@ -36,15 +38,6 @@ defmodule VutuvWeb.Admin.TagController do
       query: query,
       pager_query: (query != "" && %{"q" => query}) || %{}
     )
-  end
-
-  # Filter tags by a case-insensitive substring of name or slug (the same
-  # match the public tag search uses). An empty query lists every tag.
-  defp search_tags(""), do: from(t in Tag)
-
-  defp search_tags(query) do
-    infix = SearchText.contains(query)
-    from(t in Tag, where: ilike(t.name, ^infix) or ilike(t.slug, ^infix))
   end
 
   def new(conn, _params) do

--- a/lib/vutuv_web/live/admin/tag_merge_live.ex
+++ b/lib/vutuv_web/live/admin/tag_merge_live.ex
@@ -1,0 +1,482 @@
+defmodule VutuvWeb.Admin.TagMergeLive do
+  @moduledoc """
+  The tag merge screen (`/admin/tags/merge`, issue #1338): fold several tags for
+  one topic into one page.
+
+  Pick the tag to absorb and the tag that survives, and the screen says what the
+  merge would move **before** anything happens — how many profiles, posts,
+  follows and job postings change hands, and how many rows would be dropped
+  because their owner already carries both spellings. That preview is the point
+  of the page: absorbing a tag moves rows people put there deliberately.
+
+  Everything here is reversible. The merge history below the form lists what was
+  done, by whom, and offers "Revert" on each entry, which puts every row back
+  where it was, restores the rows that had to go, and unfiles the alias.
+
+  Two smaller tools share the screen because they are the same subject: filing a
+  name as an alternative *before* anyone types it (so `ROR` never becomes a page
+  of its own), and marking a pair as deliberately distinct, which refuses the
+  merge and keeps an assisted pass from proposing it again.
+
+  Lives in the `:admin` live_session (`on_mount :require_admin`, see the router)
+  so the dead `:admin` pipeline 403s the disconnected render and the on_mount
+  guards the socket.
+  """
+
+  use VutuvWeb, :live_view
+
+  alias Vutuv.Repo
+  alias Vutuv.Tags
+  alias Vutuv.Tags.Merge
+  alias Vutuv.Tags.Tag
+
+  # Enough to recognise the tag you meant; an admin who sees too many narrows
+  # the query rather than scrolling a picker.
+  @results_limit 12
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, gettext("Merge tags"))
+     |> assign(:absorbed, nil)
+     |> assign(:canonical, nil)
+     |> assign(:absorbed_query, "")
+     |> assign(:canonical_query, "")
+     |> assign(:absorbed_results, [])
+     |> assign(:canonical_results, [])
+     |> assign(:alias_name, "")
+     |> load_preview()
+     |> load_history()}
+  end
+
+  @impl true
+  def handle_event("search", %{"side" => side, "q" => q}, socket) do
+    {:noreply,
+     socket
+     |> assign(:"#{side}_query", q)
+     |> assign(:"#{side}_results", search(q))}
+  end
+
+  def handle_event("pick", %{"side" => side, "id" => id}, socket) do
+    {:noreply,
+     socket
+     |> assign(:"#{side}", Repo.get(Tag, id))
+     |> assign(:"#{side}_results", [])
+     |> assign(:"#{side}_query", "")
+     |> load_preview()}
+  end
+
+  def handle_event("clear", %{"side" => side}, socket) do
+    {:noreply, socket |> assign(:"#{side}", nil) |> load_preview()}
+  end
+
+  def handle_event("merge", _params, socket) do
+    %{absorbed: absorbed, canonical: canonical} = socket.assigns
+
+    case Merge.merge(absorbed, canonical, actor: socket.assigns.current_user) do
+      {:ok, _merge} ->
+        {:noreply,
+         socket
+         |> put_flash(
+           :info,
+           gettext("%{absorbed} is now an alternative name for %{canonical}.",
+             absorbed: absorbed.name,
+             canonical: canonical.name
+           )
+         )
+         |> assign(:absorbed, nil)
+         |> assign(:canonical, Repo.get(Tag, canonical.id))
+         |> load_preview()
+         |> load_history()}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, refusal(reason))}
+    end
+  end
+
+  def handle_event("mark-distinct", _params, socket) do
+    %{absorbed: absorbed, canonical: canonical} = socket.assigns
+    {:ok, _} = Merge.mark_distinct(absorbed, canonical, actor: socket.assigns.current_user)
+
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       gettext("%{a} and %{b} are recorded as different topics.",
+         a: absorbed.name,
+         b: canonical.name
+       )
+     )
+     |> load_preview()}
+  end
+
+  def handle_event("revert", %{"id" => id}, socket) do
+    case Merge.get_merge(id) do
+      nil ->
+        {:noreply, put_flash(socket, :error, gettext("That merge is no longer on record."))}
+
+      merge ->
+        case Merge.revert(merge) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, gettext("The merge was reverted."))
+             |> assign(
+               :canonical,
+               socket.assigns.canonical && Repo.get(Tag, socket.assigns.canonical.id)
+             )
+             |> load_preview()
+             |> load_history()}
+
+          {:error, reason} ->
+            {:noreply, put_flash(socket, :error, refusal(reason))}
+        end
+    end
+  end
+
+  def handle_event("alias-name", %{"name" => name}, socket) do
+    {:noreply, assign(socket, :alias_name, name)}
+  end
+
+  def handle_event("add-alias", %{"name" => name}, socket) do
+    case Merge.add_alias(socket.assigns.canonical, name) do
+      {:ok, _tag} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("Added %{name} as an alternative name.", name: name))
+         |> assign(:alias_name, "")
+         |> load_preview()}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, put_flash(socket, :error, changeset_message(changeset))}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, refusal(reason))}
+    end
+  end
+
+  def handle_event("remove-alias", %{"id" => id}, socket) do
+    case id |> then(&Repo.get(Tag, &1)) |> Merge.remove_alias() do
+      {:ok, _} -> {:noreply, socket |> put_flash(:info, gettext("Removed.")) |> load_preview()}
+      {:error, reason} -> {:noreply, put_flash(socket, :error, refusal(reason))}
+    end
+  end
+
+  defp search(query) do
+    case String.trim(to_string(query)) do
+      "" -> []
+      q -> q |> Tags.admin_search(limit: @results_limit) |> Repo.all()
+    end
+  end
+
+  # The preview is recomputed on every pick, so what the screen shows is always
+  # the answer for the pair currently named — including the refusal, which is
+  # shown in place of the button rather than only after pressing it.
+  defp load_preview(socket) do
+    %{absorbed: absorbed, canonical: canonical} = socket.assigns
+
+    preview =
+      case {absorbed, canonical} do
+        {%Tag{}, %Tag{}} -> Merge.preview(absorbed, canonical)
+        _ -> nil
+      end
+
+    assign(socket, :preview, preview)
+    |> assign(:aliases, canonical && Tag.aliases_of(canonical))
+  end
+
+  defp load_history(socket), do: assign(socket, :history, Merge.history())
+
+  # Why a merge is refused, in the reviewer's words rather than the code's.
+  defp refusal(:same_tag), do: gettext("A tag cannot absorb itself.")
+
+  defp refusal(:honor_tag),
+    do: gettext("Honor tags are granted, not spelled. They are never merged.")
+
+  defp refusal(:already_merged),
+    do: gettext("That tag is already an alternative name. Revert its merge first.")
+
+  defp refusal(:target_is_alias),
+    do: gettext("The surviving tag is itself an alternative name. Pick its topic instead.")
+
+  defp refusal(:marked_distinct),
+    do: gettext("These two are recorded as different topics.")
+
+  defp refusal(:punctuation_only_difference),
+    do:
+      gettext(
+        "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
+      )
+
+  defp refusal(:name_taken),
+    do: gettext("That name is already a tag. Merge it instead, so its entries come along.")
+
+  defp refusal(:from_merge),
+    do: gettext("This name came from a merge. Revert that merge to take it back.")
+
+  defp refusal(:not_an_alias), do: gettext("That tag is not an alternative name.")
+  defp refusal(:already_reverted), do: gettext("That merge was already reverted.")
+  defp refusal(_other), do: gettext("That did not work.")
+
+  defp changeset_message(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, _opts} -> msg end)
+    |> Enum.map_join(" ", fn {field, messages} -> "#{field}: #{Enum.join(messages, ", ")}" end)
+  end
+
+  defp total(nil), do: 0
+  defp total(counts), do: counts |> Map.values() |> Enum.sum()
+
+  # The tables named in a preview, in the words an admin thinks in.
+  defp row_label("user_tags"), do: gettext("profiles carrying the tag")
+  defp row_label("post_tags"), do: gettext("posts filed under it")
+  defp row_label("post_hashtags"), do: gettext("hashtags in post bodies")
+  defp row_label("tag_follows"), do: gettext("members following it")
+  defp row_label("job_posting_tags"), do: gettext("job postings")
+  defp row_label("fediverse_post_tags"), do: gettext("posts from other networks")
+  defp row_label("newsletter_groups"), do: gettext("newsletter audiences")
+  defp row_label(other), do: other
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.page_header
+      title={gettext("Merge tags")}
+      crumbs={[
+        {gettext("Admin"), ~p"/admin"},
+        {gettext("Tags"), ~p"/admin/tags"},
+        gettext("Merge tags")
+      ]}
+    />
+
+    <div class="card-list">
+      <section class="card">
+        <h1>{gettext("Merge tags")}</h1>
+        <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+          {gettext(
+            "One topic sometimes ends up under several tags. Pick the tag to absorb and the tag that stays: everything filed under the first moves to the second, and the absorbed name becomes an alternative name that keeps pointing there. Every merge can be reverted below."
+          )}
+        </p>
+
+        <div class="mt-6 grid gap-6 md:grid-cols-2">
+          <.tag_picker
+            side="absorbed"
+            id="absorbed"
+            label={gettext("Tag to absorb")}
+            hint={gettext("Its entries move away and its page redirects.")}
+            tag={@absorbed}
+            query={@absorbed_query}
+            results={@absorbed_results}
+          />
+          <.tag_picker
+            side="canonical"
+            id="canonical"
+            label={gettext("Tag that stays")}
+            hint={gettext("The topic's one page from now on.")}
+            tag={@canonical}
+            query={@canonical_query}
+            results={@canonical_results}
+          />
+        </div>
+      </section>
+
+      <section :if={@preview} class="card" id="merge-preview">
+        <h2 class="card__label">{gettext("What this merge would move")}</h2>
+
+        <%= case @preview do %>
+          <% {:error, reason} -> %>
+            <p class="alert alert-danger" role="alert">{refusal(reason)}</p>
+          <% preview -> %>
+            <div class="card__tablewrap">
+              <table class="pure-table">
+                <thead>
+                  <tr>
+                    <th>{gettext("What")}</th>
+                    <th>{gettext("Moves")}</th>
+                    <th>{gettext("Dropped as duplicate")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr :for={{table, _} <- Map.merge(preview.moved, preview.dropped)}>
+                    <td>{row_label(table)}</td>
+                    <td>{delimited_count(Map.get(preview.moved, table, 0))}</td>
+                    <td>{delimited_count(Map.get(preview.dropped, table, 0))}</td>
+                  </tr>
+                  <tr :if={total(preview.moved) == 0 and total(preview.dropped) == 0}>
+                    <td colspan="3">{gettext("Nothing is filed under this tag.")}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <p :if={total(preview.dropped) > 0} class="mt-3 text-sm text-slate-600 dark:text-slate-400">
+              {gettext(
+                "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
+              )}
+            </p>
+
+            <div class="editform__actions mt-4">
+              <button id="do-merge" type="button" class="button" phx-click="merge">
+                {gettext("Merge")}
+              </button>
+              <button
+                id="mark-distinct"
+                type="button"
+                class="button button--cancel"
+                phx-click="mark-distinct"
+              >
+                {gettext("These are different topics")}
+              </button>
+            </div>
+        <% end %>
+      </section>
+
+      <section :if={@canonical} class="card" id="alias-editor">
+        <h2 class="card__label">
+          {gettext("Alternative names for %{tag}", tag: @canonical.name)}
+        </h2>
+
+        <ul :if={@aliases != []} class="thumbs">
+          <li :for={tag_alias <- @aliases} id={"alias-#{tag_alias.id}"}>
+            <span>{tag_alias.name}</span>
+            <button
+              type="button"
+              class="button button--cancel button--small"
+              phx-click="remove-alias"
+              phx-value-id={tag_alias.id}
+              data-confirm={gettext("Are you sure?")}
+            >
+              {gettext("Remove")}
+            </button>
+          </li>
+        </ul>
+
+        <p :if={@aliases == []} class="card__empty">{gettext("Nothing here yet.")}</p>
+
+        <form id="add-alias" phx-submit="add-alias" phx-change="alias-name" class="editform mt-4">
+          <div class="editform__field">
+            <label for="alias-name">{gettext("Add an alternative name")}</label>
+            <input type="text" id="alias-name" name="name" value={@alias_name} />
+            <p class="editform__hint">
+              {gettext(
+                "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
+              )}
+            </p>
+          </div>
+          <div class="editform__actions">
+            <button type="submit" class="button">{gettext("Add")}</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="card" id="merge-history">
+        <h2 class="card__label">{gettext("Merges so far")}</h2>
+
+        <p :if={@history == []} class="card__empty">{gettext("Nothing here yet.")}</p>
+
+        <div :if={@history != []} class="card__tablewrap">
+          <table class="pure-table">
+            <thead>
+              <tr>
+                <th>{gettext("Absorbed")}</th>
+                <th>{gettext("Into")}</th>
+                <th>{gettext("Rows")}</th>
+                <th>{gettext("When")}</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr :for={merge <- @history} id={"merge-#{merge.id}"}>
+                <td>{merge.absorbed_tag && merge.absorbed_tag.name}</td>
+                <td>
+                  <.link
+                    :if={merge.canonical_tag}
+                    navigate={~p"/tags/#{merge.canonical_tag}"}
+                    class="text-sm font-semibold text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+                  >
+                    {merge.canonical_tag.name}
+                  </.link>
+                </td>
+                <td>{delimited_count(total(merge.moved_counts))}</td>
+                <td><.local_time at={merge.inserted_at} id={"merge-time-#{merge.id}"} /></td>
+                <td class="text-right">
+                  <span :if={merge.reverted_at} class="text-sm text-slate-600 dark:text-slate-400">
+                    {gettext("Reverted")}
+                  </span>
+                  <button
+                    :if={is_nil(merge.reverted_at)}
+                    type="button"
+                    class="button button--cancel button--small"
+                    phx-click="revert"
+                    phx-value-id={merge.id}
+                    data-confirm={gettext("Are you sure?")}
+                  >
+                    {gettext("Revert")}
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+    """
+  end
+
+  attr(:side, :string, required: true)
+  attr(:id, :string, required: true)
+  attr(:label, :string, required: true)
+  attr(:hint, :string, required: true)
+  attr(:tag, :any, default: nil)
+  attr(:query, :string, default: "")
+  attr(:results, :list, default: [])
+
+  defp tag_picker(assigns) do
+    ~H"""
+    <div>
+      <h2 class="card__label">{@label}</h2>
+      <p class="text-sm text-slate-600 dark:text-slate-400">{@hint}</p>
+
+      <div :if={@tag} class="mt-2 flex items-center gap-3" id={"picked-#{@id}"}>
+        <.chip navigate={~p"/tags/#{@tag}"}>{@tag.name}</.chip>
+        <button
+          type="button"
+          class="button button--cancel button--small"
+          phx-click="clear"
+          phx-value-side={@side}
+        >
+          {gettext("Change")}
+        </button>
+      </div>
+
+      <form :if={is_nil(@tag)} id={"search-#{@id}"} phx-change="search" phx-submit="search" class="mt-2">
+        <input type="hidden" name="side" value={@side} />
+        <input
+          type="text"
+          id={"q-#{@id}"}
+          name="q"
+          value={@query}
+          autocomplete="off"
+          placeholder={gettext("Search by name or slug")}
+        />
+      </form>
+
+      <ul :if={is_nil(@tag) and @results != []} class="thumbs mt-2">
+        <li :for={result <- @results}>
+          <button
+            type="button"
+            id={"pick-#{@side}-#{result.id}"}
+            class="button button--small"
+            phx-click="pick"
+            phx-value-side={@side}
+            phx-value-id={result.id}
+          >
+            {result.name}
+          </button>
+        </li>
+      </ul>
+    </div>
+    """
+  end
+end

--- a/lib/vutuv_web/router.ex
+++ b/lib/vutuv_web/router.ex
@@ -752,6 +752,13 @@ defmodule VutuvWeb.Router do
       # entry in the reading admin's own log.
       live("/activity", ActivityLive, :index)
 
+      # Folding several tags for one topic into one page (issue #1338): preview
+      # what a merge moves, do it, take it back. Its own path segment rather
+      # than `/admin/tags/merge`, because the `resources("/tags", …)` catalog is
+      # defined earlier in this router and would match `merge` as a tag slug —
+      # the same reason `/admin/honor_tags` is not `/admin/tags/honor`.
+      live("/tag_merges", TagMergeLive, :index)
+
       # The moderation queue + case page: rulings (uphold/reject) act reload-free
       # and drop back to the queue. /moderation/reporters + /:id/evidence stay
       # classic (defined earlier above, so they match before this :id route).

--- a/lib/vutuv_web/templates/admin/admin/index.html.heex
+++ b/lib/vutuv_web/templates/admin/admin/index.html.heex
@@ -254,6 +254,18 @@ per-IP rate limiter and the security email only ever see the proxy hop. --%>
     </.admin_card>
 
     <.admin_card
+      icon="tag"
+      title={gettext("Merge tags")}
+      href={~p"/admin/tag_merges"}
+      id="admin-tag-merges-link"
+      cta={gettext("Merge tags")}
+    >
+      {gettext(
+        "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
+      )}
+    </.admin_card>
+
+    <.admin_card
       icon="medal"
       title={gettext("Honor tags")}
       count={@honor_tags_count}

--- a/lib/vutuv_web/templates/admin/tag/index.html.heex
+++ b/lib/vutuv_web/templates/admin/tag/index.html.heex
@@ -10,6 +10,7 @@
   <section class="card">
     <p>
       <%= link gettext("Honor tags ›"), to: ~p"/admin/honor_tags", class: "card__morelink" %>
+      <%= link gettext("Merge tags ›"), to: ~p"/admin/tag_merges", class: "card__morelink" %>
     </p>
 
     <form method="get" action={~p"/admin/tags"} class="mb-4 flex flex-wrap items-end gap-3">
@@ -62,6 +63,14 @@
               :if={tag.honor?}
               class="ml-1 inline-flex items-center rounded-full bg-brand-50 px-2 py-0.5 text-[11px] font-semibold text-brand-700 dark:bg-brand-900/40 dark:text-brand-200"
             ><%= gettext "Honor tag" %></span>
+            <%!-- The catalog is the one listing that still shows alternative
+            names (issue #1338), so a tag looked up by an absorbed name is
+            findable — marked, and pointing at the topic it belongs to. --%>
+            <span
+              :if={tag.merged_into}
+              data-tag-alias-of={tag.merged_into.slug}
+              class="ml-1 text-xs text-slate-600 dark:text-slate-400"
+            >{gettext("Alternative name for %{tag}", tag: tag.merged_into.name)}</span>
           </td>
           <td><%= tag.slug %></td>
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Vutuv.MixProject do
   def project do
     [
       app: :vutuv,
-      version: "7.234.0",
+      version: "7.235.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -18,6 +18,7 @@ msgstr "Impressum"
 #: lib/vutuv_web/components/ui.ex:3434
 #: lib/vutuv_web/components/ui.ex:3439
 #: lib/vutuv_web/live/admin/screenshot_live.ex:245
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:365
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -81,6 +82,8 @@ msgstr "Schon ein Mitglied? Einloggen."
 #: lib/vutuv_web/components/ui.ex:3229
 #: lib/vutuv_web/components/ui.ex:3323
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:345
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:410
 #, elixir-autogen
 msgid "Are you sure?"
 msgstr "Sind Sie sicher?"
@@ -460,7 +463,7 @@ msgstr "Mehr"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:590
 #: lib/vutuv_web/live/cv_live.ex:145
 #: lib/vutuv_web/templates/access_token/new.html.heex:11
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:50
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:51
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:17
 #: lib/vutuv_web/templates/dev_app/form_content.html.heex:5
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:5
@@ -644,7 +647,7 @@ msgstr "Speichern"
 #: lib/vutuv_web/live/tag_live/timeline.ex:282
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:29
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:30
 #: lib/vutuv_web/templates/layout/app.html.heex:126
 #, elixir-autogen
 msgid "Search"
@@ -665,7 +668,7 @@ msgstr "Anzeigen"
 msgid "Sign up for a free account"
 msgstr "Gratis-Konto erstellen"
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:51
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:52
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:24
 #, elixir-autogen
 msgid "Slug"
@@ -1178,6 +1181,7 @@ msgstr "Lokalisierung hinzufügen"
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:172
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:244
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -1264,7 +1268,7 @@ msgstr "PIN eingeben"
 msgid "Enter your pin"
 msgstr "PIN eingeben"
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:84
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:93
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:2
 #, elixir-autogen
 msgid "New tag"
@@ -1308,12 +1312,12 @@ msgstr "Tag-Synonym anzeigen"
 msgid "Show tag url"
 msgstr "Tag-URL anzeigen"
 
-#: lib/vutuv_web/controllers/admin/tag_controller.ex:59
+#: lib/vutuv_web/controllers/admin/tag_controller.ex:52
 #, elixir-autogen
 msgid "Tag created successfully."
 msgstr "Tag erfolgreich erstellt."
 
-#: lib/vutuv_web/controllers/admin/tag_controller.ex:96
+#: lib/vutuv_web/controllers/admin/tag_controller.ex:89
 #, elixir-autogen
 msgid "Tag deleted successfully."
 msgstr "Tag erfolgreich gelöscht."
@@ -1366,7 +1370,7 @@ msgstr "Tag-Synonym erfolgreich aktualisiert."
 msgid "Tag synonyms"
 msgstr "Tag-Synonyme"
 
-#: lib/vutuv_web/controllers/admin/tag_controller.ex:83
+#: lib/vutuv_web/controllers/admin/tag_controller.ex:76
 #, elixir-autogen
 msgid "Tag updated successfully."
 msgstr "Tag erfolgreich aktualisiert."
@@ -1403,6 +1407,7 @@ msgstr "Tag-URLs"
 #: lib/vutuv_web/cv/html.ex:156
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:245
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
@@ -1776,6 +1781,8 @@ msgstr "Netzwerk"
 
 #: lib/vutuv_web/components/post_components.ex:391
 #: lib/vutuv_web/components/ui.ex:3436
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:352
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:373
 #: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -2251,6 +2258,7 @@ msgstr "Weniger anzeigen"
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:347
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
@@ -4253,7 +4261,7 @@ msgstr ""
 "vutuv zeigt eine einzige, reine Textanzeige pro Kalendertag: dezent, "
 "zwischen Navigation und Inhalt, im Stil klassischer Textanzeigen."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:420
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "%{formatted} ad is waiting for approval."
 msgid_plural "%{formatted} ads are waiting for approval."
@@ -4268,7 +4276,7 @@ msgstr "Anzeigen-Abnahme"
 
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:5
 #: lib/vutuv_web/templates/admin/ad/show.html.heex:5
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:410
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "Ads"
 msgstr "Anzeigen"
@@ -4339,7 +4347,7 @@ msgstr "Meine Anzeigenbuchungen"
 msgid "My bookings"
 msgstr "Meine Buchungen"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:418
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "No ads waiting for approval."
 msgstr "Keine Anzeigen warten auf Freischaltung."
@@ -4349,7 +4357,7 @@ msgstr "Keine Anzeigen warten auf Freischaltung."
 msgid "No upcoming ads."
 msgstr "Keine anstehenden Anzeigen."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:415
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:427
 #, elixir-autogen, elixir-format
 msgid "Open the ad review"
 msgstr "Zur Anzeigen-Abnahme"
@@ -5038,7 +5046,7 @@ msgstr "\"%{name}\" hat keinen Zugriff mehr auf Ihr Konto."
 msgid "%{app} wants to access your vutuv account. It would be allowed to:"
 msgstr "%{app} möchte auf Ihr vutuv-Konto zugreifen. Es dürfte:"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:399
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "%{formatted} registered third-party application. Suspending one cuts off all of its tokens."
 msgid_plural "%{formatted} registered third-party applications. Suspending one cuts off all of its tokens."
@@ -5052,7 +5060,7 @@ msgstr[1] ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:21
 #: lib/vutuv_web/live/admin/api_app_live.ex:57
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:393
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:405
 #, elixir-autogen, elixir-format
 msgid "API applications"
 msgstr "API-Anwendungen"
@@ -5145,7 +5153,7 @@ msgid "Generate a new client secret? The current one stops working."
 msgstr ""
 "Neues Client-Secret erzeugen? Das aktuelle funktioniert dann nicht mehr."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:397
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "Manage applications"
 msgstr "Anwendungen verwalten"
@@ -5662,6 +5670,7 @@ msgstr "Über Sie"
 msgid "Account"
 msgstr "Konto"
 
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:446
 #: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -6353,7 +6362,7 @@ msgstr[1] "%{count} Jahre"
 msgid "Age"
 msgstr "Alter"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:309
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Confirmed new registrations and the day's posts, reposts, likes and bookmarks. Time-travel to any past day."
 msgstr ""
@@ -6365,7 +6374,7 @@ msgstr ""
 msgid "Count"
 msgstr "Anzahl"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:304
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:316
 #: lib/vutuv_web/templates/admin/report/index.html.heex:2
 #: lib/vutuv_web/templates/admin/report/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -6412,7 +6421,7 @@ msgstr "Nächster Tag"
 msgid "No activity on this day."
 msgstr "An diesem Tag gab es keine Aktivität."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:307
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "Open the daily report"
 msgstr "Tagesbericht öffnen"
@@ -6754,6 +6763,7 @@ msgstr "Das rohe Bounce-Protokoll, neueste zuerst."
 #: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:382
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:230
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
@@ -7282,7 +7292,7 @@ msgstr "Mit Ihren eigenen Kontodaten für die Variablen dargestellt."
 
 #: lib/vutuv_web/live/cv_live.ex:241
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:281
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:35
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Reset"
 msgstr "Zurücksetzen"
@@ -7836,7 +7846,7 @@ msgstr "Kommunikation"
 msgid "Content & taxonomy"
 msgstr "Inhalte & Taxonomie"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:301
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:313
 #, elixir-autogen, elixir-format
 msgid "System & insights"
 msgstr "System & Auswertungen"
@@ -7853,19 +7863,19 @@ msgstr ""
 "Tags anlegen, umbenennen und entfernen, die Mitglieder ihrem Profil "
 "hinzufügen können."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:271
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:283
 #: lib/vutuv_web/templates/admin/username/index.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Usernames"
 msgstr "Benutzernamen"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:274
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:286
 #: lib/vutuv_web/templates/admin/username/index.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Disable a username"
 msgstr "Benutzernamen deaktivieren"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:276
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Take an unwanted username away from a member by force-renaming the account."
 msgstr ""
@@ -8956,7 +8966,7 @@ msgstr ""
 msgid "Content"
 msgstr "Inhalt"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:362
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "Edit the legal pages"
 msgstr "Rechtstexte bearbeiten"
@@ -8974,7 +8984,7 @@ msgstr ""
 msgid "Impressum"
 msgstr "Impressum"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:364
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:376
 #, elixir-autogen, elixir-format
 msgid "Impressum, Datenschutzerklärung and Nutzungsbedingungen: every installation publishes its own operator identity here."
 msgstr ""
@@ -8987,7 +8997,7 @@ msgid "Last edited"
 msgstr "Zuletzt bearbeitet"
 
 #: lib/vutuv_web/controllers/admin/legal_page_controller.ex:22
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:359
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:371
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:2
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:3
@@ -9050,7 +9060,7 @@ msgstr "Unter Admin › Rechtstexte verfassen"
 #: lib/vutuv_web/controllers/settings_controller.ex:389
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:286
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:329
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
@@ -9462,7 +9472,7 @@ msgstr "Ja"
 
 #: lib/vutuv_web/components/ui.ex:1436
 #: lib/vutuv_web/components/ui.ex:1437
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:64
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Honor tag"
@@ -9937,7 +9947,7 @@ msgstr "Ehren-Tag erstellen"
 msgid "Enter a single word with no spaces."
 msgstr "Bitte ein einzelnes Wort ohne Leerzeichen eingeben."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:258
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:270
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:2
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -9958,7 +9968,7 @@ msgstr ""
 msgid "Honor tags ›"
 msgstr "Ehren-Tags ›"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:262
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:274
 #, elixir-autogen, elixir-format
 msgid "Manage honor tags"
 msgstr "Ehren-Tags verwalten"
@@ -9978,7 +9988,7 @@ msgstr "Neuer Ehren-Tag (ein einzelnes Wort)"
 msgid "No honor tags yet. Create one above."
 msgstr "Noch keine Ehren-Tags. Erstellen Sie oben einen."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:264
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "Official badges you grant, like vutuv_developer for the core team. See who holds each and add or remove members."
 msgstr ""
@@ -10262,45 +10272,45 @@ msgstr "Kopiert"
 msgid "Copy"
 msgstr "Kopieren"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:345
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:357
 #, elixir-autogen, elixir-format
 msgid "%{followers} remote followers, %{queue} queued for delivery."
 msgstr ""
 "%{followers} Fediverse-Follower, %{queue} in der Zustellwarteschlange."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:337
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Attention:"
 msgstr "Achtung:"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:343
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "Outbound federation is healthy."
 msgstr "Die ausgehende Föderation läuft störungsfrei."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:337
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "stuck outbound delivery."
 msgid_plural "stuck outbound deliveries."
 msgstr[0] "hängende ausgehende Zustellung."
 msgstr[1] "hängende ausgehende Zustellungen."
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:40
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "No tags match your search."
 msgstr "Keine Tags entsprechen Ihrer Suche."
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:43
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "No tags yet."
 msgstr "Noch keine Tags."
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:18
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Search tags"
 msgstr "Tags durchsuchen"
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:25
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "name or slug"
 msgstr "Name oder Slug"
@@ -11113,7 +11123,7 @@ msgstr[1] ""
 msgid "Changed for this installation."
 msgstr "Für diese Installation geändert."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:375
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Edit the defaults"
 msgstr "Voreinstellungen bearbeiten"
@@ -11123,7 +11133,7 @@ msgstr "Voreinstellungen bearbeiten"
 msgid "Follows the installation default."
 msgstr "Folgt dem Standard der Installation."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:382
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:394
 #, elixir-autogen, elixir-format
 msgid "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} default differs from the shipped value."
 msgid_plural "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} defaults differ from the shipped values."
@@ -11134,7 +11144,7 @@ msgstr[1] ""
 "Wie sich Beiträge und Karten für alle verhalten, die nicht selbst gewählt "
 "haben. %{formatted} Standards weichen von den mitgelieferten Werten ab."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:378
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "How posts and maps behave for everyone who has not chosen for themselves. This installation runs on the shipped defaults."
 msgstr ""
@@ -11172,7 +11182,7 @@ msgstr ""
 "Anzeige-Einstellungen für Beiträge auf die Standardwerte zurückgesetzt."
 
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:55
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:371
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:383
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:6
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:7
 #, elixir-autogen, elixir-format
@@ -12295,7 +12305,7 @@ msgstr "Verknüpfung entfernen"
 msgid "former"
 msgstr "ehemalig"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:291
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:303
 #, elixir-autogen, elixir-format
 msgid "%{formatted} alias matches another verified organization and is flagged for review."
 msgid_plural "%{formatted} aliases match another verified organization and are flagged for review."
@@ -12457,7 +12467,7 @@ msgid "Nothing here yet. Organizations you like show up here."
 msgstr ""
 "Hier ist noch nichts. Organisationen, die Ihnen gefallen, erscheinen hier."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:286
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "Open organization oversight"
 msgstr "Organisations-Aufsicht öffnen"
@@ -12491,7 +12501,7 @@ msgstr "Organisationsseite"
 #: lib/vutuv_web/live/admin/organization_live.ex:25
 #: lib/vutuv_web/live/admin/organization_live.ex:188
 #: lib/vutuv_web/live/admin/organization_live.ex:189
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:281
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Organization pages"
 msgstr "Organisationsseiten"
@@ -12581,7 +12591,7 @@ msgstr ""
 msgid "Verified organization pages on vutuv."
 msgstr "Verifizierte Organisationsseiten auf vutuv."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:289
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "Verified organization pages: domains, team roles, aliases and rename history. Freeze, archive or delete a page."
 msgstr ""
@@ -13766,6 +13776,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr "Das hat nicht funktioniert."
@@ -15364,17 +15375,17 @@ msgstr "Bisher hat uns kein Server etwas geschickt."
 msgid "How much each server has stored here. Use it to decide what to block."
 msgstr "Wie viel jeder Server hier gespeichert hat. Danach entscheiden Sie, was Sie blockieren."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:334
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "Block servers and see inbound volume"
 msgstr "Server blockieren und eingehendes Volumen ansehen"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:351
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:363
 #, elixir-autogen, elixir-format
 msgid "%{blocked} servers blocked, busiest inbound: %{host}."
 msgstr "%{blocked} Server blockiert, am aktivsten eingehend: %{host}."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:353
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "none yet"
 msgstr "noch keiner"
@@ -16281,6 +16292,7 @@ msgstr "Diese Antwort können Sie nicht entfernen."
 msgid "View the original"
 msgstr "Original ansehen"
 
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:292
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:190
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:231
 #, elixir-autogen, elixir-format
@@ -17855,7 +17867,7 @@ msgstr "Gleichstand bei %{count} Ergebnissen. Keine der beiden Überschriften se
 msgid "Every logged-out visitor to the start page is shown one of two founder quotes at random and keeps it for their session. Counted per variant: the visitors who saw it, the sign-up forms that created an account, and the PINs that turned such an account into a real member."
 msgstr "Jeder ausgeloggte Besucher der Startseite bekommt zufällig eines von zwei Gründerzitaten und behält es für seine Sitzung. Gezählt wird je Variante: die Besucher, die es gesehen haben, die Anmeldeformulare, die ein Konto angelegt haben, und die PINs, die aus so einem Konto ein echtes Mitglied gemacht haben."
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:316
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:328
 #: lib/vutuv_web/templates/admin/experiment/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Headline test"
@@ -17882,7 +17894,7 @@ msgstr "Bisher nichts gezählt."
 msgid "Result"
 msgstr "Ergebnis"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:319
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "See which start page wins"
 msgstr "Sehen, welche Startseite gewinnt"
@@ -17908,7 +17920,7 @@ msgstr "Registrierungen"
 msgid "Sign-ups:"
 msgstr "Registrierungen:"
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:321
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "The start page shows one of two founder quotes at random. Views, sign-ups and confirmed members per variant, and whether the difference is real yet."
 msgstr "Die Startseite zeigt zufällig eines von zwei Gründerzitaten. Aufrufe, Registrierungen und bestätigte Mitglieder je Variante, und ob der Unterschied schon belastbar ist."
@@ -20410,3 +20422,253 @@ msgstr "Ihre Regel"
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
 msgstr "löschen entfernen beiträge alter alt ablaufen verfallen automatisch aufräumen aufbewahrung"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:83
+#, elixir-autogen, elixir-format
+msgid "%{absorbed} is now an alternative name for %{canonical}."
+msgstr "%{absorbed} ist jetzt ein Zweitname von %{canonical}."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:106
+#, elixir-autogen, elixir-format
+msgid "%{a} and %{b} are recorded as different topics."
+msgstr "%{a} und %{b} sind als verschiedene Themen vermerkt."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:311
+#, elixir-autogen, elixir-format
+msgid "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
+msgstr "Ein wegfallender Eintrag gehört jemandem, der das bleibende Tag schon trägt; danach trägt diese Person das Thema einmal. Empfehlungen ziehen auf den Eintrag um, der bleibt."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:189
+#, elixir-autogen, elixir-format
+msgid "A tag cannot absorb itself."
+msgstr "Ein Tag kann sich nicht selbst aufnehmen."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:379
+#, elixir-autogen, elixir-format
+msgid "Absorbed"
+msgstr "Aufgenommen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:356
+#, elixir-autogen, elixir-format
+msgid "Add an alternative name"
+msgstr "Zweitnamen hinzufügen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:144
+#, elixir-autogen, elixir-format
+msgid "Added %{name} as an alternative name."
+msgstr "%{name} wurde als Zweitname hinzugefügt."
+
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:73
+#, elixir-autogen, elixir-format
+msgid "Alternative name for %{tag}"
+msgstr "Zweitname von %{tag}"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:334
+#, elixir-autogen, elixir-format
+msgid "Alternative names for %{tag}"
+msgstr "Zweitnamen von %{tag}"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:294
+#, elixir-autogen, elixir-format
+msgid "Dropped as duplicate"
+msgstr "Fällt als Dublette weg"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
+#, elixir-autogen, elixir-format
+msgid "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
+msgstr "Für einen Namen, den noch niemand getippt hat, damit daraus nie eine eigene Seite wird. Ein Name, der bereits ein Tag ist, muss stattdessen zusammengelegt werden."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:380
+#, elixir-autogen, elixir-format
+msgid "Into"
+msgstr "Aufgenommen in"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:264
+#, elixir-autogen, elixir-format
+msgid "Its entries move away and its page redirects."
+msgstr "Seine Einträge ziehen um, seine Seite leitet weiter."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:318
+#, elixir-autogen, elixir-format
+msgid "Merge"
+msgstr "Zusammenlegen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:41
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:242
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:246
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:252
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:258
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:261
+#, elixir-autogen, elixir-format
+msgid "Merge tags"
+msgstr "Tags zusammenlegen"
+
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "Merge tags ›"
+msgstr "Tags zusammenlegen ›"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
+#, elixir-autogen, elixir-format
+msgid "Merges so far"
+msgstr "Bisherige Zusammenlegungen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:293
+#, elixir-autogen, elixir-format
+msgid "Moves"
+msgstr "Zieht um"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:304
+#, elixir-autogen, elixir-format
+msgid "Nothing is filed under this tag."
+msgstr "Unter diesem Tag ist nichts abgelegt."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:254
+#, elixir-autogen, elixir-format
+msgid "One topic sometimes ends up under several tags. Pick the tag to absorb and the tag that stays: everything filed under the first moves to the second, and the absorbed name becomes an alternative name that keeps pointing there. Every merge can be reverted below."
+msgstr "Ein Thema landet manchmal unter mehreren Tags. Wählen Sie das Tag, das aufgenommen wird, und das Tag, das bleibt: Alles, was unter dem ersten liegt, zieht zum zweiten um, und der aufgenommene Name wird zu einem Zweitnamen, der weiter dorthin zeigt. Jede Zusammenlegung lässt sich unten rückgängig machen."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:158
+#, elixir-autogen, elixir-format
+msgid "Removed."
+msgstr "Entfernt."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:412
+#, elixir-autogen, elixir-format
+msgid "Revert"
+msgstr "Rückgängig machen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:402
+#, elixir-autogen, elixir-format
+msgid "Reverted"
+msgstr "Rückgängig gemacht"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
+#, elixir-autogen, elixir-format
+msgid "Rows"
+msgstr "Einträge"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:458
+#, elixir-autogen, elixir-format
+msgid "Search by name or slug"
+msgstr "Nach Name oder Slug suchen"
+
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:263
+#, elixir-autogen, elixir-format
+msgid "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
+msgstr "Mehrere Tags für ein Thema werden eine Seite: sehen, was eine Zusammenlegung verschiebt, sie durchführen und wieder zurücknehmen, falls sie falsch war."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:272
+#, elixir-autogen, elixir-format
+msgid "Tag that stays"
+msgstr "Tag, das bleibt"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:263
+#, elixir-autogen, elixir-format
+msgid "Tag to absorb"
+msgstr "Tag, das aufgenommen wird"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:117
+#, elixir-autogen, elixir-format
+msgid "That merge is no longer on record."
+msgstr "Diese Zusammenlegung ist nicht mehr vermerkt."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:216
+#, elixir-autogen, elixir-format
+msgid "That merge was already reverted."
+msgstr "Diese Zusammenlegung wurde bereits rückgängig gemacht."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:210
+#, elixir-autogen, elixir-format
+msgid "That name is already a tag. Merge it instead, so its entries come along."
+msgstr "Dieser Name ist bereits ein Tag. Legen Sie es stattdessen zusammen, damit seine Einträge mitkommen."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:195
+#, elixir-autogen, elixir-format
+msgid "That tag is already an alternative name. Revert its merge first."
+msgstr "Dieses Tag ist bereits ein Zweitname. Machen Sie zuerst seine Zusammenlegung rückgängig."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "That tag is not an alternative name."
+msgstr "Dieses Tag ist kein Zweitname."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:124
+#, elixir-autogen, elixir-format
+msgid "The merge was reverted."
+msgstr "Die Zusammenlegung wurde rückgängig gemacht."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:198
+#, elixir-autogen, elixir-format
+msgid "The surviving tag is itself an alternative name. Pick its topic instead."
+msgstr "Das bleibende Tag ist selbst ein Zweitname. Wählen Sie stattdessen sein Thema."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:273
+#, elixir-autogen, elixir-format
+msgid "The topic's one page from now on."
+msgstr "Ab jetzt die eine Seite des Themas."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:326
+#, elixir-autogen, elixir-format
+msgid "These are different topics"
+msgstr "Das sind verschiedene Themen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:205
+#, elixir-autogen, elixir-format
+msgid "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
+msgstr "Diese Namen unterscheiden sich nur in Zeichen, die der Slug weglässt (etwa + oder #). Genau daran unterscheiden sich C, C++ und C#. Sie werden nicht zusammengelegt."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:201
+#, elixir-autogen, elixir-format
+msgid "These two are recorded as different topics."
+msgstr "Diese beiden sind als verschiedene Themen vermerkt."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:213
+#, elixir-autogen, elixir-format
+msgid "This name came from a merge. Revert that merge to take it back."
+msgstr "Dieser Name stammt aus einer Zusammenlegung. Machen Sie diese rückgängig, um ihn zurückzunehmen."
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:282
+#, elixir-autogen, elixir-format
+msgid "What this merge would move"
+msgstr "Was diese Zusammenlegung verschieben würde"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:231
+#, elixir-autogen, elixir-format
+msgid "hashtags in post bodies"
+msgstr "Hashtags in Beiträgen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:233
+#, elixir-autogen, elixir-format
+msgid "job postings"
+msgstr "Stellenanzeigen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:232
+#, elixir-autogen, elixir-format
+msgid "members following it"
+msgstr "Mitglieder, die ihm folgen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:235
+#, elixir-autogen, elixir-format
+msgid "newsletter audiences"
+msgstr "Newsletter-Zielgruppen"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:230
+#, elixir-autogen, elixir-format
+msgid "posts filed under it"
+msgstr "Beiträge darunter"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:234
+#, elixir-autogen, elixir-format
+msgid "posts from other networks"
+msgstr "Beiträge aus anderen Netzwerken"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "profiles carrying the tag"
+msgstr "Profile mit diesem Tag"
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:192
+#, elixir-autogen, elixir-format
+msgid "Honor tags are granted, not spelled. They are never merged."
+msgstr "Ehren-Tags werden vergeben, nicht geschrieben. Sie werden nie zusammengelegt."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -20,6 +20,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3434
 #: lib/vutuv_web/components/ui.ex:3439
 #: lib/vutuv_web/live/admin/screenshot_live.ex:245
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:365
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -83,6 +84,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3229
 #: lib/vutuv_web/components/ui.ex:3323
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:345
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:410
 #, elixir-autogen
 msgid "Are you sure?"
 msgstr ""
@@ -460,7 +463,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:590
 #: lib/vutuv_web/live/cv_live.ex:145
 #: lib/vutuv_web/templates/access_token/new.html.heex:11
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:50
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:51
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:17
 #: lib/vutuv_web/templates/dev_app/form_content.html.heex:5
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:5
@@ -644,7 +647,7 @@ msgstr ""
 #: lib/vutuv_web/live/tag_live/timeline.ex:282
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:29
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:30
 #: lib/vutuv_web/templates/layout/app.html.heex:126
 #, elixir-autogen
 msgid "Search"
@@ -665,7 +668,7 @@ msgstr ""
 msgid "Sign up for a free account"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:51
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:52
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:24
 #, elixir-autogen
 msgid "Slug"
@@ -1154,6 +1157,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:172
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:244
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -1237,7 +1241,7 @@ msgstr ""
 msgid "Enter your pin"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:84
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:93
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:2
 #, elixir-autogen
 msgid "New tag"
@@ -1281,12 +1285,12 @@ msgstr ""
 msgid "Show tag url"
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/tag_controller.ex:59
+#: lib/vutuv_web/controllers/admin/tag_controller.ex:52
 #, elixir-autogen
 msgid "Tag created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/tag_controller.ex:96
+#: lib/vutuv_web/controllers/admin/tag_controller.ex:89
 #, elixir-autogen
 msgid "Tag deleted successfully."
 msgstr ""
@@ -1339,7 +1343,7 @@ msgstr ""
 msgid "Tag synonyms"
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/tag_controller.ex:83
+#: lib/vutuv_web/controllers/admin/tag_controller.ex:76
 #, elixir-autogen
 msgid "Tag updated successfully."
 msgstr ""
@@ -1376,6 +1380,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:156
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:245
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
@@ -1741,6 +1746,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:391
 #: lib/vutuv_web/components/ui.ex:3436
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:352
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:373
 #: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -2206,6 +2213,7 @@ msgstr ""
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:347
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
@@ -4115,7 +4123,7 @@ msgstr ""
 msgid "vutuv shows a single, text-only ad per calendar day: discreet, between the navigation and the content, in the style of classic text ads."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:420
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "%{formatted} ad is waiting for approval."
 msgid_plural "%{formatted} ads are waiting for approval."
@@ -4130,7 +4138,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:5
 #: lib/vutuv_web/templates/admin/ad/show.html.heex:5
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:410
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "Ads"
 msgstr ""
@@ -4195,7 +4203,7 @@ msgstr ""
 msgid "My bookings"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:418
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "No ads waiting for approval."
 msgstr ""
@@ -4205,7 +4213,7 @@ msgstr ""
 msgid "No upcoming ads."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:415
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:427
 #, elixir-autogen, elixir-format
 msgid "Open the ad review"
 msgstr ""
@@ -4850,7 +4858,7 @@ msgstr ""
 msgid "%{app} wants to access your vutuv account. It would be allowed to:"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:399
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "%{formatted} registered third-party application. Suspending one cuts off all of its tokens."
 msgid_plural "%{formatted} registered third-party applications. Suspending one cuts off all of its tokens."
@@ -4860,7 +4868,7 @@ msgstr[1] ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:21
 #: lib/vutuv_web/live/admin/api_app_live.ex:57
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:393
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:405
 #, elixir-autogen, elixir-format
 msgid "API applications"
 msgstr ""
@@ -4950,7 +4958,7 @@ msgstr ""
 msgid "Generate a new client secret? The current one stops working."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:397
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "Manage applications"
 msgstr ""
@@ -5437,6 +5445,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:446
 #: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -6107,7 +6116,7 @@ msgstr[1] ""
 msgid "Age"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:309
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Confirmed new registrations and the day's posts, reposts, likes and bookmarks. Time-travel to any past day."
 msgstr ""
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:304
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:316
 #: lib/vutuv_web/templates/admin/report/index.html.heex:2
 #: lib/vutuv_web/templates/admin/report/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -6164,7 +6173,7 @@ msgstr ""
 msgid "No activity on this day."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:307
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "Open the daily report"
 msgstr ""
@@ -6485,6 +6494,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:382
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:230
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
@@ -6990,7 +7000,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:241
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:281
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:35
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Reset"
 msgstr ""
@@ -7518,7 +7528,7 @@ msgstr ""
 msgid "Content & taxonomy"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:301
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:313
 #, elixir-autogen, elixir-format
 msgid "System & insights"
 msgstr ""
@@ -7533,19 +7543,19 @@ msgstr ""
 msgid "Create, rename and remove the tags members can add to their profile."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:271
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:283
 #: lib/vutuv_web/templates/admin/username/index.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Usernames"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:274
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:286
 #: lib/vutuv_web/templates/admin/username/index.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Disable a username"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:276
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Take an unwanted username away from a member by force-renaming the account."
 msgstr ""
@@ -8533,7 +8543,7 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:362
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "Edit the legal pages"
 msgstr ""
@@ -8548,7 +8558,7 @@ msgstr ""
 msgid "Impressum"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:364
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:376
 #, elixir-autogen, elixir-format
 msgid "Impressum, Datenschutzerklärung and Nutzungsbedingungen: every installation publishes its own operator identity here."
 msgstr ""
@@ -8559,7 +8569,7 @@ msgid "Last edited"
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/legal_page_controller.ex:22
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:359
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:371
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:2
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:3
@@ -8619,7 +8629,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:389
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:286
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:329
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
@@ -8992,7 +9002,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1436
 #: lib/vutuv_web/components/ui.ex:1437
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:64
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Honor tag"
@@ -9465,7 +9475,7 @@ msgstr ""
 msgid "Enter a single word with no spaces."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:258
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:270
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:2
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -9482,7 +9492,7 @@ msgstr ""
 msgid "Honor tags ›"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:262
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:274
 #, elixir-autogen, elixir-format
 msgid "Manage honor tags"
 msgstr ""
@@ -9502,7 +9512,7 @@ msgstr ""
 msgid "No honor tags yet. Create one above."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:264
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "Official badges you grant, like vutuv_developer for the core team. See who holds each and add or remove members."
 msgstr ""
@@ -9774,44 +9784,44 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:345
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:357
 #, elixir-autogen, elixir-format
 msgid "%{followers} remote followers, %{queue} queued for delivery."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:337
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Attention:"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:343
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "Outbound federation is healthy."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:337
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "stuck outbound delivery."
 msgid_plural "stuck outbound deliveries."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:40
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "No tags match your search."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:43
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "No tags yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:18
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Search tags"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:25
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "name or slug"
 msgstr ""
@@ -10549,7 +10559,7 @@ msgstr[1] ""
 msgid "Changed for this installation."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:375
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Edit the defaults"
 msgstr ""
@@ -10559,14 +10569,14 @@ msgstr ""
 msgid "Follows the installation default."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:382
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:394
 #, elixir-autogen, elixir-format
 msgid "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} default differs from the shipped value."
 msgid_plural "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} defaults differ from the shipped values."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:378
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "How posts and maps behave for everyone who has not chosen for themselves. This installation runs on the shipped defaults."
 msgstr ""
@@ -10597,7 +10607,7 @@ msgid "Post display settings reset to the site defaults."
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:55
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:371
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:383
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:6
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:7
 #, elixir-autogen, elixir-format
@@ -11662,7 +11672,7 @@ msgstr ""
 msgid "former"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:291
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:303
 #, elixir-autogen, elixir-format
 msgid "%{formatted} alias matches another verified organization and is flagged for review."
 msgid_plural "%{formatted} aliases match another verified organization and are flagged for review."
@@ -11801,7 +11811,7 @@ msgstr ""
 msgid "Nothing here yet. Organizations you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:286
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "Open organization oversight"
 msgstr ""
@@ -11835,7 +11845,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:25
 #: lib/vutuv_web/live/admin/organization_live.ex:188
 #: lib/vutuv_web/live/admin/organization_live.ex:189
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:281
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Organization pages"
 msgstr ""
@@ -11919,7 +11929,7 @@ msgstr ""
 msgid "Verified organization pages on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:289
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "Verified organization pages: domains, team roles, aliases and rename history. Freeze, archive or delete a page."
 msgstr ""
@@ -13091,6 +13101,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -14650,17 +14661,17 @@ msgstr ""
 msgid "How much each server has stored here. Use it to decide what to block."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:334
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "Block servers and see inbound volume"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:351
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:363
 #, elixir-autogen, elixir-format
 msgid "%{blocked} servers blocked, busiest inbound: %{host}."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:353
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "none yet"
 msgstr ""
@@ -15553,6 +15564,7 @@ msgstr ""
 msgid "View the original"
 msgstr ""
 
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:292
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:190
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:231
 #, elixir-autogen, elixir-format
@@ -17108,7 +17120,7 @@ msgstr ""
 msgid "Every logged-out visitor to the start page is shown one of two founder quotes at random and keeps it for their session. Counted per variant: the visitors who saw it, the sign-up forms that created an account, and the PINs that turned such an account into a real member."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:316
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:328
 #: lib/vutuv_web/templates/admin/experiment/index.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Headline test"
@@ -17135,7 +17147,7 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:319
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "See which start page wins"
 msgstr ""
@@ -17161,7 +17173,7 @@ msgstr ""
 msgid "Sign-ups:"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:321
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "The start page shows one of two founder quotes at random. Views, sign-ups and confirmed members per variant, and whether the difference is real yet."
 msgstr ""
@@ -19622,4 +19634,254 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3686
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:83
+#, elixir-autogen, elixir-format
+msgid "%{absorbed} is now an alternative name for %{canonical}."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:106
+#, elixir-autogen, elixir-format
+msgid "%{a} and %{b} are recorded as different topics."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:311
+#, elixir-autogen, elixir-format
+msgid "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:189
+#, elixir-autogen, elixir-format
+msgid "A tag cannot absorb itself."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:379
+#, elixir-autogen, elixir-format
+msgid "Absorbed"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:356
+#, elixir-autogen, elixir-format
+msgid "Add an alternative name"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:144
+#, elixir-autogen, elixir-format
+msgid "Added %{name} as an alternative name."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:73
+#, elixir-autogen, elixir-format
+msgid "Alternative name for %{tag}"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:334
+#, elixir-autogen, elixir-format
+msgid "Alternative names for %{tag}"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:294
+#, elixir-autogen, elixir-format
+msgid "Dropped as duplicate"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
+#, elixir-autogen, elixir-format
+msgid "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:380
+#, elixir-autogen, elixir-format
+msgid "Into"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:264
+#, elixir-autogen, elixir-format
+msgid "Its entries move away and its page redirects."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:318
+#, elixir-autogen, elixir-format
+msgid "Merge"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:41
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:242
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:246
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:252
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:258
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:261
+#, elixir-autogen, elixir-format
+msgid "Merge tags"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "Merge tags ›"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
+#, elixir-autogen, elixir-format
+msgid "Merges so far"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:293
+#, elixir-autogen, elixir-format
+msgid "Moves"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:304
+#, elixir-autogen, elixir-format
+msgid "Nothing is filed under this tag."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:254
+#, elixir-autogen, elixir-format
+msgid "One topic sometimes ends up under several tags. Pick the tag to absorb and the tag that stays: everything filed under the first moves to the second, and the absorbed name becomes an alternative name that keeps pointing there. Every merge can be reverted below."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:158
+#, elixir-autogen, elixir-format
+msgid "Removed."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:412
+#, elixir-autogen, elixir-format
+msgid "Revert"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:402
+#, elixir-autogen, elixir-format
+msgid "Reverted"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
+#, elixir-autogen, elixir-format
+msgid "Rows"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:458
+#, elixir-autogen, elixir-format
+msgid "Search by name or slug"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:263
+#, elixir-autogen, elixir-format
+msgid "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:272
+#, elixir-autogen, elixir-format
+msgid "Tag that stays"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:263
+#, elixir-autogen, elixir-format
+msgid "Tag to absorb"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:117
+#, elixir-autogen, elixir-format
+msgid "That merge is no longer on record."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:216
+#, elixir-autogen, elixir-format
+msgid "That merge was already reverted."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:210
+#, elixir-autogen, elixir-format
+msgid "That name is already a tag. Merge it instead, so its entries come along."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:195
+#, elixir-autogen, elixir-format
+msgid "That tag is already an alternative name. Revert its merge first."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "That tag is not an alternative name."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:124
+#, elixir-autogen, elixir-format
+msgid "The merge was reverted."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:198
+#, elixir-autogen, elixir-format
+msgid "The surviving tag is itself an alternative name. Pick its topic instead."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:273
+#, elixir-autogen, elixir-format
+msgid "The topic's one page from now on."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:326
+#, elixir-autogen, elixir-format
+msgid "These are different topics"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:205
+#, elixir-autogen, elixir-format
+msgid "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:201
+#, elixir-autogen, elixir-format
+msgid "These two are recorded as different topics."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:213
+#, elixir-autogen, elixir-format
+msgid "This name came from a merge. Revert that merge to take it back."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:282
+#, elixir-autogen, elixir-format
+msgid "What this merge would move"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:231
+#, elixir-autogen, elixir-format
+msgid "hashtags in post bodies"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:233
+#, elixir-autogen, elixir-format
+msgid "job postings"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:232
+#, elixir-autogen, elixir-format
+msgid "members following it"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:235
+#, elixir-autogen, elixir-format
+msgid "newsletter audiences"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:230
+#, elixir-autogen, elixir-format
+msgid "posts filed under it"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:234
+#, elixir-autogen, elixir-format
+msgid "posts from other networks"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "profiles carrying the tag"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:192
+#, elixir-autogen, elixir-format
+msgid "Honor tags are granted, not spelled. They are never merged."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -18,6 +18,7 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3434
 #: lib/vutuv_web/components/ui.ex:3439
 #: lib/vutuv_web/live/admin/screenshot_live.ex:245
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:365
 #: lib/vutuv_web/live/organization_live/domains.ex:255
 #: lib/vutuv_web/live/organization_live/edit.ex:396
 #: lib/vutuv_web/live/organization_live/roles.ex:202
@@ -81,6 +82,8 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3229
 #: lib/vutuv_web/components/ui.ex:3323
 #: lib/vutuv_web/live/admin/newsletter_broadcast_live.ex:200
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:345
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:410
 #, elixir-autogen
 msgid "Are you sure?"
 msgstr ""
@@ -458,7 +461,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:590
 #: lib/vutuv_web/live/cv_live.ex:145
 #: lib/vutuv_web/templates/access_token/new.html.heex:11
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:50
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:51
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:17
 #: lib/vutuv_web/templates/dev_app/form_content.html.heex:5
 #: lib/vutuv_web/templates/qualification/form_content.html.heex:5
@@ -642,7 +645,7 @@ msgstr ""
 #: lib/vutuv_web/live/tag_live/timeline.ex:282
 #: lib/vutuv_web/templates/admin/account/index.html.heex:23
 #: lib/vutuv_web/templates/admin/account/index.html.heex:39
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:29
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:30
 #: lib/vutuv_web/templates/layout/app.html.heex:126
 #, elixir-autogen
 msgid "Search"
@@ -663,7 +666,7 @@ msgstr ""
 msgid "Sign up for a free account"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:51
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:52
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:24
 #, elixir-autogen
 msgid "Slug"
@@ -1152,6 +1155,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/newsletter_group_live.ex:693
 #: lib/vutuv_web/live/admin/organization_live.ex:189
 #: lib/vutuv_web/live/admin/screenshot_live.ex:172
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:244
 #: lib/vutuv_web/live/admin/user_delete_live.ex:104
 #: lib/vutuv_web/live/admin/user_detail_live.ex:68
 #: lib/vutuv_web/live/admin/user_live.ex:165
@@ -1235,7 +1239,7 @@ msgstr ""
 msgid "Enter your pin"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:84
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:93
 #: lib/vutuv_web/templates/admin/tag/new.html.heex:2
 #, elixir-autogen
 msgid "New tag"
@@ -1279,12 +1283,12 @@ msgstr ""
 msgid "Show tag url"
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/tag_controller.ex:59
+#: lib/vutuv_web/controllers/admin/tag_controller.ex:52
 #, elixir-autogen
 msgid "Tag created successfully."
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/tag_controller.ex:96
+#: lib/vutuv_web/controllers/admin/tag_controller.ex:89
 #, elixir-autogen
 msgid "Tag deleted successfully."
 msgstr ""
@@ -1337,7 +1341,7 @@ msgstr ""
 msgid "Tag synonyms"
 msgstr ""
 
-#: lib/vutuv_web/controllers/admin/tag_controller.ex:83
+#: lib/vutuv_web/controllers/admin/tag_controller.ex:76
 #, elixir-autogen
 msgid "Tag updated successfully."
 msgstr ""
@@ -1374,6 +1378,7 @@ msgstr ""
 #: lib/vutuv_web/cv/html.ex:156
 #: lib/vutuv_web/cv/latex.ex:131
 #: lib/vutuv_web/cv/odt.ex:148
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:245
 #: lib/vutuv_web/live/cv_live.ex:315
 #: lib/vutuv_web/live/job_board_live.ex:277
 #: lib/vutuv_web/live/job_posting_live/form.ex:510
@@ -1739,6 +1744,8 @@ msgstr ""
 
 #: lib/vutuv_web/components/post_components.ex:391
 #: lib/vutuv_web/components/ui.ex:3436
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:352
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:373
 #: lib/vutuv_web/live/admin/user_live.ex:286
 #: lib/vutuv_web/live/job_posting_live/dashboard.ex:124
 #, elixir-autogen, elixir-format
@@ -2204,6 +2211,7 @@ msgstr ""
 #: lib/vutuv_web/components/job_exclusion_components.ex:194
 #: lib/vutuv_web/components/post_components.ex:1006
 #: lib/vutuv_web/live/admin/screenshot_live.ex:317
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:347
 #: lib/vutuv_web/live/job_search_exclusions_live.ex:234
 #: lib/vutuv_web/live/organization_live/domains.ex:229
 #: lib/vutuv_web/live/organization_live/edit.ex:373
@@ -4113,7 +4121,7 @@ msgstr ""
 msgid "vutuv shows a single, text-only ad per calendar day: discreet, between the navigation and the content, in the style of classic text ads."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:420
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:432
 #, elixir-autogen, elixir-format
 msgid "%{formatted} ad is waiting for approval."
 msgid_plural "%{formatted} ads are waiting for approval."
@@ -4128,7 +4136,7 @@ msgstr ""
 
 #: lib/vutuv_web/templates/admin/ad/index.html.heex:5
 #: lib/vutuv_web/templates/admin/ad/show.html.heex:5
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:410
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:422
 #, elixir-autogen, elixir-format
 msgid "Ads"
 msgstr ""
@@ -4193,7 +4201,7 @@ msgstr ""
 msgid "My bookings"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:418
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:430
 #, elixir-autogen, elixir-format
 msgid "No ads waiting for approval."
 msgstr ""
@@ -4203,7 +4211,7 @@ msgstr ""
 msgid "No upcoming ads."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:415
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:427
 #, elixir-autogen, elixir-format
 msgid "Open the ad review"
 msgstr ""
@@ -4848,7 +4856,7 @@ msgstr ""
 msgid "%{app} wants to access your vutuv account. It would be allowed to:"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:399
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "%{formatted} registered third-party application. Suspending one cuts off all of its tokens."
 msgid_plural "%{formatted} registered third-party applications. Suspending one cuts off all of its tokens."
@@ -4858,7 +4866,7 @@ msgstr[1] ""
 #: lib/vutuv_web/live/admin/api_app_live.ex:21
 #: lib/vutuv_web/live/admin/api_app_live.ex:57
 #: lib/vutuv_web/live/admin/api_app_live.ex:58
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:393
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:405
 #, elixir-autogen, elixir-format
 msgid "API applications"
 msgstr ""
@@ -4948,7 +4956,7 @@ msgstr ""
 msgid "Generate a new client secret? The current one stops working."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:397
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "Manage applications"
 msgstr ""
@@ -5435,6 +5443,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:446
 #: lib/vutuv_web/live/organization_live/edit.ex:443
 #, elixir-autogen, elixir-format
 msgid "Change"
@@ -6105,7 +6114,7 @@ msgstr[1] ""
 msgid "Age"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:309
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:321
 #, elixir-autogen, elixir-format
 msgid "Confirmed new registrations and the day's posts, reposts, likes and bookmarks. Time-travel to any past day."
 msgstr ""
@@ -6115,7 +6124,7 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:304
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:316
 #: lib/vutuv_web/templates/admin/report/index.html.heex:2
 #: lib/vutuv_web/templates/admin/report/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -6162,7 +6171,7 @@ msgstr ""
 msgid "No activity on this day."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:307
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:319
 #, elixir-autogen, elixir-format
 msgid "Open the daily report"
 msgstr ""
@@ -6483,6 +6492,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/activity_live.ex:142
 #: lib/vutuv_web/live/admin/deliverability_live.ex:213
 #: lib/vutuv_web/live/admin/deliverability_live.ex:250
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:382
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:189
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:230
 #: lib/vutuv_web/templates/admin/newsletter/clicks.html.heex:27
@@ -6988,7 +6998,7 @@ msgstr ""
 
 #: lib/vutuv_web/live/cv_live.ex:241
 #: lib/vutuv_web/templates/admin/newsletter/show.html.heex:281
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:35
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Reset"
 msgstr ""
@@ -7516,7 +7526,7 @@ msgstr ""
 msgid "Content & taxonomy"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:301
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:313
 #, elixir-autogen, elixir-format
 msgid "System & insights"
 msgstr ""
@@ -7531,19 +7541,19 @@ msgstr ""
 msgid "Create, rename and remove the tags members can add to their profile."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:271
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:283
 #: lib/vutuv_web/templates/admin/username/index.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Usernames"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:274
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:286
 #: lib/vutuv_web/templates/admin/username/index.html.heex:2
 #, elixir-autogen, elixir-format
 msgid "Disable a username"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:276
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:288
 #, elixir-autogen, elixir-format
 msgid "Take an unwanted username away from a member by force-renaming the account."
 msgstr ""
@@ -8531,7 +8541,7 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:362
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:374
 #, elixir-autogen, elixir-format
 msgid "Edit the legal pages"
 msgstr ""
@@ -8546,7 +8556,7 @@ msgstr ""
 msgid "Impressum"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:364
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:376
 #, elixir-autogen, elixir-format
 msgid "Impressum, Datenschutzerklärung and Nutzungsbedingungen: every installation publishes its own operator identity here."
 msgstr ""
@@ -8557,7 +8567,7 @@ msgid "Last edited"
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/legal_page_controller.ex:22
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:359
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:371
 #: lib/vutuv_web/templates/admin/legal_page/edit.html.heex:5
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:2
 #: lib/vutuv_web/templates/admin/legal_page/index.html.heex:3
@@ -8617,7 +8627,7 @@ msgstr ""
 #: lib/vutuv_web/controllers/settings_controller.ex:389
 #: lib/vutuv_web/live/fediverse_followers_live.ex:169
 #: lib/vutuv_web/live/fediverse_following_live.ex:286
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:329
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:341
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:5
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:8
 #: lib/vutuv_web/templates/settings/fediverse.html.heex:12
@@ -8990,7 +9000,7 @@ msgstr ""
 
 #: lib/vutuv_web/components/ui.ex:1436
 #: lib/vutuv_web/components/ui.ex:1437
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:64
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:65
 #: lib/vutuv_web/templates/admin/tag/show.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Honor tag"
@@ -9463,7 +9473,7 @@ msgstr ""
 msgid "Enter a single word with no spaces."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:258
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:270
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:2
 #: lib/vutuv_web/templates/admin/honor_tag/index.html.heex:5
 #, elixir-autogen, elixir-format
@@ -9480,7 +9490,7 @@ msgstr ""
 msgid "Honor tags ›"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:262
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:274
 #, elixir-autogen, elixir-format
 msgid "Manage honor tags"
 msgstr ""
@@ -9500,7 +9510,7 @@ msgstr ""
 msgid "No honor tags yet. Create one above."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:264
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "Official badges you grant, like vutuv_developer for the core team. See who holds each and add or remove members."
 msgstr ""
@@ -9772,44 +9782,44 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:345
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:357
 #, elixir-autogen, elixir-format
 msgid "%{followers} remote followers, %{queue} queued for delivery."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:337
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "Attention:"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:343
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "Outbound federation is healthy."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:337
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:349
 #, elixir-autogen, elixir-format
 msgid "stuck outbound delivery."
 msgid_plural "stuck outbound deliveries."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:40
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "No tags match your search."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:43
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:44
 #, elixir-autogen, elixir-format
 msgid "No tags yet."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:18
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Search tags"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/tag/index.html.heex:25
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "name or slug"
 msgstr ""
@@ -10547,7 +10557,7 @@ msgstr[1] ""
 msgid "Changed for this installation."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:375
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:387
 #, elixir-autogen, elixir-format
 msgid "Edit the defaults"
 msgstr ""
@@ -10557,14 +10567,14 @@ msgstr ""
 msgid "Follows the installation default."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:382
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:394
 #, elixir-autogen, elixir-format
 msgid "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} default differs from the shipped value."
 msgid_plural "How posts and maps behave for everyone who has not chosen for themselves. %{formatted} defaults differ from the shipped values."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:378
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:390
 #, elixir-autogen, elixir-format
 msgid "How posts and maps behave for everyone who has not chosen for themselves. This installation runs on the shipped defaults."
 msgstr ""
@@ -10595,7 +10605,7 @@ msgid "Post display settings reset to the site defaults."
 msgstr ""
 
 #: lib/vutuv_web/controllers/admin/pref_controller.ex:55
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:371
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:383
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:6
 #: lib/vutuv_web/templates/admin/pref/index.html.heex:7
 #, elixir-autogen, elixir-format
@@ -11660,7 +11670,7 @@ msgstr ""
 msgid "former"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:291
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:303
 #, elixir-autogen, elixir-format
 msgid "%{formatted} alias matches another verified organization and is flagged for review."
 msgid_plural "%{formatted} aliases match another verified organization and are flagged for review."
@@ -11799,7 +11809,7 @@ msgstr ""
 msgid "Nothing here yet. Organizations you like show up here."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:286
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "Open organization oversight"
 msgstr ""
@@ -11833,7 +11843,7 @@ msgstr ""
 #: lib/vutuv_web/live/admin/organization_live.ex:25
 #: lib/vutuv_web/live/admin/organization_live.ex:188
 #: lib/vutuv_web/live/admin/organization_live.ex:189
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:281
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:293
 #, elixir-autogen, elixir-format
 msgid "Organization pages"
 msgstr ""
@@ -11917,7 +11927,7 @@ msgstr ""
 msgid "Verified organization pages on vutuv."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:289
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "Verified organization pages: domains, team roles, aliases and rename history. Freeze, archive or delete a page."
 msgstr ""
@@ -13089,6 +13099,7 @@ msgstr ""
 #: lib/vutuv_web/components/saved_search_components.ex:43
 #: lib/vutuv_web/controllers/settings_controller.ex:650
 #: lib/vutuv_web/controllers/settings_controller.ex:668
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
@@ -14648,17 +14659,17 @@ msgstr ""
 msgid "How much each server has stored here. Use it to decide what to block."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:334
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:346
 #, elixir-autogen, elixir-format
 msgid "Block servers and see inbound volume"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:351
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:363
 #, elixir-autogen, elixir-format
 msgid "%{blocked} servers blocked, busiest inbound: %{host}."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:353
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:365
 #, elixir-autogen, elixir-format
 msgid "none yet"
 msgstr ""
@@ -15551,6 +15562,7 @@ msgstr ""
 msgid "View the original"
 msgstr ""
 
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:292
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:190
 #: lib/vutuv_web/templates/admin/fediverse/index.html.heex:231
 #, elixir-autogen, elixir-format
@@ -17106,7 +17118,7 @@ msgstr ""
 msgid "Every logged-out visitor to the start page is shown one of two founder quotes at random and keeps it for their session. Counted per variant: the visitors who saw it, the sign-up forms that created an account, and the PINs that turned such an account into a real member."
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:316
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:328
 #: lib/vutuv_web/templates/admin/experiment/index.html.heex:5
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Headline test"
@@ -17133,7 +17145,7 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:319
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:331
 #, elixir-autogen, elixir-format
 msgid "See which start page wins"
 msgstr ""
@@ -17159,7 +17171,7 @@ msgstr ""
 msgid "Sign-ups:"
 msgstr ""
 
-#: lib/vutuv_web/templates/admin/admin/index.html.heex:321
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "The start page shows one of two founder quotes at random. Views, sign-ups and confirmed members per variant, and whether the difference is real yet."
 msgstr ""
@@ -19620,4 +19632,254 @@ msgstr ""
 #: lib/vutuv_web/components/ui.ex:3686
 #, elixir-autogen, elixir-format
 msgid "delete remove erase posts age old expire automatic cleanup retention purge"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:83
+#, elixir-autogen, elixir-format
+msgid "%{absorbed} is now an alternative name for %{canonical}."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:106
+#, elixir-autogen, elixir-format
+msgid "%{a} and %{b} are recorded as different topics."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:311
+#, elixir-autogen, elixir-format
+msgid "A dropped row belongs to somebody who already carries the surviving tag, so they end up carrying the topic once. Endorsements move to the row that stays."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:189
+#, elixir-autogen, elixir-format
+msgid "A tag cannot absorb itself."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:379
+#, elixir-autogen, elixir-format
+msgid "Absorbed"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:356
+#, elixir-autogen, elixir-format
+msgid "Add an alternative name"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:144
+#, elixir-autogen, elixir-format
+msgid "Added %{name} as an alternative name."
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:73
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Alternative name for %{tag}"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:334
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Alternative names for %{tag}"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:294
+#, elixir-autogen, elixir-format
+msgid "Dropped as duplicate"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:359
+#, elixir-autogen, elixir-format
+msgid "For a name nobody has typed yet, so it never becomes a page of its own. A name that is already a tag has to be merged instead."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:380
+#, elixir-autogen, elixir-format
+msgid "Into"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:264
+#, elixir-autogen, elixir-format
+msgid "Its entries move away and its page redirects."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:318
+#, elixir-autogen, elixir-format
+msgid "Merge"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:41
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:242
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:246
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:252
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:258
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:261
+#, elixir-autogen, elixir-format
+msgid "Merge tags"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/tag/index.html.heex:13
+#, elixir-autogen, elixir-format
+msgid "Merge tags ›"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:371
+#, elixir-autogen, elixir-format
+msgid "Merges so far"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:293
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Moves"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:304
+#, elixir-autogen, elixir-format
+msgid "Nothing is filed under this tag."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:254
+#, elixir-autogen, elixir-format
+msgid "One topic sometimes ends up under several tags. Pick the tag to absorb and the tag that stays: everything filed under the first moves to the second, and the absorbed name becomes an alternative name that keeps pointing there. Every merge can be reverted below."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:158
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Removed."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:412
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Revert"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:402
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Reverted"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:381
+#, elixir-autogen, elixir-format
+msgid "Rows"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:458
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Search by name or slug"
+msgstr ""
+
+#: lib/vutuv_web/templates/admin/admin/index.html.heex:263
+#, elixir-autogen, elixir-format
+msgid "Several tags for one topic become one page: see what a merge would move, do it, and take it back if it was wrong."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:272
+#, elixir-autogen, elixir-format
+msgid "Tag that stays"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:263
+#, elixir-autogen, elixir-format
+msgid "Tag to absorb"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:117
+#, elixir-autogen, elixir-format
+msgid "That merge is no longer on record."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:216
+#, elixir-autogen, elixir-format
+msgid "That merge was already reverted."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:210
+#, elixir-autogen, elixir-format
+msgid "That name is already a tag. Merge it instead, so its entries come along."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:195
+#, elixir-autogen, elixir-format
+msgid "That tag is already an alternative name. Revert its merge first."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "That tag is not an alternative name."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:124
+#, elixir-autogen, elixir-format
+msgid "The merge was reverted."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:198
+#, elixir-autogen, elixir-format
+msgid "The surviving tag is itself an alternative name. Pick its topic instead."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:273
+#, elixir-autogen, elixir-format
+msgid "The topic's one page from now on."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:326
+#, elixir-autogen, elixir-format
+msgid "These are different topics"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:205
+#, elixir-autogen, elixir-format
+msgid "These names differ only in characters the slug drops (like + or #), which is how C, C++ and C# tell each other apart. They are not merged."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:201
+#, elixir-autogen, elixir-format
+msgid "These two are recorded as different topics."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:213
+#, elixir-autogen, elixir-format
+msgid "This name came from a merge. Revert that merge to take it back."
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:282
+#, elixir-autogen, elixir-format
+msgid "What this merge would move"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:231
+#, elixir-autogen, elixir-format
+msgid "hashtags in post bodies"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:233
+#, elixir-autogen, elixir-format, fuzzy
+msgid "job postings"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:232
+#, elixir-autogen, elixir-format, fuzzy
+msgid "members following it"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:235
+#, elixir-autogen, elixir-format, fuzzy
+msgid "newsletter audiences"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:230
+#, elixir-autogen, elixir-format
+msgid "posts filed under it"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:234
+#, elixir-autogen, elixir-format, fuzzy
+msgid "posts from other networks"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "profiles carrying the tag"
+msgstr ""
+
+#: lib/vutuv_web/live/admin/tag_merge_live.ex:192
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Honor tags are granted, not spelled. They are never merged."
 msgstr ""

--- a/priv/repo/migrations/20260810110916_add_tag_merges.exs
+++ b/priv/repo/migrations/20260810110916_add_tag_merges.exs
@@ -1,0 +1,59 @@
+defmodule Vutuv.Repo.Migrations.AddTagMerges do
+  use Ecto.Migration
+
+  # Issue #1338: absorbing a tag moves rows that people put there deliberately —
+  # the tag on their profile, the vouches under it, the posts they filed. An
+  # unreviewable merge is worse than a duplicate, so every merge is written down
+  # and can be taken back.
+  #
+  # `undo` carries what a revert needs and nothing else: the ids of the rows
+  # that moved (grouped per table, so a big merge is a few arrays and not a few
+  # thousand objects) and the full content of the rows that had to be dropped
+  # because their owner already held the surviving tag. Those are re-inserted
+  # verbatim, id and all, via `jsonb_populate_record` — same row, not a copy of
+  # it, so anything pointing at it (an endorsement) lands where it was.
+  #
+  # `tag_distinctions` is the other half of the same story: a pair a human has
+  # looked at and called two different topics never comes back as a candidate.
+  def change do
+    create table(:tag_merges, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+
+      add(:canonical_tag_id, references(:tags, type: :binary_id, on_delete: :delete_all),
+        null: false
+      )
+
+      add(:absorbed_tag_id, references(:tags, type: :binary_id, on_delete: :delete_all),
+        null: false
+      )
+
+      # Who did it. Nilified rather than cascading: the ledger outlives the
+      # admin account, the same way the moderation trail does.
+      add(:admin_user_id, references(:users, type: :binary_id, on_delete: :nilify_all))
+
+      add(:moved_counts, :map, null: false, default: %{})
+      add(:undo, :map, null: false, default: %{})
+      add(:reverted_at, :naive_datetime)
+
+      timestamps()
+    end
+
+    create(index(:tag_merges, [:canonical_tag_id]))
+    create(index(:tag_merges, [:absorbed_tag_id]))
+
+    create table(:tag_distinctions, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+
+      add(:tag_a_id, references(:tags, type: :binary_id, on_delete: :delete_all), null: false)
+      add(:tag_b_id, references(:tags, type: :binary_id, on_delete: :delete_all), null: false)
+      add(:admin_user_id, references(:users, type: :binary_id, on_delete: :nilify_all))
+
+      timestamps()
+    end
+
+    # The pair is stored with the smaller id first, so "these two are different
+    # topics" is one fact rather than two, whichever way round it is stated.
+    create(unique_index(:tag_distinctions, [:tag_a_id, :tag_b_id]))
+    create(index(:tag_distinctions, [:tag_b_id]))
+  end
+end

--- a/test/vutuv/tags/merge_test.exs
+++ b/test/vutuv/tags/merge_test.exs
@@ -1,0 +1,252 @@
+defmodule Vutuv.Tags.MergeTest do
+  use Vutuv.DataCase, async: true
+
+  # Issue #1338: folding one topic's several tags into one page. Absorbing a tag
+  # moves rows that people put there deliberately — the tag on their profile,
+  # the vouches under it, the posts they filed — so the two things this file
+  # cares about most are that nothing is lost on the way over and that the whole
+  # act can be taken back.
+
+  alias Vutuv.Newsletters.NewsletterGroup
+  alias Vutuv.Posts.PostHashtag
+  alias Vutuv.Posts.PostTag
+  alias Vutuv.Tags.Merge
+  alias Vutuv.Tags.Tag
+  alias Vutuv.Tags.TagFollow
+  alias Vutuv.Tags.UserTag
+  alias Vutuv.Tags.UserTagEndorsement
+
+  defp tag(name) do
+    insert(:tag, name: name, slug: Vutuv.SlugHelpers.gen_slug_unique(name, Tag, :slug))
+  end
+
+  setup do
+    %{
+      canonical: tag(unique_tag_name("Ruby on Rails")),
+      absorbed: tag(unique_tag_name("rubyonrails")),
+      admin: insert(:activated_user)
+    }
+  end
+
+  describe "preview/2" do
+    test "counts what would move, per kind", ctx do
+      insert(:user_tag, user: insert(:activated_user), tag: ctx.absorbed)
+      insert(:user_tag, user: insert(:activated_user), tag: ctx.absorbed)
+      Repo.insert!(%PostTag{post_id: insert(:post).id, tag_id: ctx.absorbed.id})
+      insert(:tag_follow, user: insert(:activated_user), tag: ctx.absorbed)
+
+      preview = Merge.preview(ctx.absorbed, ctx.canonical)
+
+      assert preview.moved["user_tags"] == 2
+      assert preview.moved["post_tags"] == 1
+      assert preview.moved["tag_follows"] == 1
+      assert preview.dropped == %{}
+    end
+
+    test "separates the rows a member already holds on both tags", ctx do
+      both = insert(:activated_user)
+      insert(:user_tag, user: both, tag: ctx.canonical)
+      insert(:user_tag, user: both, tag: ctx.absorbed)
+      insert(:user_tag, user: insert(:activated_user), tag: ctx.absorbed)
+
+      preview = Merge.preview(ctx.absorbed, ctx.canonical)
+
+      # One member carries the topic twice, so one of their two rows goes; the
+      # other member's row simply moves. An admin has to see that before saying
+      # yes, which is the whole point of a preview.
+      assert preview.moved["user_tags"] == 1
+      assert preview.dropped["user_tags"] == 1
+    end
+
+    test "says why a merge is refused, without touching anything", ctx do
+      assert {:error, :same_tag} = Merge.preview(ctx.canonical, ctx.canonical)
+    end
+  end
+
+  describe "merge/3" do
+    test "moves every kind of row over and files the tag as an alias", ctx do
+      holder = insert(:activated_user)
+      user_tag = insert(:user_tag, user: holder, tag: ctx.absorbed)
+      post = insert(:post)
+      post_tag = Repo.insert!(%PostTag{post_id: post.id, tag_id: ctx.absorbed.id})
+      hashtag = Repo.insert!(%PostHashtag{post_id: post.id, tag_id: ctx.absorbed.id})
+      follow = insert(:tag_follow, user: insert(:activated_user), tag: ctx.absorbed)
+
+      group =
+        Repo.insert!(%NewsletterGroup{name: unique_tag_name("Audience"), tag_id: ctx.absorbed.id})
+
+      assert {:ok, merge} = Merge.merge(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+
+      assert Repo.get!(UserTag, user_tag.id).tag_id == ctx.canonical.id
+      assert Repo.get!(PostTag, post_tag.id).tag_id == ctx.canonical.id
+      assert Repo.get!(PostHashtag, hashtag.id).tag_id == ctx.canonical.id
+      assert Repo.get!(TagFollow, follow.id).tag_id == ctx.canonical.id
+      assert Repo.get!(NewsletterGroup, group.id).tag_id == ctx.canonical.id
+
+      # The absorbed tag is not deleted: its row is what keeps the old URL alive
+      # and what a revert puts back.
+      absorbed = Repo.get!(Tag, ctx.absorbed.id)
+      assert absorbed.merged_into_id == ctx.canonical.id
+      assert absorbed.alias_kind == "former"
+
+      assert merge.canonical_tag_id == ctx.canonical.id
+      assert merge.absorbed_tag_id == ctx.absorbed.id
+      assert merge.admin_user_id == ctx.admin.id
+    end
+
+    test "a member holding both tags keeps one row, and their vouches follow it", ctx do
+      both = insert(:activated_user)
+      survivor = insert(:user_tag, user: both, tag: ctx.canonical)
+      doomed = insert(:user_tag, user: both, tag: ctx.absorbed)
+
+      endorser = insert(:activated_user)
+      moved = insert(:user_tag_endorsement, user: endorser, user_tag: doomed)
+
+      # The same person endorsed both spellings, so one of the two endorsements
+      # is a duplicate under (endorser, user_tag) and cannot come along.
+      shared = insert(:activated_user)
+      insert(:user_tag_endorsement, user: shared, user_tag: survivor)
+      dropped = insert(:user_tag_endorsement, user: shared, user_tag: doomed)
+
+      assert {:ok, _merge} = Merge.merge(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+
+      refute Repo.get(UserTag, doomed.id)
+      assert Repo.get!(UserTag, survivor.id).tag_id == ctx.canonical.id
+
+      # The vouch somebody gave for this person's skill is not collateral.
+      assert Repo.get!(UserTagEndorsement, moved.id).user_tag_id == survivor.id
+      refute Repo.get(UserTagEndorsement, dropped.id)
+
+      assert Repo.aggregate(from(ut in UserTag, where: ut.user_id == ^both.id), :count) == 1
+    end
+
+    test "the counts it reports are the rows it really moved", ctx do
+      insert(:user_tag, user: insert(:activated_user), tag: ctx.absorbed)
+      Repo.insert!(%PostTag{post_id: insert(:post).id, tag_id: ctx.absorbed.id})
+
+      {:ok, merge} = Merge.merge(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+
+      assert merge.moved_counts["user_tags"] == 1
+      assert merge.moved_counts["post_tags"] == 1
+    end
+  end
+
+  describe "merge/3 refusals" do
+    test "a tag cannot absorb itself", ctx do
+      assert {:error, :same_tag} = Merge.merge(ctx.canonical, ctx.canonical, actor: ctx.admin)
+    end
+
+    test "an honor tag is never merged, in either direction", ctx do
+      honor = ctx.absorbed |> Ecto.Changeset.change(honor?: true) |> Repo.update!()
+
+      # An honor tag is an authoritative badge an admin granted, not a spelling
+      # somebody chose.
+      assert {:error, :honor_tag} = Merge.merge(honor, ctx.canonical, actor: ctx.admin)
+      assert {:error, :honor_tag} = Merge.merge(ctx.canonical, honor, actor: ctx.admin)
+    end
+
+    test "an alias cannot be absorbed again, nor be absorbed into", ctx do
+      {:ok, _} = Merge.merge(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+      absorbed = Repo.get!(Tag, ctx.absorbed.id)
+      other = tag(unique_tag_name("rails"))
+
+      assert {:error, :already_merged} = Merge.merge(absorbed, other, actor: ctx.admin)
+      assert {:error, :target_is_alias} = Merge.merge(other, absorbed, actor: ctx.admin)
+    end
+
+    test "a pair marked deliberately distinct stays refused", ctx do
+      {:ok, _} = Merge.mark_distinct(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+
+      assert {:error, :marked_distinct} =
+               Merge.merge(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+
+      # The mark holds whichever way round the pair is named.
+      assert {:error, :marked_distinct} =
+               Merge.merge(ctx.canonical, ctx.absorbed, actor: ctx.admin)
+    end
+
+    test "names differing only in characters the slugifier strips are refused", ctx do
+      # The #1337 bucket: `c`, `c++`, `c#` and `µc` all slugify to `c`, and they
+      # are four languages. This is a hard rule, not a matter of judgement, and
+      # it applies to a hand-driven merge as much as to a proposed one.
+      c = tag("c")
+      cpp = tag("c++")
+      csharp = tag("c#")
+
+      assert {:error, :punctuation_only_difference} = Merge.merge(cpp, c, actor: ctx.admin)
+      assert {:error, :punctuation_only_difference} = Merge.merge(csharp, c, actor: ctx.admin)
+      assert {:error, :punctuation_only_difference} = Merge.merge(csharp, cpp, actor: ctx.admin)
+
+      # A pair that differs in letters, not in punctuation, is not caught by it.
+      assert {:ok, _} = Merge.merge(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+    end
+
+    test "a separator is not punctuation the slugifier strips", ctx do
+      # `open source` and `OpenSource` differ only in a space, which the
+      # slugifier folds rather than deletes — that pair is the ordinary
+      # mechanical variant and must stay mergeable.
+      spaced = tag("open source")
+      run_together = tag("OpenSource")
+
+      assert {:ok, _} = Merge.merge(run_together, spaced, actor: ctx.admin)
+    end
+  end
+
+  describe "revert/1" do
+    test "puts every moved row back and unfiles the alias", ctx do
+      holder = insert(:activated_user)
+      user_tag = insert(:user_tag, user: holder, tag: ctx.absorbed)
+      post_tag = Repo.insert!(%PostTag{post_id: insert(:post).id, tag_id: ctx.absorbed.id})
+
+      {:ok, merge} = Merge.merge(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+      assert {:ok, reverted} = Merge.revert(merge)
+
+      assert Repo.get!(UserTag, user_tag.id).tag_id == ctx.absorbed.id
+      assert Repo.get!(PostTag, post_tag.id).tag_id == ctx.absorbed.id
+      assert is_nil(Repo.get!(Tag, ctx.absorbed.id).merged_into_id)
+      assert is_nil(Repo.get!(Tag, ctx.absorbed.id).alias_kind)
+      assert reverted.reverted_at
+    end
+
+    test "restores the rows that were dropped as duplicates, with their vouches", ctx do
+      both = insert(:activated_user)
+      insert(:user_tag, user: both, tag: ctx.canonical)
+      doomed = insert(:user_tag, user: both, tag: ctx.absorbed)
+      endorsement = insert(:user_tag_endorsement, user: insert(:activated_user), user_tag: doomed)
+
+      {:ok, merge} = Merge.merge(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+      refute Repo.get(UserTag, doomed.id)
+
+      assert {:ok, _} = Merge.revert(merge)
+
+      # Same row, same id: a revert restores the state, not something that
+      # merely looks like it.
+      restored = Repo.get!(UserTag, doomed.id)
+      assert restored.tag_id == ctx.absorbed.id
+      assert restored.user_id == both.id
+      assert Repo.get!(UserTagEndorsement, endorsement.id).user_tag_id == doomed.id
+    end
+
+    test "a merge is reverted once", ctx do
+      insert(:user_tag, user: insert(:activated_user), tag: ctx.absorbed)
+      {:ok, merge} = Merge.merge(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+      {:ok, reverted} = Merge.revert(merge)
+
+      assert {:error, :already_reverted} = Merge.revert(reverted)
+    end
+  end
+
+  describe "mark_distinct/3" do
+    test "records the pair whichever way round it is named", ctx do
+      {:ok, _} = Merge.mark_distinct(ctx.canonical, ctx.absorbed, actor: ctx.admin)
+
+      assert Merge.distinct?(ctx.absorbed, ctx.canonical)
+      assert Merge.distinct?(ctx.canonical, ctx.absorbed)
+    end
+
+    test "marking the same pair twice is not an error", ctx do
+      {:ok, _} = Merge.mark_distinct(ctx.canonical, ctx.absorbed, actor: ctx.admin)
+      assert {:ok, _} = Merge.mark_distinct(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+    end
+  end
+end

--- a/test/vutuv_web/live/admin/tag_merge_live_test.exs
+++ b/test/vutuv_web/live/admin/tag_merge_live_test.exs
@@ -1,0 +1,156 @@
+defmodule VutuvWeb.Admin.TagMergeLiveTest do
+  @moduledoc """
+  The tag merge screen (`/admin/tags` → "Merge tags", issue #1338): admins only,
+  pick two tags, see what the merge would move before confirming, do it, and
+  take it back from the history below.
+  """
+  use VutuvWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Vutuv.Tags.Merge
+  alias Vutuv.Tags.Tag
+  alias Vutuv.Tags.UserTag
+
+  defp tag(name) do
+    insert(:tag, name: name, slug: Vutuv.SlugHelpers.gen_slug_unique(name, Tag, :slug))
+  end
+
+  describe "authorization" do
+    test "non-admins are locked out", %{conn: conn} do
+      {conn, _user} = create_and_login_user(conn)
+      assert html_response(get(conn, ~p"/admin/tag_merges"), 403)
+    end
+  end
+
+  describe "merging" do
+    setup %{conn: conn} do
+      {conn, admin} = create_and_login_admin(conn)
+
+      %{
+        conn: conn,
+        admin: admin,
+        canonical: tag(unique_tag_name("Ruby on Rails")),
+        absorbed: tag(unique_tag_name("rubyonrails"))
+      }
+    end
+
+    test "shows what the merge would move before it is confirmed", ctx do
+      insert(:user_tag, user: insert(:activated_user), tag: ctx.absorbed)
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+
+      pick(lv, ctx.absorbed, "absorbed")
+      html = pick(lv, ctx.canonical, "canonical")
+
+      assert has_element?(lv, "#merge-preview")
+      assert html =~ "profiles carrying the tag"
+      # Nothing has happened yet: the preview is a promise, not a receipt.
+      assert is_nil(Repo.get!(Tag, ctx.absorbed.id).merged_into_id)
+    end
+
+    test "merging moves the rows and files the absorbed name", ctx do
+      user_tag = insert(:user_tag, user: insert(:activated_user), tag: ctx.absorbed)
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      pick(lv, ctx.absorbed, "absorbed")
+      pick(lv, ctx.canonical, "canonical")
+
+      lv |> element("#do-merge") |> render_click()
+
+      assert Repo.get!(UserTag, user_tag.id).tag_id == ctx.canonical.id
+      assert Repo.get!(Tag, ctx.absorbed.id).merged_into_id == ctx.canonical.id
+      assert has_element?(lv, "#merge-history")
+    end
+
+    test "a refused pair says why, in place of the button", ctx do
+      c = tag("c")
+      cpp = tag("c++")
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      pick(lv, cpp, "absorbed")
+      html = pick(lv, c, "canonical")
+
+      # The #1337 bucket: four languages one normalization would fold into one.
+      assert html =~ "differ only in characters"
+      refute has_element?(lv, "#do-merge")
+    end
+
+    test "the German screen is German", ctx do
+      # A screen whose new labels were never checked in German ships whatever
+      # the extract guessed, and the extract guesses badly: this page's
+      # "Reverted" came back as "Geprüft" (checked) before it was written out.
+      {:ok, _lv, html} =
+        ctx.conn
+        |> recycle()
+        |> put_req_header("accept-language", "de-DE,de")
+        |> live(~p"/admin/tag_merges")
+
+      assert html =~ "Tags zusammenlegen"
+      assert html =~ "Tag, das aufgenommen wird"
+      assert html =~ "Tag, das bleibt"
+      refute html =~ "Tag to absorb"
+    end
+
+    test "a merge can be reverted from the history", ctx do
+      user_tag = insert(:user_tag, user: insert(:activated_user), tag: ctx.absorbed)
+      {:ok, merge} = Merge.merge(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      lv |> element("#merge-#{merge.id} button", "Revert") |> render_click()
+
+      assert Repo.get!(UserTag, user_tag.id).tag_id == ctx.absorbed.id
+      assert is_nil(Repo.get!(Tag, ctx.absorbed.id).merged_into_id)
+    end
+
+    test "a pair can be marked as different topics", ctx do
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      pick(lv, ctx.absorbed, "absorbed")
+      pick(lv, ctx.canonical, "canonical")
+
+      lv |> element("#mark-distinct") |> render_click()
+
+      assert Merge.distinct?(ctx.absorbed, ctx.canonical)
+      # And the merge is refused from now on, whoever tries it.
+      assert {:error, :marked_distinct} =
+               Merge.merge(ctx.absorbed, ctx.canonical, actor: ctx.admin)
+    end
+  end
+
+  describe "alternative names" do
+    setup %{conn: conn} do
+      {conn, admin} = create_and_login_admin(conn)
+      %{conn: conn, admin: admin, canonical: tag(unique_tag_name("Ruby on Rails"))}
+    end
+
+    test "a name nobody has typed yet can be filed pre-emptively", ctx do
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      pick(lv, ctx.canonical, "canonical")
+
+      name = unique_tag_name("ROR")
+      lv |> form("#add-alias", %{"name" => name}) |> render_submit()
+
+      # Typing it now attaches the topic instead of minting a second page.
+      assert Tag.find_by_value(name).id == ctx.canonical.id
+    end
+
+    test "a name that is already a tag has to be merged instead", ctx do
+      existing = tag(unique_tag_name("rails"))
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/admin/tag_merges")
+      pick(lv, ctx.canonical, "canonical")
+
+      html = lv |> form("#add-alias", %{"name" => existing.name}) |> render_submit()
+
+      assert html =~ "Merge it instead"
+      assert is_nil(Repo.get!(Tag, existing.id).merged_into_id)
+    end
+  end
+
+  # Search for a tag and click its result, the way an admin picks one.
+  defp pick(lv, tag, side) do
+    lv |> form("#search-#{side}", %{"side" => side, "q" => tag.name}) |> render_change()
+
+    lv |> element("#pick-#{side}-#{tag.id}") |> render_click()
+  end
+end


### PR DESCRIPTION
**TL;DR** Zweiter von drei Schritten zu #1338: Admins können mehrere Tags eines Themas zusammenlegen, sehen vorher was das verschiebt, und können jede Zusammenlegung wieder zurücknehmen.

**Wo:** `Vutuv.Tags.Merge`, `/admin/tag_merges` (`VutuvWeb.Admin.TagMergeLive`).

**Was verschoben wird:** Profil-Tags samt Empfehlungen, Beiträge und Body-Hashtags, Tag-Abos, Stellenanzeigen, zwischengespeicherte Beiträge aus anderen Netzwerken, Newsletter-Zielgruppen. Gelöscht wird nur, was der Unique-Index (Eigentümer, Tag) nicht zulässt: wer beide Schreibweisen trug, trägt danach das Thema einmal. Die Empfehlungen ziehen vorher auf den Eintrag um, der bleibt – eine Empfehlung ist das, was jemand anderes über diese Person gesagt hat.

**Umkehrbar heißt exakt umkehrbar.** `tag_merges` hält die ids der verschobenen Zeilen und den vollständigen Inhalt der weggefallenen; `revert/1` schiebt zurück und setzt die weggefallenen per `jsonb_populate_record` wortgleich wieder ein, mit derselben id, so dass auch die Empfehlungen wieder an ihrem Eintrag hängen. Das Verschieben steht deshalb in SQL statt in Ecto: eine Rücknahme muss eine *Zeile* wiederherstellen, nicht das, was ein Schema für sie hält.

**Vier Verweigerungen als Regel, nicht als Ermessensfrage**

- ein Ehren-Tag wird nie zusammengelegt (vergeben, nicht geschrieben),
- ein Zweitname nicht noch einmal,
- ein als „verschiedene Themen" vermerktes Paar bleibt getrennt, in beiden Richtungen,
- ein Paar, dessen Namen sich nur in Zeichen unterscheiden, die der Slugifier löscht, wird abgelehnt: der Eimer `c` / `c++` / `c#` / `µc` aus #1337. Ein Trennzeichen zählt nicht dazu, `open source` / `OpenSource` bleibt der Normalfall, für den es die Zusammenlegung gibt.

**Die Oberfläche** zeigt vor dem Bestätigen, was die Zusammenlegung bewegen würde, getrennt nach „zieht um" und „fällt als Dublette weg"; darunter die bisherigen Zusammenlegungen mit „Rückgängig machen". Sie nimmt außerdem einen Zweitnamen vorab auf (damit `ROR` nie eine eigene Seite wird) und vermerkt ein Paar als verschiedene Themen. Der Tag-Katalog markiert Zweitnamen jetzt und verlinkt ihr Thema.

**Deutsch:** alle 49 neuen Strings von Hand geschrieben. Der Extract hatte elf fuzzy vorbelegt, darunter „Reverted" als „Geprüft" und „Search by name or slug" als „Nach Name oder Stadt suchen".

**Geprüft:** `mix precommit` grün (7073 Tests), Migration gegen `vutuv1_dev` gelaufen, deutsche Ausgabe mit echtem `Accept-Language: de-DE,de` getestet.

**Als Nächstes:** Schritt 3, der einmalige assistierte Durchlauf, der Vorschläge zur Freigabe erzeugt.

*Diesen Text hat ein KI-Agent in meinem Namen geschrieben, ungeprüft von mir. Die Arbeit dahinter ist meine, nur das Aufschreiben habe ich delegiert.*